### PR TITLE
fix: support recursive nominal types

### DIFF
--- a/calcit/test-generics.cirru
+++ b/calcit/test-generics.cirru
@@ -18,6 +18,13 @@
               :box $ :: 'Box 'T
           :examples $ []
           :schema $ :: 'Dynamic
+        |Node $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defstruct Node
+              :next $ :: 'Optional Node
+              :value 'Number
+          :examples $ []
+          :schema $ :: 'Dynamic
         |Pair $ %{} :CodeEntry (:doc "|Generic pair struct")
           :code $ quote
             defstruct Pair ([] 'T 'U) (:left 'T) (:right 'U)
@@ -25,7 +32,7 @@
           :schema $ :: 'Dynamic
         |main! $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn main! () $ do (println "|Testing generics...") (println "|  - generic structs") (test-struct-generics) (println "|  - function generics and where-bounds") (test-fn-generics) (println "|Generics tests passed")
+            defn main! () $ do (println "|Testing generics...") (println "|  - generic structs") (test-struct-generics) (println "|  - function generics and where-bounds") (test-recursive-struct) (test-fn-generics) (println "|Generics tests passed")
           :examples $ []
           :schema $ :: 'Dynamic
         |pair-right $ %{} :CodeEntry (:doc "|Return the right value from a generic pair")
@@ -82,6 +89,17 @@
               &inspect-type n
               &inspect-type s
               &inspect-type show-id
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-recursive-struct $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defn test-recursive-struct () (println "|Testing recursive struct support...")
+              let
+                  leaf $ %{} Node (:next nil) (:value 1)
+                  nested $ %{} Node (:next leaf) (:value 2)
+                assert= 1 $ :value (:next nested)
+                assert= 2 $ :value nested
+                println "|Recursive struct support passed"
           :examples $ []
           :schema $ :: 'Dynamic
         |test-struct-generics $ %{} :CodeEntry (:doc |)

