### PR TITLE
add cirru-quote variant for better meta programming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.6.0-a2"
+version = "0.6.0-a3"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.5.48"
+version = "0.6.0-a1"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.6.0-a1"
+version = "0.6.0-a2"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.6.0-a2"
+version = "0.6.0-a3"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.6.0-a1"
+version = "0.6.0-a2"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.5.48"
+version = "0.6.0-a1"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/calcit/test-string.cirru
+++ b/calcit/test-string.cirru
@@ -135,8 +135,7 @@
 
               assert=
                 {}
-                  :code $ :: 'quote
-                    [] |+ |1 |2 |3
+                  :code $ cirru-quote $ + 1 2 3
                 parse-cirru-edn "|{} $ :code $ quote $ + 1 2 3"
 
               assert=
@@ -146,6 +145,10 @@
               assert= "|{} $ :code\n  quote $ + 1 2 3"
                 trim $ format-cirru-edn $ {}
                   :code $ :: 'quote $ [] |+ |1 |2 |3
+
+              assert= "|{} $ :code\n  quote $ + 1 2 3"
+                trim $ format-cirru-edn $ {}
+                  :code $ cirru-quote $ + 1 2 3
 
               assert= "|[] 'a"
                 trim $ format-cirru-edn $ [] 'a

--- a/calcit/test-string.cirru
+++ b/calcit/test-string.cirru
@@ -177,6 +177,10 @@
               assert= "|:: :&core-list-class $ [] 1 2 3"
                 trim $ format-cirru-edn $ :: &core-list-class $ [] 1 2 3
 
+              assert=
+                &cirru-quote:to-list $ cirru-quote $ a b c $ d
+                [] |a |b |c $ [] |d
+
               assert= (.escape "|\n") "|\"\\n\""
               assert= (.escape "|\t") "|\"\\t\""
               assert= (.escape "|a") "|\"a\""

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -124,12 +124,12 @@
           fn ()
             log-title "|Testing Cirru parser"
             assert=
-              parse-cirru "|def f (a b) $ + a b"
+              parse-cirru-list "|def f (a b) $ + a b"
               [] $ [] |def |f ([] |a |b)
                 [] |+ |a |b
 
             assert=
-              parse-cirru "|{,} :a 1 :b false"
+              parse-cirru-list "|{,} :a 1 :b false"
               [] $ [] |{,} |:a |1 |:b |false
 
             assert=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.5.48",
+  "version": "0.6.0-a1",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@calcit/procs",
-  "version": "0.6.0-a1",
+  "version": "0.6.0-a2",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^18.0.6",
     "typescript": "^4.7.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.6.0-a2",
+  "version": "0.6.0-a3",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^18.0.6",

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -56,6 +56,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "write-file"
       // external format
       | "parse-cirru"
+      | "parse-cirru-list"
       | "format-cirru"
       | "parse-cirru-edn"
       | "format-cirru-edn"
