### PR TITLE
wasm: fix nil? lowering and bump v0.12.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.12.26"
+version = "0.12.27"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.12.26"
+version = "0.12.27"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/docs/wasm-codegen.md
+++ b/docs/wasm-codegen.md
@@ -26,7 +26,8 @@ Calcit 提供了一个最小化的 WASM 编译目标，将纯数值函数子集�
 | List / Map / Set                       | ✅   | 线性内存 bump allocator  |
 | `println` / `echo` / IO               | ✅   | 通过 `io/log_value` host import |
 | 字符串字面量                           | ✅   | 编译期写入数据段         |
-| `&str:count` / `&str:nth` / `&str:first` / `&str:rest` / `&str:slice` | ✅ | UTF-8 字节操作 |
+| `&str:count` / `&str:first` / `&str:rest` / `&str:slice` | ✅ | UTF-8 字节操作 |
+| `&str:nth`                            | ✅   | 返回单字符字符串或 nil |
 | `&str:concat`                          | ✅   | bump alloc + `memory.copy` |
 | `&str:compare`                         | ✅   | 逐字节字典序比较         |
 | `&str:contains?`                       | ✅   | 字节索引范围检查         |

--- a/editing-history/202604231419-v0.12.26-wasm-bisection-fixes.md
+++ b/editing-history/202604231419-v0.12.26-wasm-bisection-fixes.md
@@ -1,0 +1,7 @@
+- Fixed WASM `&str:nth` to return a one-character string or nil, matching native Calcit semantics.
+- Added string-content-aware `=` handling in WASM while keeping `identical?` as raw-value equality.
+- Inlined imported top-level value defs in WASM so string constants like `dictionary` are usable at runtime.
+- Fixed `nil?` lowering in WASM to match the backend's nil representation.
+- Corrected `&map:diff-new` argument semantics in WASM codegen.
+- Updated WASM tests/docs to match current `&str:nth` semantics.
+- Validated with `cargo clippy -- -D warnings`, `yarn compile`, `cargo test`, and `yarn check-all` before bumping version to `0.12.26`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.12.26",
+  "version": "0.12.27",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.0.9",

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1612,7 +1612,21 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     CalcitProc::ListQuestion => emit_type_predicate(ctx, "list", args),
     CalcitProc::TagQuestion => emit_type_predicate(ctx, "tag", args),
     CalcitProc::SymbolQuestion => emit_type_predicate(ctx, "symbol", args),
-    CalcitProc::NilQuestion => emit_type_predicate(ctx, "nil", args),
+    CalcitProc::NilQuestion => {
+      // nil is represented as 0.0 (no heap allocation), so we can't use emit_type_predicate.
+      // Inline: if value == 0.0 then 1.0 else 0.0
+      // WASM select pops [condition(i32), val2(f64), val1(f64)] from top; returns val1 if cond!=0.
+      if args.len() != 1 {
+        return Err(format!("nil? expects 1 arg, got {}", args.len()));
+      }
+      ctx.emit(f64_const(1.0)); // val1: result when nil (cond == true)
+      ctx.emit(f64_const(0.0)); // val2: result when not nil
+      emit_expr(ctx, &args[0])?; // the value to test
+      ctx.emit(f64_const(0.0)); // compare against nil (0.0)
+      ctx.emit(Instruction::F64Eq); // i32 condition: 1 if value == 0.0
+      ctx.emit(Instruction::Select);
+      Ok(())
+    }
     CalcitProc::StringQuestion => emit_type_predicate(ctx, "string", args),
     CalcitProc::MapQuestion => emit_type_predicate(ctx, "map", args),
     CalcitProc::NumberQuestion => emit_type_predicate(ctx, "number", args),


### PR DESCRIPTION
Rebased on top of main (after squash merge of #274 as v0.12.26).

Changes:
- Fix `nil?` lowering in WASM: inline check `value == 0.0` instead of heap type predicate (nil has no heap tag)
- Inherits all WASM codegen work from origin/main v0.12.26 (string semantics, lazy globals, generic equality)
- Bump version 0.12.26 → 0.12.27