### PR TITLE
feat: add strict typed Cirru EDN decoding

### DIFF
--- a/RFCs/08-04-strict-cirru-edn-decoding-rfc.md
+++ b/RFCs/08-04-strict-cirru-edn-decoding-rfc.md
@@ -254,7 +254,7 @@ PatchNode =
 应满足：
 
 > `apply(shape<T>, old, diff(shape<T>, old, next, strategy)) = Ok(next)`
-
+>
 > `apply(shape<T>, old, patch) = Ok(value)` 蕴含 `value: T`，且保持 struct/enum 名义身份。
 
 ### 7.1 核心与 Recollect 的职责边界

--- a/RFCs/08-04-strict-cirru-edn-decoding-rfc.md
+++ b/RFCs/08-04-strict-cirru-edn-decoding-rfc.md
@@ -1,0 +1,260 @@
+# RFC: Cirru EDN 严格类型化反序列化
+
+状态：Implemented / Phase 1（非递归类型）
+日期：2026-08-04
+关联：`07-31-unsafe-coerce-driven-static-type-boundary-plan.md`、`06-01-generic-binding-unification-rfc.md`、`05-31-generic-where-bounds-mfs.md`、Issue #295
+
+## 1. 摘要
+
+新增语言级类型边界：
+
+```cirru
+parse-cirru-edn-as text TypeExpr
+```
+
+它把 Cirru EDN 文本直接解码为满足 `TypeExpr` 的 Calcit 值，并保证：只要调用成功，返回值的完整递归结构、容器元素、struct 字段、enum variant/payload、泛型实参以及名义类型身份都符合目标类型。
+
+该操作不等价于：
+
+```cirru
+unsafe-coerce (parse-cirru-edn text) TypeExpr
+```
+
+后者只建立静态声明，不提供运行时证明；新操作则必须完成实际解析、验证与名义值构造，建立 `validated` 类型证据。
+
+现有 `parse-cirru-edn` 保持兼容，继续作为动态数据接口。严格 API 不允许以 `Dynamic` 作为逃生口；确实需要任意 EDN 时，应显式使用旧动态 API。
+
+## 2. 问题
+
+当前 `parse-cirru-edn` 的返回类型是 `Dynamic`。它的第二个 options map 只根据名称把 record/enum 重新连接到声明对象：
+
+- 不验证 List/Map/Set 内部元素；
+- 不验证 record 字段值的声明类型；
+- 不验证 enum variant 和 payload 类型；
+- 不验证泛型实参与 `:where` 约束；
+- record 字段集合不一致时存在不可恢复的 `unreachable!` 路径；
+- 调用方即使紧接 `assert-type`，当前浅层匹配也不能形成深度证明。
+
+因此 options map 解决的是“名义身份恢复”，不是“类型化反序列化”。把返回值交给 `unsafe-coerce` 只会隐藏边界风险。
+
+## 3. 设计原则
+
+1. **动态与已验证边界分离**：动态解析和严格解码使用不同名字、不同静态语义。
+2. **禁止隐式退化**：严格解码图中不存在 `Dynamic`、未绑定类型变量或未知自定义节点。
+3. **直接构造目标值**：严格解码从 `cirru_edn::Edn` 直接生成目标 Calcit 值，不先生成动态值再做浅检查。
+4. **名义身份精确**：struct/enum 使用编译器解析到的实际声明对象，不能仅凭同名结构冒充。
+5. **Native/JS 同一规则**：两个后端使用同构的解码图和错误路径语义。
+6. **失败可定位**：错误包含目标类型与数据路径，例如 `$.friends[2].age`。
+7. **旧 API 兼容**：本 RFC 不改变 `parse-cirru-edn` 的现有成功结果；迁移由调用方逐处完成。
+
+## 4. 表面语法与静态语义
+
+### 4.1 基本形式
+
+```cirru
+parse-cirru-edn-as raw Person
+
+parse-cirru-edn-as raw $ :: 'List 'Number
+
+parse-cirru-edn-as raw $ :: Box 'String
+```
+
+`TypeExpr` 使用现有类型表达式规则。命名 struct/enum 推荐直接使用声明值（如 `Person`、`Box`）；内建类型与泛型应用继续使用现有 `::` 表达方式。
+
+该形式是 syntax，而不是普通 proc，原因有三点：
+
+- 编译器必须在运行前解析并验证 `TypeExpr`；
+- 返回类型就是 `TypeExpr`，不能退化为 proc 的固定 `Dynamic`；
+- JS codegen 需要把类型解析结果编译为后端无关的解码图。
+
+### 4.2 允许的目标类型
+
+Phase 1 支持：
+
+- `Unit`、`Bool`、`Number`、`String`、`Symbol`、`Tag`、`Buffer`、`CirruQuote`；
+- `Optional<T>`；
+- `List<T>`、`Set<T>`、`Map<K,V>`、`Ref<T>`；
+- 具有完整字段类型的 `defstruct`；
+- 具有完整 variant/payload 类型的 `defenum`；
+- 上述类型的有限组合；
+- 所有泛型实参均已给出的 struct/enum 应用。
+
+Phase 1 明确拒绝：
+
+- `Dynamic`，以及裸 `List`/`Map`/`Set`/`Ref` 所隐含的 Dynamic 参数；
+- 未绑定 `TypeVar`、未解析或未绑定的 `TypeSlot`；
+- 泛型参数缺失、过多或不满足 `:where`；
+- `Fn`、proc、trait、impl、`JsObject`、任意宿主引用；
+- 未知 `Custom` 类型；
+- 没有 enum 声明身份的普通 tuple；
+- `Variadic<T>`（它是函数参数约束，不是数据类型）。
+
+拒绝发生在预处理/编译阶段。动态输入不能迫使编译器生成“遇到不懂的节点就接受”的解码器。
+
+### 4.3 返回类型
+
+静态分析把整个表达式推断为已经解析、完成泛型替换后的 `TypeExpr`，其证据等级为 `validated`。Phase 1 先把类型本身接入现有推断；证据等级的结构化查询等后续静态分析基础设施具备后再暴露。
+
+### 4.4 错误模型
+
+为保持与 `parse-cirru-edn` 一致，Phase 1 在失败时抛出可被 `try` 捕获的错误，而不是额外引入标准库 `Result` 依赖。
+
+错误至少包含：
+
+- 错误类别：文本解析失败、kind 不匹配、名义名称不匹配、字段集合不匹配、variant 不存在、payload arity 不匹配、值类型不匹配；
+- 目标类型；
+- 结构路径；
+- 实际 EDN kind 或名称。
+
+示例：
+
+```text
+parse-cirru-edn-as failed at $.friends[2].age: expected number, got string
+```
+
+## 5. 严格构造规则
+
+### 5.1 标量和容器
+
+- 标量必须匹配对应 EDN variant，不做字符串到数字等隐式转换；
+- `Optional<T>` 只把 EDN `nil` 解释为缺失，否则按 `T` 解码；
+- List/Set/Map 对每个元素或键值递归解码；
+- `Ref<T>` 只接受 EDN `atom`，并对 atom 内部值递归解码；
+- Map key 与 value 都必须满足各自目标类型。
+
+### 5.2 Struct
+
+- 输入必须是 `%{}` record，不能把普通 map 自动提升为 struct；
+- EDN record 名必须和声明名一致；
+- 字段集合必须精确一致：未知字段和缺失字段都是错误；
+- 不以 `nil` 代替缺失字段，不读取默认值；
+- 字段值按泛型替换后的字段类型递归解码；
+- 成功值的 `struct_ref` 必须是目标声明对象，保留其 trait/impl。
+
+### 5.3 Enum
+
+- 输入必须是 `%::` enum tuple，普通 `::` tuple 不自动升级；
+- EDN enum 名必须和声明名一致；
+- variant 必须存在；
+- payload arity 必须精确一致；
+- payload 按泛型替换后的类型逐项递归解码；
+- 成功值的 `sum_type` 必须是目标 enum 声明对象。
+
+### 5.4 泛型和 `:where`
+
+对 `Box<String>`：
+
+1. 检查 `Box` 的泛型参数数量；
+2. 建立 `{T -> String}` 绑定；
+3. 检查 `T` 对应的 `:where` trait 约束；
+4. 把字段/variant 中的 `T` 替换为 `String`；
+5. 对替换后的图递归执行同样的可解码性检查。
+
+泛型函数内部不能依赖运行时反射出 `T`。后续公开 `EdnDecoder<T>` 后，泛型函数必须显式接收 decoder dictionary。
+
+## 6. `EdnDecoderGraph` 的具体价值
+
+`EdnDecoderGraph` 是编译器生成、后端执行的闭合解码程序，而不是允许 Dynamic 的 schema 描述。它的节点只有：
+
+```text
+Scalar
+Optional(node)
+List(node)
+Set(node)
+Map(key-node, value-node)
+Ref(node)
+Struct(nominal-ref, fields)
+Enum(nominal-ref, variants)
+```
+
+图使用 node id 引用其他节点，为共享子图、缓存以及后续递归类型支持保留稳定表示。例如未来的递归图可以表示为：
+
+```text
+#0 = Struct User { friends: #1 }
+#1 = List #0
+```
+
+Phase 1 不接受自引用 struct/enum。当前声明类型解析链尚未完整 cycle-safe；在该基础设施修复前，编译器应明确拒绝递归派生，不能通过无限展开或增加运行栈规避。node id 格式保证后续加入递归支持时不需要推翻 decoder ABI。
+
+它提供以下不可由“运行时拿 TypeExpr 随便判断”替代的价值：
+
+- **封闭性证明**：图构建成功即证明所有节点可解码，不存在 Dynamic fallback；
+- **一次解析，多后端执行**：名称解析、泛型替换、arity 和 where-bound 在编译器完成；Native/JS 只执行同一组节点语义；
+- **递归终止**：node id 和构建中占位节点处理递归定义；
+- **精确名义引用**：节点携带声明路径和后端运行时对象，不靠字符串同名猜测；
+- **路径错误**：执行器天然知道当前字段、索引、map key/value 和 payload 位置；
+- **可缓存**：同一闭合类型的图可以按类型指纹 hoist/cache，避免每次解析重新解释类型表达式；
+- **演进位置清晰**：版本迁移、默认值、字段别名等策略若未来加入，应成为显式 Custom decoder 节点，而不能污染基础严格规则。
+
+关键不变量：
+
+> `decode(graph<T>, edn) = Ok(value)` 蕴含 `value` 在递归结构与名义身份上满足 `T`。
+
+### 6.1 为什么 Phase 1 不公开 `EdnDecoder<T>` 值
+
+当前类型系统能表达命名类型应用，但尚未为“编译器派生的、不透明、可作为值传递的泛型字典”建立稳定 ABI。过早把 graph 暴露为普通动态 record，会再次允许伪造 decoder。
+
+因此 Phase 1 只公开 `parse-cirru-edn-as` syntax，graph 是编译产物；Phase 2 再新增不可伪造的 `EdnDecoder<T>` 类型和值构造规则：
+
+```cirru
+edn-decoder Person
+decode-cirru-edn person-decoder raw
+```
+
+届时 `parse-cirru-edn-as raw Person` 只是二者的语法糖。公开值仍不得包含 Dynamic 节点。
+
+## 7. 与旧 API 的关系
+
+| API | 用途 | 静态结果 | 运行时保证 |
+| --- | --- | --- | --- |
+| `parse-cirru-edn text [options]` | 任意 EDN、旧代码兼容 | `Dynamic` | 语法有效；options 仅恢复部分身份 |
+| `unsafe-coerce value T` | 显式信任外部保证 | `T` / trusted | 不验证、不转换 |
+| `assert-type value T` | 现有浅层断言 | 原值 | 仅当前 matcher 覆盖范围 |
+| `parse-cirru-edn-as text T` | 严格类型化反序列化 | `T` / validated | 深度结构与名义身份满足 `T` |
+
+旧 API 不自动弃用，因为 REPL、配置浏览、代码数据和开放 EDN 都有合理的动态使用场景。文档应把它称为动态解析，并优先向业务状态恢复推荐严格 API。
+
+## 8. 实施阶段
+
+### Phase 1：严格闭环
+
+- 新增 `parse-cirru-edn-as` syntax 和静态返回类型；
+- 构建无 Dynamic 节点的 `EdnDecoderGraph`；
+- Native 执行器直接从 `cirru_edn::Edn` 构造类型化值；
+- JS codegen 输出等价 graph，JS runtime 执行同样规则；
+- 支持有限 struct/enum 组合、泛型替换与 where-bound；
+- 增加成功、深层失败、名义名称失败、字段集合失败、variant/arity 失败和编译期拒绝用例；
+- 文档明确旧 options map 的能力边界。
+
+### Phase 2：一等 decoder dictionary
+
+- 引入不可伪造的 `EdnDecoder<T>`；
+- 先让命名类型解析和 schema 展开具备 cycle-safe 能力，再开放递归 struct/enum graph；
+- `edn-decoder T` 编译期派生并 hoist graph；
+- 泛型函数显式接收 `EdnDecoder<T>`；
+- 提供 `decode-cirru-edn` 和 `decode-edn` 的 Result 版本；
+- 允许显式组合 decoder，但不允许从普通 Map/Record 构造。
+
+### Phase 3：受控的格式演进
+
+- 设计显式 custom decoder / migration API；
+- 默认值、旧字段名、版本迁移只能通过 custom 节点引入；
+- custom decoder 的结果仍必须进入最终目标类型的已验证构造路径。
+
+## 9. 兼容性与风险
+
+- 新 syntax 不改变旧代码；
+- 严格 API 有意拒绝不完整类型，不能为了兼容改成 warning 或 Dynamic fallback；
+- 编译期图构建可能增加时间，后续按规范化类型指纹缓存；
+- 后续 recursive graph 必须设置构建中占位节点和执行深度/输入规模保护，避免恶意数据造成栈或资源耗尽；
+- Native/JS 任一端暂不支持的节点应在编译期统一拒绝，不能只让某后端失败。
+
+## 10. 验收标准
+
+1. `parse-cirru-edn-as` 的推断结果为目标闭合类型；
+2. `List<Map<Tag, Person>>` 等嵌套值逐层校验；
+3. struct/enum 成功值携带精确声明身份和 impl；
+4. Dynamic、缺泛型、未绑定变量、函数/trait/JS object 在运行前被拒绝；
+5. Native 与 JS 对相同输入同时成功，或在同一路径以同一错误类别失败；
+6. 旧 `parse-cirru-edn` 行为保持兼容，并移除 record 字段不匹配的 panic 路径；
+7. 文档与集成测试覆盖动态解析、严格解码和 unsafe coercion 三种边界的区别。

--- a/RFCs/08-04-strict-cirru-edn-decoding-rfc.md
+++ b/RFCs/08-04-strict-cirru-edn-decoding-rfc.md
@@ -1,6 +1,6 @@
 # RFC: Cirru EDN 严格类型化反序列化
 
-状态：Implemented / Phase 1（非递归类型）
+状态：Implemented / Phase 1 + DataShape 内核（非递归类型）
 日期：2026-08-04
 关联：`07-31-unsafe-coerce-driven-static-type-boundary-plan.md`、`06-01-generic-binding-unification-rfc.md`、`05-31-generic-where-bounds-mfs.md`、Issue #295
 
@@ -152,58 +152,128 @@ parse-cirru-edn-as failed at $.friends[2].age: expected number, got string
 
 泛型函数内部不能依赖运行时反射出 `T`。后续公开 `EdnDecoder<T>` 后，泛型函数必须显式接收 decoder dictionary。
 
-## 6. `EdnDecoderGraph` 的具体价值
+## 6. 共享的闭合数据形状
 
-`EdnDecoderGraph` 是编译器生成、后端执行的闭合解码程序，而不是允许 Dynamic 的 schema 描述。它的节点只有：
+严格 EDN 解码已经提炼为编译器内部的 `DataShapeGraph`。EDN 执行器只负责“怎样从 EDN 读取节点”；名称解析、泛型替换、`:where` 检查和名义类型绑定都只在 shape 构建阶段执行一次。后续 JSON、FFI、持久化和 diff/patch 必须复用该 shape，不能各自实现一套不完整的类型反射。
 
-```text
-Scalar
-Optional(node)
-List(node)
-Set(node)
-Map(key-node, value-node)
-Ref(node)
-Struct(nominal-ref, fields)
-Enum(nominal-ref, variants)
-```
-
-图使用 node id 引用其他节点，为共享子图、缓存以及后续递归类型支持保留稳定表示。例如未来的递归图可以表示为：
+### 6.1 当前 ABI
 
 ```text
-#0 = Struct User { friends: #1 }
-#1 = List #0
+DataShapeGraph {
+  version: 1
+  root: NodeId
+  fingerprint: MD5(ABI version + complete normalized graph)
+  nodes: [DataShapeNode]
+}
+
+DataShapeNode =
+  Unit | Bool | Number | String | Symbol | Tag | Buffer | CirruQuote
+  Optional(NodeId)
+  List(NodeId)
+  Set(NodeId)
+  Map { key: NodeId, value: NodeId }
+  Ref(NodeId)
+  Struct {
+    nominal_path: Namespace/Definition
+    type_args: [ClosedType]
+    fields: [(FieldTag, NodeId)]
+  }
+  Enum {
+    nominal_path: Namespace/Definition
+    type_args: [ClosedType]
+    variants: [(VariantTag, [NodeId])]
+  }
 ```
 
-Phase 1 不接受自引用 struct/enum。当前声明类型解析链尚未完整 cycle-safe；在该基础设施修复前，编译器应明确拒绝递归派生，不能通过无限展开或增加运行栈规避。node id 格式保证后续加入递归支持时不需要推翻 decoder ABI。
+`fingerprint` 覆盖 ABI 版本、root、所有节点、名义声明路径、完整泛型实参、字段顺序和 variant payload。它不是安全散列或输入签名，而是防止把一个类型的编译产物误用于另一个 schema 的兼容性标识。
 
-它提供以下不可由“运行时拿 TypeExpr 随便判断”替代的价值：
+构建阶段拒绝 Dynamic、未绑定变量、不完整泛型、失败的 where-bound、未知 custom 类型和递归 slot。每个 child node id 在 graph 完成时校验。Phase 1 暂不接受递归类型；node id 表示使未来增加 cycle-safe 占位节点时不必改写消费者模型。
 
-- **封闭性证明**：图构建成功即证明所有节点可解码，不存在 Dynamic fallback；
-- **一次解析，多后端执行**：名称解析、泛型替换、arity 和 where-bound 在编译器完成；Native/JS 只执行同一组节点语义；
-- **递归终止**：node id 和构建中占位节点处理递归定义；
-- **精确名义引用**：节点携带声明路径和后端运行时对象，不靠字符串同名猜测；
-- **路径错误**：执行器天然知道当前字段、索引、map key/value 和 payload 位置；
-- **可缓存**：同一闭合类型的图可以按类型指纹 hoist/cache，避免每次解析重新解释类型表达式；
-- **演进位置清晰**：版本迁移、默认值、字段别名等策略若未来加入，应成为显式 Custom decoder 节点，而不能污染基础严格规则。
+关键不变量是：
 
-关键不变量：
+> `DataShape<T>` 构建成功，表示 `T` 是一个可由编译器完整遍历并精确重建名义身份的闭合数据类型。
 
-> `decode(graph<T>, edn) = Ok(value)` 蕴含 `value` 在递归结构与名义身份上满足 `T`。
+### 6.2 数据边界如何复用 shape
 
-### 6.1 为什么 Phase 1 不公开 `EdnDecoder<T>` 值
+每一种边界由两部分组成：共享 shape + 格式策略。
 
-当前类型系统能表达命名类型应用，但尚未为“编译器派生的、不透明、可作为值传递的泛型字典”建立稳定 ABI。过早把 graph 暴露为普通动态 record，会再次允许伪造 decoder。
+| 能力 | 共享部分 | 格式专有部分 |
+| --- | --- | --- |
+| Cirru EDN decode | `DataShape<T>` | EDN kind、record/enum 编码与错误路径 |
+| JSON decode | `DataShape<T>` | tag、map key、enum 的 JSON 表示策略 |
+| FFI/message decode | `DataShape<T>` | 宿主值读取与资源限制 |
+| typed patch | `DataShape<T>` | patch 操作、冲突和集合 diff 策略 |
 
-因此 Phase 1 只公开 `parse-cirru-edn-as` syntax，graph 是编译产物；Phase 2 再新增不可伪造的 `EdnDecoder<T>` 类型和值构造规则：
+新边界要么返回经过完整 shape 验证的 `T`，要么明确返回 Dynamic。禁止以浅层 `assert-type` 或只恢复 record 名称的方式把动态值升级成 `T`。
 
-```cirru
-edn-decoder Person
-decode-cirru-edn person-decoder raw
+当前不公开可伪造的普通 record 形式 `DataShape<T>`。一等 `EdnDecoder<T>` / `DataShape<T>` 需要先有编译器派生、不可伪造的泛型 dictionary ABI；在此之前 `parse-cirru-edn-as` 继续是公开入口。
+
+### 6.3 typed struct 更新是 patch 的前置能力
+
+typed patch 不能建立在返回宽泛 `Record` 的 `assoc` 上。对于已知 `Struct<A...>`，核心语言必须保证：
+
+1. 字段存在；
+2. 写入值满足泛型替换后的字段类型；
+3. `assoc` / `with` 返回原接收者的精确名义类型和泛型实参；
+4. 编译器可把字段 tag 改写为位置索引，运行时仍保留 tag 作为一致性检查。
+
+当前实现已覆盖以上四点：预处理按替换后的字段类型检查并生成 index/tag，Native indexed runtime 也会重新核对非负整数 index 与 field tag，防止旧 patch 在 schema 漂移后静默写入相邻字段。这一能力应成为所有 typed patch apply 的唯一 struct 写入路径。
+
+## 7. `Patch<T>` 的具体协议
+
+Recollect 当前的 `diff-twig` / `patch-twig` 继续处理开放数据树，其 Dynamic 签名是合理的兼容 API。静态业务状态另行使用不可伪造的 `Patch<T>`：
+
+```text
+Patch<T> {
+  shape_version: 1
+  shape_fingerprint: String
+  root: PatchNode
+}
+
+PatchNode =
+  Keep { node: NodeId }
+  Replace { node: NodeId, value: TypedValue(node) }
+  StructFields { node: NodeId, fields: [(FieldIndex, PatchNode)] }
+  EnumPayload { node: NodeId, variant: VariantIndex, payloads: [(PayloadIndex, PatchNode)] }
+  ListOps { node: NodeId, ops: [TypedListOp] }
+  MapOps { node: NodeId, ops: [TypedMapOp] }
+  SetOps { node: NodeId, ops: [TypedSetOp] }
+  RefValue { node: NodeId, patch: PatchNode }
 ```
 
-届时 `parse-cirru-edn-as raw Person` 只是二者的语法糖。公开值仍不得包含 Dynamic 节点。
+具体约束：
 
-## 7. 与旧 API 的关系
+- 每个 patch node 都声明它对应的 shape node；apply 时必须逐层匹配；
+- `Replace` 和容器 op 的 payload 在创建或反序列化 patch 时按对应子 shape 验证，内部不得出现 Dynamic payload；
+- struct path 使用 field index，apply 同时核对声明中的 field tag，避免 schema 漂移后误写相邻字段；
+- enum variant 变化直接使用 `Replace`；variant 相同时才允许 payload 增量；
+- `Ref<T>` 默认按 opaque/replace 处理，只有显式策略才递归修改可变引用；
+- apply 首先校验 `shape_version` 和 `shape_fingerprint`，成功返回的类型始终为原来的 `T`；
+- 网络或磁盘中的 patch 不是可信内部值，必须通过专用的 strict patch decoder 构造。
+
+应满足：
+
+> `apply(shape<T>, old, diff(shape<T>, old, next, strategy)) = Ok(next)`
+
+> `apply(shape<T>, old, patch) = Ok(value)` 蕴含 `value: T`，且保持 struct/enum 名义身份。
+
+### 7.1 核心与 Recollect 的职责边界
+
+| Calcit 核心负责 | Recollect 负责 |
+| --- | --- |
+| `DataShape<T>` 派生、ABI 与 fingerprint | diff 启发式与遍历调度 |
+| typed struct/enum 构造和 indexed 更新 | keyed list（如 `:id`）策略 |
+| 不透明 `Patch<T>` 的校验和 apply 原语 | patch 合并、压缩和 memoization |
+| Native/JS/WASM 一致的节点语义 | 开放 Dynamic tree 的兼容 API |
+| patch strict decoder | 面向应用的 strategy 组合 API |
+
+`DiffStrategy<T>` 绑定到 shape node 或静态路径。Recollect 的 `{:key :id}` 在派生 strategy 时应验证目标节点是 list、元素是 struct/map，且 key 字段存在并具有可比较的闭合类型；不能等运行到某条动态数据才发现策略不适用。
+
+首个内部落地切片已实现 `Keep`、`Replace`、`StructFields` 和 `EnumPayload`：patch 创建和 apply 都核对 node id，替换值通过子 shape 验证，apply 核对 ABI version/fingerprint，并保留 base struct/enum 的名义对象。它暂时不暴露语言 API，也不接受普通 Map/tuple 伪造；下一步才是 dictionary/decoder surface 与 Recollect list/map/set strategy 的接入。
+
+Recollect 的现有 Dynamic API 已先完成一项兼容性收紧：`change-op` 统一用名义 enum 构造，`:map-splice` 的 removed payload 修正为 `Set<Dynamic>`。这能在 operation 产生时检查 variant/arity/container kind，但不把 Dynamic payload 冒充为 `Patch<T>`。
+
+## 8. 与旧 API 的关系
 
 | API | 用途 | 静态结果 | 运行时保证 |
 | --- | --- | --- | --- |
@@ -214,20 +284,22 @@ decode-cirru-edn person-decoder raw
 
 旧 API 不自动弃用，因为 REPL、配置浏览、代码数据和开放 EDN 都有合理的动态使用场景。文档应把它称为动态解析，并优先向业务状态恢复推荐严格 API。
 
-## 8. 实施阶段
+## 9. 实施阶段
 
-### Phase 1：严格闭环
+### Phase 1：严格闭环（已完成）
 
 - 新增 `parse-cirru-edn-as` syntax 和静态返回类型；
-- 构建无 Dynamic 节点的 `EdnDecoderGraph`；
+- 构建无 Dynamic 节点的 `DataShapeGraph`；
 - Native 执行器直接从 `cirru_edn::Edn` 构造类型化值；
 - JS codegen 输出等价 graph，JS runtime 执行同样规则；
 - 支持有限 struct/enum 组合、泛型替换与 where-bound；
 - 增加成功、深层失败、名义名称失败、字段集合失败、variant/arity 失败和编译期拒绝用例；
 - 文档明确旧 options map 的能力边界。
 
-### Phase 2：一等 decoder dictionary
+### Phase 2：共享 data shape 内核（内部实现已完成）与一等 decoder dictionary
 
+- 已从 decoder 派生逻辑中提炼编译器内部 `DataShapeGraph`，Native/JS strict EDN 共用；
+- 已让 typed record assoc/with 校验替换后的字段类型并保持精确接收者类型；
 - 引入不可伪造的 `EdnDecoder<T>`；
 - 先让命名类型解析和 schema 展开具备 cycle-safe 能力，再开放递归 struct/enum graph；
 - `edn-decoder T` 编译期派生并 hoist graph；
@@ -235,13 +307,23 @@ decode-cirru-edn person-decoder raw
 - 提供 `decode-cirru-edn` 和 `decode-edn` 的 Result 版本；
 - 允许显式组合 decoder，但不允许从普通 Map/Record 构造。
 
-### Phase 3：受控的格式演进
+### Phase 3：typed diff/patch（内部最小 apply 内核已完成）
+
+- 已实现内部 `DataPatch` 的 `Keep`、`Replace`、`StructFields`、`EnumPayload`；
+- 已让 struct 字段和 enum payload patch 绑定到 `DataShapeGraph` node，并校验 index/tag；
+- 已让内部 patch apply 校验 ABI/fingerprint、递归结果类型并保持名义身份；
+- 引入一等、不透明的 `Patch<T>` 与 `DiffStrategy<T>` surface；
+- 增加 list/map/set typed operations 和 strategy；
+- 为 patch 的跨进程传输提供同样严格的 decoder，不暴露 Dynamic payload；
+- 以 Recollect 的 round-trip 和嵌套 record/map fixtures 验证语义，再决定共享执行器的下沉边界。
+
+### Phase 4：受控的格式演进
 
 - 设计显式 custom decoder / migration API；
 - 默认值、旧字段名、版本迁移只能通过 custom 节点引入；
 - custom decoder 的结果仍必须进入最终目标类型的已验证构造路径。
 
-## 9. 兼容性与风险
+## 10. 兼容性与风险
 
 - 新 syntax 不改变旧代码；
 - 严格 API 有意拒绝不完整类型，不能为了兼容改成 warning 或 Dynamic fallback；
@@ -249,7 +331,7 @@ decode-cirru-edn person-decoder raw
 - 后续 recursive graph 必须设置构建中占位节点和执行深度/输入规模保护，避免恶意数据造成栈或资源耗尽；
 - Native/JS 任一端暂不支持的节点应在编译期统一拒绝，不能只让某后端失败。
 
-## 10. 验收标准
+## 11. 验收标准
 
 1. `parse-cirru-edn-as` 的推断结果为目标闭合类型；
 2. `List<Map<Tag, Person>>` 等嵌套值逐层校验；

--- a/RFCs/README.md
+++ b/RFCs/README.md
@@ -1,6 +1,6 @@
 # RFC 整理索引
 
-更新时间：2026-07-30
+更新时间：2026-08-04
 
 ## 目录原则
 
@@ -39,6 +39,7 @@
 | `07-28-git-module-store-rfc.md`                     | Draft         | 保持 `deps.cirru` 与 Git 模块路径，以 tag 为最佳实践并使用 pnpm 式全局目录存储；不引入 registry、lockfile、workspace 或多版本。 |
 | `07-28-project-tooling-contract-rfc.md`             | Draft         | 在既有 `cr` 子命令上补强单项目工具契约，保持 EDN 树形事实来源。                                                        |
 | `07-28-persistent-tree-cursor-rfc.md`               | Draft         | `.calcit/` 本地状态、虚拟 cursor、region/marks/last-query、结构化 clipboard 与 path 迁移。                            |
+| `08-04-strict-cirru-edn-decoding-rfc.md`            | Implemented   | Phase 1：`parse-cirru-edn-as` 严格类型化反序列化、无 Dynamic 的 `EdnDecoderGraph`、名义身份与 Native/JS 一致性。    |
 
 ## 已执行的清理
 

--- a/calcit/test-edn.cirru
+++ b/calcit/test-edn.cirru
@@ -214,6 +214,21 @@
               assert= true $ try
                 do (parse-cirru-edn-as "|%{} :Person (:name |Ada)" Person) false
                 fn (error) true
+              assert= true $ try
+                do
+                  parse-cirru-edn-as "|#{} (%{} :Person (:age 23) (:name |Ada)) (%{} :Person (:name |Ada) (:age 23))" $ :: 'Set Person
+                  , false
+                fn (error) true
+              assert= true $ try
+                do
+                  parse-cirru-edn-as "|{} ((%{} :Person (:age 23) (:name |Ada)) |first) ((%{} :Person (:name |Ada) (:age 23)) |second)" $ :: 'Map Person 'String
+                  , false
+                fn (error) true
+              assert= (#{} 1)
+                parse-cirru-edn-as "|#{} 1 1" $ :: 'Set 'Number
+              assert=
+                {} $ :a |second
+                parse-cirru-edn-as "|{} (:a |first) (:a |second)" $ :: 'Map 'Tag 'String
           :examples $ []
           :schema $ :: 'Dynamic
       :ns $ %{} :NsEntry (:doc |)

--- a/calcit/test-edn.cirru
+++ b/calcit/test-edn.cirru
@@ -12,6 +12,11 @@
             defstruct A $ :a 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
+        |Box $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defstruct Box ([] 'T) (:value 'T)
+          :examples $ []
+          :schema $ :: 'Dynamic
         |DemoEnum $ %{} :CodeEntry (:doc |)
           :code $ quote
             defenum DemoEnum (:ok) (:err 'String)
@@ -22,11 +27,24 @@
             defstruct Person (:name 'String) (:age 'Number)
           :examples $ []
           :schema $ :: 'Dynamic
+        |Team $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defstruct Team $ :members (:: 'List Person)
+          :examples $ []
+          :schema $ :: 'Dynamic
         |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing edn") (test-edn) (test-edn-comment)
               inside-eval: $ test-symbol
               test-atom
+              test-typed-edn
+              test-imported-typed-edn
+              test-top-level-typed-edn
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |reload! $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn reload! () nil
           :examples $ []
           :schema $ :: 'Dynamic
         |test-atom $ %{} :CodeEntry (:doc |)
@@ -126,6 +144,13 @@
               assert= (:: :a 1) (parse-cirru-edn "|:: :a (; comment) 1")
           :examples $ []
           :schema $ :: 'Dynamic
+        |test-imported-typed-edn $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-imported-typed-edn () $ assert=
+              %{} External $ :label |linked
+              parse-cirru-edn-as "|%{} :External (:label |linked)" External
+          :examples $ []
+          :schema $ :: 'Dynamic
         |test-symbol $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn test-symbol () (log-title "|Testing symbol to edn")
@@ -150,7 +175,58 @@
                 assert= code $ eval (&data-to-code code)
           :examples $ []
           :schema $ :: 'Dynamic
+        |test-top-level-typed-edn $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-top-level-typed-edn () $ assert=
+              %{} Person (:name |Top) (:age 23)
+              , typed-person
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-typed-edn $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-typed-edn () $ let
+                person $ parse-cirru-edn-as "|%{} :Person (:age 23) (:name |Ada)" Person
+                people $ parse-cirru-edn-as "|[] $ %{} :Person (:age 23) (:name |Ada)" (:: 'List Person)
+                team $ parse-cirru-edn-as "|%{} :Team (:members ([] (%{} :Person (:age 23) (:name |Ada))))" Team
+                boxed $ parse-cirru-edn-as "|%{} :Box (:value |hello)" (:: Box 'String)
+                enum-value $ parse-cirru-edn-as "|%:: :DemoEnum :err |oops" DemoEnum
+              assert=
+                %{} Person (:name |Ada) (:age 23)
+                , person
+              assert= ([] person) people
+              assert=
+                %{} Team $ :members ([] person)
+                , team
+              assert=
+                %{} Box $ :value |hello
+                , boxed
+              assert= :err $ &tuple:nth enum-value 0
+              assert= true $ try
+                do
+                  parse-cirru-edn-as "|[] $ %{} :Person (:age |old) (:name |Ada)" $ :: 'List Person
+                  , false
+                fn (error) true
+              assert= true $ try
+                do (parse-cirru-edn-as "|%{} :Person (:name |Ada)" Person) false
+                fn (error) true
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |typed-person $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def typed-person $ parse-cirru-edn-as "|%{} :Person (:age 23) (:name |Top)" Person
+          :examples $ []
+          :schema $ :: 'Dynamic
       :ns $ %{} :NsEntry (:doc |)
         :code $ quote
           ns test-edn.main $ :require
             util.core :refer $ inside-eval: log-title
+            test-edn.schema :refer $ External
+    |test-edn.schema $ %{} :FileEntry
+      :defs $ {}
+        |External $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defstruct External $ :label 'String
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} :NsEntry (:doc |)
+        :code $ quote (ns test-edn.schema)

--- a/calcit/test-edn.cirru
+++ b/calcit/test-edn.cirru
@@ -12,6 +12,11 @@
             defstruct A $ :a 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
+        |A-typed-person $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def A-typed-person $ parse-cirru-edn-as "|%{} :Person (:age 23) (:name |Top)" Person
+          :examples $ []
+          :schema $ :: 'Dynamic
         |Box $ %{} :CodeEntry (:doc |)
           :code $ quote
             defstruct Box ([] 'T) (:value 'T)
@@ -179,7 +184,7 @@
           :code $ quote
             defn test-top-level-typed-edn () $ assert=
               %{} Person (:name |Top) (:age 23)
-              , typed-person
+              , A-typed-person
           :examples $ []
           :schema $ :: 'Dynamic
         |test-typed-edn $ %{} :CodeEntry (:doc |)
@@ -209,11 +214,6 @@
               assert= true $ try
                 do (parse-cirru-edn-as "|%{} :Person (:name |Ada)" Person) false
                 fn (error) true
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |typed-person $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            def typed-person $ parse-cirru-edn-as "|%{} :Person (:age 23) (:name |Top)" Person
           :examples $ []
           :schema $ :: 'Dynamic
       :ns $ %{} :NsEntry (:doc |)

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -14,10 +14,43 @@ entry_for:
 
 Cirru EDN is Calcit's typed data interchange format, inspired by [Clojure EDN](https://github.com/edn-format/edn). Use it when Calcit-specific identity matters; use JSON only when interoperating with JSON systems.
 
-The two runtime APIs are:
+The runtime APIs are:
 
 - `parse-cirru-edn text [type-options]`
+- `parse-cirru-edn-as text TypeExpr`
 - `format-cirru-edn value`
+
+`parse-cirru-edn` is the dynamic API: its result is `Dynamic`, and its optional type map only restores nominal identity. Use `parse-cirru-edn-as` when persisted or external data must enter typed application code.
+
+## Strict typed decoding
+
+`parse-cirru-edn-as` is a language syntax that derives a closed decoder graph at compile time, then validates and constructs the complete value recursively:
+
+```cirru.no-run
+def Person $ defstruct Person (:name 'String) (:age 'Number)
+
+defn decode-person (raw)
+  parse-cirru-edn-as raw Person
+```
+
+Container and generic targets use the existing type-expression syntax:
+
+```cirru.no-check
+parse-cirru-edn-as "|[] 1 2 3" $ :: 'List 'Number
+parse-cirru-edn-as "|%{} :Box (:value |hi)" $ :: Box 'String
+```
+
+Successful decoding guarantees the recursive container elements, struct fields, enum variant and payloads, generic arguments, and nominal struct/enum identity all match the target type. It does not coerce strings to numbers, maps to structs, or ordinary tuples to enums.
+
+Strict decoder derivation rejects `Dynamic`, bare containers with implicit Dynamic elements, missing generic arguments, unbound type variables/type slots, functions, traits, impls, `JsObject`, and unknown custom types. This is a compile-time error rather than a warning or runtime Dynamic fallback.
+
+Runtime failures include a structural path:
+
+```text
+parse-cirru-edn-as failed at $.friends[2].age: expected number, got string
+```
+
+The failure is raised like `parse-cirru-edn` errors and can be handled with `try`.
 
 Map and Set iteration order is not a semantic guarantee. The formatter applies a stable order for readable, reproducible output; callers must not use that order as application data.
 
@@ -50,7 +83,7 @@ let
     :Person $ %{} Person (:name |)
 ```
 
