### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/ts-src/calcit.procs.ts
+++ b/ts-src/calcit.procs.ts
@@ -499,7 +499,7 @@ export let _$n_list_$o_rest = (xs: CalcitValue): CalcitValue => {
 };
 
 export let _$n_str_$o_rest = (xs: CalcitValue): CalcitValue => {
-  if (typeof xs === "string") return xs.substr(1);
+  if (typeof xs === "string") return xs.slice(1);
 
   console.error(xs);
   throw new Error("Expects a string");
@@ -571,7 +571,7 @@ export let butlast = (xs: CalcitValue): CalcitValue => {
     return xs.slice(0, xs.len() - 1);
   }
   if (typeof xs === "string") {
-    return xs.substr(0, xs.length - 1);
+    return xs.slice(0, -1);
   }
   console.error(xs);
   throw new Error("Data not ready for butlast");

--- a/ts-src/js-cirru.ts
+++ b/ts-src/js-cirru.ts
@@ -112,10 +112,10 @@ export let extract_cirru_edn = (x: CirruEdnFormat): CalcitValue => {
       return x.slice(1);
     }
     if (x[0] === ":") {
-      return kwd(x.substr(1));
+      return kwd(x.slice(1));
     }
     if (x[0] === "'") {
-      return new CalcitSymbol(x.substr(1));
+      return new CalcitSymbol(x.slice(1));
     }
     if (x.match(/^(-?)\d+(\.\d*$)?/)) {
       return parseFloat(x);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.