--- a/history/202608061335-recursive-nominal-display.md
+++ b/history/202608061335-recursive-nominal-display.md
@@ -1,0 +1,28 @@
+# Recursive nominal types and symbol presentation
+
+## Background
+
+`defstruct` field annotations eagerly resolved a reference to their own
+definition. A recursive field such as `(:: 'Optional Node)` therefore expanded
+`Node` while it was being declared and could exhaust the Rust stack. In
+addition, nominal record, struct, and enum names were displayed as tags even
+though they are type symbols.
+
+## Changes
+
+- Preserve a strict self-reference as `TypeRef` during type annotation parsing,
+  while keeping normal trait reference resolution unchanged.
+- Add native and snapshot regression coverage for nil and nested recursive
+  nodes, plus a required recursive field that produces a regular type error.
+- Render record, struct, and enum names as quoted symbols in Rust and the JS
+  runtime.
+- Extend the browser custom formatter to expose nominal struct field types and
+  enum payload types, with structured runtime checks for the formatter output.
+
+## Verification
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-all`

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -17,6 +17,40 @@ try {
   const runtimeB = await import(pathToFileURL(join(runtimeBPath, "calcit.procs.mjs")).href);
   assert.equal(runtimeA.get_env, runtimeA._$n_get_env, "legacy get_env export should delegate to the raw proc");
   assert.equal(runtimeA.get_env("CALCIT_MISSING_ENV_FOR_RUNTIME_TEST", "fallback"), "fallback");
+
+  const todoName = runtimeA.newTag("TodoState");
+  const todoField = runtimeA.newTag("draft");
+  const todoType = new runtimeA.CalcitSymbol("String");
+  const todoRecord = new runtimeA.CalcitRecord(todoName, [todoField], [""]);
+  const todoStruct = new runtimeA.CalcitStruct(todoName, [todoField], [todoType]);
+  const todoEnum = new runtimeA.CalcitEnum(new runtimeA.CalcitRecord(todoName, [todoField], [todoType]));
+  assert.equal(todoRecord.toString(), "(%{} 'TodoState (:draft |))");
+  assert.equal(todoStruct.toString(), "(%struct 'TodoState (:draft 'String))");
+  assert.equal(todoEnum.toString(), "(%enum 'TodoState)");
+
+  runtimeA.load_console_formatter_$x_();
+  const formatter = globalThis.devtoolsFormatters.at(-1);
+  const embeddedObjects = (node, found = []) => {
+    if (Array.isArray(node)) {
+      if (node[0] === "object" && node[1]?.object != null) found.push(node[1].object);
+      for (const item of node) embeddedObjects(item, found);
+    } else if (node != null && typeof node === "object") {
+      for (const value of Object.values(node)) embeddedObjects(value, found);
+    }
+    return found;
+  };
+  const assertNominalNameIsSymbol = (value, kind) => {
+    const name = embeddedObjects(formatter.header(value)).find((item) => item?.value === "TodoState");
+    assert.ok(name instanceof runtimeA.CalcitSymbol, `${kind} formatter should render its name as a symbol`);
+  };
+  assertNominalNameIsSymbol(todoRecord, "record");
+  assertNominalNameIsSymbol(todoStruct, "struct");
+  assertNominalNameIsSymbol(todoEnum, "enum");
+  assert.ok(formatter.hasBody(todoStruct), "struct formatter should expose field types");
+  assert.ok(formatter.hasBody(todoEnum), "enum formatter should expose variants");
+  assert.ok(embeddedObjects(formatter.body(todoStruct)).includes(todoType), "struct formatter should embed field types");
+  assert.ok(embeddedObjects(formatter.body(todoEnum)).includes(todoType), "enum formatter should embed variant payload types");
+
   const foreignField = runtimeA.newTag("show");
   const method = () => "demo";
   const foreignImpl = new runtimeA.CalcitImpl(runtimeA.newTag("ForeignImpl"), [foreignField], [method], null);

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -1512,6 +1512,26 @@ mod tests {
   }
 
   #[test]
+  fn required_recursive_field_returns_a_type_error_without_recursing() {
+    let struct_def = CalcitStruct {
+      name: EdnTag::new("RequiredNode"),
+      fields: Arc::new(vec![EdnTag::new("next")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from("RequiredNode"),
+        Arc::new(vec![]),
+      ))]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    };
+
+    let err = call_record(&[Calcit::Struct(struct_def), Calcit::tag("next"), Calcit::Nil])
+      .expect_err("a required recursive field must reject nil instead of recursing");
+
+    assert!(err.msg.contains("expects type `'RequiredNode`"), "unexpected error: {err:?}");
+  }
+
+  #[test]
   fn indexed_record_updates_reject_stale_field_tags() {
     let record = indexed_record_fixture();
     let assoc_error = record_assoc_at(&[record.clone(), Calcit::Number(0.0), Calcit::tag("y"), Calcit::Number(3.0)])

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -256,7 +256,7 @@ impl fmt::Display for Calcit {
         if record::LOOSE_RECORD_NAME == struct_ref.name.ref_str() {
           f.write_str("(?{}")?;
         } else {
-          f.write_str(&format!("(%{{}} {}", Tag(struct_ref.name.to_owned())))?;
+          f.write_str(&format!("(%{{}} '{}", struct_ref.name))?;
         }
         for idx in 0..struct_ref.fields.len() {
           f.write_str(&format!(" ({} {})", Calcit::tag(struct_ref.fields[idx].ref_str()), values[idx]))?;
@@ -267,7 +267,7 @@ impl fmt::Display for Calcit {
         name, fields, field_types, ..
       }) => {
         f.write_str("(%struct ")?;
-        f.write_str(&format!(":{name}"))?;
+        f.write_str(&format!("'{name}"))?;
         for (k, t) in fields.iter().zip(field_types.iter()) {
           f.write_char(' ')?;
           f.write_str(&format!("(:{k} {})", t.to_brief_string()))?;
@@ -276,7 +276,7 @@ impl fmt::Display for Calcit {
       }
       Enum(enum_def) => {
         f.write_str("(%enum ")?;
-        f.write_str(&format!(":{}", enum_def.name()))?;
+        f.write_str(&format!("'{}", enum_def.name()))?;
         for variant in enum_def.variants() {
           f.write_char(' ')?;
           f.write_str(&format!("(:{}", variant.tag))?;
@@ -1605,9 +1605,21 @@ mod tests {
     };
     let enum_value = Calcit::Enum(CalcitEnum::from_record(enum_record).expect("valid enum"));
     let text = enum_value.to_string();
-    assert!(text.starts_with("(%enum :Result"), "unexpected display: {text}");
+    assert!(text.starts_with("(%enum 'Result"), "unexpected display: {text}");
     assert!(text.contains(":ok)"), "missing zero-payload variant: {text}");
     assert!(text.contains(":err :string)"), "missing payload variant: {text}");
+  }
+
+  #[test]
+  fn named_data_display_uses_symbol_name() {
+    let record = Calcit::Record(CalcitRecord {
+      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("TodoState"), vec![EdnTag::new("draft")])),
+      values: Arc::new(vec![Calcit::Str(Arc::from(""))]),
+    });
+    let struct_def = Calcit::Struct(CalcitStruct::from_fields(EdnTag::new("TodoState"), vec![EdnTag::new("draft")]));
+
+    assert_eq!(record.to_string(), "(%{} 'TodoState (:draft |))");
+    assert!(struct_def.to_string().starts_with("(%struct 'TodoState"));
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2065,6 +2065,17 @@ impl CalcitTypeAnnotation {
       }
     }
 
+    // Keep a self-referential field annotation nominal. Resolving it would
+    // eagerly rebuild its struct and unfold the declaration until the process
+    // exhausts its stack. Other named forms retain their existing resolution
+    // behavior (notably trait references).
+    if strict_named_refs
+      && matches!(form, Calcit::Symbol { sym, info, .. } if sym == &info.at_def)
+      && let Some(name) = Self::extract_type_ref_name(form)
+    {
+      return Arc::new(CalcitTypeAnnotation::TypeRef(name, Arc::new(vec![])));
+    }
+
     if let Some(resolved) = resolve_calcit_value(form) {
       match resolved {
         Calcit::Trait(trait_def) => return Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def))),
@@ -3575,6 +3586,29 @@ mod tests {
       }),
       location: None,
     }
