### PR TITLE
fix keywords in error snapshot

### DIFF
--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -85,7 +85,11 @@ fn main() -> Result<(), String> {
         println!("running entry: {}", entry);
         snapshot.configs = snapshot.entries[entry].to_owned();
       } else {
-        return Err(format!("unknown entry `{}` among {:?}", entry, snapshot.entries.keys()));
+        return Err(format!(
+          "unknown entry `{}` in `{}`",
+          entry,
+          snapshot.entries.keys().map(|x| (*x).to_owned()).collect::<Vec<_>>().join("/")
+        ));
       }
     }
 

--- a/src/call_stack.rs
+++ b/src/call_stack.rs
@@ -93,10 +93,10 @@ pub fn display_stack(failure: &str, stack: &CallStackList, location: Option<&Nod
       args.push(edn::calcit_to_edn(a)?);
     }
     let info = Edn::map_from_iter([
-      ("def".into(), format!("{}/{}", s.ns, s.def).into()),
-      ("code".into(), cirru::calcit_to_cirru(&s.code)?.into()),
-      ("args".into(), args.into()),
-      ("kind".into(), (&s.kind).to_string().into()),
+      (Edn::kwd("def"), format!("{}/{}", s.ns, s.def).into()),
+      (Edn::kwd("code"), cirru::calcit_to_cirru(&s.code)?.into()),
+      (Edn::kwd("args"), args.into()),
+      (Edn::kwd("kind"), (&s.kind).to_string().into()),
     ]);
 
     stack_list.push(info);
@@ -104,10 +104,10 @@ pub fn display_stack(failure: &str, stack: &CallStackList, location: Option<&Nod
 
   let content = cirru_edn::format(
     &Edn::map_from_iter([
-      ("message".into(), failure.into()),
-      ("stack".into(), stack_list.into()),
+      (Edn::kwd("message"), failure.into()),
+      (Edn::kwd("stack"), stack_list.into()),
       (
-        "location".into(),
+        Edn::kwd("location"),
         match location {
           Some(l) => l.into(),
           None => Edn::Nil,

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -693,9 +693,9 @@ pub struct NodeLocation {
 impl From<NodeLocation> for Edn {
   fn from(v: NodeLocation) -> Self {
     Edn::map_from_iter([
-      ("ns".into(), v.ns.into()),
-      ("def".into(), v.def.into()),
-      ("coord".into(), v.coord.into()),
+      (Edn::kwd("ns"), v.ns.into()),
+      (Edn::kwd("def"), v.def.into()),
+      (Edn::kwd("coord"), v.coord.into()),
     ])
   }
 }


### PR DESCRIPTION
keywords are expected in http://repo.calcit-lang.org/calcit-error-viewer/ .