### PR TITLE
refactor gensym into syntax for stable index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.5.33"
+version = "0.5.34"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.5.33"
+version = "0.5.34"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/calcit/debug/macro-ns.cirru
+++ b/calcit/debug/macro-ns.cirru
@@ -1,0 +1,26 @@
+
+{} (:package |macro-ns)
+  :configs $ {} (:init-fn |macro-ns.main/main!) (:reload-fn |macro-ns.main/reload!)
+    :modules $ []
+  :files $ {}
+    |macro-ns.lib $ {}
+      :ns $ quote
+        ns macro-ns.lib $ :require
+          [] util.core :refer $ [] log-title inside-eval:
+      :defs $ {}
+        |v $ quote
+          def v 100
+        |expand-1 $ quote
+          defmacro expand-1 (n)
+            println "|local data" v
+            quasiquote
+              println ~n ~v
+
+    |macro-ns.main $ {}
+      :ns $ quote
+        ns macro-ns.main $ :require
+          macro-ns.lib :refer $ expand-1
+      :defs $ {}
+        |main! $ quote
+          defn main! ()
+            expand-1 1

--- a/calcit/test-macro.cirru
+++ b/calcit/test-macro.cirru
@@ -219,11 +219,8 @@
               &reset-gensym-index!
               assert= (gensym) 'G__1
               assert=
-                gensym 'a
-                , 'a__2
-              assert=
                 gensym |a
-                , 'a__3
+                , 'a__2
 
         |test-w-log $ quote
           fn ()

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -50,7 +50,9 @@
             assert-detect not $ bool? $ fn () 1
 
             assert-detect fn? &=
