### PR TITLE
chore: release 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608061340-release-0.13.1.md
+++ b/editing-history/202608061340-release-0.13.1.md
@@ -1,0 +1,6 @@
+# 发布 0.13.1
+
+- 将 Cargo crate 与 npm package 的版本同步升级到 0.13.1。
+- 本 patch 修复自递归 nominal struct 的类型注解解析，避免 Optional 自引用在定义时递归展开。
+- record、struct 与 enum 的展示名称统一为 symbol；JS DevTools formatter 同步展示 nominal 定义与 enum payload。
+- 发布前通过 Rust、TypeScript 与全量集成验证。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Release 0.13.1

Patch release for recursive nominal struct annotations and nominal symbol presentation.

## Verification
- cargo fmt
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-all