### PR TITLE
chore: release 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.12.59"
+version = "0.13.0"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.12.59"
+version = "0.13.0"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608060220-release-0.13.0.md
+++ b/editing-history/202608060220-release-0.13.0.md
@@ -1,0 +1,5 @@
+# 发布 0.13.0
+
+- 将 Cargo crate 与 npm package 的版本同步升级到 0.13.0。
+- 该 minor 版本承载 Option、Result、Unit 与 JsNullish 公共契约的集中 breaking change，作为后续 nil 安全 API 的稳定基线。
+- 发布前后继续通过 Calcit 全量验证与 Respo 真实页面回归，避免将未被类型系统发现的 JS FFI 兼容问题带入后续版本。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.12.59",
+  "version": "0.13.0",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Summary

- bump the Rust crate and npm package to 0.13.0
- refresh Cargo.lock
- establish the released baseline for the Option/Result/Unit/JsNullish API migration

## Validation

- cargo fmt
- cargo clippy -- -D warnings
- yarn compile
- cargo test
- yarn check-all
- yarn check-agent-interface
- Respo check-only passes with the migrated API usage