### PR TITLE
new macro tag-match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.6.8"
+version = "0.6.9"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/calcit/test-cond.cirru
+++ b/calcit/test-cond.cirru
@@ -126,6 +126,24 @@
                 match-ab (' :c 1 2)
                 [] "|no match"
 
+        |test-tag-match $ quote
+          fn ()
+            log-title "|Testing tag-match"
+            &let
+              match-ab $ fn (data)
+                tag-match data
+                  :a a $ [] :a $ :a a
+                  :b b $ [] :b $ :b b
+                  _ :other
+              assert=
+                match-ab (&{} :tag :a :a 1)
+                [] :a 1
+              assert=
+                match-ab (&{} :tag :b :b 2)
+                [] :b 2
+              assert= :other
+                match-ab (&{} :tag :c)
+
         |main! $ quote
           defn main! ()
             log-title "|Testing cond"
@@ -138,6 +156,7 @@
             test-case
 
             test-key-match
+            test-tag-match
 
             , true
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@calcit/procs",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
-    "@types/node": "^18.7.23",
+    "@types/node": "^18.11.3",
     "typescript": "^4.8.4"
   },
   "scripts": {

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.6.8";
+export const calcit_version = "0.6.9";
 
 import { parse, ICirruNode } from "@cirru/parser.ts";
 import { writeCirruCode } from "@cirru/writer.ts";

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   resolved "https://registry.yarnpkg.com/@cirru/writer.ts/-/writer.ts-0.1.3.tgz#5f54bdecaa20ba3dab16cbe6da711854138a9c0a"
   integrity sha512-vJnhmhm7we5UfQIwmZfQpF3bAFbVybzT6LbmkbQHxgijaQg3gPfNVsnSIa3g3KpmWVtvkzEx+nUy5aMwsJiV1A==
 
-"@types/node@^18.7.23":
-  version "18.7.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
-  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
+"@types/node@^18.11.3":
+  version "18.11.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
+  integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
 
 typescript@^4.8.4:
   version "4.8.4"


### PR DESCRIPTION
`tag-match` provides arms that matches `:tag` field in a HashMap and give it a new name:

```cirru
tag-match data
  :a new-name-a
    str-spaced "|found branch of" :a "|with value" $ :sth-of-a new-name-a
  :b new-name-b
    str-spaced "|found branch of" :b "|with value" $ :sth-of-b new-name-b
  _ :other
```

`data` should match `map? data` with a field `:tag`, for example:
```cirru
{}
  :tag :a
  :sth-of-a "|some data belongs to a"
```
