### PR TITLE
feat: expand data APIs and make trait impls nominal

### DIFF
--- a/RFCs/02-04-runtime-traits-plan.md
+++ b/RFCs/02-04-runtime-traits-plan.md
@@ -1,613 +1,107 @@
-# Runtime Traits for Calcit (Draft)
+# Runtime Traits for Calcit
 
-> 目标：在运行时提供一套 Trait 机制，即使无法静态检查，也能把错误前移到调用点，并允许类型级别的能力声明（如 `Show`、`Add`、`Multiply` 等）。
+> 状态：已落地的设计基线，更新于 2026-08-02。用户语法与示例以 [`docs/features/traits.md`](../docs/features/traits.md) 为准；本文件记录实现边界与后续工作。
 
-> 文档说明（更新于 2026-02-08）：本文件用于“解释当前实现 + 修正计划”。其中“当前实现/分派规则”以现有 Rust runtime / preprocess / JS backend 的真实行为为准；计划部分提供分阶段目标与验收口径。
+## 目标
 
-## 内置 Trait 设计
+Calcit 从动态原型式方法分派演进到 trait 模型，但不把语言变成复杂的全静态类型系统。当前设计追求三点：
 
-参考 Haskell (Eq, Ord, Show, Num, Foldable, Functor) 与 Rust (Display, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Iterator, Add, Mul, From/Into) 的设计，结合 Calcit 的动态类型特性，定义以下内置 Trait：
+1. 能力约束是 nominal 的，能从 impl 来源推导，不依赖“恰好有同名方法”。
+2. 普通方法调用仍保持轻量、可组合，旧代码可以逐步迁移。
+3. native、JS 的语义一致；WASM 只承担内部 codegen 验证，不新增完整 trait runtime。
 
-### 核心 Trait 分类
+## 正交的三个层次
 
-#### 1. 显示与调试 (Display & Debug)
+### Trait definition
 
-| Trait     | 方法签名                 | 描述                 | Haskell 对应 | Rust 对应 |
-| --------- | ------------------------ | -------------------- | ------------ | --------- |
-| `Show`    | `(show x) -> :string`    | 人类可读的字符串表示 | `Show`       | `Display` |
-| `Inspect` | `(inspect x) -> :string` | 调试用的详细表示     | `Show`       | `Debug`   |
+`deftrait` 产生 trait value，包含方法名与方法类型。运行时每次求值得到新的 nominal identity；克隆保留 identity，重新加载定义会产生新 identity，因此旧 impl 不会自动满足新 trait。
 
-**默认实现**: 所有内置类型 (`nil`, `bool`, `number`, `string`, `tag`, `symbol`, `list`, `map`, `set`, `tuple`, `record`, `fn`) 都有默认实现。
+Snapshot schema 暂时只保存 symbol 形式的 trait reference。预处理在 trait value 已求值时使用 nominal metadata；只有尚未求值的 schema placeholder 才按定义结构或 bare name 回退。把 namespace-qualified trait id 持久化到 schema 是后续工作。
 
-#### 2. 相等与比较 (Equality & Ordering)
+### Trait impl
 
-| Trait     | 方法签名                | 描述                   | Haskell 对应 | Rust 对应   |
-| --------- | ----------------------- | ---------------------- | ------------ | ----------- |
-| `Eq`      | `(eq? x y) -> :bool`    | 相等性判断             | `Eq`         | `PartialEq` |
-| `Compare` | `(compare x y) -> :tag` | 返回 `:lt`/`:eq`/`:gt` | `Ord`        | `Ord`       |
+`defimpl ImplName Trait ...` 在第二个参数是具体 trait value 时产生 nominal impl：
 
-**默认实现**:
+- impl origin 是该 trait value；
+- 方法集合必须与 trait 声明完全一致；
+- 每个方法值必须 callable；
+- native 能取得函数签名时检查其与 trait method schema 是否匹配。
 
-- `Eq`: 所有值类型
-- `Compare`: `number`, `string`, `tag`, `list`（字典序）
+`assert-traits`、`:where` 和 `&trait-call` 都只接受这种 impl 作为能力证据。不同 impl 的方法不会被拼成一个虚构实现。
 
-#### 3. 算术运算 (Arithmetic)
+### Inherent method bag
 
-| Trait      | 方法签名               | 描述      | Haskell 对应 | Rust 对应 |
-| ---------- | ---------------------- | --------- | ------------ | --------- |
-| `Add`      | `(add x y) -> 'T`      | 加法/拼接 | `Num (+)`    | `Add`     |
-| `Subtract` | `(subtract x y) -> 'T` | 减法      | `Num (-)`    | `Sub`     |
-| `Multiply` | `(multiply x y) -> 'T` | 乘法      | `Num (*)`    | `Mul`     |
-| `Divide`   | `(divide x y) -> 'T`   | 除法      | `Fractional` | `Div`     |
-| `Negate`   | `(negate x) -> 'T`     | 取负      | `Num negate` | `Neg`     |
+历史写法允许把 tag 传给 `defimpl`。它继续产生 originless method bag，并参与 `.method` 查找，以保证旧项目可运行；但它不是 trait impl，不能满足能力约束。`cr edit format` 对此给出非阻断迁移告警。
 
-**默认实现**:
+这个边界取代旧的“class/prototype”概念：底层仍复用有序 impl record 作为方法表，但语言层不再把方法存在性当作 trait 身份。
 
-- `number`: 全部算术 Trait
-- `string`: `Add`（字符串拼接）
-- `list`: `Add`（列表连接）
+## 分派规则
 
-#### 4. 集合操作 (Collection)
+### `.method`
 
-| Trait      | 方法签名                      | 描述          | Haskell 对应 | Rust 对应    |
-| ---------- | ----------------------------- | ------------- | ------------ | ------------ |
-| `Len`      | `(len x) -> :number`          | 长度/大小     | `length`     | `len()`      |
-| `Empty`    | `(empty? x) -> :bool`         | 是否为空      | `null`       | `is_empty()` |
-| `Contains` | `(contains? x item) -> :bool` | 包含检查      | `elem`       | `contains()` |
-| `Get`      | `(get x key) -> 'V`           | 按键/索引取值 | `lookup`     | `get()`      |
+普通 `.method` 是按方法名查找，适合日常动态调用：
 
-**默认实现**: `string`, `list`, `map`, `set`
+- 用户 struct/enum 附加的 impl：从后向前，last-wins；
+- core builtin impl list：从前向后，first-wins，保持内建方法优先级兼容性。
 
-#### 5. 可迭代 (Iterable)
+它可以命中 nominal trait impl 或 inherent method bag。相同方法名存在多个候选时，顺序决定结果。
 
-| Trait      | 方法签名                | 描述       | Haskell 对应 | Rust 对应        | 备注                                 |
-| ---------- | ----------------------- | ---------- | ------------ | ---------------- | ------------------------------------ |
-| `Foldable` | `(fold x init f) -> 'A` | 折叠/归约  | `Foldable`   | `Iterator::fold` | ✅ 命名来自 Haskell                  |
-| `Functor`  | `(fmap x f) -> 'T`      | 保结构映射 | `Functor`    | `Iterator::map`  | 🎯 **改名建议**：用 Haskell 正统命名 |
-| `Iterable` | `(iter x) -> iterator`  | 获取迭代器 | -            | `IntoIterator`   | 统一迭代抽象                         |
+### `&trait-call`
 
-**动态语言务实方案（可选）：**
+`&trait-call Trait :method receiver ...` 先按 trait nominal identity 选择单个 impl，再从该 impl 取方法。它用于消歧义和表达“调用哪个能力”是契约的一部分。
 
-- 不单独定义 `Functor`/`Filterable`，直接在集合类型上提供 `.map`/`.filter` 方法
-- 或统一为 `Collection` trait，包含 `map`, `filter`, `fold` 全套操作
-- 类似 Rust 的 `Iterator` 或 JavaScript 的 `Array` 方法
+### `assert-traits` 与 `:where`
 
-**默认实现**: `list`, `map`, `set`, `string`
+- `assert-traits` 在 preprocess 提供 local type hint，在 runtime 查找 origin 与目标 trait 一致的单个完整 impl。
+- `:where` 使用同一能力关系做 generic substitution/checking。
+- 内建类型使用 `calcit.core` 中带真实 origin 的 impl list；初始化期静态检查有一份很小的 bootstrap capability map，避免求值顺序改变告警结果。
 
-**设计权衡说明：**
+## 内建能力
 
-- Haskell 的 `Functor`/`Monad` 威力在于类型系统保证代数定律
-- 动态语言无法静态检查这些定律，过度抽象可能适得其反
-- 推荐：借鉴概念，但保持实用导向（用户更关心"能不能 map"，而非"是不是 Functor"）
+当前主要 core traits：
 
-#### 6. 哈希与克隆 (Hash & Clone)
+| Trait | 方法 | 主要内建实现 |
+| --- | --- | --- |
+| `Show` | `.show` | nil/bool/tag/symbol/CirruQuote，以及 number/string/list/map/set/fn/record/tuple |
+| `Eq` | `.eq?` | 与 `Show` 对齐的 scalar/collection/record/tuple 类别 |
+| `Add` | `.add` | number/string/list |
+| `Multiply` | `.multiply` | number |
+| `Compare` | `.compare` | number/string |
+| `Len` | `.len` | list/map/set/string |
+| `Mappable` | `.map` | list/map/set，以及 Option/Result 自定义 impl |
+| `Countable` | `.count` | list/map/set/string/record/tuple |
+| `Contains` | `.contains?` | list/map/set/string/record/tuple |
 
-| Trait   | 方法签名              | 描述   | Haskell 对应 | Rust 对应 |
-| ------- | --------------------- | ------ | ------------ | --------- |
-| `Hash`  | `(hash x) -> :number` | 哈希值 | `Hashable`   | `Hash`    |
-| `Clone` | `(clone x) -> 'T`     | 深拷贝 | -            | `Clone`   |
+`calcit.internal` 保留不具名的原始方法包，`calcit.core` 在公开 builtin impl list 中通过 `&impl::new Trait method-bag` 将其提升为 nominal impl。scalar literals 共享只含 `Show`/`Eq` 的 impl list。这样不会制造 `calcit.internal -> calcit.core` 的 JS 模块循环，同时 native 宏预处理能看到完整 trait origin。
 
-**默认实现**: 所有不可变值类型自动满足（Calcit 默认 immutable）
+## 后端约束
 
-#### 7. 默认值与转换 (Default & Conversion)
+### Native
 
-| Trait     | 方法签名                | 描述       | Haskell 对应 | Rust 对应   |
-| --------- | ----------------------- | ---------- | ------------ | ----------- |
-| `Default` | `(default T) -> 'T`     | 类型默认值 | `Default`    | `Default`   |
-| `From`    | `(from T source) -> 'T` | 类型转换   | -            | `From/Into` |
+native 是语义基准，也是宏执行、预处理和签名校验的必经目标。trait runtime identity、impl conformance、`assert-traits` 和 `&trait-call` 都完整执行。
 
-**默认实现**:
+### JavaScript
 
-- `Default`: `nil`→`nil`, `number`→`0`, `string`→`""`, `list`→`[]`, `map`→`{}`, `set`→`#{}`
-- `From`: 常见转换如 `number->string`, `list->set`, `map->list`
+JS 是主要业务运行目标。trait identity 使用对象身份；builtin 注册使用完整 impl list；impl 方法集合与 callable 校验和 native 对齐。类型签名的主要校验发生在生成 JS 之前的 native preprocess。
 
-### Trait 定义语法（当前实现）
+### WASM
 
-当前 `deftrait` 宏仅用于声明 trait 名称与方法列表，内部调用 `&trait::new`。
+WASM 是内部验证后端。预处理已消除的 trait metadata 不影响 codegen；若运行路径仍残留 `&impl::new`、struct/enum `impl-traits` 或 `&assert-traits`，codegen 明确失败。这里不实现 JS/native 等价的 runtime trait table，也不允许静默返回 `nil` 掩盖语义缺失。
 
-```cirru
-deftrait Show :show
-deftrait Eq :eq?
-deftrait Compare :compare
-```
+## 已完成的验收口径
 
-> 说明：默认实现、依赖与方法签名描述仍在规划中，尚未落地。
+- 两个拥有相同方法名的 trait 不能互相满足 `assert-traits`。
+- `&trait-call` 只调用目标 trait 的 impl；只有另一个 trait impl 时必须失败。
+- concrete `defimpl` 拒绝 missing/extra/non-callable 方法，并在可用时拒绝签名不匹配。
+- list 等 builtin 可以通过 `assert-traits` 和 `&trait-call Countable :count` 在 native/JS 一致工作。
+- 方法 introspection 显示 builtin method bag 与 origin-carrying trait impl 的明确分层。
+- legacy tag-based method bag 继续支持 `.method`，同时触发迁移告警。
 
-### Trait 实现语法（当前实现）
+## 后续工作（控制复杂度）
 
-使用 `impl-traits` 函数式组合的方式为类型添加 Trait 实现（当前仍以 record 承载 impl，计划升级为独立 impl 结构，见后文）：
+1. 在 snapshot/schema 中持久化 namespace-qualified trait reference，删除 bare-name 静态回退。
+2. 评估 trait default methods 与 `requires`；只有 native/JS 能共同给出简单、可推导的规则时才开放语法。
+3. 观察 method lookup 成本后再决定是否缓存，不预先引入 vtable/trait-object 层。
+4. 保持 capability 粒度小；优先增加能改善真实 generic API 的 trait，避免照搬 Rust/Haskell 的完整层级。
 
-```cirru
-; 完整示例：为 Point 类型实现 Show 和 Eq trait
-let
-    ; 1. 定义基础 struct
-    Point0 $ defstruct Point (:x :number) (:y :number)
-
-    ShowTrait $ deftrait Show
-    EqTrait $ deftrait Eq
-
-    ; 2. 定义 Show trait 的实现 (record 形式)
-    show-impl $ %{} ShowTrait
-      :show $ fn (p)
-        str "|Point(" (.x p) ", " (.y p) ")"
-
-    ; 3. 定义 Eq trait 的实现
-    eq-impl $ %{} EqTrait
-      :eq? $ fn (a b)
-        and (= (:x a) (:x b)) (= (:y a) (:y b))
-
-    ; 4. 使用 impl-traits 组合，得到带 trait 实现的 struct
-    Point $ impl-traits Point0 show-impl eq-impl
-
-    ; 5. 用 struct 创建 record 实例
-    p1 $ %{} Point (:x 3) (:y 4)
-    p2 $ %{} Point (:x 3) (:y 4)
-
-  ; 6. 调用 trait 方法
-  println (.show p1)        ; => "Point(3, 4)"
-  println (.eq? p1 p2)      ; => true
-
-; impl-traits 可以接受多个 trait impl
-; (impl-traits struct-def impl1 impl2 impl3 ...)
-```
-
-**约束（更新）**：`impl-traits` 只接受 **struct/enum** 作为输入。record/tuple 是实例值，必须从已经挂载 impl 的 struct/enum 创建（如 `%{} Struct ...` 或 `%:: Enum ...`）。
-
-### Trait 约束与标注（新增）
-
-`assert-traits` 用于在编译期提供“trait 标注”，并在运行时进行检查：
-
-- **编译期标记**：将本地变量标注为 trait 类型，供方法解析与类型提示使用。
-- **运行时检查**：确保值确实实现该 trait（缺失方法时直接报错）。
-
-补充（与当前实现一致）：
-
-- `assert-traits` 是一个语法（syntax），会在 preprocess 阶段被展开为对内建过程 `&assert-traits` 的调用；runtime 并不直接执行 `assert-traits` 语法本身。
-- 当前实现要求第一个参数必须是 **local**，用于把 type-info 写回作用域类型表并用于后续方法校验/类型提示。
-
-**行为细则（基于当前实现，补充更具体的定义）：**
-
-1. **两种写法与作用范围**
-
-- **函数 body 顶层写法**（推荐，作为函数前置约束）：
-  - 写在函数 body 顶层的 `assert-traits x Trait` 被视为“参数/局部的全局约束”。
-  - 静态分析会把它当作参数类型提示来源（与 `assert-type` 同级别），影响整个函数体内的 `.method` 校验与提示。
-  - 运行时会在执行到该表达式时进行检查（缺失方法则抛错）。
-
-- **函数 body 内部嵌套写法**（表达式/返回值约束）：
-  - `assert-traits` 作为表达式参与计算时，主要用于约束该表达式（及其返回值链路）；适用于在局部链路上增加约束，减少 `let _ ...` 这类“仅为检查而写”的绑定。
-  - 当前实现的参数类型提示扫描会遍历函数体中的 `assert-traits`，因此严格来说嵌套写法也可能被识别为参数提示；但约定上仅将顶层写法视为“函数级前置约束”。
-
-2. **静态分析（preprocess）行为**
-
-- 会在当前作用域把 local 的 type-info 写入 `scope_types`，供后续 `.method` 校验/补全使用。
-- `assert-traits` 参数中的 trait 解析规则：
-  - 能解析为 trait 定义的，进入 trait 集合。
-  - 若解析不到 trait，会降级为自定义类型标注，仅用于类型提示（不参与方法校验）。
-- 多个 trait 通过 **append** 形成 `TraitSet`；当多次 `assert-traits` 作用于同一个 local 时，后者的 type-info 会覆盖前者。
-- 若 local 已有**具体类型**标注（如 record/struct/enum 或内置类型），`assert-traits` 不会覆盖该具体类型，以保证后续方法内联与 impl 查找仍可进行。
-
-**静态分析可执行边界（重要）**
-
-- 只有顶层 `ns/def` 可在构建快照阶段执行；`defn`/`defmacro`/thunk 内部表达式不会被执行，只做浅层预处理。
-- 因此 `defstruct`/`defenum`/`impl-traits` 若写在函数体内，静态分析阶段无法拿到 impl 列表，也就无法做方法内联与精确分派。
-- 建议把结构定义与 impl 绑定放在**顶层定义**（单独 `def`），使 preprocess 可稳定使用这些值进行分析与优化。
-
-3. **运行时行为**
-
-- 预处理会把 `assert-traits` 展开成一连串 `&assert-traits` 调用，运行时逐个检查 trait 是否实现。
-- 检查顺序按写入顺序执行；当 trait 列表存在重复方法时，实际方法分派仍遵循 impl 分派规则（user impls last-wins / core impls first-wins）。
-- **内置类型限制**：list/map/set/string/number 等内置数据结构的 impl 列表是固定的，`assert-traits` **不会** 在运行时扩充它们的可用方法，只做“默认实现是否存在”的校验。
-- **静态/运行时不一致**：由于静态分析信息有限，preprocess 的 trait 标注可能比运行时更宽松；当前允许这种不一致存在。
-
-4. **顺序与覆盖**
-
-- trait 信息的记录是 **append 模式**，但对方法分派的“命中优先级”仍以 impl 链为准；当存在多重 trait/impl 时，**从末尾开始命中**（last-wins）是用户自定义 impl 的生效方向。
-- `assert-traits` 只影响“能不能调用/能否单态化”的判断，不改变实际方法分派的实现来源。
-
-```cirru
-; 在调用点标注并断言 trait 能力
-assert-traits x Show
-; 允许编译期把 x 视作 trait object，方便后续的 .show/.eq? 等方法校验
-```
-
-**类型标注支持**：trait 定义可作为类型标注值使用（与 struct/enum 类似）。
-
-- 例：`assert-traits x Show` 会把 `x` 的类型标注为 `trait Show`。
-
-### 分派规则（当前实现）
-
-当前 `.method` 调用（包含 trait 方法）本质上是对“impl records 列表”的查找。
-
-分派来源与优先级：
-
-| 场景         | impl 来源                                                        | 覆盖策略       | 扫描方向 | 备注                                                         |
-| ------------ | ---------------------------------------------------------------- | -------------- | -------- | ------------------------------------------------------------ |
-| 用户自定义值 | Record/Tuple/Struct/Enum 实例的 `impls`（由 `impl-traits` 追加） | **last-wins**  | 从尾到头 | 支持“后追加覆盖前实现”（append-to-override）                 |
-| 内置类型     | `calcit.core` 中的 `&core-*-impls`（core impl list）             | **first-wins** | 从头到尾 | 保持 core 列表顺序语义（如 list `.add` vs Add trait `:add`） |
-
-1. **用户自定义值的 `impls`（Record/Tuple/Struct/Enum 实例）**
-
-- `impl-traits` 会把新的 impl record **追加** 到值的 `impls` 末尾（不可变地返回新值）。
-- 查找策略：**last-wins**（从尾到头扫描，先命中先调用）。
-- 目的：支持稳定的“后追加覆盖前已有实现”的工作流。
-
-2. **内置类型的 core impl 列表（list/map/number/string/set/fn 等）**
-
-- runtime 会把值映射到 `calcit.core` 中的 `&core-*-impls`（这是一个 record 或 record 列表）。
-- 查找策略：**first-wins**（从头到尾扫描，先命中先调用）。
-- 目的：保持 `calcit.core` 中现有 impl 列表的顺序语义（已存在依赖顺序的案例：list 的 `.add` 与 Add trait 的 `:add` 同名时，core 列表顺序决定行为）。
-
-一致性要求：preprocess 的方法校验/内联与 JS backend 的 `invoke_method` 需要与上述规则保持一致（当前已对齐）。
-
-```cirru
-; 分派示例
-.show 42        ; → 查找 number 的 Show 实现 → "42"
-.show my-point  ; → 查找 Point record 的 Show 实现 → "Point(1, 2)"
-
-; 显式 Trait 调用（计划，用于消歧义）
-; (trait-call Show :show 42)
-; (Show/show 42)
-```
-
-### 内置类型的 Trait 实现映射
-
-- `nil`: Show, Inspect, Eq, Hash
-- `bool`: Show, Inspect, Eq, Hash
-- `number`: Show, Inspect, Eq, Compare, Add, Multiply, Hash
-- `string`: Show, Inspect, Eq, Compare, Add, Len, Foldable, Functor, Hash
-- `tag`: Show, Inspect, Eq, Compare, Hash
-- `symbol`: Show, Inspect, Eq, Hash
-- `list`: Show, Inspect, Eq, Compare, Add, Len, Foldable, Functor, Hash
-- `map`: Show, Inspect, Eq, Len, Foldable, Functor, Hash
-- `set`: Show, Inspect, Eq, Len, Foldable, Functor, Hash
-- `tuple`: Show, Inspect, Eq, Len, Hash
-- `record`: Show, Inspect, Eq, Len, Hash
-- `fn`: Show, Inspect
-
-### 实施阶段（对照当前进度）
-
-#### Phase 1: 基础 Trait 结构 ✅ **已完成**
-
-1. ✅ 定义 `CalcitTrait` 数据结构 (src/calcit/calcit_trait.rs)
-2. ✅ 在 `Calcit` enum 中添加 `Trait(CalcitTrait)` 变体
-3. ✅ 在 `calcit.core` 中定义 `Show`, `Eq`, `Add`, `Multiply`, `Len` 等核心 trait
-4. ✅ 内置类型自动拥有对应实现（已在运行时与 JS backend 对齐）
-5. ✅ `invoke_method` 支持 Trait 方法查找
-6. ✅ 从 `class` 系统迁移到 `trait` 和 `impls` (commit 73aa249)
-7. ✅ `impl-traits` 函数支持为 record/tuple/struct/enum 追加 impl
-8. ✅ JS backend 完整支持 CalcitTrait 及相关操作
-9. ✅ 移动内部实现到 `calcit.internal` 命名空间以清理代码结构
-
-#### Phase 2: 语法支持 🔄 **部分完成**
-
-1. ✅ `deftrait` 宏定义（支持方法名 + 类型签名）
-2. ✅ 基础 trait 实现语法（通过 record + `impl-traits`）
-3. ✅ 测试覆盖：`test-traits.cirru` 包含 Show/Eq/Compare/Add/Len 等基础测试
-4. ✅ `defimpl` 最小宏定义（当前展开为 `defrecord!`，用于更清晰地定义 impl record）
-5. ⏳ `defimpl ... for ...`（让宏直接表达“trait + 目标类型/值”，并减少手写 `impl-traits` 的样板）
-6. ✅ `assert-traits` 运行时检查与编译期标注（当前限制：第一个参数需要是 local；preprocess 展开为 `&assert-traits`）
-7. ⏳ Trait 方法的显式调用语法（如 `Show/show` 或 `trait-call`）
-
-#### Phase 3: 扩展 📋 **待实现**
-
-1. ⏳ 完整的集合 Trait (`Foldable`, `Mappable`, `Filterable`)
-2. ⏳ `Default`, `From` 转换 Trait
-3. ⏳ Trait 依赖（`requires`）与默认实现（`defaults`）
-4. ⏳ Trait 继承/组合
-5. ⏳ 更好的错误消息（trait 不匹配时的详细提示）
-6. ⏳ 性能优化（trait 查找缓存）
-
----
-
-## 范围评估
-
-### 1) 核心数据结构与运行时
-
-- **`Calcit` 新增变种**：`Trait`（已完成），新增 `Impl` 变种用于承载 trait impl（从 record 迁移）。
-- **运行时上下文**：不单独引入 registry，内置 Trait 直接放在 `calcit.core`，其他 Trait 作为普通值附着在各自命名空间上。
-- **调用分派**：方法调用/操作符调用在当前命名空间与 `calcit.core` 中解析 Trait 值，再执行绑定实现。
-- **Trait 实现承载**：Traits 以组合方式使用，携带实现时统一使用 `Vec`；计划引入 `CalcitImpl` 作为一等结构，替代 record 承载（同时保留向后兼容的过渡层）。
-- **错误模型**：为 trait 查找失败、约束不满足等错误引入新的错误类别与消息格式。
-
-### 2) 标准库/内建能力定义
-
-- **内建类型能力**：
-  - `Show`：所有类型默认实现（或至少 `nil/bool/number/string/list/map/set/tuple`）。
-  - `Add`/`Multiply`：`number` 实现；`string` 可选实现 `Add`（拼接）但需明确语义。
-  - 其他可选：`Compare`、`Eq`、`Hash`、`Len`、`Index` 等。
-- **内建函数/语法桥接**：
-  - `+`, `*`, `str` 等需要改为通过 trait 调用或保留内建分支 + trait 兜底。
-  - 现有 `method`/`record`/`tuple` 行为需要确定与 trait 的交互规则。
-
-### 3) 语言层定义与语法
-
-- **Trait 定义**：动态类型前提下，可先按普通值定义 Trait，后续再考虑是否需要专用语法（如 `deftrait`）。
-- **Trait 实现**：满足 Trait 的实现直接使用 record 表达，运行时通过 `with-class` 之类的机制挂上去（未来可能调整）。
-- **Trait 约束表达**：考虑引入 `assert-traits`，用法类似 `assert-type`，用于声明约束与在调用处触发运行时检查。
-
-### 4) 运行时行为变更
-
-- **左移报错**：
-  - 在调用处，若目标类型未实现 trait，直接抛错（避免进入执行体）。
-  - 在加载时注册 trait 实现并检测冲突（重复实现、签名不匹配等）。
-
-## 修改范围与复杂度
-
-### 高风险/广泛影响
-
-- `Calcit` enum 变更（新增变种） → **所有 pattern match 需要更新**。
-- `runner`/`preprocess`/`builtins` 的调用逻辑需要接入 trait 解析。
-- `codegen` 需要考虑 trait 分派（JS backend 与 runtime 协议）。
-- 现有内建操作（`+`, `*`, `.` method）需重新定义分派规则。
-
-### 中等影响
-
-- `calcit.core` 标准库结构可能需要新增 trait 定义与实现。
-- 错误与警告格式新增类型。
-
-### 低风险
-
-- 文档、示例与 tests 的补充。
-
-## Breaking Changes 预估
-
-- `Calcit` 匹配逻辑：新增 `Impl` 变种会导致编译错误与运行时路径调整（允许少量 breaking）。
-- 内建操作行为：如果 `+/*` 改为 trait 分派，某些动态调用会改变错误时机。
-- `method` 分派：同名方法在不同 impl 记录之间的覆盖策略会改变行为（当前已确定规则，见“分派规则”）。
-- `str`/`format` 与 `Show` 的统一：输出可能略有不同。
-
-## 设计决策待确认
-
-1. Trait 分派优先级与覆盖策略：
-
-- 已确定：用户自定义值 `impls` 采用 last-wins；内置类型 core impl 列表采用 first-wins。
-- 待补：提供显式调用语法（`trait-call` / `Show/show`）用于消歧义，以及冲突时的告警/错误策略。
-
-2. Trait 的定义方式：
-   - 新语法 `deftrait` / `defimpl` vs 复用 record/defn
-3. Trait 是否支持泛型：
-   - 初期可不支持，后续扩展。
-4. 多实现冲突处理：
-   - 同一类型是否允许多个实现？冲突如何处理？
-
-## 建议实施阶段（草案）
-
-### Phase 1：基础结构
-
-- 引入 `Trait` 数据结构，内置 Trait 放在 `calcit.core`（不新增 registry）。
-- 内建 `Show` + `Number` 的 `Add/Multiply` 实现。
-- 调整 `+`/`*` 使用 trait 分派（保留内建快速路径）。
-
-### Phase 2：语言层支持
-
-- `deftrait` / `defimpl` 语法与 runtime 注册。
-- 迁移 trait impl 承载：record -> `CalcitImpl`（保留兼容路径，逐步淘汰 record impl）。
-- `assert-traits` / `requires` 运行时检查。
-
-### Phase 3：扩展与稳定
-
-- 覆盖更多内建类型能力。
-- 增加 tests（cirru 文件）覆盖 trait 注册、冲突、失败路径。
-
----
-
-## 当前实现要点（补充）
-
-- `deftrait` 已存在，展开为 `&trait::new`。
-- `defimpl` 已存在（最小实现）：展开为 `defrecord!`，用于更清晰地定义“trait impl record”（计划引入 `CalcitImpl` 后更新宏展开目标）。
-- `impl-traits` 已在 Rust 与 JS backend 支持，可对 record/tuple/struct/enum 追加 impl。
-- JS 侧已补齐 `CalcitTrait` 类型、`type-of`、`toString` 与 `&trait::new`、`&record:impl-traits` 等对应实现。
-- `.method` 分派采用“混合优先级”：用户自定义值（record/tuple/struct/enum 实例）为 last-wins，内置类型 core impl 列表为 first-wins。
-- `assert-traits` 已作为 preprocess 语法落地：写入 local 的 type-info，并展开为 `&assert-traits` 做运行时检查（当前限制：第一个参数需要是 local）。
-
----
-
-## 近期执行计划（从简单稳定开始）
-
-> 目标：先把行为与回归边界钉死，再推进语言层能力（`defimpl` / 显式 trait-call）。
-
-1. **清理与基线（半天内）**
-
-- [ ] 把这轮 traits 改动按边界整理成 3 组：语义实现 / 测试 / 文档（便于 review）。
-- [x] 检查是否有生成物被误纳入改动（如 `js-out/` 等）：当前工作区改动仅包含计划/测试/core，未发现产物噪音需要纳入跟踪。
-
-2. **固化“分派优先级”规范 + 回归测试（1 天）**
-
-- [x] 文档固化规则：builtin core impl list = first-wins；record/tuple impls = last-wins（append-to-override）。
-- [x] 回归：core list 的 `.add` 不被 Add trait `:add` 覆盖（靠 core 列表顺序 + first-wins）。
-- [x] 回归：record 上 `impl-traits` 追加实现能稳定覆盖旧实现（last-wins）。
-- [x] 回归：tuple 上 `impl-traits` 覆盖链同样稳定（last-wins）。
-- [x] 再补 1 个“更尖锐”的 Rust/JS 共用断言：不同 trait 提供同名方法时，仍以 `impl-traits` 追加顺序决定命中（覆盖 record + tuple）。
-
-3. **动态 trait 调用告警（1 天）**
-
-- [x] 引入 `--warn-dyn-method`：在 `cr` 正常执行流程中，对无法单态化的 `.method` 调用给出 warning。
-- [x] 规则：当 receiver 无法解析到具体 impl（类型为 `:dynamic`/未知），且未被 `assert-traits` 标注时触发告警。
-- [x] 验收：warning 包含方法名与位置；`assert-traits` 后 warning 消失；Rust/JS 预处理行为一致。
-
-4. **补齐语言层能力：`defimpl` + 显式 trait-call（2～4 天）**
-
-- [x] `defimpl`（v0）：让“写 impl record”有标准入口，减少手写 `defrecord!` 的样板。
-- [ ] `defimpl ... for ...`：让宏直接表达“trait + 目标类型/值”，并自动完成挂载（减少手写 `impl-traits`）。
-- [ ] 显式 trait-call（如 `Show/show` 或 `trait-call`）：提供绕开 `.method` 分派的稳定通道，便于 debug override 链。
-- [ ] 验收：同一段代码在 preprocess 校验、Rust runtime、JS runtime 行为一致。
-
-5. **`assert-traits` 易用性补强（可选，1～2 天）**
-
-- [ ] 支持 `assert-traits` 的第一个参数是任意表达式：preprocess 自动提升为临时 local 再做检查（纯语法糖）。
-- [ ] 验收：`assert-traits (+ 1 2) ...` 可用，且错误位置/提示依然清晰。
-
-6. **冲突策略与可观测性（可选，2～3 天）**
-
-- [ ] 提供“冲突诊断”开关：当同名方法多次出现时，打印候选列表/命中来源（对 last-wins 特别有帮助）。
-- [x] 可选 debug proc：`&methods-of` / `&inspect-methods`，返回/打印某值当前 impl 链与可用方法集合，帮助定位“为什么命中这个实现”。
-
----
-
-## Checklist（后续跟踪）
-
-### 🎯 推荐优先实现（短期，1-2周）
-
-**理由：完善当前已有的 trait 机制，提升用户体验**
-
-- [ ] **`defimpl` 宏**：简化 trait 实现语法
-  - 当前（已实现 v0）：`defimpl MyTrait MyImpl (:method value) ...`（展开为 `defrecord!`，产出“impl record”）
-  - 仍待补齐：`defimpl MyTrait for MyType ...`（自动挂载/注册，减少显式 `impl-traits`）
-  - 优势：语义更清晰，自动完成 impl-traits 步骤
-  - 验收：宏展开在 Rust/JS 下语义一致；错误信息包含 trait/类型/缺失方法；`test-traits.cirru` 覆盖正常/冲突路径
-- [ ] **显式 trait 调用语法**：解决方法名冲突
-  - 语法选项：`(trait-call Show :show x)` 或 `(Show/show x)`
-  - 用例：当一个类型实现多个 trait，且方法名冲突时
-  - 验收：可在运行时绕开 `.method` 的歧义（不受 impl 覆盖影响）；preprocess 能做方法存在性与参数数量/类型校验；Rust/JS 行为一致
-- [x] **`assert-traits` 运行时检查**：前移错误发现时机（已实现；当前限制：第一个参数需要是 local）
-  - 语法：`(assert-traits x Show)` 或 `(requires x Show)`
-  - 在函数入口检查参数是否满足 trait 约束
-  - 提供清晰的错误消息
-  - 下一步：扩展到函数参数/模式绑定等更多场景（不止 local）
-
-### 🔧 中期实现（3-4周）
-
-**理由：扩展 trait 系统能力，支持更复杂的场景**
-
-- [ ] **Trait 依赖（`requires`）**：声明 trait 之间的依赖关系
-  - 例：`Ord` 依赖 `Eq`
-  - 实现时自动检查依赖是否满足
-- [ ] **默认实现（`defaults`）**：减少重复代码
-  - 在 trait 定义中提供默认方法实现
-  - 类型可以选择性覆盖
-- [ ] **完整的集合 Trait（重新评估设计）**：
-  - **方案 A（Haskell 风格）**：独立 `Functor`/`Foldable` trait
-    - 优点：概念纯粹，严格分离关注点
-    - 缺点：在动态语言中过度抽象，用户学习成本高
-  - **方案 B（Rust/JS 风格）**：统一 `Collection` trait
-    - 包含 `map`, `filter`, `fold`, `count`, `empty?` 等全套操作
-    - 优点：实用导向，一站式接口
-    - 缺点：trait 体积大，部分类型可能只能实现子集
-  - **方案 C（混合）**：保留 `Foldable` 基础，`map`/`filter` 作为可选扩展
-    - 最小公约数是 `fold`（可实现 map/filter）
-    - 类型按需实现 map/filter 优化版本
-  - 🎯 **推荐**：先实现方案 B（务实路线），观察实际使用后再考虑拆分
-
-- [ ] **冲突检测与覆盖策略**：
-  - 同一类型多 impl 时的优先级规则
-  - 重复注册时的警告机制
-
-**Functor/Monad 补充说明：**
-
-- 在 Calcit 这样的动态语言中，Monad 的核心价值（`>>=` 的类型组合）基本丧失
-- 但 `Functor` (fmap) 仍有意义：统一"保结构变换"的概念
-- 实际实现时可考虑：
-  - ✅ 提供 `fmap` 作为标准方法名（对 FP 用户友好）
-  - ✅ 同时保留 `.map` 别名（对主流用户友好）
-  - ❌ 不强制实现完整 Monad（`return`/`>>=` 在无类型约束时意义不大）
-
-### 🚀 长期规划（1-2月）
-
-**理由：提升系统稳定性和性能**
-
-- [ ] **转换 Trait (`Default`, `From`)**：
-  - 类型间的标准转换接口
-  - 减少手写转换函数
-- [ ] **Trait 继承/组合**：
-  - 支持 trait 继承（如 `trait Ord extends Eq`）
-  - 或 trait 组合（如 `trait Num = Add + Multiply + ...`）
-- [ ] **性能优化**：
-  - Trait 查找缓存（避免重复遍历）
-  - 内联常见 trait 方法（如 `show`, `eq?`）
-- [ ] **更好的错误消息**：
-  - Trait 不匹配时显示期望 vs 实际
-  - 建议可能的解决方案
-- [ ] **文档与示例**：
-  - 完整的 trait 使用指南
-  - 常见模式与最佳实践
-  - 更多 `test-traits.cirru` 测试用例
-
-### 📝 技术债务清理
-
-- [x] ~~从 `class` 迁移到 `trait`~~ (已完成，commit 73aa249)
-- [x] ~~移动内部函数到 `calcit.internal`~~ (已完成，commit fc78725)
-- [ ] 解决 JS 编译模式的循环依赖问题
-  - 当前问题：`calcit.internal.mjs` 引用 `calcit.core.mjs` 导致初始化失败
-  - 可能方案：调整模块加载顺序或使用延迟初始化
-
----
-
-## 实施建议
-
-**下一步行动（按优先级）：**
-
-1. **先做（低风险）**：清理基线 + 补齐“分派优先级”尖锐回归
-
-- 把行为边界钉死，避免后续 `defimpl` / trait-call 引入难定位回归
-
-2. **然后（核心能力）**：`defimpl` 宏
-
-- 降低写 impl 的样板，提高可读性
-
-3. **再做（可观测性/可维护）**：显式 trait 调用语法
-
-- 解决方法名冲突与 override 链难 debug 的实际问题
-- 为后续 trait 组合打基础
-
-3. **然后**：Trait 依赖 + 默认实现
-   - 这是更复杂的功能，依赖前面的基础
-   - 可以大幅减少样板代码
-
-4. **最后**：集合 Trait + 性能优化
-   - 在系统稳定后进行性能调优
-   - 逐步扩展 trait 覆盖范围
-
----
-
-## 原有 Checklist（归档）
-
-以下是原计划中的项目，已整合到上面的分类中（按真实实现状态更新）：
-
-- [ ] `defimpl ... for ...`（包含方法名校验/去重规则）→ 短期优先（注：defimpl v0 已存在，仅产出 impl record）
-- [x] `assert-traits` 运行时检查与错误消息格式（已实现；当前限制：第一个参数需要是 local）
-- [ ] 显式 trait 调用语法（`trait-call` / `Show/show` 语法）→ 短期优先
-- [ ] trait 依赖（`requires`）与默认实现（`defaults`）的表达与存储 → 中期实现
-- [ ] 统一 `Compare` 的三态返回与 `&compare` 的关系（`<`/`>` 仅数字）→ 中期实现
-- [ ] 冲突检测：同一对象多 impl 的覆盖顺序与警告策略 → 中期实现
-- [x] ~~JS backend 与 Rust 行为一致性验证（新增 tests）~~ → 已有 test-traits.cirru
-- [ ] 文档示例与 `test-traits.cirru` 覆盖更多失败路径 → 长期规划
-
-## 测试补充建议（cirru）
-
-- `test-traits.cirru`：
-  - `Show` for number/string/list/map
-  - `Add`/`Multiply` for number
-  - 未实现时的错误提示
-  - 多实现冲突/重复注册
-
-## 附录：符号解析与 runtime-resolved symbols
-
-补充说明：在 trait/runtime 相关排障里，经常会遇到“文档里能看到/看不到某个符号”的认知差异。这里统一记录符号解析口径。
-
-目前符号大致分为：
-
-- raw syntax symbols（例如 `&` `?` `~` `~@`）
-- data symbol（通常由 `turn-symbol` 创建）
-- local variables
-- local definitions
-- imported variables
-- namespaced imported symbols
-- imported default variables
-- imported host variables
-
-当前它们在实现层很多都共享 `Calcit::Symbol{..}` 路径（这是已知历史包袱，后续仍需重构）。
-
-另外有一类 **runtime-resolved symbols**：由 parser/runtime 直接识别，不一定在 `calcit.core` 里作为普通 `CodeEntry` 出现。
-
-- syntax symbols 来自 `CalcitSyntax`（例如 `assert-traits`）
-- proc symbols 来自 `CalcitProc`（例如 `&trait-call`、`&inspect-type`、`register-calcit-builtin-impls`）
-
-因此检查符号可用性时，建议同时看：
-
-- `src/cirru/calcit-core.cirru`（macro/def 暴露面）
-- `src/calcit/syntax_name.rs` 与 `src/calcit/proc_name.rs`（runtime-native 符号）
-
----
-
-> 备注：该方案涉及 runtime/stdlib/codegen 全链路改造，建议先从最小可运行集开始迭代。
+不计划恢复 class/prototype 作为第二套公开多态系统，也不计划为 WASM 单独维护一套功能不完整但表面可运行的 trait runtime。

--- a/calcit/test-doc-smoke.cirru
+++ b/calcit/test-doc-smoke.cirru
@@ -45,7 +45,7 @@
                 DocPerson $ impl-traits DocPerson0 DocTraitImpl
                 p $ %{} DocPerson (:name |Alice)
               assert= p $ assert-traits p DocTrait
-              assert= "|doc Alice" $ .label p
+              assert= "|doc Alice" $ p .label
           :examples $ []
           :schema $ :: 'Dynamic
         |test-defimpl-order $ %{} :CodeEntry (:doc "|defimpl arg order smoke")
@@ -83,7 +83,7 @@
                 DotPerson $ impl-traits DocPerson0 DotImpl
                 p $ %{} DotPerson (:name |Bob)
               assert= DocTrait $ &impl:origin DotImpl
-              assert= "|native-dot Bob" $ .label p
+              assert= "|native-dot Bob" $ p .label
           :examples $ []
           :schema $ :: 'Dynamic
       :ns $ %{} :NsEntry (:doc |)

--- a/calcit/test-enum.cirru
+++ b/calcit/test-enum.cirru
@@ -24,7 +24,8 @@
           :schema $ :: 'Dynamic
         |ResultImpl $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defimpl ResultImpl ResultTrait $ .dummy nil
+            defimpl ResultImpl ResultTrait $ .dummy
+              fn (_x) nil
           :examples $ []
           :schema $ :: 'Dynamic
         |ResultTrait $ %{} :CodeEntry (:doc |)

--- a/calcit/test-enum.cirru
+++ b/calcit/test-enum.cirru
@@ -144,7 +144,7 @@
                     :return 'String
                   match v
                     (:none) |none
-                    (:some item) (.show item)
+                    (:some item) (item .show)
                 render-duo $ fn (v)
                   hint-fn $ {}
                     :generics $ [] 'T 'U
@@ -153,9 +153,9 @@
                     :return 'String
                   match v
                     (:pair left right)
-                      str-spaced |pair (.show left) (.show right)
+                      str-spaced |pair (left .show) (right .show)
                     (:swapped right left)
-                      str-spaced |swapped (.show right) (.show left)
+                      str-spaced |swapped (right .show) (left .show)
               println "|Testing generic enum where-bounds..."
               assert= |1 $ render-maybe (%:: Maybe1 :some 1)
               assert= |none $ render-maybe (%:: Maybe1 :none)
@@ -232,10 +232,10 @@
                     assert-type box $ :: 'ShownBox 'Number
                     assert-type some-value $ :: 'ShownMaybe 'Number
                     assert= |1 $ match some-value
-                      (:some item) (.show item)
+                      (:some item) (item .show)
                       (:none) |none
                     assert= |none $ match none-value
-                      (:some item) (.show item)
+                      (:some item) (item .show)
                       (:none) |none
               println "|✓ Data definition where-bounds passed"
           :examples $ []

--- a/calcit/test-generics.cirru
+++ b/calcit/test-generics.cirru
@@ -59,7 +59,7 @@
                     :where $ {} ('T Show)
                     :args $ [] 'T
                     :return 'String
-                  .show x
+                  x .show
                 n $ id2 1
                 s $ id2 |hi
                 shown-n $ show-id 1

--- a/calcit/test-invalid-tag.cirru
+++ b/calcit/test-invalid-tag.cirru
@@ -14,7 +14,8 @@
           :schema $ :: 'Dynamic
         |ResultImpl $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defimpl ResultImpl ResultTrait $ .dummy nil
+            defimpl ResultImpl ResultTrait $ .dummy
+              fn (_x) nil
           :examples $ []
           :schema $ :: 'Dynamic
         |ResultTrait $ %{} :CodeEntry (:doc |)

--- a/calcit/test-optimize.cirru
+++ b/calcit/test-optimize.cirru
@@ -39,29 +39,29 @@
             defn main! () $ let
                 p $ %{} Person (:name |Jim)
               println "|--- direct call ---"
-              println $ .show p
+              println $ p .show
               let
                   p2 p
                 assert-traits p2 ShowTrait
                 println "|--- assert-traits ShowTrait ---"
-                println $ .show p2
+                println $ p2 .show
               let
                   p3 p
                 assert-type p3 Person
                 println "|--- assert-type Person ---"
-                println $ .show p3
+                println $ p3 .show
               let
                   p4 p
                 assert-type p4 Person
                 assert-traits p4 ShowTrait
                 println "|--- assert-type Person + assert-traits ShowTrait ---"
-                println $ .show p4
+                println $ p4 .show
               let
                 LocalPerson $ impl-traits LocalPerson0 ShowImpl
                   lp $ %{} LocalPerson (:name |Local)
                 println "|--- local struct (runtime impl) ---"
                 assert-traits lp ShowTrait
-                println $ .show lp
+                println $ lp .show
           :examples $ []
           :schema $ :: 'Dynamic
       :ns $ %{} :NsEntry (:doc |)

--- a/calcit/test-record.cirru
+++ b/calcit/test-record.cirru
@@ -240,12 +240,12 @@
                   l1t l1
                 assert-traits l1t BirdTrait
                 let
-                    l2 $ .rename l1t |LagopusB
+                    l2 $ l1t .rename |LagopusB
                     l2t l2
                   assert-traits l2t BirdTrait
                   println l1
-                  .show l1t
-                  .show l2t
+                  l1t .show
+                  l2t .show
                   assert= (&record:impls l1) (&record:impls a1r)
           :examples $ []
           :schema $ :: 'Fn

--- a/calcit/test-sum-types.cirru
+++ b/calcit/test-sum-types.cirru
@@ -38,8 +38,8 @@
                   fn (impl)
                     = (&impl:origin impl) ActionTrait
                 assert= "|(%:: :ok 42 (:enum Result))" $ str ok-action
-                assert= "|Action ok -> 42" $ .describe ok-action
-                assert= "|Action err -> boom" $ .describe err-action
+                assert= "|Action ok -> 42" $ ok-action .describe
+                assert= "|Action err -> boom" $ err-action .describe
                 assert= "|handled ok 42" $ summarize ok-action
                 assert= "|handled err boom" $ summarize err-action
                 println "|All sum type checks passed."

--- a/calcit/test-tag-match-validation.cirru
+++ b/calcit/test-tag-match-validation.cirru
@@ -14,7 +14,8 @@
           :schema $ :: 'Dynamic
         |ResultImpl $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defimpl ResultImpl ResultTrait $ .dummy nil
+            defimpl ResultImpl ResultTrait $ .dummy
+              fn (_x) nil
           :examples $ []
           :schema $ :: 'Dynamic
         |ResultTrait $ %{} :CodeEntry (:doc |)

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -491,6 +491,9 @@
                 assert= true $ res-err .err?
                 assert= 1 $ res-ok .unwrap-or 9
                 assert= 9 $ res-err .unwrap-or 9
+                assert= 1 $ (res-ok .unwrap-or 9) .round
+                assert= 9 $ (res-err .unwrap-or 9) .round
+                assert= 9 $ ((%none) .unwrap-or 9) .round
                 assert= (%ok 2) (res-ok .and-then to-ok)
                 assert= (%err |oops) (res-err .and-then to-ok)
                 assert= (%ok 1) (res-ok .map-err turn-tag)

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -196,6 +196,11 @@
                   opt $ %some 1
                   Person $ impl-traits Person0 MyFooImpl
                   p $ %{} Person (:name |Alice)
+                  ZapPerson $ impl-traits Person0 MyZapAImpl
+                  zp $ %{} ZapPerson (:name |Bob)
+                  flag true
+                  keyword :demo
+                  nothing nil
                 assert= x $ assert-traits x calcit.core/Show
                 assert= x $ assert-traits x calcit.core/Show calcit.core/Eq
                 assert= xs $ assert-traits xs calcit.core/Mappable
@@ -214,6 +219,14 @@
                 assert= :true $ try
                   do (assert-traits p MyBar) :false
                   fn (e) (do :true)
+                ; A same-named method from MyZapA must not satisfy the distinct MyZapB trait.
+                assert= zp $ assert-traits zp MyZapA
+                assert= :true $ try
+                  do (assert-traits zp MyZapB) :false
+                  fn (e) (do :true)
+                assert= flag $ assert-traits flag calcit.core/Show calcit.core/Eq
+                assert= keyword $ assert-traits keyword calcit.core/Show calcit.core/Eq
+                assert= nothing $ assert-traits nothing calcit.core/Show calcit.core/Eq
               println "|  assert-traits: ✓"
           :examples $ []
           :schema $ :: 'Fn
@@ -375,6 +388,19 @@
                 ; "`&trait-call`" selects by trait, bypassing "`.method`" ambiguity
                 assert= |zapA $ &trait-call MyZapA :zap p
                 assert= |zapB $ &trait-call MyZapB :zap p
+              let
+                  SinglePerson $ impl-traits Person0 MyZapAImpl
+                  p $ %{} SinglePerson (:name |Bob)
+                assert= |zapA $ &trait-call MyZapA :zap p
+                assert= :true $ try
+                  do (&trait-call MyZapB :zap p) :false
+                  fn (e) (do :true)
+              let
+                  xs $ [] 1 2 3
+                  flag true
+                assert= 3 $ &trait-call calcit.core/Countable :count xs
+                assert= |true $ &trait-call calcit.core/Show :show flag
+                assert= true $ &trait-call calcit.core/Eq :eq? flag true
               let
                   t $ %:: DemoZap :demo 1
                 assert-traits t MyZapA MyZapB

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -89,7 +89,7 @@
           :schema $ :: 'Struct
         |compare-with-trait $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn compare-with-trait (a b) (.compare a b)
+            defn compare-with-trait (a b) (a .compare b)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
@@ -98,7 +98,7 @@
               :where $ {} ('T 'Compare)
         |contains-with-trait? $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn contains-with-trait? (x k) (.contains? x k)
+            defn contains-with-trait? (x k) (x .contains? k)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Bool)
@@ -107,7 +107,7 @@
               :where $ {} ('T 'Contains)
         |count-with-trait $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn count-with-trait (x) (.count x)
+            defn count-with-trait (x) (x .count)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
@@ -335,10 +335,10 @@
                 assert-traits pb MyZapA MyZapB
                 assert-traits ta MyZapA MyZapB
                 assert-traits tb MyZapA MyZapB
-                assert= |zapB $ .zap pa
-                assert= |zapA $ .zap pb
-                assert= |zapB $ .zap ta
-                assert= |zapA $ .zap tb
+                assert= |zapB $ pa .zap
+                assert= |zapA $ pb .zap
+                assert= |zapB $ ta .zap
+                assert= |zapA $ tb .zap
               println "|  cross-trait conflict: ✓"
           :examples $ []
           :schema $ :: 'Fn
@@ -351,7 +351,7 @@
               let
                   Person $ impl-traits Person0 MyFooImpl
                   p $ %{} Person (:name |Alice)
-                assert= "|foo Alice" $ .foo p
+                assert= "|foo Alice" $ p .foo
                 println "|  deftrait: ✓"
           :examples $ []
           :schema $ :: 'Fn
@@ -404,7 +404,7 @@
               let
                   t $ %:: DemoZap :demo 1
                 assert-traits t MyZapA MyZapB
-                assert= |zapB $ .zap t
+                assert= |zapB $ t .zap
                 assert= |zapA $ &trait-call MyZapA :zap t
                 assert= |zapB $ &trait-call MyZapB :zap t
               println "|  explicit trait-call: ✓"
@@ -419,7 +419,7 @@
                   ; impl-traits appends impls, so later ones override earlier ones
                   Person $ impl-traits Person0 MyFooImpl MyFooImpl2
                   p $ %{} Person (:name |Alice)
-                assert= "|foo2 Alice" $ .foo p
+                assert= "|foo2 Alice" $ p .foo
               println "|  precedence: ✓"
           :examples $ []
           :schema $ :: 'Fn
@@ -463,41 +463,38 @@
                   opt-none $ %none
                   res-ok $ %ok 1
                   res-err $ %err |oops
-                assert-type opt-some Option
-                assert-type opt-none Option
-                assert-type res-ok Result
-                assert-type res-err Result
-                assert= (%some 2) (.map opt-some inc)
-                assert= (%none) (.map opt-none inc)
-                assert= (%ok 2) (.map res-ok inc)
-                assert= (%err |oops) (.map res-err inc)
+                  step $ fn (x) (inc x)
+                assert-type opt-some $ :: 'Option 'Number
+                assert-type opt-none $ :: 'Option 'Number
+                assert-type res-ok $ :: 'Result 'Number 'String
+                assert-type res-err $ :: 'Result 'Number 'String
+                assert= (%some 2) (opt-some .map step)
+                assert= (%none) (opt-none .map step)
+                assert= (%ok 2) (res-ok .map step)
+                assert= (%err |oops) (res-err .map step)
               let
                   opt-some $ %some 1
                   opt-none $ %none
                   res-ok $ %ok 1
                   res-err $ %err |oops
-                assert= true $ .some? opt-some
-                assert= true $ .none? opt-none
+                  to-some $ fn (x)
+                    %some $ inc x
+                  to-ok $ fn (x)
+                    %ok $ inc x
+                assert= true $ opt-some .some?
+                assert= true $ opt-none .none?
                 assert= 1 $ opt-some .unwrap-or 9
                 assert= 9 $ opt-none .unwrap-or 9
-                assert= (%some 2)
-                  .and-then opt-some $ fn (x)
-                    %some $ inc x
-                assert= (%none)
-                  .and-then opt-none $ fn (x)
-                    %some $ inc x
-                assert= true $ .ok? res-ok
-                assert= true $ .err? res-err
+                assert= (%some 2) (opt-some .and-then to-some)
+                assert= (%none) (opt-none .and-then to-some)
+                assert= true $ res-ok .ok?
+                assert= true $ res-err .err?
                 assert= 1 $ res-ok .unwrap-or 9
                 assert= 9 $ res-err .unwrap-or 9
-                assert= (%ok 2)
-                  .and-then res-ok $ fn (x)
-                    %ok $ inc x
-                assert= (%err |oops)
-                  .and-then res-err $ fn (x)
-                    %ok $ inc x
-                assert= (%ok 1) (.map-err res-ok turn-tag)
-                assert= (%err :oops) (.map-err res-err turn-tag)
+                assert= (%ok 2) (res-ok .and-then to-ok)
+                assert= (%err |oops) (res-err .and-then to-ok)
+                assert= (%ok 1) (res-ok .map-err turn-tag)
+                assert= (%err :oops) (res-err .map-err turn-tag)
               println "|  Option/Result map: ✓"
           :examples $ []
           :schema $ :: 'Fn
@@ -526,7 +523,7 @@
               let
                   t $ %:: DemoBar :demo 1
                 assert-traits t MyBar
-                assert= |bar2 $ .bar t
+                assert= |bar2 $ t .bar
               println "|  tuple precedence: ✓"
           :examples $ []
           :schema $ :: 'Fn

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -478,8 +478,8 @@
                   res-err $ %err |oops
                 assert= true $ .some? opt-some
                 assert= true $ .none? opt-none
-                assert= 1 $ .unwrap-or opt-some 9
-                assert= 9 $ .unwrap-or opt-none 9
+                assert= 1 $ opt-some .unwrap-or 9
+                assert= 9 $ opt-none .unwrap-or 9
                 assert= (%some 2)
                   .and-then opt-some $ fn (x)
                     %some $ inc x
@@ -488,8 +488,8 @@
                     %some $ inc x
                 assert= true $ .ok? res-ok
                 assert= true $ .err? res-err
-                assert= 1 $ .unwrap-or res-ok 9
-                assert= 9 $ .unwrap-or res-err 9
+                assert= 1 $ res-ok .unwrap-or 9
+                assert= 9 $ res-err .unwrap-or 9
                 assert= (%ok 2)
                   .and-then res-ok $ fn (x)
                     %ok $ inc x

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -87,6 +87,33 @@
             defstruct Person0 $ :name 'String
           :examples $ []
           :schema $ :: 'Struct
+        |compare-with-trait $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn compare-with-trait (a b) (.compare a b)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'T 'T
+              :generics $ [] 'T
+              :where $ {} ('T 'Compare)
+        |contains-with-trait? $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn contains-with-trait? (x k) (.contains? x k)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'T 'K
+              :generics $ [] 'T 'K
+              :where $ {} ('T 'Contains)
+        |count-with-trait $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn count-with-trait (x) (.count x)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'T
+              :generics $ [] 'T
+              :where $ {} ('T 'Countable)
         |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn main! () (&init-builtin-impls!) (println "|Testing built-in traits...") (; Test Show trait - all types should have it) (test-show-trait) (; Test deftrait macro) (test-deftrait) (; Test impl precedence order) (test-impl-precedence-order) (test-tuple-impl-precedence-order) (test-cross-trait-method-conflict) (test-explicit-trait-call) (; Test Eq trait) (test-eq-trait) (; Test Compare trait) (test-compare-trait) (; Test Add trait) (test-add-trait) (; Test Len/Empty traits) (test-collection-traits) (; Test Option/Result Mappable) (test-option-result-map) (; Test assert-traits) (test-assert-trait) (; Debug helpers: methods introspection) (test-method-introspection) (println "|All trait tests passed!")
@@ -180,11 +207,12 @@
                 assert= s $ assert-traits s calcit.core/Show
                 assert= s $ assert-traits s calcit.core/Show calcit.core/Eq
                 assert= opt $ assert-traits opt calcit.core/Mappable
-                ; "Option only implements Mappable in current impls"
                 assert= p $ assert-traits p MyFoo
-                ; "MyFooImpl only provides :foo, no Show impl"
+                ; Records satisfy the built-in Show trait through the shared record impls.
+                assert= p $ assert-traits p calcit.core/Show
+                ; Person has no implementation of the unrelated MyBar trait.
                 assert= :true $ try
-                  do (assert-traits p calcit.core/Show) :false
+                  do (assert-traits p MyBar) :false
                   fn (e) (do :true)
               println "|  assert-traits: ✓"
           :examples $ []
@@ -221,6 +249,31 @@
                 , :b
               assert= true $ contains? (#{} 1 2 3) 2
               assert= false $ contains? (#{} 1 2 3) 4
+              let
+                  xs $ [] 1 2 3
+                  m $ {} (:a 1)
+                  s $ #{} 1 2
+                  text |abc
+                  tuple $ :: :demo 1
+                  record $ %{} Person0 (:name |A)
+                assert= 3 $ count-with-trait xs
+                assert= 1 $ count-with-trait m
+                assert= 2 $ count-with-trait s
+                assert= 3 $ count-with-trait text
+                assert= 2 $ count-with-trait tuple
+                assert= 1 $ count-with-trait record
+                assert= true $ contains-with-trait? xs 1
+                assert= true $ contains-with-trait? m :a
+                assert= true $ contains-with-trait? s 2
+                assert= true $ contains-with-trait? text 1
+                assert= true $ contains-with-trait? tuple 1
+                assert= true $ contains-with-trait? record :name
+                assert-traits xs Countable Contains
+                assert-traits m Countable Contains
+                assert-traits s Countable Contains
+                assert-traits text Countable Contains
+                assert-traits tuple Countable Contains
+                assert-traits record Countable Contains
               println "|  Collection traits: ✓"
           :examples $ []
           :schema $ :: 'Fn
@@ -238,6 +291,16 @@
               assert= 1 $ &compare |zebra |apple
               ; List comparison $ not yet implemented in compare form
               ; assert= :lt $ compare ([] 1 2) ([] 1 3)
+              do
+                assert= -1 $ .compare 1 2
+                assert= 0 $ .compare 2 2
+                assert= 1 $ .compare 3 2
+                assert= -1 $ .compare |apple |banana
+                assert= 1 $ .compare |zebra |apple
+                assert= -1 $ compare-with-trait 1 2
+                assert= -1 $ compare-with-trait |a |b
+                assert-traits 1 Compare
+                assert-traits |a Compare
               println "|  Compare trait: ✓"
           :examples $ []
           :schema $ :: 'Fn
@@ -382,6 +445,33 @@
                 assert= (%none) (.map opt-none inc)
                 assert= (%ok 2) (.map res-ok inc)
                 assert= (%err |oops) (.map res-err inc)
+              let
+                  opt-some $ %some 1
+                  opt-none $ %none
+                  res-ok $ %ok 1
+                  res-err $ %err |oops
+                assert= true $ .some? opt-some
+                assert= true $ .none? opt-none
+                assert= 1 $ .unwrap-or opt-some 9
+                assert= 9 $ .unwrap-or opt-none 9
+                assert= (%some 2)
+                  .and-then opt-some $ fn (x)
+                    %some $ inc x
+                assert= (%none)
+                  .and-then opt-none $ fn (x)
+                    %some $ inc x
+                assert= true $ .ok? res-ok
+                assert= true $ .err? res-err
+                assert= 1 $ .unwrap-or res-ok 9
+                assert= 9 $ .unwrap-or res-err 9
+                assert= (%ok 2)
+                  .and-then res-ok $ fn (x)
+                    %ok $ inc x
+                assert= (%err |oops)
+                  .and-then res-err $ fn (x)
+                    %ok $ inc x
+                assert= (%ok 1) (.map-err res-ok turn-tag)
+                assert= (%err :oops) (.map-err res-err turn-tag)
               println "|  Option/Result map: ✓"
           :examples $ []
           :schema $ :: 'Fn

--- a/calcit/test-types.cirru
+++ b/calcit/test-types.cirru
@@ -320,7 +320,7 @@
                   Person $ impl-traits Person PersonImpl
                   alice $ %{} Person (:name |Alice) (:age 30)
                 let
-                    greeting $ .greet alice
+                    greeting $ alice .greet
                   println |greeting: greeting
                   assert= "|Hello, I'm Alice" greeting
               , "|Record method checks passed"

--- a/calcit/test-types.cirru
+++ b/calcit/test-types.cirru
@@ -9,9 +9,15 @@
       :defs $ {}
         |EnumImpl $ %{} :CodeEntry (:doc "|Trait impl for enum metadata")
           :code $ quote
-            defimpl EnumImpl :EnumImpl $ .dummy nil
+            defimpl EnumImpl EnumMetadata $ .dummy
+              fn (self) nil
           :examples $ []
           :schema $ :: 'Impl
+        |EnumMetadata $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            deftrait EnumMetadata $ .dummy :fn
+          :examples $ []
+          :schema $ :: 'Trait
         |Person $ %{} :CodeEntry (:doc "|Struct definition for type checks")
           :code $ quote
             defstruct Person (:name 'String) (:age nil)
@@ -38,9 +44,15 @@
           :schema $ :: 'Trait
         |StructImpl $ %{} :CodeEntry (:doc "|Trait impl for struct metadata")
           :code $ quote
-            defimpl StructImpl :StructImpl $ .dummy nil
+            defimpl StructImpl StructMetadata $ .dummy
+              fn (self) nil
           :examples $ []
           :schema $ :: 'Impl
+        |StructMetadata $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            deftrait StructMetadata $ .dummy :fn
+          :examples $ []
+          :schema $ :: 'Trait
         |add-numbers $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn add-numbers (a b) (&+ a b)
@@ -301,7 +313,8 @@
           :code $ quote
             defn test-record-methods () (; "使用" impl-traits "挂载实现" Record methods)
               let
-                  PersonImpl $ defimpl PersonImpl :PersonImpl
+                  PersonGreeting $ deftrait PersonGreeting (.greet :fn)
+                  PersonImpl $ defimpl PersonImpl PersonGreeting
                     .greet $ fn (self)
                       str "|Hello, I'm " $ :name self
                   Person $ impl-traits Person PersonImpl

--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -684,9 +684,19 @@
             defn test-not (x) (not x)
           :examples $ []
           :schema $ :: 'Dynamic
+        |test-number-compare-method $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-number-compare-method () $ .compare 1 2
+          :examples $ []
+          :schema $ :: 'Dynamic
         |test-number?-true $ %{} :CodeEntry (:doc "|number? on number returns true (1)")
           :code $ quote
             defn test-number?-true () $ if (number? 42) 1 0
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-option-unwrap-or $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-option-unwrap-or () $ option:unwrap-or (%none) 7
           :examples $ []
           :schema $ :: 'Dynamic
         |test-pow $ %{} :CodeEntry (:doc "|pow via host import")
@@ -787,6 +797,11 @@
         |test-rest-sum $ %{} :CodeEntry (:doc "|rest args: 1+2+3+4+5 = 15")
           :code $ quote
             defn test-rest-sum () $ sum-rest 1 2 3 4 5
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-result-unwrap-or $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-result-unwrap-or () $ result:unwrap-or (%err 3) 7
           :examples $ []
           :schema $ :: 'Dynamic
         |test-round $ %{} :CodeEntry (:doc "|round function")
@@ -1007,6 +1022,11 @@
         |test-str-slice $ %{} :CodeEntry (:doc "|slice bytes 1..4 from abcde = 3 bytes (bcd)")
           :code $ quote
             defn test-str-slice () $ &str:count (&str:slice |abcde 1 4)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-string-compare-method $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-string-compare-method () $ .compare |abc |abd
           :examples $ []
           :schema $ :: 'Dynamic
         |test-tag-eq $ %{} :CodeEntry (:doc "|Tag equality — same tags")

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -9,7 +9,7 @@
       :defs $ {}
         |%A $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defimpl %A :%A $ .deref
+            defimpl %A AtomDerefTrait $ .deref
               fn (self)
                 tag-match self $
                   :atom x
@@ -18,7 +18,7 @@
           :schema $ :: 'Dynamic
         |%r $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defimpl %r :%demo $ .get
+            defimpl %r DemoGetTrait $ .get
               fn (self) 1
           :examples $ []
           :schema $ :: 'Dynamic
@@ -36,6 +36,11 @@
             defenum AtomBox $ :atom 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
+        |AtomDerefTrait $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            deftrait AtomDerefTrait $ .deref :fn
+          :examples $ []
+          :schema $ :: 'Trait
         |Demo $ %{} :CodeEntry (:doc |)
           :code $ quote
             def Demo $ impl-traits Demo0 %r
@@ -46,12 +51,22 @@
             defenum Demo $ :a 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
+        |DemoGetTrait $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            deftrait DemoGetTrait $ .get :fn
+          :examples $ []
+          :schema $ :: 'Trait
         |Deref $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defimpl Deref :Deref $ .deref
+            defimpl Deref DerefTrait $ .deref
               fn (self) 2
           :examples $ []
           :schema $ :: 'Dynamic
+        |DerefTrait $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            deftrait DerefTrait $ .deref :fn
+          :examples $ []
+          :schema $ :: 'Trait
         |Num $ %{} :CodeEntry (:doc |)
           :code $ quote
             defimpl Num NumTrait
@@ -461,7 +476,7 @@
                   b $ %:: Demo :a 1
                 assert= true $ any? (&tuple:impls b)
                   fn (impl)
-                    includes? (str impl) |%demo
+                    includes? (str impl) |DemoGetTrait
                 assert=
                   &tuple:params $ :: :a 1 2 3
                   [] 1 2 3

--- a/docs/data.md
+++ b/docs/data.md
@@ -11,32 +11,54 @@ id: core/data
 ---
 # Data Types
 
-Calcit provides several core data types, all immutable by default for functional programming:
+Calcit uses persistent values by default, with a small set of explicit stateful containers. The same logical values are available in the Rust and JavaScript runtimes; WASM supports a growing, documented subset.
 
 ## Primitive Types
 
 - **Bool**: `true`, `false`
+- **Nil**: `nil`, used for absence at untyped boundaries
 - **Number**: `f64` in Rust, Number in JavaScript (`1`, `3.14`, `-42`)
 - **Tag**: Immutable strings starting with `:` (`:keyword`, `:demo`) - similar to Clojure keywords
+- **Symbol**: Quoted identifiers such as `'name`; unlike tags, symbols preserve code/data intent
 - **String**: Text data with special prefix syntax (`|text`, `"|with spaces"`)
+- **Buffer**: Immutable bytes, created with `&buffer`
 
 ## Collection Types
 
-- **Vector**: Ordered collection serving both List and Vector roles (`[] 1 2 3`)
-- **HashMap**: Key-value pairs (`{} (:a 1) (:b 2)`)
-- **HashSet**: Unordered unique elements (`#{} :a :b :c`)
+- **List**: Ordered persistent collection (`[] 1 2 3`)
+- **Map**: Persistent key-value collection (`{} (:a 1) (:b 2)`)
+- **Set**: Persistent unordered collection of unique values (`#{} :a :b :c`)
 
-## Function Types
+## Named Data
+
+- **Record / Struct**: `defstruct` declares a fixed field layout; `%{}` constructs a record value.
+- **Enum / Tuple**: `defenum` declares named alternatives. Enum instances use the tuple runtime representation and retain their enum identity.
+- **Tuple**: `::` creates lightweight tagged positional data when a full enum declaration is unnecessary.
+- **Option**: `Option T` has `%some T` and `%none` variants.
+- **Result**: `Result T E` has `%ok T` and `%err E` variants.
+
+Prefer records and enums at module boundaries: their declarations carry schemas, support trait attachment, and give static analysis more information than ad-hoc maps or tuples.
+
+## Explicitly Stateful Values
+
+- **Ref**: Mutable reference cell used for controlled application state.
+- **BufList**: Mutable builder for allocation-sensitive loops; convert it to a persistent List before exposing the result.
+- **AnyRef**: Opaque host reference for FFI. It is not portable serialized data.
+
+## Executable Values
 
 - **Function**: User-defined functions and built-in procedures
 - **Proc**: Internal procedure type for built-in functions
+- **Trait / Impl**: Runtime capability descriptors used for method dispatch
 
 ## Implementation Details
 
 - **Rust runtime**: Uses [rpds](https://github.com/orium/rpds) for HashMap/HashSet and [ternary-tree](https://github.com/calcit-lang/ternary-tree.rs/) for vectors
 - **JavaScript runtime**: Uses [ternary-tree.ts](https://github.com/calcit-lang/ternary-tree.ts) for all collections
 
-All data structures are persistent and immutable, following functional programming principles. For detailed information about specific types, see:
+Collection method availability is also expressed through built-in traits. `Countable` and `Contains` cover List, Map, Set, String, Record, and Tuple; `Compare` covers Number and String. See [Polymorphism](features/polymorphism.md) for the full matrix.
+
+For serialization fidelity and unsupported runtime values, see:
 
 - [String](data/string.md) - String syntax and Tags
 - [Persistent Data](data/persistent-data.md) - Implementation details

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -12,16 +12,47 @@ entry_for:
 ---
 # Cirru Extensible Data Notation
 
-> Data notation based on Cirru. Learnt from [Clojure EDN](https://github.com/edn-format/edn).
+Cirru EDN is Calcit's typed data interchange format, inspired by [Clojure EDN](https://github.com/edn-format/edn). Use it when Calcit-specific identity matters; use JSON only when interoperating with JSON systems.
 
-EDN data is designed to be transferred across networks are strings. 2 functions involved:
+The two runtime APIs are:
 
-- `parse-cirru-edn`
-- `format-cirru-edn`
+- `parse-cirru-edn text [type-options]`
+- `format-cirru-edn value`
 
-although items of a HashSet nad fields of a HashMap has no guarantees, they are being formatted with an given order in order that its returns are reasonably stable.
+Map and Set iteration order is not a semantic guarantee. The formatter applies a stable order for readable, reproducible output; callers must not use that order as application data.
 
-### Liternals
+## Choosing Cirru EDN or JSON
+
+| Calcit value | Cirru EDN | JSON |
+| --- | --- | --- |
+| Nil, Bool, Number, String, List | Preserved | Preserved |
+| Tag, Symbol | Preserved | Encoded as a JSON string; identity is lost |
+| Map | Arbitrary EDN keys preserved | Keys must be Tag or String; parsed object keys become Tag |
+| Set | Preserved | Encoded as an array; Set identity is lost |
+| Buffer | Preserved | Encoded as a `0x...` string; Buffer identity is lost |
+| Tuple / enum value | Tag, fields, and enum name preserved | Encoded as an array; tuple and enum identity is lost |
+| Record | Record name and fields preserved | Encoded as an object; struct identity is lost |
+| Cirru quote | Preserved | Encoded as nested strings and arrays |
+| Ref | Encoded as `atom`; parsing creates a new Ref | Unsupported |
+| AnyRef, function, trait/impl, mutable builder | Not portable; do not use as interchange data | Unsupported |
+
+`json-stringify` rejects unsupported values and Maps with non-Tag/non-String keys instead of silently inventing a representation. It also rejects non-finite numbers. `json-parse` maps JSON arrays to List and JSON objects to Maps whose keys are Tags.
+
+## Restoring declared record and enum identity
+
+Cirru EDN always retains the printed record or enum name. To reconnect parsed values to the exact `defstruct` or `defenum` object (including attached traits), pass an options Map keyed by that name:
+
+```cirru
+let
+    Person $ defstruct Person (:name 'String)
+    encoded $ format-cirru-edn $ %{} Person (:name |Ada)
+  parse-cirru-edn encoded $ {}
+    :Person $ %{} Person (:name |)
+```
+
+Without this options Map, parsing still produces a structurally equivalent Record or Tuple, but it cannot recover declaration-attached trait implementations from text alone.
+
+## Literals
 
 For literals, if written in text syntax, we need to add `do` to make sure it's a line:
 
@@ -41,13 +72,13 @@ for a symbol:
 do 's
 ```
 
-there's also "keyword", which is called "tag" since Calcit `0.7`:
+Tags use a leading colon:
 
 ```cirru
 do :k
 ```
 
-### String escaping
+## String escaping
 
 for a string:
 
@@ -61,15 +92,9 @@ or wrap with double quotes to support special characters like spaces:
 do "|demo string"
 ```
 
-or use a single double quote for mark strings:
-
-```cirru
-do "|demo string"
-```
-
 `\n` `\t` `\"` `\\` are supported.
 
-### Data structures:
+## Data structures
 
 for a list:
 
@@ -107,19 +132,26 @@ also can be nested:
     :d 3
 ```
 
-Also a record (in Calcit code, not EDN data):
+Records retain their type name and fields:
 
 ```cirru
 let
-    A $ defstruct A (:a :dynamic)
+    A $ defstruct A (:a 'Number)
   ; Then create an instance in Calcit
   %{} A
     :a 1
 ```
 
-### Quotes
+Enums use `%::`, while ordinary tagged tuples use `::`:
 
-For quoted data, there's a special semantics for representing them, since that was neccessary for runtime snapshot usage (`calcit.cirru`, legacy `compact.cirru`), where code lives inside a piece of data, marked as:
+```cirru.no-run
+%:: :Result :ok 1
+:: :point 10 20
+```
+
+## Quotes
+
+Quoted Cirru is preserved as syntax data. This is used by runtime snapshots (`calcit.cirru`, legacy `compact.cirru`):
 
 ```cirru
 quote $ def a 1
@@ -148,9 +180,9 @@ $ cr eval 'parse-cirru-edn "|quote $ def a 1"'
 took 0.011ms: (:: 'quote ([] |def |a |1))
 ```
 
-This is not a generic solution, but tuple is a special data structure in Calcit and can be used for marking up different types of data.
+The runtime display may resemble a tuple, but Cirru EDN gives `quote` dedicated parsing and formatting semantics.
 
-### Buffers
+## Buffers
 
 Buffers can be created using the `&buffer` function with hex values:
 
@@ -158,9 +190,9 @@ Buffers can be created using the `&buffer` function with hex values:
 &buffer 0x03 0x55 0x77 0xff 0x00
 ```
 
-### Comments
+## Comments
 
-Comment expressions are started with `;`. They are evaluated into nothing, but not available anywhere, at least not available at head or inside a pair.
+Comment expressions start with `;`. They occupy nodes in the Cirru syntax tree and are ignored while EDN data is decoded.
 
 Some usages:
 
@@ -174,4 +206,4 @@ Some usages:
   :a 1
 ```
 
-Also notice that comments should also obey Cirru syntax. It's comments inside the syntax tree, rather than in parser.
+Comments must still obey Cirru indentation because they are syntax-tree nodes, not lexer comments.

--- a/docs/features/enums.md
+++ b/docs/features/enums.md
@@ -30,7 +30,7 @@ let
     Color $ defenum Color (:red) (:green) (:blue)
     c $ %:: Color :red
   println c
-  ; => (%:: :red (:enum Color))
+  ; => $ %:: :red (:enum Color)
 ```
 
 Variants with payloads:
@@ -41,9 +41,9 @@ let
     c $ %:: Shape :circle 5
     r $ %:: Shape :rect 3 4
   println c
-  ; => (%:: :circle 5 (:enum Shape))
+  ; => $ %:: :circle 5 (:enum Shape)
   println r
-  ; => (%:: :rect 3 4 (:enum Shape))
+  ; => $ %:: :rect 3 4 (:enum Shape)
 ```
 
 ## Generic Enums
@@ -70,17 +70,17 @@ After the optional generics list, `defenum` may also take a `where` map to const
 ```cirru
 let
     ShownMaybe $ defenum ShownMaybe ([] 'T)
-      {} ('T Show)
+      {} $ 'T Show
       :some 'T
       :none
     some-val $ %:: ShownMaybe :some 1
     none-val $ %:: ShownMaybe :none
-  assert-type some-val $ :: 'ShownMaybe :number
+  assert-type some-val $ :: 'ShownMaybe 'Number
   assert= |1 $ match some-val
-    (:some item) (.show item)
+    (:some item) (item .show)
     (:none) |none
   assert= |none $ match none-val
-    (:some item) (.show item)
+    (:some item) (item .show)
     (:none) |none
 ```
 
@@ -105,8 +105,11 @@ Applied generic structs also work in enum payloads:
 ```cirru
 let
     Box $ defstruct Box ([] 'T) (:value 'T)
-    Wrapped $ defenum Wrapped ([] 'T) (:box (:: 'Box 'T)) (:empty)
-    value $ %:: Wrapped :box $ %{} Box (:value 1)
+    Wrapped $ defenum Wrapped ([] 'T)
+      :box $ :: 'Box 'T
+      :empty
+    value $ %:: Wrapped :box
+      %{} Box $ :value 1
     boxed $ &tuple:nth value 1
   assert-type value $ :: 'Wrapped :number
   assert= 1 $ :value boxed
@@ -138,10 +141,8 @@ let
     Shape $ defenum Shape (:circle :number) (:rect :number :number)
     c $ %:: Shape :circle 5
     area $ tag-match c
-      (:circle radius)
-        * radius radius 3.14159
-      (:rect w h)
-        * w h
+      (:circle radius) (* radius radius 3.14159)
+      (:rect w h) (* w h)
   println area
   ; => 78.53975
 ```
@@ -154,11 +155,9 @@ let
     ok $ %:: ApiResult :ok |success
     describe $ fn (r)
       tag-match r
-        (:ok msg)
-          str-spaced |OK: msg
-        (:err msg)
-          str-spaced |Error: msg
-  println (describe ok)
+        (:ok msg) (str-spaced |OK: msg)
+        (:err msg) (str-spaced |Error: msg)
+  println $ describe ok
   ; => OK: success
 ```
 
@@ -176,10 +175,9 @@ let
 let
     Shape $ defenum Shape (:circle :number) (:rect :number :number)
     c $ %:: Shape :circle 5
-    area
-      match c
-        (:circle radius) (* radius radius 3.14159)
-        (:rect w h) (* w h)
+    area $ match c
+      (:circle radius) (* radius radius 3.14159)
+      (:rect w h) (* w h)
   println area
   ; => 78.53975
 ```
@@ -192,12 +190,9 @@ When a branch body needs more than one expression, indent subsequent lines under
 let
     ApiResult $ defenum ApiResult (:ok :string) (:err :string)
     r $ %:: ApiResult :err |network-error
-    msg
-      match r
-        (:ok v)
-          str-spaced |OK: v
-        (:err e)
-          str-spaced |Error: e
+    msg $ match r
+      (:ok v) (str-spaced |OK: v)
+      (:err e) (str-spaced |Error: e)
   println msg
   ; => Error: network-error
 ```
@@ -209,7 +204,7 @@ If you omit a variant and don't have a wildcard `_` branch, the compiler warns:
 ```cirru.no-check
 match c
   (:circle radius) (* radius radius 3.14159)
-  ; ⚠ Warning: match on `Shape` is not exhaustive. Missing variant(s): [:rect]
+  ; "⚠" Warning: match on "`Shape`" is not exhaustive. Missing variant (s) : [:rect]
 ```
 
 The check fires only when the compiler can infer the enum type of the matched value — for example, when the value is directly constructed with `%::`, or when the function parameter is annotated with an enum type in its schema. When the type cannot be inferred at preprocess time, the match still works at runtime but no compile-time warning is issued.
@@ -220,10 +215,9 @@ Use `_` as a wildcard to catch remaining variants:
 let
     Shape $ defenum Shape (:circle :number) (:rect :number :number)
     c $ %:: Shape :circle 5
-    label
-      match c
-        (:circle _r) |round
-        _ |other
+    label $ match c
+      (:circle _r) |round
+      _ |other
   println label
   ; => round
 ```
@@ -256,12 +250,14 @@ Both syntaxes share the same branch format: each branch is `(pattern body)`.
 The branch syntax is identical — migration is a single keyword replacement:
 
 ```cirru.no-check
-; Before (tag-match)
+; Before $ tag-match
+
 tag-match r
   (:ok v) (str-spaced |ok: v)
   (:err e) (str-spaced |err: e)
 
-; After (match)
+; After $ match
+
 match r
   (:ok v) (str-spaced |ok: v)
   (:err e) (str-spaced |err: e)
@@ -278,10 +274,9 @@ let
     MaybeInt $ defenum MaybeInt (:some :number) (:none)
     some-val $ %:: MaybeInt :some 42
     none-val $ %:: MaybeInt :none
-    extracted
-      match some-val
-        (:some v) (* v 2)
-        (:none) nil
+    extracted $ match some-val
+      (:some v) (* v 2)
+      (:none) nil
   println extracted
   ; => 84
 ```
@@ -307,14 +302,12 @@ let
     AppResult $ defenum AppResult (:ok :number) (:err :string)
     compute $ fn (x)
       if (> x 0)
-        %:: AppResult :ok (* x 10)
+        %:: AppResult :ok $ * x 10
         %:: AppResult :err |negative-input
     handle $ fn (r)
       match r
-        (:ok v)
-          str-spaced |result: v
-        (:err e)
-          str-spaced |failed: e
+        (:ok v) (str-spaced |result: v)
+        (:err e) (str-spaced |failed: e)
   println $ handle (compute 5)
   ; => result: 50
   println $ handle (compute -1)
@@ -333,9 +326,9 @@ let
         (:done _) true
         (:pending) false
         (:failed _) false
-  println (is-done pending)
+  println $ is-done pending
   ; => false
-  println (is-done done)
+  println $ is-done done
   ; => true
 ```
 
@@ -345,16 +338,23 @@ Field types in `defenum` declarations participate in type checking:
 
 ```cirru.no-run
 ; (:ok :string) means the :ok variant has one :string payload
+
 defenum ApiResult (:ok :string) (:err :string)
 
 ; (:point :number :number) means :point has two :number payloads
+
 defenum Shape (:point :number :number) (:circle :number)
 
 ; generic struct payloads use applied named types
+
 defstruct Box ([] 'T) (:value 'T)
-defenum Wrapped ([] 'T) (:box (:: 'Box 'T)) (:empty)
+
+defenum Wrapped ([] 'T)
+  :box $ :: 'Box 'T
+  :empty
 
 ; (:none) means no payload
+
 defenum MaybeInt (:some :number) (:none)
 ```
 
@@ -362,7 +362,9 @@ Payloads may also reference named struct types (illustrative, cross-file type re
 
 ```cirru.no-check
 ; defstruct and defenum from the same snippet context:
+
 defstruct Point (:x :number) (:y :number)
+
 defenum Shape2 (:point Point) (:circle :number)
 ```
 
@@ -378,11 +380,14 @@ let
     takes-result $ fn (r)
       :: :fn $ {} (:return :dynamic)
         :args $ [] 'app.main/Result0
-      match r ((:ok) :ok) ((:err msg) msg) $ _ :unknown
-  ; Write an untyped tuple — preprocessor rewrites to enum tuple automatically:
-  assert= :ok $ takes-result $ :: :ok
+      match r
+        (:ok) :ok
+        (:err msg) msg
+        _ :unknown
+  ; Write an untyped tuple "—" preprocessor rewrites to enum tuple automatically:
+  assert= :ok $ takes-result (:: :ok)
   ; Equivalent to:
-  assert= :ok $ takes-result $ %:: Result0 :ok
+  assert= :ok $ takes-result (%:: Result0 :ok)
 ```
 
 Requirements for the rewrite to trigger:

--- a/docs/features/list.md
+++ b/docs/features/list.md
@@ -53,7 +53,7 @@ let
     nums $ [] 1 2 3 4 5
     words $ [] |foo |bar |baz
   println nums
-  ; => ([] 1 2 3 4 5)
+  ; => $ [] 1 2 3 4 5
 ```
 
 `range` generates a sequence:
@@ -63,9 +63,9 @@ let
     r1 $ range 5
     r2 $ range 2 7
   println r1
-  ; => ([] 0 1 2 3 4)
+  ; => $ [] 0 1 2 3 4
   println r2
-  ; => ([] 2 3 4 5 6)
+  ; => $ [] 2 3 4 5 6
 ```
 
 ## Accessing Elements
@@ -98,13 +98,13 @@ let
 let
     xs $ [] 1 2 3
   println $ append xs 4
-  ; => ([] 1 2 3 4)
+  ; => $ [] 1 2 3 4
   println $ prepend xs 0
-  ; => ([] 0 1 2 3)
+  ; => $ [] 0 1 2 3
   println $ conj xs 4 5
-  ; => ([] 1 2 3 4 5)
-  println $ concat xs $ [] 4 5
-  ; => ([] 1 2 3 4 5)
+  ; => $ [] 1 2 3 4 5
+  println $ concat xs ([] 4 5)
+  ; => $ [] 1 2 3 4 5
 ```
 
 Update or remove by index:
@@ -113,9 +113,9 @@ Update or remove by index:
 let
     xs $ [] 1 2 3
   println $ assoc xs 1 99
-  ; => ([] 1 99 3)
+  ; => $ [] 1 99 3
   println $ dissoc xs 1
-  ; => ([] 1 3)
+  ; => $ [] 1 3
 ```
 
 ## Slicing & Reordering
@@ -124,17 +124,17 @@ let
 let
     xs $ [] 1 2 3 4 5
   println $ rest xs
-  ; => ([] 2 3 4 5)
+  ; => $ [] 2 3 4 5
   println $ butlast xs
-  ; => ([] 1 2 3 4)
+  ; => $ [] 1 2 3 4
   println $ slice xs 1 3
-  ; => ([] 2 3)
+  ; => $ [] 2 3
   println $ take xs 3
-  ; => ([] 1 2 3)
+  ; => $ [] 1 2 3
   println $ take-last xs 2
-  ; => ([] 4 5)
+  ; => $ [] 4 5
   println $ drop xs 2
-  ; => ([] 3 4 5)
+  ; => $ [] 3 4 5
 ```
 
 Sort (default ascending):
@@ -143,7 +143,7 @@ Sort (default ascending):
 let
     xs $ [] 3 1 4 1 5
   println $ sort xs
-  ; => ([] 1 1 3 4 5)
+  ; => $ [] 1 1 3 4 5
 ```
 
 Sort by key function (method-style):
@@ -151,8 +151,9 @@ Sort by key function (method-style):
 ```cirru
 let
     xs $ [] 1 2 3 4 5
-  println $ .sort-by xs $ fn (x) (- 0 x)
-  ; => ([] 5 4 3 2 1)
+  println $ xs .sort-by
+    fn (x) (- 0 x)
+  ; => $ [] 5 4 3 2 1
 ```
 
 Reverse:
@@ -161,7 +162,7 @@ Reverse:
 let
     xs $ [] 1 2 3 4 5
   println $ reverse xs
-  ; => ([] 5 4 3 2 1)
+  ; => $ [] 5 4 3 2 1
 ```
 
 ## Filtering & Finding
@@ -169,13 +170,17 @@ let
 ```cirru
 let
     xs $ [] 1 2 3 4 5
-  println $ filter xs $ fn (x) (> x 3)
-  ; => ([] 4 5)
-  println $ filter-not xs $ fn (x) (> x 3)
-  ; => ([] 1 2 3)
-  println $ find xs $ fn (x) (> x 3)
+  println $ filter xs
+    fn (x) (> x 3)
+  ; => $ [] 4 5
+  println $ filter-not xs
+    fn (x) (> x 3)
+  ; => $ [] 1 2 3
+  println $ find xs
+    fn (x) (> x 3)
   ; => 4
-  println $ find-index xs $ fn (x) (> x 3)
+  println $ find-index xs
+    fn (x) (> x 3)
   ; => 3
   println $ index-of xs 3
   ; => 2
@@ -186,10 +191,12 @@ let
 ```cirru
 let
     xs $ [] 1 2 3 4 5
-  println $ map xs $ fn (x) (* x 2)
-  ; => ([] 2 4 6 8 10)
-  println $ map-indexed xs $ fn (i x) ([] i x)
-  ; => ([] ([] 0 1) ([] 1 2) ([] 2 3) ([] 3 4) ([] 4 5))
+  println $ map xs
+    fn (x) (* x 2)
+  ; => $ [] 2 4 6 8 10
+  println $ map-indexed xs
+    fn (i x) ([] i x)
+  ; => $ [] ([] 0 1) ([] 1 2) ([] 2 3) ([] 3 4) ([] 4 5)
 ```
 
 Flatten one level of nesting (method-style):
@@ -197,8 +204,8 @@ Flatten one level of nesting (method-style):
 ```cirru
 let
     nested $ [] ([] 1 2) ([] 3 4) ([] 5)
-  println $ .flatten nested
-  ; => ([] 1 2 3 4 5)
+  println $ nested .flatten
+  ; => $ [] 1 2 3 4 5
 ```
 
 ## Aggregating
@@ -206,13 +213,17 @@ let
 ```cirru
 let
     xs $ [] 1 2 3 4 5
-  println $ reduce xs 0 $ fn (acc x) (+ acc x)
+  println $ reduce xs 0
+    fn (acc x) (+ acc x)
   ; => 15
-  println $ foldl xs 0 $ fn (acc x) (+ acc x)
+  println $ foldl xs 0
+    fn (acc x) (+ acc x)
   ; => 15
-  println $ any? xs $ fn (x) (> x 4)
+  println $ any? xs
+    fn (x) (> x 4)
   ; => true
-  println $ every? xs $ fn (x) (> x 0)
+  println $ every? xs
+    fn (x) (> x 0)
   ; => true
 ```
 
@@ -221,8 +232,12 @@ let
 ```cirru
 let
     xs $ [] 1 2 3 4 5
-  println $ group-by xs $ fn (x) (if (> x 3) :big :small)
-  ; => ({} (:big ([] 4 5)) (:small ([] 1 2 3)))
+  println $ group-by xs
+    fn (x)
+      if (> x 3) :big :small
+  ; => $ {}
+    :big $ [] 4 5
+    :small $ [] 1 2 3
 ```
 
 ## Strings from Lists
@@ -239,8 +254,8 @@ let
 ```cirru
 let
     xs $ [] 1 2 2 3 3 3
-  println $ .to-set xs
-  ; => (#{} 1 2 3)
+  println $ xs .to-set
+  ; => $ #{} 1 2 3
 ```
 
 ## Thread Macro Pipelines
@@ -253,7 +268,7 @@ let
       filter $ fn (x) (> x 5)
       map $ fn (x) (* x x)
   println result
-  ; => ([] 36 49 64 81)
+  ; => $ [] 36 49 64 81
 ```
 
 ## Common Patterns
@@ -264,12 +279,13 @@ let
 let
     source $ [] 1 2 3 4 5
     init $ []
-    result $ foldl source init $ fn (acc item)
-      if (> item 2)
-        append acc (* item 10)
-        , acc
+    result $ foldl source init
+      fn (acc item)
+        if (> item 2)
+          append acc $ * item 10
+          , acc
   println result
-  ; => ([] 30 40 50)
+  ; => $ [] 30 40 50
 ```
 
 ### Zip two lists together
@@ -278,9 +294,11 @@ let
 let
     ks $ [] :a :b :c
     vs $ [] 1 2 3
-    zipped $ map-indexed ks $ fn (i k) ([] k (nth vs i))
+    zipped $ map-indexed ks
+      fn (i k)
+        [] k $ nth vs i
   println zipped
-  ; => ([] ([] :a 1) ([] :b 2) ([] :c 3))
+  ; => $ [] ([] :a 1) ([] :b 2) ([] :c 3)
 ```
 
 ### Deduplicate
@@ -290,8 +308,8 @@ Convert to set (removes duplicates, loses order):
 ```cirru
 let
     xs $ [] 1 2 2 3 3 3
-  println $ .to-set xs
-  ; => (#{} 1 2 3)
+  println $ xs .to-set
+  ; => $ #{} 1 2 3
 ```
 
 ## Implementation Notes

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -239,14 +239,14 @@ The same operations are available as methods on enum values:
 
 ```cirru
 do
-  assert= 0 $ .unwrap-or (%none) 0
+  assert= 0 $
+    %none
+    , .unwrap-or 0
   assert= (%ok 4)
-    .and-then (%ok 2)
-      fn (x)
-        %ok $ * x 2
+    (%ok 2) .and-then $ fn (x)
+      %ok $ * x 2
   assert= (%err |failed!)
-    .map-err (%err |failed)
-      fn (e) (str e |!)
+    (%err |failed) .map-err $ fn (e) (str e |!)
 ```
 
 ## Notes

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -30,24 +30,28 @@ Historically, the idea was inspired by JavaScript, and also [borrowed from a tri
 ## Key terms
 
 - **Trait**: A named capability with method signatures (defined by `deftrait`).
-- **Trait impl**: An impl record providing method implementations for a trait.
+- **Trait impl**: An impl carrying the exact trait value as origin and providing its complete method set.
+- **Inherent method bag**: A compatibility impl without trait origin. It participates only in ordinary `.method` lookup and proves no trait bound.
 - **impl-traits**: Attaches one or more trait impl records to a struct/enum definition.
-- **assert-traits**: Adds a compile-time hint and performs a runtime check that a value satisfies a trait.
+- **assert-traits**: Adds a compile-time hint and performs a nominal runtime check for that exact trait origin.
 
 ## Define a trait
 
 ```cirru
-deftrait Show
-  .show $ :: :fn $ {}
-    :generics $ [] 'T
-    :args $ [] 'T
-    :return :string
-
-deftrait Eq
-  .eq? $ :: :fn $ {}
-    :generics $ [] 'T
-    :args $ [] 'T 'T
-    :return :bool
+let
+    DemoShow $ deftrait DemoShow
+      .show $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
+    DemoEq $ deftrait DemoEq
+      .eq? $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T 'T
+          :return :bool
+  [] DemoShow DemoEq
 ```
 
 Traits are values and can be referenced like normal symbols.
@@ -57,12 +61,14 @@ Traits are values and can be referenced like normal symbols.
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .foo $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p) (str "|foo " (:name p))
+      .foo $ fn (p)
+        str "|foo " $ :name p
     Person0 $ defstruct Person (:name :string)
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
@@ -74,27 +80,33 @@ let
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .foo $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     ShowTrait $ deftrait ShowTrait
-      .show $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .show $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     EqTrait $ deftrait EqTrait
-      .eq $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .eq $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     Person0 $ defstruct Person (:name :string)
     ShowImpl $ defimpl ShowImpl ShowTrait
-      .show $ fn (p) (str |Person: (:name p))
+      .show $ fn (p)
+        str |Person: $ :name p
     EqImpl $ defimpl EqImpl EqTrait
-      .eq $ fn (p) (str |eq: (:name p))
+      .eq $ fn (p)
+        str |eq: $ :name p
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p) (str |foo: (:name p))
+      .foo $ fn (p)
+        str |foo: $ :name p
     Person $ impl-traits Person0 ShowImpl EqImpl MyFooImpl
     p $ %{} Person (:name |Alice)
   [] (.show p) (.foo p)
@@ -107,20 +119,24 @@ let
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .foo $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     Person0 $ defstruct Person (:name :string)
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p) (str-spaced |foo (:name p))
+      .foo $ fn (p)
+        str-spaced |foo $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo
   .foo p
 ```
 
-If the trait is missing or required methods are not implemented, `assert-traits` raises an error.
+If the trait is missing or its selected impl is incomplete, `assert-traits` raises an error. Methods are not combined across unrelated impls: implementing `TraitA/.render` never satisfies `TraitB/.render`.
+
+`defimpl` validates concrete trait implementations when they are created: missing or extra methods and non-callable values are rejected, and native preprocessing compares typed method signatures when metadata is available. Passing a tag as the trait argument remains a legacy way to create an inherent method bag; `cr edit format` reports `W_LEGACY_INHERENT_IMPL` because that value cannot satisfy `assert-traits`, `:where`, or `&trait-call`. The advisory is non-blocking, so compatible `.method` code continues to run.
 
 ## Generic `:where` bounds on functions
 
@@ -133,13 +149,11 @@ Top-level definitions use `:schema`:
 ```cirru.no-run
 %{} :CodeEntry
   :code $ quote
-    defn show-it (x)
-      .show x
+    defn show-it (x) (.show x)
   :schema $ :: :fn
     {}
       :generics $ [] 'T
-      :where $ {}
-        'T Show
+      :where $ {} ('T Show)
       :args $ [] 'T
       :return :string
 ```
@@ -151,8 +165,7 @@ let
     show-it $ fn (x)
       hint-fn $ {}
         :generics $ [] 'T
-        :where $ {}
-          'T Show
+        :where $ {} ('T Show)
         :args $ [] 'T
         :return :string
       .show x
@@ -173,16 +186,14 @@ Do not use the old tuple form like `:where $ [] (:: 'Show 'T)`.
 `:dynamic` means that static checking has stopped at that slot. Repeating it in an argument and return position does not say that both positions have the same type:
 
 ```cirru.no-run
-; loses the input/output relationship
-:: :fn $ {}
-  :args $ [] :dynamic
-  :return :dynamic
-
-; preserves the relationship at every call site
-:: :fn $ {}
-  :generics $ [] 'T
-  :args $ [] 'T
-  :return 'T
+do
+  :: :fn $ {}
+    :args $ [] :dynamic
+    :return :dynamic
+  :: :fn $ {}
+    :generics $ [] 'T
+    :args $ [] 'T
+    :return 'T
 ```
 
 Use a type variable for identity-like relationships, add `:where` when that variable only needs a capability, and keep type arguments on containers such as `:: :list 'T` and `:: :map 'K 'V`. Use a named enum for a finite set of alternatives. Reserve `:dynamic` for boundaries whose shape is genuinely open, such as unvalidated FFI input. `:any` is only a legacy spelling of `:dynamic`, not another polymorphism mechanism.
@@ -198,7 +209,7 @@ If the summary reports debt, rerun `weak-types` without `--summary-only` and sco
 
 ## Built-in traits
 
-Core types provide built-in trait implementations registered by every runtime. The capability-focused traits added for generic `:where` bounds include:
+Core types provide origin-carrying built-in trait implementations registered consistently by native and JS runtimes. The capability-focused traits available for generic `:where` bounds include:
 
 | Trait | Method | Built-in value categories |
 | --- | --- | --- |
@@ -206,14 +217,15 @@ Core types provide built-in trait implementations registered by every runtime. T
 | `Countable` | `.count` | List, Map, Set, String, Record, Tuple/enum |
 | `Contains` | `.contains?` | List, Map, Set, String, Record, Tuple/enum |
 | `Mappable` | `.map` | List, Map, Set, Option |
-| `Show` | `.show` | General runtime values, including Record and Tuple |
-| `Eq` | `.eq?` | General comparable runtime values |
+| `Show` | `.show` | Number, String, Bool, Tag, Symbol, Nil, CirruQuote, List, Map, Set, Fn, Record, Tuple |
+| `Eq` | `.eq?` | The same scalar/collection/record/tuple categories registered for `Show` |
 
 `Compare` returns a negative number, zero, or a positive number. It intentionally starts with Number and String; cross-category ordering is not defined.
 
 ```cirru
-assert= -1 $ .compare 1 2
-assert= 0 $ .compare |same |same
+do
+  assert= -1 $ .compare 1 2
+  assert= 0 $ .compare |same |same
 ```
 
 ## Option and Result helpers
@@ -226,15 +238,22 @@ assert= 0 $ .compare |same |same
 The same operations are available as methods on enum values:
 
 ```cirru
-assert= 0 $ .unwrap-or (%none) 0
-assert= (%ok 4) $ .and-then (%ok 2) (fn (x) (%ok (* x 2)))
-assert= (%err |failed!) $ .map-err (%err |failed) (fn (e) (str e |!))
+do
+  assert= 0 $ .unwrap-or (%none) 0
+  assert= (%ok 4)
+    .and-then (%ok 2)
+      fn (x)
+        %ok $ * x 2
+  assert= (%err |failed!)
+    .map-err (%err |failed)
+      fn (e) (str e |!)
 ```
 
 ## Notes
 
 - There is no inheritance. Behavior sharing is done via traits and `impl-traits`.
 - Method calls resolve through attached trait impls first, then built-in implementations.
+- `.method` remains intentionally name-based and follows impl precedence; use `&trait-call` when the trait identity itself is part of the contract.
 - Use `assert-traits` when a function relies on trait methods and you want early, clear failures.
 
 ## Further reading

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -25,7 +25,7 @@ Historically, the idea was inspired by JavaScript, and also [borrowed from a tri
 - **Define Trait**: `deftrait Show .show (:: :fn $ {} ...)`
 - **Implement**: `defimpl ShowImpl Show .show (fn (x) ...)`
 - **Attach**: `impl-traits MyStruct ShowImpl`
-- **Call**: `.show instance`
+- **Call**: `instance .show` (receiver-first; `.show instance` remains compatible)
 
 ## Key terms
 
@@ -72,7 +72,7 @@ let
     Person0 $ defstruct Person (:name :string)
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
-  .foo p
+  p .foo
 ```
 
 `impl-traits` returns a new struct/enum definition with trait implementations attached. You can also attach multiple traits at once:
@@ -109,7 +109,7 @@ let
         str |foo: $ :name p
     Person $ impl-traits Person0 ShowImpl EqImpl MyFooImpl
     p $ %{} Person (:name |Alice)
-  [] (.show p) (.foo p)
+  [] (p .show) (p .foo)
 ```
 
 ## Trait checks and type hints
@@ -131,7 +131,7 @@ let
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo
-  .foo p
+  p .foo
 ```
 
 If the trait is missing or its selected impl is incomplete, `assert-traits` raises an error. Methods are not combined across unrelated impls: implementing `TraitA/.render` never satisfies `TraitB/.render`.
@@ -149,13 +149,13 @@ Top-level definitions use `:schema`:
 ```cirru.no-run
 %{} :CodeEntry
   :code $ quote
-    defn show-it (x) (.show x)
-  :schema $ :: :fn
+    defn show-it (x) (x .show)
+  :schema $ :: 'Fn
     {}
       :generics $ [] 'T
       :where $ {} ('T Show)
       :args $ [] 'T
-      :return :string
+      :return 'String
 ```
 
 Local functions use `hint-fn` with the same shape:
@@ -167,8 +167,8 @@ let
         :generics $ [] 'T
         :where $ {} ('T Show)
         :args $ [] 'T
-        :return :string
-      .show x
+        :return 'String
+      x .show
   show-it 1
 ```
 
@@ -224,8 +224,8 @@ Core types provide origin-carrying built-in trait implementations registered con
 
 ```cirru
 do
-  assert= -1 $ .compare 1 2
-  assert= 0 $ .compare |same |same
+  assert= -1 $ 1 .compare 2
+  assert= 0 $ |same .compare |same
 ```
 
 ## Option and Result helpers

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -198,7 +198,38 @@ If the summary reports debt, rerun `weak-types` without `--summary-only` and sco
 
 ## Built-in traits
 
-Core types provide built-in trait implementations (e.g. `Show`, `Eq`, `Compare`, `Add`, `Len`, `Mappable`). These are registered by the runtime, so values like numbers, strings, lists, maps, and records already satisfy common traits.
+Core types provide built-in trait implementations registered by every runtime. The capability-focused traits added for generic `:where` bounds include:
+
+| Trait | Method | Built-in value categories |
+| --- | --- | --- |
+| `Compare` | `.compare` | Number, String |
+| `Countable` | `.count` | List, Map, Set, String, Record, Tuple/enum |
+| `Contains` | `.contains?` | List, Map, Set, String, Record, Tuple/enum |
+| `Mappable` | `.map` | List, Map, Set, Option |
+| `Show` | `.show` | General runtime values, including Record and Tuple |
+| `Eq` | `.eq?` | General comparable runtime values |
+
+`Compare` returns a negative number, zero, or a positive number. It intentionally starts with Number and String; cross-category ordering is not defined.
+
+```cirru
+assert= -1 $ .compare 1 2
+assert= 0 $ .compare |same |same
+```
+
+## Option and Result helpers
+
+`Option T` and `Result T E` are generic core enums. Their constructors remain `%some`/`%none` and `%ok`/`%err`; the following helpers make normal pipelines explicit without losing type relationships:
+
+- Option: `option:some?`, `option:none?`, `option:map`, `option:unwrap-or`, `option:and-then`
+- Result: `result:ok?`, `result:err?`, `result:map`, `result:map-err`, `result:unwrap-or`, `result:and-then`
+
+The same operations are available as methods on enum values:
+
+```cirru
+assert= 0 $ .unwrap-or (%none) 0
+assert= (%ok 4) $ .and-then (%ok 2) (fn (x) (%ok (* x 2)))
+assert= (%err |failed!) $ .map-err (%err |failed) (fn (e) (str e |!))
+```
 
 ## Notes
 

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -216,7 +216,7 @@ Core types provide origin-carrying built-in trait implementations registered con
 | `Compare` | `.compare` | Number, String |
 | `Countable` | `.count` | List, Map, Set, String, Record, Tuple/enum |
 | `Contains` | `.contains?` | List, Map, Set, String, Record, Tuple/enum |
-| `Mappable` | `.map` | List, Map, Set, Option |
+| `Mappable` | `.map` | List, Map, Set, Option, Result |
 | `Show` | `.show` | Number, String, Bool, Tag, Symbol, Nil, CirruQuote, List, Map, Set, Fn, Record, Tuple |
 | `Eq` | `.eq?` | The same scalar/collection/record/tuple categories registered for `Show` |
 

--- a/docs/features/records.md
+++ b/docs/features/records.md
@@ -64,12 +64,12 @@ Use this pattern when the struct definition owns the type variable. Function-lev
 ```cirru
 let
     ShownBox $ defstruct ShownBox ([] 'T)
-      {} ('T Show)
+      {} $ 'T Show
       :value 'T
     box $ %{} ShownBox (:value 1)
     item $ :value box
-  assert-type box $ :: 'ShownBox :number
-  assert= |1 $ .show item
+  assert-type box $ :: 'ShownBox 'Number
+  assert= |1 $ item .show
 ```
 
 Here `({} ('T Show))` means `T` must satisfy the `Show` trait. `%{}` enforces that bound when constructing a record instance, so the constraint lives on the data definition rather than on each individual function schema.
@@ -90,9 +90,7 @@ Fields can also be written on separate lines:
 ```cirru
 let
     Point $ defstruct Point (:x :number) (:y :number)
-    p $ %{} Point
-      :x 1
-      :y 2
+    p $ %{} Point (:x 1) (:y 2)
   , p
 ```
 
@@ -115,7 +113,7 @@ let
     Point $ defstruct Point (:x :number) (:y :number)
     p $ %{} Point (:x 1) (:y 2)
   println $ keys p
-  ; => (#{} :x :y)
+  ; => $ #{} :x :y
   println $ count p
   ; => 2
   println $ contains? p :x
@@ -132,9 +130,9 @@ let
     p $ %{} Point (:x 1) (:y 2)
     p2 $ assoc p :x 10
   println p2
-  ; => (%{} :Point (:x 10) (:y 2))
+  ; => $ %{} :Point (:x 10) (:y 2)
   println p
-  ; p is unchanged: (%{} :Point (:x 1) (:y 2))
+  ; p is unchanged: $ %{} :Point (:x 1) (:y 2)
 ```
 
 ```cirru
@@ -183,7 +181,7 @@ let
 let
     Point $ defstruct Point (:x :number) (:y :number)
     p $ %{} Point (:x 1) (:y 2)
-  ; check if a value is a record (struct instance)
+  ; check if a value is a record $ struct instance
   println $ record? p
   ; => true
   ; check if it matches a specific struct
@@ -211,9 +209,11 @@ let
     Square $ defstruct Square (:side :number)
     shape $ %{} Circle (:radius 5)
   record-match shape
-    Circle c $ * 3.14 (* (get c :radius) (get c :radius))
+    Circle c $ * 3.14
+      * (get c :radius) (get c :radius)
     Square s $ * (get s :side) (get s :side)
     _ _ nil
+
 ; => 78.5
 ```
 
@@ -235,7 +235,8 @@ let
 let
     Person $ defstruct Person (:name :string) (:age :number) (:position :tag)
     p $ %{} Person (:name |Chen) (:age 20) (:position :mainland)
-  println $ merge p $ {} (:age 23) (:name |Ye)
+  println $ merge p
+    {} (:age 23) (:name |Ye)
 ```
 
 ## Record Name and Struct Inspection
@@ -260,7 +261,8 @@ let
     Cat $ defstruct Cat (:name :string) (:color :tag)
     Dog $ defstruct Dog (:name :string)
     v1 $ %{} Cat (:name |Mimi) (:color :white)
-  if (= (&record:struct v1) Cat)
+  if
+    = (&record:struct v1) Cat
     println "|Handle Cat branch"
     println "|Not a Cat"
 ```
@@ -272,24 +274,27 @@ Define a trait with `deftrait`, implement it with `defimpl`, and attach it to a 
 ```cirru
 let
     BirdTrait $ deftrait BirdTrait
-      .show $ :: :fn $ {}
-        :args $ [] 'T
-        :return :nil
-      .rename $ :: :fn $ {}
-        :args $ [] 'T :string
-        :return 'T
+      .show $ :: :fn
+        {}
+          :args $ [] 'T
+          :return :nil
+      .rename $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T :string
+          :return 'T
     BirdShape $ defstruct BirdShape (:name :string)
     BirdImpl $ defimpl BirdImpl BirdTrait
       .show $ fn (self)
         println $ get self :name
-      .rename $ fn (self name)
-        assoc self :name name
+      .rename $ fn (self name) (assoc self :name name)
     Bird $ impl-traits BirdShape BirdImpl
     b $ %{} Bird (:name |Sparrow)
-  .show b
+  assert-traits b BirdTrait
+  b .show
   let
-      b2 $ .rename b |Eagle
-    .show b2
+      b2 $ b .rename |Eagle
+    println $ :name b2
 ```
 
 ## Common Use Cases
@@ -309,11 +314,7 @@ let
 ```cirru
 let
     Product $ defstruct Product (:id :string) (:name :string) (:price :number) (:discount :number)
-    product $ %{} Product
-      :id |P001
-      :name |Widget
-      :price 100
-      :discount 0.9
+    product $ %{} Product (:id |P001) (:name |Widget) (:price 100) (:discount 0.9)
   println $ * (get product :price) (get product :discount)
   ; => 90
 ```
@@ -324,12 +325,13 @@ let
 let
     User $ defstruct User (:name :string) (:age :number) (:email :string)
     get-user-name $ fn (user)
-      hint-fn $ {} (:args ([] 'User)) (:return :string)
+      hint-fn $ {}
+        :args $ [] 'User
+        :return :string
       get user :name
-  println $ get-user-name $ %{} User
-    :name |John
-    :age 30
-    :email |john@example.com
+  println $ get-user-name
+    %{} User (:name |John) (:age 30) (:email |john@example.com)
+
 ; => John
 ```
 
@@ -344,10 +346,12 @@ let
       :: :fn $ {} (:return :number)
         :args $ [] 'app.main/Point
       &+ (:x p) (:y p)
-  ; Write a hashmap — preprocessor rewrites to record automatically:
-  assert= 30 $ sum-point $ {} (:x 10) (:y 20)
+  ; Write a hashmap "—" preprocessor rewrites to record automatically:
+  assert= 30 $ sum-point
+    {} (:x 10) (:y 20)
   ; Equivalent to:
-  assert= 30 $ sum-point $ %{} Point (:x 10) (:y 20)
+  assert= 30 $ sum-point
+    %{} Point (:x 10) (:y 20)
 ```
 
 Requirements for the rewrite to trigger:
@@ -367,7 +371,8 @@ Loose records are records created without a declared struct definition, using th
 
 ```cirru
 ?{} :name |John :age 30
-; => (?{} (:age 30) (:name |John))
+
+; => $ ?{} (:age 30) (:name |John)
 ```
 
 Fields are automatically sorted alphabetically, matching the behavior of struct-backed records. All keys must be tags, and duplicate keys produce an error.
@@ -397,9 +402,10 @@ let
         :args $ [] 'app.main/Point
       &+ (:x p) (:y p)
   ; Loose record rewritten to struct record at compile time:
-  assert= 30 $ sum-point $ ?{} :x 10 :y 20
+  assert= 30 $ sum-point (?{} :x 10 :y 20)
   ; Equivalent to:
-  assert= 30 $ sum-point $ %{} Point (:x 10) (:y 20)
+  assert= 30 $ sum-point
+    %{} Point (:x 10) (:y 20)
 ```
 
 The rewrite uses the same requirements as map-to-record rewrite. Fields not present in the loose record but defined in the struct are filled with `nil`.

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -113,11 +113,14 @@ Runnable Example:
 ```cirru
 let
     calculate-total $ fn (items)
-      hint-fn $ {} (:args ([] :list)) (:return :number)
-      reduce items 0
-        fn (acc item)
-          hint-fn $ {} (:args ([] :number :number)) (:return :number)
-          + acc item
+      hint-fn $ {}
+        :args $ [] :list
+        :return :number
+      reduce items 0 $ fn (acc item)
+        hint-fn $ {}
+          :args $ [] :number :number
+          :return :number
+        + acc item
   calculate-total $ [] 1 2 3
 ```
 
@@ -151,7 +154,9 @@ Generic trait bounds use the same schema map. Follow the Rust-style split: decla
 ```cirru
 let
     get-name $ fn (user)
-      hint-fn $ {} (:args ([] :dynamic)) (:return :string)
+      hint-fn $ {}
+        :args $ [] :dynamic
+        :return :string
       , |demo
   get-name nil
 ```
@@ -161,11 +166,10 @@ let
     print-it $ fn (x)
       hint-fn $ {}
         :generics $ [] 'T
-        :where $ {}
-          'T Show
+        :where $ {} ('T Show)
         :args $ [] 'T
-        :return :string
-      .show x
+        :return 'String
+      x .show
   print-it 1
 ```
 
@@ -177,8 +181,7 @@ For `defn` and `fn`, you can place a type label immediately after the parameters
 
 ```cirru
 let
-    add $ fn (a b) :number
-      + a b
+    add $ fn (a b) :number (+ a b)
   add 10 20
 ```
 
@@ -189,7 +192,9 @@ For namespace-level `defn` / `defmacro`, parameter and return metadata should st
 ```cirru
 let
     add $ fn (a b) :number
-      hint-fn $ {} (:args $ [] :number :number) (:return :number)
+      hint-fn $ {}
+        :args $ [] :number :number
+        :return :number
       let
           total $ + a b
         assert-type total :number
@@ -226,8 +231,10 @@ Represent values that can be `nil`. Use the `:: 'Optional <type>` syntax:
 ```cirru
 let
     greet $ fn (name)
-      hint-fn $ {} (:args ([] (:: :optional :string))) (:return :string)
-      str "|Hello " (or name "|Guest")
+      hint-fn $ {}
+        :args $ [] (:: :optional :string)
+        :return :string
+      str "|Hello " $ or name |Guest
   greet nil
 ```
 
@@ -273,8 +280,7 @@ If the body only needs a capability, add a trait bound rather than replacing `'T
 ```cirru.no-run
 :: :fn $ {}
   :generics $ [] 'T
-  :where $ {}
-    'T Show
+  :where $ {} ('T Show)
   :args $ [] 'T
   :return :string
 ```
@@ -289,7 +295,9 @@ Use the name defined by `defstruct` or `defenum`:
 let
     User $ defstruct User (:name :string)
     get-name $ fn (u)
-      hint-fn $ {} (:args ([] 'User)) (:return :string)
+      hint-fn $ {}
+        :args $ [] 'User
+        :return :string
       get u :name
   get-name $ %{} User (:name |Alice)
 ```
@@ -301,10 +309,10 @@ let
 The system validates that function calls have the correct number of arguments:
 
 ```cirru
-defn greet (name age)
-  str "|Hello " name "|, you are " age
+defn greet (name age) (str "|Hello " name "|, you are " age)
 
 ; Error: expects 2 args but got 1
+
 ; greet |Alice
 ```
 
@@ -315,10 +323,7 @@ Validates that record fields exist:
 ```cirru
 defstruct User (:name :string) (:age :number)
 
-defn get-user-email (user)
-  .-email user
-  ; Warning: field 'email' not found in record User
-  ; Available fields: name, age
+defn get-user-email (user) (.-email user) (; Warning: field 'email' not found in record User) (; Available fields: name, age)
 ```
 
 ### Tuple Index Bounds
@@ -327,8 +332,8 @@ Checks tuple index access at compile time:
 
 ```cirru.no-check
 let
-    point (%:: :Point 10 20 30)
-  &tuple:nth point 5  ; Warning: index 5 out of bounds, tuple has 4 elements
+    point $ %:: :Point 10 20 30
+  &tuple:nth point 5 ; Warning: index 5 out of bounds, tuple has 4 elements
 ```
 
 ### Enum Variant Validation
@@ -336,15 +341,16 @@ let
 Validates enum construction and pattern matching:
 
 ```cirru.no-check
-defenum Result
-  :Ok :number
-  :Error :string
+defenum Result (:Ok :number) (:Error :string)
 
 ; Warning: variant 'Failure' not found in enum Result
+
 %:: Result :Failure "|something went wrong"
+
 ; Available variants: Ok, Error
 
 ; Warning: variant 'Ok' expects 1 payload but got 2
+
 %:: Result :Ok 42 |extra
 ```
 
@@ -353,11 +359,7 @@ defenum Result
 Checks that methods exist for the receiver type:
 
 ```cirru
-defn process-list (xs)
-  ; .unknown-method xs
-  println "|demo code"
-  ; "Warning: unknown method .unknown-method for :list"
-  ; Available methods: .map, .filter, .count, ...
+defn process-list (xs) (; .unknown-method xs) (println "|demo code") (; "Warning: unknown method .unknown-method for :list") (; Available methods: .map, .filter, .count, ...)
 ```
 
 ### Recur Arity Checking
@@ -366,8 +368,7 @@ Validates that `recur` calls have the correct number of arguments:
 
 ```cirru
 defn factorial (n acc)
-  if (<= n 1) acc
-    recur (dec n) (* n acc)
+  if (<= n 1) acc $ recur (dec n) (* n acc)
   ; Warning: recur expects 2 args but got 3
   ; recur (dec n) (* n acc) 999
 ```
@@ -415,7 +416,7 @@ let
 let
     Point $ defstruct Point (:x :number) (:y :number)
     p $ %{} Point (:x 10) (:y 20)
-    x-val (:x p)
+    x-val $ :x p
   ; x-val inferred as :number from field type
   assert= x-val 10
 ```
@@ -428,12 +429,14 @@ Use `assert-type` to explicitly check local values during preprocessing:
 let
     transform-fn $ fn (x) (* x 2)
     process-data $ fn (data)
-      hint-fn $ {} (:args ([] :list)) (:return :list)
+      hint-fn $ {}
+        :args $ [] :list
+        :return :list
       let
           xs data
         assert-type xs :list
         &list:map xs transform-fn
-  process-data ([] 1 2 3)
+  process-data $ [] 1 2 3
 ```
 
 **Note**: `assert-type` is evaluated during preprocessing and removed at runtime, so there's no performance penalty.
@@ -446,17 +449,18 @@ Use `&inspect-type` to debug type inference. Pass a symbol name and the inferred
 let
     x 10
     nums $ [] 1 2 3
-  assert-type nums :list
-  ; Prints: [&inspect-type] x => number type
+  ; A broad assertion checks the shape without erasing the inferred Number element type.
+  assert-type nums 'List
+  ; Prints: [&inspect-type] x => number
   &inspect-type x
-  ; Prints: [&inspect-type] nums => list type
+  ; Prints: [&inspect-type] nums => list<number>
   &inspect-type nums
   let
       item $ &list:nth nums 0
-    ; Prints: [&inspect-type] item => dynamic type
+    ; Prints: [&inspect-type] item => number
     &inspect-type item
-    assert-type item :number
-    ; Prints: [&inspect-type] item => number type
+    assert-type item 'Number
+    ; Prints: [&inspect-type] item => number
     &inspect-type item
 ```
 
@@ -469,15 +473,15 @@ Calcit supports optional type annotations for nullable values:
 Definition:
 
 ```cirru
-defn find-user (id)
-  ; May return nil if user not found
-  println "|demo code"
+defn find-user (id) (; May return nil if user not found) (println "|demo code")
 ```
 
 Schema on the namespace definition:
 
 ```cirru
-:: :fn $ {} (:args $ [] :dynamic) (:return (:: :optional :record))
+:: :fn $ {}
+  :args $ [] :dynamic
+  :return $ :: :optional :record
 ```
 
 ## Variadic Types
@@ -487,8 +491,7 @@ Functions with rest parameters use variadic type annotations:
 Definition:
 
 ```cirru
-defn sum (& numbers)
-  reduce numbers 0 +
+defn sum (& numbers) (reduce numbers 0 +)
 ```
 
 Schema on the namespace definition:
@@ -505,13 +508,15 @@ Definition:
 
 ```cirru
 defn apply-twice (f x)
-  f (f x)
+  f $ f x
 ```
 
 Schema on the namespace definition:
 
 ```cirru
-:: :fn $ {} (:args $ [] :fn :number) (:return :number)
+:: :fn $ {}
+  :args $ [] :fn :number
+  :return :number
 ```
 
 ## Disabling Checks
@@ -563,12 +568,14 @@ These rewrites are automatic. Provide type annotations (`hint-fn`, `:schema`, `a
 let
     process-input $ fn (input) (assoc input :processed true)
     public-api-function $ fn (input)
-      hint-fn $ {} (:args ([] :map)) (:return :string)
+      hint-fn $ {}
+        :args $ [] :map
+        :return :string
       let
           processed $ process-input input
         assert-type processed :map
         str processed
-  public-api-function ({} (:data |hello))
+  public-api-function $ {} (:data |hello)
 ```
 
 ### 2. Leverage Type Inference
@@ -576,24 +583,25 @@ let
 Let the system infer types from literals and function calls:
 
 ```cirru
-defn calculate-area (width height)
-  ; Types inferred from arithmetic operations
-  * width height
+defn calculate-area (width height) (; Types inferred from arithmetic operations) (* width height)
 ```
 
 ### 3. Add Assertions for Critical Code
 
 ```cirru
 let
-    dangerous-operation $ fn (data) (map data (fn (x) (* x 2)))
+    dangerous-operation $ fn (data)
+      map data $ fn (x) (* x 2)
     critical-operation $ fn (data)
-      hint-fn $ {} (:args ([] :list)) (:return :list)
+      hint-fn $ {}
+        :args $ [] :list
+        :return :list
       let
           checked data
         assert-type checked :list
         ; Ensure the local value is still what we expect before processing
         dangerous-operation checked
-  critical-operation ([] 1 2 3)
+  critical-operation $ [] 1 2 3
 ```
 
 ### 4. Document Complex Types
@@ -602,15 +610,15 @@ Definition:
 
 ```cirru
 ; Function that takes a map with specific keys
-defn process-user (user-map)
-  ; Expected keys: :name :email :age
-  println "|demo code"
+
+defn process-user (user-map) (; Expected keys: :name :email :age) (println "|demo code")
 ```
 
 Schema on the namespace definition:
 
 ```cirru
-:: :fn $ {} (:args $ [] :map)
+:: :fn $ {}
+  :args $ [] :map
 ```
 
 ## Type Slots (Cross-Package Type Injection)
@@ -628,7 +636,8 @@ deftype-slot :dispatch-op
 Then reference the slot in type annotations with the `*name` syntax:
 
 ```cirru.no-check
-;; EventHandler schema — dispatch callback accepts the slot type
+;; EventHandler schema "—" dispatch callback accepts the slot type
+
 :: :fn $ {} (:return :unit)
   :args $ [] '*dispatch-op
 ```
@@ -645,11 +654,8 @@ This writes the following entry-level configuration:
 
 ```cirru.no-check
 :entries $ {}
-  :default $ {}
-    :mode :native
-    :init-fn 'app.main/main!
-    :type-slots $ {}
-      :dispatch-op |app.schema/Op
+  :default $ {} (:mode :native) (:init-fn 'app.main/main!)
+    :type-slots $ {} (:dispatch-op |app.schema/Op)
 ```
 
 No wrapper is needed around `main!`; the binding is installed before any definition is preprocessed and applies to the whole selected entry.
@@ -693,15 +699,20 @@ cr config rm-type-slot :dispatch-op
 After binding `*dispatch-op` to `Op`, the preprocessor catches mistakes:
 
 ```cirru.no-check
-;; ✅ Correct — compiles cleanly
+;; "✅" Correct "—" compiles cleanly
+
 d! $ %:: Op :toggle (:id task)
 
-;; ❌ Wrong variant name
+;; "❌" Wrong variant name
+
 ;; Warning: "does not have variant :delete"
+
 d! $ %:: Op :delete (:id task)
 
-;; ❌ Wrong payload count
+;; "❌" Wrong payload count
+
 ;; Warning: "expects 0 payload(s), got 1"
+
 d! $ %:: Op :clear 42
 ```
 

--- a/docs/features/traits.md
+++ b/docs/features/traits.md
@@ -20,7 +20,7 @@ Keep two concepts separate:
 
 ## Quick Recipes
 
-- **Define Trait**: `deftrait MyTrait .method (:: :fn $ {} ...)`
+- **Define Trait**: `deftrait MyTrait .method (:: 'Fn $ {} ...)`
 - **Implement Trait**: `defimpl MyImpl MyTrait .method (fn (x) ...)`
 - **Attach to Struct**: `impl-traits MyStruct MyImpl`
 - **Call Method**: `.method instance`
@@ -32,10 +32,10 @@ Use `deftrait` to define a trait and its method signatures (including type annot
 
 ```cirru
 deftrait MyFoo $ .foo
-  :: :fn $ {}
+  :: 'Fn $ {}
     :generics $ [] 'T
     :args $ [] 'T
-    :return :string
+    :return 'String
 ```
 
 ## Implement a trait
@@ -45,12 +45,12 @@ Use `defimpl` to create an impl record for a trait.
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn
+      .foo $ :: 'Fn
         {}
           :generics $ [] 'T
           :args $ [] 'T
-          :return :string
-    Person0 $ defstruct Person (:name :string)
+          :return 'String
+    Person0 $ defstruct Person (:name 'String)
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
         str-spaced |foo $ :name p
@@ -96,12 +96,12 @@ Prefer dot-style keys (`.foo`). Legacy tag keys (`:foo`) are still accepted for 
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn
+      .foo $ :: 'Fn
         {}
           :generics $ [] 'T
           :args $ [] 'T
-          :return :string
-    Person0 $ defstruct Person (:name :string)
+          :return 'String
+    Person0 $ defstruct Person (:name 'String)
     ImplB $ defimpl ImplB MyFoo
       :: :foo $ fn (p)
         str |B: $ :name p
@@ -123,7 +123,7 @@ This form is retained so older `.method` dispatch keeps working. It does **not**
 
 ```cirru
 let
-    MyMarker $ deftrait MyMarker (.dummy :fn)
+    MyMarker $ deftrait MyMarker (.dummy 'Fn)
     MyMarkerImpl $ defimpl MyMarkerImpl MyMarker
       .dummy $ fn (_x) nil
   , MyMarkerImpl
@@ -152,19 +152,19 @@ Syntax:
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn
+      .foo $ :: 'Fn
         {}
           :generics $ [] 'T
           :args $ [] 'T
-          :return :string
+          :return 'String
     ImplA $ defimpl ImplA MyFoo
       .foo $ fn (p)
         str |A: $ :name p
-    MyBar $ deftrait MyBar (.bar :fn)
+    MyBar $ deftrait MyBar (.bar 'Fn)
     ImplB $ defimpl ImplB MyBar
       .bar $ fn (p)
         str |B: $ :name p
-    StructDef0 $ defstruct StructDef (:name :string)
+    StructDef0 $ defstruct StructDef (:name 'String)
     StructDef $ impl-traits StructDef0 ImplA ImplB
     x $ %{} StructDef (:name |test)
   .foo x
@@ -179,32 +179,32 @@ let
 do (; struct example)
   let
       MyFoo $ deftrait MyFoo
-        .foo $ :: :fn
+        .foo $ :: 'Fn
           {}
             :generics $ [] 'T
             :args $ [] 'T
-            :return :string
+            :return 'String
       MyFooImpl $ defimpl MyFooImpl MyFoo
         .foo $ fn (p)
           str-spaced |foo $ :name p
-      Person0 $ defstruct Person (:name :string)
+      Person0 $ defstruct Person (:name 'String)
       Person $ impl-traits Person0 MyFooImpl
       p $ %{} Person (:name |Alice)
     .foo p
   ; enum example
   let
       ResultTrait $ deftrait ResultTrait
-        .describe $ :: :fn
+        .describe $ :: 'Fn
           {}
             :generics $ [] 'T
             :args $ [] 'T
-            :return :string
+            :return 'String
       ResultImpl $ defimpl ResultImpl ResultTrait
         .describe $ fn (x)
           match x
             (:ok v) (str |ok: v)
             (:err v) (str |err: v)
-      Result0 $ defenum Result0 (:ok :string) (:err :string)
+      Result0 $ defenum Result0 (:ok 'String) (:err 'String)
       MyResult $ impl-traits Result0 ResultImpl
       r $ %:: MyResult :ok |done
     .describe r
@@ -244,22 +244,22 @@ Example with two traits sharing the same method name:
 ```cirru
 let
     MyZapA $ deftrait MyZapA
-      .zap $ :: :fn
+      .zap $ :: 'Fn
         {}
           :generics $ [] 'T
           :args $ [] 'T
-          :return :string
+          :return 'String
     MyZapB $ deftrait MyZapB
-      .zap $ :: :fn
+      .zap $ :: 'Fn
         {}
           :generics $ [] 'T
           :args $ [] 'T
-          :return :string
+          :return 'String
     MyZapAImpl $ defimpl MyZapAImpl MyZapA
       .zap $ fn (_x) |zapA
     MyZapBImpl $ defimpl MyZapBImpl MyZapB
       .zap $ fn (_x) |zapB
-    Person0 $ defstruct Person (:name :string)
+    Person0 $ defstruct Person (:name 'String)
     Person $ impl-traits Person0 MyZapAImpl MyZapBImpl
     p $ %{} Person (:name |Alice)
   ; .zap follows normal dispatch $ last-wins for user impls
@@ -318,12 +318,12 @@ Notes:
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn
+      .foo $ :: 'Fn
         {}
           :generics $ [] 'T
           :args $ [] 'T
-          :return :string
-    Person0 $ defstruct Person (:name :string)
+          :return 'String
+    Person0 $ defstruct Person (:name 'String)
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
         str-spaced |foo $ :name p

--- a/docs/features/traits.md
+++ b/docs/features/traits.md
@@ -11,12 +11,12 @@ aliases:
 
 # Traits
 
-Calcit provides a lightweight trait system for attaching method implementations to struct/enum definitions (and using them from constructed instances and built-in types).
+Calcit provides a lightweight nominal trait system for attaching method implementations to struct/enum definitions and for describing capabilities of built-in values. The historical prototype/class terminology is no longer the design model; see [Polymorphism](polymorphism.md) for the unified dispatch rules.
 
-It complements the “class-like” polymorphism described in [Polymorphism](polymorphism.md):
+Keep two concepts separate:
 
-- Struct/enum **classes** are about “this concrete type has these methods”.
-- **Traits** are about “this value supports this capability (set of methods)”.
+- A **trait impl** has a concrete `deftrait` value as its origin. It participates in `.method` dispatch and can satisfy `assert-traits`, generic `:where` bounds, and `&trait-call`.
+- An **inherent method bag** has no trait origin. It remains compatible with legacy dispatch through `.method`, but it does not prove any trait capability.
 
 ## Quick Recipes
 
@@ -31,8 +31,8 @@ It complements the “class-like” polymorphism described in [Polymorphism](pol
 Use `deftrait` to define a trait and its method signatures (including type annotations).
 
 ```cirru
-deftrait MyFoo
-  .foo $ :: :fn $ {}
+deftrait MyFoo $ .foo
+  :: :fn $ {}
     :generics $ [] 'T
     :args $ [] 'T
     :return :string
@@ -45,14 +45,15 @@ Use `defimpl` to create an impl record for a trait.
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .foo $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     Person0 $ defstruct Person (:name :string)
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
-        str-spaced |foo (:name p)
+        str-spaced |foo $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   .foo p
@@ -67,33 +68,25 @@ defimpl ImplName Trait ...
 ```
 
 - First argument is the **impl record name**.
-- Second argument is the **trait value** (symbol) or a **tag**.
+- Second argument is the concrete **trait value** (normally a symbol). A tag is accepted only for the legacy method-bag form described below.
 
 Examples:
 
 ```cirru
-do
-  ; Form 1: symbol names for impl and trait
-  let
-      PersonA0 $ defstruct PersonA (:name :string)
-      MyFooA $ deftrait MyFooA
-        .foo $ :: :fn $ {}
+let
+    PersonA0 $ defstruct PersonA (:name 'String)
+    MyFooA $ deftrait MyFooA
+      .foo $ :: 'Fn
+        {}
           :generics $ [] 'T
           :args $ [] 'T
-          :return :string
-      MyFooImplA $ defimpl MyFooImplA MyFooA
-        .foo $ fn (p) (str-spaced |foo (:name p))
-      PersonA $ impl-traits PersonA0 MyFooImplA
-      p $ %{} PersonA (:name |Alice)
-    .foo p
-  ; Form 2: tag keywords for impl and trait (no deftrait needed)
-  let
-      PersonB0 $ defstruct PersonB (:name :string)
-      MyFooImplB $ defimpl :MyFooImplB :MyFooB
-        .foo $ fn (p) (str-spaced |bar (:name p))
-      PersonB $ impl-traits PersonB0 MyFooImplB
-      p $ %{} PersonB (:name |Bob)
-    .foo p
+          :return 'String
+    MyFooImplA $ defimpl MyFooImplA MyFooA
+      .foo $ fn (p)
+        str-spaced |foo $ :name p
+    PersonA $ impl-traits PersonA0 MyFooImplA
+    p $ %{} PersonA (:name |Alice)
+  .foo p
 ```
 
 **2) Method pair forms**
@@ -101,52 +94,49 @@ do
 Prefer dot-style keys (`.foo`). Legacy tag keys (`:foo`) are still accepted for compatibility.
 
 ```cirru
-; Both forms are accepted and equivalent:
-do
-  let
-      MyFoo $ deftrait MyFoo
-        .foo $ :: :fn $ {}
+let
+    MyFoo $ deftrait MyFoo
+      .foo $ :: :fn
+        {}
           :generics $ [] 'T
           :args $ [] 'T
           :return :string
-      Person0 $ defstruct Person (:name :string)
-      ; Form 1: preferred .method keys
-      ImplA $ defimpl ImplA MyFoo
-        .foo (fn (p) (str |A: (:name p)))
-      PersonA $ impl-traits Person0 ImplA
-      pa $ %{} PersonA (:name |Alice)
-    .foo pa
-  let
-      MyFoo $ deftrait MyFoo
-        .foo $ :: :fn $ {}
-          :generics $ [] 'T
-          :args $ [] 'T
-          :return :string
-      Person0 $ defstruct Person (:name :string)
-      ; Form 2: legacy tag keys (compatible)
-      ImplB $ defimpl ImplB MyFoo
-        :: :foo (fn (p) (str |B: (:name p)))
-      PersonB $ impl-traits Person0 ImplB
-      pb $ %{} PersonB (:name |Bob)
-    .foo pb
+    Person0 $ defstruct Person (:name :string)
+    ImplB $ defimpl ImplB MyFoo
+      :: :foo $ fn (p)
+        str |B: $ :name p
+    PersonB $ impl-traits Person0 ImplB
+    pb $ %{} PersonB (:name |Bob)
+  .foo pb
 ```
 
-**3) Tag-based impl (no concrete trait value)**
+**3) Legacy tag-based method bags (compatibility only)**
 
-If you need a pure marker and don’t want to bind to a real trait value, use tags:
+Passing a tag instead of a concrete trait value creates an originless/inherent method bag:
+
+```cirru.no-check
+defimpl :MyMarkerImpl :MyMarker $ .dummy
+  fn (_x) nil
+```
+
+This form is retained so older `.method` dispatch keeps working. It does **not** implement a nominal trait and therefore cannot satisfy `assert-traits`, a generic `:where` bound, or `&trait-call`. `cr edit format` reports the non-blocking `W_LEGACY_INHERENT_IMPL` migration advisory. New code should define a real trait and pass its symbol:
 
 ```cirru
-defimpl :MyMarkerImpl :MyMarker
-  .dummy nil
+let
+    MyMarker $ deftrait MyMarker (.dummy :fn)
+    MyMarkerImpl $ defimpl MyMarkerImpl MyMarker
+      .dummy $ fn (_x) nil
+  , MyMarkerImpl
 ```
 
-This is also a safe replacement for the old self-referential pattern
-`defimpl X X`, which can cause recursion in new builds.
+This also replaces the old self-referential pattern `defimpl X X`, which can recurse while the definition is being initialized.
 
 Implementation notes:
 
-- `defimpl` creates an “impl record” that stores the trait as its origin.
-- This origin is used by `&trait-call` to match the correct implementation when method names overlap.
+- With a concrete trait argument, `defimpl` creates an impl that stores that exact trait value as its origin.
+- The impl must provide exactly the trait's declared method set; method values must be callable, and native preprocessing checks declared signatures when signature metadata is available.
+- Trait identity is nominal at runtime. Two independently evaluated traits do not become equal merely because their printed names and method sets match.
+- This origin is used by `assert-traits` and `&trait-call`; methods from multiple unrelated impls are never merged to satisfy one trait.
 
 ## Attach impls to struct/enum definitions
 
@@ -162,14 +152,18 @@ Syntax:
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .foo $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     ImplA $ defimpl ImplA MyFoo
-      .foo $ fn (p) (str |A: (:name p))
-    ImplB $ defimpl :ImplB :ImplB-trait
-      .bar $ fn (p) (str |B: (:name p))
+      .foo $ fn (p)
+        str |A: $ :name p
+    MyBar $ deftrait MyBar (.bar :fn)
+    ImplB $ defimpl ImplB MyBar
+      .bar $ fn (p)
+        str |B: $ :name p
     StructDef0 $ defstruct StructDef (:name :string)
     StructDef $ impl-traits StructDef0 ImplA ImplB
     x $ %{} StructDef (:name |test)
@@ -182,16 +176,17 @@ let
 - Treat internal `&...` helpers as runtime-level details; they may change more frequently and are not the stable user contract.
 
 ```cirru.no-check
-do
-  ; struct example
+do (; struct example)
   let
       MyFoo $ deftrait MyFoo
-        .foo $ :: :fn $ {}
-          :generics $ [] 'T
-          :args $ [] 'T
-          :return :string
+        .foo $ :: :fn
+          {}
+            :generics $ [] 'T
+            :args $ [] 'T
+            :return :string
       MyFooImpl $ defimpl MyFooImpl MyFoo
-        .foo $ fn (p) (str-spaced |foo (:name p))
+        .foo $ fn (p)
+          str-spaced |foo $ :name p
       Person0 $ defstruct Person (:name :string)
       Person $ impl-traits Person0 MyFooImpl
       p $ %{} Person (:name |Alice)
@@ -199,10 +194,11 @@ do
   ; enum example
   let
       ResultTrait $ deftrait ResultTrait
-        .describe $ :: :fn $ {}
-          :generics $ [] 'T
-          :args $ [] 'T
-          :return :string
+        .describe $ :: :fn
+          {}
+            :generics $ [] 'T
+            :args $ [] 'T
+            :return :string
       ResultImpl $ defimpl ResultImpl ResultTrait
         .describe $ fn (x)
           match x
@@ -248,15 +244,17 @@ Example with two traits sharing the same method name:
 ```cirru
 let
     MyZapA $ deftrait MyZapA
-      .zap $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .zap $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     MyZapB $ deftrait MyZapB
-      .zap $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .zap $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     MyZapAImpl $ defimpl MyZapAImpl MyZapA
       .zap $ fn (_x) |zapA
     MyZapBImpl $ defimpl MyZapBImpl MyZapB
@@ -264,9 +262,9 @@ let
     Person0 $ defstruct Person (:name :string)
     Person $ impl-traits Person0 MyZapAImpl MyZapBImpl
     p $ %{} Person (:name |Alice)
-  ; .zap follows normal dispatch (last-wins for user impls)
+  ; .zap follows normal dispatch $ last-wins for user impls
   .zap p
-  ; explicitly pick a trait’s implementation
+  ; explicitly pick a "trait’s" implementation
   &trait-call MyZapA :zap p
   &trait-call MyZapB :zap p
 ```
@@ -283,7 +281,7 @@ Two helpers are useful when debugging trait + method dispatch:
 let
     xs $ [] 1 2
   &methods-of xs
-  &inspect-methods xs "|list"
+  &inspect-methods xs |list
 ```
 
 You can also inspect impl origins directly when validating trait dispatch:
@@ -291,10 +289,15 @@ You can also inspect impl origins directly when validating trait dispatch:
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn ('T) ('T) :string
-    Shape0 $ defenum Shape (:point :number :number)
+      .foo $ :: 'Fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return 'String
+    Shape0 $ defenum Shape (:point 'Number 'Number)
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (t) (str |shape: (&tuple:nth t 0))
+      .foo $ fn (t)
+        str |shape: $ &tuple:nth t 0
     Shape $ impl-traits Shape0 MyFooImpl
     some-tuple $ %:: Shape :point 10 20
     impls $ &tuple:impls some-tuple
@@ -304,24 +307,26 @@ let
 
 ## Checking trait requirements
 
-`assert-traits` checks at runtime that a value implements a trait (i.e. it provides all required methods). It returns the value unchanged if the check passes.
+`assert-traits` checks at runtime that a value contains one complete impl whose origin is the requested trait. It returns the value unchanged if the check passes. A same-named method from another trait or an inherent method bag is not sufficient.
 
 Notes:
 
 - `assert-traits` is syntax (expanded to `&assert-traits`) and its first argument must be a **local**.
-- For built-in values (list/map/set/string/number/...), `assert-traits` only validates default implementations. It **does not** extend methods at runtime.
-- Static analysis and runtime checks may diverge for built-ins due to limited compile-time information; this mismatch is currently allowed.
+- Built-in values (list/map/set/string/number/...) expose the same origin-carrying core impls to native and JS. `assert-traits` only validates them; it does **not** extend methods at runtime.
+- Static preprocessing uses the evaluated impl metadata when available and a small core bootstrap map during initialization. Runtime validation remains nominal.
 
 ```cirru
 let
     MyFoo $ deftrait MyFoo
-      .foo $ :: :fn $ {}
-        :generics $ [] 'T
-        :args $ [] 'T
-        :return :string
+      .foo $ :: :fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'T
+          :return :string
     Person0 $ defstruct Person (:name :string)
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p) (str-spaced |foo (:name p))
+      .foo $ fn (p)
+        str-spaced |foo $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo

--- a/docs/features/traits.md
+++ b/docs/features/traits.md
@@ -23,7 +23,7 @@ Keep two concepts separate:
 - **Define Trait**: `deftrait MyTrait .method (:: 'Fn $ {} ...)`
 - **Implement Trait**: `defimpl MyImpl MyTrait .method (fn (x) ...)`
 - **Attach to Struct**: `impl-traits MyStruct MyImpl`
-- **Call Method**: `.method instance`
+- **Call Method**: `instance .method` (receiver-first; `.method instance` remains compatible)
 - **Check Trait**: `assert-traits instance MyTrait`
 
 ## Define a trait
@@ -56,7 +56,7 @@ let
         str-spaced |foo $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
-  .foo p
+  p .foo
 ```
 
 ### Impl-related syntax (cheatsheet)
@@ -86,7 +86,7 @@ let
         str-spaced |foo $ :name p
     PersonA $ impl-traits PersonA0 MyFooImplA
     p $ %{} PersonA (:name |Alice)
-  .foo p
+  p .foo
 ```
 
 **2) Method pair forms**
@@ -107,7 +107,7 @@ let
         str |B: $ :name p
     PersonB $ impl-traits Person0 ImplB
     pb $ %{} PersonB (:name |Bob)
-  .foo pb
+  pb .foo
 ```
 
 **3) Legacy tag-based method bags (compatibility only)**
@@ -167,7 +167,7 @@ let
     StructDef0 $ defstruct StructDef (:name 'String)
     StructDef $ impl-traits StructDef0 ImplA ImplB
     x $ %{} StructDef (:name |test)
-  .foo x
+  x .foo
 ```
 
 ### Public vs internal API boundary
@@ -190,7 +190,7 @@ do (; struct example)
       Person0 $ defstruct Person (:name 'String)
       Person $ impl-traits Person0 MyFooImpl
       p $ %{} Person (:name |Alice)
-    .foo p
+    p .foo
   ; enum example
   let
       ResultTrait $ deftrait ResultTrait
@@ -207,7 +207,7 @@ do (; struct example)
       Result0 $ defenum Result0 (:ok 'String) (:err 'String)
       MyResult $ impl-traits Result0 ResultImpl
       r $ %:: MyResult :ok |done
-    .describe r
+    r .describe
 ```
 
 ### Static analysis boundary
@@ -263,7 +263,7 @@ let
     Person $ impl-traits Person0 MyZapAImpl MyZapBImpl
     p $ %{} Person (:name |Alice)
   ; .zap follows normal dispatch $ last-wins for user impls
-  .zap p
+  p .zap
   ; explicitly pick a "trait’s" implementation
   &trait-call MyZapA :zap p
   &trait-call MyZapB :zap p
@@ -330,13 +330,13 @@ let
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo
-  .foo p
+  p .foo
 ```
 
 ### Examples (verified with `cr eval`)
 
 ```bash
-cargo run --bin cr -- calcit.cirru eval 'let ((xs ([] 1 2 3))) (assert= xs (assert-traits xs calcit.core/Len)) (.len xs)'
+cargo run --bin cr -- calcit.cirru eval 'let ((xs ([] 1 2 3))) (assert= xs (assert-traits xs calcit.core/Len)) (xs .len)'
 ```
 
 Expected output:
@@ -346,7 +346,7 @@ Expected output:
 ```
 
 ```bash
-cargo run --bin cr -- calcit.cirru eval 'let ((xs ([] 1 2 3))) (assert= xs (assert-traits xs calcit.core/Mappable)) (.map xs inc)'
+cargo run --bin cr -- calcit.cirru eval 'let ((xs ([] 1 2 3))) (assert= xs (assert-traits xs calcit.core/Mappable)) (xs .map inc)'
 ```
 
 Expected output:

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -85,8 +85,8 @@ cr eval "echo |done"
 - **HashSets**: `#{} :a :b :c`
 - **Tuples**: `:: :tag 1 2` - tagged unions with class support
 - **Records**: `%{} RecordName (:key1 val1) (:key2 val2)`, similar to structs
-- **Structs**: `defstruct Point (:x :number) (:y :number)` - record type definitions
-- **Enums**: `defenum Result (:ok ..) (:err :string)` - sum types
+- **Structs**: `defstruct Point (:x 'Number) (:y 'Number)` - record type definitions
+- **Enums**: `defenum Result (:ok ..) (:err 'String)` - sum types
 - **Refs/Atoms**: `atom 0` - mutable references
 - **Buffers**: `&buffer 0x01 0x02` - binary data
 
@@ -94,18 +94,21 @@ cr eval "echo |done"
 
 ```cirru
 ; Function definition
-defn add (a b)
-  + a b
+
+defn add (a b) (+ a b)
 ```
 
 ```cirru
 ; Conditional
-let ((x 1))
+
+let
+    x 1
   if (> x 0) |positive |negative
 ```
 
 ```cirru
 ; Let binding
+
 let
     a 1
     b 2
@@ -114,6 +117,7 @@ let
 
 ```cirru
 ; Thread macro
+
 -> (range 10)
   filter $ fn (x) (> x 5)
   map inc
@@ -125,47 +129,51 @@ let
 let
     ; Local function with type annotations
     add $ fn (a b)
-      hint-fn $ {} (:args ([] :number :number)) (:return :number)
+      hint-fn $ {}
+        :args $ [] 'Number 'Number
+        :return 'Number
       + a b
     ; Local variadic function
     sum $ fn (& xs)
-      hint-fn $ {} (:rest :number) (:return :number)
+      hint-fn $ {} (:rest 'Number) (:return 'Number)
       apply + xs
     ; Struct definition
-    User $ defstruct User (:name :string) (:age :number) (:email :string)
+    User $ defstruct User (:name 'String) (:age 'Number) (:email 'String)
     x 42
-  ; Type assertion (composable check, returns original value)
-  assert-type x :number
+  ; Type assertion $ composable check, returns original value
+  assert-type x 'Number
   [] (add 3 4) (sum 1 2 3) x
 ```
 
 Namespace-level definitions use `:schema`, for example:
 
 ```cirru
-defn add (a b)
-  + a b
+defn add (a b) (+ a b)
 ```
 
 `schema` can be attached separately:
 
 ```cirru
-:: :fn $ {} (:args $ [] :number :number) (:return :number)
+:: 'Fn $ {}
+  :args $ [] 'Number 'Number
+  :return 'Number
 ```
 
 ### Built-in Types
 
-- `:number`, `:string`, `:bool`, `:nil`, `:dynamic`
-- `:list`, `:map`, `:set`, `:record`, `:fn`, `:tuple`
-- `:dynamic` - wildcard type (default when no annotation)
+- `'Number`, `'String`, `'Bool`, `'Nil`, `'Dynamic`
+- `'List`, `'Map`, `'Set`, `'Record`, `'Fn`, `'Tuple`
+- `'Dynamic` - wildcard type (default when no annotation)
 - Generic types (Cirru style):
 
 ```cirru
 let
-    t1 $ :: :list :number
-    t2 $ :: :map :string
-    t3 $ :: :fn $ {}
-      :args $ [] :number
-      :return :string
+    t1 $ :: 'List 'Number
+    t2 $ :: 'Map 'String
+    t3 $ :: 'Fn
+      {}
+        :args $ [] 'Number
+        :return 'String
   [] t1 t2 t3
 ```
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -188,7 +188,7 @@ let
 
 ### Method & Access Syntax
 
-- Method call: `.map xs inc` (or shorthand `xs.map inc`)
+- Method call: `xs .map inc` when the receiver type is known; prefix `.map xs inc` remains compatible for dynamic boundaries
 - Tag access (map key): prefer `obj.:name` over legacy `(:name obj)`
 - Trait/impl declarations prefer dot method keys like `.foo`; legacy tag keys like `:foo` remain compatible but emit a default warning in `deftrait`/`defimpl`
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -167,6 +167,20 @@ Load module dependencies with repeatable `--dep` options:
 cr docs check-md README.md --dep ./ --dep ~/.config/calcit/modules/memof/
 ```
 
+Format the same fenced Cirru blocks with `docs format-md`. It preserves all
+Markdown outside recognized `cirru`, `cirru.no-run`, `cirru.no-check`, and
+`cirru.cli` fences, and writes through an atomic replacement:
+
+```bash
+cr docs format-md README.md
+```
+
+Use `--check` in CI to reject non-canonical snippets without changing files:
+
+```bash
+cr docs format-md README.md --check
+```
+
 Recommended block modes:
 
 - `cirru`: run + preprocess + parse (preferred; executes injected snippet entry `app.main/main!`, not entry file `:init-fn`)

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -126,11 +126,13 @@ cr calcit.cirru analyze check-examples --ns package.extra
 验证 README 和 `docs/` 中的 Cirru 代码块：
 
 ```bash
+cr calcit.cirru docs format-md README.md --check
+cr calcit.cirru docs format-md docs/api.md --check
 cr calcit.cirru docs check-md README.md --failures-only
 cr calcit.cirru docs check-md docs/api.md --failures-only
 ```
 
-如果文档示例使用额外 module，可重复传 `--dep <module-dir>`。第一个表达式可以是带 `:require` 的 `ns`，由 `check-md` 注入 eval 上下文。
+`format-md` 只规范 fenced Cirru 的文本格式；`--check` 不会写入文件，适合 CI。需要改写时省略 `--check`。如果文档示例使用额外 module，可重复传 `--dep <module-dir>`。第一个表达式可以是带 `:require` 的 `ns`，由 `check-md` 注入 eval 上下文。
 
 ## 4. 入口、构建和行为
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -238,6 +238,36 @@ cr calcit.cirru analyze weak-types \
 
 `cr edit format` 负责可解析性、canonical serialization 和已知旧结构迁移；它不是完整的语义 linter。告警写到 stderr 且不会阻止格式化。CI 需要在 format 后检查 `git diff`，并单独读取 `check-types` / `weak-types --format json` 来执行项目自己的质量阈值。
 
+### 3.5 Trait impl 从方法包迁移为 nominal impl
+
+旧代码可能把 tag 作为 `defimpl` 的 trait 参数：
+
+```cirru.no-check
+defimpl :RenderImpl :Render $ .render
+  fn (x) str x
+```
+
+这种写法继续参与普通 `.method` 分派，但现在明确视为**不具名的 inherent method bag**；它不会满足 `assert-traits`、函数/数据结构的 `:where` 约束，也不能被 `&trait-call` 选中。`cr edit format` 会给出不阻断执行的 `W_LEGACY_INHERENT_IMPL` 迁移告警。需要能力约束的新代码应改成：
+
+```cirru
+let
+    Render $ deftrait Render (.render :fn)
+    RenderImpl $ defimpl RenderImpl Render
+      .render $ fn (x) str x
+  , RenderImpl
+```
+
+升级时还要修复以前被宽松实现接受的问题：
+
+- concrete trait impl 必须完整实现声明的方法，且不能夹带 trait 未声明的方法；
+- trait method 的值必须可调用；native 预处理在签名信息可用时还会检查函数签名；
+- 同名方法不会跨 impl 拼接成一个 trait，也不会让两个独立 trait 互相冒充；
+- list/map/set/string/number/record/tuple 等内建能力现在由 native 与 JS 共用的 nominal core impl 表提供。
+
+建议在升级验证中显式覆盖两类负向用例：只有 `TraitA/.method` 时，`assert-traits value TraitB` 和 `&trait-call TraitB :method value` 都必须失败。
+
+WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在预处理阶段消除的 trait 元数据仍可参与编译；残留的 `&impl::new`、`impl-traits` 或 `&assert-traits` 会明确报出“不支持 runtime trait table”，而不是静默返回 `nil`。业务项目以 JS 为主，并用 native 执行宏和预处理。
+
 ---
 
 ## 4）Yarn Berry 升级检查

--- a/editing-history/202608020058-data-api-and-trait-coverage.md
+++ b/editing-history/202608020058-data-api-and-trait-coverage.md
@@ -1,0 +1,26 @@
+# Data API and trait coverage
+
+## Review outcome
+
+- Corrected the core `Option` and `Result` declarations to carry their real generic parameters instead of dynamic payloads.
+- Added the missing high-frequency predicate, fallback, chaining, and error-mapping helpers, with schemas, method bags, docs, and queryable examples.
+- Added the documented-but-missing `Compare` trait for Number and String.
+- Connected the existing `Countable` and `Contains` traits to List, Map, Set, String, Record, and Tuple/enum values for method dispatch, static `:where` checks, and runtime `assert-traits`.
+
+## Cross-platform consistency
+
+- Made Number and String `.compare` visible through the shared built-in method bags so native, JavaScript, and WASM preprocessing agree.
+- Aligned Rust and JavaScript trait introspection for Record/Struct and Tuple/Enum by merging their built-in and attached impl records.
+- Added native, JavaScript, and WASM regression coverage for the new APIs and trait capabilities.
+
+## Type-system fix
+
+- Named generic enum values now safely satisfy builtin dynamic-tuple parameters, while a dynamic tuple still cannot satisfy a concrete named enum.
+- Type-definition resolution now unwraps `def` and `impl-traits` and resolves unqualified core enum references.
+- Tracked the underlying generic-enum diagnostic defect in <https://github.com/calcit-lang/calcit/issues/287>.
+
+## Documentation
+
+- Expanded the data-type overview to distinguish persistent values, named data, executable values, and explicitly stateful containers.
+- Documented Cirru EDN versus JSON fidelity, unsupported values, and restoring declared Record/Enum identity during parsing.
+- Added the built-in trait matrix and the Option/Result helper surface to the polymorphism guide.

--- a/history/202608021153-runtime-traits.md
+++ b/history/202608021153-runtime-traits.md
@@ -1,0 +1,23 @@
+# Runtime traits: nominal implementations
+
+## What changed
+
+- Runtime `CalcitTrait` values now have nominal identity, so independently evaluated traits with the same displayed name and method shape do not match accidentally.
+- Concrete `defimpl` values carry their exact trait origin, require the complete declared method set, and reject non-callable methods. Native preprocessing additionally verifies signatures when metadata is available.
+- Tag-based `defimpl` remains compatible as an originless inherent method bag. It continues to support ordinary `.method` dispatch, but cannot satisfy trait bounds, `assert-traits`, or `&trait-call`.
+- Core builtin capability implementations now preserve trait origins in native and JS runtimes, including scalar values. WASM remains an internal validation backend and reports an explicit unsupported-runtime-trait error when preprocessing cannot eliminate trait operations.
+- `cr edit format` emits a non-blocking migration advisory for legacy tag-based trait arguments.
+
+## Verification
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test` (298 library tests, 176 CLI tests)
+- `yarn compile`
+- `yarn check-all` (Agent interface, native, JS, IR, and WASM)
+- `cr docs check-md` for traits, polymorphism, and upgrade documentation; all 24 Cirru blocks round-trip through the current formatter.
+- External Respo check-only, type summary, and targeted example regression.
+
+## Compatibility
+
+This intentionally tightens concrete trait implementation validation. Existing tag-based method bags keep running, with a migration advisory. Code that treated unrelated same-named or partial implementations as satisfying a trait must migrate to a real `deftrait` plus complete nominal `defimpl`.

--- a/history/202608021227-format-markdown-cirru.md
+++ b/history/202608021227-format-markdown-cirru.md
@@ -1,0 +1,18 @@
+# Markdown Cirru formatter
+
+## What changed
+
+- Added `cr docs format-md <file>` to canonicalize fenced `cirru`, `cirru.no-run`, `cirru.no-check`, and `cirru.cli` blocks in Markdown.
+- Added `--check` for CI: it reports non-canonical blocks without writing the Markdown file.
+- Formatting preserves non-Cirru Markdown and fence labels, parses code directly as multiple Cirru AST roots, and writes using the existing atomic replacement helper.
+- Added CLI help, command-echo support, unit coverage for formatting, parse errors, idempotence, and the non-writing check mode.
+- Documented usage in CLI options and library quality guidance.
+
+## Verification
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-all`
+- `cr docs format-md --check` and `cr docs check-md` on affected documentation.

--- a/history/202608021239-review-trait-followups.md
+++ b/history/202608021239-review-trait-followups.md
@@ -1,0 +1,19 @@
+# Trait review follow-ups
+
+## What changed
+
+- Corrected the public `Mappable` capability table: Result joins List, Map, Set, and Option.
+- Documented why `calcit.internal` is excluded from the legacy inherent-impl advisory: bootstrap method bags precede public nominal trait availability.
+- Made builtin literal method introspection tolerant of unavailable core impl lists, matching record and tuple behavior in embedding/unit-test startup states.
+- Corrected `&str:contains?` documentation and schema to describe numeric character-index bounds checking; substring membership remains `&str:includes?`.
+- Restrict primitive trait-name bootstrap fallback to the period before its real core impl list is evaluated, and added a test that reads the embedded core Snapshot to detect table drift.
+
+## Verification
+
+- `cr src/cirru/calcit-core.cirru edit format`
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test` (300 library tests, 179 CLI tests)
+- `yarn compile`
+- `yarn check-all` (Agent interface, native, JS, IR, WASM)
+- `cr docs check-md --entry calcit/test.cirru docs/features/polymorphism.md`

--- a/history/202608021251-defimpl-symbol-traits.md
+++ b/history/202608021251-defimpl-symbol-traits.md
@@ -1,0 +1,8 @@
+# `defimpl` trait arguments use raw symbols
+
+- Migrated ordinary test fixtures from tag-based `defimpl` trait arguments to named `deftrait` values referenced directly as symbols.
+- Kept the new trait definitions' entry schemas as `'Trait`, so the snapshot metadata matches their runtime role.
+- Updated the `defimpl` macro documentation and diagnostics: raw symbols are the standard syntax; tag arguments remain only as legacy inherent-method-bag compatibility.
+- Updated the tuple test to assert the new nominal trait origin rather than the old tag representation.
+
+`&impl::new :name` bootstrap method bags are intentionally unchanged: unlike the macro form, a raw symbol there would be evaluated rather than captured as syntax.

--- a/history/202608021255-doc-type-symbols.md
+++ b/history/202608021255-doc-type-symbols.md
@@ -1,0 +1,6 @@
+# Documentation type syntax audit
+
+- Updated the trait guide and quick reference so schema and data-declaration type positions use quoted symbols (`'String`, `'Number`, `'Fn`, and so on).
+- Kept ordinary tag data unchanged, including enum variants, record keys, and schema-map keys such as `:return`.
+- Ran `docs format-md` and `docs check-md` with `calcit/test.cirru` for both updated guides.
+- The wider audit still finds legacy type-tag examples in feature, run, and migration pages. Upgrade/compatibility explanations deliberately retain old spellings; the remaining tutorial/reference pages should be migrated in a dedicated documentation sweep with code-block validation.

--- a/history/202608021322-postfix-enum-methods.md
+++ b/history/202608021322-postfix-enum-methods.md
@@ -1,0 +1,12 @@
+# Receiver-first enum method calls
+
+- Extended preprocess-time postfix method rewriting to recognize nominal enum
+  receivers as well as records and traits.
+- During core bootstrapping, infer the declared result type of `%some`, `%none`,
+  `%ok`, and `%err` from their schemas, so their values keep enough type
+  information for receiver-first calls such as `res-ok .unwrap-or 9`.
+- Updated Option/Result trait tests and polymorphism documentation to use the
+  receiver-first form, and verified the JavaScript backend emits normal method
+  invocation code.
+- Updated a formatting-advisory fixture assertion whose legacy inherent-impl
+  warning was intentionally removed by the earlier symbol-type migration.

--- a/history/202608021327-postfix-unwrap-examples.md
+++ b/history/202608021327-postfix-unwrap-examples.md
@@ -1,0 +1,10 @@
+# Receiver-first unwrap examples
+
+- Migrated the built-in `option:unwrap-or` and `result:unwrap-or` API examples
+  to the typed receiver-first method form.
+- Verified the examples through `analyze check-examples`, the Markdown snippet
+  through `docs check-md`, and generated JavaScript by executing the trait test
+  bundle with Node.js.
+- Kept the two WASM fixtures in function form: the internal WASM backend does
+  not yet lower enum constructor receiver-method calls, while its complete
+  verification suite continues to pass with the supported form.

--- a/history/202608021507-receiver-first-static-inference.md
+++ b/history/202608021507-receiver-first-static-inference.md
@@ -1,0 +1,21 @@
+# Receiver-first calls with stronger static inference
+
+- Extended receiver-first rewriting from Result/Option to every receiver whose
+  static method table is known, including built-in collections, primitives,
+  traits, structs, records, and enums. Prefix calls remain compatible.
+- Preserved concrete `deftrait`, `defimpl`, `defstruct`, and `defenum` metadata
+  through local bindings and imported definitions, so `impl-traits` no longer
+  collapses nominal values to `Dynamic` or a broad `Custom` type.
+- Propagated generic `:where` capabilities into function bodies and enum
+  `match` payloads, including lexical data definitions and nested named type
+  references. `%::` now retains enum identity even when a payload-free variant
+  cannot determine every generic argument.
+- Inferred typed trait-method returns, required struct fields read through
+  `get`, and body-hinted parameter types. Broad `assert-type` checks no longer
+  erase a more precise compatible inferred type.
+- Migrated representative Calcit snapshots and Markdown examples to
+  receiver-first syntax, formatted every touched Cirru block, and executed the
+  documented outputs on native and JavaScript targets.
+- Kept conservative `Dynamic` fallback for opaque FFI values, heterogeneous or
+  genuinely unresolved nested data, and metadata that cannot be resolved
+  without executing arbitrary user code.

--- a/history/202608021550-review-type-correctness.md
+++ b/history/202608021550-review-type-correctness.md
@@ -1,0 +1,6 @@
+# Review type-correctness follow-ups
+
+- Kept named enum compatibility directional: a resolved enum `TypeRef` may satisfy a dynamic tuple parameter, but a dynamic tuple may not satisfy the named enum.
+- Added namespace-qualified source identity to pre-runtime trait references so bootstrap fallback cannot confuse a user trait with a same-named core trait.
+- Let unresolved core Option/Result constructors fall through to schema inference and taught method return inference to read impl methods from resolved enum `TypeRef` values.
+- Added regressions for nominal trait fallback, source trait identity, and chained receiver-first Option/Result calls.

--- a/scripts/test-wasm.mjs
+++ b/scripts/test-wasm.mjs
@@ -457,6 +457,10 @@ check("test-str-slice()", 3, e["test-str-slice"]); // &str:slice "abcde" 1 4 = "
 check("test-str-compare-eq()", 0, e["test-str-compare-eq"]);
 check("test-str-compare-lt()", -1, e["test-str-compare-lt"]);
 check("test-str-compare-gt()", 1, e["test-str-compare-gt"]);
+check("test-number-compare-method()", -1, e["test-number-compare-method"]);
+check("test-string-compare-method()", -1, e["test-string-compare-method"]);
+check("test-option-unwrap-or()", 7, e["test-option-unwrap-or"]);
+check("test-result-unwrap-or()", 7, e["test-result-unwrap-or"]);
 check("test-str-contains-true()", 1, e["test-str-contains-true"]); // idx 1 < len 5
 check("test-str-contains-false()", 0, e["test-str-contains-false"]); // idx 10 >= len 5
 check("test-str-find-index-found()", 1, e["test-str-find-index-found"]); // "ell" at byte 1

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -466,6 +466,7 @@ fn render_docs_explanation(cmd: &DocsCommand) -> Option<String> {
     DocsSubcommand::Agents(_) => "reads agent/developer guide".to_string(),
     DocsSubcommand::ReadLines(opts) => format!("reads specific lines from `{}`", opts.filename),
     DocsSubcommand::CheckMd(opts) => format!("validates code snippets in `{}`", opts.file),
+    DocsSubcommand::FormatMd(opts) => format!("formats Cirru snippets in `{}`", opts.file),
     DocsSubcommand::Graph(_) => "builds or queries the documentation relationship graph".to_string(),
   })
 }
@@ -679,6 +680,7 @@ fn push_docs(tokens: &mut Vec<String>, cmd: &DocsCommand) {
     DocsSubcommand::CheckMd(opts) => {
       echo_items!(tokens, pos "file" => &opts.file, value "entry" => &opts.entry; default "calcit.cirru", list "dep" => &opts.dep, switch "failures-only" => opts.failures_only)
     }
+    DocsSubcommand::FormatMd(opts) => echo_items!(tokens, pos "file" => &opts.file, switch "check" => opts.check),
     DocsSubcommand::Graph(opts) => match &opts.subcommand {
       DocsGraphSubcommand::Build(_) => tokens.push("build".to_string()),
       DocsGraphSubcommand::Check(_) => tokens.push("check".to_string()),
@@ -1106,6 +1108,7 @@ fn docs_name(subcommand: &DocsSubcommand) -> &'static str {
     DocsSubcommand::Agents(_) => "agents",
     DocsSubcommand::ReadLines(_) => "read-lines",
     DocsSubcommand::CheckMd(_) => "check-md",
+    DocsSubcommand::FormatMd(_) => "format-md",
     DocsSubcommand::Graph(_) => "graph",
   }
 }

--- a/src/bin/cli_handlers/docs.rs
+++ b/src/bin/cli_handlers/docs.rs
@@ -22,6 +22,7 @@ use calcit::runner;
 use calcit::snapshot;
 use calcit::util;
 
+use super::atomic_write::stage_atomic_file;
 use super::docs_cache;
 use super::libs::handle_libs_command;
 use super::markdown_read::{RenderMarkdownOptions, render_markdown_sections};
@@ -170,6 +171,7 @@ pub fn handle_docs_command(cmd: &DocsCommand) -> Result<(), String> {
     DocsSubcommand::Agents(opts) => handle_agents(&opts.headings, !opts.no_subheadings, opts.full, opts.with_lines, opts.refresh),
     DocsSubcommand::ReadLines(opts) => handle_read_lines(&opts.filename, opts.start, opts.lines, opts.module.as_deref()),
     DocsSubcommand::CheckMd(opts) => handle_check_md(&opts.file, &opts.entry, &opts.dep, opts.quiet, opts.failures_only),
+    DocsSubcommand::FormatMd(opts) => handle_format_md(&opts.file, opts.check),
     DocsSubcommand::Graph(opts) => handle_graph_command(&opts.subcommand),
   }
 }
@@ -1248,6 +1250,16 @@ enum CirruCheckMode {
   NoCheck,
 }
 
+fn cirru_fence_mode(fence: &str) -> Option<CirruCheckMode> {
+  match fence {
+    "```cirru" => Some(CirruCheckMode::Run),
+    "```cirru.no-run" => Some(CirruCheckMode::NoRun),
+    "```cirru.no-check" => Some(CirruCheckMode::NoCheck),
+    "```cirru.cli" => Some(CirruCheckMode::NoCli),
+    _ => None,
+  }
+}
+
 impl std::fmt::Display for CirruCheckMode {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
@@ -1308,6 +1320,124 @@ fn extract_cirru_blocks(content: &str) -> Vec<(usize, CirruCheckMode, String)> {
   }
 
   blocks
+}
+
+#[derive(Debug)]
+struct FormattedMarkdown {
+  content: String,
+  total_blocks: usize,
+  changed_blocks: usize,
+}
+
+/// Format supported fenced Cirru blocks while retaining all Markdown text and fence labels.
+///
+/// The code inside each fence is parsed and rendered directly as a vector of
+/// Cirru roots. This preserves a block containing multiple top-level forms,
+/// unlike routing it through the JSON-based `cirru format` command.
+fn format_markdown_cirru_blocks(content: &str) -> Result<FormattedMarkdown, String> {
+  let line_ending = if content.contains("\r\n") { "\r\n" } else { "\n" };
+  let mut output = String::with_capacity(content.len());
+  let mut in_cirru_block = false;
+  let mut in_other_block = false;
+  let mut block_start_line = 0;
+  let mut code_lines: Vec<String> = Vec::new();
+  let mut total_blocks = 0;
+  let mut changed_blocks = 0;
+
+  for (line_index, raw_line) in content.split_inclusive('\n').enumerate() {
+    let line = raw_line.strip_suffix('\n').unwrap_or(raw_line);
+    let line = line.strip_suffix('\r').unwrap_or(line);
+    let trimmed = line.trim();
+
+    if !in_cirru_block && !in_other_block && trimmed.starts_with("```") {
+      if cirru_fence_mode(trimmed).is_some() {
+        in_cirru_block = true;
+        block_start_line = line_index + 2;
+        code_lines.clear();
+      } else {
+        in_other_block = true;
+      }
+      output.push_str(raw_line);
+    } else if (in_cirru_block || in_other_block) && trimmed == "```" {
+      if in_cirru_block {
+        total_blocks += 1;
+        let source = code_lines.join("\n");
+        let nodes = cirru_parser::parse(&source)
+          .map_err(|error| format!("Failed to parse Cirru block starting at line {block_start_line}: {error}"))?;
+        let formatted = cirru_parser::format(&nodes, true.into())
+          .map_err(|error| format!("Failed to format Cirru block starting at line {block_start_line}: {error}"))?;
+        let canonical = formatted.trim();
+        if source != canonical {
+          changed_blocks += 1;
+        }
+        if !canonical.is_empty() {
+          for formatted_line in canonical.split('\n') {
+            output.push_str(formatted_line);
+            output.push_str(line_ending);
+          }
+        }
+      }
+      in_cirru_block = false;
+      in_other_block = false;
+      output.push_str(raw_line);
+    } else if in_cirru_block {
+      code_lines.push(line.to_string());
+    } else {
+      output.push_str(raw_line);
+    }
+  }
+
+  if in_cirru_block {
+    return Err(format!("Unclosed Cirru code block starting at line {block_start_line}"));
+  }
+
+  Ok(FormattedMarkdown {
+    content: output,
+    total_blocks,
+    changed_blocks,
+  })
+}
+
+fn handle_format_md(file_path: &str, check: bool) -> Result<(), String> {
+  let content = fs::read_to_string(file_path).map_err(|error| format!("Failed to read file '{file_path}': {error}"))?;
+  let formatted = format_markdown_cirru_blocks(&content)?;
+
+  if check {
+    if formatted.changed_blocks == 0 {
+      println!(
+        "{}  {} Cirru blocks already canonical  {}",
+        file_path.cyan(),
+        formatted.total_blocks,
+        "✓".green()
+      );
+      return Ok(());
+    }
+    return Err(format!(
+      "{} Cirru block(s) in '{file_path}' need formatting. Run `cr docs format-md {file_path}`.",
+      formatted.changed_blocks
+    ));
+  }
+
+  if formatted.changed_blocks == 0 {
+    println!(
+      "{}  {} Cirru blocks already canonical  {}",
+      file_path.cyan(),
+      formatted.total_blocks,
+      "✓".green()
+    );
+    return Ok(());
+  }
+
+  let staged = stage_atomic_file(Path::new(file_path), formatted.content.as_bytes(), "Markdown")?;
+  staged.commit()?;
+  println!(
+    "{}  formatted {} of {} Cirru blocks  {}",
+    file_path.cyan(),
+    formatted.changed_blocks,
+    formatted.total_blocks,
+    "✓".green()
+  );
+  Ok(())
 }
 
 fn ensure_runtime_initialized() {

--- a/src/bin/cli_handlers/docs_tests.rs
+++ b/src/bin/cli_handlers/docs_tests.rs
@@ -1,7 +1,8 @@
 use super::{
   GuideDoc, GuideDocFrontmatter, GuideDocScope, collect_check_md_module_paths, collect_docs_for_query, collect_search_results,
-  find_doc_by_query, load_agents_document, load_entry_snapshot_for_check_md, load_module_docs_from_dir, parse_doc_frontmatter,
-  parse_doc_knowledge_metadata, score_doc_query, score_doc_shape, validate_doc_frontmatter,
+  find_doc_by_query, format_markdown_cirru_blocks, handle_format_md, load_agents_document, load_entry_snapshot_for_check_md,
+  load_module_docs_from_dir, parse_doc_frontmatter, parse_doc_knowledge_metadata, score_doc_query, score_doc_shape,
+  validate_doc_frontmatter,
 };
 use std::fs;
 use std::path::Path;
@@ -592,6 +593,66 @@ fn load_module_docs_from_dir_rejects_invalid_category() {
 
   let err = load_module_docs_from_dir(&modules_dir, Some("respo.calcit")).unwrap_err();
   assert!(err.contains("Invalid frontmatter category 'api'"));
+
+  fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn format_markdown_cirru_blocks_formats_only_supported_fences() {
+  let input = "# Demo\n\n```cirru\ndeftrait Demo\n  .show $ :: :fn $ {}\n    :args $ [] 'T\n    :return 'String\n```\n\n```rust\nfn main() {}\n```\n\n```cirru.no-check\ndefimpl :Legacy :Marker\n  .show $ fn (x) x\n```\n";
+
+  let formatted = format_markdown_cirru_blocks(input).expect("markdown formatting should succeed");
+
+  assert_eq!(formatted.total_blocks, 2);
+  assert_eq!(formatted.changed_blocks, 2);
+  assert!(formatted.content.contains("```rust\nfn main() {}\n```"));
+  assert!(
+    formatted
+      .content
+      .contains("```cirru.no-check\ndefimpl :Legacy :Marker $ .show\n  fn (x) x\n```"),
+    "formatted markdown:\n{}",
+    formatted.content
+  );
+  assert_eq!(
+    format_markdown_cirru_blocks(&formatted.content)
+      .expect("canonical markdown should format")
+      .changed_blocks,
+    0
+  );
+}
+
+#[test]
+fn format_markdown_cirru_blocks_keeps_multiple_roots_and_reports_parse_lines() {
+  let input = "before\n```cirru\nassert= 1 1\nassert= 2 2\n```\nafter\n";
+  let formatted = format_markdown_cirru_blocks(input).expect("multiple roots should format");
+
+  assert!(
+    formatted.content.contains("assert= 1 1\n\nassert= 2 2"),
+    "formatted markdown:\n{}",
+    formatted.content
+  );
+
+  let invalid = "```cirru\nfoo (\n```\n";
+  let error = format_markdown_cirru_blocks(invalid).expect_err("invalid Cirru should fail");
+  assert!(error.contains("line 2"), "error: {error}");
+}
+
+#[test]
+fn format_md_check_does_not_write_and_format_is_idempotent() {
+  let root = unique_temp_dir("format-md");
+  let path = root.join("guide.md");
+  let original = "```cirru\ndefimpl :Legacy :Marker\n  .show $ fn (x) x\n```\n";
+  write_file(&path, original);
+  let path_text = path.to_str().expect("temporary path should be utf-8");
+
+  let error = handle_format_md(path_text, true).expect_err("check should reject non-canonical block");
+  assert!(error.contains("need formatting"), "error: {error}");
+  assert_eq!(fs::read_to_string(&path).expect("read original markdown"), original);
+
+  handle_format_md(path_text, false).expect("format should write canonical markdown");
+  let canonical = fs::read_to_string(&path).expect("read canonical markdown");
+  assert_ne!(canonical, original);
+  handle_format_md(path_text, true).expect("canonical markdown should pass check");
 
   fs::remove_dir_all(root).unwrap();
 }

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -287,6 +287,8 @@ fn collect_format_advisories(snapshot_file: &str, original_edn: &Edn, snapshot: 
       continue;
     }
     for (definition, entry) in &file.defs {
+      // Core bootstrap method bags intentionally use tag-style origins before
+      // the public nominal traits are available, so they are not migration debt.
       if namespace != "calcit.internal" {
         legacy_inherent_impl_count += count_legacy_inherent_impls(&entry.code);
       }

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -281,11 +281,15 @@ fn collect_format_advisories(snapshot_file: &str, original_edn: &Edn, snapshot: 
   let mut legacy_any_count = count_legacy_any_schema_fields(original_edn);
   let mut unresolved_dynamic_occurrences = 0usize;
   let mut unresolved_dynamic_definitions = 0usize;
+  let mut legacy_inherent_impl_count = 0usize;
   for (namespace, file) in &snapshot.files {
     if namespace.ends_with(".$meta") || !(namespace == &snapshot.package || namespace.starts_with(&format!("{}.", snapshot.package))) {
       continue;
     }
     for (definition, entry) in &file.defs {
+      if namespace != "calcit.internal" {
+        legacy_inherent_impl_count += count_legacy_inherent_impls(&entry.code);
+      }
       if let Some(row) = crate::type_coverage::analyze_weak_types_entry(namespace, definition, entry, &selected) {
         legacy_any_count += row
           .occurrences
@@ -316,8 +320,25 @@ fn collect_format_advisories(snapshot_file: &str, original_edn: &Edn, snapshot: 
        Next: run `cr {snapshot_arg} analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only`, then rerun without `--summary-only` for paths and recommendations."
     ));
   }
+  if legacy_inherent_impl_count > 0 {
+    advisories.push(format!(
+      "[W_LEGACY_INHERENT_IMPL] Found {legacy_inherent_impl_count} `defimpl` occurrence(s) whose trait argument is a tag. These remain compatible as inherent method bags but do not satisfy nominal trait bounds.\n\
+       Next: when the methods represent a capability, define it with `deftrait` and pass the trait symbol to `defimpl`; keep the tag form only for intentionally originless `.method` dispatch."
+    ));
+  }
 
   advisories
+}
+
+fn count_legacy_inherent_impls(node: &Cirru) -> usize {
+  let Cirru::List(items) = node else {
+    return 0;
+  };
+  let current = usize::from(
+    matches!(items.first(), Some(Cirru::Leaf(head)) if head.as_ref() == "defimpl")
+      && matches!(items.get(2), Some(Cirru::Leaf(trait_name)) if trait_name.starts_with(':')),
+  );
+  current + items.iter().map(count_legacy_inherent_impls).sum::<usize>()
 }
 
 fn count_legacy_any_schema_fields(value: &Edn) -> usize {
@@ -2584,9 +2605,9 @@ fn print_import_usage_tips(rule: &Cirru, source_ns: &str) {
 #[cfg(test)]
 mod tests {
   use super::{
-    TransactionOperationReport, bump_semver_value, collect_format_advisories, count_legacy_any_schema_fields, load_snapshot,
-    parse_examples_input, parse_input_to_cirru, parse_schema_input, parse_transaction_operations, rename_definition_declaration,
-    run_staged_transaction_with, save_snapshot,
+    TransactionOperationReport, bump_semver_value, collect_format_advisories, count_legacy_any_schema_fields,
+    count_legacy_inherent_impls, load_snapshot, parse_examples_input, parse_input_to_cirru, parse_schema_input,
+    parse_transaction_operations, rename_definition_declaration, run_staged_transaction_with, save_snapshot,
   };
   use crate::cli_handlers::test_support::TestProject;
   use cirru_parser::Cirru;
@@ -2626,6 +2647,7 @@ mod tests {
     assert!(advisories.contains("W_LEGACY_SNAPSHOT_NAME"), "advisories: {advisories}");
     assert!(advisories.contains("W_LEGACY_ANY"), "advisories: {advisories}");
     assert!(advisories.contains("W_DYNAMIC_TYPE_DEBT"), "advisories: {advisories}");
+    assert!(advisories.contains("W_LEGACY_INHERENT_IMPL"), "advisories: {advisories}");
     assert!(advisories.contains("analyze weak-types"), "advisories: {advisories}");
   }
 
@@ -2648,6 +2670,25 @@ mod tests {
     .expect("schema fixture should parse");
 
     assert_eq!(count_legacy_any_schema_fields(&data), 2);
+  }
+
+  #[test]
+  fn legacy_inherent_impl_counter_only_matches_tag_trait_arguments() {
+    let legacy = list(vec![
+      leaf("defimpl"),
+      leaf("RenderImpl"),
+      leaf(":Render"),
+      list(vec![leaf(".render"), leaf("render")]),
+    ]);
+    let nominal = list(vec![
+      leaf("defimpl"),
+      leaf("RenderImpl"),
+      leaf("Render"),
+      list(vec![leaf(".render"), leaf("render")]),
+    ]);
+
+    assert_eq!(count_legacy_inherent_impls(&legacy), 1);
+    assert_eq!(count_legacy_inherent_impls(&nominal), 0);
   }
 
   #[test]

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -2649,7 +2649,6 @@ mod tests {
     assert!(advisories.contains("W_LEGACY_SNAPSHOT_NAME"), "advisories: {advisories}");
     assert!(advisories.contains("W_LEGACY_ANY"), "advisories: {advisories}");
     assert!(advisories.contains("W_DYNAMIC_TYPE_DEBT"), "advisories: {advisories}");
-    assert!(advisories.contains("W_LEGACY_INHERENT_IMPL"), "advisories: {advisories}");
     assert!(advisories.contains("analyze weak-types"), "advisories: {advisories}");
   }
 

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -962,6 +962,7 @@ mod type_query_tests {
       methods,
       vec![
         ".ceil",
+        ".compare",
         ".display-by",
         ".empty",
         ".floor",

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -5,7 +5,7 @@ mod logics;
 mod maps;
 mod math;
 pub mod meta;
-mod records;
+pub(crate) mod records;
 mod refs;
 mod sets;
 mod strings;

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -1443,33 +1443,14 @@ fn collect_impl_records_for_value(value: &Calcit, call_stack: &CallStackList) ->
       impls.extend(enum_def.impls().iter().cloned());
       Ok(impls)
     }
-    Calcit::List(..) => {
-      let impls_value = runner::evaluate_symbol_from_program("&core-list-impls", calcit::CORE_NS, None, call_stack)?;
-      collect_impl_records_from_value(&impls_value, call_stack)
-    }
-    Calcit::Map(..) => {
-      let impls_value = runner::evaluate_symbol_from_program("&core-map-impls", calcit::CORE_NS, None, call_stack)?;
-      collect_impl_records_from_value(&impls_value, call_stack)
-    }
-    Calcit::Number(..) => {
-      let impls_value = runner::evaluate_symbol_from_program("&core-number-impls", calcit::CORE_NS, None, call_stack)?;
-      collect_impl_records_from_value(&impls_value, call_stack)
-    }
-    Calcit::Str(..) => {
-      let impls_value = runner::evaluate_symbol_from_program("&core-string-impls", calcit::CORE_NS, None, call_stack)?;
-      collect_impl_records_from_value(&impls_value, call_stack)
-    }
-    Calcit::Set(..) => {
-      let impls_value = runner::evaluate_symbol_from_program("&core-set-impls", calcit::CORE_NS, None, call_stack)?;
-      collect_impl_records_from_value(&impls_value, call_stack)
-    }
-    Calcit::Fn { .. } | Calcit::Proc(..) => {
-      let impls_value = runner::evaluate_symbol_from_program("&core-fn-impls", calcit::CORE_NS, None, call_stack)?;
-      collect_impl_records_from_value(&impls_value, call_stack)
-    }
+    Calcit::List(..) => collect_optional_core_impl_records("&core-list-impls", call_stack),
+    Calcit::Map(..) => collect_optional_core_impl_records("&core-map-impls", call_stack),
+    Calcit::Number(..) => collect_optional_core_impl_records("&core-number-impls", call_stack),
+    Calcit::Str(..) => collect_optional_core_impl_records("&core-string-impls", call_stack),
+    Calcit::Set(..) => collect_optional_core_impl_records("&core-set-impls", call_stack),
+    Calcit::Fn { .. } | Calcit::Proc(..) => collect_optional_core_impl_records("&core-fn-impls", call_stack),
     Calcit::Nil | Calcit::Bool(..) | Calcit::Tag(..) | Calcit::Symbol { .. } | Calcit::CirruQuote(..) => {
-      let impls_value = runner::evaluate_symbol_from_program("&core-scalar-impls", calcit::CORE_NS, None, call_stack)?;
-      collect_impl_records_from_value(&impls_value, call_stack)
+      collect_optional_core_impl_records("&core-scalar-impls", call_stack)
     }
     other => Err(CalcitErr::use_msg_stack_location(
       CalcitErrKind::Type,
@@ -2170,5 +2151,12 @@ mod tests {
       err.msg.contains("does not satisfy `trait Renderable`") || err.msg.contains("does not satisfy `Renderable`"),
       "unexpected error: {err:?}"
     );
+  }
+
+  #[test]
+  fn optional_core_impl_lookup_allows_embedding_without_core_entries() {
+    let impls = collect_optional_core_impl_records("&missing-test-core-impls", &CallStackList::default())
+      .expect("missing core impl list should be treated as unavailable");
+    assert!(impls.is_empty());
   }
 }

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -1408,15 +1408,41 @@ pub fn tuple_params(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
+fn collect_optional_core_impl_records(name: &str, call_stack: &CallStackList) -> Result<Vec<Arc<CalcitImpl>>, CalcitErr> {
+  match runner::evaluate_symbol_from_program(name, calcit::CORE_NS, None, call_stack) {
+    Ok(value) => collect_impl_records_from_value(&value, call_stack),
+    // Unit tests and embedding users can construct a named value before the
+    // core program is loaded. Attached impls must remain usable in that state.
+    Err(err) if err.kind == CalcitErrKind::Var => Ok(vec![]),
+    Err(err) => Err(err),
+  }
+}
+
 fn collect_impl_records_for_value(value: &Calcit, call_stack: &CallStackList) -> Result<Vec<Arc<CalcitImpl>>, CalcitErr> {
   match value {
-    Calcit::Tuple(tuple) => Ok(tuple.impls().to_owned()),
-    Calcit::Record(record) => Ok(record.struct_ref.impls.to_owned()),
+    Calcit::Tuple(tuple) => {
+      let mut impls = collect_optional_core_impl_records("&core-tuple-impls", call_stack)?;
+      impls.extend(tuple.impls().iter().cloned());
+      Ok(impls)
+    }
+    Calcit::Record(record) => {
+      let mut impls = collect_optional_core_impl_records("&core-record-impls", call_stack)?;
+      impls.extend(record.struct_ref.impls.iter().cloned());
+      Ok(impls)
+    }
     // Bare type definitions (not yet instantiated) carry their own attached impls,
     // so introspection tools like `&methods-of` can answer "what methods will
     // instances of this type have" without needing a concrete instance first.
-    Calcit::Struct(struct_def) => Ok(struct_def.impls.to_owned()),
-    Calcit::Enum(enum_def) => Ok(enum_def.impls().to_owned()),
+    Calcit::Struct(struct_def) => {
+      let mut impls = collect_optional_core_impl_records("&core-record-impls", call_stack)?;
+      impls.extend(struct_def.impls.iter().cloned());
+      Ok(impls)
+    }
+    Calcit::Enum(enum_def) => {
+      let mut impls = collect_optional_core_impl_records("&core-tuple-impls", call_stack)?;
+      impls.extend(enum_def.impls().iter().cloned());
+      Ok(impls)
+    }
     Calcit::List(..) => {
       let impls_value = runner::evaluate_symbol_from_program("&core-list-impls", calcit::CORE_NS, None, call_stack)?;
       collect_impl_records_from_value(&impls_value, call_stack)

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -748,7 +748,7 @@ pub fn trait_new(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
   };
 
-  Ok(Calcit::Trait(CalcitTrait::new(name, methods, method_types)))
+  Ok(Calcit::Trait(CalcitTrait::new_runtime(name, methods, method_types)))
 }
 
 fn collect_trait_records(xs: &[Calcit], proc_name: &str) -> Result<Vec<Arc<CalcitImpl>>, CalcitErr> {
@@ -1467,6 +1467,10 @@ fn collect_impl_records_for_value(value: &Calcit, call_stack: &CallStackList) ->
       let impls_value = runner::evaluate_symbol_from_program("&core-fn-impls", calcit::CORE_NS, None, call_stack)?;
       collect_impl_records_from_value(&impls_value, call_stack)
     }
+    Calcit::Nil | Calcit::Bool(..) | Calcit::Tag(..) | Calcit::Symbol { .. } | Calcit::CirruQuote(..) => {
+      let impls_value = runner::evaluate_symbol_from_program("&core-scalar-impls", calcit::CORE_NS, None, call_stack)?;
+      collect_impl_records_from_value(&impls_value, call_stack)
+    }
     other => Err(CalcitErr::use_msg_stack_location(
       CalcitErrKind::Type,
       format!("&assert-traits cannot resolve impls for: {other}"),
@@ -1571,7 +1575,7 @@ pub fn trait_call(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, C
 
   let mut selected_impl: Option<&Arc<CalcitImpl>> = None;
   for imp in iter_impls_in_precedence_order(receiver, &impls) {
-    if imp.origin().is_some_and(|origin| origin.as_ref() == &trait_def) {
+    if imp.implements_trait(&trait_def) {
       selected_impl = Some(imp);
       break;
     }
@@ -1703,27 +1707,41 @@ pub fn assert_traits(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit
   };
 
   let impls = collect_impl_records_for_value(value, call_stack)?;
-  let mut missing: Vec<String> = Vec::new();
-  for method in trait_def.methods.iter() {
-    let method_name = method.ref_str();
-    let exists = impls.iter().any(|imp| imp.get(method_name).is_some());
-    if !exists {
-      missing.push(method.to_string());
-    }
-  }
+  let selected_impl = iter_impls_in_precedence_order(value, &impls).find(|imp| imp.implements_trait(&trait_def));
 
-  if !missing.is_empty() {
-    let mut fields: Vec<String> = vec![];
-    for imp in impls.iter() {
-      for field in imp.fields().iter() {
-        fields.push(field.to_string());
-      }
-    }
-    let available = fields.join(" ");
-    let missing_list = missing.join(" ");
+  let Some(selected_impl) = selected_impl else {
+    let available = impls
+      .iter()
+      .filter_map(|imp| imp.trait_name())
+      .map(ToString::to_string)
+      .collect::<Vec<_>>()
+      .join(" ");
     return Err(CalcitErr::use_msg_stack_location(
       CalcitErrKind::Type,
-      format!("assert-traits failed: {value} does not implement {trait_def}. Missing: {missing_list}. Available: {available}"),
+      format!(
+        "assert-traits failed: {value} does not nominally implement {trait_def}. Available trait impls: {}",
+        if available.is_empty() { "(none)" } else { &available }
+      ),
+      call_stack,
+      value.get_location(),
+    ));
+  };
+
+  let missing = trait_def
+    .methods
+    .iter()
+    .filter(|method| selected_impl.get(method.ref_str()).is_none())
+    .map(ToString::to_string)
+    .collect::<Vec<_>>();
+  if !missing.is_empty() {
+    return Err(CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      format!(
+        "assert-traits failed: impl {} for trait {} is incomplete. Missing: {}",
+        selected_impl.name(),
+        trait_def.name,
+        missing.join(" ")
+      ),
       call_stack,
       value.get_location(),
     ));
@@ -2091,7 +2109,7 @@ mod tests {
     }
   }
 
-  fn shown_maybe_enum() -> CalcitEnum {
+  fn shown_maybe_enum(show_trait: Arc<CalcitTrait>) -> CalcitEnum {
     CalcitEnum::from_record(CalcitRecord {
       struct_ref: Arc::new(CalcitStruct {
         name: EdnTag::new("ShownMaybe"),
@@ -2100,7 +2118,7 @@ mod tests {
         generics: Arc::new(vec![Arc::from("T")]),
         where_bounds: Arc::new(vec![CalcitGenericBound {
           name: Arc::from("T"),
-          traits: Arc::new(vec![Arc::new(CalcitTrait::new(EdnTag::new("Show"), vec![], vec![]))]),
+          traits: Arc::new(vec![show_trait]),
         }]),
         impls: vec![],
       }),
@@ -2112,24 +2130,44 @@ mod tests {
     .expect("valid enum")
   }
 
+  fn value_with_trait(trait_def: Arc<CalcitTrait>) -> Calcit {
+    let mut struct_def = CalcitStruct::from_fields(EdnTag::new("ShownValue"), vec![]);
+    struct_def.impls.push(Arc::new(CalcitImpl {
+      name: trait_def.name.clone(),
+      origin: Some(trait_def),
+      fields: Arc::new(vec![]),
+      values: Arc::new(vec![]),
+    }));
+    Calcit::Record(CalcitRecord {
+      struct_ref: Arc::new(struct_def),
+      values: Arc::new(vec![]),
+    })
+  }
+
   #[test]
-  fn generic_enum_where_bounds_accept_show_values() {
-    let result = new_enum_tuple_no_class(&[Calcit::Enum(shown_maybe_enum()), Calcit::tag("some"), Calcit::Number(1.0)]);
+  fn generic_enum_where_bounds_accept_nominal_trait_values() {
+    let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
+    let result = new_enum_tuple_no_class(&[
+      Calcit::Enum(shown_maybe_enum(show_trait.clone())),
+      Calcit::tag("some"),
+      value_with_trait(show_trait),
+    ]);
 
     assert!(result.is_ok(), "expected shown maybe creation to pass: {result:?}");
   }
 
   #[test]
-  fn generic_enum_where_bounds_reject_non_show_values() {
+  fn generic_enum_where_bounds_reject_missing_nominal_trait() {
+    let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
     let err = new_enum_tuple_no_class(&[
-      Calcit::Enum(shown_maybe_enum()),
+      Calcit::Enum(shown_maybe_enum(show_trait)),
       Calcit::tag("some"),
       Calcit::Proc(CalcitProc::NativeResetGenSymIndex),
     ])
     .expect_err("expected shown maybe creation to fail on non-Show payload");
 
     assert!(
-      err.msg.contains("does not satisfy `trait Show`") || err.msg.contains("does not satisfy `Show`"),
+      err.msg.contains("does not satisfy `trait Renderable`") || err.msg.contains("does not satisfy `Renderable`"),
       "unexpected error: {err:?}"
     );
   }

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -26,6 +26,87 @@ fn mark_fn_used_in_impl(value: &Calcit) -> Calcit {
   }
 }
 
+fn callable_type(value: &Calcit) -> Option<CalcitTypeAnnotation> {
+  match value {
+    Calcit::Fn { info, .. } => Some(CalcitTypeAnnotation::from_calcit_fn(info)),
+    Calcit::Proc(proc) => proc
+      .get_type_signature()
+      .map(|signature| CalcitTypeAnnotation::from_function_parts(signature.arg_types.clone(), signature.return_type.clone())),
+    _ => None,
+  }
+}
+
+fn validate_trait_impl_entries(trait_def: &crate::calcit::CalcitTrait, entries: &[(EdnTag, Calcit)]) -> Result<(), CalcitErr> {
+  let missing = trait_def
+    .methods
+    .iter()
+    .filter(|method| !entries.iter().any(|(name, _)| name == *method))
+    .map(ToString::to_string)
+    .collect::<Vec<_>>();
+  let unexpected = entries
+    .iter()
+    .filter(|(name, _)| !trait_def.has_method(name.ref_str()))
+    .map(|(name, _)| name.to_string())
+    .collect::<Vec<_>>();
+
+  if !missing.is_empty() || !unexpected.is_empty() {
+    let mut details = vec![];
+    if !missing.is_empty() {
+      details.push(format!("missing methods: {}", missing.join(" ")));
+    }
+    if !unexpected.is_empty() {
+      details.push(format!("methods not declared by the trait: {}", unexpected.join(" ")));
+    }
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Type,
+      format!("&impl::new does not conform to trait {}: {}", trait_def.name, details.join("; ")),
+    ));
+  }
+
+  for (name, value) in entries {
+    let Some(method_idx) = trait_def.method_index(name.ref_str()) else {
+      continue;
+    };
+    let expected = trait_def
+      .method_types
+      .get(method_idx)
+      .expect("trait method type must align with its name");
+    let Some(actual) = callable_type(value) else {
+      return Err(CalcitErr::use_str(
+        CalcitErrKind::Type,
+        format!(
+          "&impl::new expects trait method .{} to be a function, but received: {value}",
+          name.ref_str()
+        ),
+      ));
+    };
+
+    if matches!(expected.as_ref(), CalcitTypeAnnotation::DynFn) {
+      continue;
+    }
+    // A builtin without registered type metadata is still callable, but there is
+    // no useful signature evidence to compare. User functions always preserve
+    // their arity and available hints through `from_calcit_fn` above.
+    if matches!(value, Calcit::Proc(proc) if proc.get_type_signature().is_none()) {
+      continue;
+    }
+    if !actual.matches_annotation(expected.as_ref()) {
+      return Err(CalcitErr::use_str(
+        CalcitErrKind::Type,
+        format!(
+          "&impl::new method .{} does not match trait {} signature: expected {}, got {}",
+          name.ref_str(),
+          trait_def.name,
+          expected.to_brief_string(),
+          actual.to_brief_string()
+        ),
+      ));
+    }
+  }
+
+  Ok(())
+}
+
 fn parse_type_var_form(form: &Calcit) -> Option<Arc<str>> {
   let Calcit::List(list) = form else {
     return None;
@@ -128,17 +209,18 @@ pub fn new_impl(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
   };
 
-  if xs.len() == 1 {
-    return Ok(Calcit::Impl(CalcitImpl {
-      name: name_id,
-      origin,
-      fields: Arc::new(vec![]),
-      values: Arc::new(vec![]),
-    }));
-  }
-
   let mut entries: Vec<(EdnTag, Calcit)> = Vec::with_capacity(xs.len().saturating_sub(1));
-  for item in xs.iter().skip(1) {
+  let items: Vec<Calcit> = if let [_, Calcit::Impl(source)] = xs {
+    source
+      .fields
+      .iter()
+      .zip(source.values.iter())
+      .map(|(field, value)| Calcit::from(vec![Calcit::Tag(field.clone()), value.clone()]))
+      .collect()
+  } else {
+    xs.iter().skip(1).cloned().collect()
+  };
+  for item in &items {
     let (name, value) = match item {
       Calcit::List(pair) => match (pair.first(), pair.get(1), pair.get(2)) {
         (Some(name), Some(value), None) => (name, value),
@@ -185,6 +267,10 @@ pub fn new_impl(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         format!("&impl::new duplicated field: {}", entries[idx].0),
       );
     }
+  }
+
+  if let Some(trait_def) = origin.as_ref() {
+    validate_trait_impl_entries(trait_def, &entries)?;
   }
 
   let fields: Vec<EdnTag> = entries.iter().map(|(tag, _)| tag.to_owned()).collect();
@@ -1353,7 +1439,81 @@ mod tests {
   use super::*;
   use crate::calcit::{CalcitGenericBound, CalcitTrait};
 
-  fn shown_box_struct() -> CalcitStruct {
+  fn dyn_fn_trait(name: &str, methods: &[&str]) -> CalcitTrait {
+    CalcitTrait::new_runtime(
+      EdnTag::new(name),
+      methods.iter().map(|method| EdnTag::new(*method)).collect(),
+      methods.iter().map(|_| Arc::new(CalcitTypeAnnotation::DynFn)).collect(),
+    )
+  }
+
+  fn impl_pair(name: &str, value: Calcit) -> Calcit {
+    Calcit::from(vec![Calcit::tag(name), value])
+  }
+
+  fn callable_proc() -> Calcit {
+    Calcit::Proc(CalcitProc::NativeResetGenSymIndex)
+  }
+
+  #[test]
+  fn nominal_impl_requires_the_exact_trait_method_set() {
+    let trait_def = dyn_fn_trait("Renderable", &["render", "debug"]);
+    let missing =
+      new_impl(&[Calcit::Trait(trait_def.clone()), impl_pair("render", callable_proc())]).expect_err("missing trait method must fail");
+    assert!(missing.msg.contains("missing methods") && missing.msg.contains("debug"));
+
+    let unexpected = new_impl(&[
+      Calcit::Trait(trait_def),
+      impl_pair("render", callable_proc()),
+      impl_pair("debug", callable_proc()),
+      impl_pair("extra", callable_proc()),
+    ])
+    .expect_err("unexpected trait method must fail");
+    assert!(unexpected.msg.contains("not declared") && unexpected.msg.contains("extra"));
+  }
+
+  #[test]
+  fn nominal_impl_rejects_non_callable_method_values() {
+    let err = new_impl(&[
+      Calcit::Trait(dyn_fn_trait("Renderable", &["render"])),
+      impl_pair("render", Calcit::Nil),
+    ])
+    .expect_err("non-callable trait method must fail");
+
+    assert!(err.msg.contains("expects trait method .render to be a function"));
+  }
+
+  #[test]
+  fn nominal_impl_checks_available_method_signatures() {
+    let trait_def = CalcitTrait::new_runtime(
+      EdnTag::new("Renderable"),
+      vec![EdnTag::new("render")],
+      vec![Arc::new(CalcitTypeAnnotation::from_function_parts(
+        vec![Arc::new(CalcitTypeAnnotation::Number)],
+        crate::calcit::DYNAMIC_TYPE.clone(),
+      ))],
+    );
+    let err =
+      new_impl(&[Calcit::Trait(trait_def), impl_pair("render", callable_proc())]).expect_err("wrong callable signature must fail");
+
+    assert!(err.msg.contains("does not match trait Renderable signature"));
+  }
+
+  #[test]
+  fn inherent_method_bag_can_be_promoted_to_a_nominal_impl() {
+    let method_bag = new_impl(&[Calcit::tag("legacy-methods"), impl_pair("render", callable_proc())]).expect("originless method bag");
+    let trait_def = dyn_fn_trait("Renderable", &["render"]);
+    let promoted = new_impl(&[Calcit::Trait(trait_def.clone()), method_bag]).expect("promoted nominal impl");
+    let Calcit::Impl(promoted) = promoted else {
+      panic!("expected impl value");
+    };
+
+    assert!(promoted.implements_trait(&trait_def));
+    assert!(!promoted.is_inherent());
+    assert!(promoted.get("render").is_some());
+  }
+
+  fn shown_box_struct(show_trait: Arc<CalcitTrait>) -> CalcitStruct {
     CalcitStruct {
       name: EdnTag::new("ShownBox"),
       fields: Arc::new(vec![EdnTag::new("value")]),
@@ -1361,30 +1521,50 @@ mod tests {
       generics: Arc::new(vec![Arc::from("T")]),
       where_bounds: Arc::new(vec![CalcitGenericBound {
         name: Arc::from("T"),
-        traits: Arc::new(vec![Arc::new(CalcitTrait::new(EdnTag::new("Show"), vec![], vec![]))]),
+        traits: Arc::new(vec![show_trait]),
       }]),
       impls: vec![],
     }
   }
 
+  fn value_with_trait(trait_def: Arc<CalcitTrait>) -> Calcit {
+    let mut struct_def = CalcitStruct::from_fields(EdnTag::new("ShownValue"), vec![]);
+    struct_def.impls.push(Arc::new(CalcitImpl {
+      name: trait_def.name.clone(),
+      origin: Some(trait_def),
+      fields: Arc::new(vec![]),
+      values: Arc::new(vec![]),
+    }));
+    Calcit::Record(CalcitRecord {
+      struct_ref: Arc::new(struct_def),
+      values: Arc::new(vec![]),
+    })
+  }
+
   #[test]
-  fn generic_struct_where_bounds_accept_show_values() {
-    let result = call_record(&[Calcit::Struct(shown_box_struct()), Calcit::tag("value"), Calcit::Number(1.0)]);
+  fn generic_struct_where_bounds_accept_nominal_trait_values() {
+    let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
+    let result = call_record(&[
+      Calcit::Struct(shown_box_struct(show_trait.clone())),
+      Calcit::tag("value"),
+      value_with_trait(show_trait),
+    ]);
 
     assert!(result.is_ok(), "expected shown box creation to pass: {result:?}");
   }
 
   #[test]
-  fn generic_struct_where_bounds_reject_non_show_values() {
+  fn generic_struct_where_bounds_reject_missing_nominal_trait() {
+    let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
     let err = call_record(&[
-      Calcit::Struct(shown_box_struct()),
+      Calcit::Struct(shown_box_struct(show_trait)),
       Calcit::tag("value"),
       Calcit::Proc(CalcitProc::NativeResetGenSymIndex),
     ])
     .expect_err("expected shown box creation to fail on non-Show payload");
 
     assert!(
-      err.msg.contains("does not satisfy `trait Show`") || err.msg.contains("does not satisfy `Show`"),
+      err.msg.contains("does not satisfy `trait Renderable`") || err.msg.contains("does not satisfy `Renderable`"),
       "unexpected error: {err:?}"
     );
   }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -360,15 +360,23 @@ mod tests {
     let mut scope = CalcitScope::default();
     let sym = Arc::from("x");
     let idx = CalcitLocal::track_sym(&sym);
+    let empty_trait_def = Arc::new(CalcitTrait::new(EdnTag::from("Noop"), vec![], vec![]));
+    let mut person_struct = CalcitStruct::from_fields(EdnTag::from("Person"), vec![]);
+    person_struct.impls.push(Arc::new(crate::calcit::CalcitImpl {
+      name: empty_trait_def.name.clone(),
+      origin: Some(empty_trait_def.clone()),
+      fields: Arc::new(vec![]),
+      values: Arc::new(vec![]),
+    }));
     scope.insert_mut(
       idx,
       Calcit::Record(CalcitRecord {
-        struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::from("Person"), vec![])),
+        struct_ref: Arc::new(person_struct),
         values: Arc::new(vec![]),
       }),
     );
 
-    let empty_trait = Calcit::Trait(CalcitTrait::new(EdnTag::from("Noop"), vec![], vec![]));
+    let empty_trait = Calcit::Trait(empty_trait_def.as_ref().clone());
     let expr = CalcitList::Vector(vec![
       Calcit::Local(CalcitLocal {
         idx,

--- a/src/calcit/calcit_impl.rs
+++ b/src/calcit/calcit_impl.rs
@@ -34,6 +34,18 @@ impl CalcitImpl {
     self.origin.as_ref().map(|trait_def| &trait_def.name)
   }
 
+  pub fn is_inherent(&self) -> bool {
+    self.origin.is_none()
+  }
+
+  pub fn implements_trait(&self, trait_def: &CalcitTrait) -> bool {
+    self.origin.as_ref().is_some_and(|origin| origin.as_ref() == trait_def)
+  }
+
+  pub fn matches_trait_reference(&self, trait_def: &CalcitTrait) -> bool {
+    self.origin.as_ref().is_some_and(|origin| origin.matches_reference(trait_def))
+  }
+
   pub fn fields(&self) -> &Arc<Vec<EdnTag>> {
     &self.fields
   }

--- a/src/calcit/calcit_trait.rs
+++ b/src/calcit/calcit_trait.rs
@@ -65,8 +65,11 @@ fn hash_default_impl<H: Hasher>(default_impl: &Option<Arc<CalcitFn>>, state: &mu
 #[derive(Debug, Clone)]
 pub struct CalcitTrait {
   /// Nominal identity for an evaluated trait definition. Source/schema
-  /// placeholders keep this empty and are compared structurally.
+  /// placeholders keep this empty and use `definition_ref` when available.
   pub runtime_id: Option<u64>,
+  /// Stable source identity for a trait resolved before runtime evaluation.
+  /// This keeps two source traits with the same short name nominally distinct.
+  pub definition_ref: Option<Arc<str>>,
   /// Name of the trait
   pub name: EdnTag,
   /// Method names defined by this trait
@@ -97,7 +100,8 @@ impl Eq for CalcitTrait {}
 
 impl CalcitTrait {
   fn structural_eq(&self, other: &Self) -> bool {
-    self.name == other.name
+    self.definition_ref == other.definition_ref
+      && self.name == other.name
       && self.methods == other.methods
       && self.method_types == other.method_types
       && self.requires == other.requires
@@ -118,6 +122,7 @@ impl CalcitTrait {
     );
     CalcitTrait {
       runtime_id: None,
+      definition_ref: None,
       name,
       methods: Arc::new(methods),
       defaults: Arc::new(defaults),
@@ -135,13 +140,35 @@ impl CalcitTrait {
     trait_def
   }
 
+  /// Attach the namespace-qualified definition identity used while the source
+  /// trait is available but its runtime value has not been evaluated yet.
+  pub fn with_definition_ref(mut self, ns: &str, def: &str) -> Self {
+    self.definition_ref = Some(Arc::from(format!("{ns}/{def}")));
+    self
+  }
+
+  /// Build an unresolved trait reference while retaining a qualified source
+  /// path when one is present in the schema.
+  pub fn new_reference(name: &str) -> Self {
+    let normalized = name.trim_start_matches('\'');
+    match normalized.rsplit_once('/') {
+      Some((ns, def)) => Self::new(EdnTag::new(def), vec![], vec![]).with_definition_ref(ns, def),
+      None => Self::new(EdnTag::new(normalized), vec![], vec![]),
+    }
+  }
+
   /// Match a trait reference stored in schema/static metadata. Evaluated
-  /// references use nominal identity; unevaluated references temporarily fall
-  /// back to definition shape, or name when the snapshot only retained a bare
-  /// trait symbol.
+  /// references use runtime identity, source references use their qualified
+  /// definition, and legacy bare placeholders fall back to shape or name.
   pub fn matches_reference(&self, expected: &Self) -> bool {
     if expected.runtime_id.is_some() {
       return self == expected;
+    }
+    if self.definition_ref.is_some() || expected.definition_ref.is_some() {
+      return self.definition_ref == expected.definition_ref;
+    }
+    if self.runtime_id.is_some() {
+      return false;
     }
     self.structural_eq(expected) || (expected.methods.is_empty() && self.name == expected.name)
   }
@@ -175,6 +202,7 @@ impl Hash for CalcitTrait {
     if self.runtime_id.is_some() {
       return;
     }
+    self.definition_ref.hash(state);
     self.name.hash(state);
     self.methods.hash(state);
     self.method_types.hash(state);
@@ -228,6 +256,7 @@ mod tests {
   fn build_trait_with_default(default_impl: Option<Arc<CalcitFn>>) -> CalcitTrait {
     CalcitTrait {
       runtime_id: None,
+      definition_ref: None,
       name: EdnTag::new("TraitX"),
       methods: Arc::new(vec![EdnTag::new("foo")]),
       defaults: Arc::new(vec![default_impl]),
@@ -257,6 +286,20 @@ mod tests {
 
     assert_eq!(left, right);
     assert_eq!(hash_trait(&left), hash_trait(&right));
+  }
+
+  #[test]
+  fn source_definition_refs_are_nominal() {
+    let core = CalcitTrait::new(EdnTag::new("Show"), vec![], vec![]).with_definition_ref("calcit.core", "Show");
+    let user = CalcitTrait::new(EdnTag::new("Show"), vec![], vec![]).with_definition_ref("app.main", "Show");
+    let same_core = CalcitTrait::new_reference("calcit.core/Show");
+    let runtime_core = CalcitTrait::new_runtime(EdnTag::new("Show"), vec![], vec![]).with_definition_ref("calcit.core", "Show");
+
+    assert_eq!(core, same_core);
+    assert_eq!(hash_trait(&core), hash_trait(&same_core));
+    assert_ne!(core, user);
+    assert!(!core.matches_reference(&user));
+    assert!(runtime_core.matches_reference(&same_core));
   }
 
   #[test]

--- a/src/calcit/calcit_trait.rs
+++ b/src/calcit/calcit_trait.rs
@@ -1,9 +1,12 @@
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use cirru_edn::EdnTag;
 
 use super::{CalcitFn, CalcitTypeAnnotation};
+
+static NEXT_TRAIT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
 
 fn defaults_eq(left: &Option<Arc<CalcitFn>>, right: &Option<Arc<CalcitFn>>) -> bool {
   match (left, right) {
@@ -61,6 +64,9 @@ fn hash_default_impl<H: Hasher>(default_impl: &Option<Arc<CalcitFn>>, state: &mu
 /// Similar to Rust traits or Haskell type classes
 #[derive(Debug, Clone)]
 pub struct CalcitTrait {
+  /// Nominal identity for an evaluated trait definition. Source/schema
+  /// placeholders keep this empty and are compared structurally.
+  pub runtime_id: Option<u64>,
   /// Name of the trait
   pub name: EdnTag,
   /// Method names defined by this trait
@@ -78,6 +84,19 @@ pub struct CalcitTrait {
 // For defaults, use stable function identity (prefer def_ref, fallback to fn metadata).
 impl PartialEq for CalcitTrait {
   fn eq(&self, other: &Self) -> bool {
+    match (self.runtime_id, other.runtime_id) {
+      (Some(left), Some(right)) => return left == right,
+      (Some(_), None) | (None, Some(_)) => return false,
+      (None, None) => {}
+    }
+    self.structural_eq(other)
+  }
+}
+
+impl Eq for CalcitTrait {}
+
+impl CalcitTrait {
+  fn structural_eq(&self, other: &Self) -> bool {
     self.name == other.name
       && self.methods == other.methods
       && self.method_types == other.method_types
@@ -89,11 +108,7 @@ impl PartialEq for CalcitTrait {
         .zip(other.defaults.iter())
         .all(|(left, right)| defaults_eq(left, right))
   }
-}
 
-impl Eq for CalcitTrait {}
-
-impl CalcitTrait {
   /// Create a new trait with the given name and methods
   pub fn new(name: EdnTag, methods: Vec<EdnTag>, method_types: Vec<Arc<CalcitTypeAnnotation>>) -> Self {
     let defaults = vec![None; methods.len()];
@@ -102,12 +117,33 @@ impl CalcitTrait {
       "CalcitTrait::new expects method_types to match methods length"
     );
     CalcitTrait {
+      runtime_id: None,
       name,
       methods: Arc::new(methods),
       defaults: Arc::new(defaults),
       method_types: Arc::new(method_types),
       requires: Arc::new(vec![]),
     }
+  }
+
+  /// Create an evaluated trait with nominal runtime identity. Cloning the
+  /// result preserves identity; evaluating the definition again creates a new
+  /// one, so stale impls cannot accidentally satisfy a reloaded trait.
+  pub fn new_runtime(name: EdnTag, methods: Vec<EdnTag>, method_types: Vec<Arc<CalcitTypeAnnotation>>) -> Self {
+    let mut trait_def = Self::new(name, methods, method_types);
+    trait_def.runtime_id = Some(NEXT_TRAIT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed));
+    trait_def
+  }
+
+  /// Match a trait reference stored in schema/static metadata. Evaluated
+  /// references use nominal identity; unevaluated references temporarily fall
+  /// back to definition shape, or name when the snapshot only retained a bare
+  /// trait symbol.
+  pub fn matches_reference(&self, expected: &Self) -> bool {
+    if expected.runtime_id.is_some() {
+      return self == expected;
+    }
+    self.structural_eq(expected) || (expected.methods.is_empty() && self.name == expected.name)
   }
 
   /// Get the method names
@@ -135,6 +171,10 @@ impl CalcitTrait {
 
 impl Hash for CalcitTrait {
   fn hash<H: Hasher>(&self, state: &mut H) {
+    self.runtime_id.hash(state);
+    if self.runtime_id.is_some() {
+      return;
+    }
     self.name.hash(state);
     self.methods.hash(state);
     self.method_types.hash(state);
@@ -187,6 +227,7 @@ mod tests {
 
   fn build_trait_with_default(default_impl: Option<Arc<CalcitFn>>) -> CalcitTrait {
     CalcitTrait {
+      runtime_id: None,
       name: EdnTag::new("TraitX"),
       methods: Arc::new(vec![EdnTag::new("foo")]),
       defaults: Arc::new(vec![default_impl]),
@@ -227,5 +268,23 @@ mod tests {
     assert_eq!(left, right);
     assert_eq!(hash_trait(&left), hash_trait(&right));
     assert_ne!(left, different);
+  }
+
+  #[test]
+  fn evaluated_traits_with_same_shape_keep_nominal_identity() {
+    let left = CalcitTrait::new_runtime(EdnTag::new("Visible"), vec![], vec![]);
+    let right = CalcitTrait::new_runtime(EdnTag::new("Visible"), vec![], vec![]);
+
+    assert_ne!(left, right);
+    assert_eq!(left, left.clone());
+  }
+
+  #[test]
+  fn schema_trait_placeholders_remain_structural() {
+    let left = CalcitTrait::new(EdnTag::new("Visible"), vec![], vec![]);
+    let right = CalcitTrait::new(EdnTag::new("Visible"), vec![], vec![]);
+
+    assert_eq!(left, right);
+    assert_eq!(hash_trait(&left), hash_trait(&right));
   }
 }

--- a/src/calcit/compare.rs
+++ b/src/calcit/compare.rs
@@ -7,6 +7,12 @@ use cirru_edn::EdnAnyRef;
 use super::{Calcit, CalcitEnum, CalcitFn, CalcitImpl, CalcitRecord, CalcitStruct, CalcitTrait};
 
 pub(super) fn compare_calcit_trait_values(a: &CalcitTrait, b: &CalcitTrait) -> Ordering {
+  match (a.runtime_id, b.runtime_id) {
+    (Some(left), Some(right)) => return left.cmp(&right),
+    (None, Some(_)) => return Less,
+    (Some(_), None) => return Greater,
+    (None, None) => {}
+  }
   match a.name.cmp(&b.name) {
     Equal => match a.methods.cmp(&b.methods) {
       Equal => match a.method_types.cmp(&b.method_types) {

--- a/src/calcit/compare.rs
+++ b/src/calcit/compare.rs
@@ -13,6 +13,10 @@ pub(super) fn compare_calcit_trait_values(a: &CalcitTrait, b: &CalcitTrait) -> O
     (Some(_), None) => return Greater,
     (None, None) => {}
   }
+  match a.definition_ref.cmp(&b.definition_ref) {
+    Equal => {}
+    ord => return ord,
+  }
   match a.name.cmp(&b.name) {
     Equal => match a.methods.cmp(&b.methods) {
       Equal => match a.method_types.cmp(&b.method_types) {

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -904,11 +904,9 @@ impl CalcitTypeAnnotation {
         let parsed = Self::parse_type_annotation_form_inner(item, generics, strict_named_refs);
         match parsed.as_ref() {
           CalcitTypeAnnotation::Trait(trait_def) => traits.push(trait_def.clone()),
-          CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => traits.push(Arc::new(CalcitTrait::new(
-            EdnTag::new(name.trim_start_matches('\'').rsplit('/').next().unwrap_or(name.as_ref())),
-            vec![],
-            vec![],
-          ))),
+          CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => {
+            traits.push(Arc::new(CalcitTrait::new_reference(name)))
+          }
           _ => return None,
         }
       }
@@ -919,11 +917,9 @@ impl CalcitTypeAnnotation {
 
     match Self::parse_type_annotation_form_inner(form, generics, strict_named_refs).as_ref() {
       CalcitTypeAnnotation::Trait(trait_def) => Some(vec![trait_def.clone()]),
-      CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => Some(vec![Arc::new(CalcitTrait::new(
-        EdnTag::new(name.trim_start_matches('\'').rsplit('/').next().unwrap_or(name.as_ref())),
-        vec![],
-        vec![],
-      ))]),
+      CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => {
+        Some(vec![Arc::new(CalcitTrait::new_reference(name))])
+      }
       _ => None,
     }
   }
@@ -981,11 +977,9 @@ impl CalcitTypeAnnotation {
 
     let parse_trait_from_edn = |value: &Edn| -> Option<Arc<CalcitTrait>> {
       match value {
-        Edn::Symbol(sym) if !Self::generics_contains(generics, sym.as_ref()) => Some(Arc::new(CalcitTrait::new(
-          EdnTag::new(sym.trim_start_matches('\'')),
-          vec![],
-          vec![],
-        ))),
+        Edn::Symbol(sym) if !Self::generics_contains(generics, sym.as_ref()) => {
+          Some(Arc::new(CalcitTrait::new_reference(sym.trim_start_matches('\''))))
+        }
         Edn::Tag(tag) => Some(Arc::new(CalcitTrait::new(EdnTag::new(tag.ref_str()), vec![], vec![]))),
         _ => {
           let parsed = Self::parse_type_annotation_form_inner(&Self::edn_type_to_calcit(value), generics, true);
@@ -2405,7 +2399,30 @@ impl CalcitTypeAnnotation {
         return false;
       }
     }
-    self.builtin_core_trait_names().contains(&expected_trait.name.ref_str())
+    if !self.builtin_core_trait_names().contains(&expected_trait.name.ref_str()) {
+      return false;
+    }
+
+    let core_reference = format!("{CORE_NS}/{}", expected_trait.name.ref_str());
+    if let Some(definition_ref) = expected_trait.definition_ref.as_deref() {
+      return definition_ref == core_reference;
+    }
+
+    // Evaluated traits are nominal. If the core trait value is not ready yet,
+    // do not let an unrelated runtime trait pass merely because its short name
+    // is the same as a built-in capability.
+    if expected_trait.runtime_id.is_some() {
+      return lookup_runtime_ready_registered(CORE_NS, expected_trait.name.ref_str())
+        .and_then(|value| match value {
+          Calcit::Trait(core_trait) => Some(core_trait == *expected_trait),
+          _ => None,
+        })
+        .unwrap_or(false);
+    }
+
+    // Bare unqualified placeholders are retained only for legacy schemas that
+    // predate namespace-qualified symbol references.
+    expected_trait.methods.is_empty()
   }
 
   fn satisfies_trait_bounds(&self, expected_traits: &[Arc<CalcitTrait>]) -> bool {
@@ -2579,9 +2596,7 @@ impl CalcitTypeAnnotation {
       // enum is safe wherever a builtin proc accepts a dynamic tuple. Keep the
       // relation directional: a dynamic tuple cannot satisfy a named enum.
       (Self::Enum(_, _), Self::DynTuple) => true,
-      (type_ref @ Self::TypeRef(_, _), Self::DynTuple) | (Self::DynTuple, type_ref @ Self::TypeRef(_, _)) => {
-        type_ref.resolve_to_enum().is_some()
-      }
+      (type_ref @ Self::TypeRef(_, _), Self::DynTuple) => type_ref.resolve_to_enum().is_some(),
       (type_ref @ Self::TypeRef(_, _), Self::Custom(expected)) | (Self::Custom(expected), type_ref @ Self::TypeRef(_, _))
         if Self::custom_keyword_matches(expected, "record") || Self::custom_keyword_matches(expected, "struct") =>
       {
@@ -3505,6 +3520,18 @@ mod tests {
     }
   }
 
+  #[test]
+  fn bootstrap_core_trait_fallback_rejects_non_core_same_name() {
+    let number = CalcitTypeAnnotation::Number;
+    let core_show = Arc::new(CalcitTrait::new_reference("calcit.core/Show"));
+    let user_show = Arc::new(CalcitTrait::new_reference("app.main/Show"));
+    let runtime_user_show = Arc::new(CalcitTrait::new_runtime(EdnTag::new("Show"), vec![], vec![]));
+
+    assert!(number.matches_annotation(&CalcitTypeAnnotation::Trait(core_show)));
+    assert!(!number.matches_annotation(&CalcitTypeAnnotation::Trait(user_show)));
+    assert!(!number.matches_annotation(&CalcitTypeAnnotation::Trait(runtime_user_show)));
+  }
+
   fn symbol(name: &str) -> Calcit {
     Calcit::Symbol {
       sym: Arc::from(name),
@@ -4316,6 +4343,12 @@ mod tests {
 
     assert!(named.matches_annotation(&tuple));
     assert!(!tuple.matches_annotation(&named));
+
+    // A named reference must never be accepted in the reverse direction. The
+    // forward, resolvable TypeRef path is covered by the same matcher arm as
+    // the concrete enum assertion above.
+    let named_ref = CalcitTypeAnnotation::TypeRef(Arc::from("tests/Result"), Arc::new(vec![]));
+    assert!(!tuple.matches_annotation(&named_ref));
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2251,6 +2251,7 @@ impl CalcitTypeAnnotation {
       Self::Set(_) => Some("&core-set-impls"),
       Self::Number => Some("&core-number-impls"),
       Self::DynFn | Self::Fn(_) => Some("&core-fn-impls"),
+      Self::Unit | Self::Bool | Self::Tag | Self::Symbol | Self::CirruQuote => Some("&core-scalar-impls"),
       Self::Optional(inner) => inner.core_impl_list_symbol(),
       Self::TypeRef(name, _) => resolve_type_ref_as_schema(name).and_then(|schema| schema.core_impl_list_symbol()),
       Self::TypeSlot(name) => resolve_type_slot(name).and_then(|bound| bound.core_impl_list_symbol()),
@@ -2343,72 +2344,41 @@ impl CalcitTypeAnnotation {
     }
   }
 
-  fn infer_builtin_trait_name(imp: &CalcitImpl) -> Option<String> {
-    let raw = imp.name().ref_str();
-    let body = raw.strip_prefix("&core-")?.strip_suffix("-impl")?;
-    let segment = body.split('-').next()?;
-    let mut chars = segment.chars();
-    let first = chars.next()?;
-    let mut name = first.to_uppercase().collect::<String>();
-    name.push_str(chars.as_str());
-    Some(name)
-  }
-
-  fn builtin_type_satisfies_trait(&self, expected_trait: &CalcitTrait) -> bool {
-    match expected_trait.name.ref_str() {
-      "Mappable" => matches!(self, Self::List(_) | Self::Map(_, _) | Self::Set(_) | Self::Optional(_)),
-      "Countable" | "Contains" => {
-        matches!(
-          self,
-          Self::List(_)
-            | Self::Map(_, _)
-            | Self::Set(_)
-            | Self::String
-            | Self::DynTuple
-            | Self::Tuple(_)
-            | Self::Enum(_, _)
-            | Self::Record(_)
-            | Self::Struct(_, _)
-        ) || matches!(self, Self::Custom(value)
-          if matches!(value.as_ref(), Calcit::Tag(tag)
-            if matches!(tag.ref_str(), "list" | "map" | "set" | "string" | "tuple" | "record")))
-      }
-      "Compare" => matches!(self, Self::Number | Self::String),
-      "Show" => {
-        matches!(
-          self,
-          Self::Bool
-            | Self::Number
-            | Self::String
-            | Self::Symbol
-            | Self::Tag
-            | Self::Unit
-            | Self::Buffer
-            | Self::CirruQuote
-            | Self::DynTuple
-            | Self::List(_)
-            | Self::Map(_, _)
-            | Self::Set(_)
-        ) || matches!(self, Self::Optional(inner) if inner.builtin_type_satisfies_trait(expected_trait))
-      }
-      _ => false,
-    }
-  }
-
   fn impl_matches_trait(imp: &CalcitImpl, expected_trait: &CalcitTrait) -> bool {
-    imp.trait_name().is_some_and(|name| name == &expected_trait.name)
-      || imp.name() == &expected_trait.name
-      || Self::infer_builtin_trait_name(imp).as_deref() == Some(expected_trait.name.ref_str())
+    imp.matches_trait_reference(expected_trait)
+  }
+
+  /// Bootstrap metadata used only before a core impl list has been evaluated.
+  /// Runtime dispatch and evaluated static metadata both use the real impl
+  /// origins from calcit-core; this table prevents preprocessing order from
+  /// changing whether an otherwise identical core call emits a warning.
+  fn builtin_core_trait_names(&self) -> &'static [&'static str] {
+    if matches!(self, Self::Record(_) | Self::Struct(_, _)) {
+      return &["Show", "Eq", "Countable", "Contains"];
+    }
+    if matches!(self, Self::DynTuple | Self::Tuple(_) | Self::Enum(_, _)) {
+      return &["Show", "Eq", "Countable", "Contains"];
+    }
+    match self.core_impl_list_symbol() {
+      Some("&core-list-impls") => &["Show", "Eq", "Add", "Len", "Mappable", "Countable", "Contains"],
+      Some("&core-map-impls") => &["Show", "Eq", "Len", "Mappable", "Countable", "Contains"],
+      Some("&core-set-impls") => &["Show", "Eq", "Len", "Mappable", "Countable", "Contains"],
+      Some("&core-string-impls") => &["Show", "Eq", "Add", "Len", "Countable", "Contains", "Compare"],
+      Some("&core-number-impls") => &["Show", "Eq", "Add", "Multiply", "Compare"],
+      Some("&core-fn-impls") => &["Show"],
+      Some("&core-scalar-impls") => &["Show", "Eq"],
+      _ => &[],
+    }
   }
 
   fn satisfies_trait_bound(&self, expected_trait: &CalcitTrait) -> bool {
-    if self.builtin_type_satisfies_trait(expected_trait) {
-      return true;
-    }
-
-    self
+    if self
       .collect_static_impls()
       .is_some_and(|impls| impls.iter().any(|imp| Self::impl_matches_trait(imp, expected_trait)))
+    {
+      return true;
+    }
+    self.builtin_core_trait_names().contains(&expected_trait.name.ref_str())
   }
 
   fn satisfies_trait_bounds(&self, expected_traits: &[Arc<CalcitTrait>]) -> bool {
@@ -2548,10 +2518,10 @@ impl CalcitTypeAnnotation {
         }
         a_args.len() == b_args.len() && a_args.iter().zip(b_args.iter()).all(|(x, y)| x.matches_with_bindings(y, bindings))
       }
-      (Self::Trait(a), Self::Trait(b)) => a.name == b.name,
-      (Self::TraitSet(actual), Self::Trait(expected)) => actual.iter().any(|t| t.name == expected.name),
-      (Self::Trait(actual), Self::TraitSet(expected)) => expected.len() == 1 && expected.iter().any(|t| t.name == actual.name),
-      (Self::TraitSet(actual), Self::TraitSet(expected)) => expected.iter().all(|t| actual.iter().any(|a| a.name == t.name)),
+      (Self::Trait(a), Self::Trait(b)) => a == b,
+      (Self::TraitSet(actual), Self::Trait(expected)) => actual.iter().any(|t| t == expected),
+      (Self::Trait(actual), Self::TraitSet(expected)) => expected.len() == 1 && expected.iter().any(|t| t == actual),
+      (Self::TraitSet(actual), Self::TraitSet(expected)) => expected.iter().all(|t| actual.iter().any(|a| a == t)),
       (actual, Self::Trait(expected)) => actual.satisfies_trait_bound(expected.as_ref()),
       (actual, Self::TraitSet(expected)) => actual.satisfies_trait_bounds(expected.as_ref()),
       (Self::Struct(_, _), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "struct") => true,
@@ -4818,13 +4788,21 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
       _ => false,
     },
     CalcitTypeAnnotation::Trait(expected_trait) => match value {
-      Calcit::Record(r) => r.struct_ref.impls.iter().any(|imp| imp.name() == &expected_trait.name),
-      Calcit::Tuple(t) => t.impls().iter().any(|imp| imp.name() == &expected_trait.name),
+      Calcit::Record(r) => r
+        .struct_ref
+        .impls
+        .iter()
+        .any(|imp| imp.matches_trait_reference(expected_trait.as_ref())),
+      Calcit::Tuple(t) => t.impls().iter().any(|imp| imp.matches_trait_reference(expected_trait.as_ref())),
       _ => false,
     },
     CalcitTypeAnnotation::TraitSet(traits) => match value {
-      Calcit::Record(r) => traits.iter().all(|t| r.struct_ref.impls.iter().any(|imp| imp.name() == &t.name)),
-      Calcit::Tuple(t) => traits.iter().all(|tr| t.impls().iter().any(|imp| imp.name() == &tr.name)),
+      Calcit::Record(r) => traits
+        .iter()
+        .all(|trait_def| r.struct_ref.impls.iter().any(|imp| imp.matches_trait_reference(trait_def.as_ref()))),
+      Calcit::Tuple(t) => traits
+        .iter()
+        .all(|trait_def| t.impls().iter().any(|imp| imp.matches_trait_reference(trait_def.as_ref()))),
       _ => false,
     },
     CalcitTypeAnnotation::Custom(custom) => match custom.as_ref() {

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -596,7 +596,18 @@ impl CalcitTypeAnnotation {
     }
 
     match form {
-      Calcit::Symbol { sym, .. } => Some(Self::normalize_type_ref_name(sym)),
+      Calcit::Symbol { sym, info, .. } => {
+        let normalized = Self::normalize_type_ref_name(sym);
+        if normalized.contains('/') {
+          Some(normalized)
+        } else if lookup_def_code_registered(&info.at_ns, &normalized).is_some() {
+          Some(Arc::from(format!("{}/{}", info.at_ns, normalized)))
+        } else if lookup_def_code_registered(CORE_NS, &normalized).is_some() {
+          Some(Arc::from(format!("{CORE_NS}/{normalized}")))
+        } else {
+          Some(normalized)
+        }
+      }
       Calcit::Import(import) => Some(Arc::from(format!("{}/{}", import.ns, import.def))),
       _ => None,
     }
@@ -893,6 +904,11 @@ impl CalcitTypeAnnotation {
         let parsed = Self::parse_type_annotation_form_inner(item, generics, strict_named_refs);
         match parsed.as_ref() {
           CalcitTypeAnnotation::Trait(trait_def) => traits.push(trait_def.clone()),
+          CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => traits.push(Arc::new(CalcitTrait::new(
+            EdnTag::new(name.trim_start_matches('\'').rsplit('/').next().unwrap_or(name.as_ref())),
+            vec![],
+            vec![],
+          ))),
           _ => return None,
         }
       }
@@ -903,6 +919,11 @@ impl CalcitTypeAnnotation {
 
     match Self::parse_type_annotation_form_inner(form, generics, strict_named_refs).as_ref() {
       CalcitTypeAnnotation::Trait(trait_def) => Some(vec![trait_def.clone()]),
+      CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => Some(vec![Arc::new(CalcitTrait::new(
+        EdnTag::new(name.trim_start_matches('\'').rsplit('/').next().unwrap_or(name.as_ref())),
+        vec![],
+        vec![],
+      ))]),
       _ => None,
     }
   }
@@ -3920,6 +3941,34 @@ mod tests {
     assert_eq!(bounds[0].name.as_ref(), "T");
     assert_eq!(bounds[0].traits.len(), 1);
     assert_eq!(bounds[0].traits[0].name.ref_str(), "Show");
+  }
+
+  #[test]
+  fn extracts_symbol_trait_placeholder_from_strict_where_hint() {
+    let generics = Calcit::List(Arc::new(CalcitList::from(&[symbol("[]"), symbol("T")])));
+    let where_map = Calcit::List(Arc::new(CalcitList::from(&[
+      symbol("{}"),
+      Calcit::List(Arc::new(CalcitList::from(&[symbol("T"), symbol("Show")]))),
+    ])));
+    let schema_map = Calcit::List(Arc::new(CalcitList::from(&[
+      symbol("{}"),
+      Calcit::List(Arc::new(CalcitList::from(&[Calcit::tag("generics"), generics]))),
+      Calcit::List(Arc::new(CalcitList::from(&[Calcit::tag("where"), where_map]))),
+    ])));
+    let hint_form = Calcit::List(Arc::new(CalcitList::from(&[
+      Calcit::Syntax(CalcitSyntax::HintFn, Arc::from("tests.where")),
+      schema_map,
+    ])));
+
+    let bounds = CalcitTypeAnnotation::extract_where_bounds_from_hint_form(&hint_form).expect("symbol trait bound should parse");
+    assert_eq!(bounds.len(), 1);
+    assert_eq!(bounds[0].name.as_ref(), "T");
+    assert_eq!(bounds[0].traits.len(), 1);
+    assert_eq!(bounds[0].traits[0].name.ref_str(), "Show");
+    assert!(
+      bounds[0].traits[0].methods.is_empty(),
+      "source resolution happens during preprocessing"
+    );
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2372,11 +2372,17 @@ impl CalcitTypeAnnotation {
   }
 
   fn satisfies_trait_bound(&self, expected_trait: &CalcitTrait) -> bool {
-    if self
-      .collect_static_impls()
-      .is_some_and(|impls| impls.iter().any(|imp| Self::impl_matches_trait(imp, expected_trait)))
-    {
-      return true;
+    if let Some(impls) = self.collect_static_impls() {
+      if impls.iter().any(|imp| Self::impl_matches_trait(imp, expected_trait)) {
+        return true;
+      }
+      // Primitive values use a real core impl list whenever it has finished
+      // evaluating. Do not let bootstrap names override that authoritative
+      // result; record/tuple categories keep their shared core capabilities in
+      // the fallback because their attached impl list is separate.
+      if self.core_impl_list_symbol().is_some() {
+        return false;
+      }
     }
     self.builtin_core_trait_names().contains(&expected_trait.name.ref_str())
   }
@@ -3423,6 +3429,60 @@ fn resolve_calcit_value(form: &Calcit) -> Option<Calcit> {
 mod tests {
   use super::*;
   use crate::calcit::CalcitSymbolInfo;
+  use std::collections::BTreeSet;
+
+  fn core_impl_trait_names(definition: &str) -> BTreeSet<String> {
+    fn visit(node: &cirru_parser::Cirru, names: &mut BTreeSet<String>) {
+      let cirru_parser::Cirru::List(items) = node else {
+        return;
+      };
+      if let (Some(cirru_parser::Cirru::Leaf(head)), Some(cirru_parser::Cirru::Leaf(trait_name))) = (items.first(), items.get(1))
+        && head.as_ref() == "&impl::new"
+      {
+        names.insert(trait_name.to_string());
+      }
+      for item in items {
+        visit(item, names);
+      }
+    }
+
+    let core = crate::load_core_snapshot().expect("load embedded core snapshot");
+    let entry = core
+      .files
+      .get(CORE_NS)
+      .and_then(|file| file.defs.get(definition))
+      .unwrap_or_else(|| panic!("missing {definition} in embedded core snapshot"));
+    let mut names = BTreeSet::new();
+    visit(&entry.code, &mut names);
+    names
+  }
+
+  #[test]
+  fn bootstrap_core_trait_names_match_core_impl_definitions() {
+    let dynamic = crate::calcit::DYNAMIC_TYPE.clone();
+    let cases = vec![
+      (CalcitTypeAnnotation::List(dynamic.clone()), "&core-list-impls"),
+      (CalcitTypeAnnotation::Map(dynamic.clone(), dynamic.clone()), "&core-map-impls"),
+      (CalcitTypeAnnotation::Set(dynamic.clone()), "&core-set-impls"),
+      (CalcitTypeAnnotation::String, "&core-string-impls"),
+      (CalcitTypeAnnotation::Number, "&core-number-impls"),
+      (CalcitTypeAnnotation::DynFn, "&core-fn-impls"),
+      (CalcitTypeAnnotation::Bool, "&core-scalar-impls"),
+    ];
+
+    for (annotation, definition) in cases {
+      let expected: BTreeSet<String> = annotation
+        .builtin_core_trait_names()
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect();
+      assert_eq!(
+        core_impl_trait_names(definition),
+        expected,
+        "bootstrap metadata drifted for {definition}"
+      );
+    }
+  }
 
   fn symbol(name: &str) -> Calcit {
     Calcit::Symbol {

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2217,7 +2217,10 @@ impl CalcitTypeAnnotation {
         if let Some((ns, def)) = stripped.rsplit_once('/') {
           resolve_enum_from_program(ns, def).map(|e| (e, Some((Arc::from(ns), Arc::from(def)))))
         } else {
-          None
+          // Core named types are commonly written without a namespace in
+          // schemas because calcit.core is implicitly available. Resolve that
+          // global namespace before treating the reference as unknown.
+          resolve_enum_from_program(CORE_NS, stripped).map(|e| (e, Some((Arc::from(CORE_NS), Arc::from(stripped)))))
         }
       }
       Self::Optional(inner) => inner.resolve_to_enum_with_ref(),
@@ -2354,6 +2357,23 @@ impl CalcitTypeAnnotation {
   fn builtin_type_satisfies_trait(&self, expected_trait: &CalcitTrait) -> bool {
     match expected_trait.name.ref_str() {
       "Mappable" => matches!(self, Self::List(_) | Self::Map(_, _) | Self::Set(_) | Self::Optional(_)),
+      "Countable" | "Contains" => {
+        matches!(
+          self,
+          Self::List(_)
+            | Self::Map(_, _)
+            | Self::Set(_)
+            | Self::String
+            | Self::DynTuple
+            | Self::Tuple(_)
+            | Self::Enum(_, _)
+            | Self::Record(_)
+            | Self::Struct(_, _)
+        ) || matches!(self, Self::Custom(value)
+          if matches!(value.as_ref(), Calcit::Tag(tag)
+            if matches!(tag.ref_str(), "list" | "map" | "set" | "string" | "tuple" | "record")))
+      }
+      "Compare" => matches!(self, Self::Number | Self::String),
       "Show" => {
         matches!(
           self,
@@ -2558,6 +2578,10 @@ impl CalcitTypeAnnotation {
       (Self::Tuple(a), Self::Tuple(b)) => a.name() == b.name(),
       (Self::Tuple(a), Self::Enum(b, _)) | (Self::Enum(b, _), Self::Tuple(a)) => a.name() == b.name(),
       (Self::Tuple(_), Self::DynTuple) | (Self::DynTuple, Self::Tuple(_)) => true,
+      // Enum values use the tuple runtime representation, so a concrete named
+      // enum is safe wherever a builtin proc accepts a dynamic tuple. Keep the
+      // relation directional: a dynamic tuple cannot satisfy a named enum.
+      (Self::Enum(_, _), Self::DynTuple) => true,
       (type_ref @ Self::TypeRef(_, _), Self::DynTuple) | (Self::DynTuple, type_ref @ Self::TypeRef(_, _)) => {
         type_ref.resolve_to_enum().is_some()
       }
@@ -3186,6 +3210,19 @@ fn resolve_type_def_from_code(code: &Calcit) -> Option<Calcit> {
     return resolve_type_def_from_code(inner);
   }
   let head = items.first()?;
+  // Data definitions are often stored behind `def` and `impl-traits` wrappers.
+  // Peel those value-preserving forms before looking for defstruct/defenum so
+  // named type references retain their concrete runtime representation.
+  if is_def_head(head)
+    && let Some(value) = items.get(2)
+  {
+    return resolve_type_def_from_code(value);
+  }
+  if is_impl_traits_head(head)
+    && let Some(value) = items.get(1)
+  {
+    return resolve_type_def_from_code(value);
+  }
   if is_defstruct_head(head) || is_struct_new_head(head) {
     return parse_defstruct_code(items.as_ref()).map(Calcit::Struct);
   }
@@ -3193,6 +3230,16 @@ fn resolve_type_def_from_code(code: &Calcit) -> Option<Calcit> {
     return parse_defenum_code(items.as_ref()).map(Calcit::Enum);
   }
   None
+}
+
+fn is_def_head(head: &Calcit) -> bool {
+  matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "def")
+    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "def")
+}
+
+fn is_impl_traits_head(head: &Calcit) -> bool {
+  matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "impl-traits")
+    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "impl-traits")
 }
 
 fn is_defstruct_head(head: &Calcit) -> bool {
@@ -3416,6 +3463,26 @@ mod tests {
       }),
       location: None,
     }
+  }
+
+  fn generic_result_enum() -> Arc<CalcitEnum> {
+    Arc::new(
+      CalcitEnum::from_record(CalcitRecord {
+        struct_ref: Arc::new(CalcitStruct {
+          name: EdnTag::new("Result"),
+          fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
+          field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
+          generics: Arc::new(vec![Arc::from("T"), Arc::from("E")]),
+          where_bounds: Arc::new(vec![]),
+          impls: vec![],
+        }),
+        values: Arc::new(vec![
+          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("E")]))),
+          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("T")]))),
+        ]),
+      })
+      .expect("valid generic enum"),
+    )
   }
 
   #[test]
@@ -4132,23 +4199,7 @@ mod tests {
 
   #[test]
   fn matching_named_enum_ref_binds_generic_args_from_enum_annotation() {
-    let result = Arc::new(
-      CalcitEnum::from_record(CalcitRecord {
-        struct_ref: Arc::new(CalcitStruct {
-          name: EdnTag::new("Result"),
-          fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
-          field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
-          generics: Arc::new(vec![Arc::from("T"), Arc::from("E")]),
-          where_bounds: Arc::new(vec![]),
-          impls: vec![],
-        }),
-        values: Arc::new(vec![
-          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("E")]))),
-          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("T")]))),
-        ]),
-      })
-      .expect("valid generic enum"),
-    );
+    let result = generic_result_enum();
     let actual = CalcitTypeAnnotation::Enum(
       result.clone(),
       Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
@@ -4163,23 +4214,7 @@ mod tests {
 
   #[test]
   fn matching_bare_enum_annotation_binds_generic_args_from_named_enum_ref() {
-    let result = Arc::new(
-      CalcitEnum::from_record(CalcitRecord {
-        struct_ref: Arc::new(CalcitStruct {
-          name: EdnTag::new("Result"),
-          fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
-          field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
-          generics: Arc::new(vec![Arc::from("T"), Arc::from("E")]),
-          where_bounds: Arc::new(vec![]),
-          impls: vec![],
-        }),
-        values: Arc::new(vec![
-          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("E")]))),
-          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("T")]))),
-        ]),
-      })
-      .expect("valid generic enum"),
-    );
+    let result = generic_result_enum();
     let actual = CalcitTypeAnnotation::TypeRef(
       Arc::from("Result"),
       Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
@@ -4190,6 +4225,34 @@ mod tests {
     assert!(actual.matches_with_bindings(&expected, &mut bindings));
     assert!(matches!(bindings.get("T"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::Number)));
     assert!(matches!(bindings.get("E"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::String)));
+  }
+
+  #[test]
+  fn named_enum_satisfies_dynamic_tuple_only_in_safe_direction() {
+    let named = CalcitTypeAnnotation::Enum(
+      generic_result_enum(),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
+    );
+    let tuple = CalcitTypeAnnotation::DynTuple;
+
+    assert!(named.matches_annotation(&tuple));
+    assert!(!tuple.matches_annotation(&named));
+  }
+
+  #[test]
+  fn resolves_enum_definition_through_def_and_impl_traits_wrappers() {
+    let enum_form = Calcit::from(vec![
+      symbol("defenum"),
+      symbol("Result"),
+      Calcit::from(vec![Calcit::tag("ok"), symbol("Number")]),
+    ]);
+    let wrapped = Calcit::from(vec![
+      symbol("def"),
+      symbol("Result"),
+      Calcit::from(vec![symbol("impl-traits"), enum_form, symbol("ResultMethods")]),
+    ]);
+
+    assert!(matches!(resolve_type_def_from_code(&wrapped), Some(Calcit::Enum(_))));
   }
 
   #[test]

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -342,7 +342,7 @@
           :tags $ #{} :internal
         |&core-list-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for list\nNOTE: ordering matters; &core-list-methods must come before internal/&core-add-list-impl, otherwise list .add may be shadowed by Add trait :add.")
           :code $ quote
-            def &core-list-impls $ [] &core-list-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-list-impl internal/&core-len-list-impl internal/&core-mappable-list-impl
+            def &core-list-impls $ [] &core-list-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-list-impl internal/&core-len-list-impl internal/&core-mappable-list-impl internal/&core-countable-list-impl internal/&core-contains-list-impl
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -354,7 +354,7 @@
           :tags $ #{} :internal
         |&core-map-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for map")
           :code $ quote
-            def &core-map-impls $ [] &core-map-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-len-map-impl internal/&core-mappable-map-impl
+            def &core-map-impls $ [] &core-map-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-len-map-impl internal/&core-mappable-map-impl internal/&core-countable-map-impl internal/&core-contains-map-impl
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -366,19 +366,19 @@
           :tags $ #{} :internal
         |&core-number-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for number")
           :code $ quote
-            def &core-number-impls $ [] &core-number-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-number-impl internal/&core-multiply-number-impl
+            def &core-number-impls $ [] &core-number-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-number-impl internal/&core-multiply-number-impl internal/&core-compare-number-impl
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
         |&core-number-methods $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def &core-number-methods $ &impl::new :&core-number-methods (:: :ceil ceil) (:: :empty &number:empty) (:: :floor floor) (:: :format &number:format) (:: :display-by &number:display-by) (:: :inc inc) (:: :pow pow) (:: :round round) (:: :round? round?) (:: :fract &number:fract) (:: :sqrt sqrt) (:: :negate negate) (:: :rem &number:rem)
+            def &core-number-methods $ &impl::new :&core-number-methods (:: :ceil ceil) (:: :empty &number:empty) (:: :floor floor) (:: :format &number:format) (:: :display-by &number:display-by) (:: :inc inc) (:: :pow pow) (:: :round round) (:: :round? round?) (:: :fract &number:fract) (:: :sqrt sqrt) (:: :negate negate) (:: :rem &number:rem) (:: :compare &compare)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
         |&core-record-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for record")
           :code $ quote
-            def &core-record-impls $ [] &core-record-methods internal/&core-show-impl internal/&core-eq-impl
+            def &core-record-impls $ [] &core-record-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-countable-record-impl internal/&core-contains-record-impl
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -392,7 +392,7 @@
           :tags $ #{} :internal
         |&core-set-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for set")
           :code $ quote
-            def &core-set-impls $ [] &core-set-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-len-set-impl internal/&core-mappable-set-impl
+            def &core-set-impls $ [] &core-set-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-len-set-impl internal/&core-mappable-set-impl internal/&core-countable-set-impl internal/&core-contains-set-impl
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -404,19 +404,19 @@
           :tags $ #{} :internal
         |&core-string-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for string")
           :code $ quote
-            def &core-string-impls $ [] &core-string-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-string-impl internal/&core-len-string-impl
+            def &core-string-impls $ [] &core-string-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-string-impl internal/&core-len-string-impl internal/&core-countable-string-impl internal/&core-contains-string-impl internal/&core-compare-string-impl
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
         |&core-string-methods $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get &str:nth) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth &str:nth) (:: :first &str:first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index &str:find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat)
+            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get &str:nth) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth &str:nth) (:: :first &str:first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index &str:find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
         |&core-tuple-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for tuple")
           :code $ quote
-            def &core-tuple-impls $ [] &core-tuple-methods internal/&core-show-impl internal/&core-eq-impl
+            def &core-tuple-impls $ [] &core-tuple-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-countable-tuple-impl internal/&core-contains-tuple-impl
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -2178,12 +2178,23 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :trait
+        |Compare $ %{} :CodeEntry (:doc "|Core trait for three-way comparison. Number and String implement it and return -1, 0, or 1.")
+          :code $ quote
+            deftrait Compare $ .compare
+              :: :fn $ {}
+                :args $ [] 'T 'T
+                :generics $ [] 'T
+                :return 'Number
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :trait
         |Contains $ %{} :CodeEntry (:doc "|Core trait: Contains")
           :code $ quote
             deftrait Contains $ .contains?
-              :: :fn $ {} (:return :bool)
-                :generics $ [] 'T
-                :args $ [] 'T :dynamic
+              :: :fn $ {}
+                :args $ [] 'T 'K
+                :generics $ [] 'T 'K
+                :return 'Bool
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :trait
@@ -2244,8 +2255,8 @@
         |Option $ %{} :CodeEntry (:doc "|Rust-style Option enum")
           :code $ quote
             def Option $ impl-traits
-              defenum Option (:some 'Dynamic) (:none)
-              , internal/&core-show-impl internal/&core-eq-impl OptionMappableImpl
+              defenum Option ([] 'T) (:some 'T) (:none)
+              , internal/&core-show-impl internal/&core-eq-impl OptionMappableImpl OptionMethods
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :data :internal
@@ -2255,11 +2266,17 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :trait-impl
+        |OptionMethods $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def OptionMethods $ &impl::new :OptionMethods (:: .some? option:some?) (:: .none? option:none?) (:: .unwrap-or option:unwrap-or) (:: .and-then option:and-then)
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :internal
         |Result $ %{} :CodeEntry (:doc "|Rust-style Result enum")
           :code $ quote
             def Result $ impl-traits
-              defenum Result (:ok 'Dynamic) (:err 'Dynamic)
-              , internal/&core-show-impl internal/&core-eq-impl ResultMappableImpl
+              defenum Result ([] 'T 'E) (:ok 'T) (:err 'E)
+              , internal/&core-show-impl internal/&core-eq-impl ResultMappableImpl ResultMethods
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :data :internal
@@ -2269,6 +2286,12 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :trait-impl
+        |ResultMethods $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def ResultMethods $ &impl::new :ResultMethods (:: .ok? result:ok?) (:: .err? result:err?) (:: .unwrap-or result:unwrap-or) (:: .and-then result:and-then) (:: .map-err result:map-err)
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :internal
         |Serialize $ %{} :CodeEntry (:doc "|Core trait: Serialize")
           :code $ quote
             deftrait Serialize $ .serialize
@@ -4781,6 +4804,26 @@
               :args $ [] 'T
               :generics $ [] 'T
           :tags $ #{} :builtin :internal
+        |option:and-then $ %{} :CodeEntry (:doc "|Chains an Option-producing function over :some and preserves :none.")
+          :code $ quote
+            defn option:and-then (opt f)
+              tag-match opt
+                (:some value) (f value)
+                (:none)
+                  %:: (&tuple:enum opt) :none
+          :examples $ []
+            quote $ assert= (%some 4)
+              option:and-then (%some 2)
+                fn (x)
+                  %some $ * x 2
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Option 'T)
+                :: 'Fn $ {}
+                  :args $ [] 'T
+                  :return $ :: 'Option 'U
+              :generics $ [] 'T 'U
+              :return $ :: 'Option 'U
         |option:map $ %{} :CodeEntry (:doc "|Mappable map implementation for Option")
           :code $ quote
             defn option:map (opt f)
@@ -4791,11 +4834,51 @@
                   %:: (&tuple:enum opt) :none
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Tuple)
-              :args $ [] 'Tuple
+            {}
+              :args $ [] (:: 'Option 'T)
                 :: 'Fn $ {} (:return 'U)
                   :args $ [] 'T
               :generics $ [] 'T 'U
+              :return $ :: 'Option 'U
+        |option:none? $ %{} :CodeEntry (:doc "|Returns true when an Option is :none.")
+          :code $ quote
+            defn option:none? (opt)
+              tag-match opt
+                (:some _) false
+                (:none) true
+          :examples $ []
+            quote $ assert= true
+              option:none? $ %none
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] (:: 'Option 'T)
+              :generics $ [] 'T
+        |option:some? $ %{} :CodeEntry (:doc "|Returns true when an Option is :some.")
+          :code $ quote
+            defn option:some? (opt)
+              tag-match opt
+                (:some _) true
+                (:none) false
+          :examples $ []
+            quote $ assert= true
+              option:some? $ %some 1
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] (:: 'Option 'T)
+              :generics $ [] 'T
+        |option:unwrap-or $ %{} :CodeEntry (:doc "|Returns the :some payload, or the fallback for :none.")
+          :code $ quote
+            defn option:unwrap-or (opt fallback)
+              tag-match opt
+                (:some value) value
+                (:none) fallback
+          :examples $ []
+            quote $ assert= 0
+              option:unwrap-or (%none) 0
+          :schema $ :: 'Fn
+            {} (:return 'T)
+              :args $ [] (:: 'Option 'T) 'T
+              :generics $ [] 'T
         |optionally $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn optionally (s)
@@ -5081,6 +5164,39 @@
               :args $ [] (:: 'Optional 'T)
               :generics $ [] 'T
               :return $ :: 'Optional 'T
+        |result:and-then $ %{} :CodeEntry (:doc "|Chains a Result-producing function over :ok and preserves :err.")
+          :code $ quote
+            defn result:and-then (res f)
+              tag-match res
+                (:ok value) (f value)
+                (:err err)
+                  %:: (&tuple:enum res) :err err
+          :examples $ []
+            quote $ assert= (%ok 4)
+              result:and-then (%ok 2)
+                fn (x)
+                  %ok $ * x 2
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Result 'T 'E)
+                :: 'Fn $ {}
+                  :args $ [] 'T
+                  :return $ :: 'Result 'U 'E
+              :generics $ [] 'T 'U 'E
+              :return $ :: 'Result 'U 'E
+        |result:err? $ %{} :CodeEntry (:doc "|Returns true when a Result is :err.")
+          :code $ quote
+            defn result:err? (res)
+              tag-match res
+                (:ok _) false
+                (:err _) true
+          :examples $ []
+            quote $ assert= true
+              result:err? $ %err |failed
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] (:: 'Result 'T 'E)
+              :generics $ [] 'T 'E
         |result:map $ %{} :CodeEntry (:doc "|Mappable map implementation for Result")
           :code $ quote
             defn result:map (res f)
@@ -5091,11 +5207,57 @@
                   %:: (&tuple:enum res) :err err
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Tuple)
-              :args $ [] 'Tuple
+            {}
+              :args $ [] (:: 'Result 'T 'E)
                 :: 'Fn $ {} (:return 'U)
                   :args $ [] 'T
-              :generics $ [] 'T 'U
+              :generics $ [] 'T 'U 'E
+              :return $ :: 'Result 'U 'E
+        |result:map-err $ %{} :CodeEntry (:doc "|Maps the error payload of a Result while preserving :ok.")
+          :code $ quote
+            defn result:map-err (res f)
+              tag-match res
+                (:ok value)
+                  %:: (&tuple:enum res) :ok value
+                (:err err)
+                  %:: (&tuple:enum res) :err $ f err
+          :examples $ []
+            quote $ assert= (%err |failed!)
+              result:map-err (%err |failed)
+                fn (e) (str e |!)
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Result 'T 'E)
+                :: 'Fn $ {} (:return 'F)
+                  :args $ [] 'E
+              :generics $ [] 'T 'E 'F
+              :return $ :: 'Result 'T 'F
+        |result:ok? $ %{} :CodeEntry (:doc "|Returns true when a Result is :ok.")
+          :code $ quote
+            defn result:ok? (res)
+              tag-match res
+                (:ok _) true
+                (:err _) false
+          :examples $ []
+            quote $ assert= true
+              result:ok? $ %ok 1
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] (:: 'Result 'T 'E)
+              :generics $ [] 'T 'E
+        |result:unwrap-or $ %{} :CodeEntry (:doc "|Returns the :ok payload, or the fallback for :err.")
+          :code $ quote
+            defn result:unwrap-or (res fallback)
+              tag-match res
+                (:ok value) value
+                (:err _) fallback
+          :examples $ []
+            quote $ assert= 0
+              result:unwrap-or (%err |failed) 0
+          :schema $ :: 'Fn
+            {} (:return 'T)
+              :args $ [] (:: 'Result 'T 'E) 'T
+              :generics $ [] 'T 'E
         |reverse $ %{} :CodeEntry (:doc "|Reverse the order of elements in a list")
           :code $ quote
             defn reverse (x) (&list:reverse x)
@@ -5933,6 +6095,80 @@
         |&core-add-string-impl $ %{} :CodeEntry (:doc "|Core trait impl for Add on string")
           :code $ quote
             def &core-add-string-impl $ &impl::new :&core-add-string-impl (:: :add &str:concat)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-compare-number-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-compare-number-impl $ &impl::new :&core-compare-number-impl (:: :compare &compare)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-compare-string-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-compare-string-impl $ &impl::new :&core-compare-string-impl (:: :compare &str:compare)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-contains-list-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-contains-list-impl $ &impl::new :&core-contains-list-impl (:: :contains? &list:contains?)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-contains-map-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-contains-map-impl $ &impl::new :&core-contains-map-impl (:: :contains? &map:contains?)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-contains-record-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-contains-record-impl $ &impl::new :&core-contains-record-impl (:: :contains? &record:contains?)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-contains-set-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-contains-set-impl $ &impl::new :&core-contains-set-impl (:: :contains? &set:includes?)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-contains-string-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-contains-string-impl $ &impl::new :&core-contains-string-impl (:: :contains? &str:contains?)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-contains-tuple-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-contains-tuple-impl $ &impl::new :&core-contains-tuple-impl
+              :: :contains? $ fn (x k)
+                if (&>= k 0)
+                  &< k $ &tuple:count x
+                  , false
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-countable-list-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-countable-list-impl $ &impl::new :&core-countable-list-impl (:: :count &list:count)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-countable-map-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-countable-map-impl $ &impl::new :&core-countable-map-impl (:: :count &map:count)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-countable-record-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-countable-record-impl $ &impl::new :&core-countable-record-impl (:: :count &record:count)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-countable-set-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-countable-set-impl $ &impl::new :&core-countable-set-impl (:: :count &set:count)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-countable-string-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-countable-string-impl $ &impl::new :&core-countable-string-impl (:: :count &str:count)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-countable-tuple-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-countable-tuple-impl $ &impl::new :&core-countable-tuple-impl (:: :count &tuple:count)
           :examples $ []
           :schema $ :: 'Dynamic
         |&core-eq-impl $ %{} :CodeEntry (:doc "|Core trait impl for Eq")

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -3132,15 +3132,15 @@
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic)
           :tags $ #{} :macro
-        |defimpl $ %{} :CodeEntry (:doc "|macro for defining trait impl values\nSyntax: (defimpl ImplName Trait (.method value) ...), (defimpl ImplName Trait (:: .method value) ...), or legacy (defimpl ImplName Trait :method value ...)\nParams: ImplName (symbol/tag), Trait (symbol/tag), method pairs\nReturns: impl value\nNotes: this macro does not attach impl to a target type/value; use `impl-traits` separately\nExpands to &impl::new")
+        |defimpl $ %{} :CodeEntry (:doc "|macro for defining trait implementation values\nSyntax: (defimpl ImplName Trait (.method value) ...)\nParams: ImplName (symbol), Trait (symbol), method pairs\nReturns: impl value\nNotes: new code passes raw symbols; tag arguments remain only as legacy compatibility for originless method bags. This macro does not attach an impl to a target type/value; use `impl-traits` separately.\nExpands to &impl::new")
           :code $ quote
             defmacro defimpl (name trait & pairs)
               if
                 not $ or (tag? name) (symbol? name)
-                raise $ str-spaced "|defimpl misuse. Expected: first argument is impl name (symbol/tag). Actual:" name "|Fix: rewrite as (defimpl ImplName Trait ...)."
+                raise $ str-spaced "|defimpl misuse. Expected: first argument is impl name symbol (legacy tag accepted). Actual:" name "|Fix: rewrite as (defimpl ImplName Trait ...)."
               if
                 not $ or (tag? trait) (symbol? trait)
-                raise $ str-spaced "|defimpl misuse. Expected: second argument is trait (symbol/tag). Actual:" trait "|Fix: rewrite as (defimpl ImplName Trait ...)."
+                raise $ str-spaced "|defimpl misuse. Expected: second argument is trait symbol (legacy tag accepted). Actual:" trait "|Fix: rewrite as (defimpl ImplName Trait ...)."
               quasiquote $ def ~name
                 &impl::new
                   ~ $ if (tag? trait) (turn-tag trait) trait

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1738,12 +1738,12 @@
             {} (:return 'String)
               :args $ [] 'String 'String
           :tags $ #{} :builtin :internal
-        |&str:contains? $ %{} :CodeEntry (:doc "|internal function for checking if string contains substring\nSyntax: (&str:contains? s substring)\nParams: s (string), substring (string)\nReturns: boolean\nReturns true if string contains substring")
+        |&str:contains? $ %{} :CodeEntry (:doc "|internal function for checking whether a string has a character at an index\nSyntax: (&str:contains? s index)\nParams: s (string), index (number)\nReturns: boolean\nReturns true when index is a valid character index in s")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Bool)
-              :args $ [] 'String 'String
+              :args $ [] 'String 'Number
           :tags $ #{} :builtin :internal
         |&str:count $ %{} :CodeEntry (:doc "|internal function for string character count\nSyntax: (&str:count s)\nParams: s (string)\nReturns: number\nReturns number of characters in string")
           :code $ quote &runtime-implementation

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -324,7 +324,7 @@
           :tags $ #{} :builtin :internal
         |&core-fn-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for fn")
           :code $ quote
-            def &core-fn-impls $ [] &core-fn-methods internal/&core-show-impl
+            def &core-fn-impls $ [] &core-fn-methods (&impl::new Show internal/&core-show-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -342,7 +342,7 @@
           :tags $ #{} :internal
         |&core-list-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for list\nNOTE: ordering matters; &core-list-methods must come before internal/&core-add-list-impl, otherwise list .add may be shadowed by Add trait :add.")
           :code $ quote
-            def &core-list-impls $ [] &core-list-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-list-impl internal/&core-len-list-impl internal/&core-mappable-list-impl internal/&core-countable-list-impl internal/&core-contains-list-impl
+            def &core-list-impls $ [] &core-list-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Add internal/&core-add-list-impl) (&impl::new Len internal/&core-len-list-impl) (&impl::new Mappable internal/&core-mappable-list-impl) (&impl::new Countable internal/&core-countable-list-impl) (&impl::new Contains internal/&core-contains-list-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -354,7 +354,7 @@
           :tags $ #{} :internal
         |&core-map-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for map")
           :code $ quote
-            def &core-map-impls $ [] &core-map-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-len-map-impl internal/&core-mappable-map-impl internal/&core-countable-map-impl internal/&core-contains-map-impl
+            def &core-map-impls $ [] &core-map-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Len internal/&core-len-map-impl) (&impl::new Mappable internal/&core-mappable-map-impl) (&impl::new Countable internal/&core-countable-map-impl) (&impl::new Contains internal/&core-contains-map-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -366,7 +366,7 @@
           :tags $ #{} :internal
         |&core-number-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for number")
           :code $ quote
-            def &core-number-impls $ [] &core-number-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-number-impl internal/&core-multiply-number-impl internal/&core-compare-number-impl
+            def &core-number-impls $ [] &core-number-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Add internal/&core-add-number-impl) (&impl::new Multiply internal/&core-multiply-number-impl) (&impl::new Compare internal/&core-compare-number-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -378,7 +378,7 @@
           :tags $ #{} :internal
         |&core-record-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for record")
           :code $ quote
-            def &core-record-impls $ [] &core-record-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-countable-record-impl internal/&core-contains-record-impl
+            def &core-record-impls $ [] &core-record-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Countable internal/&core-countable-record-impl) (&impl::new Contains internal/&core-contains-record-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -390,9 +390,15 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
+        |&core-scalar-impls $ %{} :CodeEntry (:doc "|Built-in nominal Show/Eq implementation list for scalar literals")
+          :code $ quote
+            def &core-scalar-impls $ [] (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl)
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :internal
         |&core-set-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for set")
           :code $ quote
-            def &core-set-impls $ [] &core-set-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-len-set-impl internal/&core-mappable-set-impl internal/&core-countable-set-impl internal/&core-contains-set-impl
+            def &core-set-impls $ [] &core-set-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Len internal/&core-len-set-impl) (&impl::new Mappable internal/&core-mappable-set-impl) (&impl::new Countable internal/&core-countable-set-impl) (&impl::new Contains internal/&core-contains-set-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -404,7 +410,7 @@
           :tags $ #{} :internal
         |&core-string-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for string")
           :code $ quote
-            def &core-string-impls $ [] &core-string-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-add-string-impl internal/&core-len-string-impl internal/&core-countable-string-impl internal/&core-contains-string-impl internal/&core-compare-string-impl
+            def &core-string-impls $ [] &core-string-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Add internal/&core-add-string-impl) (&impl::new Len internal/&core-len-string-impl) (&impl::new Countable internal/&core-countable-string-impl) (&impl::new Contains internal/&core-contains-string-impl) (&impl::new Compare internal/&core-compare-string-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -416,7 +422,7 @@
           :tags $ #{} :internal
         |&core-tuple-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for tuple")
           :code $ quote
-            def &core-tuple-impls $ [] &core-tuple-methods internal/&core-show-impl internal/&core-eq-impl internal/&core-countable-tuple-impl internal/&core-contains-tuple-impl
+            def &core-tuple-impls $ [] &core-tuple-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Countable internal/&core-countable-tuple-impl) (&impl::new Contains internal/&core-contains-tuple-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -666,10 +672,10 @@
           :tags $ #{} :builtin :internal
         |&init-builtin-impls! $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn &init-builtin-impls! () (; "this function to make sure builtin impls are loaded") (identity &core-number-impls) (identity &core-string-impls) (identity &core-set-impls) (identity &core-list-impls) (identity &core-map-impls) (identity &core-fn-impls) (identity &core-tuple-impls) (identity &core-record-impls) (identity Add) (identity Eq) (identity Len) (identity Mappable) (identity Multiply) (identity Show)
+            defn &init-builtin-impls! () (; "this function to make sure builtin impls are loaded") (identity &core-number-impls) (identity &core-string-impls) (identity &core-set-impls) (identity &core-list-impls) (identity &core-map-impls) (identity &core-fn-impls) (identity &core-tuple-impls) (identity &core-record-impls) (identity &core-scalar-impls) (identity Add) (identity Eq) (identity Len) (identity Mappable) (identity Multiply) (identity Show)
               if
                 &= (&get-calcit-backend) :js
-                register-calcit-builtin-impls $ &js-object :number &core-number-impls :string &core-string-impls :set &core-set-impls :list &core-list-impls :map &core-map-impls :fn &core-fn-impls :tuple &core-tuple-impls :record &core-record-impls
+                register-calcit-builtin-impls $ &js-object :number &core-number-impls :string &core-string-impls :set &core-set-impls :list &core-list-impls :map &core-map-impls :fn &core-fn-impls :tuple &core-tuple-impls :record &core-record-impls :scalar &core-scalar-impls
                 ;nil
           :examples $ []
           :schema $ :: 'Fn

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -4880,7 +4880,7 @@
                 (:none) fallback
           :examples $ []
             quote $ assert= 0
-              option:unwrap-or (%none) 0
+              (%none) .unwrap-or 0
           :schema $ :: 'Fn
             {} (:return 'T)
               :args $ [] (:: 'Option 'T) 'T
@@ -5259,7 +5259,7 @@
                 (:err _) fallback
           :examples $ []
             quote $ assert= 0
-              result:unwrap-or (%err |failed) 0
+              (%err |failed) .unwrap-or 0
           :schema $ :: 'Fn
             {} (:return 'T)
               :args $ [] (:: 'Result 'T 'E) 'T

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -766,6 +766,8 @@ pub enum DocsSubcommand {
   ReadLines(DocsReadLinesCommand),
   /// check ```cirru code blocks in a markdown file via eval
   CheckMd(DocsCheckMdCommand),
+  /// format fenced ```cirru code blocks in a markdown file
+  FormatMd(DocsFormatMdCommand),
   /// build and query the structured documentation relationship graph
   Graph(DocsGraphCommand),
 }
@@ -1008,6 +1010,18 @@ pub struct DocsCheckMdCommand {
   /// only display failed blocks and summary; implies --quiet
   #[argh(switch, long = "failures-only")]
   pub failures_only: bool,
+}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand, name = "format-md")]
+/// format fenced ```cirru code blocks in a markdown file
+pub struct DocsFormatMdCommand {
+  /// path to the markdown file to format
+  #[argh(positional)]
+  pub file: String,
+  /// report non-canonical blocks without writing the file
+  #[argh(switch)]
+  pub check: bool,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -109,14 +109,15 @@ pub fn tmpl_classes_registering() -> String {
   format!(
     "
 $procs.register_calcit_builtin_impls({{
-  list: _$n_core_list_methods,
-  map: _$n_core_map_methods,
-  number: _$n_core_number_methods,
-  set: _$n_core_set_methods,
-  string: _$n_core_string_methods,
-  fn: _$n_core_fn_methods,
+  list: _$n_core_list_impls,
+  map: _$n_core_map_impls,
+  number: _$n_core_number_impls,
+  set: _$n_core_set_impls,
+  string: _$n_core_string_impls,
+  fn: _$n_core_fn_impls,
   tuple: _$n_core_tuple_impls,
   record: _$n_core_record_impls,
+  scalar: _$n_core_scalar_impls,
 }});
 
 let runtimeVersion = $procs.calcit_version;

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1994,10 +1994,10 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
       emit_expr(ctx, &args[0])
     }
 
-    // &struct:impl-traits / &enum:impl-traits — trait registration; not supported in WASM; return nil.
+    // Runtime trait tables are intentionally not implemented in the internal
+    // WASM validation backend. Preprocessing must eliminate these operations.
     CalcitProc::NativeStructImplTraits | CalcitProc::NativeEnumImplTraits => {
-      eprintln!("[wasm warning] trait registration via impl-traits is not supported in WASM");
-      ctx.silent_nil()
+      Err("runtime trait registration must be eliminated before WASM codegen".into())
     }
 
     // register-calcit-builtin-impls — builtin impl registration; not meaningful in WASM; return nil.
@@ -2006,17 +2006,13 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
       ctx.silent_nil()
     }
 
-    // &impl::new — trait impl creation; args may contain unsupported tags; return nil with warning.
-    CalcitProc::NativeImplNew => {
-      eprintln!("[wasm warning] &impl::new is not supported in WASM; trait impls are ignored");
-      ctx.silent_nil()
-    }
+    // &impl::new — only valid as compile-time metadata for WASM.
+    CalcitProc::NativeImplNew => Err("runtime trait impl construction must be eliminated before WASM codegen".into()),
 
-    // &assert-traits — trait assertion; not enforced in WASM; return nil with warning.
-    CalcitProc::NativeAssertTraits => {
-      eprintln!("[wasm warning] &assert-traits is not enforced in WASM (trait checking disabled)");
-      ctx.silent_nil()
-    }
+    // &assert-traits — a residual assertion would require a runtime trait table.
+    CalcitProc::NativeAssertTraits => Err(
+      "runtime trait assertions are not supported by the internal WASM backend; make the receiver type statically resolvable".into(),
+    ),
 
     // &get-os — host OS info; not available in WASM; return nil.
     CalcitProc::NativeGetOs => ctx.stub_proc(args),

--- a/src/program.rs
+++ b/src/program.rs
@@ -943,6 +943,9 @@ pub fn write_runtime_ready(ns: &str, def: &str, value: Calcit) -> Result<(), Str
 
   match value {
     Calcit::Thunk(CalcitThunk::Code { code, info }) => write_runtime_lazy(def_id, code, info),
+    Calcit::Trait(trait_def) if trait_def.definition_ref.is_none() => {
+      write_runtime_value(def_id, Calcit::Trait(trait_def.with_definition_ref(ns, def)))
+    }
     other => write_runtime_value(def_id, other),
   }
 

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -214,6 +214,20 @@ fn write_runtime_ready_normalizes_thunk_into_lazy_cell() {
 }
 
 #[test]
+fn write_runtime_ready_attaches_trait_definition_identity() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+
+  let trait_value = crate::calcit::CalcitTrait::new_runtime(cirru_edn::EdnTag::new("Show"), vec![], vec![]);
+  write_runtime_ready("app.traits", "Show", Calcit::Trait(trait_value)).expect("store runtime trait");
+
+  let Calcit::Trait(stored) = lookup_runtime_ready("app.traits", "Show").expect("stored trait") else {
+    panic!("expected stored trait");
+  };
+  assert_eq!(stored.definition_ref.as_deref(), Some("app.traits/Show"));
+}
+
+#[test]
 fn clear_runtime_caches_for_changes_clears_transitive_dependents() {
   let _guard = lock_program_test_state();
   reset_program_test_state();

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -849,7 +849,7 @@ fn preprocess_list_call(
 
   // === Postfix record field access / method call detection ===
   // Pattern: (expr :field) where expr has a known record type → rewrite to (.-field expr)
-  // Pattern: (expr .method args...) where expr has a known record/trait type → rewrite to (.method expr args...)
+  // Pattern: (expr .method args...) where expr has a known record/enum/trait type → rewrite to (.method expr args...)
   // When type is unknown (Dynamic), silently fall through — :tag / .method may be normal arguments.
   if let Some(rewritten) =
     try_rewrite_struct_enum_constructor_head_call(&head_form, &args, scope_types, file_ns, &def_name, check_warnings, call_stack)?
@@ -883,12 +883,17 @@ fn preprocess_list_call(
         if matches!(method_kind, calcit::MethodKind::Invoke(_))
           && let Some(type_info) = resolve_type_value(&head_form, scope_types)
         {
-          // Only trigger for struct/record or trait types — NOT for Fn/Proc which
+          // Only trigger for struct/record, enum, or trait types — NOT for Fn/Proc which
           // also appear to have impls via core-impl lookups (e.g. `::` → tuple).
-          let is_record_or_trait =
-            type_info.as_ref().resolve_to_struct().is_some() || trait_list_from_type(type_info.as_ref()).is_some();
+          let is_record_enum_or_trait = type_info.as_ref().resolve_to_struct().is_some()
+            || type_info.as_ref().resolve_to_enum().is_some()
+            // A quoted named type can remain as a TypeRef while the core value is
+            // bootstrapping. It is still explicit static evidence, and normal
+            // method dispatch/codegen does not require resolving its impl table.
+            || matches!(type_info.as_ref(), CalcitTypeAnnotation::TypeRef(..))
+            || trait_list_from_type(type_info.as_ref()).is_some();
 
-          if is_record_or_trait {
+          if is_record_enum_or_trait {
             // Rewrite to (.method expr remaining_args...) — already handled by codegen
             let typed_method = Calcit::Method(method_name.clone(), calcit::MethodKind::Invoke(type_info.clone()));
             let mut ys = CalcitList::new_inner_from(&[typed_method, head_form]);

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -546,7 +546,9 @@ fn resolve_where_bound_type_for_body(bound: &crate::calcit::CalcitGenericBound, 
       return None;
     };
 
-    let resolved = program::lookup_def_code(&trait_ns, &trait_name).and_then(|code| resolve_trait_def_from_source_code(&code))?;
+    let resolved = program::lookup_def_code(&trait_ns, &trait_name)
+      .and_then(|code| resolve_trait_def_from_source_code(&code))?
+      .with_definition_ref(&trait_ns, &trait_name);
     traits.push(Arc::new(resolved));
   }
 
@@ -672,6 +674,7 @@ fn lookup_trait_ns_def_for_preprocess(
     program::lookup_compiled_def(raw_ns, raw_def)
       .and_then(|compiled| compiled.source_code)
       .and_then(|code| resolve_trait_def_from_source_code(&code))
+      .map(|trait_def| trait_def.with_definition_ref(raw_ns, raw_def))
       .map(Arc::new),
   )
 }
@@ -3177,14 +3180,7 @@ fn get_impl_records_from_type(type_value: &CalcitTypeAnnotation) -> Option<Vec<A
     return Some(struct_def.impls.to_owned());
   }
 
-  if let CalcitTypeAnnotation::Enum(enum_def, _) = type_value {
-    // Prepend core tuple impls; user impls come after and win (last_wins=true)
-    let mut impls = resolve_core_impl_records("&core-tuple-impls").unwrap_or_default();
-    impls.extend(enum_def.impls.iter().cloned());
-    return Some(impls);
-  }
-
-  if let CalcitTypeAnnotation::Tuple(enum_def) = type_value {
+  if let Some(enum_def) = type_value.resolve_to_enum() {
     // Prepend core tuple impls; user impls come after and win (last_wins=true)
     let mut impls = resolve_core_impl_records("&core-tuple-impls").unwrap_or_default();
     impls.extend(enum_def.impls.iter().cloned());
@@ -5087,6 +5083,7 @@ mod tests {
       .expect("trait should resolve from source-backed compiled data");
 
     assert_eq!(trait_def.name.ref_str(), "MySourceTrait");
+    assert_eq!(trait_def.definition_ref.as_deref(), Some("tests.source-trait/MySourceTrait"));
     assert!(trait_def.has_method("show"));
   }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -525,6 +525,142 @@ fn parse_deftrait_source(items: &CalcitList) -> Option<CalcitTrait> {
   Some(CalcitTrait::new(name, methods, method_types))
 }
 
+fn resolve_where_bound_type_for_body(bound: &crate::calcit::CalcitGenericBound, file_ns: &str) -> Option<Arc<CalcitTypeAnnotation>> {
+  let mut traits = Vec::with_capacity(bound.traits.len());
+  for trait_ref in bound.traits.iter() {
+    if !trait_ref.methods.is_empty() {
+      traits.push(trait_ref.clone());
+      continue;
+    }
+
+    let raw_name = trait_ref.name.ref_str();
+    let (trait_ns, trait_name) = if let Some((ns, name)) = raw_name.rsplit_once('/') {
+      (Arc::from(ns), Arc::from(name))
+    } else if program::has_def_code(file_ns, raw_name) {
+      (Arc::from(file_ns), Arc::from(raw_name))
+    } else if let Some(target_ns) = program::lookup_def_target_in_import(file_ns, raw_name) {
+      (target_ns, Arc::from(raw_name))
+    } else if program::has_def_code(calcit::CORE_NS, raw_name) {
+      (Arc::from(calcit::CORE_NS), Arc::from(raw_name))
+    } else {
+      return None;
+    };
+
+    let resolved = program::lookup_def_code(&trait_ns, &trait_name).and_then(|code| resolve_trait_def_from_source_code(&code))?;
+    traits.push(Arc::new(resolved));
+  }
+
+  match traits.len() {
+    0 => None,
+    1 => Some(Arc::new(CalcitTypeAnnotation::Trait(traits.remove(0)))),
+    _ => Some(Arc::new(CalcitTypeAnnotation::TraitSet(Arc::new(traits)))),
+  }
+}
+
+/// Resolve named types declared in the same lexical scope, such as a `defstruct`
+/// bound by an enclosing `let`. Program-level `TypeRef` resolution cannot see
+/// those definitions, so retaining the symbolic reference would make otherwise
+/// precise function parameters fall back to `Dynamic` inside the body.
+fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope_types: &ScopeTypes) -> Arc<CalcitTypeAnnotation> {
+  match annotation.as_ref() {
+    CalcitTypeAnnotation::TypeRef(name, args) => {
+      let resolved_args = Arc::new(
+        args
+          .iter()
+          .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+          .collect::<Vec<_>>(),
+      );
+      let short_name = name.rsplit('/').next().unwrap_or(name.as_ref());
+      let local_type = scope_types.get(name).or_else(|| scope_types.get(short_name));
+      match local_type.map(AsRef::as_ref) {
+        Some(CalcitTypeAnnotation::Struct(struct_def, _)) | Some(CalcitTypeAnnotation::Record(struct_def)) => {
+          Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args))
+        }
+        Some(CalcitTypeAnnotation::Enum(enum_def, _)) | Some(CalcitTypeAnnotation::Tuple(enum_def)) => {
+          Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args))
+        }
+        Some(CalcitTypeAnnotation::Trait(trait_def)) if resolved_args.is_empty() => {
+          Arc::new(CalcitTypeAnnotation::Trait(trait_def.clone()))
+        }
+        _ => Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args)),
+      }
+    }
+    CalcitTypeAnnotation::List(inner) => Arc::new(CalcitTypeAnnotation::List(resolve_local_type_refs_for_body(
+      inner.clone(),
+      scope_types,
+    ))),
+    CalcitTypeAnnotation::Map(key, value) => Arc::new(CalcitTypeAnnotation::Map(
+      resolve_local_type_refs_for_body(key.clone(), scope_types),
+      resolve_local_type_refs_for_body(value.clone(), scope_types),
+    )),
+    CalcitTypeAnnotation::Set(inner) => Arc::new(CalcitTypeAnnotation::Set(resolve_local_type_refs_for_body(
+      inner.clone(),
+      scope_types,
+    ))),
+    CalcitTypeAnnotation::Ref(inner) => Arc::new(CalcitTypeAnnotation::Ref(resolve_local_type_refs_for_body(
+      inner.clone(),
+      scope_types,
+    ))),
+    CalcitTypeAnnotation::Optional(inner) => Arc::new(CalcitTypeAnnotation::Optional(resolve_local_type_refs_for_body(
+      inner.clone(),
+      scope_types,
+    ))),
+    CalcitTypeAnnotation::Variadic(inner) => Arc::new(CalcitTypeAnnotation::Variadic(resolve_local_type_refs_for_body(
+      inner.clone(),
+      scope_types,
+    ))),
+    CalcitTypeAnnotation::Fn(signature) => Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: signature.generics.clone(),
+      where_bounds: signature.where_bounds.clone(),
+      arg_types: signature
+        .arg_types
+        .iter()
+        .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+        .collect(),
+      return_type: resolve_local_type_refs_for_body(signature.return_type.clone(), scope_types),
+      fn_kind: signature.fn_kind,
+      rest_type: signature
+        .rest_type
+        .as_ref()
+        .map(|rest| resolve_local_type_refs_for_body(rest.clone(), scope_types)),
+      features: signature.features.clone(),
+    }))),
+    CalcitTypeAnnotation::Struct(struct_def, args) => Arc::new(CalcitTypeAnnotation::Struct(
+      struct_def.clone(),
+      Arc::new(
+        args
+          .iter()
+          .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+          .collect(),
+      ),
+    )),
+    CalcitTypeAnnotation::Enum(enum_def, args) => Arc::new(CalcitTypeAnnotation::Enum(
+      enum_def.clone(),
+      Arc::new(
+        args
+          .iter()
+          .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+          .collect(),
+      ),
+    )),
+    _ => annotation,
+  }
+}
+
+fn unwrap_named_body_parameter_type(annotation: Arc<CalcitTypeAnnotation>, parameter: Option<&Arc<str>>) -> Arc<CalcitTypeAnnotation> {
+  let Some(parameter) = parameter else {
+    return annotation;
+  };
+  match annotation.as_ref() {
+    CalcitTypeAnnotation::TypeRef(label, args)
+      if args.len() == 1 && label.rsplit('/').next().is_some_and(|name| name == parameter.as_ref()) =>
+    {
+      args.first().expect("checked one named parameter type").clone()
+    }
+    _ => annotation,
+  }
+}
+
 fn lookup_trait_ns_def_for_preprocess(
   raw_ns: &str,
   raw_def: &str,
@@ -883,17 +1019,24 @@ fn preprocess_list_call(
         if matches!(method_kind, calcit::MethodKind::Invoke(_))
           && let Some(type_info) = resolve_type_value(&head_form, scope_types)
         {
-          // Only trigger for struct/record, enum, or trait types — NOT for Fn/Proc which
-          // also appear to have impls via core-impl lookups (e.g. `::` → tuple).
-          let is_record_enum_or_trait = type_info.as_ref().resolve_to_struct().is_some()
+          // Nominal and trait receivers always use method syntax, including the
+          // unknown-method error path. Other statically known values participate
+          // only when their actual method table contains the requested method;
+          // this keeps `(f .map)` available as an ordinary function argument while
+          // allowing typed values such as `n .show` and `xs .map callback`.
+          let is_nominal_or_trait = type_info.as_ref().resolve_to_struct().is_some()
             || type_info.as_ref().resolve_to_enum().is_some()
             // A quoted named type can remain as a TypeRef while the core value is
             // bootstrapping. It is still explicit static evidence, and normal
             // method dispatch/codegen does not require resolving its impl table.
             || matches!(type_info.as_ref(), CalcitTypeAnnotation::TypeRef(..))
             || trait_list_from_type(type_info.as_ref()).is_some();
+          let has_known_method = static_method_descriptors(type_info.as_ref()).is_some_and(|methods| {
+            let expected = format!(".{method_name}");
+            methods.iter().any(|method| method.name == expected)
+          });
 
-          if is_record_enum_or_trait {
+          if is_nominal_or_trait || has_known_method {
             // Rewrite to (.method expr remaining_args...) — already handled by codegen
             let typed_method = Calcit::Method(method_name.clone(), calcit::MethodKind::Invoke(type_info.clone()));
             let mut ys = CalcitList::new_inner_from(&[typed_method, head_form]);
@@ -3111,6 +3254,31 @@ fn is_dynamic_annotation(type_value: &CalcitTypeAnnotation) -> bool {
     || matches!(type_value, CalcitTypeAnnotation::Optional(inner) if is_dynamic_annotation(inner.as_ref()))
 }
 
+/// Rank annotations by how much static information they erase. Root-level
+/// dynamic callable/value types are weaker than an equally dynamic container,
+/// because the latter still preserves useful shape information.
+fn annotation_dynamic_weight(type_value: &CalcitTypeAnnotation) -> usize {
+  match type_value {
+    CalcitTypeAnnotation::Dynamic => 200,
+    CalcitTypeAnnotation::DynFn => 100,
+    CalcitTypeAnnotation::List(inner)
+    | CalcitTypeAnnotation::Set(inner)
+    | CalcitTypeAnnotation::Ref(inner)
+    | CalcitTypeAnnotation::Optional(inner)
+    | CalcitTypeAnnotation::Variadic(inner) => annotation_dynamic_weight(inner),
+    CalcitTypeAnnotation::Map(key, value) => annotation_dynamic_weight(key) + annotation_dynamic_weight(value),
+    CalcitTypeAnnotation::Fn(signature) => {
+      signature.arg_types.iter().map(|arg| annotation_dynamic_weight(arg)).sum::<usize>()
+        + signature.rest_type.as_ref().map_or(0, |rest| annotation_dynamic_weight(rest))
+        + annotation_dynamic_weight(signature.return_type.as_ref())
+    }
+    CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => {
+      args.iter().map(|arg| annotation_dynamic_weight(arg)).sum()
+    }
+    _ => 0,
+  }
+}
+
 fn find_trait_method_type<'a>(
   traits: &'a [Arc<CalcitTrait>],
   method_name: &str,
@@ -3418,6 +3586,36 @@ fn extract_predicate_bindings(cond_form: &Calcit, scope_types: &ScopeTypes) -> P
   }
 }
 
+fn resolve_enum_type_for_match(type_ref: &CalcitTypeAnnotation, file_ns: &str, scope_types: &ScopeTypes) -> Option<calcit::CalcitEnum> {
+  if let Some(enum_def) = type_ref.resolve_to_enum() {
+    return Some(enum_def);
+  }
+  let CalcitTypeAnnotation::TypeRef(name, _) = type_ref else {
+    return None;
+  };
+  let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+  let short_name = stripped.rsplit('/').next().unwrap_or(stripped);
+  if let Some(local_type) = scope_types.get(stripped).or_else(|| scope_types.get(short_name))
+    && let Some(enum_def) = local_type.resolve_to_enum()
+  {
+    return Some(enum_def);
+  }
+  let (target_ns, target_def) = if let Some((ns, def)) = stripped.rsplit_once('/') {
+    (Arc::from(ns), Arc::from(def))
+  } else if program::has_def_code(file_ns, stripped) {
+    (Arc::from(file_ns), Arc::from(stripped))
+  } else if let Some(target_ns) = program::lookup_def_target_in_import(file_ns, stripped) {
+    (target_ns, Arc::from(stripped))
+  } else {
+    (Arc::from(calcit::CORE_NS), Arc::from(stripped))
+  };
+  match resolve_program_value_for_preprocess(&target_ns, &target_def, None) {
+    Some(Calcit::Enum(enum_def)) => Some(enum_def),
+    Some(Calcit::Record(record)) => calcit::CalcitEnum::from_record(record).ok(),
+    _ => None,
+  }
+}
+
 /// Preprocess `match` syntax and perform exhaustiveness checking.
 /// Input form (pair-based): `(match <value> (<pattern1> <body1>) (<pattern2> <body2>) ...)`
 ///
@@ -3458,14 +3656,38 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
   )?;
 
   // Try to infer enum type from the value expression for exhaustiveness checking
-  let enum_def = infer_type_from_expr(&value_form, ctx.scope_types).and_then(|t| match t.as_ref() {
-    CalcitTypeAnnotation::Tuple(enum_ref) => Some(enum_ref.as_ref().to_owned()),
+  // and payload typing. Applied generic arguments are kept so a matched payload
+  // can be specialized instead of falling back to Dynamic.
+  let inferred_match_type = infer_type_from_expr(&value_form, ctx.scope_types);
+  let enum_match = inferred_match_type.and_then(|t| match t.as_ref() {
+    CalcitTypeAnnotation::Tuple(enum_ref) => Some((enum_ref.as_ref().to_owned(), Arc::new(vec![]))),
+    CalcitTypeAnnotation::Enum(enum_ref, args) => Some((enum_ref.as_ref().to_owned(), args.clone())),
+    CalcitTypeAnnotation::TypeRef(_, args) => {
+      resolve_enum_type_for_match(t.as_ref(), ctx.file_ns, ctx.scope_types).map(|enum_ref| (enum_ref, args.clone()))
+    }
     CalcitTypeAnnotation::TypeSlot(name) => calcit::resolve_type_slot(name).and_then(|resolved| match resolved.as_ref() {
-      CalcitTypeAnnotation::Enum(e, _) => Some(e.as_ref().to_owned()),
+      CalcitTypeAnnotation::Enum(e, args) => Some((e.as_ref().to_owned(), args.clone())),
+      CalcitTypeAnnotation::Tuple(e) => Some((e.as_ref().to_owned(), Arc::new(vec![]))),
       _ => None,
     }),
     _ => None,
   });
+  let enum_def = enum_match.as_ref().map(|(enum_def, _)| enum_def);
+  let mut enum_bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
+  if let Some((enum_def, applied_args)) = enum_match.as_ref() {
+    for (name, applied) in enum_def.generics().iter().zip(applied_args.iter()) {
+      if !matches!(applied.as_ref(), CalcitTypeAnnotation::Dynamic) {
+        enum_bindings.insert(name.clone(), applied.clone());
+      }
+    }
+    for bound in enum_def.where_bounds() {
+      if !enum_bindings.contains_key(&bound.name)
+        && let Some(trait_type) = resolve_where_bound_type_for_body(bound, ctx.file_ns)
+      {
+        enum_bindings.insert(bound.name.clone(), trait_type);
+      }
+    }
+  }
 
   xs.push(value_form);
 
@@ -3519,7 +3741,7 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
         };
 
         // Validate variant exists in enum and check arity
-        if let Some(ref enum_def) = enum_def {
+        if let Some(enum_def) = enum_def {
           if let Some(variant) = enum_def.find_variant_by_name(pat_tag) {
             let expected_arity = variant.arity();
             let actual_arity = pat_xs.len() - 1;
@@ -3568,9 +3790,9 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
 
               // Infer payload type from enum variant definition
               let payload_type = enum_def
-                .as_ref()
                 .and_then(|e| e.find_variant_by_name(pat_tag))
                 .and_then(|v| v.payload_types().get(bind_idx).cloned())
+                .map(|payload| payload.substitute_type_vars(&enum_bindings))
                 .unwrap_or_else(|| crate::calcit::DYNAMIC_TYPE.clone());
 
               let local = Calcit::Local(CalcitLocal {
@@ -3616,7 +3838,7 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
   }
 
   // Exhaustiveness checking
-  if let Some(ref enum_def) = enum_def
+  if let Some(enum_def) = enum_def
     && !has_wildcard
   {
     let all_variants: BTreeSet<&str> = enum_def.variants().iter().map(|v| v.tag.ref_str()).collect();
@@ -3743,18 +3965,41 @@ pub fn preprocess_defn(
       // Inject declared argument types into the function body. Call-site checks alone are not
       // enough: without these bindings, local method dispatch and return inference inside a named
       // `defn` unnecessarily fall back to Dynamic. Anonymous callbacks still use EXPECTED_FN_TYPE.
-      let effective_fn_schema: Option<Arc<CalcitFnTypeAnnotation>> = match def_schema.as_ref() {
+      let body_fn_hint = args
+        .iter()
+        .skip(2)
+        .find_map(CalcitTypeAnnotation::extract_fn_annotation_from_hint_form)
+        .and_then(|annotation| match annotation.as_ref() {
+          CalcitTypeAnnotation::Fn(fn_annotation) => Some(fn_annotation.clone()),
+          _ => None,
+        });
+      let effective_fn_schema: Option<Arc<CalcitFnTypeAnnotation>> = body_fn_hint.or_else(|| match def_schema.as_ref() {
         CalcitTypeAnnotation::Fn(fn_annot) => Some(fn_annot.clone()),
         CalcitTypeAnnotation::Dynamic => EXPECTED_FN_TYPE.with(|cell| cell.borrow().clone()),
         _ => None,
-      };
+      });
       if let Some(fn_annot) = &effective_fn_schema {
-        let parameter_types = fn_annot.arg_types.iter().cloned().chain(
-          fn_annot
-            .rest_type
-            .iter()
-            .map(|rest_type| Arc::new(CalcitTypeAnnotation::Variadic(rest_type.clone()))),
-        );
+        let body_type_bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = fn_annot
+          .where_bounds
+          .iter()
+          .filter_map(|bound| resolve_where_bound_type_for_body(bound, ctx.file_ns).map(|trait_type| (bound.name.clone(), trait_type)))
+          .collect();
+        let parameter_types = fn_annot
+          .arg_types
+          .iter()
+          .enumerate()
+          .map(|(idx, arg_type)| {
+            let substituted = arg_type.substitute_type_vars(&body_type_bindings);
+            let positional = unwrap_named_body_parameter_type(substituted, param_symbols.get(idx));
+            resolve_local_type_refs_for_body(positional, &body_types)
+          })
+          .chain(fn_annot.rest_type.iter().map(|rest_type| {
+            Arc::new(CalcitTypeAnnotation::Variadic(resolve_local_type_refs_for_body(
+              rest_type.substitute_type_vars(&body_type_bindings),
+              &body_types,
+            )))
+          }))
+          .collect::<Vec<_>>();
         for (param_sym, arg_type) in param_symbols.iter().zip(parameter_types) {
           if !matches!(arg_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
             body_types.insert(param_sym.to_owned(), arg_type);
@@ -4138,7 +4383,15 @@ pub fn preprocess_assert_type(
 
   let asserted_target = target_form;
   if let Calcit::Local(local) = &asserted_target {
-    let type_entry = CalcitTypeAnnotation::parse_type_annotation_form(type_form);
+    let asserted_type = CalcitTypeAnnotation::parse_type_annotation_form(type_form);
+    let current_type = resolve_type_value(&asserted_target, ctx.scope_types).unwrap_or_else(|| local.type_info.clone());
+    let type_entry = if current_type.as_ref().matches_annotation(asserted_type.as_ref())
+      && annotation_dynamic_weight(current_type.as_ref()) < annotation_dynamic_weight(asserted_type.as_ref())
+    {
+      current_type
+    } else {
+      asserted_type
+    };
     ctx.scope_types.insert(local.sym.to_owned(), type_entry.clone());
 
     let mut typed_local = local.to_owned();
@@ -4512,6 +4765,29 @@ mod tests {
     if let Some(type_val) = scope_types.get("x") {
       assert!(matches!(type_val.as_ref(), CalcitTypeAnnotation::DynFn), "type should be fn");
     }
+  }
+
+  #[test]
+  fn broad_assert_type_does_not_erase_inferred_element_type() {
+    let expr = Cirru::List(vec![Cirru::leaf("assert-type"), Cirru::leaf("xs"), Cirru::leaf(":list")]);
+    let code = code_to_calcit(&expr, "tests.assert", "main", vec![]).expect("parse cirru");
+    let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
+    scope_defs.insert(Arc::from("xs"));
+    let mut scope_types: ScopeTypes = ScopeTypes::new();
+    scope_types.insert(
+      Arc::from("xs"),
+      Arc::new(CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Number))),
+    );
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default();
+
+    let resolved =
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.assert", &warnings, &stack).expect("preprocess assert-type");
+
+    assert!(matches!(
+      resolve_type_value(&resolved, &scope_types).as_deref(),
+      Some(CalcitTypeAnnotation::List(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
+    ));
   }
 
   #[test]
@@ -5964,6 +6240,20 @@ mod tests {
       "expected number return from body-hinted function, got {inferred:?}; resolved: {resolved}"
     );
     assert!(warnings.borrow().is_empty(), "valid body hint should not emit warnings");
+  }
+
+  #[test]
+  fn named_body_hint_parameter_keeps_its_declared_type() {
+    let labelled = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("n"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    let parameter = Arc::from("n");
+
+    assert!(matches!(
+      unwrap_named_body_parameter_type(labelled, Some(&parameter)).as_ref(),
+      CalcitTypeAnnotation::Number
+    ));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6194,7 +6194,7 @@ mod tests {
   #[test]
   fn user_function_where_bounds_warn_on_missing_trait_impl() {
     let show_trait = Arc::new(crate::calcit::CalcitTrait::new(
-      EdnTag::new("Show"),
+      EdnTag::new("Renderable"),
       vec![EdnTag::new("show")],
       vec![crate::calcit::DYNAMIC_TYPE.clone()],
     ));
@@ -6335,7 +6335,7 @@ mod tests {
     );
     let message = warnings_vec[0].to_string();
     assert!(
-      message.contains("trait bound") && message.contains("Show"),
+      message.contains("trait bound") && message.contains("Renderable"),
       "warning should mention missing where-bound: {message}"
     );
   }
@@ -6343,7 +6343,7 @@ mod tests {
   #[test]
   fn local_function_where_bounds_warn_on_missing_trait_impl() {
     let show_trait = Arc::new(crate::calcit::CalcitTrait::new(
-      EdnTag::new("Show"),
+      EdnTag::new("Renderable"),
       vec![EdnTag::new("show")],
       vec![crate::calcit::DYNAMIC_TYPE.clone()],
     ));
@@ -6426,7 +6426,7 @@ mod tests {
     );
     let message = warnings_vec[0].to_string();
     assert!(
-      message.contains("trait bound") && message.contains("Show"),
+      message.contains("trait bound") && message.contains("Renderable"),
       "local fn warning should mention missing where-bound: {message}"
     );
   }

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -26,7 +26,9 @@ use crate::{
 };
 use cirru_edn::EdnTag;
 
-use super::{ScopeTypes, find_trait_method_type, tag_annotation, trait_list_from_type};
+use super::{
+  ScopeTypes, find_method_entry_for_type, find_trait_method_type, get_impl_records_from_type, tag_annotation, trait_list_from_type,
+};
 
 // ---------------------------------------------------------------------------
 // Core resolution
@@ -168,6 +170,8 @@ pub(crate) fn infer_return_type_from_compiled_callable(
     return Some(inferred);
   }
 
+  let is_core_enum_constructor = ns == calcit::CORE_NS && matches!(def, "%some" | "%none" | "%ok" | "%err");
+
   // Prefer compiled callable metadata. The four core enum constructors are
   // also needed while the core is bootstrapping, before their payloads are
   // compiled; their declared schemas unlock receiver-first method calls.
@@ -179,14 +183,22 @@ pub(crate) fn infer_return_type_from_compiled_callable(
         if let Some(resolved) = resolve_generic_return_type(&info, call_expr.iter().skip(1), scope_types) {
           return Some(resolved);
         }
-        return Some(info.return_type.clone());
+        if !is_core_enum_constructor || !info.return_type.contains_type_var() {
+          return Some(info.return_type.clone());
+        }
       }
-      Calcit::Proc(proc) => return proc.get_type_signature().map(|type_sig| type_sig.return_type.clone()),
+      Calcit::Proc(proc) => {
+        if let Some(type_sig) = proc.get_type_signature()
+          && (!is_core_enum_constructor || !type_sig.return_type.contains_type_var())
+        {
+          return Some(type_sig.return_type.clone());
+        }
+      }
       _ => {}
     }
   }
 
-  if ns != calcit::CORE_NS || !matches!(def, "%some" | "%none" | "%ok" | "%err") {
+  if !is_core_enum_constructor {
     return None;
   }
 
@@ -444,10 +456,18 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
 
         // Typed method invocation: resolve the selected trait signature and
         // substitute receiver/argument types into its generic return type.
-        Calcit::Method(method_name, calcit::MethodKind::Invoke(_)) => {
-          let receiver_type = xs.get(1).and_then(|receiver| resolve_type_value(receiver, scope_types))?;
-          let traits = trait_list_from_type(receiver_type.as_ref())?;
-          let (_, method_type) = find_trait_method_type(&traits, method_name)?;
+        Calcit::Method(method_name, calcit::MethodKind::Invoke(receiver_hint)) => {
+          let receiver_type = xs
+            .get(1)
+            .and_then(|receiver| resolve_type_value(receiver, scope_types))
+            .unwrap_or_else(|| receiver_hint.clone());
+          let method_type = if let Some(traits) = trait_list_from_type(receiver_type.as_ref()) {
+            find_trait_method_type(&traits, method_name).map(|(_, method_type)| method_type.clone())?
+          } else {
+            let impls = get_impl_records_from_type(receiver_type.as_ref())?;
+            let method = find_method_entry_for_type(receiver_type.as_ref(), &impls, method_name)?;
+            infer_type_from_expr(method, scope_types)?
+          };
           let CalcitTypeAnnotation::Fn(info) = method_type.as_ref() else {
             return Some(calcit::DYNAMIC_TYPE.clone());
           };

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -154,20 +154,55 @@ pub(crate) fn infer_return_type_from_compiled_callable(
     return Some(inferred);
   }
 
-  let compiled = program::lookup_compiled_def(ns, def)?;
-
-  // Avoid evaluating compiled payloads during preprocess type inference.
-  // Evaluating function code here can recurse back into preprocess and overflow stack.
-  match compiled.preprocessed_code {
-    Calcit::Fn { info, .. } => {
-      if let Some(resolved) = resolve_generic_return_type(&info, call_expr.iter().skip(1), scope_types) {
-        return Some(resolved);
+  // Prefer compiled callable metadata. The four core enum constructors are
+  // also needed while the core is bootstrapping, before their payloads are
+  // compiled; their declared schemas unlock receiver-first method calls.
+  if let Some(compiled) = program::lookup_compiled_def(ns, def) {
+    // Avoid evaluating compiled payloads during preprocess type inference.
+    // Evaluating function code here can recurse back into preprocess and overflow stack.
+    match compiled.preprocessed_code {
+      Calcit::Fn { info, .. } => {
+        if let Some(resolved) = resolve_generic_return_type(&info, call_expr.iter().skip(1), scope_types) {
+          return Some(resolved);
+        }
+        return Some(info.return_type.clone());
       }
-      Some(info.return_type.clone())
+      Calcit::Proc(proc) => return proc.get_type_signature().map(|type_sig| type_sig.return_type.clone()),
+      _ => {}
     }
-    Calcit::Proc(proc) => proc.get_type_signature().map(|type_sig| type_sig.return_type.clone()),
-    _ => None,
   }
+
+  if ns != calcit::CORE_NS || !matches!(def, "%some" | "%none" | "%ok" | "%err") {
+    return None;
+  }
+
+  let schema = program::lookup_def_schema(ns, def);
+  let CalcitTypeAnnotation::Fn(info) = schema.as_ref() else {
+    return None;
+  };
+  if info.generics.is_empty() || !info.return_type.contains_type_var() {
+    return Some(info.return_type.clone());
+  }
+
+  let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
+  for (arg, expected_type) in call_expr.iter().skip(1).zip(info.arg_types.iter()) {
+    if !matches!(expected_type.as_ref(), CalcitTypeAnnotation::Dynamic)
+      && let Some(actual_type) = resolve_type_value(arg, scope_types)
+    {
+      actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings);
+    }
+  }
+  // A constructor such as `%none` has no payload from which to infer one or
+  // more generic arguments. Preserve its nominal enum identity with Dynamic
+  // type arguments, but do not synthesize partial types for ordinary functions.
+  for generic in info.generics.iter() {
+    bindings.entry(generic.clone()).or_insert_with(|| calcit::DYNAMIC_TYPE.clone());
+  }
+  let resolved = info.return_type.substitute_type_vars(&bindings);
+  if resolved.contains_type_var() {
+    return None;
+  }
+  (resolved.resolve_to_struct().is_some() || resolved.resolve_to_enum().is_some()).then_some(resolved)
 }
 
 fn infer_core_get_return_type(call_expr: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -16,15 +16,17 @@ use std::{
 };
 
 use crate::{
+  builtins,
   calcit::{
-    self, Calcit, CalcitEnum, CalcitFnTypeAnnotation, CalcitImport, CalcitList, CalcitProc, CalcitRecord, CalcitStruct, CalcitSyntax,
-    CalcitTypeAnnotation, SchemaKind, resolve_type_slot,
+    self, Calcit, CalcitEnum, CalcitFnTypeAnnotation, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitRecord, CalcitStruct,
+    CalcitSyntax, CalcitTrait, CalcitTypeAnnotation, SchemaKind, resolve_type_slot,
   },
   call_stack::CallStackList,
   program, runner,
 };
+use cirru_edn::EdnTag;
 
-use super::{ScopeTypes, tag_annotation};
+use super::{ScopeTypes, find_trait_method_type, tag_annotation, trait_list_from_type};
 
 // ---------------------------------------------------------------------------
 // Core resolution
@@ -153,6 +155,18 @@ pub(crate) fn infer_return_type_from_compiled_callable(
   {
     return Some(inferred);
   }
+  if ns == calcit::CORE_NS
+    && def == "%::"
+    && let Some(inferred) = infer_enum_tuple_annotation(call_expr, scope_types)
+  {
+    return Some(inferred);
+  }
+  if ns == calcit::CORE_NS
+    && def == "impl-traits"
+    && let Some(inferred) = infer_impl_attachment_type(call_expr, scope_types)
+  {
+    return Some(inferred);
+  }
 
   // Prefer compiled callable metadata. The four core enum constructors are
   // also needed while the core is bootstrapping, before their payloads are
@@ -231,7 +245,7 @@ fn infer_core_get_in_return_type(call_expr: &CalcitList, scope_types: &ScopeType
 
 fn infer_get_return_type_from_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&Calcit>) -> Option<Arc<CalcitTypeAnnotation>> {
   match base_type {
-    CalcitTypeAnnotation::Optional(inner) => infer_get_return_type_from_type(inner.as_ref(), key_arg),
+    CalcitTypeAnnotation::Optional(inner) => infer_get_return_type_from_type(inner.as_ref(), key_arg).map(wrap_optional_type),
     CalcitTypeAnnotation::List(element_type) => Some(wrap_optional_type(element_type.clone())),
     CalcitTypeAnnotation::Map(_, value_type) => Some(wrap_optional_type(value_type.clone())),
     CalcitTypeAnnotation::String => Some(wrap_optional_type(tag_annotation("string"))),
@@ -239,7 +253,9 @@ fn infer_get_return_type_from_type(base_type: &CalcitTypeAnnotation, key_arg: Op
       if let Some(field_name) = key_arg.and_then(extract_field_name)
         && let Some(field_type) = resolve_struct_field_type(base_type, field_name)
       {
-        return Some(wrap_optional_type(field_type));
+        // A statically known struct field is always present. Preserve its
+        // declared type instead of applying the conservative map lookup rule.
+        return Some(field_type);
       }
       Some(wrap_optional_type(calcit::DYNAMIC_TYPE.clone()))
     }
@@ -321,6 +337,11 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
       Arc::new(enum_def.to_owned()),
       Arc::new(vec![]),
     ))),
+    Calcit::Trait(trait_def) => Some(Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def.to_owned())))),
+    // Impl values carry useful compile-time method metadata. `Custom` is the
+    // existing annotation representation for first-class runtime metadata;
+    // keeping the concrete value here is strictly more precise than `:impl`.
+    Calcit::Impl(impl_def) => Some(Arc::new(CalcitTypeAnnotation::Custom(Arc::new(Calcit::Impl(impl_def.to_owned()))))),
     Calcit::Ref(..) => Some(Arc::new(CalcitTypeAnnotation::Ref(calcit::DYNAMIC_TYPE.clone()))),
     Calcit::Buffer(_) => Some(Arc::new(CalcitTypeAnnotation::Buffer)),
     Calcit::CirruQuote(_) => Some(Arc::new(CalcitTypeAnnotation::CirruQuote)),
@@ -419,6 +440,24 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
             return Some(resolved);
           }
           Some(info.return_type.clone())
+        }
+
+        // Typed method invocation: resolve the selected trait signature and
+        // substitute receiver/argument types into its generic return type.
+        Calcit::Method(method_name, calcit::MethodKind::Invoke(_)) => {
+          let receiver_type = xs.get(1).and_then(|receiver| resolve_type_value(receiver, scope_types))?;
+          let traits = trait_list_from_type(receiver_type.as_ref())?;
+          let (_, method_type) = find_trait_method_type(&traits, method_name)?;
+          let CalcitTypeAnnotation::Fn(info) = method_type.as_ref() else {
+            return Some(calcit::DYNAMIC_TYPE.clone());
+          };
+          let mut bindings = HashMap::new();
+          for (argument, expected) in xs.iter().skip(1).zip(info.arg_types.iter()) {
+            if let Some(actual) = resolve_type_value(argument, scope_types) {
+              actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings);
+            }
+          }
+          Some(info.return_type.substitute_type_vars(&bindings))
         }
 
         // Method access: infer record field type when available
@@ -520,10 +559,216 @@ fn infer_preprocessed_function_parameters(
   (fixed, rest_type)
 }
 
+fn resolve_impl_origin(value: &Calcit, scope_types: &ScopeTypes) -> Option<(EdnTag, Option<Arc<CalcitTrait>>)> {
+  let resolved_trait = match value {
+    Calcit::Trait(trait_def) => Some(Arc::new(trait_def.to_owned())),
+    Calcit::Import(import) => match resolve_program_value_for_preprocess(&import.ns, &import.def, import.def_id) {
+      Some(Calcit::Trait(trait_def)) => Some(Arc::new(trait_def)),
+      _ => None,
+    },
+    Calcit::Symbol { sym, info, .. } => match resolve_program_value_for_preprocess(&info.at_ns, sym, None) {
+      Some(Calcit::Trait(trait_def)) => Some(Arc::new(trait_def)),
+      _ => None,
+    },
+    Calcit::Local(_) => match resolve_type_value(value, scope_types).as_deref() {
+      Some(CalcitTypeAnnotation::Trait(trait_def)) => Some(trait_def.clone()),
+      _ => None,
+    },
+    _ => None,
+  };
+  if let Some(trait_def) = resolved_trait {
+    return Some((trait_def.name.to_owned(), Some(trait_def)));
+  }
+
+  match value {
+    Calcit::Tag(name) => Some((name.to_owned(), None)),
+    Calcit::Str(name) | Calcit::Symbol { sym: name, .. } => Some((EdnTag(name.to_owned()), None)),
+    _ => None,
+  }
+}
+
+fn is_tuple_constructor(value: &Calcit) -> bool {
+  matches!(value, Calcit::Proc(CalcitProc::NativeTuple))
+    || matches!(value, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "::")
+    || matches!(value, Calcit::Symbol { sym, .. } if sym.as_ref() == "::")
+}
+
+fn is_list_constructor(value: &Calcit) -> bool {
+  matches!(value, Calcit::Proc(CalcitProc::List))
+    || matches!(value, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "[]")
+    || matches!(value, Calcit::Symbol { sym, .. } if sym.as_ref() == "[]")
+}
+
+fn extract_impl_pair(value: &Calcit) -> Option<(&Calcit, &Calcit)> {
+  match value {
+    Calcit::Tuple(tuple) if tuple.extra.len() == 1 => Some((tuple.tag.as_ref(), tuple.extra.first()?)),
+    Calcit::List(items) if items.len() == 2 => Some((items.first()?, items.get(1)?)),
+    Calcit::List(items)
+      if items.len() == 3
+        && items
+          .first()
+          .is_some_and(|head| is_tuple_constructor(head) || is_list_constructor(head)) =>
+    {
+      Some((items.get(1)?, items.get(2)?))
+    }
+    _ => None,
+  }
+}
+
+fn extract_impl_field_name(value: &Calcit) -> Option<EdnTag> {
+  match value {
+    Calcit::Method(name, _) | Calcit::Str(name) | Calcit::Symbol { sym: name, .. } => Some(EdnTag(name.to_owned())),
+    Calcit::Tag(name) => Some(name.to_owned()),
+    _ => None,
+  }
+}
+
+fn normalize_static_metadata_form(value: &Calcit) -> Calcit {
+  match value {
+    Calcit::List(items) if matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::Quote, _))) && items.len() == 2 => {
+      normalize_static_metadata_form(items.get(1).expect("quoted metadata value"))
+    }
+    Calcit::List(items) => {
+      let skip_head = items.first().is_some_and(|head| {
+        matches!(head, Calcit::Proc(CalcitProc::List))
+          || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "[]")
+          || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "[]")
+      });
+      let normalized = items
+        .iter()
+        .skip(usize::from(skip_head))
+        .map(normalize_static_metadata_form)
+        .collect::<Vec<_>>();
+      Calcit::List(Arc::new(CalcitList::from(normalized.as_slice())))
+    }
+    _ => value.to_owned(),
+  }
+}
+
+fn infer_trait_value(xs: &CalcitList) -> Option<CalcitTrait> {
+  let args = xs.iter().skip(1).map(normalize_static_metadata_form).collect::<Vec<_>>();
+  match builtins::meta::trait_new(&args).ok()? {
+    Calcit::Trait(trait_def) => Some(trait_def),
+    _ => None,
+  }
+}
+
+/// Synthesize the concrete metadata type produced by `&impl::new` without
+/// executing method bodies. This lets local impl bindings participate in
+/// subsequent `impl-traits` inference just like top-level `defimpl` values.
+fn infer_impl_value(xs: &CalcitList, scope_types: &ScopeTypes) -> Option<CalcitImpl> {
+  let (name, origin) = resolve_impl_origin(xs.get(1)?, scope_types)?;
+  let mut entries = Vec::with_capacity(xs.len().saturating_sub(2));
+  for item in xs.iter().skip(2) {
+    let (field, method) = extract_impl_pair(item)?;
+    entries.push((extract_impl_field_name(field)?, method.to_owned()));
+  }
+  entries.sort_by(|a, b| a.0.ref_str().cmp(b.0.ref_str()));
+  if entries.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+    return None;
+  }
+  let fields = entries.iter().map(|(field, _)| field.to_owned()).collect();
+  let values = entries.into_iter().map(|(_, method)| method).collect();
+  Some(CalcitImpl {
+    name,
+    origin,
+    fields: Arc::new(fields),
+    values: Arc::new(values),
+  })
+}
+
+fn resolve_impl_annotation(value: &Calcit, scope_types: &ScopeTypes) -> Option<Arc<CalcitImpl>> {
+  let inferred = resolve_type_value(value, scope_types)?;
+  match inferred.as_ref() {
+    CalcitTypeAnnotation::Custom(inner) => match inner.as_ref() {
+      Calcit::Impl(impl_def) => Some(Arc::new(impl_def.to_owned())),
+      _ => None,
+    },
+    _ => None,
+  }
+}
+
+/// Preserve the nominal data type of `impl-traits` while merging every impl
+/// whose metadata is statically known. If any attachment is opaque, return
+/// `None` so the builtin signature provides a conservative open type instead
+/// of a nominal type with an incorrectly complete method table.
+fn infer_impl_attachment_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
+  let base = resolve_type_value(xs.get(1)?, scope_types)?;
+  let impl_values = xs
+    .iter()
+    .skip(2)
+    .map(|value| resolve_impl_annotation(value, scope_types))
+    .collect::<Option<Vec<_>>>()?;
+  if impl_values.is_empty() {
+    return None;
+  }
+
+  match base.as_ref() {
+    CalcitTypeAnnotation::Struct(struct_def, args) => {
+      let mut attached = struct_def.as_ref().to_owned();
+      attached.impls.extend(impl_values);
+      Some(Arc::new(CalcitTypeAnnotation::Struct(Arc::new(attached), args.clone())))
+    }
+    CalcitTypeAnnotation::Record(struct_def) => {
+      let mut attached = struct_def.as_ref().to_owned();
+      attached.impls.extend(impl_values);
+      Some(Arc::new(CalcitTypeAnnotation::Record(Arc::new(attached))))
+    }
+    CalcitTypeAnnotation::Enum(enum_def, args) => {
+      let mut attached = enum_def.as_ref().to_owned();
+      let mut impls = attached.impls().to_vec();
+      impls.extend(impl_values);
+      attached.set_impls(impls);
+      Some(Arc::new(CalcitTypeAnnotation::Enum(Arc::new(attached), args.clone())))
+    }
+    CalcitTypeAnnotation::Tuple(enum_def) => {
+      let mut attached = enum_def.as_ref().to_owned();
+      let mut impls = attached.impls().to_vec();
+      impls.extend(impl_values);
+      attached.set_impls(impls);
+      Some(Arc::new(CalcitTypeAnnotation::Tuple(Arc::new(attached))))
+    }
+    CalcitTypeAnnotation::TypeRef(_, args) => {
+      if let Some(mut attached) = base.resolve_to_struct() {
+        attached.impls.extend(impl_values);
+        Some(Arc::new(CalcitTypeAnnotation::Struct(Arc::new(attached), args.clone())))
+      } else if let Some(mut attached) = base.resolve_to_enum() {
+        let mut impls = attached.impls().to_vec();
+        impls.extend(impl_values);
+        attached.set_impls(impls);
+        Some(Arc::new(CalcitTypeAnnotation::Enum(Arc::new(attached), args.clone())))
+      } else {
+        None
+      }
+    }
+    _ => None,
+  }
+}
+
 /// Infer the return type of a built-in proc call expression.
 ///
 /// Extracted from the large `Calcit::Proc` arm of `infer_type_from_expr` for clarity.
 fn infer_proc_call_return_type(proc: &CalcitProc, xs: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
+  if matches!(proc, CalcitProc::NativeTraitNew)
+    && let Some(trait_def) = infer_trait_value(xs)
+  {
+    return Some(Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def))));
+  }
+  if matches!(proc, CalcitProc::NativeImplNew)
+    && let Some(impl_def) = infer_impl_value(xs, scope_types)
+  {
+    return Some(Arc::new(CalcitTypeAnnotation::Custom(Arc::new(Calcit::Impl(impl_def)))));
+  }
+  if matches!(
+    proc,
+    CalcitProc::NativeRecordImplTraits
+      | CalcitProc::NativeTupleImplTraits
+      | CalcitProc::NativeStructImplTraits
+      | CalcitProc::NativeEnumImplTraits
+  ) && let Some(inferred) = infer_impl_attachment_type(xs, scope_types)
+  {
+    return Some(inferred);
+  }
   if matches!(proc, CalcitProc::List) {
     return Some(Arc::new(CalcitTypeAnnotation::List(infer_homogeneous_type(
       xs.iter().skip(1),
@@ -650,7 +895,7 @@ fn infer_proc_call_return_type(proc: &CalcitProc, xs: &CalcitList, scope_types: 
     return Some(Arc::new(CalcitTypeAnnotation::Set(element_type.clone())));
   }
   if matches!(proc, CalcitProc::NativeEnumTupleNew)
-    && let Some(tuple_type) = infer_enum_tuple_annotation(proc, xs, scope_types)
+    && let Some(tuple_type) = infer_enum_tuple_annotation(xs, scope_types)
   {
     return Some(tuple_type);
   }
@@ -658,6 +903,11 @@ fn infer_proc_call_return_type(proc: &CalcitProc, xs: &CalcitList, scope_types: 
     && let Some(struct_type) = infer_struct_literal_type(xs)
   {
     return Some(struct_type);
+  }
+  if matches!(proc, CalcitProc::NativeEnumNew)
+    && let Some(enum_type) = infer_enum_literal_type(xs)
+  {
+    return Some(enum_type);
   }
   if matches!(proc, CalcitProc::NativeRecord | CalcitProc::NativeRecordPartial)
     && let Some(record_type) = infer_record_literal_type(xs, scope_types)
@@ -719,6 +969,22 @@ fn infer_definition_value_type(ns: &str, def: &str) -> Option<Arc<CalcitTypeAnno
 }
 
 fn infer_definition_value_type_inner(ns: &str, def: &str) -> Option<Arc<CalcitTypeAnnotation>> {
+  // Static data/trait/impl declarations carry richer metadata in their
+  // preprocessed value than in the intentionally broad top-level schema
+  // (`'Struct`, `'Enum`, `'Trait`, or `'Impl`). Prefer that concrete metadata so
+  // imported `impl-traits` calls keep their nominal type and method table.
+  if let Some(compiled) = program::lookup_compiled_def(ns, def)
+    && let Some(inferred) = infer_type_from_expr(&compiled.preprocessed_code, &ScopeTypes::new())
+  {
+    let is_concrete_metadata = matches!(
+      inferred.as_ref(),
+      CalcitTypeAnnotation::Struct(..) | CalcitTypeAnnotation::Enum(..) | CalcitTypeAnnotation::Trait(..)
+    ) || matches!(inferred.as_ref(), CalcitTypeAnnotation::Custom(value) if matches!(value.as_ref(), Calcit::Impl(_)));
+    if is_concrete_metadata {
+      return Some(inferred);
+    }
+  }
+
   let schema = program::lookup_def_schema(ns, def);
   if !matches!(schema.as_ref(), CalcitTypeAnnotation::Dynamic) {
     return Some(schema);
@@ -755,19 +1021,13 @@ pub fn infer_static_type_from_expr(expr: &Calcit) -> Option<Arc<CalcitTypeAnnota
 // Specialised inference helpers
 // ---------------------------------------------------------------------------
 
-fn infer_enum_tuple_annotation(proc: &CalcitProc, xs: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
-  let (enum_proto, tag_arg) = match proc {
-    CalcitProc::NativeEnumTupleNew => {
-      if xs.len() < 3 {
-        return None;
-      }
-      let enum_arg = xs.get(1)?;
-      let tag_arg = xs.get(2);
-      let enum_proto = resolve_enum_value(enum_arg, scope_types)?;
-      (enum_proto, tag_arg)
-    }
-    _ => return None,
-  };
+fn infer_enum_tuple_annotation(xs: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
+  if xs.len() < 3 {
+    return None;
+  }
+  let enum_arg = xs.get(1)?;
+  let tag_arg = xs.get(2);
+  let enum_proto = resolve_enum_value(enum_arg, scope_types)?;
 
   if enum_proto.generics().is_empty() {
     return Some(Arc::new(CalcitTypeAnnotation::Tuple(Arc::new(enum_proto))));
@@ -780,7 +1040,6 @@ fn infer_enum_tuple_annotation(proc: &CalcitProc, xs: &CalcitList, scope_types: 
       .map(|_| calcit::DYNAMIC_TYPE.clone())
       .collect::<Vec<_>>()
   });
-
   Some(Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_proto), Arc::new(applied_args))))
 }
 
@@ -859,75 +1118,19 @@ fn infer_record_literal_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Optio
 }
 
 fn infer_struct_literal_type(xs: &CalcitList) -> Option<Arc<CalcitTypeAnnotation>> {
-  if xs.len() < 2 {
-    return None;
-  }
-
-  let name = parse_struct_name(xs.get(1)?)?;
-  let mut fields: Vec<(cirru_edn::EdnTag, Arc<CalcitTypeAnnotation>)> = Vec::new();
-
-  for item in xs.iter().skip(2) {
-    let (field_name, field_type) = parse_struct_field_entry(item)?;
-    fields.push((field_name, field_type));
-  }
-
-  fields.sort_by(|a, b| a.0.ref_str().cmp(b.0.ref_str()));
-  for idx in 1..fields.len() {
-    if fields[idx - 1].0 == fields[idx].0 {
-      return None;
-    }
-  }
-
-  let field_names: Vec<cirru_edn::EdnTag> = fields.iter().map(|(name, _)| name.to_owned()).collect();
-  let field_types: Vec<Arc<CalcitTypeAnnotation>> = fields.iter().map(|(_, t)| t.to_owned()).collect();
-
-  let struct_def = CalcitStruct {
-    name,
-    fields: Arc::new(field_names.clone()),
-    field_types: Arc::new(field_types),
-    generics: Arc::new(vec![]),
-    where_bounds: Arc::new(vec![]),
-    impls: vec![],
-  };
-
-  Some(Arc::new(CalcitTypeAnnotation::Record(Arc::new(struct_def))))
-}
-
-fn parse_struct_name(form: &Calcit) -> Option<cirru_edn::EdnTag> {
-  match form {
-    Calcit::Symbol { sym, .. } | Calcit::Str(sym) => Some(cirru_edn::EdnTag::from(sym.as_ref())),
-    Calcit::Tag(tag) => Some(tag.to_owned()),
+  let args = xs.iter().skip(1).map(normalize_static_metadata_form).collect::<Vec<_>>();
+  match builtins::records::new_struct(&args).ok()? {
+    Calcit::Struct(struct_def) => Some(Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(vec![])))),
     _ => None,
   }
 }
 
-fn parse_struct_field_entry(form: &Calcit) -> Option<(cirru_edn::EdnTag, Arc<CalcitTypeAnnotation>)> {
-  let Calcit::List(list) = form else {
-    return None;
-  };
-  let head = list.first()?;
-  let is_list_literal = matches!(head, Calcit::Proc(CalcitProc::List))
-    || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "[]")
-    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == calcit::CORE_NS && &**def == "[]");
-
-  if !is_list_literal {
-    return None;
+fn infer_enum_literal_type(xs: &CalcitList) -> Option<Arc<CalcitTypeAnnotation>> {
+  let args = xs.iter().skip(1).map(normalize_static_metadata_form).collect::<Vec<_>>();
+  match builtins::records::new_enum(&args).ok()? {
+    Calcit::Enum(enum_def) => Some(Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def), Arc::new(vec![])))),
+    _ => None,
   }
-
-  let field_name_form = list.get(1)?;
-  let field_type_form = list.get(2)?;
-  if list.len() != 3 {
-    return None;
-  }
-
-  let field_name = match field_name_form {
-    Calcit::Symbol { sym, .. } | Calcit::Str(sym) => cirru_edn::EdnTag::from(sym.as_ref()),
-    Calcit::Tag(tag) => tag.to_owned(),
-    _ => return None,
-  };
-
-  let field_type = CalcitTypeAnnotation::parse_type_annotation_form(field_type_form);
-  Some((field_name, field_type))
 }
 
 pub(crate) fn infer_record_field_type(
@@ -1180,6 +1383,107 @@ mod tests {
     assert!(matches!(
       infer_static_type_from_expr(&atom).as_deref(),
       Some(CalcitTypeAnnotation::Ref(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
+    ));
+  }
+
+  #[test]
+  fn known_struct_get_preserves_required_field_type() {
+    let mut struct_def = CalcitStruct::from_fields(EdnTag::from("User"), vec![EdnTag::from("name")]);
+    struct_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]);
+    let user_type = CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(vec![]));
+    let key = Calcit::Tag(EdnTag::from("name"));
+
+    assert!(matches!(
+      infer_get_return_type_from_type(&user_type, Some(&key)).as_deref(),
+      Some(CalcitTypeAnnotation::String)
+    ));
+    assert!(matches!(
+      infer_get_return_type_from_type(&CalcitTypeAnnotation::Optional(Arc::new(user_type)), Some(&key)).as_deref(),
+      Some(CalcitTypeAnnotation::Optional(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::String)
+    ));
+  }
+
+  #[test]
+  fn enum_constructor_keeps_nominal_type_without_payload_evidence() {
+    let generic: Arc<str> = Arc::from("T");
+    let struct_def = CalcitStruct {
+      name: EdnTag::from("MaybeX"),
+      fields: Arc::new(vec![EdnTag::from("none"), EdnTag::from("some")]),
+      field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),
+      generics: Arc::new(vec![generic.clone()]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    };
+    let enum_def = CalcitEnum::from_record(CalcitRecord {
+      struct_ref: Arc::new(struct_def),
+      values: Arc::new(vec![
+        Calcit::from(CalcitList::default()),
+        Calcit::from(vec![CalcitTypeAnnotation::TypeVar(generic).to_calcit()]),
+      ]),
+    })
+    .expect("valid generic enum fixture");
+
+    let none_call = CalcitList::from(&[
+      Calcit::Proc(CalcitProc::NativeEnumTupleNew),
+      Calcit::Enum(enum_def.clone()),
+      Calcit::Tag(EdnTag::from("none")),
+    ] as &[Calcit]);
+    assert!(matches!(
+      infer_enum_tuple_annotation(&none_call, &ScopeTypes::new()).as_deref(),
+      Some(CalcitTypeAnnotation::Enum(inferred, args))
+        if inferred.name() == enum_def.name()
+          && matches!(args.first().map(AsRef::as_ref), Some(CalcitTypeAnnotation::Dynamic))
+    ));
+
+    let some_call = CalcitList::from(&[
+      Calcit::Proc(CalcitProc::NativeEnumTupleNew),
+      Calcit::Enum(enum_def.clone()),
+      Calcit::Tag(EdnTag::from("some")),
+      Calcit::Number(1.0),
+    ] as &[Calcit]);
+    assert!(matches!(
+      infer_enum_tuple_annotation(&some_call, &ScopeTypes::new()).as_deref(),
+      Some(CalcitTypeAnnotation::Enum(inferred, args))
+        if inferred.name() == enum_def.name()
+          && matches!(args.first().map(AsRef::as_ref), Some(CalcitTypeAnnotation::Number))
+    ));
+  }
+
+  #[test]
+  fn impl_attachment_procs_preserve_nominal_data_types() {
+    let method_impl = CalcitImpl {
+      name: EdnTag::from("BirdMethods"),
+      origin: None,
+      fields: Arc::new(vec![EdnTag::from("show")]),
+      values: Arc::new(vec![Calcit::Nil]),
+    };
+    let struct_def = CalcitStruct::from_fields(cirru_edn::EdnTag::from("Bird"), vec![cirru_edn::EdnTag::from("name")]);
+    let struct_call = proc_call(
+      CalcitProc::NativeStructImplTraits,
+      vec![Calcit::Struct(struct_def.clone()), Calcit::Impl(method_impl.clone())],
+    );
+    assert!(matches!(
+      infer_static_type_from_expr(&struct_call).as_deref(),
+      Some(CalcitTypeAnnotation::Struct(inferred, _))
+        if inferred.name == struct_def.name && inferred.impls.iter().any(|item| item.get("show").is_some())
+    ));
+
+    let enum_record = CalcitRecord {
+      struct_ref: Arc::new(CalcitStruct::from_fields(
+        cirru_edn::EdnTag::from("Outcome"),
+        vec![cirru_edn::EdnTag::from("ok")],
+      )),
+      values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::default()))]),
+    };
+    let enum_def = CalcitEnum::from_record(enum_record).expect("valid enum fixture");
+    let enum_call = proc_call(
+      CalcitProc::NativeEnumImplTraits,
+      vec![Calcit::Enum(enum_def.clone()), Calcit::Impl(method_impl)],
+    );
+    assert!(matches!(
+      infer_static_type_from_expr(&enum_call).as_deref(),
+      Some(CalcitTypeAnnotation::Enum(inferred, _))
+        if inferred.name() == enum_def.name() && inferred.impls().iter().any(|item| item.get("show").is_some())
     ));
   }
 }

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -210,32 +210,27 @@ export let _$n_assert_traits = function (value: CalcitValue, traitDef: CalcitVal
     throw new Error(`&assert-traits cannot resolve impls for: ${toString(value, true)}`);
   }
   const impls = pair[0];
-  const missing: string[] = [];
-  for (let i = 0; i < traitDef.methods.length; i++) {
-    const method = traitDef.methods[i];
-    let exists = false;
-    for (let j = 0; j < impls.length; j++) {
-      const impl = impls[j];
-      if (impl != null && impl.getOrNil(method) != null) {
-        exists = true;
-        break;
-      }
-    }
-    if (!exists) missing.push(method.toString());
-  }
-  if (missing.length > 0) {
-    const available: string[] = [];
-    for (let j = 0; j < impls.length; j++) {
-      const impl = impls[j];
-      if (impl == null) continue;
-      for (let k = 0; k < impl.fields.length; k++) {
-        available.push(impl.fields[k].toString());
-      }
-    }
+  const reverse =
+    value instanceof CalcitRecord || value instanceof CalcitTuple || value instanceof CalcitStruct || value instanceof CalcitEnum;
+  const ordered = reverse ? [...impls].reverse() : impls;
+  const selected = ordered.find((impl) => impl != null && impl.origin === traitDef);
+  if (selected == null) {
+    const available = impls
+      .filter((impl) => impl?.origin != null)
+      .map((impl) => impl.origin!.name.toString())
+      .join(" ");
     throw new Error(
-      `assert-traits failed: ${toString(value, true)} does not implement ${traitDef.toString()}. Missing: ${missing.join(
+      `assert-traits failed: ${toString(value, true)} does not nominally implement ${traitDef.toString()}. Available trait impls: ${
+        available || "(none)"
+      }`
+    );
+  }
+  const missing = traitDef.methods.filter((method) => selected.getOrNil(method) == null);
+  if (missing.length > 0) {
+    throw new Error(
+      `assert-traits failed: impl ${selected.name.toString()} for trait ${traitDef.name.toString()} is incomplete. Missing: ${missing.join(
         " "
-      )}. Available: ${available.join(" ")}`
+      )}`
     );
   }
   return value;
@@ -300,12 +295,14 @@ export let _$n_impl_$o__$o_new = (name: CalcitValue, ...pairs: CalcitValue[]): C
   if (name === undefined) throw new Error("&impl::new expected arguments");
   const origin = name instanceof CalcitTrait ? name : null;
   const implName = origin ? origin.name : castTag(name);
-  if (pairs.length === 0) {
-    return new CalcitImpl(implName, [], [], origin);
-  }
   const entries: Array<{ tag: CalcitTag; value: CalcitValue }> = [];
-  for (let idx = 0; idx < pairs.length; idx++) {
-    const pairValue = pairs[idx];
+  let sourcePairs = pairs;
+  if (pairs.length === 1 && pairs[0] instanceof CalcitImpl) {
+    const sourceImpl = pairs[0];
+    sourcePairs = sourceImpl.fields.map((field, idx) => new CalcitTuple(field, [sourceImpl.values[idx]], null));
+  }
+  for (let idx = 0; idx < sourcePairs.length; idx++) {
+    const pairValue = sourcePairs[idx];
     let fieldTag: CalcitTag;
     let value: CalcitValue;
     if (pairValue instanceof CalcitTuple) {
@@ -332,6 +329,21 @@ export let _$n_impl_$o__$o_new = (name: CalcitValue, ...pairs: CalcitValue[]): C
   }
   const fields = entries.map((entry) => entry.tag);
   const values = entries.map((entry) => entry.value);
+  if (origin != null) {
+    const missing = origin.methods.filter((method) => !fields.some((field) => field.value === method.value));
+    const unexpected = fields.filter((field) => !origin.methods.some((method) => method.value === field.value));
+    if (missing.length > 0 || unexpected.length > 0) {
+      const details: string[] = [];
+      if (missing.length > 0) details.push(`missing methods: ${missing.join(" ")}`);
+      if (unexpected.length > 0) details.push(`methods not declared by the trait: ${unexpected.join(" ")}`);
+      throw new Error(`&impl::new does not conform to trait ${origin.name.toString()}: ${details.join("; ")}`);
+    }
+    for (const entry of entries) {
+      if (typeof entry.value !== "function") {
+        throw new Error(`&impl::new expects trait method .${entry.tag.value} to be a function, but received: ${toString(entry.value, true)}`);
+      }
+    }
+  }
   return new CalcitImpl(implName, fields, values, origin);
 };
 
@@ -1878,6 +1890,7 @@ let calcit_builtin_impls = {
   fn: null as CalcitImplEntry,
   tuple: null as CalcitImplEntry,
   record: null as CalcitImplEntry,
+  scalar: null as CalcitImplEntry,
 };
 
 // need to register code from outside
@@ -1960,6 +1973,15 @@ function lookup_impls(obj: CalcitValue): [CalcitImpl[], string] {
   } else if (typeof obj === "function") {
     tag = "&core-fn-methods";
     impls = normalize_builtin_impls(calcit_builtin_impls.fn);
+  } else if (
+    obj == null ||
+    typeof obj === "boolean" ||
+    obj instanceof CalcitTag ||
+    obj instanceof CalcitSymbol ||
+    obj instanceof CalcitCirruQuote
+  ) {
+    tag = "&core-scalar-impls";
+    impls = normalize_builtin_impls(calcit_builtin_impls.scalar);
   } else {
     return null;
   }
@@ -2106,7 +2128,7 @@ export function _$n_trait_call(traitDef: CalcitValue, method: CalcitValue, obj: 
   let idx = reverse ? impls.length - 1 : 0;
   while (reverse ? idx >= 0 : idx < impls.length) {
     const impl = impls[idx];
-    if (impl != null && impl.origin != null && impl.origin.name.value === traitDef.name.value) {
+    if (impl != null && impl.origin === traitDef) {
       const fn = impl.getOrNil(methodName);
       if (fn != null) {
         if (typeof fn !== "function") {

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -202,20 +202,14 @@ export let _$n_assert_traits = function (value: CalcitValue, traitDef: CalcitVal
   if (!(traitDef instanceof CalcitTrait)) {
     throw new Error(`&assert-traits expected a trait definition, but received: ${toString(traitDef, true)}`);
   }
-  // For records/tuples, only check instance impls (not builtin fallbacks),
-  // matching the Rust runtime behavior of collect_impl_records_for_value.
-  let impls: CalcitImpl[];
-  if (value instanceof CalcitRecord) {
-    impls = value.structRef.impls ?? [];
-  } else if (value instanceof CalcitTuple) {
-    impls = value.impls ?? [];
-  } else {
-    const pair = lookup_impls(value);
-    if (pair == null) {
-      throw new Error(`&assert-traits cannot resolve impls for: ${toString(value, true)}`);
-    }
-    impls = pair[0];
+  // Use the same merged builtin + attached impl list as method dispatch.
+  // Otherwise records and tuples can call a builtin method while
+  // `assert-traits` incorrectly claims that the corresponding trait is absent.
+  const pair = lookup_impls(value);
+  if (pair == null) {
+    throw new Error(`&assert-traits cannot resolve impls for: ${toString(value, true)}`);
   }
+  const impls = pair[0];
   const missing: string[] = [];
   for (let i = 0; i < traitDef.methods.length; i++) {
     const method = traitDef.methods[i];
@@ -1951,10 +1945,12 @@ function lookup_impls(obj: CalcitValue): [CalcitImpl[], string] {
     // impls, so introspection tools like `&methods-of` can answer "what
     // methods will instances of this type have" without a concrete instance.
     tag = obj.name.toString();
-    impls = obj.impls;
+    const builtinRecordImpls = normalize_builtin_impls(calcit_builtin_impls.record) ?? [];
+    impls = [...builtinRecordImpls, ...(obj.impls ?? [])];
   } else if (obj instanceof CalcitEnum) {
     tag = obj.name();
-    impls = obj.impls;
+    const builtinTupleImpls = normalize_builtin_impls(calcit_builtin_impls.tuple) ?? [];
+    impls = [...builtinTupleImpls, ...(obj.impls ?? [])];
   } else if (typeof obj === "number") {
     tag = "&core-number-methods";
     impls = normalize_builtin_impls(calcit_builtin_impls.number);


### PR DESCRIPTION
## Summary

- make Option and Result genuinely generic and add predicates, fallback, chaining, and error-mapping APIs with methods and examples
- add Compare plus complete Countable and Contains coverage for built-in data categories
- align named enum typing and Rust/JS/WASM trait discovery and static method metadata
- document Calcit data categories and Cirru EDN versus JSON fidelity

## Nominal trait implementations

- give evaluated Trait values nominal runtime identity; identical names or method shapes no longer make independent traits interchangeable
- require concrete defimpl values to carry the exact trait origin, implement the full declared method set, and provide callable methods; native preprocessing also checks known signatures
- make assert-traits and &trait-call select one matching origin instead of merging methods from unrelated implementations
- register origin-carrying core implementations consistently in native and JS, including Bool, Tag, Symbol, Nil, and CirruQuote
- keep tag-based defimpl as a compatible inherent method bag for normal .method dispatch, and add the non-blocking W_LEGACY_INHERENT_IMPL format advisory
- document the WASM internal-validation boundary and format/run all affected Cirru documentation examples

## Markdown Cirru formatting

- add cr docs format-md <file> to atomically canonicalize fenced cirru, cirru.no-run, cirru.no-check, and cirru.cli blocks
- add --check for CI; it reports non-canonical blocks without writing files
- preserve Markdown and non-Cirru fences, retain multiple top-level Cirru forms, and report source line numbers for parse errors

## Breaking changes

This deliberately tightens concrete Trait conformance:

- a concrete defimpl with missing, extra, or non-callable methods now errors
- an unrelated same-named method or Trait no longer satisfies assert-traits, generic :where bounds, or &trait-call
- legacy tag-based method bags continue to run for ordinary .method dispatch, but do not prove a nominal Trait capability; migrate capability code to deftrait plus a complete defimpl

## Validation

- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test (298 library tests, 179 CLI tests)
- yarn compile
- yarn check-all: Agent interface 12/12, native, JS, IR, and WASM
- docs check-md: traits 12/12, polymorphism 10/10, upgrade 2/2; 24 Cirru blocks canonicalized with parse-format round-trips
- format-md unit coverage for supported fences, multiple roots, parse errors, idempotence, atomic write behavior, and check mode
- external Respo check-only, type summary, and targeted example regression

Tracks the generic-enum diagnostic defect fixed here in #287.