### PR TITLE
handle a special case of variable shadowing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.5.45"
+version = "0.5.46"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.5.45"
+version = "0.5.46"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/calcit/test-js.cirru
+++ b/calcit/test-js.cirru
@@ -76,6 +76,17 @@
                 d 5
               assert= 13 $ + a b c d
 
+            ; "a special case variable shadowing of `b`"
+            let
+                b -1
+                a $ loop
+                    xs $ []
+                    b 0
+                  if (>= b 5) xs
+                    recur (conj xs b) (inc b)
+              assert= a $ [] 0 1 2 3 4
+              assert= b -1
+
         |test-collection $ quote
           fn ()
             log-title "|Testing quick collection syntax"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@calcit/procs",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
-    "@types/node": "^17.0.29",
-    "typescript": "^4.6.3"
+    "@types/node": "^18.0.0",
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "compile": "rm -rfv lib/* && tsc",

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -20,6 +20,7 @@ use calcit::{
   ProgramEntries,
 };
 
+#[derive(Debug, Clone)]
 pub struct CLIOptions {
   entry_path: PathBuf,
   emit_path: String,

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -8,7 +8,6 @@ pub fn parse_cli() -> clap::ArgMatches {
     .arg(
       clap::Arg::new("once")
         .help("disable watching mode")
-        .default_value("false")
         .short('1')
         .long("once")
         .takes_value(false),
@@ -16,14 +15,12 @@ pub fn parse_cli() -> clap::ArgMatches {
     .arg(
       clap::Arg::new("emit-js")
         .help("emit js rather than interpreting")
-        .default_value("false")
         .long("emit-js")
         .takes_value(false),
     )
     .arg(
       clap::Arg::new("emit-ir")
         .help("emit EDN representation of program to program-ir.cirru")
-        .default_value("false")
         .long("emit-ir")
         .takes_value(false),
     )

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -738,7 +738,13 @@ fn gen_let_code(
             if scoped_defs.contains(&sym) {
               for (idx, x) in content.into_iter().enumerate() {
                 if idx == content.len() - 1 {
-                  body_part.push_str(&to_js_code(x, ns, &scoped_defs, file_imports, keywords, Some(return_label))?);
+                  // normally, last item of function body returns as return value(even in recursion)
+                  if local_defs.contains(&sym) {
+                    // however, to shallow a conflicted variable, we need to return explicitly
+                    body_part.push_str(&to_js_code(x, ns, &scoped_defs, file_imports, keywords, Some("return "))?);
+                  } else {
+                    body_part.push_str(&to_js_code(x, ns, &scoped_defs, file_imports, keywords, Some(return_label))?);
+                  }
                   body_part.push('\n');
                 } else {
                   body_part.push_str(&to_js_code(x, ns, &scoped_defs, file_imports, keywords, None)?);

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.5.45";
+export const calcit_version = "0.5.46";
 
 import { parse, ICirruNode } from "@cirru/parser.ts";
 import { writeCirruCode } from "@cirru/writer.ts";

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,12 +17,12 @@
   resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.3.tgz#5f54bdecaa20ba3dab16cbe6da711854138a9c0a"
   integrity sha512-vJnhmhm7we5UfQIwmZfQpF3bAFbVybzT6LbmkbQHxgijaQg3gPfNVsnSIa3g3KpmWVtvkzEx+nUy5aMwsJiV1A==
 
-"@types/node@^17.0.29":
-  version "17.0.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.29.tgz#7f2e1159231d4a077bb660edab0fde373e375a3d"
-  integrity sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==
+"@types/node@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
+  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==


### PR DESCRIPTION
for a case like:

```cirru
; "a special case variable shadowing of `b`"
let
    b -1
    a $ loop
        xs $ []
        b 0
      if (>= b 5) xs
        recur (conj xs b) (inc b)
  assert= a $ [] 0 1 2 3 4
  assert= b -1
```

where `b` is defined both outside and inside, which reused the `return_label` of `loop` recursion. but actually it does not forward value, it only returns. the outer context should be unaware for code in bind function.
