### PR TITLE
refactoring on spreading

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: yarn
@@ -24,7 +24,7 @@ jobs:
           toolchain: stable
 
       - uses: Swatinem/rust-cache@v2
-          
+
       - run: cargo test
       - run: cargo run --bin cr calcit/editor/compact.cirru --once
       - run: cargo run --bin cr calcit/test.cirru --once

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: yarn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cirru_edn"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219405903456d4789ff088bc37d96103abefde21f65176206b677c10d7df35fb"
+checksum = "b4e435d0f66a1d16f727720f46a89c7a203e306bf466483ba5ff65903fd0f05c"
 dependencies = [
  "bincode",
  "cirru_parser",
@@ -291,9 +291,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "im_ternary_tree"
-version = "0.0.17"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148c4e9b5a8d46fde17d94b44f205436f7b633db1692591a1b849396d37b37f7"
+checksum = "a55470afb2d20e366d19d0b03c5a5e7f868e34debcaf84883aa75b1a54df02b6"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "calcit"
-version = "0.8.34"
+version = "0.8.35"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "calcit"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "calcit"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "cirru_edn",
  "cirru_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,5 @@ path = "src/bin/bundle_calcit.rs"
 name = "caps"
 path = "src/bin/calcit_deps.rs"
 
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.8.35"
+version = "0.8.36"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.8.34"
+version = "0.8.35"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cirru_edn = "0.6.1"
+cirru_edn = "0.6.3"
 # cirru_edn = { path = "/Users/chenyong/repo/cirru/edn.rs" }
 cirru_parser = "0.1.29"
 # cirru_parser = { path = "/Users/chenyong/repo/cirru/parser.rs" }
@@ -32,7 +32,7 @@ notify-debouncer-mini = "0.4.1"
 walkdir = "2.4.0"
 hex = "0.4.3"
 rpds = "1.1.0"
-im_ternary_tree = "0.0.17"
+im_ternary_tree = "0.0.18"
 # im_ternary_tree = { path = "/Users/chenyong/repo/calcit-lang/ternary-tree.rs" }
 colored = "2.0.4"
 strum = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calcit"
-version = "0.8.33"
+version = "0.8.34"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,5 @@ path = "src/bin/bundle_calcit.rs"
 name = "caps"
 path = "src/bin/calcit_deps.rs"
 
-# [profile.release]
-# debug = true
+[profile.release]
+debug = true

--- a/calcit/test-js.cirru
+++ b/calcit/test-js.cirru
@@ -11,6 +11,7 @@
           :code $ quote
             defn main! () (log-title "|Testing js") (test-js) (test-let-example) (test-collection) (test-async)
               test-data-gen
+              test-regexp
               when (> 1 2)
                 raise $ str "|error of math" 2 1
                 raise "|base error"
@@ -153,6 +154,14 @@
               assert=
                 :: :code $ &cirru-nth (parse-cirru "|+ 1 2") 0
                 load-data-code "|:: :code $ quote $ + 1 2"
+        |test-regexp $ %{} :CodeEntry (:doc "|try raw code and regexp")
+          :code $ quote
+            fn ()
+              let
+                  pattern $ &raw-code "|/^\\d+$/"
+                js/console.log pattern
+                assert= true $ .!test pattern "|12"
+                assert= false $ .!test pattern "|xy"
       :ns $ %{} :CodeEntry (:doc |)
         :code $ quote
           ns test-js.main $ :require (|os :as os) (|assert :as assert)

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -211,6 +211,13 @@
                   *l $ atom 1
                 reset! *l 2
                 assert= 2 @*l
+
+              let
+                  Deref $ defrecord! Deref
+                    :deref $ fn (self) 2
+                  v $ %:: Deref :value 1
+                assert= 2 @v
+                assert= (nth v 1) 1
         |test-tag $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn test-tag ()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^20.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^20.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^20.11.8",

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -307,6 +307,7 @@ fn recall_program(content: &str, entries: &ProgramEntries, settings: &CLIOptions
 
 fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool) -> Result<(), String> {
   let started_time = Instant::now();
+  codegen::set_codegen_mode(true);
 
   if ir_mode {
     builtins::effects::modify_cli_running_mode(builtins::effects::CliRunningMode::Ir)?;

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -23,8 +23,7 @@ pub type FnType = fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calc
 pub type SyntaxType = fn(expr: &TernaryTreeList<Calcit>, scope: &CalcitScope, file_ns: &str) -> Result<Calcit, CalcitErr>;
 
 lazy_static! {
-  /// TODO dont use pub
-  pub static ref IMPORTED_PROCS: RwLock<HashMap<Arc<str>, FnType>> = RwLock::new(HashMap::new());
+  pub(crate) static ref IMPORTED_PROCS: RwLock<HashMap<Arc<str>, FnType>> = RwLock::new(HashMap::new());
 }
 
 pub fn is_proc_name(s: &str) -> bool {

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -302,5 +302,6 @@ pub fn is_js_syntax_procs(s: &str) -> bool {
       | "to-calcit-data"
       | "to-cirru-edn"
       | "to-js-data"
+      | "&raw-code"
   )
 }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -13,7 +13,7 @@ pub mod syntax;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use crate::calcit::{Calcit, CalcitErr, CalcitList, CalcitProc, CalcitScope, CalcitSyntax};
+use crate::calcit::{Calcit, CalcitErr, CalcitProc, CalcitScope, CalcitSyntax};
 use crate::call_stack::{using_stack, CallStackList};
 
 use im_ternary_tree::TernaryTreeList;
@@ -249,7 +249,7 @@ pub fn register_import_proc(name: &str, f: FnType) {
 
 pub fn handle_syntax(
   name: &CalcitSyntax,
-  nodes: &CalcitList,
+  nodes: &TernaryTreeList<Calcit>,
   scope: &CalcitScope,
   file_ns: &str,
   call_stack: &CallStackList,

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -79,6 +79,7 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     CalcitProc::NativeDataToCode => meta::data_to_code(args),
     CalcitProc::NativeCirruNth => meta::cirru_nth(args),
     CalcitProc::NativeCirruType => meta::cirru_type(args),
+    CalcitProc::IsSpreadingMark => meta::is_spreading_mark(args),
     // tuple
     CalcitProc::NativeTuple => meta::new_tuple(args), // unstable solution for the name
     CalcitProc::NativeClassTuple => meta::new_class_tuple(args),
@@ -266,12 +267,17 @@ pub fn handle_syntax(
     CalcitSyntax::Macroexpand => syntax::macroexpand(nodes, scope, file_ns, call_stack),
     CalcitSyntax::Macroexpand1 => syntax::macroexpand_1(nodes, scope, file_ns, call_stack),
     CalcitSyntax::MacroexpandAll => syntax::macroexpand_all(nodes, scope, file_ns, call_stack),
+    CalcitSyntax::CallSpread => syntax::call_spread(nodes, scope, file_ns, call_stack),
     CalcitSyntax::Try => syntax::call_try(nodes, scope, file_ns, call_stack),
     // "define reference" although it uses a confusing name "atom"
     CalcitSyntax::Defatom => refs::defatom(nodes, scope, file_ns, call_stack),
     CalcitSyntax::Reset => refs::reset_bang(nodes, scope, file_ns, call_stack),
     // different behavoirs, in Rust interpreter it's nil, in js codegen it's nothing
     CalcitSyntax::HintFn => meta::no_op(),
+    CalcitSyntax::ArgSpread => CalcitErr::err_nodes("`&` cannot be used as operator", &nodes.to_vec()),
+    CalcitSyntax::ArgOptional => CalcitErr::err_nodes("`?` cannot be used as operator", &nodes.to_vec()),
+    CalcitSyntax::MacroInterpolate => CalcitErr::err_nodes("`~` cannot be used as operator", &nodes.to_vec()),
+    CalcitSyntax::MacroInterpolateSpread => CalcitErr::err_nodes("`~@` cannot be used as operator", &nodes.to_vec()),
   }
 }
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -13,7 +13,7 @@ pub mod syntax;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use crate::calcit::{Calcit, CalcitErr, CalcitProc, CalcitScope, CalcitSyntax};
+use crate::calcit::{Calcit, CalcitErr, CalcitList, CalcitProc, CalcitScope, CalcitSyntax};
 use crate::call_stack::{using_stack, CallStackList};
 
 use im_ternary_tree::TernaryTreeList;
@@ -249,7 +249,7 @@ pub fn register_import_proc(name: &str, f: FnType) {
 
 pub fn handle_syntax(
   name: &CalcitSyntax,
-  nodes: &TernaryTreeList<Calcit>,
+  nodes: &CalcitList,
   scope: &CalcitScope,
   file_ns: &str,
   call_stack: &CallStackList,

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -72,7 +72,6 @@ pub fn is_rust_eval() -> bool {
   matches!(mode, CliRunningMode::Eval)
 }
 
-// TODO
 pub fn call_get_calcit_backend(_xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   Ok(Calcit::tag("rust"))
 }

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -478,7 +478,6 @@ pub fn sort(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, CalcitE
         });
         let mut ys = CalcitList::new_inner();
         for x in xs2.iter() {
-          // TODO ??
           ys = ys.push_right(x.to_owned())
         }
         Ok(Calcit::List(Arc::new(ys.into())))
@@ -506,7 +505,6 @@ pub fn sort(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, CalcitE
         });
         let mut ys = CalcitList::new_inner();
         for x in xs2.iter() {
-          // TODO ??
           ys = ys.push_right(x.to_owned())
         }
         Ok(Calcit::List(Arc::new(ys.into())))

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -457,9 +457,9 @@ pub fn sort(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, CalcitE
       // dirty since only functions being call directly then we become fast
       (Calcit::List(xs), Calcit::Fn { info, .. }) => {
         let mut xs2: Vec<Calcit> = vec![];
-        for x in &**xs {
-          xs2.push(x.to_owned())
-        }
+        xs.traverse(&mut |x| {
+          xs2.push(x.to_owned());
+        });
         xs2.sort_by(|a, b| -> Ordering {
           let v = runner::run_fn(&[(*a).to_owned(), (*b).to_owned()], info, call_stack);
           match v {
@@ -484,9 +484,9 @@ pub fn sort(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, CalcitE
       }
       (Calcit::List(xs), Calcit::Proc(proc)) => {
         let mut xs2: Vec<Calcit> = vec![];
-        for x in &**xs {
-          xs2.push(x.to_owned())
-        }
+        xs.traverse(&mut |x| {
+          xs2.push(x.to_owned());
+        });
         xs2.sort_by(|a, b| -> Ordering {
           let v = builtins::handle_proc(*proc, &[(*a).to_owned(), (*b).to_owned()], call_stack);
           match v {
@@ -646,9 +646,9 @@ pub fn list_to_set(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match &xs[0] {
     Calcit::List(ys) => {
       let mut zs = rpds::HashTrieSet::new_sync();
-      for y in &**ys {
-        zs.insert_mut((*y).to_owned());
-      }
+      ys.traverse(&mut |y| {
+        zs.insert_mut(y.to_owned());
+      });
       Ok(Calcit::Set(zs))
     }
     a => CalcitErr::err_str(format!("&list:to-set expected a list, got: {a}")),
@@ -662,11 +662,11 @@ pub fn distinct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match &xs[0] {
     Calcit::List(ys) => {
       let mut zs = CalcitList::new_inner();
-      for y in &**ys {
+      ys.traverse(&mut |y| {
         if zs.index_of(y).is_none() {
-          zs = zs.push_right((*y).to_owned());
+          zs = zs.push_right(y.to_owned());
         }
-      }
+      });
       Ok(Calcit::from(CalcitList(zs)))
     }
     a => CalcitErr::err_str(format!("&list:distinct expected a list, got: {a}")),

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use im_ternary_tree::TernaryTreeList;
-
 use crate::calcit::{Calcit, CalcitErr, CalcitList, CalcitRecord};
 
 use crate::util::number::is_even;
@@ -112,21 +110,16 @@ pub fn to_pairs(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     Some(Calcit::Map(ys)) => {
       let mut zs: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for (k, v) in ys {
-        let mut chunk = CalcitList::new_inner();
-        chunk = chunk.push_right(k.to_owned());
-        chunk = chunk.push_right(v.to_owned());
-
-        zs.insert_mut(Calcit::from(CalcitList::List(chunk)));
+        let chunk = vec![k.to_owned(), v.to_owned()];
+        zs.insert_mut(Calcit::from(chunk));
       }
       Ok(Calcit::Set(zs))
     }
     Some(Calcit::Record(CalcitRecord { fields, values, .. })) => {
       let mut zs: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for idx in 0..fields.len() {
-        let mut chunk = CalcitList::new_inner();
-        chunk = chunk.push_right(Calcit::Tag(fields[idx].to_owned()));
-        chunk = chunk.push_right(values[idx].to_owned());
-        zs.insert_mut(Calcit::from(CalcitList::List(chunk)));
+        let chunk = vec![Calcit::Tag(fields[idx].to_owned()), values[idx].to_owned()];
+        zs.insert_mut(Calcit::from(chunk));
       }
       Ok(Calcit::Set(zs))
     }
@@ -155,12 +148,12 @@ pub fn call_merge_non_nil(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 pub fn to_list(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match xs.first() {
     Some(Calcit::Map(m)) => {
-      let mut ys = CalcitList::new_inner();
+      let mut ys = vec![];
       for (k, v) in m {
-        let zs: TernaryTreeList<Calcit> = TernaryTreeList::from(&[k.to_owned(), v.to_owned()]);
-        ys = ys.push_right(Calcit::from(CalcitList::List(zs)));
+        let zs = vec![k.to_owned(), v.to_owned()];
+        ys.push(Calcit::from(zs));
       }
-      Ok(Calcit::from(CalcitList::List(ys)))
+      Ok(Calcit::from(ys))
     }
     Some(a) => CalcitErr::err_str(format!("&map:to-list expected a map, got: {a}")),
     None => CalcitErr::err_str("&map:to-list expected a map, got nothing"),

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -116,7 +116,7 @@ pub fn to_pairs(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         chunk = chunk.push_right(k.to_owned());
         chunk = chunk.push_right(v.to_owned());
 
-        zs.insert_mut(Calcit::from(CalcitList(chunk)));
+        zs.insert_mut(Calcit::from(CalcitList::List(chunk)));
       }
       Ok(Calcit::Set(zs))
     }
@@ -126,7 +126,7 @@ pub fn to_pairs(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         let mut chunk = CalcitList::new_inner();
         chunk = chunk.push_right(Calcit::Tag(fields[idx].to_owned()));
         chunk = chunk.push_right(values[idx].to_owned());
-        zs.insert_mut(Calcit::from(CalcitList(chunk)));
+        zs.insert_mut(Calcit::from(CalcitList::List(chunk)));
       }
       Ok(Calcit::Set(zs))
     }
@@ -158,9 +158,9 @@ pub fn to_list(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       let mut ys = CalcitList::new_inner();
       for (k, v) in m {
         let zs: TernaryTreeList<Calcit> = TernaryTreeList::from(&[k.to_owned(), v.to_owned()]);
-        ys = ys.push_right(Calcit::from(CalcitList(zs)));
+        ys = ys.push_right(Calcit::from(CalcitList::List(zs)));
       }
-      Ok(Calcit::from(CalcitList(ys)))
+      Ok(Calcit::from(CalcitList::List(ys)))
     }
     Some(a) => CalcitErr::err_str(format!("&map:to-list expected a map, got: {a}")),
     None => CalcitErr::err_str("&map:to-list expected a map, got nothing"),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 
 use cirru_parser::{Cirru, CirruWriterOptions};
-use im_ternary_tree::TernaryTreeList;
 
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::AtomicUsize;
@@ -524,11 +523,11 @@ pub fn tuple_params(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match &xs[0] {
     Calcit::Tuple(CalcitTuple { extra, .. }) => {
       // Ok(Calcit::List(extra.iter().map(|x| Arc::new(x.to_owned())).collect_into(vec![])))
-      let mut ys = TernaryTreeList::Empty;
+      let mut ys = vec![];
       for x in extra {
-        ys = ys.push_right(x.to_owned());
+        ys.push(x.to_owned());
       }
-      Ok(Calcit::from(CalcitList(ys)))
+      Ok(Calcit::from(ys))
     }
     x => CalcitErr::err_str(format!("&tuple:params expected a tuple, got: {x}")),
   }
@@ -589,7 +588,10 @@ pub fn format_ternary_tree(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     return CalcitErr::err_nodes("&format-ternary-tree expected 1 argument, got:", xs);
   }
   match &xs[0] {
-    Calcit::List(ys) => Ok(Calcit::Str(ys.0.format_inline().into())),
+    Calcit::List(ys) => match &**ys {
+      CalcitList::List(ys) => Ok(Calcit::Str(ys.format_inline().into())),
+      a => CalcitErr::err_str(format!("&format-ternary-tree expected a list, currently it's a vector: {a}")),
+    },
     a => CalcitErr::err_str(format!("&format-ternary-tree expected a list, got: {a}")),
   }
 }

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -36,7 +36,6 @@ pub fn type_of(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
   match &xs[0] {
     Calcit::Nil => Ok(Calcit::tag("nil")),
-    // CalcitRef(Calcit), // TODO
     Calcit::Bool(..) => Ok(Calcit::tag("bool")),
     Calcit::Number(..) => Ok(Calcit::tag("number")),
     Calcit::Symbol { .. } => Ok(Calcit::tag("symbol")),
@@ -129,7 +128,7 @@ pub fn js_gensym(name: &str) -> String {
   chunk
 }
 
-/// TODO, move out to calcit
+/// TODO, move to registered functions
 pub fn generate_id(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let size = match xs.first() {
     Some(Calcit::Number(n)) => match f64_to_usize(*n) {

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -1,8 +1,8 @@
 use crate::{
   builtins,
   calcit::{
-    self, gen_core_id, Calcit, CalcitErr, CalcitImport, CalcitList, CalcitLocal, CalcitRecord, CalcitSymbolInfo, CalcitTuple,
-    GENERATED_DEF, GEN_NS,
+    self, gen_core_id, Calcit, CalcitErr, CalcitImport, CalcitList, CalcitLocal, CalcitRecord, CalcitSymbolInfo, CalcitSyntax,
+    CalcitTuple, GENERATED_DEF, GEN_NS,
   },
   call_stack::{self, CallStackList},
   codegen::gen_ir::dump_code,
@@ -689,5 +689,15 @@ pub fn cirru_type(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       Cirru::Leaf(_) => Ok(Calcit::Tag("leaf".into())),
     },
     a => CalcitErr::err_str(format!("expected cirru quote, got: ${a}")),
+  }
+}
+
+pub fn is_spreading_mark(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  if xs.len() != 1 {
+    return CalcitErr::err_nodes("is-speading-mark? expected 1 argument, got:", xs);
+  }
+  match &xs[0] {
+    Calcit::Syntax(CalcitSyntax::ArgSpread, _) => Ok(Calcit::Bool(true)),
+    _ => Ok(Calcit::Bool(false)),
   }
 }

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -87,9 +87,9 @@ fn transform_code_to_cirru(x: &Calcit) -> Cirru {
   match x {
     Calcit::List(ys) => {
       let mut xs: Vec<Cirru> = Vec::with_capacity(ys.len());
-      for y in &**ys {
+      ys.traverse(&mut |y| {
         xs.push(transform_code_to_cirru(y));
-      }
+      });
       Cirru::List(xs)
     }
     Calcit::Symbol { sym, .. } => Cirru::Leaf((**sym).into()),

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -7,8 +7,9 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 
 use cirru_edn::EdnTag;
+use im_ternary_tree::TernaryTreeList;
 
-use crate::calcit::{Calcit, CalcitErr, CalcitImport, CalcitList, CalcitScope};
+use crate::calcit::{Calcit, CalcitErr, CalcitImport, CalcitScope};
 use crate::{call_stack::CallStackList, runner};
 
 pub(crate) type ValueAndListeners = (Calcit, HashMap<EdnTag, Calcit>);
@@ -49,8 +50,13 @@ fn modify_ref(locked_pair: Arc<Mutex<ValueAndListeners>>, v: Calcit, call_stack:
 }
 
 /// syntax to prevent expr re-evaluating
-pub fn defatom(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
-  match (expr.get_inner(0), expr.get_inner(1)) {
+pub fn defatom(
+  expr: &TernaryTreeList<Calcit>,
+  scope: &CalcitScope,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Calcit, CalcitErr> {
+  match (expr.first(), expr.get(1)) {
     (Some(Calcit::Symbol { sym, info, .. }), Some(code)) => {
       let mut path: String = (*info.at_ns).to_owned();
       path.push('/');
@@ -147,7 +153,12 @@ pub fn atom_deref(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 }
 
 /// need to be syntax since triggering internal functions requires program data
-pub fn reset_bang(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+pub fn reset_bang(
+  expr: &TernaryTreeList<Calcit>,
+  scope: &CalcitScope,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Calcit, CalcitErr> {
   if expr.len() < 2 {
     return CalcitErr::err_nodes("reset! excepted 2 arguments, got:", &expr.to_vec());
   }

--- a/src/builtins/refs.rs
+++ b/src/builtins/refs.rs
@@ -7,9 +7,8 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
 
 use cirru_edn::EdnTag;
-use im_ternary_tree::TernaryTreeList;
 
-use crate::calcit::{Calcit, CalcitErr, CalcitImport, CalcitScope};
+use crate::calcit::{Calcit, CalcitErr, CalcitImport, CalcitList, CalcitScope};
 use crate::{call_stack::CallStackList, runner};
 
 pub(crate) type ValueAndListeners = (Calcit, HashMap<EdnTag, Calcit>);
@@ -50,12 +49,7 @@ fn modify_ref(locked_pair: Arc<Mutex<ValueAndListeners>>, v: Calcit, call_stack:
 }
 
 /// syntax to prevent expr re-evaluating
-pub fn defatom(
-  expr: &TernaryTreeList<Calcit>,
-  scope: &CalcitScope,
-  file_ns: &str,
-  call_stack: &CallStackList,
-) -> Result<Calcit, CalcitErr> {
+pub fn defatom(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   match (expr.first(), expr.get(1)) {
     (Some(Calcit::Symbol { sym, info, .. }), Some(code)) => {
       let mut path: String = (*info.at_ns).to_owned();
@@ -153,12 +147,7 @@ pub fn atom_deref(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 }
 
 /// need to be syntax since triggering internal functions requires program data
-pub fn reset_bang(
-  expr: &TernaryTreeList<Calcit>,
-  scope: &CalcitScope,
-  file_ns: &str,
-  call_stack: &CallStackList,
-) -> Result<Calcit, CalcitErr> {
+pub fn reset_bang(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if expr.len() < 2 {
     return CalcitErr::err_nodes("reset! excepted 2 arguments, got:", &expr.to_vec());
   }

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -79,11 +79,11 @@ pub fn call_intersection(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 pub fn set_to_list(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match xs.first() {
     Some(Calcit::Set(xs)) => {
-      let mut ys = CalcitList::new_inner();
+      let mut ys = vec![];
       for x in xs {
-        ys = ys.push_right(x.to_owned());
+        ys.push(x.to_owned());
       }
-      Ok(Calcit::from(CalcitList(ys)))
+      Ok(Calcit::from(ys))
     }
     Some(a) => CalcitErr::err_str(format!("&set:to-list expected a set: {a}")),
     None => CalcitErr::err_str("&set:to-list expected 1 argument, got nothing"),

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -167,11 +167,12 @@ pub fn compare_string(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
+/// returns -1 if not found
 pub fn find_index(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match (xs.first(), xs.get(1)) {
     (Some(Calcit::Str(s)), Some(Calcit::Str(pattern))) => match s.find(&**pattern) {
       Some(idx) => Ok(Calcit::Number(idx as f64)),
-      None => Ok(Calcit::Number(-1.0)), // TODO maybe nil?
+      None => Ok(Calcit::Number(-1.0)),
     },
     (Some(a), Some(b)) => CalcitErr::err_str(format!("str:find-index expected 2 strings, got: {a} {b}")),
     (_, _) => CalcitErr::err_str("str:find-index expected 2 arguments, got nothing"),

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -62,13 +62,13 @@ pub fn split(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match (xs.first(), xs.get(1)) {
     (Some(Calcit::Str(s)), Some(Calcit::Str(pattern))) => {
       let pieces = (**s).split(&**pattern);
-      let mut ys = CalcitList::new_inner();
+      let mut ys = vec![];
       for p in pieces {
         if !p.is_empty() {
-          ys = ys.push_right(Calcit::Str(p.into()));
+          ys.push(Calcit::Str(p.into()));
         }
       }
-      Ok(Calcit::from(CalcitList::List(ys)))
+      Ok(Calcit::from(ys))
     }
     (Some(a), Some(b)) => CalcitErr::err_str(format!("split expected 2 strings, got: {a} {b}")),
     (_, _) => CalcitErr::err_str("split expected 2 arguments, got nothing"),

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -68,7 +68,7 @@ pub fn split(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           ys = ys.push_right(Calcit::Str(p.into()));
         }
       }
-      Ok(Calcit::from(CalcitList(ys)))
+      Ok(Calcit::from(CalcitList::List(ys)))
     }
     (Some(a), Some(b)) => CalcitErr::err_str(format!("split expected 2 strings, got: {a} {b}")),
     (_, _) => CalcitErr::err_str("split expected 2 arguments, got nothing"),
@@ -119,7 +119,7 @@ pub fn split_lines(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       for line in lines {
         ys = ys.push_right(Calcit::Str(line.to_owned().into()));
       }
-      Ok(Calcit::from(CalcitList(ys)))
+      Ok(Calcit::from(CalcitList::List(ys)))
     }
     Some(a) => CalcitErr::err_str(format!("split-lines expected 1 string, got: {a}")),
     _ => CalcitErr::err_str("split-lines expected 1 argument, got nothing"),

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -396,7 +396,7 @@ impl Hash for Calcit {
       }
       Calcit::Map(v) => {
         "map:".hash(_state);
-        // TODO order for map is not stable
+        // order for map is not stable
         let mut xs: Vec<_> = v.iter().collect();
         xs.sort();
         for x in xs {
@@ -426,7 +426,7 @@ impl Hash for Calcit {
       Calcit::Syntax(name, _ns) => {
         "syntax:".hash(_state);
         // syntax name can be used as identity
-        name.to_string().hash(_state); // TODO
+        name.to_string().hash(_state);
       }
       Calcit::Method(name, call_native) => {
         "method:".hash(_state);

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -294,7 +294,7 @@ pub fn format_to_lisp(x: &Calcit) -> String {
   match x {
     Calcit::List(ys) => {
       let mut s = String::from("(");
-      for (idx, y) in (ys.0).iter().enumerate() {
+      for (idx, y) in ys.iter().enumerate() {
         if idx > 0 {
           s.push(' ');
         }
@@ -384,7 +384,7 @@ impl Hash for Calcit {
       }
       Calcit::List(v) => {
         "list:".hash(_state);
-        v.0.hash(_state);
+        v.hash(_state);
       }
       Calcit::Set(v) => {
         "set:".hash(_state);
@@ -525,7 +525,7 @@ impl Ord for Calcit {
       (Calcit::Recur(_), _) => Less,
       (_, Calcit::Recur(_)) => Greater,
 
-      (Calcit::List(a), Calcit::List(b)) => a.0.cmp(&b.0),
+      (Calcit::List(a), Calcit::List(b)) => a.cmp(b),
       (Calcit::List(_), _) => Less,
       (_, Calcit::List(_)) => Greater,
 
@@ -615,7 +615,7 @@ impl PartialEq for Calcit {
       (Calcit::Tuple(a), Calcit::Tuple(b)) => a == b,
       (Calcit::Buffer(b), Calcit::Buffer(d)) => b == d,
       (Calcit::CirruQuote(b), Calcit::CirruQuote(d)) => b == d,
-      (Calcit::List(a), Calcit::List(b)) => a.0 == b.0,
+      (Calcit::List(a), Calcit::List(b)) => a == b,
       (Calcit::Set(a), Calcit::Set(b)) => a == b,
       (Calcit::Map(a), Calcit::Map(b)) => a == b,
       (Calcit::Record(a), Calcit::Record(b)) => a == b,
@@ -632,7 +632,13 @@ impl PartialEq for Calcit {
 
 impl From<TernaryTreeList<Calcit>> for Calcit {
   fn from(xs: TernaryTreeList<Calcit>) -> Calcit {
-    Calcit::List(Arc::new(CalcitList(xs)))
+    Calcit::List(Arc::new(CalcitList::List(xs)))
+  }
+}
+
+impl From<Vec<Calcit>> for Calcit {
+  fn from(xs: Vec<Calcit>) -> Calcit {
+    Calcit::List(Arc::new(CalcitList::Vector(xs)))
   }
 }
 

--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -40,7 +40,7 @@ pub struct CalcitFn {
   pub def_ns: Arc<str>,
   pub scope: Arc<CalcitScope>,
   pub args: Arc<CalcitFnArgs>,
-  pub body: Arc<TernaryTreeList<Calcit>>,
+  pub body: Vec<Calcit>,
 }
 
 /// Macro variant of Calcit data
@@ -50,7 +50,7 @@ pub struct CalcitMacro {
   /// where it was defined
   pub def_ns: Arc<str>,
   pub args: Arc<Vec<CalcitArgLabel>>,
-  pub body: Arc<TernaryTreeList<Calcit>>,
+  pub body: Arc<Vec<Calcit>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/calcit/list.rs
+++ b/src/calcit/list.rs
@@ -186,9 +186,8 @@ impl CalcitList {
     self.0.get(idx)
   }
 
-  /// referce to inner Calcit value
-  pub fn get_inner(&self, idx: usize) -> Option<&Calcit> {
-    self.0.get(idx)
+  pub fn first(&self) -> Option<&Calcit> {
+    self.0.first()
   }
 
   pub fn to_vec(&self) -> Vec<Calcit> {
@@ -252,6 +251,14 @@ impl CalcitList {
 
   pub fn index_of(&self, x: &Calcit) -> Option<usize> {
     self.0.index_of(x)
+  }
+
+  pub fn traverse(&self, f: &mut dyn FnMut(&Calcit)) {
+    self.0.traverse(f)
+  }
+
+  pub fn traverse_result<S>(&self, f: &mut dyn FnMut(&Calcit) -> Result<(), S>) -> Result<(), S> {
+    self.0.traverse_result(f)
   }
 
   pub fn iter(&self) -> CalcitListIterator {

--- a/src/calcit/list.rs
+++ b/src/calcit/list.rs
@@ -58,7 +58,6 @@ impl From<&CalcitList> for TernaryTreeList<Calcit> {
   }
 }
 
-// TODO maybe slow
 impl From<&TernaryTreeList<Calcit>> for CalcitList {
   fn from(xs: &TernaryTreeList<Calcit>) -> CalcitList {
     let mut ys = TernaryTreeList::Empty;
@@ -252,8 +251,7 @@ impl CalcitList {
   }
 
   pub fn index_of(&self, x: &Calcit) -> Option<usize> {
-    // TODO slow
-    self.0.index_of(&Arc::new(x.to_owned()))
+    self.0.index_of(x)
   }
 
   pub fn iter(&self) -> CalcitListIterator {

--- a/src/calcit/list.rs
+++ b/src/calcit/list.rs
@@ -184,11 +184,6 @@ impl<'a> Iterator for CalcitListIterator<'a> {
 }
 
 impl CalcitList {
-  /// create a new list without Arc
-  pub fn new_compact() -> TernaryTreeList<Calcit> {
-    TernaryTreeList::Empty
-  }
-  /// create a new list without Arc
   pub fn new_inner() -> TernaryTreeList<Calcit> {
     TernaryTreeList::Empty
   }
@@ -256,11 +251,7 @@ impl CalcitList {
 
   pub fn push_left(&self, x: Calcit) -> Self {
     match self {
-      CalcitList::Vector(xs) => {
-        let mut ys = vec![x];
-        ys.extend_from_slice(xs);
-        CalcitList::Vector(ys)
-      }
+      CalcitList::Vector(xs) => CalcitList::List(TernaryTreeList::from(xs).prepend(x)),
       CalcitList::List(xs) => CalcitList::List(xs.push_left(x)),
     }
   }

--- a/src/calcit/list.rs
+++ b/src/calcit/list.rs
@@ -1,28 +1,64 @@
 use core::fmt;
 use std::fmt::Display;
+use std::hash::Hash;
 use std::{fmt::Debug, ops::Index, sync::Arc};
 
 use im_ternary_tree::TernaryTreeList;
 
 use crate::Calcit;
 
-#[derive(Debug, PartialEq, Clone, Eq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Ord, PartialOrd)]
 /// abstraction over im_ternary_tree::TernaryTreeList
-pub struct CalcitList(pub TernaryTreeList<Calcit>);
+pub enum CalcitList {
+  Vector(Vec<Calcit>),
+  List(TernaryTreeList<Calcit>),
+}
 
 impl Display for CalcitList {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "(&CalcitList")?;
-    for x in &self.0 {
+    for x in self {
       write!(f, " {}", x)?;
     }
     write!(f, ")")
   }
 }
 
+impl PartialEq for CalcitList {
+  fn eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (CalcitList::Vector(xs), CalcitList::Vector(ys)) => xs == ys,
+      (CalcitList::List(xs), CalcitList::List(ys)) => xs == ys,
+      (a, b) => {
+        let a_size = a.len();
+        let b_size = b.len();
+        if a_size != b_size {
+          return false;
+        }
+        for idx in 0..a_size {
+          if a[idx] != b[idx] {
+            return false;
+          }
+        }
+        true
+      }
+    }
+  }
+}
+
+impl Eq for CalcitList {}
+
+impl Hash for CalcitList {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    for x in self {
+      x.hash(state);
+    }
+  }
+}
+
 impl From<TernaryTreeList<Calcit>> for CalcitList {
   fn from(xs: TernaryTreeList<Calcit>) -> CalcitList {
-    CalcitList(xs)
+    CalcitList::List(xs)
   }
 }
 
@@ -41,7 +77,7 @@ impl From<&CalcitList> for Calcit {
 impl From<CalcitList> for TernaryTreeList<Calcit> {
   fn from(xs: CalcitList) -> TernaryTreeList<Calcit> {
     let mut ys = TernaryTreeList::Empty;
-    for x in &xs.0 {
+    for x in &xs {
       ys = ys.push((*x).to_owned());
     }
     ys
@@ -51,7 +87,7 @@ impl From<CalcitList> for TernaryTreeList<Calcit> {
 impl From<&CalcitList> for TernaryTreeList<Calcit> {
   fn from(xs: &CalcitList) -> TernaryTreeList<Calcit> {
     let mut ys = TernaryTreeList::Empty;
-    for x in &xs.0 {
+    for x in xs {
       ys = ys.push((*x).to_owned());
     }
     ys
@@ -60,57 +96,45 @@ impl From<&CalcitList> for TernaryTreeList<Calcit> {
 
 impl From<&TernaryTreeList<Calcit>> for CalcitList {
   fn from(xs: &TernaryTreeList<Calcit>) -> CalcitList {
-    let mut ys = TernaryTreeList::Empty;
+    let mut ys = vec![];
     for x in xs {
-      ys = ys.push(x.to_owned());
+      ys.push(x.to_owned());
     }
-    CalcitList(ys)
+    CalcitList::Vector(ys)
   }
 }
 
 impl From<&Vec<Arc<Calcit>>> for CalcitList {
   fn from(xs: &Vec<Arc<Calcit>>) -> CalcitList {
-    let mut ys = TernaryTreeList::Empty;
+    let mut ys = vec![];
     for x in xs {
-      ys = ys.push((**x).to_owned());
+      ys.push((**x).to_owned());
     }
-    CalcitList(ys)
+    CalcitList::Vector(ys)
   }
 }
 
 impl From<&[Calcit]> for CalcitList {
   fn from(xs: &[Calcit]) -> CalcitList {
-    let mut ys = TernaryTreeList::Empty;
-    for x in xs {
-      ys = ys.push(x.to_owned());
-    }
-    CalcitList(ys)
+    CalcitList::Vector(xs.to_owned())
   }
 }
 
 impl From<&[Calcit; 2]> for CalcitList {
   fn from(xs: &[Calcit; 2]) -> CalcitList {
-    let mut ys = TernaryTreeList::Empty;
-    for x in xs {
-      ys = ys.push(x.to_owned());
-    }
-    CalcitList(ys)
+    CalcitList::Vector(xs.to_vec())
   }
 }
 
 impl From<&[Calcit; 3]> for CalcitList {
   fn from(xs: &[Calcit; 3]) -> CalcitList {
-    let mut ys = TernaryTreeList::Empty;
-    for x in xs {
-      ys = ys.push(x.to_owned());
-    }
-    CalcitList(ys)
+    CalcitList::Vector(xs.to_vec())
   }
 }
 
 impl Default for CalcitList {
   fn default() -> CalcitList {
-    CalcitList(TernaryTreeList::Empty)
+    CalcitList::List(TernaryTreeList::Empty)
   }
 }
 
@@ -118,7 +142,10 @@ impl Index<usize> for CalcitList {
   type Output = Calcit;
 
   fn index(&self, idx: usize) -> &Calcit {
-    &self.0[idx]
+    match self {
+      CalcitList::Vector(xs) => &xs[idx],
+      CalcitList::List(xs) => &xs[idx],
+    }
   }
 }
 
@@ -129,7 +156,7 @@ impl<'a> IntoIterator for &'a CalcitList {
 
   fn into_iter(self) -> Self::IntoIter {
     CalcitListIterator {
-      value: &self.0,
+      value: self,
       index: 0,
       size: self.len(),
     }
@@ -137,7 +164,7 @@ impl<'a> IntoIterator for &'a CalcitList {
 }
 
 pub struct CalcitListIterator<'a> {
-  value: &'a TernaryTreeList<Calcit>,
+  value: &'a CalcitList,
   index: usize,
   size: usize,
 }
@@ -147,7 +174,7 @@ impl<'a> Iterator for CalcitListIterator<'a> {
   fn next(&mut self) -> Option<Self::Item> {
     if self.index < self.size {
       // println!("get: {} {}", self.value.format_inline(), self.index);
-      let ret = self.value.loop_get(self.index);
+      let ret = self.value.get(self.index);
       self.index += 1;
       ret
     } else {
@@ -175,95 +202,211 @@ impl CalcitList {
   }
 
   pub fn len(&self) -> usize {
-    self.0.len()
+    match self {
+      CalcitList::Vector(xs) => xs.len(),
+      CalcitList::List(xs) => xs.len(),
+    }
   }
 
   pub fn is_empty(&self) -> bool {
-    self.0.is_empty()
+    match self {
+      CalcitList::Vector(xs) => xs.is_empty(),
+      CalcitList::List(xs) => xs.is_empty(),
+    }
   }
 
   pub fn get(&self, idx: usize) -> Option<&Calcit> {
-    self.0.get(idx)
+    match self {
+      CalcitList::Vector(xs) => xs.get(idx),
+      CalcitList::List(xs) => xs.get(idx),
+    }
   }
 
   pub fn first(&self) -> Option<&Calcit> {
-    self.0.first()
+    match self {
+      CalcitList::Vector(xs) => xs.first(),
+      CalcitList::List(xs) => xs.first(),
+    }
+  }
+
+  pub fn into_list(self) -> Self {
+    match self {
+      CalcitList::Vector(xs) => CalcitList::List(TernaryTreeList::from(xs)),
+      CalcitList::List(_) => self.to_owned(),
+    }
   }
 
   pub fn to_vec(&self) -> Vec<Calcit> {
-    self.0.iter().map(|x| (*x).to_owned()).collect()
+    match self {
+      CalcitList::Vector(xs) => xs.to_owned(),
+      CalcitList::List(xs) => xs.to_vec(),
+    }
   }
 
   pub fn push_right(&self, x: Calcit) -> Self {
-    let ys = self.0.push_right(x);
-    CalcitList(ys)
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.push(x);
+        CalcitList::List(ys)
+      }
+      CalcitList::List(xs) => CalcitList::List(xs.push(x)),
+    }
   }
 
   pub fn push_left(&self, x: Calcit) -> Self {
-    let ys = self.0.push_left(x);
-    CalcitList(ys)
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = vec![x];
+        ys.extend_from_slice(xs);
+        CalcitList::Vector(ys)
+      }
+      CalcitList::List(xs) => CalcitList::List(xs.push_left(x)),
+    }
   }
 
   pub fn drop_left(&self) -> Self {
-    let ys = self.0.drop_left();
-    CalcitList(ys)
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::Empty;
+        for x in xs.iter().skip(1) {
+          ys = ys.push(x.to_owned());
+        }
+        CalcitList::List(ys)
+      }
+      CalcitList::List(xs) => CalcitList::List(xs.drop_left()),
+    }
   }
 
   pub fn skip(&self, n: usize) -> Result<Self, String> {
-    let ys = self.0.skip(n)?;
-    Ok(CalcitList(ys))
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::Empty;
+        for x in xs.iter().skip(n) {
+          ys = ys.push(x.to_owned());
+        }
+        Ok(CalcitList::List(ys))
+      }
+      CalcitList::List(xs) => Ok(CalcitList::List(xs.skip(n)?)),
+    }
   }
 
   pub fn butlast(&self) -> Result<Self, String> {
-    let ys = self.0.butlast()?;
-    Ok(CalcitList(ys))
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::Empty;
+        for x in xs.iter().take(xs.len() - 1) {
+          ys = ys.push(x.to_owned());
+        }
+        Ok(CalcitList::List(ys))
+      }
+      CalcitList::List(xs) => Ok(CalcitList::List(xs.butlast()?)),
+    }
   }
 
   pub fn slice(&self, start: usize, end: usize) -> Result<Self, String> {
-    let ys = self.0.slice(start, end)?;
-    Ok(CalcitList(ys))
+    match self {
+      CalcitList::Vector(xs) => {
+        let ys = TernaryTreeList::from(xs);
+        Ok(CalcitList::List(ys.slice(start, end)?))
+      }
+      CalcitList::List(xs) => Ok(CalcitList::List(xs.slice(start, end)?)),
+    }
   }
 
   pub fn reverse(&self) -> Self {
-    let ys = self.0.reverse();
-    CalcitList(ys)
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::Empty;
+        for x in xs.iter() {
+          ys = ys.prepend(x.to_owned());
+        }
+        CalcitList::List(ys)
+      }
+      CalcitList::List(xs) => CalcitList::List(xs.reverse()),
+    }
   }
 
   pub fn assoc(&self, idx: usize, x: Calcit) -> Result<Self, String> {
-    let ys = self.0.assoc(idx, x)?;
-    Ok(CalcitList(ys))
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.assoc(idx, x)?;
+        Ok(CalcitList::List(ys))
+      }
+      CalcitList::List(xs) => Ok(CalcitList::List(xs.assoc(idx, x)?)),
+    }
   }
 
   pub fn dissoc(&self, idx: usize) -> Result<Self, String> {
-    let ys = self.0.dissoc(idx)?;
-    Ok(CalcitList(ys))
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.dissoc(idx)?;
+        Ok(CalcitList::List(ys))
+      }
+      CalcitList::List(xs) => Ok(CalcitList::List(xs.dissoc(idx)?)),
+    }
   }
 
   pub fn assoc_before(&self, idx: usize, x: Calcit) -> Result<Self, String> {
-    let ys = self.0.assoc_before(idx, x)?;
-    Ok(CalcitList(ys))
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.assoc_before(idx, x)?;
+        Ok(CalcitList::List(ys))
+      }
+      CalcitList::List(xs) => Ok(CalcitList::List(xs.assoc_before(idx, x)?)),
+    }
   }
 
   pub fn assoc_after(&self, idx: usize, x: Calcit) -> Result<Self, String> {
-    let ys = self.0.assoc_after(idx, x)?;
-    Ok(CalcitList(ys))
+    match self {
+      CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.assoc_after(idx, x)?;
+        Ok(CalcitList::List(ys))
+      }
+      CalcitList::List(xs) => Ok(CalcitList::List(xs.assoc_after(idx, x)?)),
+    }
   }
 
   pub fn index_of(&self, x: &Calcit) -> Option<usize> {
-    self.0.index_of(x)
+    match self {
+      CalcitList::Vector(xs) => xs.iter().position(|y| y == x),
+      CalcitList::List(xs) => xs.index_of(x),
+    }
   }
 
   pub fn traverse(&self, f: &mut dyn FnMut(&Calcit)) {
-    self.0.traverse(f)
+    match self {
+      CalcitList::Vector(xs) => {
+        for x in xs {
+          f(x);
+        }
+      }
+      CalcitList::List(xs) => {
+        xs.traverse(f);
+      }
+    }
   }
 
   pub fn traverse_result<S>(&self, f: &mut dyn FnMut(&Calcit) -> Result<(), S>) -> Result<(), S> {
-    self.0.traverse_result(f)
+    // self.0.traverse_result(f)
+    match self {
+      CalcitList::Vector(xs) => {
+        for x in xs {
+          f(x)?;
+        }
+        Ok(())
+      }
+      CalcitList::List(xs) => xs.traverse_result(f),
+    }
   }
 
   pub fn iter(&self) -> CalcitListIterator {
     CalcitListIterator {
-      value: &self.0,
+      value: self,
       index: 0,
       size: self.len(),
     }

--- a/src/calcit/list.rs
+++ b/src/calcit/list.rs
@@ -12,7 +12,11 @@ pub struct CalcitList(pub TernaryTreeList<Calcit>);
 
 impl Display for CalcitList {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "CalcitList({})", self.0.format_inline())
+    write!(f, "(&CalcitList")?;
+    for x in &self.0 {
+      write!(f, " {}", x)?;
+    }
+    write!(f, ")")
   }
 }
 

--- a/src/calcit/local.rs
+++ b/src/calcit/local.rs
@@ -36,4 +36,21 @@ impl CalcitLocal {
     let (_, s) = locals.load(idx);
     s.to_string()
   }
+
+  /// display local variables from numbers
+  pub fn display_args(xs: &[u16]) -> String {
+    let mut s = "(".to_owned();
+    let mut first = true;
+    for i in xs {
+      let name = Self::read_name(*i);
+      if first {
+        first = false;
+      } else {
+        s.push(' ');
+      }
+      s.push_str(&name);
+    }
+    s.push(')');
+    s
+  }
 }

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -70,6 +70,9 @@ pub enum CalcitProc {
   ReadFile,
   #[strum(serialize = "write-file")]
   WriteFile,
+  /// to detect syntax `&`
+  #[strum(serialize = "is-spreading-mark?")]
+  IsSpreadingMark,
   // external format
   #[strum(serialize = "parse-cirru")]
   ParseCirru,

--- a/src/calcit/syntax_name.rs
+++ b/src/calcit/syntax_name.rs
@@ -43,6 +43,21 @@ pub enum CalcitSyntax {
   /// a hint mark inside function, currently only used for `async`
   #[strum(serialize = "hint-fn")]
   HintFn,
+  /// special call for handling `&` spreading
+  #[strum(serialize = "&call-spread")]
+  CallSpread,
+  /// spreading in function definition and call
+  #[strum(serialize = "&")]
+  ArgSpread,
+  /// optional argument in function definition
+  #[strum(serialize = "?")]
+  ArgOptional,
+  /// interpolate value in macro
+  #[strum(serialize = "~")]
+  MacroInterpolate,
+  /// spreading interpolate value in macro
+  #[strum(serialize = "~@")]
+  MacroInterpolateSpread,
 }
 
 impl CalcitSyntax {

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1250,7 +1250,11 @@
           :code $ quote
             defmacro let[] (vars data & body)
               if
-                not $ and (list? vars) (every? vars symbol?)
+                not $ and (list? vars)
+                  every? vars $ fn (x)
+                    or
+                      symbol? x
+                      is-spreading-mark? x
                 raise $ str-spaced "|expects a list of definitions, got:" vars
               let
                   variable? $ symbol? data
@@ -1260,10 +1264,12 @@
                     defn let[]% (acc xs idx)
                       if (&list:empty? xs) acc $ &let ()
                         if
-                          not $ symbol? (&list:first xs)
+                          not $ or
+                            symbol? (&list:first xs)
+                            is-spreading-mark? (&list:first xs)
                           raise $ &str:concat "|Expected symbol for vars: " (&list:first xs)
                         if
-                          &= (&list:first xs) '&
+                          is-spreading-mark? (&list:first xs)
                           &let ()
                             assert "|expected list spreading" $ &= 2 (&list:count xs)
                             append acc $ [] (&list:nth xs 1)
@@ -1615,6 +1621,10 @@
           :code $ quote
             defn symbol? (x)
               &= (type-of x) :symbol
+        |syntax? $ %{} :CodeEntry (:doc "|detecting syntax element")
+          :code $ quote
+            defn syntax? (x)
+              &= (type-of x) :syntax
         |tag-match $ %{} :CodeEntry (:doc |)
           :code $ quote
             defmacro tag-match (value & body)

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -505,8 +505,8 @@
                 &let
                   x0 $ &list:first xs
                   if (list? x0)
-                    recur (append x0 base) & $ &list:rest xs
-                    recur ([] x0 base) & $ &list:rest xs
+                    &call-spread recur (append x0 base) & $ &list:rest xs
+                    &call-spread recur ([] x0 base) & $ &list:rest xs
         |/ $ %{} :CodeEntry (:doc |dividing)
           :code $ quote
             defn / (x & ys)

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,4 +1,20 @@
+use std::sync::atomic::AtomicBool;
+
 pub mod emit_js;
 pub mod gen_ir;
 
+lazy_static! {
+  /// switch whether in codegen mode
+  static ref CODEGEN_MODE: AtomicBool = AtomicBool::new(true);
+}
+
 pub const COMPILE_ERRORS_FILE: &str = "calcit.build-errors";
+
+pub fn codegen_mode() -> bool {
+  CODEGEN_MODE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// defaults to `true``
+pub fn set_codegen_mode(b: bool) {
+  CODEGEN_MODE.store(b, std::sync::atomic::Ordering::Relaxed);
+}

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -508,6 +508,11 @@ fn gen_call_code(
           )),
           (_, _) => Err(format!("set! expected 2 nodes, got: {}", body)),
         },
+        "&raw-code" => match body.get_inner(0) {
+          Some(Calcit::Str(s)) => Ok((**s).to_owned()),
+          Some(a) => Err(format!("&raw-code expected a string, got: {a}")),
+          None => Err(format!("&raw-code expected 1 node, got: {}", body)),
+        },
         _ => {
           // TODO
           let args_code = gen_args_code(&body, ns, local_defs, file_imports, tags)?;

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -374,7 +374,7 @@ fn gen_call_code(
               local_defs,
               file_imports,
             };
-            let ret = gen_js_func(sym, &get_raw_args_fn(ys)?, &func_body.into(), &passed_defs, false, tags, ns);
+            let ret = gen_js_func(sym, &get_raw_args_fn(ys)?, &func_body.to_vec(), &passed_defs, false, tags, ns);
             gen_stack::pop_call_stack();
             match ret {
               Ok(code) => Ok(format!("{return_code}{code}")),
@@ -936,7 +936,7 @@ fn uses_recur(xs: &Calcit) -> bool {
 fn gen_js_func(
   name: &str,
   args: &CalcitFnArgs,
-  raw_body: &TernaryTreeList<Calcit>,
+  raw_body: &[Calcit],
   passed_defs: &PassedDefs,
   exported: bool,
   tags: &RefCell<HashSet<EdnTag>>,

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use cirru_edn::{format, Edn, EdnListView};
-use im_ternary_tree::TernaryTreeList;
 
 use crate::calcit::{Calcit, CalcitArgLabel, CalcitFnArgs, CalcitImport, CalcitLocal, ImportInfo};
 use crate::program;
@@ -200,7 +199,7 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
   }
 }
 
-fn dump_items_code(xs: &TernaryTreeList<Calcit>) -> Edn {
+fn dump_items_code(xs: &[Calcit]) -> Edn {
   let mut ys = EdnListView::default();
   for x in xs {
     ys.push(dump_code(x));

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -181,9 +181,9 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
     Calcit::Thunk(thunk) => dump_code(thunk.get_code()),
     Calcit::List(xs) => {
       let mut ys: Vec<Edn> = Vec::with_capacity(xs.len());
-      for x in &**xs {
+      xs.traverse(&mut |x| {
         ys.push(dump_code(x));
-      }
+      });
       Edn::from(ys)
     }
     Calcit::Method(method, kind) => Edn::map_from_iter([

--- a/src/data.rs
+++ b/src/data.rs
@@ -35,56 +35,55 @@ pub fn data_to_calcit(x: &Calcit, ns: &str, at_def: &str) -> Result<Calcit, Stri
     Calcit::Registered(s) => Ok(Calcit::Registered(s.to_owned())),
     Calcit::Nil => Ok(Calcit::Nil),
     Calcit::Tuple(CalcitTuple { tag: t, extra, .. }) => {
-      let mut ys = CalcitList::new_inner_from(&[Calcit::Proc(CalcitProc::NativeTuple)]);
-      ys = ys.push_right(data_to_calcit(t, ns, at_def)?);
+      let mut ys = vec![Calcit::Proc(CalcitProc::NativeTuple), data_to_calcit(t, ns, at_def)?];
       for x in extra {
-        ys = ys.push_right(data_to_calcit(x, ns, at_def)?);
+        ys.push(data_to_calcit(x, ns, at_def)?);
       }
       Ok(Calcit::from(ys))
     }
     Calcit::List(xs) => {
-      let mut ys = CalcitList::new_inner_from(&[Calcit::Proc(CalcitProc::List)]);
+      let mut ys = vec![Calcit::Proc(CalcitProc::List)];
       xs.traverse_result::<String>(&mut |x| {
-        ys = ys.push_right(data_to_calcit(x, ns, at_def)?);
+        ys.push(data_to_calcit(x, ns, at_def)?);
         Ok(())
       })?;
       Ok(Calcit::from(ys))
     }
     Calcit::Set(xs) => {
-      let mut ys = CalcitList::new_inner_from(&[Calcit::Proc(CalcitProc::Set)]);
+      let mut ys = vec![Calcit::Proc(CalcitProc::Set)];
       for x in xs {
-        ys = ys.push_right(data_to_calcit(x, ns, at_def)?);
+        ys.push(data_to_calcit(x, ns, at_def)?);
       }
       Ok(Calcit::from(ys))
     }
     Calcit::Map(xs) => {
-      let mut ys = CalcitList::new_inner_from(&[Calcit::Proc(CalcitProc::NativeMap)]);
+      let mut ys = vec![Calcit::Proc(CalcitProc::NativeMap)];
       for (k, v) in xs {
-        ys = ys.push_right(data_to_calcit(k, ns, at_def)?);
-        ys = ys.push_right(data_to_calcit(v, ns, at_def)?);
+        ys.push(data_to_calcit(k, ns, at_def)?);
+        ys.push(data_to_calcit(v, ns, at_def)?);
       }
-      Ok(Calcit::List(Arc::new(ys.into())))
+      Ok(Calcit::from(ys))
     }
     Calcit::Record(CalcitRecord {
       name: tag, fields, values, ..
     }) => {
-      let mut ys = CalcitList::new_inner_from(&[Calcit::Symbol {
+      let mut ys = vec![Calcit::Symbol {
         sym: "defrecord!".into(),
         info: Arc::new(crate::calcit::CalcitSymbolInfo {
           at_ns: Arc::from(ns),
           at_def: Arc::from(at_def),
         }),
         location: None,
-      }]);
-      ys = ys.push_right(Calcit::Tag(tag.to_owned()));
+      }];
+      ys.push(Calcit::Tag(tag.to_owned()));
       let size = fields.len();
       for i in 0..size {
-        ys = ys.push(Calcit::from(CalcitList::from(&[
+        ys.push(Calcit::from(CalcitList::from(&[
           Calcit::tag(fields[i].ref_str()),
           data_to_calcit(&values[i], ns, at_def)?,
         ])))
       }
-      Ok(Calcit::from(CalcitList::from(ys)))
+      Ok(Calcit::from(ys))
     }
     Calcit::Ref(_, _) => Err(format!("data_to_calcit not implemented for ref: {}", x)),
     Calcit::Thunk(thunk) => Ok(thunk.get_code().to_owned()),

--- a/src/data.rs
+++ b/src/data.rs
@@ -44,9 +44,10 @@ pub fn data_to_calcit(x: &Calcit, ns: &str, at_def: &str) -> Result<Calcit, Stri
     }
     Calcit::List(xs) => {
       let mut ys = CalcitList::new_inner_from(&[Calcit::Proc(CalcitProc::List)]);
-      for x in &**xs {
+      xs.traverse_result::<String>(&mut |x| {
         ys = ys.push_right(data_to_calcit(x, ns, at_def)?);
-      }
+        Ok(())
+      })?;
       Ok(Calcit::from(ys))
     }
     Calcit::Set(xs) => {

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, vec};
 
 use cirru_parser::Cirru;
 
@@ -102,7 +102,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u8>) -> Result
       },
     },
     Cirru::List(ys) => {
-      let mut zs = CalcitList::new_inner();
+      let mut zs: Vec<Calcit> = vec![];
       for (idx, y) in ys.iter().enumerate() {
         let mut next_coord: Vec<u8> = (*coord).to_owned();
         next_coord.push(idx as u8); // code not supposed to be fatter than 256 children
@@ -115,7 +115,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u8>) -> Result
             if ys[0] == Cirru::leaf("cirru-quote") {
               // special rule for Cirru code
               if ys.len() == 2 {
-                zs = zs.push(Calcit::CirruQuote(ys[1].to_owned()));
+                zs.push(Calcit::CirruQuote(ys[1].to_owned()));
                 continue;
               }
               return Err(format!("expected 1 argument, got: {ys:?}"));
@@ -123,9 +123,9 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u8>) -> Result
           }
         }
 
-        zs = zs.push(code_to_calcit(y, ns, def, next_coord)?);
+        zs.push(code_to_calcit(y, ns, def, next_coord)?);
       }
-      Ok(Calcit::from(CalcitList(zs)))
+      Ok(Calcit::from(CalcitList::Vector(zs)))
     }
   }
 }
@@ -135,11 +135,11 @@ pub fn cirru_to_calcit(xs: &Cirru) -> Calcit {
   match xs {
     Cirru::Leaf(s) => Calcit::Str((**s).into()),
     Cirru::List(ys) => {
-      let mut zs = CalcitList::new_inner();
+      let mut zs: Vec<Calcit> = vec![];
       for y in ys {
-        zs = zs.push(cirru_to_calcit(y));
+        zs.push(cirru_to_calcit(y));
       }
-      Calcit::from(CalcitList(zs))
+      Calcit::from(CalcitList::Vector(zs))
     }
   }
 }

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -73,7 +73,12 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u8>) -> Result
           },
         ]))),
         '@' => Ok(Calcit::from(CalcitList::from(&[
-          Calcit::Proc(CalcitProc::AtomDeref),
+          // `deref` expands to `.deref` or `&atom:deref`
+          Calcit::Symbol {
+            sym: Arc::from("deref"),
+            info: symbol_info.to_owned(),
+            location: Some(coord.to_owned()),
+          },
           Calcit::Symbol {
             sym: Arc::from(&s[1..]),
             info: symbol_info.to_owned(),

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -56,7 +56,6 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u8>) -> Result
             location: Some(coord),
           },
         ]))),
-        // TODO also detect simple variables
         '~' if s.starts_with("~@") && s.chars().count() > 2 => Ok(Calcit::from(CalcitList::from(&[
           Calcit::Syntax(CalcitSyntax::MacroInterpolateSpread, ns.into()),
           Calcit::Symbol {
@@ -171,12 +170,12 @@ pub fn calcit_to_cirru(x: &Calcit) -> Result<Cirru, String> {
     Calcit::Bool(true) => Ok(Cirru::leaf("true")),
     Calcit::Bool(false) => Ok(Cirru::leaf("false")),
     Calcit::Number(n) => Ok(Cirru::Leaf(n.to_string().into())),
-    Calcit::Str(s) => Ok(Cirru::leaf(format!("|{s}"))),            // TODO performance
-    Calcit::Symbol { sym, .. } => Ok(Cirru::Leaf((**sym).into())), // TODO performance
-    Calcit::Local(CalcitLocal { sym, .. }) => Ok(Cirru::Leaf((**sym).into())), // TODO performance
-    Calcit::Import(CalcitImport { ns, def, .. }) => Ok(Cirru::Leaf((format!("{ns}/{def}")).into())), // TODO performance
+    Calcit::Str(s) => Ok(Cirru::leaf(format!("|{s}"))),
+    Calcit::Symbol { sym, .. } => Ok(Cirru::Leaf(sym.to_owned())),
+    Calcit::Local(CalcitLocal { sym, .. }) => Ok(Cirru::Leaf(sym.to_owned())),
+    Calcit::Import(CalcitImport { ns, def, .. }) => Ok(Cirru::Leaf((format!("{ns}/{def}")).into())),
     Calcit::Registered(s) => Ok(Cirru::Leaf(s.as_ref().into())),
-    Calcit::Tag(s) => Ok(Cirru::leaf(format!(":{s}"))), // TODO performance
+    Calcit::Tag(s) => Ok(Cirru::leaf(format!(":{s}"))),
     Calcit::List(xs) => {
       let mut ys: Vec<Cirru> = Vec::with_capacity(xs.len());
       for x in &**xs {

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -20,9 +20,10 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
     Calcit::Registered(def) => Ok(Edn::Symbol((**def).into())),
     Calcit::List(xs) => {
       let mut ys = EdnListView::default();
-      for x in &**xs {
+      xs.traverse_result::<String>(&mut |x| {
         ys.push(calcit_to_edn(x)?);
-      }
+        Ok(())
+      })?;
       Ok(ys.into())
     }
     Calcit::Set(xs) => {

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -124,11 +124,11 @@ pub fn edn_to_calcit(x: &Edn, options: &Calcit) -> Calcit {
       class: None,
     }),
     Edn::List(EdnListView(xs)) => {
-      let mut ys = CalcitList::new_inner();
+      let mut ys: Vec<Calcit> = vec![];
       for x in xs {
-        ys = ys.push_right(edn_to_calcit(x, options))
+        ys.push(edn_to_calcit(x, options))
       }
-      Calcit::from(CalcitList(ys))
+      Calcit::from(CalcitList::Vector(ys))
     }
     Edn::Set(EdnSetView(xs)) => {
       let mut ys: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -39,10 +39,7 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_sta
       evaluate_symbol(sym, scope, &info.at_ns, &info.at_def, location, call_stack)
     }
     Calcit::Local(CalcitLocal { idx, .. }) => evaluate_symbol_from_scope(*idx, scope),
-    Calcit::Import(CalcitImport { ns, def, coord, .. }) => {
-      // TODO might have quick path
-      evaluate_symbol_from_program(def, ns, *coord, call_stack)
-    }
+    Calcit::Import(CalcitImport { ns, def, coord, .. }) => evaluate_symbol_from_program(def, ns, *coord, call_stack),
     Calcit::List(xs) => match xs.get(0) {
       None => Err(CalcitErr::use_msg_stack(format!("cannot evaluate empty expr: {expr}"), call_stack)),
       Some(x) => {
@@ -190,6 +187,7 @@ pub fn call_expr(
       }
     }
     Calcit::Registered(alias) => {
+      // call directly to reduce clone
       let ps = IMPORTED_PROCS.read().expect("read procs");
       match ps.get(alias) {
         Some(f) => {

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -137,18 +137,8 @@ pub fn preprocess_expr(
       None => {
         let def_ns = &info.at_ns;
         let at_def = &info.at_def;
-        let def_ref = &**def;
-        // println!("def {} - {} {} {}", def_ref, def_ns, file_ns, at_def);
-        if def_ref == "~" || def_ref == "~@" || def_ref == "&" || def_ref == "?" {
-          Ok(Calcit::Symbol {
-            sym: def.to_owned(),
-            info: Arc::new(CalcitSymbolInfo {
-              at_ns: def_ns.to_owned(),
-              at_def: at_def.to_owned(),
-            }),
-            location: location.to_owned(),
-          })
-        } else if scope_defs.contains(def) {
+        // println!("def {} - {} {} {}", def, def_ns, file_ns, at_def);
+        if scope_defs.contains(def) {
           Ok(Calcit::Local(CalcitLocal {
             idx: CalcitLocal::track_sym(def),
             sym: def.to_owned(),
@@ -281,7 +271,7 @@ pub fn preprocess_expr(
       } else {
         // TODO whether function bothers this...
         // println!("start calling: {}", expr);
-        process_list_call(xs, scope_defs, file_ns, check_warnings, call_stack)
+        preprocess_list_call(xs, scope_defs, file_ns, check_warnings, call_stack)
       }
     }
     Calcit::Number(..) | Calcit::Str(..) | Calcit::Nil | Calcit::Bool(..) | Calcit::Tag(..) | Calcit::CirruQuote(..) => {
@@ -308,7 +298,7 @@ pub fn preprocess_expr(
   }
 }
 
-fn process_list_call(
+fn preprocess_list_call(
   xs: &CalcitList,
   scope_defs: &HashSet<Arc<str>>,
   file_ns: &str,
@@ -382,11 +372,22 @@ fn process_list_call(
         }
       }
       let mut ys = CalcitList::new_inner_from(&[head_form.to_owned()]);
+      let mut has_spread = false;
       for a in &args {
+        if let Calcit::Syntax(CalcitSyntax::ArgSpread, _) = a {
+          has_spread = true;
+          ys = ys.push(a.to_owned());
+          continue;
+        }
         let form = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
         ys = ys.push(form);
       }
-      Ok(Calcit::from(CalcitList(ys)))
+      if has_spread {
+        ys = ys.prepend(Calcit::Syntax(CalcitSyntax::CallSpread, info.def_ns.to_owned()));
+        Ok(Calcit::from(CalcitList(ys)))
+      } else {
+        Ok(Calcit::from(CalcitList(ys)))
+      }
     }
 
     _ => match &head_form {
@@ -461,6 +462,18 @@ fn process_list_call(
           check_warnings,
           call_stack,
         )?),
+        CalcitSyntax::CallSpread => {
+          let mut ys = CalcitList::new_inner_from(&[head_form]);
+          for a in &args {
+            let form = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
+            ys = ys.push(form);
+          }
+          Ok(Calcit::from(CalcitList(ys)))
+        }
+        CalcitSyntax::ArgSpread => CalcitErr::err_nodes("`&` cannot be preprocessed as operator", &xs.to_vec()),
+        CalcitSyntax::ArgOptional => CalcitErr::err_nodes("`?` cannot be preprocessed as operator", &xs.to_vec()),
+        CalcitSyntax::MacroInterpolate => CalcitErr::err_nodes("`~` cannot be preprocessed as operator", &xs.to_vec()),
+        CalcitSyntax::MacroInterpolateSpread => CalcitErr::err_nodes("`~@` cannot be preprocessed as operator", &xs.to_vec()),
       },
       Calcit::Thunk(..) => Err(CalcitErr::use_msg_stack(
         format!("does not know how to preprocess a thunk: {head}"),
@@ -469,11 +482,22 @@ fn process_list_call(
 
       Calcit::Method(_, _) => {
         let mut ys = CalcitList::new_inner_from(&[head.to_owned()]);
+        let mut has_spread = false;
         for a in &args {
+          if let Calcit::Syntax(CalcitSyntax::ArgSpread, _) = a {
+            has_spread = true;
+            ys = ys.push(a.to_owned());
+            continue;
+          }
           let form = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
           ys = ys.push(form);
         }
-        Ok(Calcit::from(CalcitList(ys)))
+        if has_spread {
+          ys = ys.prepend(Calcit::Syntax(CalcitSyntax::CallSpread, file_ns.into()));
+          Ok(Calcit::from(CalcitList(ys)))
+        } else {
+          Ok(Calcit::from(CalcitList(ys)))
+        }
       }
       Calcit::Proc(..)
       | Calcit::Local { .. }
@@ -483,11 +507,22 @@ fn process_list_call(
       | Calcit::RawCode(..)
       | Calcit::Symbol { .. } => {
         let mut ys = CalcitList::new_inner_from(&[head_form]);
+        let mut has_spread = false;
         for a in &args {
+          if let Calcit::Syntax(CalcitSyntax::ArgSpread, _) = a {
+            has_spread = true;
+            ys = ys.push(a.to_owned());
+            continue;
+          }
           let form = preprocess_expr(a, scope_defs, file_ns, check_warnings, call_stack)?;
           ys = ys.push(form);
         }
-        Ok(Calcit::from(CalcitList(ys)))
+        if has_spread {
+          ys = ys.prepend(Calcit::Syntax(CalcitSyntax::CallSpread, file_ns.into()));
+          Ok(Calcit::from(CalcitList(ys)))
+        } else {
+          Ok(Calcit::from(CalcitList(ys)))
+        }
       }
       h => {
         unreachable!("unknown head: {:?}", h);
@@ -662,7 +697,11 @@ pub fn preprocess_defn(
       let mut zs = CalcitList::new_inner();
       for y in &**ys {
         match y {
-          s @ Calcit::Symbol {
+          Calcit::Syntax(CalcitSyntax::ArgSpread, _)
+          | Calcit::Syntax(CalcitSyntax::ArgOptional, _)
+          | Calcit::Syntax(CalcitSyntax::MacroInterpolate, _)
+          | Calcit::Syntax(CalcitSyntax::MacroInterpolateSpread, _) => zs = zs.push(y.to_owned()),
+          Calcit::Symbol {
             sym,
             info,
             location: arg_location,
@@ -674,25 +713,20 @@ pub fn preprocess_defn(
               arg_location.to_owned().unwrap_or_default(),
             );
             check_symbol(sym, args, loc, check_warnings);
-            if &**sym == "&" || &**sym == "?" {
-              zs = zs.push_right(s.to_owned());
-              continue;
-            } else {
-              let s = Calcit::Local(CalcitLocal {
-                idx: CalcitLocal::track_sym(sym),
-                sym: sym.to_owned(),
-                info: Arc::new(CalcitSymbolInfo {
-                  at_ns: info.at_ns.to_owned(),
-                  at_def: info.at_def.to_owned(),
-                }),
-                location: arg_location.to_owned(),
-              });
-              // println!("created local: {:?}", s);
-              zs = zs.push_right(s);
+            let s = Calcit::Local(CalcitLocal {
+              idx: CalcitLocal::track_sym(sym),
+              sym: sym.to_owned(),
+              info: Arc::new(CalcitSymbolInfo {
+                at_ns: info.at_ns.to_owned(),
+                at_def: info.at_def.to_owned(),
+              }),
+              location: arg_location.to_owned(),
+            });
+            // println!("created local: {:?}", s);
+            zs = zs.push_right(s);
 
-              // track local in scope
-              body_defs.insert(sym.to_owned());
-            }
+            // track local in scope
+            body_defs.insert(sym.to_owned());
           }
           _ => {
             return Err(CalcitErr::use_msg_stack(
@@ -864,7 +898,7 @@ pub fn preprocess_quasiquote_internal(
   match x {
     Calcit::List(ys) if ys.is_empty() => Ok(x.to_owned()),
     Calcit::List(ys) => match &ys.0[0] {
-      Calcit::Symbol { sym, .. } if &**sym == "~" || &**sym == "~@" => {
+      Calcit::Syntax(CalcitSyntax::MacroInterpolate, _) | &Calcit::Syntax(CalcitSyntax::MacroInterpolateSpread, _) => {
         let mut xs = CalcitList::new_inner();
         for y in &ys.0 {
           let form = preprocess_expr(y, scope_defs, file_ns, check_warnings, call_stack)?;

--- a/src/runner/preprocess.rs
+++ b/src/runner/preprocess.rs
@@ -5,7 +5,7 @@ use crate::{
     CalcitSymbolInfo, CalcitSyntax, CalcitThunk, CalcitThunkInfo, ImportInfo, LocatedWarning, NodeLocation, RawCodeType, GENERATED_DEF,
   },
   call_stack::{CallStackList, StackKind},
-  program, runner,
+  codegen, program, runner,
 };
 
 use std::cell::RefCell;
@@ -232,9 +232,7 @@ pub fn preprocess_expr(
               });
               Ok(form)
             }
-            // TODO check js_mode
-            None if is_js_syntax_procs(def) => Ok(expr.to_owned()),
-            None if def.starts_with('.') => Ok(expr.to_owned()),
+            None if codegen::codegen_mode() && is_js_syntax_procs(def) => Ok(expr.to_owned()),
             None => {
               let from_default = program::lookup_default_target_in_import(def_ns, def);
               if let Some(target_ns) = from_default {

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -161,7 +161,11 @@ export let peekDefatom = (path: string): CalcitRef => {
 };
 
 export let _$n_atom_$o_deref = (x: CalcitRef): CalcitValue => {
-  return x.value;
+  if (x instanceof CalcitRef) {
+    return x.value;
+  } else {
+    throw new Error("Expected CalcitRef");
+  }
 };
 
 export let _$n__ADD_ = (x: number, y: number): number => {

--- a/ts-src/custom-formatter.mts
+++ b/ts-src/custom-formatter.mts
@@ -1,4 +1,4 @@
-import { CalcitValue } from "./js-primes.mjs";
+import { CalcitValue, is_literal } from "./js-primes.mjs";
 import { CalcitRef, CalcitSymbol, CalcitTag } from "./calcit-data.mjs";
 
 import { CalcitRecord } from "./js-record.mjs";
@@ -30,11 +30,37 @@ let embedObject = (x: CalcitValue) => {
   ];
 };
 
-let shortPreview = (x: string) => {
-  if (x.length > 102) {
-    return x.substring(0, 100) + "...";
+/** camel case to kabab case */
+let kabab = (s: string) => {
+  return s.replace(/[A-Z]/g, (m) => "-" + m.toLowerCase());
+};
+
+/** returns {style: "..."} */
+let styles = (o: any) => {
+  let styleCode = "";
+  let keys = Object.keys(o);
+  for (let idx = 0; idx < keys.length; idx++) {
+    let key = keys[idx];
+    styleCode += `${kabab(key)}: ${(o as any)[key]};`;
   }
-  return x;
+  return {
+    style: styleCode,
+  };
+};
+
+let hsl = (/** 0~360 */ h: number, /** 0~100 */ s: number, /** 0~100 */ l: number, /** 0~1 */ a?: number) => {
+  if (a != null) {
+    return `hsla(${h}, ${s}%, ${l}%, ${a})`;
+  }
+  return `hsl(${h}, ${s}%, ${l}%)`;
+};
+
+/** create element */
+let div = (style: any, ...children: any[]) => {
+  return ["div", styles(style), ...children];
+};
+let span = (style: any, ...children: any[]) => {
+  return ["span", styles(style), ...children];
 };
 
 export let load_console_formatter_$x_ = () => {
@@ -43,65 +69,88 @@ export let load_console_formatter_$x_ = () => {
       {
         header: (obj, config) => {
           if (obj instanceof CalcitTag) {
-            return ["div", { style: "color: hsl(240, 80%, 60%)" }, obj.toString()];
+            return div({ color: hsl(240, 80, 60) }, obj.toString());
           }
           if (obj instanceof CalcitSymbol) {
-            return ["div", { style: "color: hsl(340, 80%, 60%)" }, obj.toString()];
+            return div({ color: hsl(240, 80, 60) }, obj.toString());
           }
           if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
-            return [
-              "div",
-              { style: "color: hsl(280, 80%, 60%, 0.4)" },
-              shortPreview(obj.toString(true, true)),
-              ["span", { style: "font-size: 80%; vertical-align: 0.7em; color: hsl(280, 80%, 60%, 0.8)" }, `${obj.len()}`],
-            ];
+            let preview = "";
+            for (let idx = 0; idx < obj.len(); idx++) {
+              preview += " ";
+              if (is_literal(obj.get(idx))) {
+                preview += obj.get(idx).toString();
+              } else {
+                preview += "...";
+                break;
+              }
+            }
+            return div(
+              {
+                color: hsl(280, 80, 60, 0.4),
+              },
+              `[]`,
+              span(
+                {
+                  fontSize: "8px",
+                  verticalAlign: "middle",
+                  color: hsl(280, 80, 80, 0.8),
+                },
+                `${obj.len()}`
+              ),
+              " ",
+              preview
+            );
           }
           if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
-            return ["div", { style: "color: hsl(280, 80%, 60%, 0.4)" }, shortPreview(obj.toString(true, true))];
+            let preview = "";
+            for (let [k, v] of obj.pairs()) {
+              preview += " ";
+              if (is_literal(k) && is_literal(v)) {
+                preview += `(${k.toString()} ${v.toString()})`;
+              } else {
+                preview += "...";
+                break;
+              }
+            }
+            return div({ color: hsl(280, 80, 60, 0.4) }, "{}", preview);
           }
           if (obj instanceof CalcitSet) {
-            return ["div", { style: "color: hsl(280, 80%, 60%, 0.4)" }, obj.toString(true)];
+            return div({ color: hsl(280, 80, 60, 0.4) }, obj.toString(true));
           }
           if (obj instanceof CalcitRecord) {
-            let ret: any[] = ["div", { style: "color: hsl(280, 80%, 60%)" }, `%{} ${obj.name}`];
-            for (let idx = 0; idx < obj.fields.length; idx++) {
-              ret.push([
-                "div",
-                { style: "margin-left: 8px;" },
-                ["div", { style: "margin-left: 8px; display: inline-block;" }, embedObject(obj.fields[idx])],
-                ["div", { style: "margin-left: 8px; display: inline-block;" }, embedObject(obj.values[idx])],
-              ]);
-            }
+            let ret: any[] = div({ color: hsl(280, 80, 60, 0.4) }, `%{} ${obj.name} ...`);
             return ret;
           }
           if (obj instanceof CalcitTuple) {
-            let ret: any[] = ["div", {}];
-            ret.push(["div", { style: "display: inline-block; color: hsl(300, 100%, 40%); " }, "::"]);
-            ret.push(["div", { style: "margin-left: 6px; display: inline-block;" }, embedObject(obj.tag)]);
+            let ret: any[] = div(
+              {},
+              div({ display: "inline-block", color: hsl(300, 100, 40) }, "::"),
+              div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.tag))
+            );
             for (let idx = 0; idx < obj.extra.length; idx++) {
-              ret.push(["div", { style: "margin-left: 6px; display: inline-block;" }, embedObject(obj.extra[idx])]);
+              ret.push(div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.extra[idx])));
             }
             return ret;
           }
           if (obj instanceof CalcitRef) {
-            return [
-              "div",
-              { style: "color: hsl(280, 80%, 60%)" },
+            return div(
+              {
+                color: hsl(280, 80, 60),
+              },
               `Ref ${obj.path}`,
-              ["div", { style: "color: hsl(280, 80%, 60%)" }, ["div", { style: "margin-left: 8px;" }, embedObject(obj.value)]],
-            ];
+              div({ color: hsl(280, 80, 60) }, div({ marginLeft: "8px" }, embedObject(obj.value)))
+            );
           }
           if (obj instanceof CalcitCirruQuote) {
-            return [
-              "div",
-              { style: "color: hsl(240, 80%, 60%); display: flex;" },
+            return div(
+              { color: hsl(280, 80, 60), display: "flex" },
               `CirruQuote`,
-              [
-                "div",
-                { style: "color: hsl(280, 80%, 60%); padding: 4px 4px; margin: 0 4px 2px; border: 1px solid hsl(0,70%,90%); border-radius: 4px;" },
-                obj.textForm().trim(),
-              ],
-            ];
+              div(
+                { color: hsl(280, 80, 60), padding: "4px 4px", margin: "0 4px 2px", border: "1px solid hsl(0,70%,90%)", borderRadius: "4px" },
+                obj.textForm().trim()
+              )
+            );
           }
           return null;
         },
@@ -115,33 +164,45 @@ export let load_console_formatter_$x_ = () => {
           if (obj instanceof CalcitSet) {
             return obj.len() > 0;
           }
+          if (obj instanceof CalcitRecord) {
+            return obj.fields.length > 0;
+          }
           return false;
         },
         body: (obj, config) => {
           if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
             let flexMode = obj.len() > 40 ? "inline-flex" : "flex";
-            return ["div", { style: "color: hsl(280, 80%, 60%)" }].concat(
-              obj.toArray().map((x, idx) => {
-                return [
-                  "div",
-                  { style: `margin-left: 8px; display: ${flexMode}; padding-right: 16px;` },
-                  ["span", { style: "font-family: monospace; margin-right: 8px; color: hsl(280,80%,85%); flex-shrink: 0; font-size: 10px;" }, idx],
-                  embedObject(x),
-                ];
-              }) as any[]
+            return div(
+              { color: hsl(280, 80, 60), borderLeft: "1px solid #eee" },
+              ...(obj.toArray().map((x, idx) => {
+                return div(
+                  { marginLeft: "8px", display: flexMode, paddingRight: "16px" },
+                  span(
+                    {
+                      fontFamily: "monospace",
+                      marginRight: "8px",
+                      color: hsl(280, 80, 90),
+                      flexShrink: 0,
+                      fontSize: "10px",
+                    },
+                    idx
+                  ),
+                  embedObject(x)
+                );
+              }) as any[])
             );
           }
           if (obj instanceof CalcitSet) {
-            let ret: any[] = ["div", { style: "color: hsl(280, 80%, 60%)" }];
+            let ret: any[] = div({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
             let values = obj.values();
             for (let idx = 0; idx < values.length; idx++) {
               let x = values[idx];
-              ret.push(["div", { style: "margin-left: 8px; display: inline-block;" }, embedObject(x)]);
+              ret.push(div({ marginLeft: "8px", display: "inline-block" }, embedObject(x)));
             }
             return ret;
           }
           if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
-            let ret: any[] = ["div", { style: "color: hsl(280, 80%, 60%)" }];
+            let ret: any[] = div({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
             let pairs = obj.pairs();
             pairs.sort((pa, pb) => {
               let ka = pa[0].toString();
@@ -156,12 +217,32 @@ export let load_console_formatter_$x_ = () => {
             });
             for (let idx = 0; idx < pairs.length; idx++) {
               let [k, v] = pairs[idx];
-              ret.push([
-                "div",
-                { style: "margin-left: 8px; display: flex;" },
-                ["div", { style: "margin-left: 8px; flex-shrink: 0; display: inline-block;" }, embedObject(k)],
-                ["div", { style: "margin-left: 8px; display: inline-block;" }, embedObject(v)],
-              ]);
+              ret.push(
+                div(
+                  {
+                    marginLeft: "8px",
+                    display: "flex",
+                  },
+                  div({ marginLeft: "8px", flexShrink: 0, display: "inline-block" }, embedObject(k)),
+                  div({ marginLeft: "8px", display: "inline-block" }, embedObject(v))
+                )
+              );
+            }
+            return ret;
+          }
+          if (obj instanceof CalcitRecord) {
+            let ret: any[] = div({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
+            for (let idx = 0; idx < obj.fields.length; idx++) {
+              ret.push(
+                div(
+                  {
+                    marginLeft: "8px",
+                    display: "flex",
+                  },
+                  div({ marginLeft: "8px", display: "inline-block" }, embedObject(obj.fields[idx])),
+                  div({ marginLeft: "8px", display: "inline-block" }, embedObject(obj.values[idx]))
+                )
+              );
             }
             return ret;
           }

--- a/ts-src/custom-formatter.mts
+++ b/ts-src/custom-formatter.mts
@@ -41,7 +41,7 @@ let styles = (o: any) => {
   let keys = Object.keys(o);
   for (let idx = 0; idx < keys.length; idx++) {
     let key = keys[idx];
-    styleCode += `${kabab(key)}: ${(o as any)[key]};`;
+    styleCode += `${kabab(key)}:${(o as any)[key]};`;
   }
   return {
     style: styleCode,
@@ -62,6 +62,15 @@ let div = (style: any, ...children: any[]) => {
 let span = (style: any, ...children: any[]) => {
   return ["span", styles(style), ...children];
 };
+let table = (style: any, ...children: any[]) => {
+  return ["table", styles(style), ...children];
+};
+let tr = (style: any, ...children: any[]) => {
+  return ["tr", styles(style), ...children];
+};
+let td = (style: any, ...children: any[]) => {
+  return ["td", styles(style), ...children];
+};
 
 export let load_console_formatter_$x_ = () => {
   if (typeof window === "object") {
@@ -81,7 +90,7 @@ export let load_console_formatter_$x_ = () => {
               if (is_literal(obj.get(idx))) {
                 preview += obj.get(idx).toString();
               } else {
-                preview += "...";
+                preview += "..";
                 break;
               }
             }
@@ -109,7 +118,7 @@ export let load_console_formatter_$x_ = () => {
               if (is_literal(k) && is_literal(v)) {
                 preview += `(${k.toString()} ${v.toString()})`;
               } else {
-                preview += "...";
+                preview += "..";
                 break;
               }
             }
@@ -156,10 +165,24 @@ export let load_console_formatter_$x_ = () => {
         },
         hasBody: (obj) => {
           if (obj instanceof CalcitList || obj instanceof CalcitSliceList) {
-            return obj.len() > 0;
+            let has_collection = false;
+            for (let idx = 0; idx < obj.len(); idx++) {
+              if (!is_literal(obj.get(idx))) {
+                has_collection = true;
+                break;
+              }
+            }
+            return obj.len() > 0 && has_collection;
           }
           if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
-            return obj.len() > 0;
+            let has_collection = false;
+            for (let [k, v] of obj.pairs()) {
+              if (!is_literal(k) || !is_literal(v)) {
+                has_collection = true;
+                break;
+              }
+            }
+            return obj.len() > 0 && has_collection;
           }
           if (obj instanceof CalcitSet) {
             return obj.len() > 0;
@@ -202,7 +225,7 @@ export let load_console_formatter_$x_ = () => {
             return ret;
           }
           if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
-            let ret: any[] = div({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
+            let ret: any[] = table({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
             let pairs = obj.pairs();
             pairs.sort((pa, pb) => {
               let ka = pa[0].toString();
@@ -218,29 +241,27 @@ export let load_console_formatter_$x_ = () => {
             for (let idx = 0; idx < pairs.length; idx++) {
               let [k, v] = pairs[idx];
               ret.push(
-                div(
+                tr(
                   {
                     marginLeft: "8px",
-                    display: "flex",
                   },
-                  div({ marginLeft: "8px", flexShrink: 0, display: "inline-block" }, embedObject(k)),
-                  div({ marginLeft: "8px", display: "inline-block" }, embedObject(v))
+                  td({ marginLeft: "8px", verticalAlign: "top" }, embedObject(k)),
+                  td({ marginLeft: "8px" }, embedObject(v))
                 )
               );
             }
             return ret;
           }
           if (obj instanceof CalcitRecord) {
-            let ret: any[] = div({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
+            let ret: any[] = table({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
             for (let idx = 0; idx < obj.fields.length; idx++) {
               ret.push(
-                div(
+                tr(
                   {
                     marginLeft: "8px",
-                    display: "flex",
                   },
-                  div({ marginLeft: "8px", display: "inline-block" }, embedObject(obj.fields[idx])),
-                  div({ marginLeft: "8px", display: "inline-block" }, embedObject(obj.values[idx]))
+                  td({ marginLeft: "8px", verticalAlign: "top" }, embedObject(obj.fields[idx])),
+                  td({ marginLeft: "8px" }, embedObject(obj.values[idx]))
                 )
               );
             }

--- a/ts-src/js-cirru.mts
+++ b/ts-src/js-cirru.mts
@@ -1,7 +1,7 @@
 import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { CirruWriterNode, writeCirruCode } from "@cirru/writer.ts";
 
-import { CalcitValue, is_literal, _$n_compare } from "./js-primes.mjs";
+import { CalcitValue, isLiteral, _$n_compare } from "./js-primes.mjs";
 import { CalcitList, CalcitSliceList } from "./js-list.mjs";
 import { CalcitRecord } from "./js-record.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
@@ -99,10 +99,10 @@ export let to_cirru_edn = (x: CalcitValue): CirruEdnFormat => {
       pairs_buffer.push(pairs[idx]);
     }
     pairs_buffer.sort((a, b) => {
-      let a0_literal = is_literal(a[0]);
-      let a1_literal = is_literal(a[1]);
-      let b0_literal = is_literal(b[0]);
-      let b1_literal = is_literal(b[1]);
+      let a0_literal = isLiteral(a[0]);
+      let a1_literal = isLiteral(a[1]);
+      let b0_literal = isLiteral(b[0]);
+      let b1_literal = isLiteral(b[1]);
       if (a0_literal && b0_literal) {
         if (a1_literal && !b1_literal) {
           return -1;
@@ -132,8 +132,8 @@ export let to_cirru_edn = (x: CalcitValue): CirruEdnFormat => {
     }
     // placed literals first
     buffer.sort((a, b) => {
-      let a1_literal = is_literal(a[1] as CalcitValue);
-      let b1_literal = is_literal(b[1] as CalcitValue);
+      let a1_literal = isLiteral(a[1] as CalcitValue);
+      let b1_literal = isLiteral(b[1] as CalcitValue);
       if (a1_literal && !b1_literal) {
         return -1;
       } else if (!a1_literal && b1_literal) {

--- a/ts-src/js-list.mts
+++ b/ts-src/js-list.mts
@@ -1,6 +1,6 @@
 import * as ternaryTree from "@calcit/ternary-tree";
 
-import { CalcitValue } from "./js-primes.mjs";
+import { CalcitValue, isLiteral } from "./js-primes.mjs";
 
 import {
   TernaryTreeList,
@@ -105,6 +105,13 @@ export class CalcitList {
   }
   reverse() {
     return new CalcitList(ternaryTree.reverse(this.value));
+  }
+  nestedDataInChildren(): boolean {
+    for (let idx = 0; idx < this.len(); idx++) {
+      if (!isLiteral(this.get(idx))) {
+        return true;
+      }
+    }
   }
 }
 
@@ -253,6 +260,13 @@ export class CalcitSliceList {
   }
   reverse() {
     return this.turnListMode().reverse();
+  }
+  nestedDataInChildren(): boolean {
+    for (let idx = 0; idx < this.len(); idx++) {
+      if (!isLiteral(this.get(idx))) {
+        return true;
+      }
+    }
   }
 }
 

--- a/ts-src/js-map.mts
+++ b/ts-src/js-map.mts
@@ -1,6 +1,6 @@
 import * as ternaryTree from "@calcit/ternary-tree";
 
-import { CalcitValue } from "./js-primes.mjs";
+import { CalcitValue, isLiteral } from "./js-primes.mjs";
 import { CalcitSet } from "./js-set.mjs";
 
 import {
@@ -174,9 +174,18 @@ export class CalcitMap {
     }
     return new CalcitSet(ret);
   }
+
+  /** detecthing in custom formatter */
+  nestedDataInChildren() {
+    for (let [k, v] of this.pairs()) {
+      if (!isLiteral(k) || !isLiteral(v)) {
+        return true;
+      }
+    }
+  }
 }
 
-// store small map in linear array to reduce cost of building tree
+/* store small map in linear array to reduce cost of building tree  */
 export class CalcitSliceMap {
   cachedHash: Hash;
   /** in arrayMode, only flatten values, instead of tree structure */
@@ -368,5 +377,14 @@ export class CalcitSliceMap {
       }
     }
     return new CalcitSet(ret);
+  }
+
+  /** detecthing in custom formatter */
+  nestedDataInChildren() {
+    for (let [k, v] of this.pairs()) {
+      if (!isLiteral(k) || !isLiteral(v)) {
+        return true;
+      }
+    }
   }
 }

--- a/ts-src/js-primes.mts
+++ b/ts-src/js-primes.mts
@@ -25,7 +25,7 @@ export type CalcitValue =
   | CalcitCirruQuote
   | null;
 
-export let is_literal = (x: CalcitValue): boolean => {
+export let isLiteral = (x: CalcitValue): boolean => {
   if (x == null) return true;
   if (typeof x == "string") return true;
   if (typeof x == "boolean") return true;

--- a/ts-src/js-tuple.mts
+++ b/ts-src/js-tuple.mts
@@ -62,7 +62,6 @@ export class CalcitTuple {
       content += toString(args[i], false, disableJsDataWarning);
     }
     if (this.klass instanceof CalcitRecord) {
-      console.log("CLASS", this.klass);
       return `(%:: ${content} (:class ${this.klass.name.value}))`;
     } else {
       return `(:: ${content})`;


### PR DESCRIPTION
优化了一下 & 语法的 spreading 实现方案, 本机(计算 fibo34)又节省了 100ms

- 从原先的 Symbol 和 `&` 判断改成了 Syntax 节点判断, 少了一些字符串对比的开销
  - 包括 `&` `?` `~` `~@` 四个语法做了这样的处理,
- 引入 `&call-spread` 语法, 专门用于执行包含 spreading 的参数展开, 不对所有参数做检查

但有个极端情况, 因为 `&call-spread` 是在 preprocess 阶段自动插入的, `defmacro` 内部用到时, 可能还未插入, 这个特殊的情况需要手动插入一个 `&call-spread` 调用.
