### PR TITLE
Reduce enum size; optimize &str usages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "calcit"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "calcit"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "calcit"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.8.23"
+version = "0.8.24"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.8.24"
+version = "0.8.25"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.8.22"
+version = "0.8.23"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^20.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^20.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^20.11.8",

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -141,9 +141,9 @@ fn main() -> Result<(), String> {
 
   // make sure builtin classes are touched
   runner::preprocess::preprocess_ns_def(
-    calcit::primes::CORE_NS.into(),
-    calcit::primes::BUILTIN_CLASSES_ENTRY.into(),
-    calcit::primes::BUILTIN_CLASSES_ENTRY.into(),
+    calcit::primes::CORE_NS,
+    calcit::primes::BUILTIN_CLASSES_ENTRY,
+    calcit::primes::BUILTIN_CLASSES_ENTRY,
     None,
     check_warnings,
     &rpds::List::new_sync(),
@@ -272,9 +272,9 @@ fn recall_program(content: &str, entries: &ProgramEntries, settings: &CLIOptions
       // when there's services, make sure their code get preprocessed too
       let check_warnings: &RefCell<Vec<LocatedWarning>> = &RefCell::new(vec![]);
       if let Err(e) = runner::preprocess::preprocess_ns_def(
-        entries.init_ns.to_owned(),
-        entries.init_def.to_owned(),
-        entries.init_def.to_owned(),
+        &entries.init_ns,
+        &entries.init_def,
+        &entries.init_def,
         None,
         check_warnings,
         &rpds::List::new_sync(),
@@ -325,9 +325,9 @@ fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool) -> Resu
 
   // preprocess to init
   match runner::preprocess::preprocess_ns_def(
-    entries.init_ns.to_owned(),
-    entries.init_def.to_owned(),
-    entries.init_def.to_owned(),
+    &entries.init_ns,
+    &entries.init_def,
+    &entries.init_def,
     None,
     check_warnings,
     &rpds::List::new_sync(),
@@ -350,9 +350,9 @@ fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool) -> Resu
 
   // preprocess to reload
   match runner::preprocess::preprocess_ns_def(
-    entries.reload_ns.to_owned(),
-    entries.reload_def.to_owned(),
-    entries.init_def.to_owned(),
+    &entries.reload_ns,
+    &entries.reload_def,
+    &entries.init_def,
     None,
     check_warnings,
     &rpds::List::new_sync(),

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -146,15 +146,12 @@ pub fn call_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackList) -> Result
     match func(
       ys.to_owned(),
       Arc::new(move |ps: Vec<Edn>| -> Result<Edn, String> {
-        if let Calcit::Fn {
-          def_ns, scope, args, body, ..
-        } = &callback
-        {
+        if let Calcit::Fn { info, .. } = &callback {
           let mut real_args = TernaryTreeList::Empty;
           for p in ps {
             real_args = real_args.push_right(edn_to_calcit(&p, &Calcit::Nil));
           }
-          let r = runner::run_fn(&real_args, scope, args, body, def_ns.to_owned(), &copied_stack);
+          let r = runner::run_fn(&real_args, info, &copied_stack);
           match r {
             Ok(ret) => calcit_to_edn(&ret),
             Err(e) => {
@@ -234,15 +231,12 @@ pub fn blocking_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackList) -> Re
   match func(
     ys.to_owned(),
     Arc::new(move |ps: Vec<Edn>| -> Result<Edn, String> {
-      if let Calcit::Fn {
-        def_ns, scope, args, body, ..
-      } = &callback
-      {
+      if let Calcit::Fn { info, .. } = &callback {
         let mut real_args = TernaryTreeList::Empty;
         for p in ps {
           real_args = real_args.push_right(edn_to_calcit(&p, &Calcit::Nil));
         }
-        let r = runner::run_fn(&real_args, scope, args, body, def_ns.to_owned(), &copied_stack);
+        let r = runner::run_fn(&real_args, info, &copied_stack);
         match r {
           Ok(ret) => calcit_to_edn(&ret),
           Err(e) => {
@@ -276,11 +270,8 @@ pub fn on_ctrl_c(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit,
     let cb = Arc::new(xs[0].to_owned());
     let copied_stack = Arc::new(call_stack.to_owned());
     ctrlc::set_handler(move || {
-      if let Calcit::Fn {
-        def_ns, scope, args, body, ..
-      } = cb.as_ref()
-      {
-        if let Err(e) = runner::run_fn(&TernaryTreeList::Empty, scope, args, body, def_ns.to_owned(), &copied_stack) {
+      if let Calcit::Fn { info, .. } = cb.as_ref() {
+        if let Err(e) = runner::run_fn(&TernaryTreeList::Empty, info, &copied_stack) {
           eprintln!("error: {e}");
         }
       }

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -151,7 +151,7 @@ pub fn call_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackList) -> Result
           for p in ps {
             real_args = real_args.push_right(edn_to_calcit(&p, &Calcit::Nil));
           }
-          let r = runner::run_fn(&real_args, info, &copied_stack);
+          let r = runner::run_fn(real_args, info, &copied_stack);
           match r {
             Ok(ret) => calcit_to_edn(&ret),
             Err(e) => {
@@ -236,7 +236,7 @@ pub fn blocking_dylib_edn_fn(xs: &CalcitItems, call_stack: &CallStackList) -> Re
         for p in ps {
           real_args = real_args.push_right(edn_to_calcit(&p, &Calcit::Nil));
         }
-        let r = runner::run_fn(&real_args, info, &copied_stack);
+        let r = runner::run_fn(real_args, info, &copied_stack);
         match r {
           Ok(ret) => calcit_to_edn(&ret),
           Err(e) => {
@@ -271,7 +271,7 @@ pub fn on_ctrl_c(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit,
     let copied_stack = Arc::new(call_stack.to_owned());
     ctrlc::set_handler(move || {
       if let Calcit::Fn { info, .. } = cb.as_ref() {
-        if let Err(e) = runner::run_fn(&TernaryTreeList::Empty, info, &copied_stack) {
+        if let Err(e) = runner::run_fn(TernaryTreeList::Empty, info, &copied_stack) {
           eprintln!("error: {e}");
         }
       }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -246,7 +246,7 @@ pub fn handle_syntax(
   name: &CalcitSyntax,
   nodes: &CalcitItems,
   scope: &CalcitScope,
-  file_ns: Arc<str>,
+  file_ns: &str,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
   match name {

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -184,15 +184,10 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
 
     match (&xs[0], &xs[2]) {
       // dirty since only functions being call directly then we become fast
-      (
-        Calcit::List(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::List(xs), Calcit::Fn { info, .. }) => {
         for x in xs {
           let values = TernaryTreeList::from(&[ret, x.to_owned()]);
-          ret = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+          ret = runner::run_fn(&values, info, call_stack)?;
         }
         Ok(ret)
       }
@@ -204,15 +199,10 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
         Ok(ret)
       }
       // also handles set
-      (
-        Calcit::Set(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::Set(xs), Calcit::Fn { info, .. }) => {
         for x in xs {
           let values = TernaryTreeList::from(&[ret, x.to_owned()]);
-          ret = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+          ret = runner::run_fn(&values, info, call_stack)?;
         }
         Ok(ret)
       }
@@ -224,15 +214,10 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
         Ok(ret)
       }
       // also handles map
-      (
-        Calcit::Map(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::Map(xs), Calcit::Fn { info, .. }) => {
         for (k, x) in xs {
           let values = TernaryTreeList::from(&[ret, Calcit::List(TernaryTreeList::from(&[k.to_owned(), x.to_owned()]))]);
-          ret = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+          ret = runner::run_fn(&values, info, call_stack)?;
         }
         Ok(ret)
       }
@@ -270,16 +255,11 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
     let default_value = &xs[2];
     match (&xs[0], &xs[3]) {
       // dirty since only functions being call directly then we become fast
-      (
-        Calcit::List(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::List(xs), Calcit::Fn { info, .. }) => {
         let mut state = acc.to_owned();
         for x in xs {
           let values = TernaryTreeList::from(&[state, x.to_owned()]);
-          let pair = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+          let pair = runner::run_fn(&values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -313,16 +293,11 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
         Ok(default_value.to_owned())
       }
       // almost identical body, except for the type
-      (
-        Calcit::Set(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::Set(xs), Calcit::Fn { info, .. }) => {
         let mut state = acc.to_owned();
         for x in xs {
           let values = TernaryTreeList::from(&[state, x.to_owned()]);
-          let pair = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+          let pair = runner::run_fn(&values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -356,16 +331,11 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
         Ok(default_value.to_owned())
       }
       // almost identical body, escept for the type
-      (
-        Calcit::Map(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::Map(xs), Calcit::Fn { info, .. }) => {
         let mut state = acc.to_owned();
         for (k, x) in xs {
           let values = TernaryTreeList::from(&[state, Calcit::List(TernaryTreeList::from(&[k.to_owned(), x.to_owned()]))]);
-          let pair = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+          let pair = runner::run_fn(&values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -424,18 +394,13 @@ pub fn foldr_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
     // let f = runner::evaluate_expr(&expr[3], scope, file_ns)?;
     match (&xs[0], &xs[3]) {
       // dirty since only functions being call directly then we become fast
-      (
-        Calcit::List(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::List(xs), Calcit::Fn { info, .. }) => {
         let mut state = acc.to_owned();
         let size = xs.len();
         for i in 0..size {
           let x = xs[size - 1 - i].to_owned();
           let values = TernaryTreeList::from(&[state, x]);
-          let pair = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+          let pair = runner::run_fn(&values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -490,16 +455,11 @@ pub fn sort(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Calc
   if xs.len() == 2 {
     match (&xs[0], &xs[1]) {
       // dirty since only functions being call directly then we become fast
-      (
-        Calcit::List(xs),
-        Calcit::Fn {
-          def_ns, scope, args, body, ..
-        },
-      ) => {
+      (Calcit::List(xs), Calcit::Fn { info, .. }) => {
         let mut xs2: Vec<&Calcit> = xs.into_iter().collect::<Vec<&Calcit>>();
         xs2.sort_by(|a, b| -> Ordering {
           let values = TernaryTreeList::from(&[(*a).to_owned(), (*b).to_owned()]);
-          let v = runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack);
+          let v = runner::run_fn(&values, info, call_stack);
           match v {
             Ok(Calcit::Number(x)) if x < 0.0 => Ordering::Less,
             Ok(Calcit::Number(x)) if x == 0.0 => Ordering::Equal,

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -187,7 +187,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
       (Calcit::List(xs), Calcit::Fn { info, .. }) => {
         for x in xs {
           let values = TernaryTreeList::from(&[ret, x.to_owned()]);
-          ret = runner::run_fn(&values, info, call_stack)?;
+          ret = runner::run_fn(values, info, call_stack)?;
         }
         Ok(ret)
       }
@@ -202,7 +202,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
       (Calcit::Set(xs), Calcit::Fn { info, .. }) => {
         for x in xs {
           let values = TernaryTreeList::from(&[ret, x.to_owned()]);
-          ret = runner::run_fn(&values, info, call_stack)?;
+          ret = runner::run_fn(values, info, call_stack)?;
         }
         Ok(ret)
       }
@@ -217,7 +217,7 @@ pub fn foldl(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Cal
       (Calcit::Map(xs), Calcit::Fn { info, .. }) => {
         for (k, x) in xs {
           let values = TernaryTreeList::from(&[ret, Calcit::List(TernaryTreeList::from(&[k.to_owned(), x.to_owned()]))]);
-          ret = runner::run_fn(&values, info, call_stack)?;
+          ret = runner::run_fn(values, info, call_stack)?;
         }
         Ok(ret)
       }
@@ -259,7 +259,7 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
         let mut state = acc.to_owned();
         for x in xs {
           let values = TernaryTreeList::from(&[state, x.to_owned()]);
-          let pair = runner::run_fn(&values, info, call_stack)?;
+          let pair = runner::run_fn(values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -297,7 +297,7 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
         let mut state = acc.to_owned();
         for x in xs {
           let values = TernaryTreeList::from(&[state, x.to_owned()]);
-          let pair = runner::run_fn(&values, info, call_stack)?;
+          let pair = runner::run_fn(values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -335,7 +335,7 @@ pub fn foldl_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
         let mut state = acc.to_owned();
         for (k, x) in xs {
           let values = TernaryTreeList::from(&[state, Calcit::List(TernaryTreeList::from(&[k.to_owned(), x.to_owned()]))]);
-          let pair = runner::run_fn(&values, info, call_stack)?;
+          let pair = runner::run_fn(values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -400,7 +400,7 @@ pub fn foldr_shortcut(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Ca
         for i in 0..size {
           let x = xs[size - 1 - i].to_owned();
           let values = TernaryTreeList::from(&[state, x]);
-          let pair = runner::run_fn(&values, info, call_stack)?;
+          let pair = runner::run_fn(values, info, call_stack)?;
           match pair {
             Calcit::Tuple(x0, extra, _class) => match &*x0 {
               Calcit::Bool(b) => {
@@ -459,7 +459,7 @@ pub fn sort(xs: &CalcitItems, call_stack: &CallStackList) -> Result<Calcit, Calc
         let mut xs2: Vec<&Calcit> = xs.into_iter().collect::<Vec<&Calcit>>();
         xs2.sort_by(|a, b| -> Ordering {
           let values = TernaryTreeList::from(&[(*a).to_owned(), (*b).to_owned()]);
-          let v = runner::run_fn(&values, info, call_stack);
+          let v = runner::run_fn(values, info, call_stack);
           match v {
             Ok(Calcit::Number(x)) if x < 0.0 => Ordering::Less,
             Ok(Calcit::Number(x)) if x == 0.0 => Ordering::Equal,

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -316,15 +316,17 @@ pub fn invoke_method(name: &str, invoke_args: &CalcitItems, call_stack: &CallSta
     Calcit::Tuple(_tag, _extra, class) => (**class).to_owned(),
     Calcit::Record(_name, _f, _v, class) => (**class).to_owned(),
     // classed should already be preprocessed
-    Calcit::List(..) => runner::evaluate_symbol("&core-list-class", &s0, primes::CORE_NS, None, call_stack)?,
+    Calcit::List(..) => runner::evaluate_symbol("&core-list-class", &s0, primes::CORE_NS, GENERATED_DEF, &None, call_stack)?,
 
-    Calcit::Map(..) => runner::evaluate_symbol("&core-map-class", &s0, primes::CORE_NS, None, call_stack)?,
+    Calcit::Map(..) => runner::evaluate_symbol("&core-map-class", &s0, primes::CORE_NS, GENERATED_DEF, &None, call_stack)?,
 
-    Calcit::Number(..) => runner::evaluate_symbol("&core-number-class", &s0, primes::CORE_NS, None, call_stack)?,
-    Calcit::Str(..) => runner::evaluate_symbol("&core-string-class", &s0, primes::CORE_NS, None, call_stack)?,
-    Calcit::Set(..) => runner::evaluate_symbol("&core-set-class", &s0, primes::CORE_NS, None, call_stack)?,
-    Calcit::Nil => runner::evaluate_symbol("&core-nil-class", &s0, primes::CORE_NS, None, call_stack)?,
-    Calcit::Fn { .. } | Calcit::Proc(..) => runner::evaluate_symbol("&core-fn-class", &s0, primes::CORE_NS, None, call_stack)?,
+    Calcit::Number(..) => runner::evaluate_symbol("&core-number-class", &s0, primes::CORE_NS, GENERATED_DEF, &None, call_stack)?,
+    Calcit::Str(..) => runner::evaluate_symbol("&core-string-class", &s0, primes::CORE_NS, GENERATED_DEF, &None, call_stack)?,
+    Calcit::Set(..) => runner::evaluate_symbol("&core-set-class", &s0, primes::CORE_NS, GENERATED_DEF, &None, call_stack)?,
+    Calcit::Nil => runner::evaluate_symbol("&core-nil-class", &s0, primes::CORE_NS, GENERATED_DEF, &None, call_stack)?,
+    Calcit::Fn { .. } | Calcit::Proc(..) => {
+      runner::evaluate_symbol("&core-fn-class", &s0, primes::CORE_NS, GENERATED_DEF, &None, call_stack)?
+    }
     x => {
       return Err(CalcitErr::use_msg_stack_location(
         format!("cannot decide a class from: {x}"),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -10,7 +10,7 @@ use crate::{
     edn::{self, edn_to_calcit},
   },
   primes,
-  primes::{gen_core_id, Calcit, CalcitErr, CalcitItems, CalcitScope, CrListWrap, GENERATED_DEF, GEN_NS},
+  primes::{gen_core_id, Calcit, CalcitErr, CalcitItems, CalcitScope, CalcitSymbolInfo, CrListWrap, GENERATED_DEF, GEN_NS},
   runner,
   util::number::f64_to_usize,
 };
@@ -234,16 +234,20 @@ pub fn turn_symbol(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   match &xs[0] {
     Calcit::Str(s) => Ok(Calcit::Symbol {
       sym: s.to_owned(),
-      ns: primes::GEN_NS.into(),
-      at_def: primes::GENERATED_DEF.into(),
-      resolved: None,
+      info: Arc::new(CalcitSymbolInfo {
+        ns: primes::GEN_NS.into(),
+        at_def: primes::GENERATED_DEF.into(),
+        resolved: None,
+      }),
       location: None,
     }),
     Calcit::Tag(s) => Ok(Calcit::Symbol {
       sym: s.to_str(),
-      ns: primes::GEN_NS.into(),
-      at_def: primes::GENERATED_DEF.into(),
-      resolved: None,
+      info: Arc::new(CalcitSymbolInfo {
+        ns: primes::GEN_NS.into(),
+        at_def: primes::GENERATED_DEF.into(),
+        resolved: None,
+      }),
       location: None,
     }),
     a @ Calcit::Symbol { .. } => Ok(a.to_owned()),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -574,10 +574,7 @@ pub fn data_to_code(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
     return CalcitErr::err_nodes("&data-to-code expected 1 argument, got:", xs);
   }
 
-  let gen_ns: Arc<str> = Arc::from(GEN_NS);
-  let gen_def: Arc<str> = Arc::from(GENERATED_DEF);
-
-  match data_to_calcit(&xs[0], gen_ns, gen_def) {
+  match data_to_calcit(&xs[0], GEN_NS, GENERATED_DEF) {
     Ok(v) => Ok(v),
     Err(e) => CalcitErr::err_str(format!("&data-to-code failed: {e}")),
   }

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -231,23 +231,20 @@ pub fn turn_symbol(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
     return CalcitErr::err_nodes("turn-symbol expected 1 argument, got:", xs);
   }
+  let info = Arc::new(CalcitSymbolInfo {
+    ns: primes::GEN_NS.into(),
+    at_def: primes::GENERATED_DEF.into(),
+    resolved: None,
+  });
   match &xs[0] {
     Calcit::Str(s) => Ok(Calcit::Symbol {
       sym: s.to_owned(),
-      info: Arc::new(CalcitSymbolInfo {
-        ns: primes::GEN_NS.into(),
-        at_def: primes::GENERATED_DEF.into(),
-        resolved: None,
-      }),
+      info: info.to_owned(),
       location: None,
     }),
     Calcit::Tag(s) => Ok(Calcit::Symbol {
       sym: s.to_str(),
-      info: Arc::new(CalcitSymbolInfo {
-        ns: primes::GEN_NS.into(),
-        at_def: primes::GENERATED_DEF.into(),
-        resolved: None,
-      }),
+      info: info.to_owned(),
       location: None,
     }),
     a @ Calcit::Symbol { .. } => Ok(a.to_owned()),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -344,9 +344,7 @@ pub fn invoke_method(name: &str, invoke_args: &CalcitItems, call_stack: &CallSta
 
           match &values[idx] {
             // dirty copy...
-            Calcit::Fn {
-              def_ns, scope, args, body, ..
-            } => runner::run_fn(&method_args, scope, args, body, def_ns.to_owned(), call_stack),
+            Calcit::Fn { info, .. } => runner::run_fn(&method_args, info, call_stack),
             Calcit::Proc(proc) => builtins::handle_proc(*proc, &method_args, call_stack),
             Calcit::Syntax(syn, _ns) => Err(CalcitErr::use_msg_stack(
               format!("cannot get syntax here since instance is always evaluated, got: {syn}"),

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -55,8 +55,8 @@ fn modify_ref(locked_pair: Arc<Mutex<ValueAndListeners>>, v: Calcit, call_stack:
 /// syntax to prevent expr re-evaluating
 pub fn defatom(expr: &CalcitItems, scope: &CalcitScope, file_ns: Arc<str>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   match (expr.get(0), expr.get(1)) {
-    (Some(Calcit::Symbol { sym, ns, .. }), Some(code)) => {
-      let mut path: String = (**ns).to_owned();
+    (Some(Calcit::Symbol { sym, info, .. }), Some(code)) => {
+      let mut path: String = (*info.ns).to_owned();
       path.push('/');
       path.push_str(sym);
 

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -34,11 +34,9 @@ fn modify_ref(locked_pair: Arc<Mutex<ValueAndListeners>>, v: Calcit, call_stack:
 
   for f in listeners.values() {
     match f {
-      Calcit::Fn {
-        def_ns, scope, args, body, ..
-      } => {
+      Calcit::Fn { info, .. } => {
         let values = TernaryTreeList::from(&[v.to_owned(), prev.to_owned()]);
-        runner::run_fn(&values, scope, args, body, def_ns.to_owned(), call_stack)?;
+        runner::run_fn(&values, info, call_stack)?;
       }
       a => {
         return Err(CalcitErr::use_msg_stack_location(

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -51,7 +51,7 @@ fn modify_ref(locked_pair: Arc<Mutex<ValueAndListeners>>, v: Calcit, call_stack:
 }
 
 /// syntax to prevent expr re-evaluating
-pub fn defatom(expr: &CalcitItems, scope: &CalcitScope, file_ns: Arc<str>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+pub fn defatom(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   match (expr.get(0), expr.get(1)) {
     (Some(Calcit::Symbol { sym, info, .. }), Some(code)) => {
       let mut path: String = (*info.ns).to_owned();
@@ -118,13 +118,13 @@ pub fn atom_deref(xs: &CalcitItems) -> Result<Calcit, CalcitErr> {
 }
 
 /// need to be syntax since triggering internal functions requires program data
-pub fn reset_bang(expr: &CalcitItems, scope: &CalcitScope, file_ns: Arc<str>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+pub fn reset_bang(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if expr.len() < 2 {
     return CalcitErr::err_nodes("reset! excepted 2 arguments, got:", expr);
   }
   // println!("reset! {:?}", expr[0]);
-  let target = runner::evaluate_expr(&expr[0], scope, file_ns.to_owned(), call_stack)?;
-  let new_value = runner::evaluate_expr(&expr[1], scope, file_ns.to_owned(), call_stack)?;
+  let target = runner::evaluate_expr(&expr[0], scope, file_ns, call_stack)?;
+  let new_value = runner::evaluate_expr(&expr[1], scope, file_ns, call_stack)?;
   match (target, &new_value) {
     (Calcit::Ref(_path, locked_pair), v) => {
       modify_ref(locked_pair, v.to_owned(), call_stack)?;
@@ -132,7 +132,7 @@ pub fn reset_bang(expr: &CalcitItems, scope: &CalcitScope, file_ns: Arc<str>, ca
     }
     // if reset! called before deref, we need to trigger the thunk
     (Calcit::Thunk(code, _thunk_data), _) => match &expr[0] {
-      Calcit::Symbol { sym, .. } => runner::evaluate_def_thunk(&code, &file_ns, sym, call_stack),
+      Calcit::Symbol { sym, .. } => runner::evaluate_def_thunk(&code, file_ns, sym, call_stack),
       _ => CalcitErr::err_str(format!("reset! expected a symbol, got: {:?}", expr[0])),
     },
     (a, b) => Err(CalcitErr::use_msg_stack_location(

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -36,7 +36,7 @@ fn modify_ref(locked_pair: Arc<Mutex<ValueAndListeners>>, v: Calcit, call_stack:
     match f {
       Calcit::Fn { info, .. } => {
         let values = TernaryTreeList::from(&[v.to_owned(), prev.to_owned()]);
-        runner::run_fn(&values, info, call_stack)?;
+        runner::run_fn(values, info, call_stack)?;
       }
       a => {
         return Err(CalcitErr::use_msg_stack_location(

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -69,8 +69,10 @@ pub fn quote(expr: &CalcitItems, _scope: &CalcitScope, _file_ns: &str) -> Result
 }
 
 pub fn syntax_if(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  if expr.len() > 3 {
+    return CalcitErr::err_nodes("too many nodes for if, got:", expr);
+  }
   match (expr.get(0), expr.get(1)) {
-    _ if expr.len() > 3 => CalcitErr::err_nodes("too many nodes for if, got:", expr),
     (Some(cond), Some(true_branch)) => {
       let cond_value = runner::evaluate_expr(cond, scope, file_ns, call_stack)?;
       match cond_value {
@@ -322,7 +324,7 @@ pub fn call_try(expr: &CalcitItems, scope: &CalcitScope, file_ns: &str, call_sta
         match f {
           Calcit::Fn { info, .. } => {
             let values = TernaryTreeList::from(&[err_data]);
-            runner::run_fn(&values, &info, call_stack)
+            runner::run_fn(values, &info, call_stack)
           }
           Calcit::Proc(proc) => builtins::handle_proc(proc, &TernaryTreeList::from(&[err_data]), call_stack),
           a => CalcitErr::err_str(format!("try expected a function handler, got: {a}")),

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -11,7 +11,7 @@ use im_ternary_tree::TernaryTreeList;
 use crate::builtins;
 use crate::builtins::meta::NS_SYMBOL_DICT;
 use crate::call_stack::CallStackList;
-use crate::primes::{self, CrListWrap, LocatedWarning};
+use crate::primes::{self, CalcitSymbolInfo, CrListWrap, LocatedWarning};
 use crate::primes::{gen_core_id, Calcit, CalcitErr, CalcitItems, CalcitScope};
 use crate::runner;
 
@@ -381,9 +381,11 @@ pub fn gensym(xs: &CalcitItems, _scope: &CalcitScope, file_ns: Arc<str>, _call_s
   };
   Ok(Calcit::Symbol {
     sym: s.into(),
-    ns: file_ns,
-    at_def: primes::GENERATED_DEF.into(),
-    resolved: None,
+    info: Arc::new(CalcitSymbolInfo {
+      ns: file_ns,
+      at_def: primes::GENERATED_DEF.into(),
+      resolved: None,
+    }),
     location: None,
   })
 }

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -203,14 +203,13 @@ fn to_js_code(
   } else {
     let ret = match xs {
       Calcit::Symbol { sym, info, .. } => {
-        let resolved_info = info.resolved.to_owned().map(|v| (*v).to_owned());
         let passed_defs = PassedDefs {
           ns,
           local_defs,
           file_imports,
         };
 
-        gen_symbol_code(sym, &info.ns, &info.at_def, resolved_info, xs, &passed_defs)
+        gen_symbol_code(sym, &info.ns, &info.at_def, info.resolved.to_owned(), xs, &passed_defs)
       }
       Calcit::Proc(s) => {
         let proc_prefix = get_proc_prefix(ns);
@@ -627,7 +626,7 @@ fn gen_symbol_code(
       // functions under core uses built $calcit module entry
       return Ok(format!("{var_prefix}{}", escape_var(s)));
     }
-    if let Some(ImportRule::NsDefault(_s)) = import_rule.map(|x| (*x).to_owned()) {
+    if let Some(ImportRule::NsDefault(_s)) = import_rule.map(|x| x.to_owned()) {
       // imports that using :default are special
       track_ns_import(s, ImportedTarget::DefaultNs(r_ns), passed_defs.file_imports)?;
     } else {

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -608,6 +608,7 @@ fn gen_symbol_code(
       }
       Some(ResolvedRaw) => Err(format!("not going to generate from raw symbol, {s}")),
       Some(ResolvedLocal) => Err(format!("symbol with ns should not be local, {s}")),
+      Some(ResolvedRegistered) => Err(format!("symbol registered should not be local, {s}")),
       None => Err(format!("expected symbol with ns being resolved: {xs}")),
     }
   } else if is_js_syntax_procs(s) || is_proc_name(s) || CalcitSyntax::is_valid(s) {

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -202,21 +202,15 @@ fn to_js_code(
     gen_call_code(ys, ns, local_defs, xs, file_imports, tags, return_label)
   } else {
     let ret = match xs {
-      Calcit::Symbol {
-        sym,
-        ns: def_ns,
-        at_def,
-        resolved,
-        ..
-      } => {
-        let resolved_info = resolved.to_owned().map(|v| (*v).to_owned());
+      Calcit::Symbol { sym, info, .. } => {
+        let resolved_info = info.resolved.to_owned().map(|v| (*v).to_owned());
         let passed_defs = PassedDefs {
           ns,
           local_defs,
           file_imports,
         };
 
-        gen_symbol_code(sym, def_ns, at_def, resolved_info, xs, &passed_defs)
+        gen_symbol_code(sym, &info.ns, &info.at_def, resolved_info, xs, &passed_defs)
       }
       Calcit::Proc(s) => {
         let proc_prefix = get_proc_prefix(ns);

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -92,7 +92,7 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
     Calcit::Tag(s) => Edn::Tag(s.to_owned()),
     Calcit::Symbol { sym, info, location } => {
       let resolved = match &info.resolved {
-        Some(resolved) => match &**resolved {
+        Some(resolved) => match &resolved {
           ResolvedDef {
             ns: r_ns,
             def: r_def,
@@ -104,7 +104,7 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
             (Edn::tag("def"), Edn::Str((**r_def).into())),
             (
               Edn::tag("rule"),
-              match import_rule.to_owned().map(|x| (*x).to_owned()) {
+              match import_rule.to_owned().map(|x| x.to_owned()) {
                 Some(ImportRule::NsAs(_n)) => Edn::tag("ns"),
                 Some(ImportRule::NsDefault(_n)) => Edn::tag("default"),
                 Some(ImportRule::NsReferDef(_ns, _def)) => Edn::tag("def"),

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -145,15 +145,13 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
         (Edn::tag("code"), dump_items_code(body)),
       ])
     }
-    Calcit::Macro {
-      name, def_ns, args, body, ..
-    } => {
+    Calcit::Macro { info, .. } => {
       Edn::map_from_iter([
         (Edn::tag("kind"), Edn::tag("macro")),
-        (Edn::tag("name"), Edn::Str((**name).into())),
-        (Edn::tag("ns"), Edn::Str((**def_ns).into())),
-        (Edn::tag("args"), dump_args_code(args)), // TODO
-        (Edn::tag("code"), dump_items_code(body)),
+        (Edn::tag("name"), Edn::Str((*info.name).into())),
+        (Edn::tag("ns"), Edn::Str((*info.def_ns).into())),
+        (Edn::tag("args"), dump_args_code(&info.args)), // TODO
+        (Edn::tag("code"), dump_items_code(&info.body)),
       ])
     }
     Calcit::Proc(name) => Edn::map_from_iter([

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -90,14 +90,8 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
     Calcit::Str(s) => Edn::Str((**s).into()),
     Calcit::Bool(b) => Edn::Bool(b.to_owned()),
     Calcit::Tag(s) => Edn::Tag(s.to_owned()),
-    Calcit::Symbol {
-      sym,
-      ns,
-      at_def,
-      resolved,
-      location,
-    } => {
-      let resolved = match resolved {
+    Calcit::Symbol { sym, info, location } => {
+      let resolved = match &info.resolved {
         Some(resolved) => match &**resolved {
           ResolvedDef {
             ns: r_ns,
@@ -106,7 +100,7 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
           } => Edn::map_from_iter([
             (Edn::tag("kind"), Edn::tag("def")),
             (Edn::tag("ns"), Edn::Str((**r_ns).into())),
-            (Edn::tag("at-def"), Edn::Str((**at_def).into())),
+            (Edn::tag("at-def"), Edn::Str((*info.at_def).into())),
             (Edn::tag("def"), Edn::Str((**r_def).into())),
             (
               Edn::tag("rule"),
@@ -134,8 +128,8 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
       Edn::map_from_iter([
         (Edn::tag("kind"), Edn::tag("symbol")),
         (Edn::tag("val"), Edn::Str((**sym).into())),
-        (Edn::tag("at-def"), Edn::Str((**at_def).into())),
-        (Edn::tag("ns"), Edn::Str((**ns).into())),
+        (Edn::tag("at-def"), Edn::Str((*info.at_def).into())),
+        (Edn::tag("ns"), Edn::Str((*info.ns).into())),
         (Edn::tag("resolved"), resolved),
       ])
     }

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -134,15 +134,13 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
       ])
     }
 
-    Calcit::Fn {
-      name, def_ns, args, body, ..
-    } => {
+    Calcit::Fn { info, .. } => {
       Edn::map_from_iter([
         (Edn::tag("kind"), Edn::tag("fn")),
-        (Edn::tag("name"), Edn::Str((**name).into())),
-        (Edn::tag("ns"), Edn::Str((**def_ns).into())),
-        (Edn::tag("args"), dump_args_code(args)), // TODO
-        (Edn::tag("code"), dump_items_code(body)),
+        (Edn::tag("name"), Edn::Str((*info.name).into())),
+        (Edn::tag("ns"), Edn::Str((*info.def_ns).into())),
+        (Edn::tag("args"), dump_args_code(&info.args)), // TODO
+        (Edn::tag("code"), dump_items_code(&info.body)),
       ])
     }
     Calcit::Macro { info, .. } => {

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -121,6 +121,7 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
           ]),
           ResolvedLocal => Edn::map_from_iter([("kind".into(), Edn::tag("local"))]),
           ResolvedRaw => Edn::map_from_iter([("kind".into(), Edn::tag("raw"))]),
+          ResolvedRegistered => Edn::map_from_iter([("kind".into(), Edn::tag("registered"))]),
         },
         None => Edn::map_from_iter([("kind".into(), Edn::Nil)]),
       };

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,7 +10,7 @@ use crate::{
 pub mod cirru;
 pub mod edn;
 
-pub fn data_to_calcit(x: &Calcit, ns: Arc<str>, at_def: Arc<str>) -> Result<Calcit, String> {
+pub fn data_to_calcit(x: &Calcit, ns: &str, at_def: &str) -> Result<Calcit, String> {
   match x {
     Calcit::Syntax(s, ns) => Ok(Calcit::Syntax(s.to_owned(), ns.to_owned())),
     Calcit::Proc(p) => Ok(Calcit::Proc(p.to_owned())),
@@ -29,31 +29,31 @@ pub fn data_to_calcit(x: &Calcit, ns: Arc<str>, at_def: Arc<str>) -> Result<Calc
     Calcit::Nil => Ok(Calcit::Nil),
     Calcit::Tuple(t, extra, _class) => {
       let mut ys = TernaryTreeList::from(&[Calcit::Proc(CalcitProc::NativeTuple)]);
-      ys = ys.push_right(data_to_calcit(t, ns.to_owned(), at_def.to_owned())?);
+      ys = ys.push_right(data_to_calcit(t, ns, at_def)?);
       for x in extra {
-        ys = ys.push_right(data_to_calcit(x, ns.to_owned(), at_def.to_owned())?);
+        ys = ys.push_right(data_to_calcit(x, ns, at_def)?);
       }
       Ok(Calcit::List(ys))
     }
     Calcit::List(xs) => {
       let mut ys = TernaryTreeList::from(&[Calcit::Proc(CalcitProc::List)]);
       for x in xs {
-        ys = ys.push_right(data_to_calcit(x, ns.to_owned(), at_def.to_owned())?);
+        ys = ys.push_right(data_to_calcit(x, ns, at_def)?);
       }
       Ok(Calcit::List(ys))
     }
     Calcit::Set(xs) => {
       let mut ys = TernaryTreeList::from(&[Calcit::Proc(CalcitProc::Set)]);
       for x in xs {
-        ys = ys.push_right(data_to_calcit(x, ns.to_owned(), at_def.to_owned())?);
+        ys = ys.push_right(data_to_calcit(x, ns, at_def)?);
       }
       Ok(Calcit::List(ys))
     }
     Calcit::Map(xs) => {
       let mut ys = TernaryTreeList::from(&[Calcit::Proc(CalcitProc::NativeMap)]);
       for (k, v) in xs {
-        ys = ys.push_right(data_to_calcit(k, ns.to_owned(), at_def.to_owned())?);
-        ys = ys.push_right(data_to_calcit(v, ns.to_owned(), at_def.to_owned())?);
+        ys = ys.push_right(data_to_calcit(k, ns, at_def)?);
+        ys = ys.push_right(data_to_calcit(v, ns, at_def)?);
       }
       Ok(Calcit::List(ys))
     }
@@ -61,8 +61,8 @@ pub fn data_to_calcit(x: &Calcit, ns: Arc<str>, at_def: Arc<str>) -> Result<Calc
       let mut ys = TernaryTreeList::from(&[Calcit::Symbol {
         sym: "defrecord!".into(),
         info: Arc::new(crate::primes::CalcitSymbolInfo {
-          ns: ns.to_owned(),
-          at_def: at_def.to_owned(),
+          ns: Arc::from(ns),
+          at_def: Arc::from(at_def),
           resolved: None,
         }),
         location: None,
@@ -72,7 +72,7 @@ pub fn data_to_calcit(x: &Calcit, ns: Arc<str>, at_def: Arc<str>) -> Result<Calc
       for i in 0..size {
         ys = ys.push(Calcit::List(TernaryTreeList::from(&[
           Calcit::Tag(fields[i].to_owned()),
-          data_to_calcit(&values[i], ns.to_owned(), at_def.to_owned())?,
+          data_to_calcit(&values[i], ns, at_def)?,
         ])))
       }
       Ok(Calcit::List(ys))

--- a/src/data.rs
+++ b/src/data.rs
@@ -60,9 +60,11 @@ pub fn data_to_calcit(x: &Calcit, ns: Arc<str>, at_def: Arc<str>) -> Result<Calc
     Calcit::Record(tag, fields, values, _class) => {
       let mut ys = TernaryTreeList::from(&[Calcit::Symbol {
         sym: "defrecord!".into(),
-        ns: ns.to_owned(),
-        at_def: at_def.to_owned(),
-        resolved: None,
+        info: Arc::new(crate::primes::CalcitSymbolInfo {
+          ns: ns.to_owned(),
+          at_def: at_def.to_owned(),
+          resolved: None,
+        }),
         location: None,
       }]);
       ys = ys.push_right(Calcit::Tag(tag.to_owned()));

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -21,9 +21,11 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8
       // special tuple syntax
       "::" => Ok(Calcit::Symbol {
         sym: s.clone(),
-        ns,
-        at_def: def,
-        resolved: None,
+        info: Arc::new(crate::primes::CalcitSymbolInfo {
+          ns,
+          at_def: def,
+          resolved: None,
+        }),
         location: Some(Arc::new(coord.to_vec())),
       }),
       _ => match s.chars().next().expect("load first char") {
@@ -49,16 +51,20 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8
         '\'' if s.len() > 1 => Ok(Calcit::List(TernaryTreeList::from(&[
           Calcit::Symbol {
             sym: Arc::from("quote"),
-            ns: ns.to_owned(),
-            at_def: def.clone(),
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns: ns.to_owned(),
+              at_def: def.clone(),
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
           Calcit::Symbol {
             sym: Arc::from(&s[1..]),
-            ns,
-            at_def: def,
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns,
+              at_def: def,
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
         ]))),
@@ -66,48 +72,60 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8
         '~' if s.starts_with("~@") && s.chars().count() > 2 => Ok(Calcit::List(TernaryTreeList::from(&[
           Calcit::Symbol {
             sym: Arc::from("~@"),
-            ns: ns.to_owned(),
-            at_def: def.to_owned(),
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns: ns.to_owned(),
+              at_def: def.to_owned(),
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
           Calcit::Symbol {
             sym: Arc::from(&s[2..]),
-            ns,
-            at_def: def,
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns,
+              at_def: def,
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
         ]))),
         '~' if s.chars().count() > 1 && !s.starts_with("~@") => Ok(Calcit::List(TernaryTreeList::from(&[
           Calcit::Symbol {
             sym: Arc::from("~"),
-            ns: ns.to_owned(),
-            at_def: def.to_owned(),
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns: ns.to_owned(),
+              at_def: def.to_owned(),
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
           Calcit::Symbol {
             sym: Arc::from(&s[1..]),
-            ns,
-            at_def: def,
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns,
+              at_def: def,
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
         ]))),
         '@' => Ok(Calcit::List(TernaryTreeList::from(&[
           Calcit::Symbol {
             sym: Arc::from("deref"),
-            ns: ns.to_owned(),
-            at_def: def.to_owned(),
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns: ns.to_owned(),
+              at_def: def.to_owned(),
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
           Calcit::Symbol {
             sym: Arc::from(&s[1..]),
-            ns,
-            at_def: def,
-            resolved: None,
+            info: Arc::new(crate::primes::CalcitSymbolInfo {
+              ns,
+              at_def: def,
+              resolved: None,
+            }),
             location: Some(coord.clone()),
           },
         ]))),
@@ -120,9 +138,11 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8
           } else {
             Ok(Calcit::Symbol {
               sym: (**s).into(),
-              ns,
-              at_def: def,
-              resolved: None,
+              info: Arc::new(crate::primes::CalcitSymbolInfo {
+                ns,
+                at_def: def,
+                resolved: None,
+              }),
               location: Some(coord.clone()),
             })
           }

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -6,7 +6,7 @@ use im_ternary_tree::TernaryTreeList;
 use crate::primes::{Calcit, CalcitProc, MethodKind};
 
 /// code is CirruNode, and this function parse code(rather than data)
-pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8>>) -> Result<Calcit, String> {
+pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Vec<u8>) -> Result<Calcit, String> {
   match xs {
     Cirru::Leaf(s) => match &**s {
       "nil" => Ok(Calcit::Nil),
@@ -26,7 +26,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8
           at_def: def,
           resolved: None,
         }),
-        location: Some(Arc::new(coord.to_vec())),
+        location: Some(coord),
       }),
       _ => match s.chars().next().expect("load first char") {
         ':' if s.len() > 1 && s.chars().nth(1) != Some(':') => Ok(Calcit::tag(&s[1..])),
@@ -152,7 +152,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8
     Cirru::List(ys) => {
       let mut zs: Vec<Calcit> = Vec::with_capacity(ys.len());
       for (idx, y) in ys.iter().enumerate() {
-        let mut next_coord: Vec<u8> = (**coord).to_owned();
+        let mut next_coord: Vec<u8> = coord.to_owned();
         next_coord.push(idx as u8); // code not supposed to be fatter than 256 children
 
         if let Cirru::List(ys) = y {
@@ -172,7 +172,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8
           }
         }
 
-        zs.push(code_to_calcit(y, ns.to_owned(), def.to_owned(), Arc::new(next_coord))?)
+        zs.push(code_to_calcit(y, ns.to_owned(), def.to_owned(), next_coord)?)
       }
       Ok(Calcit::List(TernaryTreeList::from(&zs)))
     }

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -45,7 +45,10 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
       }
       Ok(entries.into())
     }
-    Calcit::Fn { name, def_ns, args, .. } => {
+    Calcit::Fn { info, .. } => {
+      let def_ns = &info.def_ns;
+      let name = &info.name;
+      let args = &info.args;
       println!("[Warn] fn to EDN: {def_ns}/{name} {args:?}");
       Ok(Edn::str(x.to_string()))
     }

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -104,9 +104,11 @@ pub fn edn_to_calcit(x: &Edn, options: &Calcit) -> Calcit {
     Edn::Number(n) => Calcit::Number(*n),
     Edn::Symbol(s) => Calcit::Symbol {
       sym: (**s).into(),
-      ns: primes::GEN_NS.into(),
-      at_def: primes::GENERATED_DEF.into(),
-      resolved: None,
+      info: Arc::new(crate::primes::CalcitSymbolInfo {
+        ns: primes::GEN_NS.into(),
+        at_def: primes::GENERATED_DEF.into(),
+        resolved: None,
+      }),
       location: None,
     },
     Edn::Tag(s) => Calcit::Tag(s.to_owned()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,7 @@ pub fn run_program(init_ns: Arc<str>, init_def: Arc<str>, params: CalcitItems) -
   let check_warnings = RefCell::new(LocatedWarning::default_list());
 
   // preprocess to init
-  match runner::preprocess::preprocess_ns_def(
-    init_ns.to_owned(),
-    init_def.to_owned(),
-    init_def.to_owned(),
-    None,
-    &check_warnings,
-    &rpds::List::new_sync(),
-  ) {
+  match runner::preprocess::preprocess_ns_def(&init_ns, &init_def, &init_def, None, &check_warnings, &rpds::List::new_sync()) {
     Ok(_) => (),
     Err(failure) => {
       eprintln!("\nfailed preprocessing, {failure}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub fn run_program(init_ns: Arc<str>, init_def: Arc<str>, params: CalcitItems) -
     None => CalcitErr::err_str(format!("entry not initialized: {init_ns}/{init_def}")),
     Some(entry) => match entry {
       Calcit::Fn { info, .. } => {
-        let result = runner::run_fn(&params, &info, &rpds::List::new_sync());
+        let result = runner::run_fn(params, &info, &rpds::List::new_sync());
         match result {
           Ok(v) => Ok(v),
           Err(failure) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,8 @@ pub fn run_program(init_ns: Arc<str>, init_def: Arc<str>, params: CalcitItems) -
   match program::lookup_evaled_def(&init_ns, &init_def) {
     None => CalcitErr::err_str(format!("entry not initialized: {init_ns}/{init_def}")),
     Some(entry) => match entry {
-      Calcit::Fn {
-        def_ns, scope, args, body, ..
-      } => {
-        let result = runner::run_fn(&params, &scope, &args, &body, def_ns, &rpds::List::new_sync());
+      Calcit::Fn { info, .. } => {
+        let result = runner::run_fn(&params, &info, &rpds::List::new_sync());
         match result {
           Ok(v) => Ok(v),
           Err(failure) => {

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -18,10 +18,10 @@ use cirru_edn::{Edn, EdnTag};
 use cirru_parser::Cirru;
 use im_ternary_tree::TernaryTreeList;
 
-pub use fns::{CalcitFn, CalcitMacro};
+pub use fns::{CalcitFn, CalcitMacro, CalcitScope};
 pub use proc_name::CalcitProc;
-use rpds::HashTrieMapSync;
 pub use symbol::CalcitSymbolInfo;
+pub use symbol::{ImportRule, SymbolResolved};
 pub use syntax_name::CalcitSyntax;
 
 use crate::builtins::ValueAndListeners;
@@ -29,57 +29,6 @@ use crate::call_stack::CallStackList;
 
 /// dead simple counter for ID generator, better use nanoid in business
 static ID_GEN: AtomicUsize = AtomicUsize::new(0);
-
-/// resolved value of real meaning of a symbol
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SymbolResolved {
-  /// a local variable
-  ResolvedLocal,
-  /// raw syntax, no target, for example `&` is a raw syntax
-  ResolvedRaw,
-  /// definition attached on namespace
-  ResolvedDef {
-    ns: Arc<str>,
-    def: Arc<str>,
-    rule: Option<Arc<ImportRule>>,
-  },
-}
-
-/// defRule: ns def
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ImportRule {
-  /// ns imported via `:as`
-  NsAs(Arc<str>),
-  /// (ns, def) imported via `:refer`
-  NsReferDef(Arc<str>, Arc<str>),
-  /// ns imported via `:default`, js only
-  NsDefault(Arc<str>),
-}
-
-/// scope in the semantics of persistent data structure
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CalcitScope(pub rpds::HashTrieMapSync<Arc<str>, Calcit>);
-
-impl Default for CalcitScope {
-  fn default() -> Self {
-    CalcitScope(HashTrieMapSync::new_sync())
-  }
-}
-
-impl CalcitScope {
-  /// create a new scope from a piece of hashmap
-  pub fn new(data: rpds::HashTrieMapSync<Arc<str>, Calcit>) -> Self {
-    CalcitScope(data)
-  }
-  /// load value of a symbol from the scope
-  pub fn get(&self, key: &str) -> Option<&Calcit> {
-    self.0.get(key)
-  }
-  /// mutable insertiong of variable
-  pub fn insert_mut(&mut self, key: Arc<str>, value: Calcit) {
-    self.0.insert_mut(key, value);
-  }
-}
 
 pub type CalcitItems = TernaryTreeList<Calcit>;
 

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -46,7 +46,7 @@ pub enum Calcit {
     sym: Arc<str>,
     info: Arc<CalcitSymbolInfo>,
     /// positions in the tree of Cirru
-    location: Option<Arc<Vec<u8>>>,
+    location: Option<Vec<u8>>,
   },
   /// sth between string and enum, used a key or weak identifier
   Tag(EdnTag),
@@ -702,7 +702,7 @@ impl CalcitErr {
 pub struct NodeLocation {
   pub ns: Arc<str>,
   pub def: Arc<str>,
-  pub coord: Arc<Vec<u8>>,
+  pub coord: Vec<u8>,
 }
 
 impl From<NodeLocation> for Edn {
@@ -734,7 +734,7 @@ impl fmt::Display for NodeLocation {
 }
 
 impl NodeLocation {
-  pub fn new(ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8>>) -> Self {
+  pub fn new(ns: Arc<str>, def: Arc<str>, coord: Vec<u8>) -> Self {
     NodeLocation { ns, def, coord }
   }
 }

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -1,5 +1,6 @@
 mod eval_node;
 mod proc_name;
+mod symbol;
 mod syntax_name;
 
 use core::cmp::Ord;
@@ -18,6 +19,7 @@ use im_ternary_tree::TernaryTreeList;
 
 pub use proc_name::CalcitProc;
 use rpds::HashTrieMapSync;
+pub use symbol::CalcitSymbolInfo;
 pub use syntax_name::CalcitSyntax;
 
 use crate::builtins::ValueAndListeners;
@@ -91,9 +93,7 @@ pub enum Calcit {
   Number(f64),
   Symbol {
     sym: Arc<str>,
-    ns: Arc<str>,
-    at_def: Arc<str>,
-    resolved: Option<Arc<SymbolResolved>>,
+    info: Arc<CalcitSymbolInfo>,
     /// positions in the tree of Cirru
     location: Option<Arc<Vec<u8>>>,
   },
@@ -641,9 +641,9 @@ impl Calcit {
   /// currently only symbol has node location
   pub fn get_location(&self) -> Option<NodeLocation> {
     match self {
-      Calcit::Symbol { ns, at_def, location, .. } => Some(NodeLocation::new(
-        ns.to_owned(),
-        at_def.to_owned(),
+      Calcit::Symbol { info, location, .. } => Some(NodeLocation::new(
+        info.ns.to_owned(),
+        info.at_def.to_owned(),
         location.to_owned().unwrap_or_default(),
       )),
       _ => None,

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -46,7 +46,7 @@ pub enum Calcit {
     sym: Arc<str>,
     info: Arc<CalcitSymbolInfo>,
     /// positions in the tree of Cirru
-    location: Option<Vec<u8>>,
+    location: Option<Arc<Vec<u8>>>,
   },
   /// sth between string and enum, used a key or weak identifier
   Tag(EdnTag),
@@ -586,8 +586,8 @@ impl Calcit {
   pub fn get_location(&self) -> Option<NodeLocation> {
     match self {
       Calcit::Symbol { info, location, .. } => Some(NodeLocation::new(
-        info.ns.to_owned(),
-        info.at_def.to_owned(),
+        info.ns.clone(),
+        info.at_def.clone(),
         location.to_owned().unwrap_or_default(),
       )),
       _ => None,
@@ -702,7 +702,7 @@ impl CalcitErr {
 pub struct NodeLocation {
   pub ns: Arc<str>,
   pub def: Arc<str>,
-  pub coord: Vec<u8>,
+  pub coord: Arc<Vec<u8>>,
 }
 
 impl From<NodeLocation> for Edn {
@@ -734,8 +734,12 @@ impl fmt::Display for NodeLocation {
 }
 
 impl NodeLocation {
-  pub fn new(ns: Arc<str>, def: Arc<str>, coord: Vec<u8>) -> Self {
-    NodeLocation { ns, def, coord }
+  pub fn new(ns: Arc<str>, def: Arc<str>, coord: Arc<Vec<u8>>) -> Self {
+    NodeLocation {
+      ns,
+      def,
+      coord: coord.to_owned(),
+    }
   }
 }
 

--- a/src/primes.rs
+++ b/src/primes.rs
@@ -128,13 +128,8 @@ pub enum Calcit {
     info: Arc<CalcitMacro>,
   },
   Fn {
-    name: Arc<str>,
-    /// where it was defined
-    def_ns: Arc<str>,
     id: Arc<str>,
-    scope: Arc<CalcitScope>,
-    args: Arc<Vec<Arc<str>>>,
-    body: Arc<CalcitItems>,
+    info: Arc<CalcitFn>,
   },
   /// name, ns... notice that `ns` is a meta info
   Syntax(CalcitSyntax, Arc<str>),
@@ -261,10 +256,11 @@ impl fmt::Display for Calcit {
         }
         f.write_str("))")
       }
-      Calcit::Fn { name, args, body, .. } => {
+      Calcit::Fn { info, .. } => {
+        let name = &info.name;
         f.write_str(&format!("(&fn {name} ("))?;
         let mut need_space = false;
-        for a in &**args {
+        for a in &*info.args {
           if need_space {
             f.write_str(" ")?;
           }
@@ -273,7 +269,7 @@ impl fmt::Display for Calcit {
         }
         f.write_str(") ")?;
         need_space = false;
-        for b in &**body {
+        for b in &*info.body {
           if need_space {
             f.write_str(" ")?;
           }

--- a/src/primes/fns.rs
+++ b/src/primes/fns.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use super::CalcitScope;
-use crate::CalcitItems;
+use rpds::HashTrieMapSync;
+
+use crate::{Calcit, CalcitItems};
 
 #[derive(Debug, Clone)]
 pub struct CalcitFn {
@@ -21,4 +22,29 @@ pub struct CalcitMacro {
   pub def_ns: Arc<str>,
   pub args: Arc<Vec<Arc<str>>>,
   pub body: Arc<CalcitItems>,
+}
+
+/// scope in the semantics of persistent data structure
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalcitScope(pub rpds::HashTrieMapSync<Arc<str>, Calcit>);
+
+impl Default for CalcitScope {
+  fn default() -> Self {
+    CalcitScope(HashTrieMapSync::new_sync())
+  }
+}
+
+impl CalcitScope {
+  /// create a new scope from a piece of hashmap
+  pub fn new(data: rpds::HashTrieMapSync<Arc<str>, Calcit>) -> Self {
+    CalcitScope(data)
+  }
+  /// load value of a symbol from the scope
+  pub fn get(&self, key: &str) -> Option<&Calcit> {
+    self.0.get(key)
+  }
+  /// mutable insertiong of variable
+  pub fn insert_mut(&mut self, key: Arc<str>, value: Calcit) {
+    self.0.insert_mut(key, value);
+  }
 }

--- a/src/primes/fns.rs
+++ b/src/primes/fns.rs
@@ -1,9 +1,17 @@
 use std::sync::Arc;
 
+use super::CalcitScope;
 use crate::CalcitItems;
 
 #[derive(Debug, Clone)]
-pub struct CalcitFn {}
+pub struct CalcitFn {
+  pub name: Arc<str>,
+  /// where it was defined
+  pub def_ns: Arc<str>,
+  pub scope: Arc<CalcitScope>,
+  pub args: Arc<Vec<Arc<str>>>,
+  pub body: Arc<CalcitItems>,
+}
 
 /// Macro variant of Calcit data
 #[derive(Debug, Clone)]

--- a/src/primes/fns.rs
+++ b/src/primes/fns.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use crate::CalcitItems;
+
+#[derive(Debug, Clone)]
+pub struct CalcitFn {}
+
+/// Macro variant of Calcit data
+#[derive(Debug, Clone)]
+pub struct CalcitMacro {
+  pub name: Arc<str>,
+  /// where it was defined
+  pub def_ns: Arc<str>,
+  pub args: Arc<Vec<Arc<str>>>,
+  pub body: Arc<CalcitItems>,
+}

--- a/src/primes/symbol.rs
+++ b/src/primes/symbol.rs
@@ -7,6 +7,8 @@ pub enum SymbolResolved {
   ResolvedLocal,
   /// raw syntax, no target, for example `&` is a raw syntax
   ResolvedRaw,
+  /// registered from runtime
+  ResolvedRegistered,
   /// definition attached on namespace
   ResolvedDef {
     ns: Arc<str>,

--- a/src/primes/symbol.rs
+++ b/src/primes/symbol.rs
@@ -1,10 +1,34 @@
 use std::sync::Arc;
 
-use super::SymbolResolved;
+/// resolved value of real meaning of a symbol
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SymbolResolved {
+  /// a local variable
+  ResolvedLocal,
+  /// raw syntax, no target, for example `&` is a raw syntax
+  ResolvedRaw,
+  /// definition attached on namespace
+  ResolvedDef {
+    ns: Arc<str>,
+    def: Arc<str>,
+    rule: Option<ImportRule>,
+  },
+}
+
+/// defRule: ns def
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportRule {
+  /// ns imported via `:as`
+  NsAs(Arc<str>),
+  /// (ns, def) imported via `:refer`
+  NsReferDef(Arc<str>, Arc<str>),
+  /// ns imported via `:default`, js only
+  NsDefault(Arc<str>),
+}
 
 #[derive(Debug, Clone)]
 pub struct CalcitSymbolInfo {
   pub ns: Arc<str>,
   pub at_def: Arc<str>,
-  pub resolved: Option<Arc<SymbolResolved>>,
+  pub resolved: Option<SymbolResolved>,
 }

--- a/src/primes/symbol.rs
+++ b/src/primes/symbol.rs
@@ -1,0 +1,10 @@
+use std::sync::Arc;
+
+use super::SymbolResolved;
+
+#[derive(Debug, Clone)]
+pub struct CalcitSymbolInfo {
+  pub ns: Arc<str>,
+  pub at_def: Arc<str>,
+  pub resolved: Option<Arc<SymbolResolved>>,
+}

--- a/src/program.rs
+++ b/src/program.rs
@@ -106,7 +106,7 @@ fn extract_file_data(file: &snapshot::FileInSnapShot, ns: Arc<str>) -> Result<Pr
   let mut defs: HashMap<Arc<str>, Calcit> = HashMap::with_capacity(file.defs.len());
   for (def, entry) in &file.defs {
     let at_def = def.to_owned();
-    defs.insert(def.to_owned(), code_to_calcit(&entry.code, ns.to_owned(), at_def, vec![])?);
+    defs.insert(def.to_owned(), code_to_calcit(&entry.code, &ns, &at_def, vec![])?);
   }
   Ok(ProgramFileData { import_map, defs })
 }
@@ -223,17 +223,13 @@ pub fn apply_code_changes(changes: &snapshot::ChangesDict) -> Result<(), String>
       file.import_map = extract_import_map(v)?;
     }
     for (def, code) in &info.added_defs {
-      file
-        .defs
-        .insert(def.to_owned(), code_to_calcit(code, ns.to_owned(), def.to_owned(), coord0.clone())?);
+      file.defs.insert(def.to_owned(), code_to_calcit(code, ns, def, coord0.clone())?);
     }
     for def in &info.removed_defs {
       file.defs.remove(def);
     }
     for (def, code) in &info.changed_defs {
-      file
-        .defs
-        .insert(def.to_owned(), code_to_calcit(code, ns.to_owned(), def.to_owned(), coord0.clone())?);
+      file.defs.insert(def.to_owned(), code_to_calcit(code, ns, def, coord0.clone())?);
     }
   }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -106,10 +106,7 @@ fn extract_file_data(file: &snapshot::FileInSnapShot, ns: Arc<str>) -> Result<Pr
   let mut defs: HashMap<Arc<str>, Calcit> = HashMap::with_capacity(file.defs.len());
   for (def, entry) in &file.defs {
     let at_def = def.to_owned();
-    defs.insert(
-      def.to_owned(),
-      code_to_calcit(&entry.code, ns.to_owned(), at_def, Arc::new(vec![]))?,
-    );
+    defs.insert(def.to_owned(), code_to_calcit(&entry.code, ns.to_owned(), at_def, vec![])?);
   }
   Ok(ProgramFileData { import_map, defs })
 }
@@ -211,7 +208,7 @@ pub fn clone_evaled_program() -> ProgramEvaledData {
 
 pub fn apply_code_changes(changes: &snapshot::ChangesDict) -> Result<(), String> {
   let mut program_code = PROGRAM_CODE_DATA.write().expect("open program code");
-  let coord0 = Arc::new(vec![]);
+  let coord0 = vec![];
 
   for (ns, file) in &changes.added {
     program_code.insert(ns.to_owned(), extract_file_data(file, ns.to_owned())?);

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -117,9 +117,7 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: Arc<str>, call
 
             run_fn(&values, def_scope, args, body, def_ns.to_owned(), &next_stack)
           }
-          Calcit::Macro {
-            name, def_ns, args, body, ..
-          } => {
+          Calcit::Macro { info, .. } => {
             println!(
               "[Warn] macro should already be handled during preprocessing: {}",
               Calcit::List(xs.to_owned()).lisp_str()
@@ -132,8 +130,8 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: Arc<str>, call
 
             let next_stack = extend_call_stack(
               call_stack,
-              def_ns.to_owned(),
-              name.to_owned(),
+              info.def_ns.to_owned(),
+              info.name.to_owned(),
               StackKind::Macro,
               expr.to_owned(),
               &rest_nodes,
@@ -143,8 +141,8 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: Arc<str>, call
 
             Ok(loop {
               // need to handle recursion
-              bind_args(&mut body_scope, args, &current_values, call_stack)?;
-              let code = evaluate_lines(body, &body_scope, def_ns.to_owned(), &next_stack)?;
+              bind_args(&mut body_scope, &info.args, &current_values, call_stack)?;
+              let code = evaluate_lines(&info.body, &body_scope, info.def_ns.to_owned(), &next_stack)?;
               match code {
                 Calcit::Recur(ys) => {
                   current_values = Box::new(ys.to_owned());

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -25,20 +25,17 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: Arc<str>, call
     Calcit::Symbol { sym, info, location, .. } => {
       let loc = NodeLocation::new(info.ns.to_owned(), info.at_def.to_owned(), location.to_owned().unwrap_or_default());
       match &info.resolved {
-        Some(resolved_info) => match &*resolved_info.to_owned() {
-          ResolvedDef {
-            ns: r_ns,
-            def: r_def,
-            rule,
-          } => {
-            if rule.is_some() && sym != r_def {
-              // dirty check for namespaced imported variables
-              return eval_symbol_from_program(r_def, r_ns, call_stack);
-            }
-            evaluate_symbol(r_def, scope, r_ns, Some(loc), call_stack)
+        Some(ResolvedDef {
+          ns: r_ns,
+          def: r_def,
+          rule,
+        }) => {
+          if rule.is_some() && sym != r_def {
+            // dirty check for namespaced imported variables
+            return eval_symbol_from_program(r_def, r_ns, call_stack);
           }
-          _ => evaluate_symbol(sym, scope, &info.ns, Some(loc), call_stack),
-        },
+          evaluate_symbol(r_def, scope, r_ns, Some(loc), call_stack)
+        }
         _ => evaluate_symbol(sym, scope, &info.ns, Some(loc), call_stack),
       }
     }

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -28,30 +28,30 @@ fn pick_macro_fn(x: Calcit) -> Option<Calcit> {
 /// returns the resolved symbol,
 /// if code related is not preprocessed, do it internally
 pub fn preprocess_ns_def(
-  raw_ns: Arc<str>,
-  raw_def: Arc<str>,
+  raw_ns: &str,
+  raw_def: &str,
   // pass original string representation, TODO codegen currently relies on this
-  raw_sym: Arc<str>,
+  raw_sym: &str,
   import_rule: Option<ImportRule>, // returns form and possible value
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &rpds::ListSync<CalcitStack>,
 ) -> Result<(Calcit, Option<Calcit>), CalcitErr> {
-  let ns = &raw_ns;
-  let def = &raw_def;
-  let original_sym = &raw_sym;
+  let ns = raw_ns;
+  let def = raw_def;
+  let original_sym = raw_sym;
   // println!("preprocessing def: {}/{}", ns, def);
   match program::lookup_evaled_def(ns, def) {
     Some(v) => {
       // println!("{}/{} has inited", ns, def);
       Ok((
         Calcit::Symbol {
-          sym: original_sym.to_owned(),
+          sym: Arc::from(original_sym),
           info: Arc::new(CalcitSymbolInfo {
-            ns: ns.to_owned(),
-            at_def: def.to_owned(),
+            ns: Arc::from(ns),
+            at_def: Arc::from(def),
             resolved: Some(ResolvedDef {
-              ns: ns.to_owned(),
-              def: def.to_owned(),
+              ns: Arc::from(ns),
+              def: Arc::from(def),
               rule: import_rule,
             }),
           }),
@@ -69,17 +69,17 @@ pub fn preprocess_ns_def(
 
           let next_stack = extend_call_stack(
             call_stack,
-            ns.to_owned(),
-            def.to_owned(),
+            Arc::from(ns),
+            Arc::from(def),
             StackKind::Fn,
             code.to_owned(),
             &TernaryTreeList::Empty,
           );
 
-          let (resolved_code, _resolve_value) = preprocess_expr(&code, &HashSet::new(), ns.to_owned(), check_warnings, &next_stack)?;
+          let (resolved_code, _resolve_value) = preprocess_expr(&code, &HashSet::new(), ns, check_warnings, &next_stack)?;
           // println!("\n resolve code to run: {:?}", resolved_code);
           let v = if is_fn_or_macro(&resolved_code) {
-            match runner::evaluate_expr(&resolved_code, &CalcitScope::default(), ns.to_owned(), &next_stack) {
+            match runner::evaluate_expr(&resolved_code, &CalcitScope::default(), ns, &next_stack) {
               Ok(ret) => ret,
               Err(e) => return Err(e),
             }
@@ -91,14 +91,14 @@ pub fn preprocess_ns_def(
 
           Ok((
             Calcit::Symbol {
-              sym: original_sym.to_owned(),
+              sym: Arc::from(original_sym),
               info: Arc::new(CalcitSymbolInfo {
-                ns: ns.to_owned(),
-                at_def: def.to_owned(),
+                ns: Arc::from(ns),
+                at_def: Arc::from(def),
                 resolved: Some(ResolvedDef {
-                  ns: ns.to_owned(),
-                  def: def.to_owned(),
-                  rule: Some(ImportRule::NsReferDef(ns.to_owned(), def.to_owned())),
+                  ns: Arc::from(ns),
+                  def: Arc::from(def),
+                  rule: Some(ImportRule::NsReferDef(Arc::from(ns), Arc::from(def))),
                 }),
               }),
               location: None,
@@ -108,13 +108,13 @@ pub fn preprocess_ns_def(
         }
         None if ns.starts_with('|') || ns.starts_with('"') => Ok((
           Calcit::Symbol {
-            sym: original_sym.to_owned(),
+            sym: Arc::from(original_sym),
             info: Arc::new(CalcitSymbolInfo {
-              ns: ns.to_owned(),
-              at_def: def.to_owned(),
+              ns: Arc::from(ns),
+              at_def: Arc::from(def),
               resolved: Some(ResolvedDef {
-                ns: ns.to_owned(),
-                def: def.to_owned(),
+                ns: Arc::from(ns),
+                def: Arc::from(def),
                 rule: import_rule,
               }),
             }),
@@ -145,7 +145,7 @@ fn is_fn_or_macro(code: &Calcit) -> bool {
 pub fn preprocess_expr(
   expr: &Calcit,
   scope_defs: &HashSet<Arc<str>>,
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<(Calcit, Option<Calcit>), CalcitErr> {
@@ -159,10 +159,10 @@ pub fn preprocess_expr(
           Ok((Calcit::RawCode(RawCodeType::Js, def_part), None))
         } else if let Some(target_ns) = program::lookup_ns_target_in_import(&info.ns, &ns_alias) {
           // TODO js syntax to handle in future
-          preprocess_ns_def(target_ns, def_part, def.to_owned(), None, check_warnings, call_stack)
+          preprocess_ns_def(&target_ns, &def_part, def, None, check_warnings, call_stack)
         } else if program::has_def_code(&ns_alias, &def_part) {
           // refer to namespace/def directly for some usages
-          preprocess_ns_def(ns_alias.to_owned(), def_part, def.to_owned(), None, check_warnings, call_stack)
+          preprocess_ns_def(&ns_alias, &def_part, def, None, check_warnings, call_stack)
         } else {
           Err(CalcitErr::use_msg_stack(format!("unknown ns target: {def}"), call_stack))
         }
@@ -210,16 +210,9 @@ pub fn preprocess_expr(
         } else if let Ok(p) = def.parse::<CalcitProc>() {
           Ok((Calcit::Proc(p), None))
         } else if program::has_def_code(primes::CORE_NS, def) {
-          preprocess_ns_def(
-            primes::CORE_NS.into(),
-            def.to_owned(),
-            def.to_owned(),
-            None,
-            check_warnings,
-            call_stack,
-          )
+          preprocess_ns_def(primes::CORE_NS, def, def, None, check_warnings, call_stack)
         } else if program::has_def_code(def_ns, def) {
-          preprocess_ns_def(def_ns.to_owned(), def.to_owned(), def.to_owned(), None, check_warnings, call_stack)
+          preprocess_ns_def(def_ns, def, def, None, check_warnings, call_stack)
         } else if is_registered_proc(def) {
           Ok((
             Calcit::Symbol {
@@ -238,7 +231,7 @@ pub fn preprocess_expr(
             Some(target_ns) => {
               // effect
               // TODO js syntax to handle in future
-              preprocess_ns_def(target_ns, def.to_owned(), def.to_owned(), None, check_warnings, call_stack)
+              preprocess_ns_def(&target_ns, def, def, None, check_warnings, call_stack)
             }
             // TODO check js_mode
             None if is_js_syntax_procs(def) => Ok((expr.to_owned(), None)),
@@ -271,7 +264,7 @@ pub fn preprocess_expr(
                 let mut warnings = check_warnings.borrow_mut();
                 warnings.push(LocatedWarning::new(
                   format!("[Warn] unknown `{def}` in {def_ns}/{at_def}, locals {{{}}}", names.join(" ")),
-                  NodeLocation::new(def_ns.to_owned(), at_def.to_owned(), location.to_owned().unwrap_or_default()),
+                  NodeLocation::new(def_ns.clone(), at_def.clone(), location.to_owned().unwrap_or_default()),
                 ));
                 Ok((expr.to_owned(), None))
               }
@@ -298,9 +291,9 @@ pub fn preprocess_expr(
     _ => {
       let mut warnings = check_warnings.borrow_mut();
       let loc = NodeLocation {
-        ns: file_ns,
+        ns: Arc::from(file_ns),
         def: GENERATED_DEF.into(),
-        coord: vec![],
+        coord: Arc::from(vec![]),
       };
       warnings.push(LocatedWarning::new(
         format!("[Warn] unexpected data during preprocess: {expr:?}"),
@@ -314,12 +307,12 @@ pub fn preprocess_expr(
 fn process_list_call(
   xs: &CalcitItems,
   scope_defs: &HashSet<Arc<str>>,
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<(Calcit, Option<Calcit>), CalcitErr> {
   let head = &xs[0];
-  let (head_form, head_evaled) = preprocess_expr(head, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+  let (head_form, head_evaled) = preprocess_expr(head, scope_defs, file_ns, check_warnings, call_stack)?;
   let args = xs.drop_left();
   let def_name = grab_def_name(head);
 
@@ -388,7 +381,7 @@ fn process_list_call(
         // need to handle recursion
         // println!("evaling line: {:?}", body);
         runner::bind_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
-        let code = runner::evaluate_lines(&info.body, &body_scope, file_ns.to_owned(), &next_stack)?;
+        let code = runner::evaluate_lines(&info.body, &body_scope, file_ns, &next_stack)?;
         match code {
           Calcit::Recur(ys) => {
             current_values = ys.to_owned();
@@ -402,15 +395,15 @@ fn process_list_call(
     }
     (Calcit::Syntax(name, name_ns), _) => match name {
       CalcitSyntax::Quasiquote => Ok((
-        preprocess_quasiquote(name, name_ns.to_owned(), &args, scope_defs, file_ns, check_warnings, call_stack)?,
+        preprocess_quasiquote(name, name_ns, &args, scope_defs, file_ns, check_warnings, call_stack)?,
         None,
       )),
       CalcitSyntax::Defn | CalcitSyntax::Defmacro => Ok((
-        preprocess_defn(name, name_ns.to_owned(), &args, scope_defs, file_ns, check_warnings, call_stack)?,
+        preprocess_defn(name, name_ns, &args, scope_defs, file_ns, check_warnings, call_stack)?,
         None,
       )),
       CalcitSyntax::CoreLet => Ok((
-        preprocess_core_let(name, name_ns.to_owned(), &args, scope_defs, file_ns, check_warnings, call_stack)?,
+        preprocess_core_let(name, name_ns, &args, scope_defs, file_ns, check_warnings, call_stack)?,
         None,
       )),
       CalcitSyntax::If
@@ -420,14 +413,14 @@ fn process_list_call(
       | CalcitSyntax::Macroexpand1
       | CalcitSyntax::Gensym
       | CalcitSyntax::Reset => Ok((
-        preprocess_each_items(name, name_ns.to_owned(), &args, scope_defs, file_ns, check_warnings, call_stack)?,
+        preprocess_each_items(name, name_ns, &args, scope_defs, file_ns, check_warnings, call_stack)?,
         None,
       )),
       CalcitSyntax::Quote | CalcitSyntax::Eval | CalcitSyntax::HintFn => {
-        Ok((preprocess_quote(name, name_ns.to_owned(), &args, scope_defs, file_ns)?, None))
+        Ok((preprocess_quote(name, name_ns, &args, scope_defs, file_ns)?, None))
       }
       CalcitSyntax::Defatom => Ok((
-        preprocess_defatom(name, name_ns.to_owned(), &args, scope_defs, file_ns, check_warnings, call_stack)?,
+        preprocess_defatom(name, name_ns, &args, scope_defs, file_ns, check_warnings, call_stack)?,
         None,
       )),
     },
@@ -437,18 +430,11 @@ fn process_list_call(
     )),
 
     (_, Some(Calcit::Fn { info, .. })) => {
-      check_fn_args(
-        &info.args,
-        &args,
-        file_ns.to_owned(),
-        info.name.to_owned(),
-        def_name,
-        check_warnings,
-      );
+      check_fn_args(&info.args, &args, file_ns, &info.name, &def_name, check_warnings);
       let mut ys = Vec::with_capacity(args.len() + 1);
       ys.push(head_form);
       for a in &args {
-        let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+        let (form, _v) = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
         ys.push(form);
       }
       Ok((Calcit::List(TernaryTreeList::from(&ys)), None))
@@ -457,7 +443,7 @@ fn process_list_call(
       let mut ys = Vec::with_capacity(args.len());
       ys.push(head.to_owned());
       for a in &args {
-        let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+        let (form, _v) = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
         ys.push(form);
       }
       Ok((Calcit::List(TernaryTreeList::from(&ys)), None))
@@ -471,7 +457,7 @@ fn process_list_call(
       let mut ys = Vec::with_capacity(args.len() + 1);
       ys.push(head_form);
       for a in &args {
-        let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+        let (form, _v) = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
         ys.push(form);
       }
       Ok((Calcit::List(TernaryTreeList::from(&ys)), None))
@@ -483,9 +469,9 @@ fn process_list_call(
 fn check_fn_args(
   defined_args: &[Arc<str>],
   params: &CalcitItems,
-  file_ns: Arc<str>,
-  f_name: Arc<str>,
-  def_name: Arc<str>,
+  file_ns: &str,
+  f_name: &str,
+  def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
   let mut i = 0;
@@ -519,7 +505,7 @@ fn check_fn_args(
           continue;
         } else {
           let mut warnings = check_warnings.borrow_mut();
-          let loc = NodeLocation::new(file_ns.to_owned(), GENERATED_DEF.into(), vec![]);
+          let loc = NodeLocation::new(Arc::from(file_ns), Arc::from(GENERATED_DEF), Arc::from(vec![]));
           warnings.push(LocatedWarning::new(
             format!(
               "[Warn] lack of args in {} `{:?}` with `{}`, at {}/{}",
@@ -536,7 +522,7 @@ fn check_fn_args(
       }
       (None, Some(_)) => {
         let mut warnings = check_warnings.borrow_mut();
-        let loc = NodeLocation::new(file_ns.to_owned(), GENERATED_DEF.into(), vec![]);
+        let loc = NodeLocation::new(Arc::from(file_ns), Arc::from(GENERATED_DEF), Arc::from(vec![]));
         warnings.push(LocatedWarning::new(
           format!(
             "[Warn] too many args for {} `{:?}` with `{}`, at {}/{}",
@@ -570,16 +556,16 @@ fn grab_def_name(x: &Calcit) -> Arc<str> {
 // tradition rule for processing exprs
 pub fn preprocess_each_items(
   head: &CalcitSyntax,
-  head_ns: Arc<str>,
+  head_ns: &str,
   args: &CalcitItems,
   scope_defs: &HashSet<Arc<str>>,
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns)]);
+  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), Arc::from(head_ns))]);
   for a in args {
-    let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+    let (form, _v) = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
     xs = xs.push_right(form);
   }
   Ok(Calcit::List(xs))
@@ -587,15 +573,15 @@ pub fn preprocess_each_items(
 
 pub fn preprocess_defn(
   head: &CalcitSyntax,
-  head_ns: Arc<str>,
+  head_ns: &str,
   args: &CalcitItems,
   scope_defs: &HashSet<Arc<str>>,
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
   // println!("defn args: {}", primes::CrListWrap(args.to_owned()));
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns)]);
+  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), Arc::from(head_ns))]);
   match (args.get(0), args.get(1)) {
     (
       Some(Calcit::Symbol {
@@ -626,11 +612,7 @@ pub fn preprocess_defn(
             location: arg_location,
             ..
           } => {
-            let loc = NodeLocation::new(
-              info.ns.to_owned(),
-              info.at_def.to_owned(),
-              arg_location.to_owned().unwrap_or_default(),
-            );
+            let loc = NodeLocation::new(info.ns.clone(), info.at_def.clone(), arg_location.to_owned().unwrap_or_default());
             check_symbol(sym, args, loc, check_warnings);
             zs = zs.push_right(Calcit::Symbol {
               sym: sym.to_owned(),
@@ -657,7 +639,7 @@ pub fn preprocess_defn(
       xs = xs.push_right(Calcit::List(zs));
 
       for a in args.into_iter().skip(2) {
-        let (form, _v) = preprocess_expr(a, &body_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+        let (form, _v) = preprocess_expr(a, &body_defs, file_ns, check_warnings, call_stack)?;
         xs = xs.push_right(form);
       }
       Ok(Calcit::List(xs))
@@ -693,28 +675,28 @@ fn check_symbol(sym: &str, args: &CalcitItems, location: NodeLocation, check_war
 pub fn preprocess_core_let(
   head: &CalcitSyntax,
   // where the symbol was defined
-  head_ns: Arc<str>,
+  head_ns: &str,
   args: &CalcitItems,
   scope_defs: &HashSet<Arc<str>>,
   // where called
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns.to_owned())]);
+  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), Arc::from(head_ns))]);
   let mut body_defs: HashSet<Arc<str>> = scope_defs.to_owned();
   let binding = match args.get(0) {
     Some(Calcit::List(ys)) if ys.is_empty() => Calcit::List(TernaryTreeList::Empty),
     Some(Calcit::List(ys)) if ys.len() == 2 => match (&ys[0], &ys[1]) {
       (Calcit::Symbol { sym, .. }, a) => {
         let loc = NodeLocation {
-          ns: head_ns,
+          ns: Arc::from(head_ns),
           def: GENERATED_DEF.into(),
-          coord: vec![],
+          coord: Arc::from(vec![]),
         };
         check_symbol(sym, args, loc, check_warnings);
         body_defs.insert(sym.to_owned());
-        let (form, _v) = preprocess_expr(a, &body_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+        let (form, _v) = preprocess_expr(a, &body_defs, file_ns, check_warnings, call_stack)?;
         Calcit::List(TernaryTreeList::from(&[ys[0].to_owned(), form]))
       }
       (a, b) => {
@@ -747,7 +729,7 @@ pub fn preprocess_core_let(
   };
   xs = xs.push_right(binding);
   for a in args.into_iter().skip(1) {
-    let (form, _v) = preprocess_expr(a, &body_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+    let (form, _v) = preprocess_expr(a, &body_defs, file_ns, check_warnings, call_stack)?;
     xs = xs.push_right(form);
   }
   Ok(Calcit::List(xs))
@@ -755,12 +737,12 @@ pub fn preprocess_core_let(
 
 pub fn preprocess_quote(
   head: &CalcitSyntax,
-  head_ns: Arc<str>,
+  head_ns: &str,
   args: &CalcitItems,
   _scope_defs: &HashSet<Arc<str>>,
-  _file_ns: Arc<str>,
+  _file_ns: &str,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns)]);
+  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), Arc::from(head_ns))]);
   for a in args {
     xs = xs.push_right(a.to_owned());
   }
@@ -769,17 +751,17 @@ pub fn preprocess_quote(
 
 pub fn preprocess_defatom(
   head: &CalcitSyntax,
-  head_ns: Arc<str>,
+  head_ns: &str,
   args: &CalcitItems,
   scope_defs: &HashSet<Arc<str>>,
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns)]);
+  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), Arc::from(head_ns))]);
   for a in args {
     // TODO
-    let (form, _v) = preprocess_expr(a, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+    let (form, _v) = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
     xs = xs.push_right(form.to_owned());
   }
   Ok(Calcit::List(xs))
@@ -788,22 +770,16 @@ pub fn preprocess_defatom(
 /// need to handle experssions inside unquote snippets
 pub fn preprocess_quasiquote(
   head: &CalcitSyntax,
-  head_ns: Arc<str>,
+  head_ns: &str,
   args: &CalcitItems,
   scope_defs: &HashSet<Arc<str>>,
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), head_ns)]);
+  let mut xs: CalcitItems = TernaryTreeList::from(&[Calcit::Syntax(head.to_owned(), Arc::from(head_ns))]);
   for a in args {
-    xs = xs.push_right(preprocess_quasiquote_internal(
-      a,
-      scope_defs,
-      file_ns.to_owned(),
-      check_warnings,
-      call_stack,
-    )?);
+    xs = xs.push_right(preprocess_quasiquote_internal(a, scope_defs, file_ns, check_warnings, call_stack)?);
   }
   Ok(Calcit::List(xs))
 }
@@ -811,7 +787,7 @@ pub fn preprocess_quasiquote(
 pub fn preprocess_quasiquote_internal(
   x: &Calcit,
   scope_defs: &HashSet<Arc<str>>,
-  file_ns: Arc<str>,
+  file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
@@ -821,7 +797,7 @@ pub fn preprocess_quasiquote_internal(
       Calcit::Symbol { sym, .. } if &**sym == "~" || &**sym == "~@" => {
         let mut xs: CalcitItems = TernaryTreeList::Empty;
         for y in ys {
-          let (form, _) = preprocess_expr(y, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?;
+          let (form, _) = preprocess_expr(y, scope_defs, file_ns, check_warnings, call_stack)?;
           xs = xs.push_right(form.to_owned());
         }
         Ok(Calcit::List(xs))
@@ -829,7 +805,7 @@ pub fn preprocess_quasiquote_internal(
       _ => {
         let mut xs: CalcitItems = TernaryTreeList::Empty;
         for y in ys {
-          xs = xs.push_right(preprocess_quasiquote_internal(y, scope_defs, file_ns.to_owned(), check_warnings, call_stack)?.to_owned());
+          xs = xs.push_right(preprocess_quasiquote_internal(y, scope_defs, file_ns, check_warnings, call_stack)?.to_owned());
         }
         Ok(Calcit::List(xs))
       }

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -366,31 +366,29 @@ fn process_list_call(
         Err(CalcitErr::use_msg_stack(format!("{head} expected 1 hashmap to call"), call_stack))
       }
     }
-    (
-      _,
-      Some(Calcit::Macro {
-        name,
-        def_ns,
-        args: def_args,
-        body,
-        ..
-      }),
-    ) => {
+    (_, Some(Calcit::Macro { info, .. })) => {
       let mut current_values = args.to_owned();
 
       // println!("eval macro: {}", primes::CrListWrap(xs.to_owned()));
       // println!("macro... {} {}", x, CrListWrap(current_values.to_owned()));
 
       let code = Calcit::List(xs.to_owned());
-      let next_stack = extend_call_stack(call_stack, def_ns.to_owned(), name.to_owned(), StackKind::Macro, code, &args);
+      let next_stack = extend_call_stack(
+        call_stack,
+        info.def_ns.to_owned(),
+        info.name.to_owned(),
+        StackKind::Macro,
+        code,
+        &args,
+      );
 
       let mut body_scope = CalcitScope::default();
 
       loop {
         // need to handle recursion
         // println!("evaling line: {:?}", body);
-        runner::bind_args(&mut body_scope, def_args, &current_values, &next_stack)?;
-        let code = runner::evaluate_lines(body, &body_scope, file_ns.to_owned(), &next_stack)?;
+        runner::bind_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
+        let code = runner::evaluate_lines(&info.body, &body_scope, file_ns.to_owned(), &next_stack)?;
         match code {
           Calcit::Recur(ys) => {
             current_values = ys.to_owned();

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -436,15 +436,15 @@ fn process_list_call(
       call_stack,
     )),
 
-    (
-      _,
-      Some(Calcit::Fn {
-        name: f_name,
-        args: f_args,
-        ..
-      }),
-    ) => {
-      check_fn_args(f_args, &args, file_ns.to_owned(), f_name.to_owned(), def_name, check_warnings);
+    (_, Some(Calcit::Fn { info, .. })) => {
+      check_fn_args(
+        &info.args,
+        &args,
+        file_ns.to_owned(),
+        info.name.to_owned(),
+        def_name,
+        check_warnings,
+      );
       let mut ys = Vec::with_capacity(args.len() + 1);
       ys.push(head_form);
       for a in &args {

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -300,7 +300,7 @@ pub fn preprocess_expr(
       let loc = NodeLocation {
         ns: file_ns,
         def: GENERATED_DEF.into(),
-        coord: Arc::new(vec![]),
+        coord: vec![],
       };
       warnings.push(LocatedWarning::new(
         format!("[Warn] unexpected data during preprocess: {expr:?}"),
@@ -519,7 +519,7 @@ fn check_fn_args(
           continue;
         } else {
           let mut warnings = check_warnings.borrow_mut();
-          let loc = NodeLocation::new(file_ns.to_owned(), GENERATED_DEF.into(), Arc::new(vec![]));
+          let loc = NodeLocation::new(file_ns.to_owned(), GENERATED_DEF.into(), vec![]);
           warnings.push(LocatedWarning::new(
             format!(
               "[Warn] lack of args in {} `{:?}` with `{}`, at {}/{}",
@@ -536,7 +536,7 @@ fn check_fn_args(
       }
       (None, Some(_)) => {
         let mut warnings = check_warnings.borrow_mut();
-        let loc = NodeLocation::new(file_ns.to_owned(), GENERATED_DEF.into(), Arc::new(vec![]));
+        let loc = NodeLocation::new(file_ns.to_owned(), GENERATED_DEF.into(), vec![]);
         warnings.push(LocatedWarning::new(
           format!(
             "[Warn] too many args for {} `{:?}` with `{}`, at {}/{}",
@@ -710,7 +710,7 @@ pub fn preprocess_core_let(
         let loc = NodeLocation {
           ns: head_ns,
           def: GENERATED_DEF.into(),
-          coord: Arc::new(vec![]),
+          coord: vec![],
         };
         check_symbol(sym, args, loc, check_warnings);
         body_defs.insert(sym.to_owned());

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -32,7 +32,7 @@ pub fn preprocess_ns_def(
   raw_def: Arc<str>,
   // pass original string representation, TODO codegen currently relies on this
   raw_sym: Arc<str>,
-  import_rule: Option<Arc<ImportRule>>, // returns form and possible value
+  import_rule: Option<ImportRule>, // returns form and possible value
   check_warnings: &RefCell<Vec<LocatedWarning>>,
   call_stack: &rpds::ListSync<CalcitStack>,
 ) -> Result<(Calcit, Option<Calcit>), CalcitErr> {
@@ -49,11 +49,11 @@ pub fn preprocess_ns_def(
           info: Arc::new(CalcitSymbolInfo {
             ns: ns.to_owned(),
             at_def: def.to_owned(),
-            resolved: Some(Arc::new(ResolvedDef {
+            resolved: Some(ResolvedDef {
               ns: ns.to_owned(),
               def: def.to_owned(),
               rule: import_rule,
-            })),
+            }),
           }),
           location: None,
         },
@@ -95,11 +95,11 @@ pub fn preprocess_ns_def(
               info: Arc::new(CalcitSymbolInfo {
                 ns: ns.to_owned(),
                 at_def: def.to_owned(),
-                resolved: Some(Arc::new(ResolvedDef {
+                resolved: Some(ResolvedDef {
                   ns: ns.to_owned(),
                   def: def.to_owned(),
-                  rule: Some(Arc::new(ImportRule::NsReferDef(ns.to_owned(), def.to_owned()))),
-                })),
+                  rule: Some(ImportRule::NsReferDef(ns.to_owned(), def.to_owned())),
+                }),
               }),
               location: None,
             },
@@ -112,11 +112,11 @@ pub fn preprocess_ns_def(
             info: Arc::new(CalcitSymbolInfo {
               ns: ns.to_owned(),
               at_def: def.to_owned(),
-              resolved: Some(Arc::new(ResolvedDef {
+              resolved: Some(ResolvedDef {
                 ns: ns.to_owned(),
                 def: def.to_owned(),
                 rule: import_rule,
-              })),
+              }),
             }),
             location: None,
           },
@@ -178,7 +178,7 @@ pub fn preprocess_expr(
               info: Arc::new(CalcitSymbolInfo {
                 ns: def_ns.to_owned(),
                 at_def: at_def.to_owned(),
-                resolved: Some(Arc::new(ResolvedRaw)),
+                resolved: Some(ResolvedRaw),
               }),
               location: location.to_owned(),
             },
@@ -191,7 +191,7 @@ pub fn preprocess_expr(
               info: Arc::new(CalcitSymbolInfo {
                 ns: def_ns.to_owned(),
                 at_def: at_def.to_owned(),
-                resolved: Some(Arc::new(ResolvedLocal)),
+                resolved: Some(ResolvedLocal),
               }),
               location: location.to_owned(),
             },
@@ -227,7 +227,7 @@ pub fn preprocess_expr(
               info: Arc::new(CalcitSymbolInfo {
                 ns: def_ns.to_owned(),
                 at_def: at_def.to_owned(),
-                resolved: Some(Arc::new(ResolvedRaw)),
+                resolved: Some(ResolvedRaw),
               }),
               location: location.to_owned(),
             },
@@ -246,11 +246,11 @@ pub fn preprocess_expr(
             None => {
               let from_default = program::lookup_default_target_in_import(def_ns, def);
               if let Some(target_ns) = from_default {
-                let target = Some(Arc::new(ResolvedDef {
+                let target = Some(ResolvedDef {
                   ns: target_ns.to_owned(),
                   def: def.to_owned(),
-                  rule: Some(Arc::new(ImportRule::NsDefault(target_ns))),
-                }));
+                  rule: Some(ImportRule::NsDefault(target_ns)),
+                });
                 Ok((
                   Calcit::Symbol {
                     sym: def.to_owned(),
@@ -350,11 +350,11 @@ fn process_list_call(
             info: Arc::new(crate::primes::CalcitSymbolInfo {
               ns: primes::CORE_NS.into(),
               at_def: primes::GENERATED_DEF.into(),
-              resolved: Some(Arc::new(ResolvedDef {
+              resolved: Some(ResolvedDef {
                 ns: primes::CORE_NS.into(),
                 def: "get".into(),
                 rule: None,
-              })),
+              }),
             }),
             location: None,
           },
@@ -613,7 +613,7 @@ pub fn preprocess_defn(
         info: Arc::new(CalcitSymbolInfo {
           ns: info.ns.to_owned(),
           at_def: info.at_def.to_owned(),
-          resolved: Some(Arc::new(ResolvedRaw)),
+          resolved: Some(ResolvedRaw),
         }),
         location: location.to_owned(),
       });
@@ -637,7 +637,7 @@ pub fn preprocess_defn(
               info: Arc::new(CalcitSymbolInfo {
                 ns: info.ns.to_owned(),
                 at_def: info.at_def.to_owned(),
-                resolved: Some(Arc::new(ResolvedRaw)),
+                resolved: Some(ResolvedRaw),
               }),
               location: arg_location.to_owned(),
             });

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -207,6 +207,8 @@ pub fn preprocess_expr(
             ),
             None,
           ))
+        } else if *def == info.at_def {
+          preprocess_ns_def(def_ns, def, def, None, check_warnings, call_stack)
         } else if let Ok(p) = def.parse::<CalcitProc>() {
           Ok((Calcit::Proc(p), None))
         } else if program::has_def_code(primes::CORE_NS, def) {
@@ -220,7 +222,7 @@ pub fn preprocess_expr(
               info: Arc::new(CalcitSymbolInfo {
                 ns: def_ns.to_owned(),
                 at_def: at_def.to_owned(),
-                resolved: Some(ResolvedRaw),
+                resolved: Some(ResolvedRegistered),
               }),
               location: location.to_owned(),
             },


### PR DESCRIPTION
changed Calcit enum size from 80 bytes to 48 bytes.
https://gist.github.com/tiye/e91735c53b8afcb7ba587b03ca71e8ef

```
type: `calcit::Calcit`: 48 bytes, alignment: 8 bytes
    discriminant: 1 bytes
    variant `Tuple`: 47 bytes
        padding: 7 bytes
        field `.0`: 8 bytes, alignment: 8 bytes
        field `.2`: 8 bytes
        field `.1`: 24 bytes
    variant `Recur`: 47 bytes
        padding: 7 bytes
        field `.0`: 40 bytes, alignment: 8 bytes
    variant `List`: 47 bytes
        padding: 7 bytes
        field `.0`: 40 bytes, alignment: 8 bytes
    variant `Set`: 47 bytes
        padding: 7 bytes
        field `.0`: 40 bytes, alignment: 8 bytes
    variant `Map`: 47 bytes
        padding: 7 bytes
        field `.0`: 40 bytes, alignment: 8 bytes
    variant `Record`: 47 bytes
        padding: 7 bytes
        field `.0`: 16 bytes, alignment: 8 bytes
        field `.1`: 8 bytes
        field `.2`: 8 bytes
        field `.3`: 8 bytes
    variant `Symbol`: 39 bytes
        padding: 7 bytes
        field `.location`: 8 bytes, alignment: 8 bytes
        field `.sym`: 16 bytes
        field `.info`: 8 bytes
    variant `Ref`: 31 bytes
        padding: 7 bytes
        field `.0`: 16 bytes, alignment: 8 bytes
        field `.1`: 8 bytes
    variant `Buffer`: 31 bytes
        padding: 7 bytes
        field `.0`: 24 bytes, alignment: 8 bytes
    variant `CirruQuote`: 31 bytes
        padding: 7 bytes
        field `.0`: 24 bytes, alignment: 8 bytes
    variant `Macro`: 31 bytes
        padding: 7 bytes
        field `.id`: 16 bytes, alignment: 8 bytes
        field `.info`: 8 bytes
    variant `Fn`: 31 bytes
        padding: 7 bytes
        field `.id`: 16 bytes, alignment: 8 bytes
        field `.info`: 8 bytes
    variant `Tag`: 23 bytes
        padding: 7 bytes
        field `.0`: 16 bytes, alignment: 8 bytes
    variant `Str`: 23 bytes
        padding: 7 bytes
        field `.0`: 16 bytes, alignment: 8 bytes
    variant `Thunk`: 23 bytes
        padding: 7 bytes
        field `.1`: 8 bytes, alignment: 8 bytes
        field `.0`: 8 bytes
    variant `Syntax`: 23 bytes
        field `.0`: 1 bytes
        padding: 6 bytes
        field `.1`: 16 bytes, alignment: 8 bytes
    variant `Method`: 23 bytes
        field `.1`: 1 bytes
        padding: 6 bytes
        field `.0`: 16 bytes, alignment: 8 bytes
    variant `RawCode`: 23 bytes
        field `.0`: 0 bytes
        padding: 7 bytes
        field `.1`: 16 bytes, alignment: 8 bytes
    variant `Number`: 15 bytes
        padding: 7 bytes
        field `.0`: 8 bytes, alignment: 8 bytes
    variant `Bool`: 1 bytes
        field `.0`: 1 bytes
    variant `Proc`: 1 bytes
        field `.0`: 1 bytes
    variant `Nil`: 0 bytes
```

reduce `Arc<str>` copy by using `&str`.