-Without this options Map, parsing still produces a structurally equivalent Record or Tuple, but it cannot recover declaration-attached trait implementations from text alone.
+Without this options Map, parsing still produces a structurally equivalent Record or Tuple, but it cannot recover declaration-attached trait implementations from text alone. The options Map does not validate field value types, container elements, enum payloads, generics, or constraints. Prefer `parse-cirru-edn-as` when those guarantees are required.
 
 ## Literals
 

--- a/history/202608040241-strict-cirru-edn-decoding.md
+++ b/history/202608040241-strict-cirru-edn-decoding.md
@@ -1,0 +1,27 @@
+# Strict Cirru EDN decoding
+
+## 背景
+
+`parse-cirru-edn` 面向动态 EDN。它的 options map 只能按名称恢复部分 record/enum 身份，不能证明容器元素、字段、enum payload、泛型实参和约束符合业务类型；字段集合不一致时，Native 旧路径还可能触发 panic。
+
+## 本次决策与实现
+
+- 先形成 `RFCs/08-04-strict-cirru-edn-decoding-rfc.md`，把动态解析与严格类型边界分开。
+- 新增 language syntax `parse-cirru-edn-as text TypeExpr`；预处理阶段要求目标类型闭合且可解码，静态推断结果直接采用目标类型。
+- 编译器把类型表达式派生为不含 `Dynamic` fallback 的 `EdnDecoderGraph`。Native 从 `cirru_edn::Edn` 深度验证并构造 Calcit 值，JS codegen 输出同构 graph 交给 runtime 执行。
+- struct/enum 解码检查精确名称、字段集合、variant、payload arity 和深层字段类型，并保留真实 nominal declaration；泛型应用检查参数数量和 `:where` 约束。
+- Native/JS 错误都携带结构路径，例如 `$[0].age`。
+- JS nominal struct 的字段顺序由 interned tag 决定，可能不同于 Rust 声明解析使用的词法顺序；JS 严格解码先按 graph 校验，再按运行时 `nominal.fields` 重排 values。
+- 旧动态 record options 字段不匹配时改为返回 loose record，避免 `unreachable!` panic；JS 保持相同行为。
+
+## 边界与后续
+
+- Phase 1 支持有限闭合类型图，不承诺递归 struct/enum。现有自递归名义类型在预处理构造路径会栈溢出，已记录为 GitHub Issue #295；修复 cycle-safe 类型解析后再开放递归 decoder。
+- 一等、不可伪造的 `EdnDecoder<T>` dictionary 延后到 Phase 2。当前 graph 只作为编译器内部闭合程序，避免重新暴露动态 schema 逃生口。
+- Timegrass 的 snapshot 临时副本已使用当前 `cr --check-only` 回归通过，未写入业务仓库。
+
+## 验证要点
+
+- Rust 单测覆盖深层 struct/enum、错误路径、Dynamic/缺泛型拒绝、where-bound，以及旧动态 record mismatch 非 panic。
+- `calcit/test-edn.cirru` 同时覆盖 Native 与 JS：本地及 imported nominal type、嵌套容器、泛型 struct、enum、运行时失败和 top-level decode 顺序。
+- 文档示例由 `cr docs check-md` 验证。

--- a/history/202608040954-strict-edn-review-followups.md
+++ b/history/202608040954-strict-edn-review-followups.md
@@ -1,0 +1,16 @@
+# Strict EDN review follow-ups
+
+## Review findings handled
+
+- Preprocessing now retains the derived `EdnDecoderGraph` as an internal `AnyRef` handle. Native evaluation and JS codegen reuse that graph instead of parsing and deriving the target type on every evaluation/codegen pass.
+- `collect_compiled_deps` reads nominal paths from the retained graph, so same-namespace struct/enum declarations participate in JS top-level dependency ordering. The integration fixture deliberately names the decoded value `A-typed-person`, lexically before `Person`, and verifies codegen still initializes `Person` first.
+- Native strict record decoding rejects duplicate EDN field names instead of collapsing them through `HashSet` comparison and selecting the first value.
+- Recursive `TypeSlot` resolution has a dedicated in-progress guard and returns a type error instead of overflowing the preprocessing stack.
+- JS runtime validates decoder-vs-nominal field alignment and unknown decoder node kinds explicitly.
+- The decoder module and graph types are crate-private, matching the RFC boundary for Phase 1.
+- Dynamic record fallback construction was simplified without changing its compatibility behavior.
+
+## Review decisions
+
+- The RFC/history date remains 2026-08-04. GitHub review timestamps were displayed in UTC on August 3, while the repository task timezone was Asia/Shanghai and local time was already August 4.
+- Await-aware wrapping was applied to the generated strict decode call for consistency. With an empty argument prelude it is behaviorally equivalent, while the surrounding function/top-level code still owns async context detection.

--- a/history/202608041911-typed-data-shape-patch.md
+++ b/history/202608041911-typed-data-shape-patch.md
@@ -1,0 +1,30 @@
+# Typed data shapes and nominal patch foundation
+
+## 背景
+
+严格 EDN 解码已经能在反序列化边界恢复闭合静态类型，但其类型图原先仍属于解码器私有实现。struct 更新和 Recollect diff/patch 也缺少同一套可校验的名义数据约束，容易在新的数据边界重新引入 Dynamic。
+
+## 本次实现
+
+- 将解码器类型图提取为 backend-neutral 的 `DataShapeGraph`，保留 ABI version、稳定 fingerprint、名义类型路径和闭合子节点关系。
+- 为 `DataShapeGraph` 增加运行时值验证，覆盖标量、容器、ref、struct 和 enum；struct/enum 必须匹配名义定义、字段或 variant 及递归 payload 类型。
+- 严格 EDN Native/JS 路径复用同一 data shape；JS graph 同时携带 ABI version 和 fingerprint，并拒绝畸形 graph 元数据。
+- 新增内部 `DataPatch` 第一阶段执行器，支持 keep、replace、struct 字段 patch 和 enum payload patch。patch 与 shape 的 ABI/fingerprint 必须一致，且应用后继续保持原有 struct/enum 名义对象。
+- struct indexed 更新同时校验编译期 index 与 field tag，并拒绝负数、非整数及越界索引，避免 schema 演化后静默更新相邻字段。
+- 类型推断对 record assoc/with 的普通与 indexed 形式保留精确 receiver 类型，包括泛型实参；预处理同步检查更新值类型。
+
+## Recollect 联动
+
+- `change-op` 的真实构造迁移到名义 enum，避免 diff 结果退化为无约束 tuple。
+- `:map-splice` 的 removed payload 修正为 Set，与 diff 产物及 patch 消费端一致。
+- collection diff 策略暂时保留在 Recollect；后续应按 `DataShapeNode` 绑定 list/map/set 的 typed patch 策略，而不是把 Dynamic collection payload 直接搬进编译器核心。
+
+## 验证
+
+- `cargo fmt -- --check`
+- `cargo clippy -- -D warnings`
+- `cargo test -- --test-threads=1`：513 项通过
+- `yarn compile`
+- `yarn check-all`
+- `yarn check-agent-interface`：12/12 通过
+- Recollect check-only 零告警，Native、JavaScript 和阻断性 WASM 回归通过

--- a/history/202608042252-reject-decoded-edn-collisions.md
+++ b/history/202608042252-reject-decoded-edn-collisions.md
@@ -1,0 +1,11 @@
+# Reject decoded EDN collection collisions
+
+## Change summary
+
+- Strict typed EDN set decoding now rejects distinct source items that decode to the same Calcit value, reporting the colliding `$.item` path.
+- Strict typed EDN map decoding now rejects distinct source keys that decode to the same Calcit key, reporting the colliding `$.key` path before decoding or overwriting the associated value.
+- Regression tests cover set-value and map-key collisions caused by record field-order normalization, along with successful decoding when collection entries remain unique.
+
+## Knowledge point
+
+EDN collection uniqueness is not sufficient after typed decoding because normalization can make distinct EDN values equal as Calcit values. Collision checks must therefore use the decoded collection's equality semantics immediately before insertion.

