### PR TITLE
chore: release 0.12.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.12.57"
+version = "0.12.58"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.12.57"
+version = "0.12.58"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/history/202608021730-release-0.12.58.md
+++ b/history/202608021730-release-0.12.58.md
@@ -1,0 +1,5 @@
+# Release 0.12.58
+
+- Release the receiver-first method inference and trait nominal-identity fixes merged in PR #288.
+- Synchronize the crate, npm package, and Cargo lockfile versions at `0.12.58`.
+- The merge commit passed the main Test and CodeQL workflows before this release commit.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.12.57",
+  "version": "0.12.58",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
Release preparation for 0.12.58.\n\n- Synchronize Cargo and npm package versions\n- Refresh Cargo.lock\n- Record release notes\n\nThe preceding main merge (PR #288) passed Test and CodeQL.