### PR TITLE
chore: release 0.12.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.12.58"
+version = "0.12.59"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.12.58"
+version = "0.12.59"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/history/202608021928-release-0.12.59.md
+++ b/history/202608021928-release-0.12.59.md
@@ -1,0 +1,5 @@
+# Release 0.12.59
+
+- Release the top-level nominal value schema fix from PR #291.
+- Synchronize the crate, npm package, and Cargo lockfile versions at `0.12.59`.
+- The merged main commit passed Test and CodeQL before this release preparation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.12.58",
+  "version": "0.12.59",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
Release preparation for 0.12.59.

- Synchronize Cargo and npm package versions
- Refresh Cargo.lock
- Record release notes

Includes the top-level nominal value schema fix from PR #291.