--- a/history/202608042338-strict-edn-js-collision-parity.md
+++ b/history/202608042338-strict-edn-js-collision-parity.md
@@ -1,0 +1,21 @@
+# Strict EDN JS collision parity and final review
+
+## Knowledge
+
+- Strict typed decoding must observe source collection entries before runtime collection constructors normalize or deduplicate them; otherwise decoded-value collisions cannot be detected reliably.
+- Exact duplicate source set items keep ordinary set semantics, and exact duplicate source map keys keep last-value-wins semantics. Distinct source values that normalize to the same typed value must instead fail with an item/key path.
+- Data-shape validation promises nominal identity, so structurally equal struct or enum declarations are insufficient; validation must retain and compare the exact declaration `Arc`.
+
+## Changes
+
+- Added an internal typed-EDN set view and a strict JS extraction path that preserves collision evidence without changing dynamic `parse-cirru-edn` behavior.
+- Added JS set/map decoded-collision checks and shared Native/JS integration fixtures for collisions and exact source duplicates.
+- Tightened struct/enum data-shape validation to pointer identity and fixed the RFC blockquote lint warning.
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo test calcit::data_shape::tests::rejects_structurally_equal_but_distinct_nominal_declarations`
+- `yarn compile`
+- `yarn try-rs`
+- `yarn try-js`

--- a/history/202608042344-isolate-strict-edn-dependency-test.md
+++ b/history/202608042344-isolate-strict-edn-dependency-test.md
@@ -1,0 +1,13 @@
+# Isolate strict EDN dependency test state
+
+## Knowledge
+
+- Program dependency tests share the global definition-ID index with cache and snapshot tests, so every test that calls `ensure_def_id` must use `PROGRAM_TEST_LOCK` and reset the shared state before asserting IDs.
+
+## Changes
+
+- Added the existing program-test lock and reset protocol to the strict EDN nominal dependency test.
+
+## Validation
+
+- `cargo test`

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -642,6 +642,7 @@ pub fn handle_syntax(
     MacroInterpolateSpread => CalcitErr::err_nodes(CalcitErrKind::Syntax, "`~@` cannot be used as operator", &nodes.to_vec()),
     AssertType => syntax::assert_type(nodes, scope, file_ns, call_stack),
     UnsafeCoerce => syntax::unsafe_coerce(nodes, scope, file_ns, call_stack),
+    ParseCirruEdnAs => syntax::parse_cirru_edn_as(nodes, scope, file_ns, call_stack),
     AssertTraits => syntax::assert_traits(nodes, scope, file_ns, call_stack),
     Match => syntax::syntax_match(nodes, scope, file_ns, call_stack),
   }

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -704,14 +704,30 @@ pub fn record_field_tag(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 /// This is the optimized path emitted by the preprocessor when the field index is known at compile time.
 pub fn record_assoc_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   // 4 args: (record, idx, :field-tag, value)
-  // The 3rd arg (field tag) is only used by JS codegen; Rust runtime ignores it.
+  // Keep the field tag as a runtime consistency check so a stale index cannot
+  // silently update an adjacent field after schema drift.
   if xs.len() != 4 {
     return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:assoc-at expected 4 arguments, but received:", xs);
   }
-  match (&xs[0], &xs[1]) {
-    (Calcit::Record(CalcitRecord { struct_ref, values }), Calcit::Number(n)) => {
-      let idx = *n as usize;
+  match (&xs[0], &xs[1], &xs[2]) {
+    (Calcit::Record(CalcitRecord { struct_ref, values }), Calcit::Number(n), Calcit::Tag(field_tag)) => {
+      let idx = checked_record_index(*n, "&record:assoc-at")?;
       if idx < values.len() {
+        let Some(expected_tag) = struct_ref.fields.get(idx) else {
+          return CalcitErr::err_str(
+            CalcitErrKind::Arity,
+            format!(
+              "&record:assoc-at record `{}` is missing field metadata at index {idx}",
+              struct_ref.name
+            ),
+          );
+        };
+        if expected_tag != field_tag {
+          return CalcitErr::err_str(
+            CalcitErrKind::Type,
+            format!("&record:assoc-at index {idx} expects field `:{expected_tag}`, but received `:{field_tag}`"),
+          );
+        }
         let mut new_values = (**values).to_owned();
         xs[3].clone_into(&mut new_values[idx]);
         Ok(Calcit::Record(CalcitRecord {
@@ -730,12 +746,13 @@ pub fn record_assoc_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         )
       }
     }
-    (a, b) => CalcitErr::err_str(
+    (a, b, field) => CalcitErr::err_str(
       CalcitErrKind::Type,
       format!(
-        "&record:assoc-at expected (record, number), but received: {} {}",
+        "&record:assoc-at expected (record, number, tag), but received: {} {} {}",
         a.lisp_str(),
-        b.lisp_str()
+        b.lisp_str(),
+        field.lisp_str()
       ),
     ),
   }
@@ -758,10 +775,25 @@ pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       let triple_count = (xs.len() - 1) / 3;
       for i in 0..triple_count {
         let base = 1 + i * 3;
-        match &xs[base] {
-          Calcit::Number(n) => {
-            let idx = *n as usize;
+        match (&xs[base], &xs[base + 1]) {
+          (Calcit::Number(n), Calcit::Tag(field_tag)) => {
+            let idx = checked_record_index(*n, "&record:with-at")?;
             if idx < new_values.len() {
+              let Some(expected_tag) = struct_ref.fields.get(idx) else {
+                return CalcitErr::err_str(
+                  CalcitErrKind::Arity,
+                  format!(
+                    "&record:with-at record `{}` is missing field metadata at index {idx}",
+                    struct_ref.name
+                  ),
+                );
+              };
+              if expected_tag != field_tag {
+                return CalcitErr::err_str(
+                  CalcitErrKind::Type,
+                  format!("&record:with-at index {idx} expects field `:{expected_tag}`, but received `:{field_tag}`"),
+                );
+              }
               xs[base + 2].clone_into(&mut new_values[idx]);
             } else {
               return CalcitErr::err_str(
@@ -775,10 +807,14 @@ pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               );
             }
           }
-          other => {
+          (index, field) => {
             return CalcitErr::err_str(
               CalcitErrKind::Type,
-              format!("&record:with-at expected number index, but received: {}", other.lisp_str()),
+              format!(
+                "&record:with-at expected number index and tag, but received: {} {}",
+                index.lisp_str(),
+                field.lisp_str()
+              ),
             );
           }
         }
@@ -793,6 +829,16 @@ pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       format!("&record:with-at expected a record, but received: {}", a.lisp_str()),
     ),
   }
+}
+
+fn checked_record_index(value: f64, operation: &str) -> Result<usize, CalcitErr> {
+  if !value.is_finite() || value < 0.0 || value.fract() != 0.0 || value > usize::MAX as f64 {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Type,
+      format!("{operation} expected a non-negative integer index, but received: {value}"),
+    ));
+  }
+  Ok(value as usize)
 }
 
 pub fn call_record(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
@@ -1453,6 +1499,43 @@ mod tests {
 
   fn callable_proc() -> Calcit {
     Calcit::Proc(CalcitProc::NativeResetGenSymIndex)
+  }
+
+  fn indexed_record_fixture() -> Calcit {
+    Calcit::Record(CalcitRecord {
+      struct_ref: Arc::new(CalcitStruct::from_fields(
+        EdnTag::new("Point"),
+        vec![EdnTag::new("x"), EdnTag::new("y")],
+      )),
+      values: Arc::new(vec![Calcit::Number(1.0), Calcit::Number(2.0)]),
+    })
+  }
+
+  #[test]
+  fn indexed_record_updates_reject_stale_field_tags() {
+    let record = indexed_record_fixture();
+    let assoc_error = record_assoc_at(&[record.clone(), Calcit::Number(0.0), Calcit::tag("y"), Calcit::Number(3.0)])
+      .expect_err("stale assoc tag must fail");
+    assert!(assoc_error.msg.contains("expects field `:x`"));
+
+    let with_error =
+      record_with_at(&[record, Calcit::Number(1.0), Calcit::tag("x"), Calcit::Number(3.0)]).expect_err("stale with tag must fail");
+    assert!(with_error.msg.contains("expects field `:y`"));
+  }
+
+  #[test]
+  fn indexed_record_updates_validate_indices_and_apply_matching_tags() {
+    let record = indexed_record_fixture();
+    let invalid_index = record_assoc_at(&[record.clone(), Calcit::Number(-1.0), Calcit::tag("x"), Calcit::Number(3.0)])
+      .expect_err("negative index must fail");
+    assert!(invalid_index.msg.contains("non-negative integer index"));
+
+    let updated =
+      record_assoc_at(&[record, Calcit::Number(0.0), Calcit::tag("x"), Calcit::Number(3.0)]).expect("matching index/tag update");
+    let Calcit::Record(updated) = updated else {
+      panic!("updated value must remain a record");
+    };
+    assert_eq!(updated.values.as_ref(), &[Calcit::Number(3.0), Calcit::Number(2.0)]);
   }
 
   #[test]

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -654,10 +654,10 @@ pub fn parse_cirru_edn_as(
   };
 
   let decoder = match expr.get(2) {
-    Some(handle) => crate::data::edn_decode::EdnDecoderGraph::from_calcit_handle(handle).ok_or_else(|| {
+    Some(handle) => crate::calcit::data_shape::DataShapeGraph::from_calcit_handle(handle).ok_or_else(|| {
       CalcitErr::use_msg_stack_location(
         CalcitErrKind::Unexpected,
-        "parse-cirru-edn-as received an invalid internal decoder graph".to_owned(),
+        "parse-cirru-edn-as received an invalid internal data shape".to_owned(),
         call_stack,
         expr.get(1).and_then(Calcit::get_location),
       )
@@ -665,10 +665,10 @@ pub fn parse_cirru_edn_as(
     None => {
       let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(&expr[1], &[]);
       Arc::new(
-        crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), file_ns).map_err(|error| {
+        crate::calcit::data_shape::DataShapeGraph::build(target.as_ref(), file_ns).map_err(|error| {
           CalcitErr::use_msg_stack_location(
             CalcitErrKind::Type,
-            error.to_string(),
+            format!("parse-cirru-edn-as cannot derive a decoder: {error}"),
             call_stack,
             expr.get(1).and_then(Calcit::get_location),
           )
@@ -684,7 +684,7 @@ pub fn parse_cirru_edn_as(
       expr.first().and_then(Calcit::get_location),
     )
   })?;
-  decoder.decode(&input).map_err(|error| {
+  crate::data::edn_decode::decode(decoder.as_ref(), &input).map_err(|error| {
     CalcitErr::use_msg_stack_location(
       CalcitErrKind::Type,
       error.to_string(),

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -635,7 +635,7 @@ pub fn parse_cirru_edn_as(
   file_ns: &str,
   call_stack: &CallStackList,
 ) -> Result<Calcit, CalcitErr> {
-  if expr.len() != 2 {
+  if expr.len() != 2 && expr.len() != 3 {
     return CalcitErr::err_nodes(
       CalcitErrKind::Arity,
       "parse-cirru-edn-as expected a string and a type expression, but received:",
@@ -653,15 +653,29 @@ pub fn parse_cirru_edn_as(
     ));
   };
 
-  let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(&expr[1], &[]);
-  let decoder = crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), file_ns).map_err(|error| {
-    CalcitErr::use_msg_stack_location(
-      CalcitErrKind::Type,
-      error.to_string(),
-      call_stack,
-      expr.get(1).and_then(Calcit::get_location),
-    )
-  })?;
+  let decoder = match expr.get(2) {
+    Some(handle) => crate::data::edn_decode::EdnDecoderGraph::from_calcit_handle(handle).ok_or_else(|| {
+      CalcitErr::use_msg_stack_location(
+        CalcitErrKind::Unexpected,
+        "parse-cirru-edn-as received an invalid internal decoder graph".to_owned(),
+        call_stack,
+        expr.get(1).and_then(Calcit::get_location),
+      )
+    })?,
+    None => {
+      let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(&expr[1], &[]);
+      Arc::new(
+        crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), file_ns).map_err(|error| {
+          CalcitErr::use_msg_stack_location(
+            CalcitErrKind::Type,
+            error.to_string(),
+            call_stack,
+            expr.get(1).and_then(Calcit::get_location),
+          )
+        })?,
+      )
+    }
+  };
   let input = cirru_edn::parse(&text).map_err(|error| {
     CalcitErr::use_msg_stack_location(
       CalcitErrKind::Syntax,

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -629,6 +629,57 @@ pub fn unsafe_coerce(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call
   runner::evaluate_expr(&expr[0], scope, file_ns, call_stack)
 }
 
+pub fn parse_cirru_edn_as(
+  expr: &CalcitList,
+  scope: &CalcitScope,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Calcit, CalcitErr> {
+  if expr.len() != 2 {
+    return CalcitErr::err_nodes(
+      CalcitErrKind::Arity,
+      "parse-cirru-edn-as expected a string and a type expression, but received:",
+      &expr.to_vec(),
+    );
+  }
+
+  let text = runner::evaluate_expr(&expr[0], scope, file_ns, call_stack)?;
+  let Calcit::Str(text) = text else {
+    return Err(CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      format!("parse-cirru-edn-as expected a string, got :{}", calcit::brief_type_of_value(&text)),
+      call_stack,
+      expr.first().and_then(Calcit::get_location),
+    ));
+  };
+
+  let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(&expr[1], &[]);
+  let decoder = crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), file_ns).map_err(|error| {
+    CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      error.to_string(),
+      call_stack,
+      expr.get(1).and_then(Calcit::get_location),
+    )
+  })?;
+  let input = cirru_edn::parse(&text).map_err(|error| {
+    CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Syntax,
+      format!("parse-cirru-edn-as failed to parse Cirru EDN: {error}"),
+      call_stack,
+      expr.first().and_then(Calcit::get_location),
+    )
+  })?;
+  decoder.decode(&input).map_err(|error| {
+    CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      error.to_string(),
+      call_stack,
+      expr.first().and_then(Calcit::get_location),
+    )
+  })
+}
+
 pub fn assert_traits(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if expr.len() < 2 {
     return CalcitErr::err_nodes(

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -2,6 +2,10 @@ mod calcit_impl;
 mod calcit_struct;
 mod calcit_trait;
 mod compare;
+// Phase 3 stages the typed patch executor before exposing language syntax.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) mod data_patch;
+pub(crate) mod data_shape;
 mod fns;
 mod list;
 mod local;

--- a/src/calcit/data_patch.rs
+++ b/src/calcit/data_patch.rs
@@ -1,0 +1,450 @@
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::Arc;
+
+use cirru_edn::EdnTag;
+
+use super::data_shape::{DataShapeGraph, DataShapeNode};
+use super::{Calcit, CalcitRecord, CalcitTuple};
+
+const MAX_PATCH_DEPTH: usize = 1024;
+
+/// Compiler-owned patch for one closed `DataShapeGraph`.
+///
+/// The first slice deliberately covers only replacement and nominal aggregate
+/// updates. Collection algorithms stay in Recollect until their strategies can
+/// be bound to shape nodes without introducing Dynamic payloads here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DataPatch {
+  version: u16,
+  fingerprint: Arc<str>,
+  root: DataPatchNode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DataPatchNode {
+  Keep {
+    node: usize,
+  },
+  Replace {
+    node: usize,
+    value: Calcit,
+  },
+  StructFields {
+    node: usize,
+    fields: Vec<(usize, EdnTag, DataPatchNode)>,
+  },
+  EnumPayload {
+    node: usize,
+    variant: usize,
+    payloads: Vec<(usize, DataPatchNode)>,
+  },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DataPatchError {
+  pub(crate) path: String,
+  pub(crate) message: String,
+}
+
+impl DataPatchError {
+  fn at(path: impl Into<String>, message: impl Into<String>) -> Self {
+    Self {
+      path: path.into(),
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for DataPatchError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "data patch failed at {}: {}", self.path, self.message)
+  }
+}
+
+impl DataPatch {
+  pub(crate) fn new(shape: &DataShapeGraph, root: DataPatchNode) -> Result<Self, DataPatchError> {
+    if root.node() != shape.root {
+      return Err(DataPatchError::at(
+        "$",
+        format!("patch root node #{} does not match shape root #{}", root.node(), shape.root),
+      ));
+    }
+    validate_patch_node(shape, &root, "$", 0)?;
+    Ok(Self {
+      version: shape.abi_version(),
+      fingerprint: Arc::from(shape.fingerprint()),
+      root,
+    })
+  }
+
+  pub(crate) fn apply(&self, shape: &DataShapeGraph, base: &Calcit) -> Result<Calcit, DataPatchError> {
+    if self.version != shape.abi_version() {
+      return Err(DataPatchError::at(
+        "$",
+        format!(
+          "patch data shape ABI version {} does not match {}",
+          self.version,
+          shape.abi_version()
+        ),
+      ));
+    }
+    if self.fingerprint.as_ref() != shape.fingerprint() {
+      return Err(DataPatchError::at(
+        "$",
+        format!(
+          "patch data shape fingerprint {} does not match {}",
+          self.fingerprint,
+          shape.fingerprint()
+        ),
+      ));
+    }
+    if self.root.node() != shape.root {
+      return Err(DataPatchError::at(
+        "$",
+        format!("patch root node #{} does not match shape root #{}", self.root.node(), shape.root),
+      ));
+    }
+
+    validate_patch_node(shape, &self.root, "$", 0)?;
+    shape
+      .validate_value(base)
+      .map_err(|error| DataPatchError::at(error.path, format!("base value: {}", error.message)))?;
+    let value = apply_patch_node(shape, &self.root, base, "$", 0)?;
+    shape
+      .validate_value(&value)
+      .map_err(|error| DataPatchError::at(error.path, format!("patched value: {}", error.message)))?;
+    Ok(value)
+  }
+}
+
+impl DataPatchNode {
+  fn node(&self) -> usize {
+    match self {
+      Self::Keep { node } | Self::Replace { node, .. } | Self::StructFields { node, .. } | Self::EnumPayload { node, .. } => *node,
+    }
+  }
+}
+
+fn validate_patch_node(shape: &DataShapeGraph, patch: &DataPatchNode, path: &str, depth: usize) -> Result<(), DataPatchError> {
+  if depth > MAX_PATCH_DEPTH {
+    return Err(DataPatchError::at(path, format!("patch nesting exceeds {MAX_PATCH_DEPTH}")));
+  }
+  let node_id = patch.node();
+  let shape_node = shape
+    .nodes
+    .get(node_id)
+    .ok_or_else(|| DataPatchError::at(path, format!("patch references missing shape node #{node_id}")))?;
+
+  match patch {
+    DataPatchNode::Keep { .. } => Ok(()),
+    DataPatchNode::Replace { value, .. } => shape
+      .validate_node_value(node_id, value, path, depth + 1)
+      .map_err(|error| DataPatchError::at(error.path, format!("replacement value: {}", error.message))),
+    DataPatchNode::StructFields { fields: updates, .. } => {
+      let DataShapeNode::Struct { fields, .. } = shape_node else {
+        return Err(DataPatchError::at(
+          path,
+          format!("StructFields requires a struct shape node, got #{node_id}"),
+        ));
+      };
+      let mut seen = HashSet::new();
+      for (field_index, field_tag, child_patch) in updates {
+        if !seen.insert(*field_index) {
+          return Err(DataPatchError::at(path, format!("duplicate struct field index {field_index}")));
+        }
+        let Some((expected_tag, child_node)) = fields.get(*field_index) else {
+          return Err(DataPatchError::at(
+            path,
+            format!("struct field index {field_index} is out of bounds"),
+          ));
+        };
+        if field_tag != expected_tag {
+          return Err(DataPatchError::at(
+            path,
+            format!("struct field index {field_index} expects :{expected_tag}, got :{field_tag}"),
+          ));
+        }
+        if child_patch.node() != *child_node {
+          return Err(DataPatchError::at(
+            format!("{path}.{}", field_tag.ref_str()),
+            format!("field patch node #{} does not match child node #{child_node}", child_patch.node()),
+          ));
+        }
+        validate_patch_node(shape, child_patch, &format!("{path}.{}", field_tag.ref_str()), depth + 1)?;
+      }
+      Ok(())
+    }
+    DataPatchNode::EnumPayload {
+      variant,
+      payloads: updates,
+      ..
+    } => {
+      let DataShapeNode::Enum { variants, .. } = shape_node else {
+        return Err(DataPatchError::at(
+          path,
+          format!("EnumPayload requires an enum shape node, got #{node_id}"),
+        ));
+      };
+      let Some((variant_tag, payload_nodes)) = variants.get(*variant) else {
+        return Err(DataPatchError::at(path, format!("enum variant index {variant} is out of bounds")));
+      };
+      let mut seen = HashSet::new();
+      for (payload_index, child_patch) in updates {
+        if !seen.insert(*payload_index) {
+          return Err(DataPatchError::at(path, format!("duplicate enum payload index {payload_index}")));
+        }
+        let Some(child_node) = payload_nodes.get(*payload_index) else {
+          return Err(DataPatchError::at(
+            path,
+            format!("enum :{variant_tag} payload index {payload_index} is out of bounds"),
+          ));
+        };
+        if child_patch.node() != *child_node {
+          return Err(DataPatchError::at(
+            format!("{path}.payload[{payload_index}]"),
+            format!("payload patch node #{} does not match child node #{child_node}", child_patch.node()),
+          ));
+        }
+        validate_patch_node(shape, child_patch, &format!("{path}.payload[{payload_index}]"), depth + 1)?;
+      }
+      Ok(())
+    }
+  }
+}
+
+fn apply_patch_node(
+  shape: &DataShapeGraph,
+  patch: &DataPatchNode,
+  base: &Calcit,
+  path: &str,
+  depth: usize,
+) -> Result<Calcit, DataPatchError> {
+  if depth > MAX_PATCH_DEPTH {
+    return Err(DataPatchError::at(path, format!("patch nesting exceeds {MAX_PATCH_DEPTH}")));
+  }
+  match patch {
+    DataPatchNode::Keep { .. } => Ok(base.clone()),
+    DataPatchNode::Replace { value, .. } => Ok(value.clone()),
+    DataPatchNode::StructFields { node, fields: updates } => {
+      let DataShapeNode::Struct { fields, .. } = &shape.nodes[*node] else {
+        return Err(DataPatchError::at(path, "StructFields reached a non-struct shape node"));
+      };
+      let Calcit::Record(record) = base else {
+        return Err(DataPatchError::at(path, "StructFields base is not a record"));
+      };
+      let mut values = record.values.as_ref().clone();
+      for (field_index, field_tag, child_patch) in updates {
+        let (_, child_node) = fields
+          .get(*field_index)
+          .ok_or_else(|| DataPatchError::at(path, format!("struct field index {field_index} is out of bounds")))?;
+        let field_value = values
+          .get(*field_index)
+          .ok_or_else(|| DataPatchError::at(path, format!("record is missing field index {field_index}")))?
+          .clone();
+        let next = apply_patch_node(
+          shape,
+          child_patch,
+          &field_value,
+          &format!("{path}.{}", field_tag.ref_str()),
+          depth + 1,
+        )?;
+        shape
+          .validate_node_value(*child_node, &next, &format!("{path}.{}", field_tag.ref_str()), depth + 1)
+          .map_err(|error| DataPatchError::at(error.path, error.message))?;
+        values[*field_index] = next;
+      }
+      Ok(Calcit::Record(CalcitRecord {
+        struct_ref: record.struct_ref.clone(),
+        values: Arc::new(values),
+      }))
+    }
+    DataPatchNode::EnumPayload {
+      node,
+      variant,
+      payloads: updates,
+    } => {
+      let DataShapeNode::Enum { variants, .. } = &shape.nodes[*node] else {
+        return Err(DataPatchError::at(path, "EnumPayload reached a non-enum shape node"));
+      };
+      let Calcit::Tuple(tuple) = base else {
+        return Err(DataPatchError::at(path, "EnumPayload base is not an enum tuple"));
+      };
+      let (expected_tag, payload_nodes) = variants
+        .get(*variant)
+        .ok_or_else(|| DataPatchError::at(path, format!("enum variant index {variant} is out of bounds")))?;
+      if !matches!(tuple.tag.as_ref(), Calcit::Tag(actual) if actual == expected_tag) {
+        return Err(DataPatchError::at(
+          path,
+          format!("base enum variant does not match :{expected_tag}; use Replace for variant changes"),
+        ));
+      }
+      let mut payloads = tuple.extra.clone();
+      for (payload_index, child_patch) in updates {
+        let child_node = payload_nodes
+          .get(*payload_index)
+          .ok_or_else(|| DataPatchError::at(path, format!("enum payload index {payload_index} is out of bounds")))?;
+        let payload = payloads
+          .get(*payload_index)
+          .ok_or_else(|| DataPatchError::at(path, format!("enum value is missing payload index {payload_index}")))?
+          .clone();
+        let next = apply_patch_node(shape, child_patch, &payload, &format!("{path}.payload[{payload_index}]"), depth + 1)?;
+        shape
+          .validate_node_value(*child_node, &next, &format!("{path}.payload[{payload_index}]"), depth + 1)
+          .map_err(|error| DataPatchError::at(error.path, error.message))?;
+        payloads[*payload_index] = next;
+      }
+      Ok(Calcit::Tuple(CalcitTuple {
+        tag: tuple.tag.clone(),
+        extra: payloads,
+        sum_type: tuple.sum_type.clone(),
+      }))
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::calcit::{CalcitEnum, CalcitList, CalcitStruct, CalcitTypeAnnotation};
+
+  fn point_fixture() -> (DataShapeGraph, Arc<CalcitStruct>, Calcit) {
+    let mut nominal = CalcitStruct::from_fields(EdnTag::new("Point"), vec![EdnTag::new("x"), EdnTag::new("label")]);
+    nominal.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]);
+    let nominal = Arc::new(nominal);
+    let shape =
+      DataShapeGraph::build(&CalcitTypeAnnotation::Struct(nominal.clone(), Arc::new(vec![])), "tests.patch").expect("point data shape");
+    let value = Calcit::Record(CalcitRecord {
+      struct_ref: nominal.clone(),
+      values: Arc::new(vec![Calcit::Number(1.0), Calcit::Str(Arc::from("old"))]),
+    });
+    (shape, nominal, value)
+  }
+
+  #[test]
+  fn applies_struct_field_patch_and_preserves_nominal_identity() {
+    let (shape, _, base) = point_fixture();
+    let DataShapeNode::Struct { fields, .. } = &shape.nodes[shape.root] else {
+      panic!("point root must be a struct");
+    };
+    let x_node = fields[0].1;
+    let patch = DataPatch::new(
+      &shape,
+      DataPatchNode::StructFields {
+        node: shape.root,
+        fields: vec![(
+          0,
+          EdnTag::new("x"),
+          DataPatchNode::Replace {
+            node: x_node,
+            value: Calcit::Number(2.0),
+          },
+        )],
+      },
+    )
+    .expect("valid point patch");
+
+    let value = patch.apply(&shape, &base).expect("apply point patch");
+    let (Calcit::Record(before), Calcit::Record(after)) = (&base, &value) else {
+      panic!("point values must be records");
+    };
+    assert!(Arc::ptr_eq(&before.struct_ref, &after.struct_ref));
+    assert_eq!(after.values.as_ref(), &[Calcit::Number(2.0), Calcit::Str(Arc::from("old"))]);
+  }
+
+  #[test]
+  fn rejects_wrong_struct_field_tag_and_replacement_type() {
+    let (shape, _, _) = point_fixture();
+    let DataShapeNode::Struct { fields, .. } = &shape.nodes[shape.root] else {
+      panic!("point root must be a struct");
+    };
+    let x_node = fields[0].1;
+    let wrong_tag = DataPatch::new(
+      &shape,
+      DataPatchNode::StructFields {
+        node: shape.root,
+        fields: vec![(0, EdnTag::new("label"), DataPatchNode::Keep { node: x_node })],
+      },
+    )
+    .expect_err("field tag must agree with its index");
+    assert!(wrong_tag.to_string().contains("expects :x"));
+
+    let wrong_value = DataPatch::new(
+      &shape,
+      DataPatchNode::StructFields {
+        node: shape.root,
+        fields: vec![(
+          0,
+          EdnTag::new("x"),
+          DataPatchNode::Replace {
+            node: x_node,
+            value: Calcit::Str(Arc::from("wrong")),
+          },
+        )],
+      },
+    )
+    .expect_err("replacement must match its child shape");
+    assert!(wrong_value.to_string().contains("expected number"));
+  }
+
+  #[test]
+  fn rejects_patch_from_another_shape_fingerprint() {
+    let (shape, _, base) = point_fixture();
+    let patch = DataPatch {
+      version: shape.abi_version(),
+      fingerprint: Arc::from("another-shape"),
+      root: DataPatchNode::Keep { node: shape.root },
+    };
+    let error = patch.apply(&shape, &base).expect_err("fingerprint mismatch must fail");
+    assert!(error.to_string().contains("fingerprint"));
+  }
+
+  #[test]
+  fn applies_payload_patch_only_to_the_declared_enum_variant() {
+    let enum_record = CalcitRecord {
+      struct_ref: Arc::new(CalcitStruct::from_fields(
+        EdnTag::new("Outcome"),
+        vec![EdnTag::new("none"), EdnTag::new("score")],
+      )),
+      values: Arc::new(vec![
+        Calcit::List(Arc::new(CalcitList::default())),
+        Calcit::List(Arc::new(CalcitList::from([CalcitTypeAnnotation::Number.to_calcit()].as_slice()))),
+      ]),
+    };
+    let nominal = Arc::new(CalcitEnum::from_record(enum_record).expect("outcome enum"));
+    let shape =
+      DataShapeGraph::build(&CalcitTypeAnnotation::Enum(nominal.clone(), Arc::new(vec![])), "tests.patch").expect("outcome shape");
+    let DataShapeNode::Enum { variants, .. } = &shape.nodes[shape.root] else {
+      panic!("outcome root must be an enum");
+    };
+    let variant = variants.iter().position(|(tag, _)| tag.ref_str() == "score").unwrap();
+    let score_node = variants[variant].1[0];
+    let base = Calcit::Tuple(CalcitTuple {
+      tag: Arc::new(Calcit::Tag(EdnTag::new("score"))),
+      extra: vec![Calcit::Number(1.0)],
+      sum_type: Some(nominal),
+    });
+    let patch = DataPatch::new(
+      &shape,
+      DataPatchNode::EnumPayload {
+        node: shape.root,
+        variant,
+        payloads: vec![(
+          0,
+          DataPatchNode::Replace {
+            node: score_node,
+            value: Calcit::Number(2.0),
+          },
+        )],
+      },
+    )
+    .expect("valid enum payload patch");
+
+    let value = patch.apply(&shape, &base).expect("apply enum patch");
+    let Calcit::Tuple(tuple) = value else {
+      panic!("patched outcome must remain an enum tuple");
+    };
+    assert_eq!(tuple.extra, vec![Calcit::Number(2.0)]);
+    assert!(tuple.sum_type.is_some());
+  }
+}

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -253,7 +253,7 @@ impl DataShapeGraph {
         let Calcit::Record(record) = value else {
           return Err(shape_kind_mismatch(path, &format!("record :{}", nominal.name), value));
         };
-        if record.struct_ref.name != nominal.name || record.struct_ref.fields != nominal.fields {
+        if !Arc::ptr_eq(&record.struct_ref, nominal) {
           return Err(DataShapeValueError::at(
             path,
             format!("expected nominal record :{}, got :{}", nominal.name, record.struct_ref.name),
@@ -291,7 +291,7 @@ impl DataShapeGraph {
             format!("expected enum :{}, got ordinary tuple", nominal.name()),
           ));
         };
-        if actual_enum.as_ref() != nominal.as_ref() {
+        if !Arc::ptr_eq(actual_enum, nominal) {
           return Err(DataShapeValueError::at(
             path,
             format!("expected nominal enum :{}, got :{}", nominal.name(), actual_enum.name()),
@@ -694,7 +694,7 @@ fn update_nominal_fingerprint(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitGenericBound, CalcitImpl, CalcitTrait};
+  use crate::calcit::{CalcitGenericBound, CalcitImpl, CalcitList, CalcitRecord, CalcitTrait, CalcitTuple};
 
   fn phantom_box() -> Arc<CalcitStruct> {
     Arc::new(CalcitStruct {
@@ -757,6 +757,37 @@ mod tests {
     super::super::pop_type_slot_override(&name);
 
     assert!(error.to_string().contains("recursive type slot"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn rejects_structurally_equal_but_distinct_nominal_declarations() {
+    let nominal = Arc::new(CalcitStruct::from_fields(EdnTag::new("Point"), vec![]));
+    let shape =
+      DataShapeGraph::build(&CalcitTypeAnnotation::Struct(nominal.clone(), Arc::new(vec![])), "tests.shape").expect("point shape");
+    let impostor = Arc::new((*nominal).clone());
+    let record = Calcit::Record(CalcitRecord {
+      struct_ref: impostor,
+      values: Arc::new(vec![]),
+    });
+
+    let error = shape.validate_value(&record).expect_err("distinct struct declaration must fail");
+    assert!(error.message.contains("expected nominal record"), "unexpected error: {error}");
+
+    let enum_prototype = || CalcitRecord {
+      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("Outcome"), vec![EdnTag::new("none")])),
+      values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::default()))]),
+    };
+    let nominal = Arc::new(CalcitEnum::from_record(enum_prototype()).expect("outcome enum"));
+    let shape = DataShapeGraph::build(&CalcitTypeAnnotation::Enum(nominal, Arc::new(vec![])), "tests.shape").expect("outcome shape");
+    let impostor = Arc::new(CalcitEnum::from_record(enum_prototype()).expect("impostor outcome enum"));
+    let tuple = Calcit::Tuple(CalcitTuple {
+      tag: Arc::new(Calcit::Tag(EdnTag::new("none"))),
+      extra: vec![],
+      sum_type: Some(impostor),
+    });
+
+    let error = shape.validate_value(&tuple).expect_err("distinct enum declaration must fail");
+    assert!(error.message.contains("expected nominal enum"), "unexpected error: {error}");
   }
 
   #[test]

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -1,0 +1,803 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::Arc;
+
+use cirru_edn::EdnTag;
+use md5::{Digest, Md5};
+
+use super::type_annotation::{TypeBindings, validate_runtime_generic_where_bounds};
+use super::{Calcit, CalcitEnum, CalcitStruct, CalcitTypeAnnotation};
+use crate::program;
+
+const DATA_SHAPE_ABI_VERSION: u16 = 1;
+const MAX_SHAPE_VALUE_DEPTH: usize = 1024;
+
+/// A closed, backend-neutral description of statically typed Calcit data.
+///
+/// The graph is compiler-owned and deliberately excludes Dynamic and other
+/// open host values. Format-specific decoders and future typed diff/patch
+/// executors consume this graph rather than resolving type expressions again.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DataShapeGraph {
+  pub(crate) root: usize,
+  pub(crate) nodes: Vec<DataShapeNode>,
+  fingerprint: Arc<str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DataShapeNode {
+  Unit,
+  Bool,
+  Number,
+  String,
+  Symbol,
+  Tag,
+  Buffer,
+  CirruQuote,
+  Optional(usize),
+  List(usize),
+  Set(usize),
+  Map {
+    key: usize,
+    value: usize,
+  },
+  Ref(usize),
+  Struct {
+    nominal: Arc<CalcitStruct>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    type_args: Arc<Vec<Arc<CalcitTypeAnnotation>>>,
+    fields: Vec<(EdnTag, usize)>,
+  },
+  Enum {
+    nominal: Arc<CalcitEnum>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    type_args: Arc<Vec<Arc<CalcitTypeAnnotation>>>,
+    variants: Vec<(EdnTag, Vec<usize>)>,
+  },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DataShapeError {
+  message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DataShapeValueError {
+  pub(crate) path: String,
+  pub(crate) message: String,
+}
+
+impl DataShapeError {
+  fn new(message: impl Into<String>) -> Self {
+    Self { message: message.into() }
+  }
+}
+
+impl fmt::Display for DataShapeError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&self.message)
+  }
+}
+
+impl DataShapeValueError {
+  fn at(path: impl Into<String>, message: impl Into<String>) -> Self {
+    Self {
+      path: path.into(),
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for DataShapeValueError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "data shape validation failed at {}: {}", self.path, self.message)
+  }
+}
+
+struct GraphBuilder {
+  nodes: Vec<Option<DataShapeNode>>,
+  nominal_nodes: HashMap<String, usize>,
+  resolving_aliases: HashSet<String>,
+  resolving_slots: HashSet<String>,
+}
+
+impl DataShapeGraph {
+  pub(crate) fn build(target: &CalcitTypeAnnotation, default_ns: &str) -> Result<Self, DataShapeError> {
+    let mut builder = GraphBuilder {
+      nodes: vec![],
+      nominal_nodes: HashMap::new(),
+      resolving_aliases: HashSet::new(),
+      resolving_slots: HashSet::new(),
+    };
+    let root = builder.build_type(target, default_ns)?;
+    let nodes = builder
+      .nodes
+      .into_iter()
+      .enumerate()
+      .map(|(idx, node)| node.ok_or_else(|| DataShapeError::new(format!("data shape node #{idx} was not completed"))))
+      .collect::<Result<Vec<_>, _>>()?;
+    Self::from_nodes(root, nodes)
+  }
+
+  pub(crate) fn from_nodes(root: usize, nodes: Vec<DataShapeNode>) -> Result<Self, DataShapeError> {
+    if nodes.get(root).is_none() {
+      return Err(DataShapeError::new(format!("data shape root #{root} is out of bounds")));
+    }
+    for (node_id, node) in nodes.iter().enumerate() {
+      for child in node.child_nodes() {
+        if nodes.get(child).is_none() {
+          return Err(DataShapeError::new(format!(
+            "data shape node #{node_id} references missing child #{child}"
+          )));
+        }
+      }
+    }
+    let fingerprint = Arc::from(shape_fingerprint(root, &nodes));
+    Ok(Self { root, nodes, fingerprint })
+  }
+
+  pub(crate) fn fingerprint(&self) -> &str {
+    &self.fingerprint
+  }
+
+  pub(crate) fn abi_version(&self) -> u16 {
+    DATA_SHAPE_ABI_VERSION
+  }
+
+  pub(crate) fn into_calcit_handle(self) -> Calcit {
+    Calcit::AnyRef(cirru_edn::EdnAnyRef::new(Arc::new(self)))
+  }
+
+  pub(crate) fn from_calcit_handle(value: &Calcit) -> Option<Arc<Self>> {
+    let Calcit::AnyRef(reference) = value else {
+      return None;
+    };
+    let guard = reference.0.read().ok()?;
+    guard.as_any().downcast_ref::<Arc<Self>>().cloned()
+  }
+
+  pub(crate) fn nominal_paths(&self) -> Vec<(Arc<str>, Arc<str>)> {
+    let mut paths = Vec::new();
+    for node in &self.nodes {
+      let path = match node {
+        DataShapeNode::Struct { nominal_path, .. } | DataShapeNode::Enum { nominal_path, .. } => nominal_path,
+        _ => continue,
+      };
+      if let Some(path) = path
+        && !paths.contains(path)
+      {
+        paths.push(path.clone());
+      }
+    }
+    paths
+  }
+
+  pub(crate) fn validate_value(&self, value: &Calcit) -> Result<(), DataShapeValueError> {
+    self.validate_node_value(self.root, value, "$", 0)
+  }
+
+  pub(crate) fn validate_node_value(
+    &self,
+    node_id: usize,
+    value: &Calcit,
+    path: &str,
+    depth: usize,
+  ) -> Result<(), DataShapeValueError> {
+    if depth > MAX_SHAPE_VALUE_DEPTH {
+      return Err(DataShapeValueError::at(
+        path,
+        format!("value nesting exceeds {MAX_SHAPE_VALUE_DEPTH}"),
+      ));
+    }
+    let node = self
+      .nodes
+      .get(node_id)
+      .ok_or_else(|| DataShapeValueError::at(path, format!("missing shape node #{node_id}")))?;
+
+    match node {
+      DataShapeNode::Unit if matches!(value, Calcit::Nil) => Ok(()),
+      DataShapeNode::Bool if matches!(value, Calcit::Bool(_)) => Ok(()),
+      DataShapeNode::Number if matches!(value, Calcit::Number(_)) => Ok(()),
+      DataShapeNode::String if matches!(value, Calcit::Str(_)) => Ok(()),
+      DataShapeNode::Symbol if matches!(value, Calcit::Symbol { .. }) => Ok(()),
+      DataShapeNode::Tag if matches!(value, Calcit::Tag(_)) => Ok(()),
+      DataShapeNode::Buffer if matches!(value, Calcit::Buffer(_)) => Ok(()),
+      DataShapeNode::CirruQuote if matches!(value, Calcit::CirruQuote(_)) => Ok(()),
+      DataShapeNode::Optional(inner) => {
+        if matches!(value, Calcit::Nil) {
+          Ok(())
+        } else {
+          self.validate_node_value(*inner, value, path, depth + 1)
+        }
+      }
+      DataShapeNode::List(inner) => {
+        let Calcit::List(values) = value else {
+          return Err(shape_kind_mismatch(path, "list", value));
+        };
+        for (idx, item) in values.iter().enumerate() {
+          self.validate_node_value(*inner, item, &format!("{path}[{idx}]"), depth + 1)?;
+        }
+        Ok(())
+      }
+      DataShapeNode::Set(inner) => {
+        let Calcit::Set(values) = value else {
+          return Err(shape_kind_mismatch(path, "set", value));
+        };
+        for item in values.iter() {
+          self.validate_node_value(*inner, item, &format!("{path}.item"), depth + 1)?;
+        }
+        Ok(())
+      }
+      DataShapeNode::Map { key, value: value_node } => {
+        let Calcit::Map(values) = value else {
+          return Err(shape_kind_mismatch(path, "map", value));
+        };
+        for (item_key, item_value) in values.iter() {
+          self.validate_node_value(*key, item_key, &format!("{path}.key"), depth + 1)?;
+          self.validate_node_value(*value_node, item_value, &format!("{path}.value"), depth + 1)?;
+        }
+        Ok(())
+      }
+      DataShapeNode::Ref(inner) => {
+        let Calcit::Ref(_, value_and_listeners) = value else {
+          return Err(shape_kind_mismatch(path, "ref", value));
+        };
+        let inner_value = value_and_listeners
+          .lock()
+          .map_err(|_| DataShapeValueError::at(path, "cannot read poisoned ref"))?
+          .0
+          .clone();
+        self.validate_node_value(*inner, &inner_value, &format!("{path}.value"), depth + 1)
+      }
+      DataShapeNode::Struct { nominal, fields, .. } => {
+        let Calcit::Record(record) = value else {
+          return Err(shape_kind_mismatch(path, &format!("record :{}", nominal.name), value));
+        };
+        if record.struct_ref.name != nominal.name || record.struct_ref.fields != nominal.fields {
+          return Err(DataShapeValueError::at(
+            path,
+            format!("expected nominal record :{}, got :{}", nominal.name, record.struct_ref.name),
+          ));
+        }
+        if record.values.len() != fields.len() {
+          return Err(DataShapeValueError::at(
+            path,
+            format!(
+              "record :{} expects {} value(s), got {}",
+              nominal.name,
+              fields.len(),
+              record.values.len()
+            ),
+          ));
+        }
+        for (idx, ((field, child), item)) in fields.iter().zip(record.values.iter()).enumerate() {
+          if record.struct_ref.fields.get(idx) != Some(field) {
+            return Err(DataShapeValueError::at(
+              path,
+              format!("record :{} field #{idx} does not match :{field}", nominal.name),
+            ));
+          }
+          self.validate_node_value(*child, item, &format!("{path}.{}", field.ref_str()), depth + 1)?;
+        }
+        Ok(())
+      }
+      DataShapeNode::Enum { nominal, variants, .. } => {
+        let Calcit::Tuple(tuple) = value else {
+          return Err(shape_kind_mismatch(path, &format!("enum :{}", nominal.name()), value));
+        };
+        let Some(actual_enum) = tuple.sum_type.as_ref() else {
+          return Err(DataShapeValueError::at(
+            path,
+            format!("expected enum :{}, got ordinary tuple", nominal.name()),
+          ));
+        };
+        if actual_enum.as_ref() != nominal.as_ref() {
+          return Err(DataShapeValueError::at(
+            path,
+            format!("expected nominal enum :{}, got :{}", nominal.name(), actual_enum.name()),
+          ));
+        }
+        let Calcit::Tag(tag) = tuple.tag.as_ref() else {
+          return Err(DataShapeValueError::at(path, "enum variant is not a tag"));
+        };
+        let Some((_, payload_nodes)) = variants.iter().find(|(candidate, _)| candidate == tag) else {
+          return Err(DataShapeValueError::at(
+            path,
+            format!("enum :{} has no variant :{tag}", nominal.name()),
+          ));
+        };
+        if tuple.extra.len() != payload_nodes.len() {
+          return Err(DataShapeValueError::at(
+            path,
+            format!(
+              "enum :{} variant :{tag} expects {} payload(s), got {}",
+              nominal.name(),
+              payload_nodes.len(),
+              tuple.extra.len()
+            ),
+          ));
+        }
+        for (idx, (child, item)) in payload_nodes.iter().zip(tuple.extra.iter()).enumerate() {
+          self.validate_node_value(*child, item, &format!("{path}.payload[{idx}]"), depth + 1)?;
+        }
+        Ok(())
+      }
+      _ => Err(shape_kind_mismatch(path, node.expected_kind(), value)),
+    }
+  }
+}
+
+impl DataShapeNode {
+  fn child_nodes(&self) -> Vec<usize> {
+    match self {
+      Self::Optional(inner) | Self::List(inner) | Self::Set(inner) | Self::Ref(inner) => vec![*inner],
+      Self::Map { key, value } => vec![*key, *value],
+      Self::Struct { fields, .. } => fields.iter().map(|(_, node)| *node).collect(),
+      Self::Enum { variants, .. } => variants.iter().flat_map(|(_, payloads)| payloads.iter().copied()).collect(),
+      _ => vec![],
+    }
+  }
+
+  fn expected_kind(&self) -> &str {
+    match self {
+      Self::Unit => "nil",
+      Self::Bool => "bool",
+      Self::Number => "number",
+      Self::String => "string",
+      Self::Symbol => "symbol",
+      Self::Tag => "tag",
+      Self::Buffer => "buffer",
+      Self::CirruQuote => "cirru-quote",
+      Self::Optional(_) => "optional value",
+      Self::List(_) => "list",
+      Self::Set(_) => "set",
+      Self::Map { .. } => "map",
+      Self::Ref(_) => "ref",
+      Self::Struct { .. } => "record",
+      Self::Enum { .. } => "enum",
+    }
+  }
+}
+
+fn shape_kind_mismatch(path: &str, expected: &str, actual: &Calcit) -> DataShapeValueError {
+  DataShapeValueError::at(
+    path,
+    format!("expected {expected}, got {}", crate::calcit::brief_type_of_value(actual)),
+  )
+}
+
+impl GraphBuilder {
+  fn push(&mut self, node: DataShapeNode) -> usize {
+    let id = self.nodes.len();
+    self.nodes.push(Some(node));
+    id
+  }
+
+  fn build_type(&mut self, target: &CalcitTypeAnnotation, default_ns: &str) -> Result<usize, DataShapeError> {
+    match target {
+      CalcitTypeAnnotation::Unit => Ok(self.push(DataShapeNode::Unit)),
+      CalcitTypeAnnotation::Bool => Ok(self.push(DataShapeNode::Bool)),
+      CalcitTypeAnnotation::Number => Ok(self.push(DataShapeNode::Number)),
+      CalcitTypeAnnotation::String => Ok(self.push(DataShapeNode::String)),
+      CalcitTypeAnnotation::Symbol => Ok(self.push(DataShapeNode::Symbol)),
+      CalcitTypeAnnotation::Tag => Ok(self.push(DataShapeNode::Tag)),
+      CalcitTypeAnnotation::Buffer => Ok(self.push(DataShapeNode::Buffer)),
+      CalcitTypeAnnotation::CirruQuote => Ok(self.push(DataShapeNode::CirruQuote)),
+      CalcitTypeAnnotation::Optional(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(DataShapeNode::Optional(inner)))
+      }
+      CalcitTypeAnnotation::List(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(DataShapeNode::List(inner)))
+      }
+      CalcitTypeAnnotation::Set(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(DataShapeNode::Set(inner)))
+      }
+      CalcitTypeAnnotation::Map(key, value) => {
+        let key = self.build_type(key, default_ns)?;
+        let value = self.build_type(value, default_ns)?;
+        Ok(self.push(DataShapeNode::Map { key, value }))
+      }
+      CalcitTypeAnnotation::Ref(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(DataShapeNode::Ref(inner)))
+      }
+      CalcitTypeAnnotation::Struct(nominal, args) => {
+        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
+        self.build_struct(nominal.clone(), args, path, default_ns)
+      }
+      CalcitTypeAnnotation::Record(nominal) => {
+        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
+        self.build_struct(nominal.clone(), &Arc::new(vec![]), path, default_ns)
+      }
+      CalcitTypeAnnotation::Enum(nominal, args) => {
+        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
+        self.build_enum(nominal.clone(), args, path, default_ns)
+      }
+      CalcitTypeAnnotation::Tuple(nominal) => {
+        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
+        self.build_enum(nominal.clone(), &Arc::new(vec![]), path, default_ns)
+      }
+      CalcitTypeAnnotation::TypeRef(name, args) => self.build_named(name, args, default_ns),
+      CalcitTypeAnnotation::TypeSlot(name) => match super::resolve_type_slot(name) {
+        Some(resolved) => {
+          let slot_key = name.to_string();
+          if !self.resolving_slots.insert(slot_key.clone()) {
+            return Err(DataShapeError::new(format!("recursive type slot `*{name}`")));
+          }
+          let result = self.build_type(&resolved, default_ns);
+          self.resolving_slots.remove(&slot_key);
+          result
+        }
+        None => Err(DataShapeError::new(format!("unbound type slot `*{name}`"))),
+      },
+      CalcitTypeAnnotation::Dynamic => Err(unsupported_type("Dynamic is forbidden in a closed data shape")),
+      CalcitTypeAnnotation::TypeVar(name) => Err(unsupported_type(&format!("generic variable '{name} is not bound"))),
+      CalcitTypeAnnotation::DynTuple => Err(unsupported_type("ordinary tuple has no declared enum schema")),
+      CalcitTypeAnnotation::DynFn | CalcitTypeAnnotation::Fn(_) => Err(unsupported_type("function values are not closed data")),
+      CalcitTypeAnnotation::Trait(_) | CalcitTypeAnnotation::TraitSet(_) => {
+        Err(unsupported_type("trait constraints are not data shapes"))
+      }
+      CalcitTypeAnnotation::JsObject => Err(unsupported_type("JsObject is an opaque host value")),
+      CalcitTypeAnnotation::Custom(value) => Err(unsupported_type(&format!("custom type `{value}` has no data shape"))),
+      CalcitTypeAnnotation::Variadic(_) => Err(unsupported_type("Variadic is a function parameter constraint")),
+    }
+  }
+
+  fn build_named(&mut self, name: &str, args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>, default_ns: &str) -> Result<usize, DataShapeError> {
+    let (ns, def) = qualify_type_ref(name, default_ns);
+    let qualified = CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), args.clone());
+    if let Some(struct_def) = qualified.resolve_to_struct() {
+      return self.build_struct(Arc::new(struct_def), args, Some((ns, def)), default_ns);
+    }
+    if let Some(enum_def) = qualified.resolve_to_enum() {
+      return self.build_enum(Arc::new(enum_def), args, Some((ns, def)), default_ns);
+    }
+
+    let schema = program::lookup_def_schema(&ns, &def);
+    if !matches!(schema.as_ref(), CalcitTypeAnnotation::Dynamic)
+      && !matches!(schema.as_ref(), CalcitTypeAnnotation::TypeRef(schema_name, _) if schema_name.as_ref() == name)
+    {
+      if !args.is_empty() {
+        return Err(DataShapeError::new(format!(
+          "cannot apply generic arguments to type alias `{ns}/{def}`"
+        )));
+      }
+      let alias_key = format!("{ns}/{def}");
+      if !self.resolving_aliases.insert(alias_key.clone()) {
+        return Err(DataShapeError::new(format!(
+          "recursive type alias `{alias_key}`; recursive data must use a nominal struct or enum"
+        )));
+      }
+      let result = self.build_type(schema.as_ref(), &ns);
+      self.resolving_aliases.remove(&alias_key);
+      return result;
+    }
+
+    Err(DataShapeError::new(format!("cannot resolve named type `{ns}/{def}`")))
+  }
+
+  fn build_struct(
+    &mut self,
+    nominal: Arc<CalcitStruct>,
+    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    default_ns: &str,
+  ) -> Result<usize, DataShapeError> {
+    validate_generic_application(&nominal.name.to_string(), &nominal.generics, args)?;
+    if nominal.fields.len() != nominal.field_types.len() {
+      return Err(DataShapeError::new(format!(
+        "cannot derive `{}`: {} fields but {} field types",
+        nominal.name,
+        nominal.fields.len(),
+        nominal.field_types.len()
+      )));
+    }
+    let owner_ns = nominal_path.as_ref().map(|(ns, _)| ns.as_ref()).unwrap_or(default_ns);
+    for arg in args.iter() {
+      self.build_type(arg, owner_ns)?;
+    }
+    let bindings = generic_bindings(&nominal.generics, args);
+    validate_runtime_generic_where_bounds(&bindings, nominal.where_bounds.as_ref())
+      .map_err(|message| DataShapeError::new(format!("cannot derive `{}`: {message}", nominal.name)))?;
+    let key = nominal_key("struct", &nominal.name, args, nominal_path.as_ref(), owner_ns);
+    if let Some(existing) = self.nominal_nodes.get(&key) {
+      return Ok(*existing);
+    }
+    let node_id = self.nodes.len();
+    self.nodes.push(None);
+    self.nominal_nodes.insert(key, node_id);
+
+    let mut fields = Vec::with_capacity(nominal.fields.len());
+    for (field, field_type) in nominal.fields.iter().zip(nominal.field_types.iter()) {
+      let resolved = field_type.substitute_type_vars(&bindings);
+      let field_node = self.build_type(resolved.as_ref(), owner_ns)?;
+      fields.push((field.clone(), field_node));
+    }
+    self.nodes[node_id] = Some(DataShapeNode::Struct {
+      nominal,
+      nominal_path,
+      type_args: args.clone(),
+      fields,
+    });
+    Ok(node_id)
+  }
+
+  fn build_enum(
+    &mut self,
+    nominal: Arc<CalcitEnum>,
+    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    default_ns: &str,
+  ) -> Result<usize, DataShapeError> {
+    validate_generic_application(&nominal.name().to_string(), nominal.generics(), args)?;
+    let owner_ns = nominal_path.as_ref().map(|(ns, _)| ns.as_ref()).unwrap_or(default_ns);
+    for arg in args.iter() {
+      self.build_type(arg, owner_ns)?;
+    }
+    let bindings = generic_bindings(nominal.generics(), args);
+    validate_runtime_generic_where_bounds(&bindings, nominal.where_bounds())
+      .map_err(|message| DataShapeError::new(format!("cannot derive `{}`: {message}", nominal.name())))?;
+    let key = nominal_key("enum", nominal.name(), args, nominal_path.as_ref(), owner_ns);
+    if let Some(existing) = self.nominal_nodes.get(&key) {
+      return Ok(*existing);
+    }
+    let node_id = self.nodes.len();
+    self.nodes.push(None);
+    self.nominal_nodes.insert(key, node_id);
+
+    let mut variants = Vec::with_capacity(nominal.variants().len());
+    for variant in nominal.variants() {
+      let mut payloads = Vec::with_capacity(variant.payload_types().len());
+      for payload_type in variant.payload_types() {
+        let resolved = payload_type.substitute_type_vars(&bindings);
+        payloads.push(self.build_type(resolved.as_ref(), owner_ns)?);
+      }
+      variants.push((variant.tag.clone(), payloads));
+    }
+    self.nodes[node_id] = Some(DataShapeNode::Enum {
+      nominal,
+      nominal_path,
+      type_args: args.clone(),
+      variants,
+    });
+    Ok(node_id)
+  }
+}
+
+fn validate_generic_application(name: &str, generics: &[Arc<str>], args: &[Arc<CalcitTypeAnnotation>]) -> Result<(), DataShapeError> {
+  if generics.len() != args.len() {
+    return Err(DataShapeError::new(format!(
+      "expected {} generic argument(s) for `{name}`, got {}",
+      generics.len(),
+      args.len()
+    )));
+  }
+  Ok(())
+}
+
+fn generic_bindings(generics: &[Arc<str>], args: &[Arc<CalcitTypeAnnotation>]) -> TypeBindings {
+  generics.iter().cloned().zip(args.iter().cloned()).collect()
+}
+
+fn qualify_type_ref(name: &str, default_ns: &str) -> (Arc<str>, Arc<str>) {
+  let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+  if let Some((ns, def)) = stripped.rsplit_once('/') {
+    (Arc::from(ns), Arc::from(def))
+  } else if program::has_def_code(default_ns, stripped) {
+    (Arc::from(default_ns), Arc::from(stripped))
+  } else if let Some(target_ns) = program::lookup_def_target_in_import(default_ns, stripped) {
+    (target_ns, Arc::from(stripped))
+  } else {
+    (Arc::from(super::CORE_NS), Arc::from(stripped))
+  }
+}
+
+fn infer_nominal_path(default_ns: &str, name: &str) -> Option<(Arc<str>, Arc<str>)> {
+  if program::has_def_code(default_ns, name) {
+    Some((Arc::from(default_ns), Arc::from(name)))
+  } else if program::has_def_code(super::CORE_NS, name) {
+    Some((Arc::from(super::CORE_NS), Arc::from(name)))
+  } else {
+    None
+  }
+}
+
+fn nominal_key(
+  kind: &str,
+  name: &EdnTag,
+  args: &[Arc<CalcitTypeAnnotation>],
+  path: Option<&(Arc<str>, Arc<str>)>,
+  owner_ns: &str,
+) -> String {
+  let identity = path
+    .map(|(ns, def)| format!("{ns}/{def}"))
+    .unwrap_or_else(|| format!("{owner_ns}/{}", name.ref_str()));
+  let rendered_args = args.iter().map(|arg| arg.to_brief_string()).collect::<Vec<_>>().join(",");
+  format!("{kind}:{identity}<{rendered_args}>")
+}
+
+fn unsupported_type(reason: &str) -> DataShapeError {
+  DataShapeError::new(format!("cannot derive a closed data shape: {reason}"))
+}
+
+fn shape_fingerprint(root: usize, nodes: &[DataShapeNode]) -> String {
+  let mut hasher = Md5::new();
+  hasher.update(format!("calcit-data-shape-v{DATA_SHAPE_ABI_VERSION};root={root};").as_bytes());
+  for (node_id, node) in nodes.iter().enumerate() {
+    hasher.update(format!("#{node_id}:").as_bytes());
+    match node {
+      DataShapeNode::Unit => hasher.update(b"unit;"),
+      DataShapeNode::Bool => hasher.update(b"bool;"),
+      DataShapeNode::Number => hasher.update(b"number;"),
+      DataShapeNode::String => hasher.update(b"string;"),
+      DataShapeNode::Symbol => hasher.update(b"symbol;"),
+      DataShapeNode::Tag => hasher.update(b"tag;"),
+      DataShapeNode::Buffer => hasher.update(b"buffer;"),
+      DataShapeNode::CirruQuote => hasher.update(b"cirru-quote;"),
+      DataShapeNode::Optional(inner) => hasher.update(format!("optional:{inner};").as_bytes()),
+      DataShapeNode::List(inner) => hasher.update(format!("list:{inner};").as_bytes()),
+      DataShapeNode::Set(inner) => hasher.update(format!("set:{inner};").as_bytes()),
+      DataShapeNode::Map { key, value } => hasher.update(format!("map:{key}:{value};").as_bytes()),
+      DataShapeNode::Ref(inner) => hasher.update(format!("ref:{inner};").as_bytes()),
+      DataShapeNode::Struct {
+        nominal,
+        nominal_path,
+        type_args,
+        fields,
+      } => {
+        update_nominal_fingerprint(&mut hasher, "struct", nominal.name.ref_str(), nominal_path.as_ref(), type_args);
+        for (field, child) in fields {
+          hasher.update(format!("field:{}:{child};", field.ref_str()).as_bytes());
+        }
+      }
+      DataShapeNode::Enum {
+        nominal,
+        nominal_path,
+        type_args,
+        variants,
+      } => {
+        update_nominal_fingerprint(&mut hasher, "enum", nominal.name().ref_str(), nominal_path.as_ref(), type_args);
+        for (variant, payloads) in variants {
+          hasher.update(format!("variant:{}:", variant.ref_str()).as_bytes());
+          for child in payloads {
+            hasher.update(format!("{child},").as_bytes());
+          }
+          hasher.update(b";");
+        }
+      }
+    }
+  }
+  format!("{:x}", hasher.finalize())
+}
+
+fn update_nominal_fingerprint(
+  hasher: &mut Md5,
+  kind: &str,
+  fallback_name: &str,
+  nominal_path: Option<&(Arc<str>, Arc<str>)>,
+  type_args: &[Arc<CalcitTypeAnnotation>],
+) {
+  let identity = nominal_path
+    .map(|(ns, def)| format!("{ns}/{def}"))
+    .unwrap_or_else(|| format!("?/{fallback_name}"));
+  hasher.update(format!("{kind}:{identity}<").as_bytes());
+  for arg in type_args {
+    hasher.update(arg.to_brief_string().as_bytes());
+    hasher.update(b",");
+  }
+  hasher.update(b">;");
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::calcit::{CalcitGenericBound, CalcitImpl, CalcitTrait};
+
+  fn phantom_box() -> Arc<CalcitStruct> {
+    Arc::new(CalcitStruct {
+      name: EdnTag::new("PhantomBox"),
+      fields: Arc::new(vec![]),
+      field_types: Arc::new(vec![]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    })
+  }
+
+  #[test]
+  fn fingerprint_includes_nominal_type_arguments_even_when_fields_do_not() {
+    let nominal = phantom_box();
+    let number = DataShapeGraph::build(
+      &CalcitTypeAnnotation::Struct(nominal.clone(), Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)])),
+      "tests.shape",
+    )
+    .expect("number shape");
+    let string = DataShapeGraph::build(
+      &CalcitTypeAnnotation::Struct(nominal, Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)])),
+      "tests.shape",
+    )
+    .expect("string shape");
+
+    assert_ne!(number.fingerprint(), string.fingerprint());
+  }
+
+  #[test]
+  fn rejects_invalid_child_references() {
+    let error = DataShapeGraph::from_nodes(0, vec![DataShapeNode::List(1)]).expect_err("missing child must fail");
+    assert!(error.to_string().contains("missing child #1"));
+  }
+
+  #[test]
+  fn rejects_dynamic_and_incomplete_generic_types() {
+    let dynamic = DataShapeGraph::build(&CalcitTypeAnnotation::Dynamic, "tests.shape").expect_err("dynamic must fail");
+    assert!(dynamic.to_string().contains("Dynamic is forbidden"));
+
+    let generic = Arc::new(CalcitStruct {
+      name: EdnTag::new("Box"),
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(Vec::<CalcitGenericBound>::new()),
+      impls: vec![],
+    });
+    let incomplete = DataShapeGraph::build(&CalcitTypeAnnotation::Struct(generic, Arc::new(vec![])), "tests.shape")
+      .expect_err("missing generic argument must fail");
+    assert!(incomplete.to_string().contains("expected 1 generic argument"));
+  }
+
+  #[test]
+  fn rejects_recursive_type_slots() {
+    let name: Arc<str> = Arc::from("data-shape-recursive-slot");
+    super::super::push_type_slot_override(name.clone(), Arc::new(CalcitTypeAnnotation::TypeSlot(name.clone())));
+    let error = DataShapeGraph::build(&CalcitTypeAnnotation::TypeSlot(name.clone()), "tests.shape")
+      .expect_err("recursive slot must fail without overflowing the stack");
+    super::super::pop_type_slot_override(&name);
+
+    assert!(error.to_string().contains("recursive type slot"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn enforces_generic_where_bounds_while_deriving() {
+    let marker = Arc::new(CalcitTrait::new(EdnTag::new("DataMarker"), vec![], vec![]));
+    let bounded = Arc::new(CalcitStruct {
+      name: EdnTag::new("MarkedBox"),
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![CalcitGenericBound {
+        name: Arc::from("T"),
+        traits: Arc::new(vec![marker.clone()]),
+      }]),
+      impls: vec![],
+    });
+
+    let rejected = DataShapeGraph::build(
+      &CalcitTypeAnnotation::Struct(bounded.clone(), Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)])),
+      "tests.shape",
+    )
+    .expect_err("Number does not implement the nominal marker trait");
+    assert!(rejected.to_string().contains("does not satisfy"));
+
+    let mut marked_value = CalcitStruct::from_fields(EdnTag::new("MarkedValue"), vec![]);
+    marked_value.impls.push(Arc::new(CalcitImpl {
+      name: EdnTag::new("MarkedValueDataMarker"),
+      origin: Some(marker),
+      fields: Arc::new(vec![]),
+      values: Arc::new(vec![]),
+    }));
+    DataShapeGraph::build(
+      &CalcitTypeAnnotation::Struct(
+        bounded,
+        Arc::new(vec![Arc::new(CalcitTypeAnnotation::Struct(
+          Arc::new(marked_value),
+          Arc::new(vec![]),
+        ))]),
+      ),
+      "tests.shape",
+    )
+    .expect("nominal marker implementation should satisfy the bound");
+  }
+}

--- a/src/calcit/syntax_name.rs
+++ b/src/calcit/syntax_name.rs
@@ -75,6 +75,9 @@ pub enum CalcitSyntax {
   /// Explicitly attach a type annotation without a runtime validation.
   #[strum(serialize = "unsafe-coerce")]
   UnsafeCoerce,
+  /// Parse Cirru EDN and deeply validate/construct the declared closed type.
+  #[strum(serialize = "parse-cirru-edn-as")]
+  ParseCirruEdnAs,
   /// placeholder for trait requirement assertions
   #[strum(serialize = "assert-traits")]
   AssertTraits,
@@ -153,6 +156,11 @@ impl CalcitSyntax {
       UnsafeCoerce => Some(SyntaxTypeSignature {
         param_names: vec!["value", "type"],
         param_types: vec![dyn_t.clone(), dyn_t.clone()],
+        return_type: dyn_t.clone(),
+      }),
+      ParseCirruEdnAs => Some(SyntaxTypeSignature {
+        param_names: vec!["text", "type"],
+        param_types: vec![Arc::new(CalcitTypeAnnotation::String), dyn_t.clone()],
         return_type: dyn_t.clone(),
       }),
       AssertTraits => Some(SyntaxTypeSignature {

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -27,6 +27,7 @@ use crate::calcit::{self, CalcitArgLabel, CalcitFnArgs, CalcitImport, CalcitList
 use crate::calcit::{Calcit, CalcitSyntax, ImportInfo};
 use crate::call_stack::StackKind;
 use crate::codegen::skip_arity_check;
+use crate::data::edn_decode::{EdnDecodeNode, EdnDecoderGraph};
 use crate::program;
 use crate::util::string::{has_ns_part, matches_js_var, wrap_js_str};
 use args::{gen_args_code, gen_call_args_with_temps};
@@ -445,6 +446,19 @@ fn gen_call_code(
           )),
           None => Err(String::from("unsafe-coerce expected a value")),
         },
+        CalcitSyntax::ParseCirruEdnAs => match (body.first(), body.get(1)) {
+          (Some(text), Some(type_form)) if body.len() == 2 => {
+            let target = calcit::CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
+            let graph = EdnDecoderGraph::build(target.as_ref(), ns).map_err(|error| error.to_string())?;
+            let graph_code = edn_decoder_graph_to_js(&graph, ns, file_imports)?;
+            let text_code = to_js_code(text, ns, local_defs, file_imports, tags, None)?;
+            Ok(format!(
+              "{return_code}{}parse_cirru_edn_as({text_code}, {graph_code})",
+              get_proc_prefix(ns)
+            ))
+          }
+          _ => Err(format!("parse-cirru-edn-as expected a string and a type expression, got: {body}")),
+        },
         CalcitSyntax::AssertTraits => Ok(format!("{return_code}null")),
         CalcitSyntax::Match => gen_match_code(&body, local_defs, xs, ns, file_imports, tags, return_label),
         _ => {
@@ -727,6 +741,82 @@ fn gen_call_code(
       Ok(wrap_call_with_prelude(prelude, call_code, return_label, detect_await(&body)))
     }
   }
+}
+
+fn edn_decoder_graph_to_js(graph: &EdnDecoderGraph, current_ns: &str, file_imports: &RefCell<ImportsDict>) -> Result<String, String> {
+  let mut nodes = Vec::with_capacity(graph.nodes.len());
+  for node in &graph.nodes {
+    let code = match node {
+      EdnDecodeNode::Unit => String::from("{kind:\"unit\"}"),
+      EdnDecodeNode::Bool => String::from("{kind:\"bool\"}"),
+      EdnDecodeNode::Number => String::from("{kind:\"number\"}"),
+      EdnDecodeNode::String => String::from("{kind:\"string\"}"),
+      EdnDecodeNode::Symbol => String::from("{kind:\"symbol\"}"),
+      EdnDecodeNode::Tag => String::from("{kind:\"tag\"}"),
+      EdnDecodeNode::Buffer => String::from("{kind:\"buffer\"}"),
+      EdnDecodeNode::CirruQuote => String::from("{kind:\"cirru-quote\"}"),
+      EdnDecodeNode::Optional(inner) => format!("{{kind:\"optional\",inner:{inner}}}"),
+      EdnDecodeNode::List(inner) => format!("{{kind:\"list\",inner:{inner}}}"),
+      EdnDecodeNode::Set(inner) => format!("{{kind:\"set\",inner:{inner}}}"),
+      EdnDecodeNode::Map { key, value } => format!("{{kind:\"map\",key:{key},value:{value}}}"),
+      EdnDecodeNode::Ref(inner) => format!("{{kind:\"ref\",inner:{inner}}}"),
+      EdnDecodeNode::Struct { nominal_path, fields, .. } => {
+        let nominal = nominal_ref_to_js(nominal_path.as_ref(), current_ns, file_imports)?;
+        let fields = fields
+          .iter()
+          .map(|(field, node_id)| format!("[{},{}]", escape_cirru_str(field.ref_str()), node_id))
+          .collect::<Vec<_>>()
+          .join(",");
+        format!("{{kind:\"struct\",nominal:{nominal},fields:[{fields}]}}")
+      }
+      EdnDecodeNode::Enum {
+        nominal_path, variants, ..
+      } => {
+        let nominal = nominal_ref_to_js(nominal_path.as_ref(), current_ns, file_imports)?;
+        let variants = variants
+          .iter()
+          .map(|(tag, payloads)| {
+            let payloads = payloads.iter().map(usize::to_string).collect::<Vec<_>>().join(",");
+            format!("{{tag:{},payload:[{payloads}]}}", escape_cirru_str(tag.ref_str()))
+          })
+          .collect::<Vec<_>>()
+          .join(",");
+        format!("{{kind:\"enum\",nominal:{nominal},variants:[{variants}]}}")
+      }
+    };
+    nodes.push(code);
+  }
+  Ok(format!("{{root:{},nodes:[{}]}}", graph.root, nodes.join(",")))
+}
+
+fn nominal_ref_to_js(
+  path: Option<&(Arc<str>, Arc<str>)>,
+  current_ns: &str,
+  file_imports: &RefCell<ImportsDict>,
+) -> Result<String, String> {
+  let Some((target_ns, target_def)) = path else {
+    return Err(String::from(
+      "parse-cirru-edn-as cannot emit JS for a nominal type without a namespace/definition path",
+    ));
+  };
+  if target_ns.as_ref() == current_ns {
+    return Ok(escape_var(target_def));
+  }
+  if target_ns.as_ref() == calcit::CORE_NS {
+    return Ok(format!("{}{}", get_proc_prefix(current_ns), escape_var(target_def)));
+  }
+
+  file_imports.borrow_mut().insert(CalcitImport {
+    ns: target_ns.clone(),
+    def: target_def.clone(),
+    info: Arc::new(ImportInfo::NsAs {
+      at_ns: Arc::from(current_ns),
+      at_def: Arc::from("parse-cirru-edn-as"),
+      alias: target_ns.clone(),
+    }),
+    def_id: None,
+  });
+  Ok(format!("{}.{}", escape_ns(target_ns), escape_var(target_def)))
 }
 
 /// a group of arguments related to scopes

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -447,15 +447,18 @@ fn gen_call_code(
           None => Err(String::from("unsafe-coerce expected a value")),
         },
         CalcitSyntax::ParseCirruEdnAs => match (body.first(), body.get(1)) {
-          (Some(text), Some(type_form)) if body.len() == 2 => {
-            let target = calcit::CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
-            let graph = EdnDecoderGraph::build(target.as_ref(), ns).map_err(|error| error.to_string())?;
-            let graph_code = edn_decoder_graph_to_js(&graph, ns, file_imports)?;
+          (Some(text), Some(type_form)) if body.len() == 2 || body.len() == 3 => {
+            let graph = match body.get(2).and_then(EdnDecoderGraph::from_calcit_handle) {
+              Some(graph) => graph,
+              None => {
+                let target = calcit::CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
+                Arc::new(EdnDecoderGraph::build(target.as_ref(), ns).map_err(|error| error.to_string())?)
+              }
+            };
+            let graph_code = edn_decoder_graph_to_js(graph.as_ref(), ns, file_imports)?;
             let text_code = to_js_code(text, ns, local_defs, file_imports, tags, None)?;
-            Ok(format!(
-              "{return_code}{}parse_cirru_edn_as({text_code}, {graph_code})",
-              get_proc_prefix(ns)
-            ))
+            let call_code = format!("{}parse_cirru_edn_as({text_code}, {graph_code})", get_proc_prefix(ns));
+            Ok(wrap_call_with_prelude(String::new(), call_code, return_label, detect_await(&body)))
           }
           _ => Err(format!("parse-cirru-edn-as expected a string and a type expression, got: {body}")),
         },

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -23,11 +23,11 @@ use cirru_edn::EdnTag;
 use crate::builtins::meta::{js_gensym, reset_js_gensym_index};
 use crate::builtins::syntax::get_raw_args_fn;
 use crate::builtins::{is_js_syntax_procs, is_proc_name};
+use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
 use crate::calcit::{self, CalcitArgLabel, CalcitFnArgs, CalcitImport, CalcitList, CalcitLocal, CalcitProc, MethodKind};
 use crate::calcit::{Calcit, CalcitSyntax, ImportInfo};
 use crate::call_stack::StackKind;
 use crate::codegen::skip_arity_check;
-use crate::data::edn_decode::{EdnDecodeNode, EdnDecoderGraph};
 use crate::program;
 use crate::util::string::{has_ns_part, matches_js_var, wrap_js_str};
 use args::{gen_args_code, gen_call_args_with_temps};
@@ -448,14 +448,14 @@ fn gen_call_code(
         },
         CalcitSyntax::ParseCirruEdnAs => match (body.first(), body.get(1)) {
           (Some(text), Some(type_form)) if body.len() == 2 || body.len() == 3 => {
-            let graph = match body.get(2).and_then(EdnDecoderGraph::from_calcit_handle) {
+            let graph = match body.get(2).and_then(DataShapeGraph::from_calcit_handle) {
               Some(graph) => graph,
               None => {
                 let target = calcit::CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
-                Arc::new(EdnDecoderGraph::build(target.as_ref(), ns).map_err(|error| error.to_string())?)
+                Arc::new(DataShapeGraph::build(target.as_ref(), ns).map_err(|error| error.to_string())?)
               }
             };
-            let graph_code = edn_decoder_graph_to_js(graph.as_ref(), ns, file_imports)?;
+            let graph_code = data_shape_graph_to_js(graph.as_ref(), ns, file_imports)?;
             let text_code = to_js_code(text, ns, local_defs, file_imports, tags, None)?;
             let call_code = format!("{}parse_cirru_edn_as({text_code}, {graph_code})", get_proc_prefix(ns));
             Ok(wrap_call_with_prelude(String::new(), call_code, return_label, detect_await(&body)))
@@ -746,24 +746,24 @@ fn gen_call_code(
   }
 }
 
-fn edn_decoder_graph_to_js(graph: &EdnDecoderGraph, current_ns: &str, file_imports: &RefCell<ImportsDict>) -> Result<String, String> {
+fn data_shape_graph_to_js(graph: &DataShapeGraph, current_ns: &str, file_imports: &RefCell<ImportsDict>) -> Result<String, String> {
   let mut nodes = Vec::with_capacity(graph.nodes.len());
   for node in &graph.nodes {
     let code = match node {
-      EdnDecodeNode::Unit => String::from("{kind:\"unit\"}"),
-      EdnDecodeNode::Bool => String::from("{kind:\"bool\"}"),
-      EdnDecodeNode::Number => String::from("{kind:\"number\"}"),
-      EdnDecodeNode::String => String::from("{kind:\"string\"}"),
-      EdnDecodeNode::Symbol => String::from("{kind:\"symbol\"}"),
-      EdnDecodeNode::Tag => String::from("{kind:\"tag\"}"),
-      EdnDecodeNode::Buffer => String::from("{kind:\"buffer\"}"),
-      EdnDecodeNode::CirruQuote => String::from("{kind:\"cirru-quote\"}"),
-      EdnDecodeNode::Optional(inner) => format!("{{kind:\"optional\",inner:{inner}}}"),
-      EdnDecodeNode::List(inner) => format!("{{kind:\"list\",inner:{inner}}}"),
-      EdnDecodeNode::Set(inner) => format!("{{kind:\"set\",inner:{inner}}}"),
-      EdnDecodeNode::Map { key, value } => format!("{{kind:\"map\",key:{key},value:{value}}}"),
-      EdnDecodeNode::Ref(inner) => format!("{{kind:\"ref\",inner:{inner}}}"),
-      EdnDecodeNode::Struct { nominal_path, fields, .. } => {
+      DataShapeNode::Unit => String::from("{kind:\"unit\"}"),
+      DataShapeNode::Bool => String::from("{kind:\"bool\"}"),
+      DataShapeNode::Number => String::from("{kind:\"number\"}"),
+      DataShapeNode::String => String::from("{kind:\"string\"}"),
+      DataShapeNode::Symbol => String::from("{kind:\"symbol\"}"),
+      DataShapeNode::Tag => String::from("{kind:\"tag\"}"),
+      DataShapeNode::Buffer => String::from("{kind:\"buffer\"}"),
+      DataShapeNode::CirruQuote => String::from("{kind:\"cirru-quote\"}"),
+      DataShapeNode::Optional(inner) => format!("{{kind:\"optional\",inner:{inner}}}"),
+      DataShapeNode::List(inner) => format!("{{kind:\"list\",inner:{inner}}}"),
+      DataShapeNode::Set(inner) => format!("{{kind:\"set\",inner:{inner}}}"),
+      DataShapeNode::Map { key, value } => format!("{{kind:\"map\",key:{key},value:{value}}}"),
+      DataShapeNode::Ref(inner) => format!("{{kind:\"ref\",inner:{inner}}}"),
+      DataShapeNode::Struct { nominal_path, fields, .. } => {
         let nominal = nominal_ref_to_js(nominal_path.as_ref(), current_ns, file_imports)?;
         let fields = fields
           .iter()
@@ -772,7 +772,7 @@ fn edn_decoder_graph_to_js(graph: &EdnDecoderGraph, current_ns: &str, file_impor
           .join(",");
         format!("{{kind:\"struct\",nominal:{nominal},fields:[{fields}]}}")
       }
-      EdnDecodeNode::Enum {
+      DataShapeNode::Enum {
         nominal_path, variants, ..
       } => {
         let nominal = nominal_ref_to_js(nominal_path.as_ref(), current_ns, file_imports)?;
@@ -789,7 +789,13 @@ fn edn_decoder_graph_to_js(graph: &EdnDecoderGraph, current_ns: &str, file_impor
     };
     nodes.push(code);
   }
-  Ok(format!("{{root:{},nodes:[{}]}}", graph.root, nodes.join(",")))
+  Ok(format!(
+    "{{version:{},root:{},fingerprint:{},nodes:[{}]}}",
+    graph.abi_version(),
+    graph.root,
+    escape_cirru_str(graph.fingerprint()),
+    nodes.join(",")
+  ))
 }
 
 fn nominal_ref_to_js(

--- a/src/data.rs
+++ b/src/data.rs
@@ -7,6 +7,7 @@ use crate::{
 
 pub mod cirru;
 pub mod edn;
+pub mod edn_decode;
 
 fn where_bounds_to_calcit_form(bounds: &[crate::calcit::CalcitGenericBound], ns: &str, at_def: &str) -> Option<Calcit> {
   if bounds.is_empty() {

--- a/src/data.rs
+++ b/src/data.rs
@@ -7,7 +7,7 @@ use crate::{
 
 pub mod cirru;
 pub mod edn;
-pub mod edn_decode;
+pub(crate) mod edn_decode;
 
 fn where_bounds_to_calcit_form(bounds: &[crate::calcit::CalcitGenericBound], ns: &str, at_def: &str) -> Option<Calcit> {
   if bounds.is_empty() {

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -27,6 +27,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u16>) -> Resul
       "~@" => Ok(Calcit::Syntax(CalcitSyntax::MacroInterpolateSpread, ns.into())),
       "assert-type" => Ok(Calcit::Syntax(CalcitSyntax::AssertType, ns.into())),
       "unsafe-coerce" => Ok(Calcit::Syntax(CalcitSyntax::UnsafeCoerce, ns.into())),
+      "parse-cirru-edn-as" => Ok(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, ns.into())),
       "assert-traits" => Ok(Calcit::Syntax(CalcitSyntax::AssertTraits, ns.into())),
       "" => Err(String::from("Empty string is invalid")),
       // special tuple syntax
@@ -309,6 +310,17 @@ mod tests {
     assert!(matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::AssertType, _))));
     assert!(matches!(items.get(1), Some(Calcit::Symbol { .. })));
     assert!(matches!(items.get(2), Some(Calcit::Tag(_))));
+  }
+
+  #[test]
+  fn parses_strict_edn_decode_as_syntax() {
+    let expr = Cirru::List(vec![Cirru::leaf("parse-cirru-edn-as"), Cirru::leaf("|do 1"), Cirru::leaf("Number")]);
+
+    let calcit = code_to_calcit(&expr, "tests.ns", "demo", vec![]).expect("parse strict EDN decoder");
+    let Calcit::List(items) = calcit else {
+      panic!("expected list");
+    };
+    assert!(matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _))));
   }
 
   #[test]

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -453,28 +453,14 @@ pub fn edn_to_calcit(x: &Edn, options: &Calcit) -> Calcit {
         values.push(edn_to_calcit(&v.1, options));
       }
 
-      match find_record_in_options(&name.arc_str(), options) {
-        Some(Calcit::Record(CalcitRecord {
-          struct_ref: pre_struct,
-          values: _pre_values,
-        })) => {
-          if fields == **pre_struct.fields {
-            Calcit::Record(CalcitRecord {
-              struct_ref: pre_struct.to_owned(),
-              values: Arc::new(values),
-            })
-          } else {
-            Calcit::Record(CalcitRecord {
-              struct_ref: Arc::new(CalcitStruct::from_fields(name.to_owned(), fields)),
-              values: Arc::new(values),
-            })
-          }
-        }
-        _ => Calcit::Record(CalcitRecord {
-          struct_ref: Arc::new(CalcitStruct::from_fields(name.to_owned(), fields)),
-          values: Arc::new(values),
-        }),
-      }
+      let struct_ref = match find_record_in_options(&name.arc_str(), options) {
+        Some(Calcit::Record(record)) if fields == *record.struct_ref.fields => Arc::clone(&record.struct_ref),
+        _ => Arc::new(CalcitStruct::from_fields(name.to_owned(), fields)),
+      };
+      Calcit::Record(CalcitRecord {
+        struct_ref,
+        values: Arc::new(values),
+      })
     }
     Edn::Buffer(buf) => Calcit::Buffer(buf.to_owned()),
     Edn::AnyRef(r) => Calcit::AnyRef(r.to_owned()),

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -464,7 +464,10 @@ pub fn edn_to_calcit(x: &Edn, options: &Calcit) -> Calcit {
               values: Arc::new(values),
             })
           } else {
-            unreachable!("record fields mismatch: {:?} vs {:?}", fields, pre_struct.fields)
+            Calcit::Record(CalcitRecord {
+              struct_ref: Arc::new(CalcitStruct::from_fields(name.to_owned(), fields)),
+              values: Arc::new(values),
+            })
           }
         }
         _ => Calcit::Record(CalcitRecord {
@@ -548,5 +551,28 @@ mod tests {
     let err_msg = format_deserialize_error("Cannot deserialize Edn type: record `Expr`", &Edn::Record(expr));
     assert!(err_msg.contains("ns app.demo"), "err={err_msg}");
     assert!(!err_msg.contains("legacy-expr"), "err={err_msg}");
+  }
+
+  #[test]
+  fn dynamic_record_options_do_not_panic_on_field_mismatch() {
+    let declared = Arc::new(CalcitStruct::from_fields(
+      EdnTag::new("Person"),
+      vec![EdnTag::new("age"), EdnTag::new("name")],
+    ));
+    let prototype = Calcit::Record(CalcitRecord {
+      struct_ref: declared.clone(),
+      values: Arc::new(vec![Calcit::Nil, Calcit::Nil]),
+    });
+    let mut options = rpds::HashTrieMap::new_sync();
+    options.insert_mut(Calcit::tag("Person"), prototype);
+
+    let mut input = EdnRecordView::new(EdnTag::new("Person"));
+    input.insert(EdnTag::new("name"), Edn::str("Ada"));
+    let decoded = edn_to_calcit(&Edn::Record(input), &Calcit::Map(options));
+    let Calcit::Record(record) = decoded else {
+      panic!("expected record");
+    };
+    assert!(!Arc::ptr_eq(&record.struct_ref, &declared));
+    assert_eq!(record.fields().as_slice(), &[EdnTag::new("name")]);
   }
 }

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -11,14 +11,14 @@ use crate::program;
 
 const MAX_DECODE_DEPTH: usize = 1024;
 
-#[derive(Debug, Clone)]
-pub struct EdnDecoderGraph {
-  pub root: usize,
-  pub nodes: Vec<EdnDecodeNode>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EdnDecoderGraph {
+  pub(crate) root: usize,
+  pub(crate) nodes: Vec<EdnDecodeNode>,
 }
 
-#[derive(Debug, Clone)]
-pub enum EdnDecodeNode {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EdnDecodeNode {
   Unit,
   Bool,
   Number,
@@ -48,7 +48,7 @@ pub enum EdnDecodeNode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EdnDecodeTypeError {
+pub(crate) struct EdnDecodeTypeError {
   message: String,
 }
 
@@ -65,9 +65,9 @@ impl fmt::Display for EdnDecodeTypeError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EdnDecodeError {
-  pub path: String,
-  pub message: String,
+pub(crate) struct EdnDecodeError {
+  pub(crate) path: String,
+  pub(crate) message: String,
 }
 
 impl EdnDecodeError {
@@ -89,14 +89,16 @@ struct GraphBuilder {
   nodes: Vec<Option<EdnDecodeNode>>,
   nominal_nodes: HashMap<String, usize>,
   resolving_aliases: HashSet<String>,
+  resolving_slots: HashSet<String>,
 }
 
 impl EdnDecoderGraph {
-  pub fn build(target: &CalcitTypeAnnotation, default_ns: &str) -> Result<Self, EdnDecodeTypeError> {
+  pub(crate) fn build(target: &CalcitTypeAnnotation, default_ns: &str) -> Result<Self, EdnDecodeTypeError> {
     let mut builder = GraphBuilder {
       nodes: vec![],
       nominal_nodes: HashMap::new(),
       resolving_aliases: HashSet::new(),
+      resolving_slots: HashSet::new(),
     };
     let root = builder.build_type(target, default_ns)?;
     let nodes = builder
@@ -108,8 +110,36 @@ impl EdnDecoderGraph {
     Ok(Self { root, nodes })
   }
 
-  pub fn decode(&self, input: &Edn) -> Result<Calcit, EdnDecodeError> {
+  pub(crate) fn decode(&self, input: &Edn) -> Result<Calcit, EdnDecodeError> {
     self.decode_node(self.root, input, "$", 0)
+  }
+
+  pub(crate) fn into_calcit_handle(self) -> Calcit {
+    Calcit::AnyRef(cirru_edn::EdnAnyRef::new(Arc::new(self)))
+  }
+
+  pub(crate) fn from_calcit_handle(value: &Calcit) -> Option<Arc<Self>> {
+    let Calcit::AnyRef(reference) = value else {
+      return None;
+    };
+    let guard = reference.0.read().ok()?;
+    guard.as_any().downcast_ref::<Arc<Self>>().cloned()
+  }
+
+  pub(crate) fn nominal_paths(&self) -> Vec<(Arc<str>, Arc<str>)> {
+    let mut paths = Vec::new();
+    for node in &self.nodes {
+      let path = match node {
+        EdnDecodeNode::Struct { nominal_path, .. } | EdnDecodeNode::Enum { nominal_path, .. } => nominal_path,
+        _ => continue,
+      };
+      if let Some(path) = path
+        && !paths.contains(path)
+      {
+        paths.push(path.clone());
+      }
+    }
+    paths
   }
 
   fn decode_node(&self, node_id: usize, input: &Edn, path: &str, depth: usize) -> Result<Calcit, EdnDecodeError> {
@@ -217,6 +247,13 @@ impl EdnDecoderGraph {
 
           let expected_names: HashSet<&str> = fields.iter().map(|(field, _)| field.ref_str()).collect();
           let actual_names: HashSet<&str> = pairs.iter().map(|(field, _)| field.ref_str()).collect();
+          if actual_names.len() != pairs.len() {
+            let duplicates = sorted_duplicate_names(pairs.iter().map(|(field, _)| field.ref_str()));
+            return Err(EdnDecodeError::at(
+              path,
+              format!("record :{} has duplicate fields [{}]", nominal.name, duplicates.join(", ")),
+            ));
+          }
           if expected_names != actual_names {
             let missing = sorted_name_diff(&expected_names, &actual_names);
             let unknown = sorted_name_diff(&actual_names, &expected_names);
@@ -353,7 +390,17 @@ impl GraphBuilder {
       }
       CalcitTypeAnnotation::TypeRef(name, args) => self.build_named(name, args, default_ns),
       CalcitTypeAnnotation::TypeSlot(name) => match calcit::resolve_type_slot(name) {
-        Some(resolved) => self.build_type(&resolved, default_ns),
+        Some(resolved) => {
+          let slot_key = name.to_string();
+          if !self.resolving_slots.insert(slot_key.clone()) {
+            return Err(EdnDecodeTypeError::new(format!(
+              "parse-cirru-edn-as found a recursive type slot at `*{name}`"
+            )));
+          }
+          let result = self.build_type(&resolved, default_ns);
+          self.resolving_slots.remove(&slot_key);
+          result
+        }
         None => Err(EdnDecodeTypeError::new(format!(
           "parse-cirru-edn-as cannot derive a decoder for unbound type slot `*{name}`"
         ))),
@@ -596,6 +643,19 @@ fn sorted_name_diff<'a>(left: &HashSet<&'a str>, right: &HashSet<&'a str>) -> Ve
   values
 }
 
+fn sorted_duplicate_names<'a>(values: impl IntoIterator<Item = &'a str>) -> Vec<&'a str> {
+  let mut seen = HashSet::new();
+  let mut duplicates = HashSet::new();
+  for value in values {
+    if !seen.insert(value) {
+      duplicates.insert(value);
+    }
+  }
+  let mut values: Vec<&str> = duplicates.into_iter().collect();
+  values.sort_unstable();
+  values
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -638,6 +698,17 @@ mod tests {
   }
 
   #[test]
+  fn rejects_duplicate_struct_fields() {
+    let person = person_struct();
+    let graph =
+      EdnDecoderGraph::build(&CalcitTypeAnnotation::Struct(person, Arc::new(vec![])), "tests.edn").expect("derive person decoder");
+    let input = cirru_edn::parse("%{} :Person (:age 23) (:age 24) (:name |Ada)").expect("parse duplicate fields");
+    let error = graph.decode(&input).expect_err("duplicate fields must fail");
+    assert_eq!(error.path, "$");
+    assert!(error.message.contains("duplicate fields [age]"), "unexpected error: {error}");
+  }
+
+  #[test]
   fn rejects_dynamic_and_incomplete_generic_types() {
     let dynamic = EdnDecoderGraph::build(&CalcitTypeAnnotation::Dynamic, "tests.edn").expect_err("dynamic must fail");
     assert!(dynamic.to_string().contains("Dynamic is forbidden"));
@@ -653,6 +724,17 @@ mod tests {
     let incomplete = EdnDecoderGraph::build(&CalcitTypeAnnotation::Struct(generic, Arc::new(vec![])), "tests.edn")
       .expect_err("missing generic argument must fail");
     assert!(incomplete.to_string().contains("expected 1 generic argument"));
+  }
+
+  #[test]
+  fn rejects_recursive_type_slots() {
+    let name: Arc<str> = Arc::from("strict-edn-recursive-slot");
+    calcit::push_type_slot_override(name.clone(), Arc::new(CalcitTypeAnnotation::TypeSlot(name.clone())));
+    let error = EdnDecoderGraph::build(&CalcitTypeAnnotation::TypeSlot(name.clone()), "tests.edn")
+      .expect_err("recursive slot must fail without overflowing the stack");
+    calcit::pop_type_slot_override(&name);
+
+    assert!(error.to_string().contains("recursive type slot"), "unexpected error: {error}");
   }
 
   #[test]

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -115,7 +115,12 @@ impl Decoder<'_> {
         Edn::Set(items) => {
           let mut values = rpds::HashTrieSet::new_sync();
           for item in items.0.iter() {
-            values.insert_mut(self.decode_node(*inner, item, &format!("{path}.item"), depth + 1)?);
+            let item_path = format!("{path}.item");
+            let decoded = self.decode_node(*inner, item, &item_path, depth + 1)?;
+            if values.contains(&decoded) {
+              return Err(EdnDecodeError::at(&item_path, "duplicate decoded set value"));
+            }
+            values.insert_mut(decoded);
           }
           Ok(Calcit::Set(values))
         }
@@ -125,7 +130,11 @@ impl Decoder<'_> {
         Edn::Map(entries) => {
           let mut values = rpds::HashTrieMap::new_sync();
           for (raw_key, raw_value) in entries.0.iter() {
-            let decoded_key = self.decode_node(*key, raw_key, &format!("{path}.key"), depth + 1)?;
+            let key_path = format!("{path}.key");
+            let decoded_key = self.decode_node(*key, raw_key, &key_path, depth + 1)?;
+            if values.contains_key(&decoded_key) {
+              return Err(EdnDecodeError::at(&key_path, "duplicate decoded map key"));
+            }
             let decoded_value = self.decode_node(*value, raw_value, &format!("{path}.value"), depth + 1)?;
             values.insert_mut(decoded_key, decoded_value);
           }
@@ -342,6 +351,53 @@ mod tests {
     let error = decode(&shape, &input).expect_err("duplicate fields must fail");
     assert_eq!(error.path, "$");
     assert!(error.message.contains("duplicate fields [age]"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn rejects_duplicate_decoded_set_values() {
+    let target = CalcitTypeAnnotation::Set(Arc::new(CalcitTypeAnnotation::Struct(person_struct(), Arc::new(vec![]))));
+    let shape = DataShapeGraph::build(&target, "tests.edn").expect("derive person set shape");
+    let input = cirru_edn::parse("#{} (%{} :Person (:age 23) (:name |Ada)) (%{} :Person (:name |Ada) (:age 23))")
+      .expect("parse colliding set values");
+    let error = decode(&shape, &input).expect_err("decoded set values must remain unique");
+    assert_eq!(error.path, "$.item");
+    assert_eq!(error.message, "duplicate decoded set value");
+  }
+
+  #[test]
+  fn rejects_duplicate_decoded_map_keys() {
+    let key = Arc::new(CalcitTypeAnnotation::Struct(person_struct(), Arc::new(vec![])));
+    let target = CalcitTypeAnnotation::Map(key, Arc::new(CalcitTypeAnnotation::String));
+    let shape = DataShapeGraph::build(&target, "tests.edn").expect("derive person map shape");
+    let input = cirru_edn::parse("{} ((%{} :Person (:age 23) (:name |Ada)) |first) ((%{} :Person (:name |Ada) (:age 23)) |second)")
+      .expect("parse colliding map keys");
+    let error = decode(&shape, &input).expect_err("decoded map keys must remain unique");
+    assert_eq!(error.path, "$.key");
+    assert_eq!(error.message, "duplicate decoded map key");
+  }
+
+  #[test]
+  fn decodes_unique_set_values_and_map_keys() {
+    let person = Arc::new(CalcitTypeAnnotation::Struct(person_struct(), Arc::new(vec![])));
+    let set_shape = DataShapeGraph::build(&CalcitTypeAnnotation::Set(person.clone()), "tests.edn").expect("derive person set shape");
+    let set_input = cirru_edn::parse("#{} (%{} :Person (:age 23) (:name |Ada)) (%{} :Person (:age 24) (:name |Bob))")
+      .expect("parse unique set values");
+    let Calcit::Set(set) = decode(&set_shape, &set_input).expect("decode unique set values") else {
+      panic!("expected set");
+    };
+    assert_eq!(set.size(), 2);
+
+    let map_shape = DataShapeGraph::build(
+      &CalcitTypeAnnotation::Map(person, Arc::new(CalcitTypeAnnotation::String)),
+      "tests.edn",
+    )
+    .expect("derive person map shape");
+    let map_input = cirru_edn::parse("{} ((%{} :Person (:age 23) (:name |Ada)) |first) ((%{} :Person (:age 24) (:name |Bob)) |second)")
+      .expect("parse unique map keys");
+    let Calcit::Map(map) = decode(&map_shape, &map_input).expect("decode unique map keys") else {
+      panic!("expected map");
+    };
+    assert_eq!(map.size(), 2);
   }
 
   #[test]

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -1,68 +1,14 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
 
-use cirru_edn::{Edn, EdnRecordView, EdnTag, EdnTupleView};
+use cirru_edn::{Edn, EdnRecordView, EdnTupleView};
 
 use crate::builtins::quick_build_atom;
-use crate::calcit::type_annotation::{TypeBindings, validate_runtime_generic_where_bounds};
-use crate::calcit::{self, Calcit, CalcitEnum, CalcitList, CalcitRecord, CalcitStruct, CalcitTuple, CalcitTypeAnnotation};
-use crate::program;
+use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
+use crate::calcit::{self, Calcit, CalcitList, CalcitRecord, CalcitTuple};
 
 const MAX_DECODE_DEPTH: usize = 1024;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct EdnDecoderGraph {
-  pub(crate) root: usize,
-  pub(crate) nodes: Vec<EdnDecodeNode>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum EdnDecodeNode {
-  Unit,
-  Bool,
-  Number,
-  String,
-  Symbol,
-  Tag,
-  Buffer,
-  CirruQuote,
-  Optional(usize),
-  List(usize),
-  Set(usize),
-  Map {
-    key: usize,
-    value: usize,
-  },
-  Ref(usize),
-  Struct {
-    nominal: Arc<CalcitStruct>,
-    nominal_path: Option<(Arc<str>, Arc<str>)>,
-    fields: Vec<(EdnTag, usize)>,
-  },
-  Enum {
-    nominal: Arc<CalcitEnum>,
-    nominal_path: Option<(Arc<str>, Arc<str>)>,
-    variants: Vec<(EdnTag, Vec<usize>)>,
-  },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct EdnDecodeTypeError {
-  message: String,
-}
-
-impl EdnDecodeTypeError {
-  fn new(message: impl Into<String>) -> Self {
-    Self { message: message.into() }
-  }
-}
-
-impl fmt::Display for EdnDecodeTypeError {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.write_str(&self.message)
-  }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EdnDecodeError {
@@ -85,89 +31,47 @@ impl fmt::Display for EdnDecodeError {
   }
 }
 
-struct GraphBuilder {
-  nodes: Vec<Option<EdnDecodeNode>>,
-  nominal_nodes: HashMap<String, usize>,
-  resolving_aliases: HashSet<String>,
-  resolving_slots: HashSet<String>,
+pub(crate) fn decode(shape: &DataShapeGraph, input: &Edn) -> Result<Calcit, EdnDecodeError> {
+  let value = Decoder { shape }.decode_node(shape.root, input, "$", 0)?;
+  if cfg!(debug_assertions) {
+    shape
+      .validate_value(&value)
+      .map_err(|error| EdnDecodeError::at(&error.path, format!("internal data shape invariant failed: {}", error.message)))?;
+  }
+  Ok(value)
 }
 
-impl EdnDecoderGraph {
-  pub(crate) fn build(target: &CalcitTypeAnnotation, default_ns: &str) -> Result<Self, EdnDecodeTypeError> {
-    let mut builder = GraphBuilder {
-      nodes: vec![],
-      nominal_nodes: HashMap::new(),
-      resolving_aliases: HashSet::new(),
-      resolving_slots: HashSet::new(),
-    };
-    let root = builder.build_type(target, default_ns)?;
-    let nodes = builder
-      .nodes
-      .into_iter()
-      .enumerate()
-      .map(|(idx, node)| node.ok_or_else(|| EdnDecodeTypeError::new(format!("decoder graph node #{idx} was not completed"))))
-      .collect::<Result<Vec<_>, _>>()?;
-    Ok(Self { root, nodes })
-  }
+struct Decoder<'a> {
+  shape: &'a DataShapeGraph,
+}
 
-  pub(crate) fn decode(&self, input: &Edn) -> Result<Calcit, EdnDecodeError> {
-    self.decode_node(self.root, input, "$", 0)
-  }
-
-  pub(crate) fn into_calcit_handle(self) -> Calcit {
-    Calcit::AnyRef(cirru_edn::EdnAnyRef::new(Arc::new(self)))
-  }
-
-  pub(crate) fn from_calcit_handle(value: &Calcit) -> Option<Arc<Self>> {
-    let Calcit::AnyRef(reference) = value else {
-      return None;
-    };
-    let guard = reference.0.read().ok()?;
-    guard.as_any().downcast_ref::<Arc<Self>>().cloned()
-  }
-
-  pub(crate) fn nominal_paths(&self) -> Vec<(Arc<str>, Arc<str>)> {
-    let mut paths = Vec::new();
-    for node in &self.nodes {
-      let path = match node {
-        EdnDecodeNode::Struct { nominal_path, .. } | EdnDecodeNode::Enum { nominal_path, .. } => nominal_path,
-        _ => continue,
-      };
-      if let Some(path) = path
-        && !paths.contains(path)
-      {
-        paths.push(path.clone());
-      }
-    }
-    paths
-  }
-
+impl Decoder<'_> {
   fn decode_node(&self, node_id: usize, input: &Edn, path: &str, depth: usize) -> Result<Calcit, EdnDecodeError> {
     if depth > MAX_DECODE_DEPTH {
       return Err(EdnDecodeError::at(path, format!("decode nesting exceeds {MAX_DECODE_DEPTH}")));
     }
-    let Some(node) = self.nodes.get(node_id) else {
-      return Err(EdnDecodeError::at(path, format!("invalid decoder graph node #{node_id}")));
+    let Some(node) = self.shape.nodes.get(node_id) else {
+      return Err(EdnDecodeError::at(path, format!("invalid data shape node #{node_id}")));
     };
 
     match node {
-      EdnDecodeNode::Unit => match input {
+      DataShapeNode::Unit => match input {
         Edn::Nil => Ok(Calcit::Nil),
         _ => Err(kind_mismatch(path, "nil", input)),
       },
-      EdnDecodeNode::Bool => match input {
+      DataShapeNode::Bool => match input {
         Edn::Bool(value) => Ok(Calcit::Bool(*value)),
         _ => Err(kind_mismatch(path, "bool", input)),
       },
-      EdnDecodeNode::Number => match input {
+      DataShapeNode::Number => match input {
         Edn::Number(value) => Ok(Calcit::Number(*value)),
         _ => Err(kind_mismatch(path, "number", input)),
       },
-      EdnDecodeNode::String => match input {
+      DataShapeNode::String => match input {
         Edn::Str(value) => Ok(Calcit::Str(value.clone())),
         _ => Err(kind_mismatch(path, "string", input)),
       },
-      EdnDecodeNode::Symbol => match input {
+      DataShapeNode::Symbol => match input {
         Edn::Symbol(value) => Ok(Calcit::Symbol {
           sym: value.clone(),
           info: Arc::new(crate::calcit::CalcitSymbolInfo {
@@ -178,26 +82,26 @@ impl EdnDecoderGraph {
         }),
         _ => Err(kind_mismatch(path, "symbol", input)),
       },
-      EdnDecodeNode::Tag => match input {
+      DataShapeNode::Tag => match input {
         Edn::Tag(value) => Ok(Calcit::Tag(value.clone())),
         _ => Err(kind_mismatch(path, "tag", input)),
       },
-      EdnDecodeNode::Buffer => match input {
+      DataShapeNode::Buffer => match input {
         Edn::Buffer(value) => Ok(Calcit::Buffer(value.clone())),
         _ => Err(kind_mismatch(path, "buffer", input)),
       },
-      EdnDecodeNode::CirruQuote => match input {
+      DataShapeNode::CirruQuote => match input {
         Edn::Quote(value) => Ok(Calcit::CirruQuote(value.clone())),
         _ => Err(kind_mismatch(path, "cirru-quote", input)),
       },
-      EdnDecodeNode::Optional(inner) => {
+      DataShapeNode::Optional(inner) => {
         if matches!(input, Edn::Nil) {
           Ok(Calcit::Nil)
         } else {
           self.decode_node(*inner, input, path, depth + 1)
         }
       }
-      EdnDecodeNode::List(inner) => match input {
+      DataShapeNode::List(inner) => match input {
         Edn::List(items) => {
           let mut values = Vec::with_capacity(items.0.len());
           for (idx, item) in items.0.iter().enumerate() {
@@ -207,7 +111,7 @@ impl EdnDecoderGraph {
         }
         _ => Err(kind_mismatch(path, "list", input)),
       },
-      EdnDecodeNode::Set(inner) => match input {
+      DataShapeNode::Set(inner) => match input {
         Edn::Set(items) => {
           let mut values = rpds::HashTrieSet::new_sync();
           for item in items.0.iter() {
@@ -217,7 +121,7 @@ impl EdnDecoderGraph {
         }
         _ => Err(kind_mismatch(path, "set", input)),
       },
-      EdnDecodeNode::Map { key, value } => match input {
+      DataShapeNode::Map { key, value } => match input {
         Edn::Map(entries) => {
           let mut values = rpds::HashTrieMap::new_sync();
           for (raw_key, raw_value) in entries.0.iter() {
@@ -229,14 +133,14 @@ impl EdnDecoderGraph {
         }
         _ => Err(kind_mismatch(path, "map", input)),
       },
-      EdnDecodeNode::Ref(inner) => match input {
+      DataShapeNode::Ref(inner) => match input {
         Edn::Atom(value) => {
           let decoded = self.decode_node(*inner, value, &format!("{path}.value"), depth + 1)?;
           Ok(quick_build_atom(decoded))
         }
         _ => Err(kind_mismatch(path, "atom", input)),
       },
-      EdnDecodeNode::Struct { nominal, fields, .. } => match input {
+      DataShapeNode::Struct { nominal, fields, .. } => match input {
         Edn::Record(EdnRecordView { tag, pairs }) => {
           if tag != &nominal.name {
             return Err(EdnDecodeError::at(
@@ -283,7 +187,7 @@ impl EdnDecoderGraph {
         }
         _ => Err(kind_mismatch(path, &format!("record :{}", nominal.name), input)),
       },
-      EdnDecodeNode::Enum { nominal, variants, .. } => match input {
+      DataShapeNode::Enum { nominal, variants, .. } => match input {
         Edn::Tuple(EdnTupleView { tag, enum_tag, extra }) => {
           let Some(actual_enum_name) = enum_tag.as_deref().and_then(edn_name) else {
             return Err(EdnDecodeError::at(
@@ -332,276 +236,6 @@ impl EdnDecoderGraph {
       },
     }
   }
-}
-
-impl GraphBuilder {
-  fn push(&mut self, node: EdnDecodeNode) -> usize {
-    let id = self.nodes.len();
-    self.nodes.push(Some(node));
-    id
-  }
-
-  fn build_type(&mut self, target: &CalcitTypeAnnotation, default_ns: &str) -> Result<usize, EdnDecodeTypeError> {
-    match target {
-      CalcitTypeAnnotation::Unit => Ok(self.push(EdnDecodeNode::Unit)),
-      CalcitTypeAnnotation::Bool => Ok(self.push(EdnDecodeNode::Bool)),
-      CalcitTypeAnnotation::Number => Ok(self.push(EdnDecodeNode::Number)),
-      CalcitTypeAnnotation::String => Ok(self.push(EdnDecodeNode::String)),
-      CalcitTypeAnnotation::Symbol => Ok(self.push(EdnDecodeNode::Symbol)),
-      CalcitTypeAnnotation::Tag => Ok(self.push(EdnDecodeNode::Tag)),
-      CalcitTypeAnnotation::Buffer => Ok(self.push(EdnDecodeNode::Buffer)),
-      CalcitTypeAnnotation::CirruQuote => Ok(self.push(EdnDecodeNode::CirruQuote)),
-      CalcitTypeAnnotation::Optional(inner) => {
-        let inner = self.build_type(inner, default_ns)?;
-        Ok(self.push(EdnDecodeNode::Optional(inner)))
-      }
-      CalcitTypeAnnotation::List(inner) => {
-        let inner = self.build_type(inner, default_ns)?;
-        Ok(self.push(EdnDecodeNode::List(inner)))
-      }
-      CalcitTypeAnnotation::Set(inner) => {
-        let inner = self.build_type(inner, default_ns)?;
-        Ok(self.push(EdnDecodeNode::Set(inner)))
-      }
-      CalcitTypeAnnotation::Map(key, value) => {
-        let key = self.build_type(key, default_ns)?;
-        let value = self.build_type(value, default_ns)?;
-        Ok(self.push(EdnDecodeNode::Map { key, value }))
-      }
-      CalcitTypeAnnotation::Ref(inner) => {
-        let inner = self.build_type(inner, default_ns)?;
-        Ok(self.push(EdnDecodeNode::Ref(inner)))
-      }
-      CalcitTypeAnnotation::Struct(nominal, args) => {
-        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
-        self.build_struct(nominal.clone(), args, path, default_ns)
-      }
-      CalcitTypeAnnotation::Record(nominal) => {
-        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
-        self.build_struct(nominal.clone(), &Arc::new(vec![]), path, default_ns)
-      }
-      CalcitTypeAnnotation::Enum(nominal, args) => {
-        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
-        self.build_enum(nominal.clone(), args, path, default_ns)
-      }
-      CalcitTypeAnnotation::Tuple(nominal) => {
-        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
-        self.build_enum(nominal.clone(), &Arc::new(vec![]), path, default_ns)
-      }
-      CalcitTypeAnnotation::TypeRef(name, args) => self.build_named(name, args, default_ns),
-      CalcitTypeAnnotation::TypeSlot(name) => match calcit::resolve_type_slot(name) {
-        Some(resolved) => {
-          let slot_key = name.to_string();
-          if !self.resolving_slots.insert(slot_key.clone()) {
-            return Err(EdnDecodeTypeError::new(format!(
-              "parse-cirru-edn-as found a recursive type slot at `*{name}`"
-            )));
-          }
-          let result = self.build_type(&resolved, default_ns);
-          self.resolving_slots.remove(&slot_key);
-          result
-        }
-        None => Err(EdnDecodeTypeError::new(format!(
-          "parse-cirru-edn-as cannot derive a decoder for unbound type slot `*{name}`"
-        ))),
-      },
-      CalcitTypeAnnotation::Dynamic => Err(unsupported_type("Dynamic is forbidden in a strict decoder")),
-      CalcitTypeAnnotation::TypeVar(name) => Err(unsupported_type(&format!("generic variable '{name} is not bound"))),
-      CalcitTypeAnnotation::DynTuple => Err(unsupported_type("ordinary tuple has no declared enum schema")),
-      CalcitTypeAnnotation::DynFn | CalcitTypeAnnotation::Fn(_) => Err(unsupported_type("function values are not EDN data")),
-      CalcitTypeAnnotation::Trait(_) | CalcitTypeAnnotation::TraitSet(_) => {
-        Err(unsupported_type("trait constraints are not serializable data types"))
-      }
-      CalcitTypeAnnotation::JsObject => Err(unsupported_type("JsObject is an opaque host value")),
-      CalcitTypeAnnotation::Custom(value) => Err(unsupported_type(&format!("custom type `{value}` is not decodable"))),
-      CalcitTypeAnnotation::Variadic(_) => Err(unsupported_type("Variadic is a function parameter constraint")),
-    }
-  }
-
-  fn build_named(
-    &mut self,
-    name: &str,
-    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
-    default_ns: &str,
-  ) -> Result<usize, EdnDecodeTypeError> {
-    let (ns, def) = qualify_type_ref(name, default_ns);
-    let qualified = CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), args.clone());
-    if let Some(struct_def) = qualified.resolve_to_struct() {
-      return self.build_struct(Arc::new(struct_def), args, Some((ns, def)), default_ns);
-    }
-    if let Some(enum_def) = qualified.resolve_to_enum() {
-      return self.build_enum(Arc::new(enum_def), args, Some((ns, def)), default_ns);
-    }
-
-    let schema = program::lookup_def_schema(&ns, &def);
-    if !matches!(schema.as_ref(), CalcitTypeAnnotation::Dynamic)
-      && !matches!(schema.as_ref(), CalcitTypeAnnotation::TypeRef(schema_name, _) if schema_name.as_ref() == name)
-    {
-      if !args.is_empty() {
-        return Err(EdnDecodeTypeError::new(format!(
-          "parse-cirru-edn-as cannot apply generic arguments to type alias `{ns}/{def}`"
-        )));
-      }
-      let alias_key = format!("{ns}/{def}");
-      if !self.resolving_aliases.insert(alias_key.clone()) {
-        return Err(EdnDecodeTypeError::new(format!(
-          "parse-cirru-edn-as found a recursive type alias at `{alias_key}`; recursive data must use a nominal struct or enum"
-        )));
-      }
-      let result = self.build_type(schema.as_ref(), &ns);
-      self.resolving_aliases.remove(&alias_key);
-      return result;
-    }
-
-    Err(EdnDecodeTypeError::new(format!(
-      "parse-cirru-edn-as cannot resolve named type `{ns}/{def}`"
-    )))
-  }
-
-  fn build_struct(
-    &mut self,
-    nominal: Arc<CalcitStruct>,
-    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
-    nominal_path: Option<(Arc<str>, Arc<str>)>,
-    default_ns: &str,
-  ) -> Result<usize, EdnDecodeTypeError> {
-    validate_generic_application(&nominal.name.to_string(), &nominal.generics, args)?;
-    if nominal.fields.len() != nominal.field_types.len() {
-      return Err(EdnDecodeTypeError::new(format!(
-        "parse-cirru-edn-as cannot derive `{}`: {} fields but {} field types",
-        nominal.name,
-        nominal.fields.len(),
-        nominal.field_types.len()
-      )));
-    }
-    let owner_ns = nominal_path.as_ref().map(|(ns, _)| ns.as_ref()).unwrap_or(default_ns);
-    for arg in args.iter() {
-      self.build_type(arg, owner_ns)?;
-    }
-    let bindings = generic_bindings(&nominal.generics, args);
-    validate_runtime_generic_where_bounds(&bindings, nominal.where_bounds.as_ref())
-      .map_err(|message| EdnDecodeTypeError::new(format!("parse-cirru-edn-as cannot derive `{}`: {message}", nominal.name)))?;
-    let key = nominal_key("struct", &nominal.name, args, nominal_path.as_ref(), owner_ns);
-    if let Some(existing) = self.nominal_nodes.get(&key) {
-      return Ok(*existing);
-    }
-    let node_id = self.nodes.len();
-    self.nodes.push(None);
-    self.nominal_nodes.insert(key, node_id);
-
-    let mut fields = Vec::with_capacity(nominal.fields.len());
-    for (field, field_type) in nominal.fields.iter().zip(nominal.field_types.iter()) {
-      let resolved = field_type.substitute_type_vars(&bindings);
-      let field_node = self.build_type(resolved.as_ref(), owner_ns)?;
-      fields.push((field.clone(), field_node));
-    }
-    self.nodes[node_id] = Some(EdnDecodeNode::Struct {
-      nominal,
-      nominal_path,
-      fields,
-    });
-    Ok(node_id)
-  }
-
-  fn build_enum(
-    &mut self,
-    nominal: Arc<CalcitEnum>,
-    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
-    nominal_path: Option<(Arc<str>, Arc<str>)>,
-    default_ns: &str,
-  ) -> Result<usize, EdnDecodeTypeError> {
-    validate_generic_application(&nominal.name().to_string(), nominal.generics(), args)?;
-    let owner_ns = nominal_path.as_ref().map(|(ns, _)| ns.as_ref()).unwrap_or(default_ns);
-    for arg in args.iter() {
-      self.build_type(arg, owner_ns)?;
-    }
-    let bindings = generic_bindings(nominal.generics(), args);
-    validate_runtime_generic_where_bounds(&bindings, nominal.where_bounds())
-      .map_err(|message| EdnDecodeTypeError::new(format!("parse-cirru-edn-as cannot derive `{}`: {message}", nominal.name())))?;
-    let key = nominal_key("enum", nominal.name(), args, nominal_path.as_ref(), owner_ns);
-    if let Some(existing) = self.nominal_nodes.get(&key) {
-      return Ok(*existing);
-    }
-    let node_id = self.nodes.len();
-    self.nodes.push(None);
-    self.nominal_nodes.insert(key, node_id);
-
-    let mut variants = Vec::with_capacity(nominal.variants().len());
-    for variant in nominal.variants() {
-      let mut payloads = Vec::with_capacity(variant.payload_types().len());
-      for payload_type in variant.payload_types() {
-        let resolved = payload_type.substitute_type_vars(&bindings);
-        payloads.push(self.build_type(resolved.as_ref(), owner_ns)?);
-      }
-      variants.push((variant.tag.clone(), payloads));
-    }
-    self.nodes[node_id] = Some(EdnDecodeNode::Enum {
-      nominal,
-      nominal_path,
-      variants,
-    });
-    Ok(node_id)
-  }
-}
-
-fn validate_generic_application(
-  name: &str,
-  generics: &[Arc<str>],
-  args: &[Arc<CalcitTypeAnnotation>],
-) -> Result<(), EdnDecodeTypeError> {
-  if generics.len() != args.len() {
-    return Err(EdnDecodeTypeError::new(format!(
-      "parse-cirru-edn-as expected {} generic argument(s) for `{name}`, got {}",
-      generics.len(),
-      args.len()
-    )));
-  }
-  Ok(())
-}
-
-fn generic_bindings(generics: &[Arc<str>], args: &[Arc<CalcitTypeAnnotation>]) -> TypeBindings {
-  generics.iter().cloned().zip(args.iter().cloned()).collect()
-}
-
-fn qualify_type_ref(name: &str, default_ns: &str) -> (Arc<str>, Arc<str>) {
-  let stripped = name.trim_start_matches('\'').trim_start_matches(':');
-  if let Some((ns, def)) = stripped.rsplit_once('/') {
-    (Arc::from(ns), Arc::from(def))
-  } else if program::has_def_code(default_ns, stripped) {
-    (Arc::from(default_ns), Arc::from(stripped))
-  } else if let Some(target_ns) = program::lookup_def_target_in_import(default_ns, stripped) {
-    (target_ns, Arc::from(stripped))
-  } else {
-    (Arc::from(calcit::CORE_NS), Arc::from(stripped))
-  }
-}
-
-fn infer_nominal_path(default_ns: &str, name: &str) -> Option<(Arc<str>, Arc<str>)> {
-  if program::has_def_code(default_ns, name) {
-    Some((Arc::from(default_ns), Arc::from(name)))
-  } else if program::has_def_code(calcit::CORE_NS, name) {
-    Some((Arc::from(calcit::CORE_NS), Arc::from(name)))
-  } else {
-    None
-  }
-}
-
-fn nominal_key(
-  kind: &str,
-  name: &EdnTag,
-  args: &[Arc<CalcitTypeAnnotation>],
-  path: Option<&(Arc<str>, Arc<str>)>,
-  owner_ns: &str,
-) -> String {
-  let identity = path
-    .map(|(ns, def)| format!("{ns}/{def}"))
-    .unwrap_or_else(|| format!("{owner_ns}/{}", name.ref_str()));
-  let rendered_args = args.iter().map(|arg| arg.to_brief_string()).collect::<Vec<_>>().join(",");
-  format!("{kind}:{identity}<{rendered_args}>")
-}
-
-fn unsupported_type(reason: &str) -> EdnDecodeTypeError {
-  EdnDecodeTypeError::new(format!("parse-cirru-edn-as cannot derive a strict decoder: {reason}"))
 }
 
 fn edn_name(value: &Edn) -> Option<&str> {
@@ -659,7 +293,9 @@ fn sorted_duplicate_names<'a>(values: impl IntoIterator<Item = &'a str>) -> Vec<
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitGenericBound, CalcitImpl, CalcitTrait, EnumVariant};
+  use crate::calcit::data_shape::DataShapeGraph;
+  use crate::calcit::{CalcitEnum, CalcitStruct, CalcitTypeAnnotation, EnumVariant};
+  use cirru_edn::EdnTag;
 
   fn person_struct() -> Arc<CalcitStruct> {
     Arc::new(CalcitStruct {
@@ -675,10 +311,10 @@ mod tests {
   #[test]
   fn decodes_struct_fields_deeply_and_preserves_nominal_identity() {
     let person = person_struct();
-    let graph = EdnDecoderGraph::build(&CalcitTypeAnnotation::Struct(person.clone(), Arc::new(vec![])), "tests.edn")
-      .expect("derive person decoder");
+    let shape =
+      DataShapeGraph::build(&CalcitTypeAnnotation::Struct(person.clone(), Arc::new(vec![])), "tests.edn").expect("derive person shape");
     let input = cirru_edn::parse("%{} :Person (:age 23) (:name |Ada)").expect("parse edn");
-    let decoded = graph.decode(&input).expect("decode person");
+    let decoded = decode(&shape, &input).expect("decode person");
     let Calcit::Record(record) = decoded else {
       panic!("expected record");
     };
@@ -690,9 +326,9 @@ mod tests {
   fn reports_nested_field_path() {
     let person = person_struct();
     let target = CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Struct(person, Arc::new(vec![]))));
-    let graph = EdnDecoderGraph::build(&target, "tests.edn").expect("derive list decoder");
+    let shape = DataShapeGraph::build(&target, "tests.edn").expect("derive list shape");
     let input = cirru_edn::parse("[] $ %{} :Person (:age |old) (:name |Ada)").expect("parse edn");
-    let error = graph.decode(&input).expect_err("age must fail");
+    let error = decode(&shape, &input).expect_err("age must fail");
     assert_eq!(error.path, "$[0].age");
     assert!(error.message.contains("expected number, got string"));
   }
@@ -700,83 +336,12 @@ mod tests {
   #[test]
   fn rejects_duplicate_struct_fields() {
     let person = person_struct();
-    let graph =
-      EdnDecoderGraph::build(&CalcitTypeAnnotation::Struct(person, Arc::new(vec![])), "tests.edn").expect("derive person decoder");
+    let shape =
+      DataShapeGraph::build(&CalcitTypeAnnotation::Struct(person, Arc::new(vec![])), "tests.edn").expect("derive person shape");
     let input = cirru_edn::parse("%{} :Person (:age 23) (:age 24) (:name |Ada)").expect("parse duplicate fields");
-    let error = graph.decode(&input).expect_err("duplicate fields must fail");
+    let error = decode(&shape, &input).expect_err("duplicate fields must fail");
     assert_eq!(error.path, "$");
     assert!(error.message.contains("duplicate fields [age]"), "unexpected error: {error}");
-  }
-
-  #[test]
-  fn rejects_dynamic_and_incomplete_generic_types() {
-    let dynamic = EdnDecoderGraph::build(&CalcitTypeAnnotation::Dynamic, "tests.edn").expect_err("dynamic must fail");
-    assert!(dynamic.to_string().contains("Dynamic is forbidden"));
-
-    let generic = Arc::new(CalcitStruct {
-      name: EdnTag::new("Box"),
-      fields: Arc::new(vec![EdnTag::new("value")]),
-      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
-      generics: Arc::new(vec![Arc::from("T")]),
-      where_bounds: Arc::new(Vec::<CalcitGenericBound>::new()),
-      impls: vec![],
-    });
-    let incomplete = EdnDecoderGraph::build(&CalcitTypeAnnotation::Struct(generic, Arc::new(vec![])), "tests.edn")
-      .expect_err("missing generic argument must fail");
-    assert!(incomplete.to_string().contains("expected 1 generic argument"));
-  }
-
-  #[test]
-  fn rejects_recursive_type_slots() {
-    let name: Arc<str> = Arc::from("strict-edn-recursive-slot");
-    calcit::push_type_slot_override(name.clone(), Arc::new(CalcitTypeAnnotation::TypeSlot(name.clone())));
-    let error = EdnDecoderGraph::build(&CalcitTypeAnnotation::TypeSlot(name.clone()), "tests.edn")
-      .expect_err("recursive slot must fail without overflowing the stack");
-    calcit::pop_type_slot_override(&name);
-
-    assert!(error.to_string().contains("recursive type slot"), "unexpected error: {error}");
-  }
-
-  #[test]
-  fn enforces_generic_where_bounds_while_deriving() {
-    let marker = Arc::new(CalcitTrait::new(EdnTag::new("EdnMarker"), vec![], vec![]));
-    let bounded = Arc::new(CalcitStruct {
-      name: EdnTag::new("MarkedBox"),
-      fields: Arc::new(vec![EdnTag::new("value")]),
-      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
-      generics: Arc::new(vec![Arc::from("T")]),
-      where_bounds: Arc::new(vec![CalcitGenericBound {
-        name: Arc::from("T"),
-        traits: Arc::new(vec![marker.clone()]),
-      }]),
-      impls: vec![],
-    });
-
-    let rejected = EdnDecoderGraph::build(
-      &CalcitTypeAnnotation::Struct(bounded.clone(), Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)])),
-      "tests.edn",
-    )
-    .expect_err("Number does not implement the nominal marker trait");
-    assert!(rejected.to_string().contains("does not satisfy"));
-
-    let mut marked_value = CalcitStruct::from_fields(EdnTag::new("MarkedValue"), vec![]);
-    marked_value.impls.push(Arc::new(CalcitImpl {
-      name: EdnTag::new("MarkedValueEdnMarker"),
-      origin: Some(marker),
-      fields: Arc::new(vec![]),
-      values: Arc::new(vec![]),
-    }));
-    EdnDecoderGraph::build(
-      &CalcitTypeAnnotation::Struct(
-        bounded,
-        Arc::new(vec![Arc::new(CalcitTypeAnnotation::Struct(
-          Arc::new(marked_value),
-          Arc::new(vec![]),
-        ))]),
-      ),
-      "tests.edn",
-    )
-    .expect("nominal marker implementation should satisfy the bound");
   }
 
   #[test]
@@ -797,17 +362,17 @@ mod tests {
     };
     let enum_def = Arc::new(CalcitEnum::from_record(prototype).expect("enum prototype"));
     assert!(matches!(enum_def.variants(), [EnumVariant { .. }, EnumVariant { .. }]));
-    let graph = EdnDecoderGraph::build(&CalcitTypeAnnotation::Enum(enum_def.clone(), Arc::new(vec![])), "tests.edn")
-      .expect("derive enum decoder");
+    let shape =
+      DataShapeGraph::build(&CalcitTypeAnnotation::Enum(enum_def.clone(), Arc::new(vec![])), "tests.edn").expect("derive enum shape");
     let input = cirru_edn::parse("%:: :ResultText :err |oops").expect("parse edn");
-    let decoded = graph.decode(&input).expect("decode enum");
+    let decoded = decode(&shape, &input).expect("decode enum");
     let Calcit::Tuple(tuple) = decoded else {
       panic!("expected tuple");
     };
     assert!(tuple.sum_type.as_ref().is_some_and(|actual| Arc::ptr_eq(actual, &enum_def)));
 
     let invalid = cirru_edn::parse("%:: :ResultText :ok 1").expect("parse invalid enum");
-    let error = graph.decode(&invalid).expect_err("arity must fail");
+    let error = decode(&shape, &invalid).expect_err("arity must fail");
     assert!(error.message.contains("expects 0 payload(s), got 1"));
   }
 }

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -1,0 +1,731 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::Arc;
+
+use cirru_edn::{Edn, EdnRecordView, EdnTag, EdnTupleView};
+
+use crate::builtins::quick_build_atom;
+use crate::calcit::type_annotation::{TypeBindings, validate_runtime_generic_where_bounds};
+use crate::calcit::{self, Calcit, CalcitEnum, CalcitList, CalcitRecord, CalcitStruct, CalcitTuple, CalcitTypeAnnotation};
+use crate::program;
+
+const MAX_DECODE_DEPTH: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub struct EdnDecoderGraph {
+  pub root: usize,
+  pub nodes: Vec<EdnDecodeNode>,
+}
+
+#[derive(Debug, Clone)]
+pub enum EdnDecodeNode {
+  Unit,
+  Bool,
+  Number,
+  String,
+  Symbol,
+  Tag,
+  Buffer,
+  CirruQuote,
+  Optional(usize),
+  List(usize),
+  Set(usize),
+  Map {
+    key: usize,
+    value: usize,
+  },
+  Ref(usize),
+  Struct {
+    nominal: Arc<CalcitStruct>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    fields: Vec<(EdnTag, usize)>,
+  },
+  Enum {
+    nominal: Arc<CalcitEnum>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    variants: Vec<(EdnTag, Vec<usize>)>,
+  },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EdnDecodeTypeError {
+  message: String,
+}
+
+impl EdnDecodeTypeError {
+  fn new(message: impl Into<String>) -> Self {
+    Self { message: message.into() }
+  }
+}
+
+impl fmt::Display for EdnDecodeTypeError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&self.message)
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EdnDecodeError {
+  pub path: String,
+  pub message: String,
+}
+
+impl EdnDecodeError {
+  fn at(path: &str, message: impl Into<String>) -> Self {
+    Self {
+      path: path.to_owned(),
+      message: message.into(),
+    }
+  }
+}
+
+impl fmt::Display for EdnDecodeError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "parse-cirru-edn-as failed at {}: {}", self.path, self.message)
+  }
+}
+
+struct GraphBuilder {
+  nodes: Vec<Option<EdnDecodeNode>>,
+  nominal_nodes: HashMap<String, usize>,
+  resolving_aliases: HashSet<String>,
+}
+
+impl EdnDecoderGraph {
+  pub fn build(target: &CalcitTypeAnnotation, default_ns: &str) -> Result<Self, EdnDecodeTypeError> {
+    let mut builder = GraphBuilder {
+      nodes: vec![],
+      nominal_nodes: HashMap::new(),
+      resolving_aliases: HashSet::new(),
+    };
+    let root = builder.build_type(target, default_ns)?;
+    let nodes = builder
+      .nodes
+      .into_iter()
+      .enumerate()
+      .map(|(idx, node)| node.ok_or_else(|| EdnDecodeTypeError::new(format!("decoder graph node #{idx} was not completed"))))
+      .collect::<Result<Vec<_>, _>>()?;
+    Ok(Self { root, nodes })
+  }
+
+  pub fn decode(&self, input: &Edn) -> Result<Calcit, EdnDecodeError> {
+    self.decode_node(self.root, input, "$", 0)
+  }
+
+  fn decode_node(&self, node_id: usize, input: &Edn, path: &str, depth: usize) -> Result<Calcit, EdnDecodeError> {
+    if depth > MAX_DECODE_DEPTH {
+      return Err(EdnDecodeError::at(path, format!("decode nesting exceeds {MAX_DECODE_DEPTH}")));
+    }
+    let Some(node) = self.nodes.get(node_id) else {
+      return Err(EdnDecodeError::at(path, format!("invalid decoder graph node #{node_id}")));
+    };
+
+    match node {
+      EdnDecodeNode::Unit => match input {
+        Edn::Nil => Ok(Calcit::Nil),
+        _ => Err(kind_mismatch(path, "nil", input)),
+      },
+      EdnDecodeNode::Bool => match input {
+        Edn::Bool(value) => Ok(Calcit::Bool(*value)),
+        _ => Err(kind_mismatch(path, "bool", input)),
+      },
+      EdnDecodeNode::Number => match input {
+        Edn::Number(value) => Ok(Calcit::Number(*value)),
+        _ => Err(kind_mismatch(path, "number", input)),
+      },
+      EdnDecodeNode::String => match input {
+        Edn::Str(value) => Ok(Calcit::Str(value.clone())),
+        _ => Err(kind_mismatch(path, "string", input)),
+      },
+      EdnDecodeNode::Symbol => match input {
+        Edn::Symbol(value) => Ok(Calcit::Symbol {
+          sym: value.clone(),
+          info: Arc::new(crate::calcit::CalcitSymbolInfo {
+            at_ns: calcit::GEN_NS.into(),
+            at_def: calcit::GENERATED_DEF.into(),
+          }),
+          location: None,
+        }),
+        _ => Err(kind_mismatch(path, "symbol", input)),
+      },
+      EdnDecodeNode::Tag => match input {
+        Edn::Tag(value) => Ok(Calcit::Tag(value.clone())),
+        _ => Err(kind_mismatch(path, "tag", input)),
+      },
+      EdnDecodeNode::Buffer => match input {
+        Edn::Buffer(value) => Ok(Calcit::Buffer(value.clone())),
+        _ => Err(kind_mismatch(path, "buffer", input)),
+      },
+      EdnDecodeNode::CirruQuote => match input {
+        Edn::Quote(value) => Ok(Calcit::CirruQuote(value.clone())),
+        _ => Err(kind_mismatch(path, "cirru-quote", input)),
+      },
+      EdnDecodeNode::Optional(inner) => {
+        if matches!(input, Edn::Nil) {
+          Ok(Calcit::Nil)
+        } else {
+          self.decode_node(*inner, input, path, depth + 1)
+        }
+      }
+      EdnDecodeNode::List(inner) => match input {
+        Edn::List(items) => {
+          let mut values = Vec::with_capacity(items.0.len());
+          for (idx, item) in items.0.iter().enumerate() {
+            values.push(self.decode_node(*inner, item, &format!("{path}[{idx}]"), depth + 1)?);
+          }
+          Ok(Calcit::List(Arc::new(CalcitList::Vector(values))))
+        }
+        _ => Err(kind_mismatch(path, "list", input)),
+      },
+      EdnDecodeNode::Set(inner) => match input {
+        Edn::Set(items) => {
+          let mut values = rpds::HashTrieSet::new_sync();
+          for item in items.0.iter() {
+            values.insert_mut(self.decode_node(*inner, item, &format!("{path}.item"), depth + 1)?);
+          }
+          Ok(Calcit::Set(values))
+        }
+        _ => Err(kind_mismatch(path, "set", input)),
+      },
+      EdnDecodeNode::Map { key, value } => match input {
+        Edn::Map(entries) => {
+          let mut values = rpds::HashTrieMap::new_sync();
+          for (raw_key, raw_value) in entries.0.iter() {
+            let decoded_key = self.decode_node(*key, raw_key, &format!("{path}.key"), depth + 1)?;
+            let decoded_value = self.decode_node(*value, raw_value, &format!("{path}.value"), depth + 1)?;
+            values.insert_mut(decoded_key, decoded_value);
+          }
+          Ok(Calcit::Map(values))
+        }
+        _ => Err(kind_mismatch(path, "map", input)),
+      },
+      EdnDecodeNode::Ref(inner) => match input {
+        Edn::Atom(value) => {
+          let decoded = self.decode_node(*inner, value, &format!("{path}.value"), depth + 1)?;
+          Ok(quick_build_atom(decoded))
+        }
+        _ => Err(kind_mismatch(path, "atom", input)),
+      },
+      EdnDecodeNode::Struct { nominal, fields, .. } => match input {
+        Edn::Record(EdnRecordView { tag, pairs }) => {
+          if tag != &nominal.name {
+            return Err(EdnDecodeError::at(
+              path,
+              format!("expected record :{}, got record :{tag}", nominal.name),
+            ));
+          }
+
+          let expected_names: HashSet<&str> = fields.iter().map(|(field, _)| field.ref_str()).collect();
+          let actual_names: HashSet<&str> = pairs.iter().map(|(field, _)| field.ref_str()).collect();
+          if expected_names != actual_names {
+            let missing = sorted_name_diff(&expected_names, &actual_names);
+            let unknown = sorted_name_diff(&actual_names, &expected_names);
+            return Err(EdnDecodeError::at(
+              path,
+              format!(
+                "record :{} fields mismatch; missing [{}], unknown [{}]",
+                nominal.name,
+                missing.join(", "),
+                unknown.join(", ")
+              ),
+            ));
+          }
+
+          let mut values = Vec::with_capacity(fields.len());
+          for (field, field_node) in fields {
+            let (_, raw_value) = pairs
+              .iter()
+              .find(|(candidate, _)| candidate == field)
+              .expect("record field sets were checked");
+            values.push(self.decode_node(*field_node, raw_value, &format!("{path}.{}", field.ref_str()), depth + 1)?);
+          }
+          Ok(Calcit::Record(CalcitRecord {
+            struct_ref: nominal.clone(),
+            values: Arc::new(values),
+          }))
+        }
+        _ => Err(kind_mismatch(path, &format!("record :{}", nominal.name), input)),
+      },
+      EdnDecodeNode::Enum { nominal, variants, .. } => match input {
+        Edn::Tuple(EdnTupleView { tag, enum_tag, extra }) => {
+          let Some(actual_enum_name) = enum_tag.as_deref().and_then(edn_name) else {
+            return Err(EdnDecodeError::at(
+              path,
+              format!("expected enum :{}, got ordinary tuple", nominal.name()),
+            ));
+          };
+          if actual_enum_name != nominal.name().ref_str() {
+            return Err(EdnDecodeError::at(
+              path,
+              format!("expected enum :{}, got enum :{actual_enum_name}", nominal.name()),
+            ));
+          }
+          let Some(actual_tag) = edn_name(tag) else {
+            return Err(EdnDecodeError::at(path, format!("enum :{} variant must be a tag", nominal.name())));
+          };
+          let Some((variant_tag, payload_nodes)) = variants.iter().find(|(candidate, _)| candidate.ref_str() == actual_tag) else {
+            return Err(EdnDecodeError::at(
+              path,
+              format!("enum :{} has no variant :{actual_tag}", nominal.name()),
+            ));
+          };
+          if extra.len() != payload_nodes.len() {
+            return Err(EdnDecodeError::at(
+              path,
+              format!(
+                "enum :{} variant :{} expects {} payload(s), got {}",
+                nominal.name(),
+                variant_tag,
+                payload_nodes.len(),
+                extra.len()
+              ),
+            ));
+          }
+          let mut values = Vec::with_capacity(payload_nodes.len());
+          for (idx, (payload_node, raw_value)) in payload_nodes.iter().zip(extra.iter()).enumerate() {
+            values.push(self.decode_node(*payload_node, raw_value, &format!("{path}.payload[{idx}]"), depth + 1)?);
+          }
+          Ok(Calcit::Tuple(CalcitTuple {
+            tag: Arc::new(Calcit::Tag(variant_tag.clone())),
+            extra: values,
+            sum_type: Some(nominal.clone()),
+          }))
+        }
+        _ => Err(kind_mismatch(path, &format!("enum :{}", nominal.name()), input)),
+      },
+    }
+  }
+}
+
+impl GraphBuilder {
+  fn push(&mut self, node: EdnDecodeNode) -> usize {
+    let id = self.nodes.len();
+    self.nodes.push(Some(node));
+    id
+  }
+
+  fn build_type(&mut self, target: &CalcitTypeAnnotation, default_ns: &str) -> Result<usize, EdnDecodeTypeError> {
+    match target {
+      CalcitTypeAnnotation::Unit => Ok(self.push(EdnDecodeNode::Unit)),
+      CalcitTypeAnnotation::Bool => Ok(self.push(EdnDecodeNode::Bool)),
+      CalcitTypeAnnotation::Number => Ok(self.push(EdnDecodeNode::Number)),
+      CalcitTypeAnnotation::String => Ok(self.push(EdnDecodeNode::String)),
+      CalcitTypeAnnotation::Symbol => Ok(self.push(EdnDecodeNode::Symbol)),
+      CalcitTypeAnnotation::Tag => Ok(self.push(EdnDecodeNode::Tag)),
+      CalcitTypeAnnotation::Buffer => Ok(self.push(EdnDecodeNode::Buffer)),
+      CalcitTypeAnnotation::CirruQuote => Ok(self.push(EdnDecodeNode::CirruQuote)),
+      CalcitTypeAnnotation::Optional(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(EdnDecodeNode::Optional(inner)))
+      }
+      CalcitTypeAnnotation::List(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(EdnDecodeNode::List(inner)))
+      }
+      CalcitTypeAnnotation::Set(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(EdnDecodeNode::Set(inner)))
+      }
+      CalcitTypeAnnotation::Map(key, value) => {
+        let key = self.build_type(key, default_ns)?;
+        let value = self.build_type(value, default_ns)?;
+        Ok(self.push(EdnDecodeNode::Map { key, value }))
+      }
+      CalcitTypeAnnotation::Ref(inner) => {
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(EdnDecodeNode::Ref(inner)))
+      }
+      CalcitTypeAnnotation::Struct(nominal, args) => {
+        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
+        self.build_struct(nominal.clone(), args, path, default_ns)
+      }
+      CalcitTypeAnnotation::Record(nominal) => {
+        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
+        self.build_struct(nominal.clone(), &Arc::new(vec![]), path, default_ns)
+      }
+      CalcitTypeAnnotation::Enum(nominal, args) => {
+        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
+        self.build_enum(nominal.clone(), args, path, default_ns)
+      }
+      CalcitTypeAnnotation::Tuple(nominal) => {
+        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
+        self.build_enum(nominal.clone(), &Arc::new(vec![]), path, default_ns)
+      }
+      CalcitTypeAnnotation::TypeRef(name, args) => self.build_named(name, args, default_ns),
+      CalcitTypeAnnotation::TypeSlot(name) => match calcit::resolve_type_slot(name) {
+        Some(resolved) => self.build_type(&resolved, default_ns),
+        None => Err(EdnDecodeTypeError::new(format!(
+          "parse-cirru-edn-as cannot derive a decoder for unbound type slot `*{name}`"
+        ))),
+      },
+      CalcitTypeAnnotation::Dynamic => Err(unsupported_type("Dynamic is forbidden in a strict decoder")),
+      CalcitTypeAnnotation::TypeVar(name) => Err(unsupported_type(&format!("generic variable '{name} is not bound"))),
+      CalcitTypeAnnotation::DynTuple => Err(unsupported_type("ordinary tuple has no declared enum schema")),
+      CalcitTypeAnnotation::DynFn | CalcitTypeAnnotation::Fn(_) => Err(unsupported_type("function values are not EDN data")),
+      CalcitTypeAnnotation::Trait(_) | CalcitTypeAnnotation::TraitSet(_) => {
+        Err(unsupported_type("trait constraints are not serializable data types"))
+      }
+      CalcitTypeAnnotation::JsObject => Err(unsupported_type("JsObject is an opaque host value")),
+      CalcitTypeAnnotation::Custom(value) => Err(unsupported_type(&format!("custom type `{value}` is not decodable"))),
+      CalcitTypeAnnotation::Variadic(_) => Err(unsupported_type("Variadic is a function parameter constraint")),
+    }
+  }
+
+  fn build_named(
+    &mut self,
+    name: &str,
+    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
+    default_ns: &str,
+  ) -> Result<usize, EdnDecodeTypeError> {
+    let (ns, def) = qualify_type_ref(name, default_ns);
+    let qualified = CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), args.clone());
+    if let Some(struct_def) = qualified.resolve_to_struct() {
+      return self.build_struct(Arc::new(struct_def), args, Some((ns, def)), default_ns);
+    }
+    if let Some(enum_def) = qualified.resolve_to_enum() {
+      return self.build_enum(Arc::new(enum_def), args, Some((ns, def)), default_ns);
+    }
+
+    let schema = program::lookup_def_schema(&ns, &def);
+    if !matches!(schema.as_ref(), CalcitTypeAnnotation::Dynamic)
+      && !matches!(schema.as_ref(), CalcitTypeAnnotation::TypeRef(schema_name, _) if schema_name.as_ref() == name)
+    {
+      if !args.is_empty() {
+        return Err(EdnDecodeTypeError::new(format!(
+          "parse-cirru-edn-as cannot apply generic arguments to type alias `{ns}/{def}`"
+        )));
+      }
+      let alias_key = format!("{ns}/{def}");
+      if !self.resolving_aliases.insert(alias_key.clone()) {
+        return Err(EdnDecodeTypeError::new(format!(
+          "parse-cirru-edn-as found a recursive type alias at `{alias_key}`; recursive data must use a nominal struct or enum"
+        )));
+      }
+      let result = self.build_type(schema.as_ref(), &ns);
+      self.resolving_aliases.remove(&alias_key);
+      return result;
+    }
+
+    Err(EdnDecodeTypeError::new(format!(
+      "parse-cirru-edn-as cannot resolve named type `{ns}/{def}`"
+    )))
+  }
+
+  fn build_struct(
+    &mut self,
+    nominal: Arc<CalcitStruct>,
+    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    default_ns: &str,
+  ) -> Result<usize, EdnDecodeTypeError> {
+    validate_generic_application(&nominal.name.to_string(), &nominal.generics, args)?;
+    if nominal.fields.len() != nominal.field_types.len() {
+      return Err(EdnDecodeTypeError::new(format!(
+        "parse-cirru-edn-as cannot derive `{}`: {} fields but {} field types",
+        nominal.name,
+        nominal.fields.len(),
+        nominal.field_types.len()
+      )));
+    }
+    let owner_ns = nominal_path.as_ref().map(|(ns, _)| ns.as_ref()).unwrap_or(default_ns);
+    for arg in args.iter() {
+      self.build_type(arg, owner_ns)?;
+    }
+    let bindings = generic_bindings(&nominal.generics, args);
+    validate_runtime_generic_where_bounds(&bindings, nominal.where_bounds.as_ref())
+      .map_err(|message| EdnDecodeTypeError::new(format!("parse-cirru-edn-as cannot derive `{}`: {message}", nominal.name)))?;
+    let key = nominal_key("struct", &nominal.name, args, nominal_path.as_ref(), owner_ns);
+    if let Some(existing) = self.nominal_nodes.get(&key) {
+      return Ok(*existing);
+    }
+    let node_id = self.nodes.len();
+    self.nodes.push(None);
+    self.nominal_nodes.insert(key, node_id);
+
+    let mut fields = Vec::with_capacity(nominal.fields.len());
+    for (field, field_type) in nominal.fields.iter().zip(nominal.field_types.iter()) {
+      let resolved = field_type.substitute_type_vars(&bindings);
+      let field_node = self.build_type(resolved.as_ref(), owner_ns)?;
+      fields.push((field.clone(), field_node));
+    }
+    self.nodes[node_id] = Some(EdnDecodeNode::Struct {
+      nominal,
+      nominal_path,
+      fields,
+    });
+    Ok(node_id)
+  }
+
+  fn build_enum(
+    &mut self,
+    nominal: Arc<CalcitEnum>,
+    args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    default_ns: &str,
+  ) -> Result<usize, EdnDecodeTypeError> {
+    validate_generic_application(&nominal.name().to_string(), nominal.generics(), args)?;
+    let owner_ns = nominal_path.as_ref().map(|(ns, _)| ns.as_ref()).unwrap_or(default_ns);
+    for arg in args.iter() {
+      self.build_type(arg, owner_ns)?;
+    }
+    let bindings = generic_bindings(nominal.generics(), args);
+    validate_runtime_generic_where_bounds(&bindings, nominal.where_bounds())
+      .map_err(|message| EdnDecodeTypeError::new(format!("parse-cirru-edn-as cannot derive `{}`: {message}", nominal.name())))?;
+    let key = nominal_key("enum", nominal.name(), args, nominal_path.as_ref(), owner_ns);
+    if let Some(existing) = self.nominal_nodes.get(&key) {
+      return Ok(*existing);
+    }
+    let node_id = self.nodes.len();
+    self.nodes.push(None);
+    self.nominal_nodes.insert(key, node_id);
+
+    let mut variants = Vec::with_capacity(nominal.variants().len());
+    for variant in nominal.variants() {
+      let mut payloads = Vec::with_capacity(variant.payload_types().len());
+      for payload_type in variant.payload_types() {
+        let resolved = payload_type.substitute_type_vars(&bindings);
+        payloads.push(self.build_type(resolved.as_ref(), owner_ns)?);
+      }
+      variants.push((variant.tag.clone(), payloads));
+    }
+    self.nodes[node_id] = Some(EdnDecodeNode::Enum {
+      nominal,
+      nominal_path,
+      variants,
+    });
+    Ok(node_id)
+  }
+}
+
+fn validate_generic_application(
+  name: &str,
+  generics: &[Arc<str>],
+  args: &[Arc<CalcitTypeAnnotation>],
+) -> Result<(), EdnDecodeTypeError> {
+  if generics.len() != args.len() {
+    return Err(EdnDecodeTypeError::new(format!(
+      "parse-cirru-edn-as expected {} generic argument(s) for `{name}`, got {}",
+      generics.len(),
+      args.len()
+    )));
+  }
+  Ok(())
+}
+
+fn generic_bindings(generics: &[Arc<str>], args: &[Arc<CalcitTypeAnnotation>]) -> TypeBindings {
+  generics.iter().cloned().zip(args.iter().cloned()).collect()
+}
+
+fn qualify_type_ref(name: &str, default_ns: &str) -> (Arc<str>, Arc<str>) {
+  let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+  if let Some((ns, def)) = stripped.rsplit_once('/') {
+    (Arc::from(ns), Arc::from(def))
+  } else if program::has_def_code(default_ns, stripped) {
+    (Arc::from(default_ns), Arc::from(stripped))
+  } else if let Some(target_ns) = program::lookup_def_target_in_import(default_ns, stripped) {
+    (target_ns, Arc::from(stripped))
+  } else {
+    (Arc::from(calcit::CORE_NS), Arc::from(stripped))
+  }
+}
+
+fn infer_nominal_path(default_ns: &str, name: &str) -> Option<(Arc<str>, Arc<str>)> {
+  if program::has_def_code(default_ns, name) {
+    Some((Arc::from(default_ns), Arc::from(name)))
+  } else if program::has_def_code(calcit::CORE_NS, name) {
+    Some((Arc::from(calcit::CORE_NS), Arc::from(name)))
+  } else {
+    None
+  }
+}
+
+fn nominal_key(
+  kind: &str,
+  name: &EdnTag,
+  args: &[Arc<CalcitTypeAnnotation>],
+  path: Option<&(Arc<str>, Arc<str>)>,
+  owner_ns: &str,
+) -> String {
+  let identity = path
+    .map(|(ns, def)| format!("{ns}/{def}"))
+    .unwrap_or_else(|| format!("{owner_ns}/{}", name.ref_str()));
+  let rendered_args = args.iter().map(|arg| arg.to_brief_string()).collect::<Vec<_>>().join(",");
+  format!("{kind}:{identity}<{rendered_args}>")
+}
+
+fn unsupported_type(reason: &str) -> EdnDecodeTypeError {
+  EdnDecodeTypeError::new(format!("parse-cirru-edn-as cannot derive a strict decoder: {reason}"))
+}
+
+fn edn_name(value: &Edn) -> Option<&str> {
+  match value {
+    Edn::Tag(value) => Some(value.ref_str()),
+    Edn::Symbol(value) | Edn::Str(value) => Some(value.as_ref()),
+    _ => None,
+  }
+}
+
+fn edn_kind(value: &Edn) -> &'static str {
+  match value {
+    Edn::Nil => "nil",
+    Edn::Bool(_) => "bool",
+    Edn::Number(_) => "number",
+    Edn::Symbol(_) => "symbol",
+    Edn::Tag(_) => "tag",
+    Edn::Str(_) => "string",
+    Edn::Quote(_) => "cirru-quote",
+    Edn::Tuple(tuple) if tuple.enum_tag.is_some() => "enum",
+    Edn::Tuple(_) => "tuple",
+    Edn::List(_) => "list",
+    Edn::Set(_) => "set",
+    Edn::Map(_) => "map",
+    Edn::Record(_) => "record",
+    Edn::Buffer(_) => "buffer",
+    Edn::AnyRef(_) => "any-ref",
+    Edn::Atom(_) => "atom",
+  }
+}
+
+fn kind_mismatch(path: &str, expected: &str, actual: &Edn) -> EdnDecodeError {
+  EdnDecodeError::at(path, format!("expected {expected}, got {}", edn_kind(actual)))
+}
+
+fn sorted_name_diff<'a>(left: &HashSet<&'a str>, right: &HashSet<&'a str>) -> Vec<&'a str> {
+  let mut values: Vec<&str> = left.difference(right).copied().collect();
+  values.sort_unstable();
+  values
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::calcit::{CalcitGenericBound, CalcitImpl, CalcitTrait, EnumVariant};
+
+  fn person_struct() -> Arc<CalcitStruct> {
+    Arc::new(CalcitStruct {
+      name: EdnTag::new("Person"),
+      fields: Arc::new(vec![EdnTag::new("age"), EdnTag::new("name")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    })
+  }
+
+  #[test]
+  fn decodes_struct_fields_deeply_and_preserves_nominal_identity() {
+    let person = person_struct();
+    let graph = EdnDecoderGraph::build(&CalcitTypeAnnotation::Struct(person.clone(), Arc::new(vec![])), "tests.edn")
+      .expect("derive person decoder");
+    let input = cirru_edn::parse("%{} :Person (:age 23) (:name |Ada)").expect("parse edn");
+    let decoded = graph.decode(&input).expect("decode person");
+    let Calcit::Record(record) = decoded else {
+      panic!("expected record");
+    };
+    assert!(Arc::ptr_eq(&record.struct_ref, &person));
+    assert_eq!(record.values.as_ref(), &[Calcit::Number(23.0), Calcit::Str(Arc::from("Ada"))]);
+  }
+
+  #[test]
+  fn reports_nested_field_path() {
+    let person = person_struct();
+    let target = CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Struct(person, Arc::new(vec![]))));
+    let graph = EdnDecoderGraph::build(&target, "tests.edn").expect("derive list decoder");
+    let input = cirru_edn::parse("[] $ %{} :Person (:age |old) (:name |Ada)").expect("parse edn");
+    let error = graph.decode(&input).expect_err("age must fail");
+    assert_eq!(error.path, "$[0].age");
+    assert!(error.message.contains("expected number, got string"));
+  }
+
+  #[test]
+  fn rejects_dynamic_and_incomplete_generic_types() {
+    let dynamic = EdnDecoderGraph::build(&CalcitTypeAnnotation::Dynamic, "tests.edn").expect_err("dynamic must fail");
+    assert!(dynamic.to_string().contains("Dynamic is forbidden"));
+
+    let generic = Arc::new(CalcitStruct {
+      name: EdnTag::new("Box"),
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(Vec::<CalcitGenericBound>::new()),
+      impls: vec![],
+    });
+    let incomplete = EdnDecoderGraph::build(&CalcitTypeAnnotation::Struct(generic, Arc::new(vec![])), "tests.edn")
+      .expect_err("missing generic argument must fail");
+    assert!(incomplete.to_string().contains("expected 1 generic argument"));
+  }
+
+  #[test]
+  fn enforces_generic_where_bounds_while_deriving() {
+    let marker = Arc::new(CalcitTrait::new(EdnTag::new("EdnMarker"), vec![], vec![]));
+    let bounded = Arc::new(CalcitStruct {
+      name: EdnTag::new("MarkedBox"),
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![CalcitGenericBound {
+        name: Arc::from("T"),
+        traits: Arc::new(vec![marker.clone()]),
+      }]),
+      impls: vec![],
+    });
+
+    let rejected = EdnDecoderGraph::build(
+      &CalcitTypeAnnotation::Struct(bounded.clone(), Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)])),
+      "tests.edn",
+    )
+    .expect_err("Number does not implement the nominal marker trait");
+    assert!(rejected.to_string().contains("does not satisfy"));
+
+    let mut marked_value = CalcitStruct::from_fields(EdnTag::new("MarkedValue"), vec![]);
+    marked_value.impls.push(Arc::new(CalcitImpl {
+      name: EdnTag::new("MarkedValueEdnMarker"),
+      origin: Some(marker),
+      fields: Arc::new(vec![]),
+      values: Arc::new(vec![]),
+    }));
+    EdnDecoderGraph::build(
+      &CalcitTypeAnnotation::Struct(
+        bounded,
+        Arc::new(vec![Arc::new(CalcitTypeAnnotation::Struct(
+          Arc::new(marked_value),
+          Arc::new(vec![]),
+        ))]),
+      ),
+      "tests.edn",
+    )
+    .expect("nominal marker implementation should satisfy the bound");
+  }
+
+  #[test]
+  fn decodes_enum_and_checks_payload_arity() {
+    let prototype = CalcitRecord {
+      struct_ref: Arc::new(CalcitStruct {
+        name: EdnTag::new("ResultText"),
+        fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
+        field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        impls: vec![],
+      }),
+      values: Arc::new(vec![
+        Calcit::List(Arc::new(CalcitList::Vector(vec![Calcit::tag("string")]))),
+        Calcit::List(Arc::new(CalcitList::Vector(vec![]))),
+      ]),
+    };
+    let enum_def = Arc::new(CalcitEnum::from_record(prototype).expect("enum prototype"));
+    assert!(matches!(enum_def.variants(), [EnumVariant { .. }, EnumVariant { .. }]));
+    let graph = EdnDecoderGraph::build(&CalcitTypeAnnotation::Enum(enum_def.clone(), Arc::new(vec![])), "tests.edn")
+      .expect("derive enum decoder");
+    let input = cirru_edn::parse("%:: :ResultText :err |oops").expect("parse edn");
+    let decoded = graph.decode(&input).expect("decode enum");
+    let Calcit::Tuple(tuple) = decoded else {
+      panic!("expected tuple");
+    };
+    assert!(tuple.sum_type.as_ref().is_some_and(|actual| Arc::ptr_eq(actual, &enum_def)));
+
+    let invalid = cirru_edn::parse("%:: :ResultText :ok 1").expect("parse invalid enum");
+    let error = graph.decode(&invalid).expect_err("arity must fail");
+    assert!(error.message.contains("expects 0 payload(s), got 1"));
+  }
+}

--- a/src/program.rs
+++ b/src/program.rs
@@ -11,11 +11,12 @@ use std::sync::RwLock;
 
 use cirru_parser::Cirru;
 
+use crate::calcit::data_shape::DataShapeGraph;
 use crate::calcit::{
   self, Calcit, CalcitErr, CalcitScope, CalcitSyntax, CalcitThunk, CalcitThunkInfo, CalcitTypeAnnotation, DYNAMIC_TYPE,
 };
 use crate::call_stack::CallStackList;
-use crate::data::{cirru::code_to_calcit, data_to_calcit, edn_decode::EdnDecoderGraph};
+use crate::data::{cirru::code_to_calcit, data_to_calcit};
 use crate::runner;
 use crate::snapshot;
 use crate::snapshot::Snapshot;
@@ -318,7 +319,7 @@ fn collect_compiled_dep_keys(code: &Calcit, deps: &mut Vec<(Arc<str>, Arc<str>)>
     }
     Calcit::List(xs) => {
       if matches!(xs.first(), Some(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _)))
-        && let Some(graph) = xs.get(3).and_then(EdnDecoderGraph::from_calcit_handle)
+        && let Some(graph) = xs.get(3).and_then(DataShapeGraph::from_calcit_handle)
       {
         deps.extend(graph.nominal_paths());
       }

--- a/src/program.rs
+++ b/src/program.rs
@@ -11,9 +11,11 @@ use std::sync::RwLock;
 
 use cirru_parser::Cirru;
 
-use crate::calcit::{self, Calcit, CalcitErr, CalcitScope, CalcitThunk, CalcitThunkInfo, CalcitTypeAnnotation, DYNAMIC_TYPE};
+use crate::calcit::{
+  self, Calcit, CalcitErr, CalcitScope, CalcitSyntax, CalcitThunk, CalcitThunkInfo, CalcitTypeAnnotation, DYNAMIC_TYPE,
+};
 use crate::call_stack::CallStackList;
-use crate::data::{cirru::code_to_calcit, data_to_calcit};
+use crate::data::{cirru::code_to_calcit, data_to_calcit, edn_decode::EdnDecoderGraph};
 use crate::runner;
 use crate::snapshot;
 use crate::snapshot::Snapshot;
@@ -315,6 +317,11 @@ fn collect_compiled_dep_keys(code: &Calcit, deps: &mut Vec<(Arc<str>, Arc<str>)>
       }
     }
     Calcit::List(xs) => {
+      if matches!(xs.first(), Some(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _)))
+        && let Some(graph) = xs.get(3).and_then(EdnDecoderGraph::from_calcit_handle)
+      {
+        deps.extend(graph.nominal_paths());
+      }
       for item in xs.iter() {
         collect_compiled_dep_keys(item, deps);
       }

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -1,8 +1,10 @@
 use super::*;
-use crate::calcit::{CalcitImport, ImportInfo};
+use crate::calcit::{CalcitImport, CalcitStruct, CalcitSyntax, ImportInfo};
 use crate::call_stack::CallStackList;
 use crate::data::cirru::code_to_calcit;
+use crate::data::edn_decode::{EdnDecodeNode, EdnDecoderGraph};
 use crate::run_program_with_docs;
+use cirru_edn::EdnTag;
 use std::sync::{LazyLock, Mutex};
 
 static PROGRAM_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -17,6 +19,29 @@ fn cirru_list(items: Vec<Cirru>) -> Cirru {
 
 fn import_rule(source: &str, kind: &str, target: Cirru) -> Cirru {
   cirru_list(vec![cirru_leaf(source), cirru_leaf(kind), target])
+}
+
+#[test]
+fn strict_edn_decoder_nominals_are_compiled_dependencies() {
+  let ns: Arc<str> = Arc::from("tests.strict-edn-dependencies");
+  let def: Arc<str> = Arc::from("Person");
+  let dep_id = ensure_def_id(&ns, &def);
+  let graph = EdnDecoderGraph {
+    root: 0,
+    nodes: vec![EdnDecodeNode::Struct {
+      nominal: Arc::new(CalcitStruct::from_fields(EdnTag::new("Person"), vec![])),
+      nominal_path: Some((ns.clone(), def.clone())),
+      fields: vec![],
+    }],
+  };
+  let code = Calcit::from(vec![
+    Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, Arc::from(calcit::CORE_NS)),
+    Calcit::Str(Arc::from("%{} :Person")),
+    Calcit::tag("Person"),
+    graph.into_calcit_handle(),
+  ]);
+
+  assert_eq!(collect_compiled_deps(&code), vec![dep_id]);
 }
 
 #[test]

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -23,6 +23,9 @@ fn import_rule(source: &str, kind: &str, target: Cirru) -> Cirru {
 
 #[test]
 fn strict_edn_decoder_nominals_are_compiled_dependencies() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+
   let ns: Arc<str> = Arc::from("tests.strict-edn-dependencies");
   let def: Arc<str> = Arc::from("Person");
   let dep_id = ensure_def_id(&ns, &def);

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
+use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
 use crate::calcit::{CalcitImport, CalcitStruct, CalcitSyntax, ImportInfo};
 use crate::call_stack::CallStackList;
 use crate::data::cirru::code_to_calcit;
-use crate::data::edn_decode::{EdnDecodeNode, EdnDecoderGraph};
 use crate::run_program_with_docs;
 use cirru_edn::EdnTag;
 use std::sync::{LazyLock, Mutex};
@@ -26,14 +26,16 @@ fn strict_edn_decoder_nominals_are_compiled_dependencies() {
   let ns: Arc<str> = Arc::from("tests.strict-edn-dependencies");
   let def: Arc<str> = Arc::from("Person");
   let dep_id = ensure_def_id(&ns, &def);
-  let graph = EdnDecoderGraph {
-    root: 0,
-    nodes: vec![EdnDecodeNode::Struct {
+  let graph = DataShapeGraph::from_nodes(
+    0,
+    vec![DataShapeNode::Struct {
       nominal: Arc::new(CalcitStruct::from_fields(EdnTag::new("Person"), vec![])),
       nominal_path: Some((ns.clone(), def.clone())),
+      type_args: Arc::new(vec![]),
       fields: vec![],
     }],
-  };
+  )
+  .expect("valid test data shape");
   let code = Calcit::from(vec![
     Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, Arc::from(calcit::CORE_NS)),
     Calcit::Str(Arc::from("%{} :Person")),

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -19,7 +19,9 @@ use type_checking::{
   check_user_fn_arg_types, detect_return_type_hint_from_processed_body,
 };
 pub use type_inference::infer_static_type_from_expr;
-use type_inference::{infer_type_from_expr, resolve_enum_value, resolve_program_value_for_preprocess, resolve_type_value};
+use type_inference::{
+  infer_record_field_type, infer_type_from_expr, resolve_enum_value, resolve_program_value_for_preprocess, resolve_type_value,
+};
 use type_rewriting::{
   build_enum_ref_node, build_struct_ref_node, try_rewrite_local_fn_tuple_args_to_enum_tuples,
   try_rewrite_loose_record_args_to_struct_records, try_rewrite_map_args_to_records, try_rewrite_tuple_args_to_enum_tuples,
@@ -1428,6 +1430,7 @@ fn preprocess_list_call(
         let processed_args = CalcitList::from(ys.drop_left()); // Skip the head, convert to CalcitList
         validate_method_call(&head_form, &processed_args, scope_types, call_stack)?;
         check_record_field_access(&head_form, &processed_args, scope_types, file_ns, check_warnings);
+        check_record_update_fields(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
         check_record_method_args(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
 
         // Optimize &record:get to &record:nth when field index can be resolved at compile time
@@ -2228,6 +2231,68 @@ fn check_record_field_access(
       // Create a tag for the field name to match the check_field_in_record signature
       let field_tag = Calcit::Tag(cirru_edn::EdnTag::from(&**field_name));
       check_field_in_record(record_arg, &field_tag, scope_types, file_ns, check_warnings);
+    }
+  }
+}
+
+/// Validate statically known record updates before they are rewritten to the indexed runtime procs.
+/// This is the checking counterpart to preserving the receiver's nominal return type in inference.
+fn check_record_update_fields(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  def_name: &str,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  let pairs: Vec<(&Calcit, &Calcit)> = match head {
+    Calcit::Proc(CalcitProc::NativeRecordAssoc) if args.len() == 3 => match (args.get(1), args.get(2)) {
+      (Some(field), Some(value)) => vec![(field, value)],
+      _ => return,
+    },
+    Calcit::Proc(CalcitProc::NativeRecordAssocAt) if args.len() == 4 => match (args.get(2), args.get(3)) {
+      (Some(field), Some(value)) => vec![(field, value)],
+      _ => return,
+    },
+    Calcit::Proc(CalcitProc::NativeRecordWith) if args.len() >= 3 && (args.len() - 1).is_multiple_of(2) => {
+      let items = args.iter().skip(1).collect::<Vec<_>>();
+      items.chunks_exact(2).map(|pair| (pair[0], pair[1])).collect()
+    }
+    Calcit::Proc(CalcitProc::NativeRecordWithAt) if args.len() >= 4 && (args.len() - 1).is_multiple_of(3) => {
+      let items = args.iter().skip(1).collect::<Vec<_>>();
+      items.chunks_exact(3).map(|triple| (triple[1], triple[2])).collect()
+    }
+    _ => return,
+  };
+
+  let Some(record_arg) = args.first() else { return };
+  for (field_arg, value_arg) in pairs {
+    check_field_in_record(record_arg, field_arg, scope_types, file_ns, check_warnings);
+
+    let field_name = match field_arg {
+      Calcit::Tag(tag) => tag.ref_str(),
+      Calcit::Str(name) => name.as_ref(),
+      Calcit::Symbol { sym, .. } => sym.as_ref(),
+      _ => continue,
+    };
+    let Some(expected_type) = infer_record_field_type(record_arg, field_name, scope_types) else {
+      continue;
+    };
+    if matches!(expected_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
+      continue;
+    }
+    if let Some(actual_type) = resolve_type_value(value_arg, scope_types)
+      && !actual_type.as_ref().matches_annotation(expected_type.as_ref())
+    {
+      gen_check_warning(
+        format!(
+          "[Warn] record update field `:{field_name}` expects type `{}`, but got `{}` at {file_ns}/{def_name}",
+          expected_type.to_brief_string(),
+          actual_type.to_brief_string(),
+        ),
+        file_ns,
+        check_warnings,
+      );
     }
   }
 }
@@ -4463,8 +4528,13 @@ pub fn preprocess_parse_cirru_edn_as(
   )?;
   let type_form = args.get(1).expect("validated parse-cirru-edn-as type");
   let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
-  let decoder = crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), ctx.file_ns).map_err(|error| {
-    CalcitErr::use_msg_stack_location(CalcitErrKind::Type, error.to_string(), ctx.call_stack, type_form.get_location())
+  let decoder = crate::calcit::data_shape::DataShapeGraph::build(target.as_ref(), ctx.file_ns).map_err(|error| {
+    CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      format!("parse-cirru-edn-as cannot derive a decoder: {error}"),
+      ctx.call_stack,
+      type_form.get_location(),
+    )
   })?;
 
   Ok(Calcit::from(vec![
@@ -4874,7 +4944,7 @@ mod tests {
   }
 
   #[test]
-  fn strict_edn_decode_retains_compiled_decoder_graph() {
+  fn strict_edn_decode_retains_compiled_data_shape() {
     let expr = Cirru::List(vec![Cirru::leaf("parse-cirru-edn-as"), Cirru::leaf("|1"), Cirru::leaf(":number")]);
     let code = code_to_calcit(&expr, "tests.edn", "main", vec![]).expect("parse strict decoder");
     let scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -4891,7 +4961,7 @@ mod tests {
     assert!(
       nodes
         .get(3)
-        .and_then(crate::data::edn_decode::EdnDecoderGraph::from_calcit_handle)
+        .and_then(crate::calcit::data_shape::DataShapeGraph::from_calcit_handle)
         .is_some(),
       "preprocessing should retain the compiled graph"
     );
@@ -5775,6 +5845,45 @@ mod tests {
     assert!(warnings.borrow().iter().any(|warning| {
       let message = warning.to_string();
       message.contains("field `:x`") && message.contains("expects type")
+    }));
+  }
+
+  #[test]
+  fn validates_typed_record_update_fields_after_generic_substitution() {
+    use cirru_edn::EdnTag;
+
+    let generic: Arc<str> = Arc::from("T");
+    let mut box_struct = CalcitStruct::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]);
+    box_struct.generics = Arc::new(vec![generic.clone()]);
+    box_struct.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(generic))]);
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("box")),
+      sym: Arc::from("box"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.record"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::Struct(
+        Arc::new(box_struct),
+        Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+      )),
+    });
+    let args = CalcitList::from(vec![receiver, Calcit::Tag(EdnTag::from("value")), Calcit::Str(Arc::from("wrong"))].as_slice());
+    let warnings = RefCell::new(vec![]);
+
+    check_record_update_fields(
+      &Calcit::Proc(CalcitProc::NativeRecordAssoc),
+      &args,
+      &ScopeTypes::new(),
+      "tests.record",
+      "demo",
+      &warnings,
+    );
+
+    assert!(warnings.borrow().iter().any(|warning| {
+      let message = warning.to_string();
+      message.contains("record update field `:value`") && message.contains("expects type `:number`")
     }));
   }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -4463,7 +4463,7 @@ pub fn preprocess_parse_cirru_edn_as(
   )?;
   let type_form = args.get(1).expect("validated parse-cirru-edn-as type");
   let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
-  crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), ctx.file_ns).map_err(|error| {
+  let decoder = crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), ctx.file_ns).map_err(|error| {
     CalcitErr::use_msg_stack_location(CalcitErrKind::Type, error.to_string(), ctx.call_stack, type_form.get_location())
   })?;
 
@@ -4471,6 +4471,7 @@ pub fn preprocess_parse_cirru_edn_as(
     Calcit::Syntax(head.to_owned(), Arc::from(head_ns)),
     text_form,
     type_form.to_owned(),
+    decoder.into_calcit_handle(),
   ]))
 }
 
@@ -4870,6 +4871,30 @@ mod tests {
     let error = preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.edn", &warnings, &stack)
       .expect_err("Dynamic decoder must be rejected before runtime");
     assert!(error.msg.contains("Dynamic is forbidden"), "unexpected error: {error:?}");
+  }
+
+  #[test]
+  fn strict_edn_decode_retains_compiled_decoder_graph() {
+    let expr = Cirru::List(vec![Cirru::leaf("parse-cirru-edn-as"), Cirru::leaf("|1"), Cirru::leaf(":number")]);
+    let code = code_to_calcit(&expr, "tests.edn", "main", vec![]).expect("parse strict decoder");
+    let scope_defs: HashSet<Arc<str>> = HashSet::new();
+    let mut scope_types: ScopeTypes = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default();
+
+    let resolved =
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.edn", &warnings, &stack).expect("preprocess strict decoder");
+    let Calcit::List(nodes) = resolved else {
+      panic!("strict decoder should remain a syntax node");
+    };
+    assert_eq!(nodes.len(), 4);
+    assert!(
+      nodes
+        .get(3)
+        .and_then(crate::data::edn_decode::EdnDecoderGraph::from_calcit_handle)
+        .is_some(),
+      "preprocessing should retain the compiled graph"
+    );
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1319,6 +1319,10 @@ fn preprocess_list_call(
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           preprocess_unsafe_coerce(name, name_ns, &args, &mut ctx)
         }
+        CalcitSyntax::ParseCirruEdnAs => {
+          let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
+          preprocess_parse_cirru_edn_as(name, name_ns, &args, &mut ctx)
+        }
         CalcitSyntax::AssertTraits => {
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           preprocess_assert_traits(name, name_ns, &args, &mut ctx)
@@ -4434,6 +4438,42 @@ pub fn preprocess_unsafe_coerce(
   ]))
 }
 
+pub fn preprocess_parse_cirru_edn_as(
+  head: &CalcitSyntax,
+  head_ns: &str,
+  args: &CalcitList,
+  ctx: &mut PreprocessContext,
+) -> Result<Calcit, CalcitErr> {
+  if args.len() != 2 {
+    return Err(CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Arity,
+      format!("{head} expected a string and a type expression, got {}", args.len()),
+      ctx.call_stack,
+      args.first().and_then(Calcit::get_location),
+    ));
+  }
+
+  let text_form = preprocess_expr(
+    args.first().expect("validated parse-cirru-edn-as text"),
+    ctx.scope_defs,
+    ctx.scope_types,
+    ctx.file_ns,
+    ctx.check_warnings,
+    ctx.call_stack,
+  )?;
+  let type_form = args.get(1).expect("validated parse-cirru-edn-as type");
+  let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
+  crate::data::edn_decode::EdnDecoderGraph::build(target.as_ref(), ctx.file_ns).map_err(|error| {
+    CalcitErr::use_msg_stack_location(CalcitErrKind::Type, error.to_string(), ctx.call_stack, type_form.get_location())
+  })?;
+
+  Ok(Calcit::from(vec![
+    Calcit::Syntax(head.to_owned(), Arc::from(head_ns)),
+    text_form,
+    type_form.to_owned(),
+  ]))
+}
+
 pub fn preprocess_assert_traits(
   head: &CalcitSyntax,
   _head_ns: &str,
@@ -4812,6 +4852,24 @@ mod tests {
       "coercing one expression must not retype every later use of the local"
     );
     assert!(warnings.borrow().is_empty());
+  }
+
+  #[test]
+  fn strict_edn_decode_rejects_dynamic_during_preprocess() {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("parse-cirru-edn-as"),
+      Cirru::leaf("|do 1"),
+      Cirru::leaf(":dynamic"),
+    ]);
+    let code = code_to_calcit(&expr, "tests.edn", "main", vec![]).expect("parse strict decoder");
+    let scope_defs: HashSet<Arc<str>> = HashSet::new();
+    let mut scope_types: ScopeTypes = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default();
+
+    let error = preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.edn", &warnings, &stack)
+      .expect_err("Dynamic decoder must be rejected before runtime");
+    assert!(error.msg.contains("Dynamic is forbidden"), "unexpected error: {error:?}");
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -400,6 +400,10 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
 
         Calcit::Syntax(CalcitSyntax::UnsafeCoerce, _) => xs.get(2).map(CalcitTypeAnnotation::parse_type_annotation_form),
 
+        Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _) => xs
+          .get(2)
+          .map(|form| CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[])),
+
         // Local variable as head (function call)
         // If it's a function type, return its return type
         Calcit::Local(local) => {
@@ -1388,6 +1392,25 @@ mod tests {
       infer_static_type_from_expr(&map).as_deref(),
       Some(CalcitTypeAnnotation::Map(key, value))
         if matches!(key.as_ref(), CalcitTypeAnnotation::Tag) && matches!(value.as_ref(), CalcitTypeAnnotation::Number)
+    ));
+  }
+
+  #[test]
+  fn strict_edn_decode_expression_has_declared_closed_type() {
+    let target = Calcit::Tuple(calcit::CalcitTuple {
+      tag: Arc::new(Calcit::tag("list")),
+      extra: vec![Calcit::tag("number")],
+      sum_type: None,
+    });
+    let expression = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, Arc::from(calcit::CORE_NS)),
+      Calcit::Str(Arc::from("[] 1 2")),
+      target,
+    ]);
+
+    assert!(matches!(
+      infer_static_type_from_expr(&expression).as_deref(),
+      Some(CalcitTypeAnnotation::List(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
     ));
   }
 

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -951,6 +951,15 @@ fn infer_proc_call_return_type(proc: &CalcitProc, xs: &CalcitList, scope_types: 
   {
     return Some(field_type);
   }
+  if matches!(
+    proc,
+    CalcitProc::NativeRecordAssoc | CalcitProc::NativeRecordAssocAt | CalcitProc::NativeRecordWith | CalcitProc::NativeRecordWithAt
+  ) && let Some(record_arg) = xs.get(1)
+    && let Some(record_type) = resolve_type_value(record_arg, scope_types)
+    && record_type.resolve_to_struct().is_some()
+  {
+    return Some(record_type);
+  }
   proc.get_type_signature().map(|type_sig| type_sig.return_type.clone())
 }
 
@@ -1358,6 +1367,7 @@ pub(crate) fn resolve_record_value(target: &Calcit, scope_types: &ScopeTypes) ->
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::calcit::{CalcitLocal, CalcitSymbolInfo};
 
   fn proc_call(proc: CalcitProc, args: Vec<Calcit>) -> Calcit {
     let mut items = Vec::with_capacity(args.len() + 1);
@@ -1444,6 +1454,59 @@ mod tests {
       infer_get_return_type_from_type(&CalcitTypeAnnotation::Optional(Arc::new(user_type)), Some(&key)).as_deref(),
       Some(CalcitTypeAnnotation::Optional(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::String)
     ));
+  }
+
+  #[test]
+  fn typed_record_updates_preserve_the_receiver_type() {
+    let generic: Arc<str> = Arc::from("T");
+    let mut struct_def = CalcitStruct::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]);
+    struct_def.generics = Arc::new(vec![generic.clone()]);
+    struct_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(generic))]);
+    let receiver_type = Arc::new(CalcitTypeAnnotation::Struct(
+      Arc::new(struct_def),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),
+    ));
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("box")),
+      sym: Arc::from("box"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.record"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: receiver_type.clone(),
+    });
+
+    for call in [
+      proc_call(
+        CalcitProc::NativeRecordAssoc,
+        vec![receiver.clone(), Calcit::Tag(EdnTag::from("value")), Calcit::Str(Arc::from("next"))],
+      ),
+      proc_call(
+        CalcitProc::NativeRecordAssocAt,
+        vec![
+          receiver.clone(),
+          Calcit::Number(0.0),
+          Calcit::Tag(EdnTag::from("value")),
+          Calcit::Str(Arc::from("next")),
+        ],
+      ),
+      proc_call(
+        CalcitProc::NativeRecordWith,
+        vec![receiver.clone(), Calcit::Tag(EdnTag::from("value")), Calcit::Str(Arc::from("next"))],
+      ),
+      proc_call(
+        CalcitProc::NativeRecordWithAt,
+        vec![
+          receiver,
+          Calcit::Number(0.0),
+          Calcit::Tag(EdnTag::from("value")),
+          Calcit::Str(Arc::from("next")),
+        ],
+      ),
+    ] {
+      assert_eq!(infer_static_type_from_expr(&call).as_deref(), Some(receiver_type.as_ref()));
+    }
   }
 
   #[test]

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1658,16 +1658,18 @@ export let parse_cirru_edn = (code: string, options: CalcitValue) => {
   }
 };
 
-type EdnDecoderNode =
+type DataShapeNode =
   | { kind: "unit" | "bool" | "number" | "string" | "symbol" | "tag" | "buffer" | "cirru-quote" }
   | { kind: "optional" | "list" | "set" | "ref"; inner: number }
   | { kind: "map"; key: number; value: number }
   | { kind: "struct"; nominal: CalcitStruct; fields: Array<[string, number]> }
   | { kind: "enum"; nominal: CalcitEnum; variants: Array<{ tag: string; payload: number[] }> };
 
-type EdnDecoderGraph = {
+type DataShapeGraph = {
+  version: number;
   root: number;
-  nodes: EdnDecoderNode[];
+  fingerprint: string;
+  nodes: DataShapeNode[];
 };
 
 const typed_edn_kind = (value: any): string => {
@@ -1696,10 +1698,10 @@ const enum_prototype_name = (value: CalcitEnum | CalcitRecord): string => {
   return value instanceof CalcitEnum ? value.name() : value.name.value;
 };
 
-const decode_typed_edn_node = (graph: EdnDecoderGraph, nodeId: number, input: any, path: string, depth: number): any => {
+const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any, path: string, depth: number): any => {
   if (depth > 1024) typed_edn_error(path, "decode nesting exceeds 1024");
   const node = graph.nodes[nodeId];
-  if (node == null) typed_edn_error(path, `invalid decoder graph node #${nodeId}`);
+  if (node == null) typed_edn_error(path, `invalid data shape node #${nodeId}`);
 
   switch (node.kind) {
     case "unit":
@@ -1820,12 +1822,16 @@ const decode_typed_edn_node = (graph: EdnDecoderGraph, nodeId: number, input: an
       return new CalcitTuple(newTag(variant.tag), values, node.nominal);
     }
     default:
-      return typed_edn_error(path, `invalid decoder graph node kind: ${(node as any).kind}`);
+      return typed_edn_error(path, `invalid data shape node kind: ${(node as any).kind}`);
   }
 };
 