@@ -247,6 +248,7 @@ fn handle_proc_internal(name: &str, args: &CalcitItems, call_stack: &CallStackLi
     "write-file" => effects::write_file(args),
     // external data format
     "parse-cirru" => meta::parse_cirru(args),
+    "parse-cirru-list" => meta::parse_cirru_list(args),
     "format-cirru" => meta::format_cirru(args),
     "parse-cirru-edn" => meta::parse_cirru_edn(args),
     "format-cirru-edn" => meta::format_cirru_edn(args),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -60,6 +60,7 @@ pub fn is_proc_name(s: &str) -> bool {
       | "format-cirru"
       | "parse-cirru-edn"
       | "format-cirru-edn"
+      | "&cirru-quote:to-list"
       // time
       | "cpu-time"
       // logics
@@ -252,6 +253,7 @@ fn handle_proc_internal(name: &str, args: &CalcitItems, call_stack: &CallStackLi
     "format-cirru" => meta::format_cirru(args),
     "parse-cirru-edn" => meta::parse_cirru_edn(args),
     "format-cirru-edn" => meta::format_cirru_edn(args),
+    "&cirru-quote:to-list" => meta::cirru_quote_to_list(args),
     // time
     "cpu-time" => effects::cpu_time(args),
     // logics

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -5,7 +5,7 @@ use crate::{
   call_stack::CallStackList,
   codegen::gen_ir::dump_code,
   data::{
-    cirru,
+    cirru::{self, cirru_to_calcit},
     edn::{self, edn_to_calcit},
   },
   primes,
@@ -207,6 +207,16 @@ pub fn format_cirru_edn(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(a) => Ok(Calcit::Str(cirru_edn::format(&edn::calcit_to_edn(a)?, true)?.into())),
     None => CalcitErr::err_str("format-cirru-edn expected 1 argument"),
+  }
+}
+
+pub fn cirru_quote_to_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
+  if xs.len() != 1 {
+    return CalcitErr::err_str(format!("&cirru-quote:to-list expected 1 argument, got: {:?}", xs));
+  }
+  match &xs[0] {
+    Calcit::CirruQuote(ys) => Ok(cirru_to_calcit(ys)),
+    a => CalcitErr::err_str(format!("&cirru-quote:to-list got invalid data: {}", a)),
   }
 }
 

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -45,6 +45,7 @@ pub fn type_of(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
     Calcit::Ref(..) => Ok(Calcit::kwd("ref")),
     Calcit::Tuple(..) => Ok(Calcit::kwd("tuple")),
     Calcit::Buffer(..) => Ok(Calcit::kwd("buffer")),
+    Calcit::CirruQuote(..) => Ok(Calcit::kwd("cirru-quote")),
     Calcit::Recur(..) => Ok(Calcit::kwd("recur")),
     Calcit::List(..) => Ok(Calcit::kwd("list")),
     Calcit::Set(..) => Ok(Calcit::kwd("set")),
@@ -149,10 +150,22 @@ pub fn display_stack(_xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
   Ok(Calcit::Nil)
 }
 
-pub fn parse_cirru(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
+pub fn parse_cirru_list(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match xs.get(0) {
     Some(Calcit::Str(s)) => match cirru_parser::parse(s) {
       Ok(nodes) => Ok(cirru::cirru_to_calcit(&Cirru::List(nodes))),
+      Err(e) => CalcitErr::err_str(format!("parse-cirru-list failed, {}", e)),
+    },
+    Some(a) => CalcitErr::err_str(format!("parse-cirru-list expected a string, got: {}", a)),
+    None => CalcitErr::err_str("parse-cirru-list expected 1 argument"),
+  }
+}
+
+/// it returns a piece of quoted Cirru data, rather than a list
+pub fn parse_cirru(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
+  match xs.get(0) {
+    Some(Calcit::Str(s)) => match cirru_parser::parse(s) {
+      Ok(nodes) => Ok(Calcit::CirruQuote(Cirru::List(nodes))),
       Err(e) => CalcitErr::err_str(format!("parse-cirru failed, {}", e)),
     },
     Some(a) => CalcitErr::err_str(format!("parse-cirru expected a string, got: {}", a)),

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -73,6 +73,7 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
       }
     }
     Calcit::Buffer(buf) => Ok(Edn::Buffer(buf.to_owned())),
+    Calcit::CirruQuote(code) => Ok(Edn::Quote(code.to_owned())),
     a => Err(format!("not able to generate EDN: {}", a)), // TODO more types to handle
   }
 }
@@ -91,16 +92,7 @@ pub fn edn_to_calcit(x: &Edn) -> Calcit {
     },
     Edn::Keyword(s) => Calcit::Keyword(s.to_owned()),
     Edn::Str(s) => Calcit::Str((**s).into()),
-    Edn::Quote(nodes) => Calcit::Tuple(
-      Arc::new(Calcit::Symbol {
-        sym: "quote".into(),
-        ns: primes::GEN_NS.into(),
-        at_def: primes::GENERATED_DEF.into(),
-        resolved: None,
-        location: None,
-      }),
-      Arc::new(cirru::cirru_to_calcit(nodes)),
-    ),
+    Edn::Quote(nodes) => Calcit::CirruQuote(nodes.to_owned()),
     Edn::Tuple(pair) => Calcit::Tuple(Arc::new(edn_to_calcit(&pair.0)), Arc::new(edn_to_calcit(&pair.1))),
     Edn::List(xs) => {
       let mut ys: primes::CalcitItems = TernaryTreeList::Empty;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -57,6 +57,7 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: Arc<str>, call
     Calcit::Ref(_) => Ok(expr.to_owned()),
     Calcit::Tuple(..) => Ok(expr.to_owned()),
     Calcit::Buffer(..) => Ok(expr.to_owned()),
+    Calcit::CirruQuote(..) => Ok(expr.to_owned()),
     Calcit::Recur(_) => unreachable!("recur not expected to be from symbol"),
     Calcit::List(xs) => match xs.get(0) {
       None => Err(CalcitErr::use_msg_stack(

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -276,7 +276,9 @@ pub fn preprocess_expr(
         process_list_call(xs, scope_defs, file_ns, check_warnings, call_stack)
       }
     }
-    Calcit::Number(..) | Calcit::Str(..) | Calcit::Nil | Calcit::Bool(..) | Calcit::Keyword(..) => Ok((expr.to_owned(), None)),
+    Calcit::Number(..) | Calcit::Str(..) | Calcit::Nil | Calcit::Bool(..) | Calcit::Keyword(..) | Calcit::CirruQuote(..) => {
+      Ok((expr.to_owned(), None))
+    }
     Calcit::Proc(..) => {
       // maybe detect method in future
       Ok((expr.to_owned(), None))

--- a/ts-src/calcit-data.mts
+++ b/ts-src/calcit-data.mts
@@ -335,7 +335,7 @@ let hashCirru = (base: number, x: CirruWriterNode) => {
   if (typeof x === "string") {
     return mergeValueHash(base, hashFunction(x));
   } else {
-    for (let idx = 0; idx <= x.length; idx++) {
+    for (let idx = 0; idx < x.length; idx++) {
       base = mergeValueHash(base, hashCirru(base, x[idx]));
     }
     return base;

--- a/ts-src/calcit-data.mts
+++ b/ts-src/calcit-data.mts
@@ -9,6 +9,7 @@ import { CalcitValue, _$n_compare } from "./js-primes.mjs";
 import { CalcitList, CalcitSliceList } from "./js-list.mjs";
 import { CalcitSet, overwriteSetComparator } from "./js-set.mjs";
 import { CalcitTuple } from "./js-tuple.mjs";
+import { CalcitCirruQuote, cirru_deep_equal } from "./js-cirru.mjs";
 
 // we have to inject cache in a dirty way in some cases
 const calcit_dirty_hash_key = "_calcit_cached_hash";
@@ -374,6 +375,9 @@ export let toString = (x: CalcitValue, escaped: boolean, disableJsDataWarning: b
   if (x instanceof CalcitTuple) {
     return x.toString(disableJsDataWarning);
   }
+  if (x instanceof CalcitCirruQuote) {
+    return x.toString();
+  }
 
   if (!disableJsDataWarning) {
     console.warn("Unknown structure to string, better use `console.log`", x);
@@ -498,6 +502,12 @@ export let _$n__$e_ = (x: CalcitValue, y: CalcitValue): boolean => {
   if (x instanceof CalcitSymbol) {
     if (y instanceof CalcitSymbol) {
       return x.value === y.value;
+    }
+    return false;
+  }
+  if (x instanceof CalcitCirruQuote) {
+    if (y instanceof CalcitCirruQuote) {
+      return cirru_deep_equal(x.value, y.value);
     }
     return false;
   }

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.6.0-a1";
+export const calcit_version = "0.6.0-a2";
 
 import { parse, ICirruNode } from "@cirru/parser.ts";
 import { writeCirruCode } from "@cirru/writer.ts";
@@ -37,7 +37,7 @@ import { CalcitList, CalcitSliceList, foldl } from "./js-list.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet } from "./js-set.mjs";
 import { CalcitTuple } from "./js-tuple.mjs";
-import { to_calcit_data, extract_cirru_edn } from "./js-cirru.mjs";
+import { to_calcit_data, extract_cirru_edn, CalcitCirruQuote } from "./js-cirru.mjs";
 
 let inNodeJs = typeof process !== "undefined" && process?.release?.name === "node";
 
@@ -1417,6 +1417,10 @@ export let _$n_buffer = (...xs: CalcitValue[]): Uint8Array => {
 
 export let _$n_hash = (x: CalcitValue): number => {
   return hashFunction(x);
+};
+
+export let _$n_cirru_quote_$o_to_list = (x: CalcitCirruQuote): CalcitValue => {
+  return x.toList();
 };
 
 // special procs have to be defined manually

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.6.0-a2";
+export const calcit_version = "0.6.0-a3";
 
 import { parse, ICirruNode } from "@cirru/parser.ts";
 import { writeCirruCode } from "@cirru/writer.ts";

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.5.48";
+export const calcit_version = "0.6.0-a1";
 
 import { parse, ICirruNode } from "@cirru/parser.ts";
 import { writeCirruCode } from "@cirru/writer.ts";
@@ -1159,6 +1159,11 @@ export let write_file = (path: string, content: string): void => {
 };
 
 export let parse_cirru = (code: string): CalcitList => {
+  return to_calcit_data(parse(code), true) as CalcitList;
+};
+
+// for JavaScript, it's same as parse_cirru
+export let parse_cirru_list = (code: string): CalcitList => {
   return to_calcit_data(parse(code), true) as CalcitList;
 };
 

--- a/ts-src/js-cirru.mts
+++ b/ts-src/js-cirru.mts
@@ -19,6 +19,9 @@ export class CalcitCirruQuote {
   toString(): string {
     return `(cirru-quote ${JSON.stringify(this.value)})`;
   }
+  toList(): CalcitValue {
+    return to_calcit_data(this.value, true);
+  }
 }
 
 export let format_cirru = (data: CalcitCirruQuote | CalcitList, useInline: boolean): string => {

--- a/ts-src/js-primes.mts
+++ b/ts-src/js-primes.mts
@@ -4,6 +4,7 @@ import { CalcitRecord } from "./js-record.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet as CalcitSet } from "./js-set.mjs";
 import { CalcitTuple } from "./js-tuple.mjs";
+import { CalcitCirruQuote, cirru_deep_equal } from "./js-cirru.mjs";
 
 export type CalcitValue =
   | string
@@ -21,6 +22,7 @@ export type CalcitValue =
   | CalcitFn
   | CalcitRecur // should not be exposed to function
   | CalcitRecord
+  | CalcitCirruQuote
   | null;
 
 export let is_literal = (x: CalcitValue): boolean => {
@@ -48,6 +50,7 @@ enum PseudoTypeIndex {
   map,
   record,
   fn,
+  cirru_quote,
 }
 
 let typeAsInt = (x: CalcitValue): number => {
@@ -66,6 +69,7 @@ let typeAsInt = (x: CalcitValue): number => {
   if (x instanceof CalcitSet) return PseudoTypeIndex.set;
   if (x instanceof CalcitMap || x instanceof CalcitSliceMap) return PseudoTypeIndex.map;
   if (x instanceof CalcitRecord) return PseudoTypeIndex.record;
+  if (x instanceof CalcitCirruQuote) return PseudoTypeIndex.cirru_quote;
   // proc, fn, macro, syntax, not distinguished
   if (t === "function") return PseudoTypeIndex.fn;
   throw new Error("unknown type to compare");
@@ -101,6 +105,8 @@ export let _$n_compare = (a: CalcitValue, b: CalcitValue): number => {
         return rawCompare(a, b);
       case PseudoTypeIndex.ref:
         return rawCompare((a as CalcitRef).path, (b as CalcitRef).path);
+      case PseudoTypeIndex.cirru_quote:
+        return rawCompare(a, b); // TODO not stable
       default:
         // TODO, need more accurate solution
         if (a < b) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.3.tgz#5f54bdecaa20ba3dab16cbe6da711854138a9c0a"
   integrity sha512-vJnhmhm7we5UfQIwmZfQpF3bAFbVybzT6LbmkbQHxgijaQg3gPfNVsnSIa3g3KpmWVtvkzEx+nUy5aMwsJiV1A==
 
-"@types/node@^18.0.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
-  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
+"@types/node@^18.0.6":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.6.tgz#0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
+  integrity sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==
 
 typescript@^4.7.4:
   version "4.7.4"


### PR DESCRIPTION
Since Cirru is a syntax for various DSLs, there are many cases we want to embed Cirru inside Calcit code to program other DSLs. To make it convenient and  more performance, `CirruQuote` variant is added into core.

New APIs:

- `cirru-quote` which is a special form are symbol reading phase,
- `parse-cirru-list`, which is previously `parse-cirru` that returns list, so it's breaking change,
- `parse-cirru`, which returns `CalcitCirruQuote` variant.
- `&cirru-quote:to-list`, which converts `CalcitCirruQuote` into Calcit list.

This is designed to simplify calcit-calx and calcit-wasmtime, and will probably break docs site.