+  }
+
+  #[test]
+  fn strict_parser_keeps_recursive_struct_name_as_type_ref() {
+    let self_symbol = Calcit::Symbol {
+      sym: Arc::from("Node"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests"),
+        at_def: Arc::from("Node"),
+      }),
+      location: None,
+    };
+    let optional_node = Calcit::from(vec![Calcit::Proc(CalcitProc::NativeTuple), symbol("Optional"), self_symbol]);
+
+    let parsed = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(&optional_node, &[]);
+    assert!(
+      matches!(
+        parsed.as_ref(),
+        CalcitTypeAnnotation::Optional(inner)
+          if matches!(inner.as_ref(), CalcitTypeAnnotation::TypeRef(name, args) if name.as_ref() == "Node" && args.is_empty())
+      ),
+      "recursive field annotation must remain a finite TypeRef, got {parsed:?}"
+    );
   }
 
   fn generic_result_enum() -> Arc<CalcitEnum> {

--- a/ts-src/custom-formatter.mts
+++ b/ts-src/custom-formatter.mts
@@ -3,6 +3,8 @@ import { CalcitSymbol, CalcitTag } from "./calcit-data.mjs";
 import { CalcitRef } from "./js-ref.mjs";
 
 import { CalcitRecord } from "./js-record.mjs";
+import { CalcitStruct } from "./js-struct.mjs";
+import { CalcitEnum } from "./js-enum.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitList, CalcitSliceList } from "./js-list.mjs";
 import { CalcitSet } from "./js-set.mjs";
@@ -180,19 +182,41 @@ export let load_console_formatter_$x_ = () => {
             );
           }
           if (obj instanceof CalcitRecord) {
+            let name = new CalcitSymbol(obj.name.value);
             if (obj.structRef.impls.length > 0) {
               let ret: any[] = div(
                 { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
                 span({}, "%{}"),
                 span({ marginLeft: "6px" }, embedObject(obj.structRef.impls[0])),
-                span({ marginLeft: "6px" }, embedObject(obj.name)),
+                span({ marginLeft: "6px" }, embedObject(name)),
                 span({ marginLeft: "6px" }, `...`)
               );
               return ret;
             } else {
-              let ret: any[] = div({ color: hsl(280, 80, 60, 0.4), maxWidth: "100%" }, `%{} ${obj.name} ...`);
+              let ret: any[] = div(
+                { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
+                "%{} ",
+                embedObject(name),
+                " ..."
+              );
               return ret;
             }
+          }
+          if (obj instanceof CalcitStruct) {
+            return div(
+              { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
+              "%struct ",
+              embedObject(new CalcitSymbol(obj.name.value)),
+              " ..."
+            );
+          }
+          if (obj instanceof CalcitEnum) {
+            return div(
+              { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
+              "%enum ",
+              embedObject(new CalcitSymbol(obj.prototype.name.value)),
+              " ..."
+            );
           }
           if (obj instanceof CalcitTuple) {
             if (obj.impls.length > 0) {
@@ -254,6 +278,9 @@ export let load_console_formatter_$x_ = () => {
           }
           if (obj instanceof CalcitRecord) {
             return obj.fields.length > 0;
+          }
+          if (obj instanceof CalcitStruct || obj instanceof CalcitEnum) {
+            return obj instanceof CalcitStruct ? obj.fields.length > 0 : obj.prototype.fields.length > 0;
           }
           return false;
         },
@@ -325,6 +352,32 @@ export let load_console_formatter_$x_ = () => {
                   {},
                   td({ paddingLeft: "8px", verticalAlign: "top", whiteSpace: "pre", minWidth: "40px" }, embedObject(obj.fields[idx])),
                   td({ paddingLeft: "8px" }, embedObject(obj.values[idx]))
+                )
+              );
+            }
+            return ret;
+          }
+          if (obj instanceof CalcitStruct) {
+            let ret: any[] = table({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
+            for (let idx = 0; idx < obj.fields.length; idx++) {
+              ret.push(
+                tr(
+                  {},
+                  td({ paddingLeft: "8px", verticalAlign: "top", whiteSpace: "pre", minWidth: "40px" }, embedObject(obj.fields[idx])),
+                  td({ paddingLeft: "8px" }, embedObject(obj.fieldTypes[idx]))
+                )
+              );
+            }
+            return ret;
+          }
+          if (obj instanceof CalcitEnum) {
+            let ret: any[] = table({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
+            for (let idx = 0; idx < obj.prototype.fields.length; idx++) {
+              ret.push(
+                tr(
+                  {},
+                  td({ paddingLeft: "8px", verticalAlign: "top", whiteSpace: "pre", minWidth: "40px" }, embedObject(obj.prototype.fields[idx])),
+                  td({ paddingLeft: "8px" }, embedObject(obj.prototype.values[idx]))
                 )
               );
             }

--- a/ts-src/js-enum.mts
+++ b/ts-src/js-enum.mts
@@ -31,6 +31,6 @@ export class CalcitEnum {
   }
 
   toString(): string {
-    return `(%enum :${this.prototype.name.value})`;
+    return `(%enum '${this.prototype.name.value})`;
   }
 }

--- a/ts-src/js-record.mts
+++ b/ts-src/js-record.mts
@@ -70,7 +70,7 @@ export class CalcitRecord {
   }
   toString(disableJsDataWarning: boolean = false): string {
     // Optimize string building using array join instead of concatenation
-    const parts = ["(%{} ", this.name.toString()];
+    const parts = ["(%{} '", this.name.value];
     for (let idx = 0; idx < this.fields.length; idx++) {
       parts.push(" (", this.fields[idx].toString(), " ", toString(this.values[idx], true, disableJsDataWarning), ")");
     }

--- a/ts-src/js-struct.mts
+++ b/ts-src/js-struct.mts
@@ -33,7 +33,7 @@ export class CalcitStruct {
     if (this.fields.length !== this.fieldTypes.length) {
       throw new Error("CalcitStruct: fields and fieldTypes length mismatch");
     }
-    const parts: string[] = ["(%struct :", this.name.value];
+    const parts: string[] = ["(%struct '", this.name.value];
     for (let idx = 0; idx < this.fields.length; idx++) {
       const field = this.fields[idx];
       const fieldType = this.fieldTypes[idx];


### PR DESCRIPTION
## Summary
- prevent self-referential struct field annotations from eagerly unfolding during type parsing
- render nominal record, struct, and enum names as symbols in Rust, JS, and DevTools
- add recursive construction and formatter regressions

## Verification
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-all