-export let parse_cirru_edn_as = (code: string, graph: EdnDecoderGraph): CalcitValue => {
+export let parse_cirru_edn_as = (code: string, graph: DataShapeGraph): CalcitValue => {
   if (typeof code !== "string") throw new Error(`parse-cirru-edn-as expected a string, got ${typed_edn_kind(code)}`);
+  if (graph.version !== 1) throw new Error(`parse-cirru-edn-as expected data shape ABI version 1, got ${graph.version}`);
+  if (typeof graph.fingerprint !== "string" || graph.fingerprint.length === 0) {
+    throw new Error("parse-cirru-edn-as expected a non-empty data shape fingerprint");
+  }
   const enumOptions: CalcitValue[] = [];
   for (const node of graph.nodes) {
     if (node.kind === "enum") enumOptions.push(newTag(node.nominal.name()), node.nominal);

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -50,7 +50,8 @@ import { CalcitList, CalcitSliceList, foldl } from "./js-list.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet } from "./js-set.mjs";
 import { CalcitTuple } from "./js-tuple.mjs";
-import { to_calcit_data, extract_cirru_edn, CalcitCirruQuote } from "./js-cirru.mjs";
+import { to_calcit_data, extract_cirru_edn, extract_cirru_edn_for_typed, CalcitCirruQuote } from "./js-cirru.mjs";
+import { TypedEdnSetView } from "./typed-edn.mjs";
 
 let inNodeJs = typeof process !== "undefined" && process?.release?.name === "node";
 
@@ -1681,7 +1682,7 @@ const typed_edn_kind = (value: any): string => {
   if (value instanceof CalcitTag) return "tag";
   if (value instanceof CalcitList || value instanceof CalcitSliceList) return "list";
   if (value instanceof CalcitMap || value instanceof CalcitSliceMap) return "map";
-  if (value instanceof CalcitSet) return "set";
+  if (value instanceof CalcitSet || value instanceof TypedEdnSetView) return "set";
   if (value instanceof CalcitRecord) return "record";
   if (value instanceof CalcitTuple) return value.enumPrototype == null ? "tuple" : "enum";
   if (value instanceof CalcitRef) return "atom";
@@ -1740,8 +1741,20 @@ const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any
       return new CalcitSliceList(values);
     }
     case "set": {
-      if (!(input instanceof CalcitSet)) return typed_edn_error(path, `expected set, got ${typed_edn_kind(input)}`);
-      return new CalcitSet(input.values().map((value) => decode_typed_edn_node(graph, node.inner, value, `${path}.item`, depth + 1)));
+      if (!(input instanceof CalcitSet || input instanceof TypedEdnSetView)) {
+        return typed_edn_error(path, `expected set, got ${typed_edn_kind(input)}`);
+      }
+      const values: any[] = [];
+      const inputValues = input instanceof TypedEdnSetView ? input.items : input.values();
+      inputValues.forEach((value) => {
+        const itemPath = `${path}.item`;
+        const decoded = decode_typed_edn_node(graph, node.inner, value, itemPath, depth + 1);
+        if (values.some((existing) => _$n__$e_(existing, decoded))) {
+          typed_edn_error(itemPath, "duplicate decoded set value");
+        }
+        values.push(decoded);
+      });
+      return new CalcitSet(values);
     }
     case "map": {
       if (!(input instanceof CalcitMap || input instanceof CalcitSliceMap)) {
@@ -1749,10 +1762,15 @@ const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any
       }
       const entries: any[] = [];
       input.pairs().forEach(([key, value]) => {
-        entries.push(
-          decode_typed_edn_node(graph, node.key, key, `${path}.key`, depth + 1),
-          decode_typed_edn_node(graph, node.value, value, `${path}.value`, depth + 1)
-        );
+        const keyPath = `${path}.key`;
+        const decodedKey = decode_typed_edn_node(graph, node.key, key, keyPath, depth + 1);
+        for (let idx = 0; idx < entries.length; idx += 2) {
+          if (_$n__$e_(entries[idx], decodedKey)) {
+            typed_edn_error(keyPath, "duplicate decoded map key");
+          }
+        }
+        const decodedValue = decode_typed_edn_node(graph, node.value, value, `${path}.value`, depth + 1);
+        entries.push(decodedKey, decodedValue);
       });
       return new CalcitSliceMap(entries);
     }
@@ -1841,7 +1859,7 @@ export let parse_cirru_edn_as = (code: string, graph: DataShapeGraph): CalcitVal
   try {
     const nodes = parse(code);
     if (nodes.length !== 1) throw new Error(`expected EDN in a single node, got ${nodes.length}`);
-    input = extract_cirru_edn(nodes[0], new CalcitSliceMap(enumOptions));
+    input = extract_cirru_edn_for_typed(nodes[0], new CalcitSliceMap(enumOptions));
   } catch (error) {
     const message = error instanceof Error ? error.message : `${error}`;
     throw new Error(`parse-cirru-edn-as failed to parse Cirru EDN: ${message}`);

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -21,7 +21,7 @@ import {
   hashFunction,
 } from "./calcit-data.mjs";
 
-import { CalcitRef } from "./js-ref.mjs";
+import { CalcitRef, atom } from "./js-ref.mjs";
 import { CalcitRecord } from "./js-record.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
 import { CalcitStruct } from "./js-struct.mjs";
@@ -1656,6 +1656,181 @@ export let parse_cirru_edn = (code: string, options: CalcitValue) => {
   } else {
     throw new Error(`Expected EDN in a single node, got ${nodes.length}`);
   }
+};
+
+type EdnDecoderNode =
+  | { kind: "unit" | "bool" | "number" | "string" | "symbol" | "tag" | "buffer" | "cirru-quote" }
+  | { kind: "optional" | "list" | "set" | "ref"; inner: number }
+  | { kind: "map"; key: number; value: number }
+  | { kind: "struct"; nominal: CalcitStruct; fields: Array<[string, number]> }
+  | { kind: "enum"; nominal: CalcitEnum; variants: Array<{ tag: string; payload: number[] }> };
+
+type EdnDecoderGraph = {
+  root: number;
+  nodes: EdnDecoderNode[];
+};
+
+const typed_edn_kind = (value: any): string => {
+  if (value == null) return "nil";
+  if (typeof value === "boolean") return "bool";
+  if (typeof value === "number") return "number";
+  if (typeof value === "string") return "string";
+  if (value instanceof CalcitSymbol) return "symbol";
+  if (value instanceof CalcitTag) return "tag";
+  if (value instanceof CalcitList || value instanceof CalcitSliceList) return "list";
+  if (value instanceof CalcitMap || value instanceof CalcitSliceMap) return "map";
+  if (value instanceof CalcitSet) return "set";
+  if (value instanceof CalcitRecord) return "record";
+  if (value instanceof CalcitTuple) return value.enumPrototype == null ? "tuple" : "enum";
+  if (value instanceof CalcitRef) return "atom";
+  if (value instanceof CalcitCirruQuote) return "cirru-quote";
+  if (value instanceof Uint8Array) return "buffer";
+  return "unsupported";
+};
+
+const typed_edn_error = (path: string, message: string): never => {
+  throw new Error(`parse-cirru-edn-as failed at ${path}: ${message}`);
+};
+
+const enum_prototype_name = (value: CalcitEnum | CalcitRecord): string => {
+  return value instanceof CalcitEnum ? value.name() : value.name.value;
+};
+
+const decode_typed_edn_node = (graph: EdnDecoderGraph, nodeId: number, input: any, path: string, depth: number): any => {
+  if (depth > 1024) typed_edn_error(path, "decode nesting exceeds 1024");
+  const node = graph.nodes[nodeId];
+  if (node == null) typed_edn_error(path, `invalid decoder graph node #${nodeId}`);
+
+  switch (node.kind) {
+    case "unit":
+      if (input == null) return null;
+      return typed_edn_error(path, `expected nil, got ${typed_edn_kind(input)}`);
+    case "bool":
+      if (typeof input === "boolean") return input;
+      return typed_edn_error(path, `expected bool, got ${typed_edn_kind(input)}`);
+    case "number":
+      if (typeof input === "number") return input;
+      return typed_edn_error(path, `expected number, got ${typed_edn_kind(input)}`);
+    case "string":
+      if (typeof input === "string") return input;
+      return typed_edn_error(path, `expected string, got ${typed_edn_kind(input)}`);
+    case "symbol":
+      if (input instanceof CalcitSymbol) return input;
+      return typed_edn_error(path, `expected symbol, got ${typed_edn_kind(input)}`);
+    case "tag":
+      if (input instanceof CalcitTag) return input;
+      return typed_edn_error(path, `expected tag, got ${typed_edn_kind(input)}`);
+    case "buffer":
+      if (input instanceof Uint8Array) return input;
+      return typed_edn_error(path, `expected buffer, got ${typed_edn_kind(input)}`);
+    case "cirru-quote":
+      if (input instanceof CalcitCirruQuote) return input;
+      return typed_edn_error(path, `expected cirru-quote, got ${typed_edn_kind(input)}`);
+    case "optional":
+      return input == null ? null : decode_typed_edn_node(graph, node.inner, input, path, depth + 1);
+    case "list": {
+      if (!(input instanceof CalcitList || input instanceof CalcitSliceList)) {
+        return typed_edn_error(path, `expected list, got ${typed_edn_kind(input)}`);
+      }
+      const values = Array.from(input.items()).map((value, idx) =>
+        decode_typed_edn_node(graph, node.inner, value, `${path}[${idx}]`, depth + 1)
+      );
+      return new CalcitSliceList(values);
+    }
+    case "set": {
+      if (!(input instanceof CalcitSet)) return typed_edn_error(path, `expected set, got ${typed_edn_kind(input)}`);
+      return new CalcitSet(input.values().map((value) => decode_typed_edn_node(graph, node.inner, value, `${path}.item`, depth + 1)));
+    }
+    case "map": {
+      if (!(input instanceof CalcitMap || input instanceof CalcitSliceMap)) {
+        return typed_edn_error(path, `expected map, got ${typed_edn_kind(input)}`);
+      }
+      const entries: any[] = [];
+      input.pairs().forEach(([key, value]) => {
+        entries.push(
+          decode_typed_edn_node(graph, node.key, key, `${path}.key`, depth + 1),
+          decode_typed_edn_node(graph, node.value, value, `${path}.value`, depth + 1)
+        );
+      });
+      return new CalcitSliceMap(entries);
+    }
+    case "ref":
+      if (!(input instanceof CalcitRef)) return typed_edn_error(path, `expected atom, got ${typed_edn_kind(input)}`);
+      return atom(decode_typed_edn_node(graph, node.inner, input.value, `${path}.value`, depth + 1));
+    case "struct": {
+      if (!(input instanceof CalcitRecord)) {
+        return typed_edn_error(path, `expected record :${node.nominal.name.value}, got ${typed_edn_kind(input)}`);
+      }
+      if (input.name.value !== node.nominal.name.value) {
+        return typed_edn_error(path, `expected record :${node.nominal.name.value}, got record :${input.name.value}`);
+      }
+      const expectedNames = node.fields.map(([name]) => name);
+      const actualNames = input.fields.map((field) => field.value);
+      const missing = expectedNames.filter((name) => !actualNames.includes(name)).sort();
+      const unknown = actualNames.filter((name) => !expectedNames.includes(name)).sort();
+      if (missing.length > 0 || unknown.length > 0 || expectedNames.length !== actualNames.length) {
+        return typed_edn_error(
+          path,
+          `record :${node.nominal.name.value} fields mismatch; missing [${missing.join(", ")}], unknown [${unknown.join(", ")}]`
+        );
+      }
+      const decodedFields = new Map<string, CalcitValue>();
+      node.fields.forEach(([name, fieldNode]) => {
+        const idx = actualNames.indexOf(name);
+        decodedFields.set(name, decode_typed_edn_node(graph, fieldNode, input.values[idx], `${path}.${name}`, depth + 1));
+      });
+      // Native declarations use lexical field order while the JS runtime keeps
+      // its interned-tag order. Re-align values to the nominal JS declaration.
+      const values = node.nominal.fields.map((field) => decodedFields.get(field.value)!);
+      return new CalcitRecord(node.nominal.name, node.nominal.fields, values, node.nominal);
+    }
+    case "enum": {
+      if (!(input instanceof CalcitTuple) || input.enumPrototype == null) {
+        return typed_edn_error(path, `expected enum :${node.nominal.name()}, got ${typed_edn_kind(input)}`);
+      }
+      const actualEnumName = enum_prototype_name(input.enumPrototype);
+      if (actualEnumName !== node.nominal.name()) {
+        return typed_edn_error(path, `expected enum :${node.nominal.name()}, got enum :${actualEnumName}`);
+      }
+      if (!(input.tag instanceof CalcitTag)) {
+        return typed_edn_error(path, `enum :${node.nominal.name()} variant must be a tag`);
+      }
+      const inputTag = input.tag;
+      const variant = node.variants.find((candidate) => candidate.tag === inputTag.value);
+      if (variant == null) {
+        return typed_edn_error(path, `enum :${node.nominal.name()} has no variant :${inputTag.value}`);
+      }
+      if (variant.payload.length !== input.extra.length) {
+        return typed_edn_error(
+          path,
+          `enum :${node.nominal.name()} variant :${variant.tag} expects ${variant.payload.length} payload(s), got ${input.extra.length}`
+        );
+      }
+      const values = variant.payload.map((payloadNode, idx) =>
+        decode_typed_edn_node(graph, payloadNode, input.extra[idx], `${path}.payload[${idx}]`, depth + 1)
+      );
+      return new CalcitTuple(newTag(variant.tag), values, node.nominal);
+    }
+  }
+};
+
+export let parse_cirru_edn_as = (code: string, graph: EdnDecoderGraph): CalcitValue => {
+  if (typeof code !== "string") throw new Error(`parse-cirru-edn-as expected a string, got ${typed_edn_kind(code)}`);
+  const enumOptions: CalcitValue[] = [];
+  for (const node of graph.nodes) {
+    if (node.kind === "enum") enumOptions.push(newTag(node.nominal.name()), node.nominal);
+  }
+
+  let input: any;
+  try {
+    const nodes = parse(code);
+    if (nodes.length !== 1) throw new Error(`expected EDN in a single node, got ${nodes.length}`);
+    input = extract_cirru_edn(nodes[0], new CalcitSliceMap(enumOptions));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : `${error}`;
+    throw new Error(`parse-cirru-edn-as failed to parse Cirru EDN: ${message}`);
+  }
+  return decode_typed_edn_node(graph, graph.root, input, "$", 0) as CalcitValue;
 };
 
 const json_to_calcit = (value: any): CalcitValue => {

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1781,7 +1781,15 @@ const decode_typed_edn_node = (graph: EdnDecoderGraph, nodeId: number, input: an
       });
       // Native declarations use lexical field order while the JS runtime keeps
       // its interned-tag order. Re-align values to the nominal JS declaration.
-      const values = node.nominal.fields.map((field) => decodedFields.get(field.value)!);
+      if (decodedFields.size !== node.nominal.fields.length) {
+        return typed_edn_error(path, `record :${node.nominal.name.value} decoder fields do not match its nominal declaration`);
+      }
+      const values = node.nominal.fields.map((field) => {
+        if (!decodedFields.has(field.value)) {
+          return typed_edn_error(path, `record :${node.nominal.name.value} is missing declared field :${field.value}`);
+        }
+        return decodedFields.get(field.value)!;
+      });
       return new CalcitRecord(node.nominal.name, node.nominal.fields, values, node.nominal);
     }
     case "enum": {
@@ -1811,6 +1819,8 @@ const decode_typed_edn_node = (graph: EdnDecoderGraph, nodeId: number, input: an
       );
       return new CalcitTuple(newTag(variant.tag), values, node.nominal);
     }
+    default:
+      return typed_edn_error(path, `invalid decoder graph node kind: ${(node as any).kind}`);
   }
 };
 