-            assert-detect macro? cond
+
+            inside-eval:
+              assert-detect macro? cond
 
             assert-detect set? $ #{} 1 2 3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^17.0.23",

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -31,7 +31,6 @@ pub fn is_proc_name(s: &str) -> bool {
       | "recur"
       | "format-to-lisp"
       | "format-to-cirru"
-      | "gensym"
       | "&reset-gensym-index!"
       | "&get-calcit-running-mode"
       | "generate-id!"
@@ -216,7 +215,6 @@ fn handle_proc_internal(name: &str, args: &CalcitItems, call_stack: &CallStackLi
     "recur" => meta::recur(args),
     "format-to-lisp" => meta::format_to_lisp(args),
     "format-to-cirru" => meta::format_to_cirru(args),
-    "gensym" => meta::gensym(args),
     "&reset-gensym-index!" => meta::reset_gensym_index(args),
     "&get-calcit-running-mode" => effects::calcit_running_mode(args),
     "generate-id!" => meta::generate_id(args),
@@ -403,6 +401,7 @@ pub fn handle_syntax(
     CalcitSyntax::Defmacro => syntax::defmacro(nodes, scope, file_ns),
     CalcitSyntax::Quote => syntax::quote(nodes, scope, file_ns),
     CalcitSyntax::Quasiquote => syntax::quasiquote(nodes, scope, file_ns, call_stack),
+    CalcitSyntax::Gensym => syntax::gensym(nodes, scope, file_ns, call_stack),
     CalcitSyntax::If => syntax::syntax_if(nodes, scope, file_ns, call_stack),
     CalcitSyntax::CoreLet => syntax::syntax_let(nodes, scope, file_ns, call_stack),
     CalcitSyntax::Macroexpand => syntax::macroexpand(nodes, scope, file_ns, call_stack),

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -405,7 +405,7 @@
               quasiquote
                 eprintln "|[Error] key-match expected some patterns and matches" ~value
               if (list? value)
-                &let (v# (gensym 'v))
+                &let (v# (gensym |v))
                   quasiquote
                     &let (~v# ~value)
                       &key-match-internal ~v# $ ~@ body

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -1276,10 +1276,8 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
           ));
           gen_stack::pop_call_stack()
         }
-        Calcit::Macro { .. } => {
-          // macro should be handled during compilation, psuedo code
-          defs_code.push_str(&snippets::tmpl_export_macro(escape_var(&def)));
-        }
+        // macro are not traced in codegen since already expanded
+        Calcit::Macro { .. } => {}
         Calcit::Syntax(_, _) => {
           // should he handled inside compiler
         }

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -115,16 +115,6 @@ export * from {};
   )
 }
 
-pub fn tmpl_export_macro(name: String) -> String {
-  format!(
-    "
-export var {} = () => {{/* Macro */}}
-{}.isMacro = true;
-",
-    name, name
-  )
-}
-
 pub fn tmpl_classes_registering() -> String {
   format!(
     "

--- a/src/primes/syntax_name.rs
+++ b/src/primes/syntax_name.rs
@@ -10,6 +10,7 @@ pub enum CalcitSyntax {
   CoreLet,
   Quote,
   Quasiquote,
+  Gensym,
   Eval,
   Macroexpand,
   Macroexpand1,
@@ -31,6 +32,7 @@ impl fmt::Display for CalcitSyntax {
       CoreLet => "&let",
       Quote => "quote",
       Quasiquote => "quasiquote",
+      Gensym => "gensym",
       Eval => "eval",
       Macroexpand => "macroexpand",
       Macroexpand1 => "macroexpand-1",
@@ -53,6 +55,7 @@ impl CalcitSyntax {
       "&let" => Ok(CoreLet),
       "quote" => Ok(Quote),
       "quasiquote" => Ok(Quasiquote),
+      "gensym" => Ok(Gensym),
       "eval" => Ok(Eval),
       "macroexpand" => Ok(Macroexpand),
       "macroexpand-1" => Ok(Macroexpand1),
@@ -74,6 +77,7 @@ impl CalcitSyntax {
         | "&let"
         | "quote"
         | "quasiquote"
+        | "gensym"
         | "eval"
         | "macroexpand"
         | "macroexpand-1"
@@ -112,6 +116,10 @@ impl Ord for CalcitSyntax {
       (Quasiquote, Quasiquote) => Equal,
       (Quasiquote, _) => Less,
       (_, Quasiquote) => Greater,
+
+      (Gensym, Gensym) => Equal,
+      (Gensym, _) => Less,
+      (_, Gensym) => Greater,
 
       (Eval, Eval) => Equal,
       (Eval, _) => Less,

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -273,7 +273,6 @@ pub fn preprocess_expr(
       // maybe detect method in future
       Ok((expr.to_owned(), None))
     }
-
     _ => {
       let mut warnings = check_warnings.borrow_mut();
       warnings.push(format!("[Warn] unexpected data during preprocess: {:?}", expr));
@@ -355,7 +354,7 @@ fn process_list_call(
         // need to handle recursion
         // println!("evaling line: {:?}", body);
         let body_scope = runner::bind_args(def_args, &current_values, &rpds::HashTrieMap::new_sync(), &next_stack)?;
-        let code = runner::evaluate_lines(body, &body_scope, def_ns.to_owned(), &next_stack)?;
+        let code = runner::evaluate_lines(body, &body_scope, file_ns.to_owned(), &next_stack)?;
         match code {
           Calcit::Recur(ys) => {
             current_values = Box::new(ys.to_owned());
@@ -385,6 +384,7 @@ fn process_list_call(
       | CalcitSyntax::Macroexpand
       | CalcitSyntax::MacroexpandAll
       | CalcitSyntax::Macroexpand1
+      | CalcitSyntax::Gensym
       | CalcitSyntax::Reset => Ok((
         preprocess_each_items(name, name_ns.to_owned(), &args, scope_defs, file_ns, check_warnings, call_stack)?,
         None,

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.5.33";
+export const calcit_version = "0.5.34";
 
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { parse, ICirruNode } from "@cirru/parser.ts";


### PR DESCRIPTION
调整以后, `gensym` 称为一个内置的语法, 可以得到解释器的 `file_ns` 状态, 在同一个 namespace 内部, 进行 symbol unique index 的自增. 并且 `file_ns` 在 preprocess 过程的传递也有调整.

测试无问题. 但是预处理的过程更复杂了, 细节的行为理解起来也更模糊了.
