### PR TITLE
chore: release 0.12.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.12.56"
+version = "0.12.57"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.12.56"
+version = "0.12.57"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608012320-release-0.12.57.md
+++ b/editing-history/202608012320-release-0.12.57.md
@@ -1,0 +1,5 @@
+# Release 0.12.57
+
+- Release the merged CLI mutation, atomic staging, and test deduplication work from PR #284.
+- Include the follow-up fixes for Windows staged-file synchronization, symlink destinations, query cloning, and cursor feedback.
+- Synchronize the Rust crate and npm package versions, then refresh the workspace lockfile before publishing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.12.56",
+  "version": "0.12.57",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Release 0.12.57

- Synchronizes the Rust crate and npm package version.
- Refreshes Cargo.lock for the release.
- Includes the required release history entry.

Validation completed locally: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, `yarn compile`, `yarn check-agent-interface`, and `yarn check-all`.