### PR TITLE
split out raw-code variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calcit"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.6.12"
+version = "0.6.13"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.6.11"
+version = "0.6.12"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^18.11.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^18.11.9",

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -56,6 +56,7 @@ pub fn type_of(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
     Calcit::Fn { .. } => Ok(Calcit::kwd("fn")),
     Calcit::Syntax(..) => Ok(Calcit::kwd("syntax")),
     Calcit::Method(..) => Ok(Calcit::kwd("method")),
+    Calcit::RawCode(..) => Ok(Calcit::kwd("raw-code")),
   }
 }
 

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -424,7 +424,7 @@ fn gen_call_code(
         "exists?" => {
           // not core syntax, but treat as macro for availability
           match body.get(0) {
-            Some(Calcit::Symbol { .. }) => {
+            Some(Calcit::Symbol { .. }) | Some(Calcit::RawCode(..)) => {
               let target = to_js_code(&body[0], ns, local_defs, file_imports, keywords, None)?; // TODO could be simpler
               Ok(format!("{return_code}(typeof {target} !== 'undefined')"))
             }

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -178,7 +178,17 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
       }
       Edn::List(ys)
     }
-    a => Edn::str(format!("TODO {a}")),
+    Calcit::Method(method, kind) => Edn::map_from_iter([
+      (Edn::kwd("kind"), Edn::kwd("method")),
+      (Edn::kwd("behavior"), Edn::Str((kind.to_string()).into())),
+      (Edn::kwd("method"), Edn::Str((method.to_string()).into())),
+    ]),
+    Calcit::RawCode(_, code) => Edn::map_from_iter([
+      (Edn::kwd("kind"), Edn::kwd("raw-code")),
+      (Edn::kwd("code"), Edn::Str((code.to_string()).into())),
+    ]),
+    Calcit::CirruQuote(code) => Edn::map_from_iter([(Edn::kwd("kind"), Edn::kwd("cirru-quote")), (Edn::kwd("code"), code.into())]),
+    a => unreachable!("invalid data for generating code: {:?}", a),
   }
 }
 

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -151,6 +151,13 @@ pub enum Calcit {
   /// Method is kind like macro, it's handled during preprocessing, into `&invoke` or `&invoke-native`
   /// method name, method kind
   Method(Arc<str>, MethodKind),
+  /// currently only JavaScript calls are handled
+  RawCode(RawCodeType, Arc<str>),
+}
+
+#[derive(Debug, Clone)]
+pub enum RawCodeType {
+  Js,
 }
 
 impl fmt::Display for Calcit {
@@ -279,6 +286,7 @@ impl fmt::Display for Calcit {
       }
       Calcit::Syntax(name, _ns) => f.write_str(&format!("(&syntax {name})")),
       Calcit::Method(name, method_kind) => f.write_str(&format!("(&{method_kind} {name})")),
+      Calcit::RawCode(_, code) => f.write_str(&format!("(&raw-code {code})")),
     }
   }
 }
@@ -432,6 +440,10 @@ impl Hash for Calcit {
         name.hash(_state);
         call_native.hash(_state);
       }
+      Calcit::RawCode(_name, code) => {
+        "raw-code:".hash(_state);
+        code.hash(_state);
+      }
     }
   }
 }
@@ -548,6 +560,10 @@ impl Ord for Calcit {
         Equal => na.cmp(nb),
         v => v,
       },
+      (Calcit::Method(..), _) => Less,
+      (_, Calcit::Method(..)) => Greater,
+
+      (Calcit::RawCode(_, a), Calcit::RawCode(_, b)) => a.cmp(b),
     }
   }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -61,6 +61,7 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: Arc<str>, call
     Calcit::Buffer(..) => Ok(expr.to_owned()),
     Calcit::CirruQuote(..) => Ok(expr.to_owned()),
     Calcit::Recur(_) => unreachable!("recur not expected to be from symbol"),
+    Calcit::RawCode(_, _) => unreachable!("native code not expected to be evaluated"),
     Calcit::List(xs) => match xs.get(0) {
       None => Err(CalcitErr::use_msg_stack(format!("cannot evaluate empty expr: {expr}"), call_stack)),
       Some(x) => {

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -3,8 +3,8 @@ use crate::{
   call_stack::{extend_call_stack, CalcitStack, CallStackList, StackKind},
   primes,
   primes::{
-    Calcit, CalcitErr, CalcitItems, CalcitScope, CalcitSyntax, ImportRule, LocatedWarning, NodeLocation, SymbolResolved::*,
-    GENERATED_DEF,
+    Calcit, CalcitErr, CalcitItems, CalcitScope, CalcitSyntax, ImportRule, LocatedWarning, NodeLocation, RawCodeType,
+    SymbolResolved::*, GENERATED_DEF,
   },
   program, runner,
 };
@@ -153,20 +153,7 @@ pub fn preprocess_expr(
     } => match runner::parse_ns_def(def) {
       Some((ns_alias, def_part)) => {
         if &*ns_alias == "js" {
-          Ok((
-            Calcit::Symbol {
-              sym: def.to_owned(),
-              ns: def_ns.to_owned(),
-              at_def: at_def.to_owned(),
-              resolved: Some(Arc::new(ResolvedDef {
-                ns: String::from("js").into(),
-                def: (*def_part).into(),
-                rule: None,
-              })),
-              location: location.to_owned(),
-            },
-            None,
-          ))
+          Ok((Calcit::RawCode(RawCodeType::Js, def_part), None))
         } else if let Some(target_ns) = program::lookup_ns_target_in_import(def_ns.to_owned(), &ns_alias) {
           // TODO js syntax to handle in future
           preprocess_ns_def(target_ns, def_part, def.to_owned(), None, check_warnings, call_stack)

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.6.12";
+export const calcit_version = "0.6.13";
 
 import { parse, ICirruNode } from "@cirru/parser.ts";
 import { writeCirruCode } from "@cirru/writer.ts";

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1,5 +1,5 @@
 // CALCIT VERSION
-export const calcit_version = "0.6.11";
+export const calcit_version = "0.6.12";
 
 import { parse, ICirruNode } from "@cirru/parser.ts";
 import { writeCirruCode } from "@cirru/writer.ts";


### PR DESCRIPTION
`raw-code` type for storing variables like `js/window` that are emitted into code directly.