--- a/ts-src/js-cirru.mts
+++ b/ts-src/js-cirru.mts
@@ -348,10 +348,9 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
       if (options instanceof CalcitMap || options instanceof CalcitSliceMap) {
         let v = options.get(extractFieldTag(name));
         if (v != null && v instanceof CalcitRecord) {
-          if (!deepEqual(v.fields, fields)) {
-            throw new Error(`Fields mismatch for ${name}, expected ${fields}, got ${v.fields}`);
+          if (deepEqual(v.fields, fields)) {
+            return new CalcitRecord(extractFieldTag(name), fields, values, v.structRef);
           }
-          return new CalcitRecord(extractFieldTag(name), fields, values, v.structRef);
         }
       }
 

--- a/ts-src/js-cirru.mts
+++ b/ts-src/js-cirru.mts
@@ -13,6 +13,7 @@ import { CalcitImpl } from "./js-impl.mjs";
 import { CalcitRef } from "./js-ref.mjs";
 import { deepEqual } from "@calcit/ternary-tree/lib/utils.mjs";
 import { atom } from "./js-ref.mjs";
+import { TypedEdnSetView } from "./typed-edn.mjs";
 
 type CirruEdnFormat = string | CirruEdnFormat[];
 
@@ -256,7 +257,7 @@ const tag_to_string = (tag: CalcitValue): string => {
   throw new Error(`Unsupported tag for EDN: ${tag}`);
 };
 
-export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): CalcitValue => {
+const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preserveSourceEntries: boolean): any => {
   if (typeof x === "string") {
     if (x === "nil") {
       return null;
@@ -291,6 +292,7 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
     }
     if (x[0] === "{}") {
       let result: Array<CalcitValue> = [];
+      const sourceKeys: CirruEdnFormat[] = [];
       x.forEach((pair, idx) => {
         if (idx === 0) {
           return; // skip first `{}` symbol
@@ -298,7 +300,15 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
         if (pair instanceof Array) {
           if (pair[0] === ";") return;
           if (pair.length === 2) {
-            result.push(extract_cirru_edn(pair[0], options), extract_cirru_edn(pair[1], options));
+            const key = extract_cirru_edn_inner(pair[0], options, preserveSourceEntries);
+            const value = extract_cirru_edn_inner(pair[1], options, preserveSourceEntries);
+            const existingIdx = preserveSourceEntries ? sourceKeys.findIndex((sourceKey) => deepEqual(sourceKey, pair[0])) : -1;
+            if (existingIdx >= 0) {
+              result[(existingIdx << 1) + 1] = value;
+            } else {
+              if (preserveSourceEntries) sourceKeys.push(pair[0]);
+              result.push(key, value);
+            }
           } else {
             throw new Error(`Expected a pair, got: ${pair}`);
           }
@@ -323,7 +333,10 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
           if (pair[0] === ";") return;
           if (pair.length === 2) {
             if (typeof pair[0] === "string") {
-              entries.push([extractFieldTag(pair[0]), extract_cirru_edn(pair[1], options)]);
+              entries.push([
+                extractFieldTag(pair[0]),
+                extract_cirru_edn_inner(pair[1], options, preserveSourceEntries),
+              ]);
             } else {
               throw new Error(`Expected string as field, got: ${pair}`);
             }
@@ -367,19 +380,19 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
         x
           .slice(1)
           .filter(notComment)
-          .map((x) => extract_cirru_edn(x, options))
+          .map((x) => extract_cirru_edn_inner(x, options, preserveSourceEntries))
       );
     }
     if (x[0] === "#{}") {
-      return new CalcitSet(
-        x
-          .slice(1)
-          .filter(notComment)
-          .map((x) => extract_cirru_edn(x, options))
-      );
+      const sourceItems = x.slice(1).filter(notComment);
+      const uniqueSourceItems = preserveSourceEntries
+        ? sourceItems.filter((item, idx) => !sourceItems.slice(0, idx).some((existing) => deepEqual(existing, item)))
+        : sourceItems;
+      const items = uniqueSourceItems.map((x) => extract_cirru_edn_inner(x, options, preserveSourceEntries));
+      return preserveSourceEntries ? new TypedEdnSetView(items) : new CalcitSet(items);
     }
     if (x[0] === "do" && x.length === 2) {
-      return extract_cirru_edn(x[1], options);
+      return extract_cirru_edn_inner(x[1], options, preserveSourceEntries);
     }
     if (x[0] === "quote") {
       if (x.length !== 2) {
@@ -392,11 +405,11 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
         throw new Error(`tuple expects at least 1 value, got: ${x}`);
       }
       return new CalcitTuple(
-        extract_cirru_edn(x[1], options),
+        extract_cirru_edn_inner(x[1], options, preserveSourceEntries),
         x
           .slice(2)
           .filter(notComment)
-          .map((x) => extract_cirru_edn(x, options))
+          .map((x) => extract_cirru_edn_inner(x, options, preserveSourceEntries))
       );
     }
     if (x[0] === "%::") {
@@ -412,11 +425,11 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
       const proto = enumPrototype != null ? unwrap_enum_prototype_local(enumPrototype) : null;
       const enumTag = proto != null ? proto.name.toString() : enumName;
       return new CalcitTuple(
-        extract_cirru_edn(x[2], options),
+        extract_cirru_edn_inner(x[2], options, preserveSourceEntries),
         x
           .slice(3)
           .filter(notComment)
-          .map((x) => extract_cirru_edn(x, options)),
+          .map((x) => extract_cirru_edn_inner(x, options, preserveSourceEntries)),
         enumPrototype
       );
     }
@@ -424,11 +437,19 @@ export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): Calcit
       if (x.length !== 2) {
         throw new Error(`atom expects 1 argument, got: ${x}`);
       }
-      return atom(extract_cirru_edn(x[1], options));
+      return atom(extract_cirru_edn_inner(x[1], options, preserveSourceEntries));
     }
   }
   console.error(x);
   throw new Error(`Unexpected data from EDN: ${x}`);
+};
+
+export let extract_cirru_edn = (x: CirruEdnFormat, options: CalcitValue): CalcitValue => {
+  return extract_cirru_edn_inner(x, options, false) as CalcitValue;
+};
+
+export let extract_cirru_edn_for_typed = (x: CirruEdnFormat, options: CalcitValue): CalcitValue | TypedEdnSetView => {
+  return extract_cirru_edn_inner(x, options, true) as CalcitValue | TypedEdnSetView;
 };
 
 export let format_cirru_edn = (data: CalcitValue, useInline: boolean = true): string => {

--- a/ts-src/typed-edn.mts
+++ b/ts-src/typed-edn.mts
@@ -1,0 +1,7 @@
+export class TypedEdnSetView {
+  readonly items: any[];
+
+  constructor(items: any[]) {
+    this.items = items;
+  }
+}


### PR DESCRIPTION
## Summary

- add the RFC and Phase 1 implementation for `parse-cirru-edn-as text TypeExpr`
- derive a closed `EdnDecoderGraph` during preprocessing and reject Dynamic or incomplete target types
- deeply decode and reconstruct scalar, container, struct, enum, generic, and where-bounded data with path-aware errors
- keep Native and JS behavior aligned, including exact nominal identity and imported types
- remove the old dynamic record-options panic on mismatched fields

## Design boundary

Phase 1 intentionally covers finite closed types. First-class `EdnDecoder<T>` values and recursive nominal types remain Phase 2 work. The existing recursive nominal preprocessing defect is tracked in #295.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- `cr docs check-md docs/data/edn.md --entry calcit/test.cirru`
- Timegrass snapshot copy with current `cr --check-only`
