### PR TITLE
feat: align nominal data model with struct and enum

### DIFF
--- a/calcit/test-algebra.cirru
+++ b/calcit/test-algebra.cirru
@@ -32,29 +32,29 @@
             defimpl AlgebraBoxApplyImpl AlgebraApply $ .apply
               fn (box fs)
                 let
-                    f $ &record:get fs :value
-                  assoc box :value $ f (&record:get box :value)
+                    f $ &struct:get fs :value
+                  assoc box :value $ f (&struct:get box :value)
           :examples $ []
           :schema $ :: 'Dynamic
         |AlgebraBoxBindImpl $ %{} :CodeEntry (:doc |)
           :code $ quote
             defimpl AlgebraBoxBindImpl AlgebraBind $ .bind
               fn (box f)
-                f $ &record:get box :value
+                f $ &struct:get box :value
           :examples $ []
           :schema $ :: 'Dynamic
         |AlgebraBoxMapImpl $ %{} :CodeEntry (:doc |)
           :code $ quote
             defimpl AlgebraBoxMapImpl AlgebraMap $ .map
               fn (box f)
-                assoc box :value $ f (&record:get box :value)
+                assoc box :value $ f (&struct:get box :value)
           :examples $ []
           :schema $ :: 'Dynamic
         |AlgebraBoxMappendImpl $ %{} :CodeEntry (:doc |)
           :code $ quote
             defimpl AlgebraBoxMappendImpl AlgebraMappend $ .mappend
               fn (a b)
-                assoc a :value $ + (&record:get a :value) (&record:get b :value)
+                assoc a :value $ + (&struct:get a :value) (&struct:get b :value)
           :examples $ []
           :schema $ :: 'Dynamic
         |AlgebraMap $ %{} :CodeEntry (:doc |)
@@ -91,7 +91,7 @@
               assert-traits bf AlgebraApply
               let
                   b2 $ .apply b1 bf
-                assert= (%some 12) (get b2 :value)
+                assert= 12 $ get b2 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -105,7 +105,7 @@
                   b2 $ .bind b1
                     fn (x)
                       %{} AlgebraBox $ :value (+ x 20)
-                assert= (%some 25) (get b2 :value)
+                assert= 25 $ get b2 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -118,7 +118,7 @@
               let
                   b2 $ .map b1
                     fn (x) (+ x 10)
-                assert= (%some 12) (get b2 :value)
+                assert= 12 $ get b2 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -132,7 +132,7 @@
               assert-traits b2 AlgebraMappend
               let
                   b3 $ .mappend b1 b2
-                assert= (%some 7) (get b3 :value)
+                assert= 7 $ get b3 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/test-def-meta.cirru
+++ b/calcit/test-def-meta.cirru
@@ -31,9 +31,9 @@
                   doc $ &get-def-doc |calcit.core/map
                   schema $ &get-def-schema |calcit.core/map
                 assert= true $ includes? doc |map
-                assert= 'Fn $ &tuple:nth schema 0
+                assert= 'Fn $ &enum:nth schema 0
                 assert= true $ option:some?
-                  get (&tuple:nth schema 1) :args
+                  get (&enum:nth schema 1) :args
           :examples $ []
           :schema $ :: 'Dynamic
         |test-local-def $ %{} :CodeEntry (:doc "|lookup local definition metadata")
@@ -43,9 +43,9 @@
                   doc $ &get-def-doc |test-def-meta.main/MetaSample
                   schema $ &get-def-schema |test-def-meta.main/MetaSample
                 assert= "|Sample definition for def metadata lookup tests" doc
-                assert= 'Fn $ &tuple:nth schema 0
+                assert= 'Fn $ &enum:nth schema 0
                 assert= (%some 'Number)
-                  get (&tuple:nth schema 1) :return
+                  get (&enum:nth schema 1) :return
           :examples $ []
           :schema $ :: 'Dynamic
         |test-missing-doc $ %{} :CodeEntry (:doc "|missing definition returns empty doc string")

--- a/calcit/test-doc-smoke.cirru
+++ b/calcit/test-doc-smoke.cirru
@@ -26,7 +26,7 @@
           :code $ quote
             defimpl DocTraitImpl DocTrait $ .label
               fn (x)
-                str-spaced |doc $ &record:get x :name
+                str-spaced |doc $ &struct:get x :name
           :examples $ []
           :schema $ :: 'Dynamic
         |main! $ %{} :CodeEntry (:doc "|Run docs smoke cases")
@@ -59,8 +59,8 @@
               let
                   DocPerson $ impl-traits DocPerson0 DocTraitImpl
                   DocEnum $ impl-traits DocEnum0 DocTraitImpl
-                assert= true $ struct? DocPerson
-                assert= true $ enum? DocEnum
+                assert= true $ struct-def? DocPerson
+                assert= true $ enum-def? DocEnum
               let
                   msg $ try
                     do
@@ -79,7 +79,7 @@
             defn test-native-impl-new-dot-method () $ let
                 DotImpl $ &impl::new DocTrait
                   :: .label $ fn (x)
-                    str-spaced |native-dot $ &record:get x :name
+                    str-spaced |native-dot $ &struct:get x :name
                 DotPerson $ impl-traits DocPerson0 DotImpl
                 p $ %{} DotPerson (:name |Bob)
               assert= (%some DocTrait) (impl-origin DotImpl)

--- a/calcit/test-edn.cirru
+++ b/calcit/test-edn.cirru
@@ -128,12 +128,12 @@
               let
                   enum-ok $ parse-cirru-edn "|%:: :DemoEnum :ok"
                     {} $ :DemoEnum DemoEnum
-                assert= :ok $ &tuple:nth enum-ok 0
+                assert= :ok $ &enum:nth enum-ok 0
                 assert= "|%:: :DemoEnum :ok" $ trim (format-cirru-edn enum-ok)
               let
                   enum-err $ parse-cirru-edn "|%:: :DemoEnum :err |oops"
                     {} $ :DemoEnum DemoEnum
-                assert= :err $ &tuple:nth enum-err 0
+                assert= :err $ &enum:nth enum-err 0
                 assert= "|%:: :DemoEnum :err |oops" $ trim (format-cirru-edn enum-err)
               assert= "|do \"|a b\"" $ trim (format-cirru-edn "|a b")
               assert= "|do |hello" $ trim (format-cirru-edn |hello)
@@ -170,7 +170,7 @@
                 assert= data $ eval (&data-to-code data)
               let
                   d $ %{}? A
-                assert= true $ record? d
+                assert= true $ struct? d
               let
                   data $ #{} 1 2 3
                 assert= data $ eval (&data-to-code data)
@@ -207,7 +207,7 @@
               assert=
                 %{} Box $ :value |hello
                 , boxed
-              assert= :err $ &tuple:nth enum-value 0
+              assert= :err $ &enum:nth enum-value 0
               assert= true $ try
                 do
                   parse-cirru-edn-as "|[] $ %{} :Person (:age |old) (:name |Ada)" $ :: 'List Person

--- a/calcit/test-enum.cirru
+++ b/calcit/test-enum.cirru
@@ -55,7 +55,7 @@
         |check-result-type $ %{} :CodeEntry (:doc "|Check if value has enum origin")
           :code $ quote
             defn check-result-type (r)
-              option:some? $ tuple-enum r
+              option:some? $ enum-definition r
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Bool)
@@ -91,17 +91,17 @@
               let
                   valid-ok $ %:: Result0 :ok
                   Result1 $ impl-traits Result0 ResultImpl
-                assert= :ok $ &tuple:nth valid-ok 0
+                assert= :ok $ &enum:nth valid-ok 0
                 let
                     ok-impl $ %:: Result1 :ok
-                  assert= true $ any? (&tuple:impls ok-impl)
+                  assert= true $ any? (&enum:impls ok-impl)
                     fn (impl)
                       includes? (str impl) |ResultTrait
-                  assert= "|(%:: :ok (:enum Result0))" $ str ok-impl
+                  assert= "|(%:: 'Result0 :ok)" $ str ok-impl
               let
                   valid-err $ %:: Result0 :err |error-msg
-                assert= :err $ &tuple:nth valid-err 0
-                assert= true $ tuple? valid-err
+                assert= :err $ &enum:nth valid-err 0
+                assert= true $ enum? valid-err
               ; Test invalid tag $ should fail - uncomment to see error
               ; let
                 (invalid (%:: Result0 :invalid))
@@ -131,9 +131,9 @@
                   unwrap-maybe $ %:: Maybe1 :some 1
                 assert= (%none)
                   unwrap-maybe $ %:: Maybe1 :none
-                assert= :pair $ &tuple:nth pair-value 0
-                assert= 1 $ &tuple:nth pair-value 1
-                assert= |hi $ &tuple:nth pair-value 2
+                assert= :pair $ &enum:nth pair-value 0
+                assert= 1 $ &enum:nth pair-value 1
+                assert= |hi $ &enum:nth pair-value 2
               println "|✓ Generic enum creation passed"
           :examples $ []
           :schema $ :: 'Fn

--- a/calcit/test-optimize.cirru
+++ b/calcit/test-optimize.cirru
@@ -26,7 +26,7 @@
           :code $ quote
             defimpl ShowImpl ShowTrait $ .show
               fn (self)
-                str "|Person: " $ &record:get self :name
+                str "|Person: " $ &struct:get self :name
           :examples $ []
           :schema $ :: 'Dynamic
         |ShowTrait $ %{} :CodeEntry (:doc |)

--- a/calcit/test-record.cirru
+++ b/calcit/test-record.cirru
@@ -85,7 +85,7 @@
           :schema $ :: 'Dynamic
         |check-point-type $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn check-point-type (p) (record? p)
+            defn check-point-type (p) (struct? p)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Bool)
@@ -119,7 +119,7 @@
                     {} $ :Lagopus0
                       %{} Lagopus $ :name nil
                 println |EDN: data
-                assert= true $ any? (&record:impls data)
+                assert= true $ any? (&struct:impls data)
                   fn (impl)
                     = (impl-origin impl) (%some BirdTrait)
               let
@@ -158,15 +158,15 @@
                   a1 $ %{} A (:a 1)
                   b1 $ %{} B (:b 2)
                   c1 $ %{} C (:c 3)
-                assert= 1 $ record-match a1
+                assert= 1 $ struct-match a1
                   A aa $ :a aa
                   B bb $ :b bb
                   _ o (println |others) :other
-                assert= 2 $ record-match b1
+                assert= 2 $ struct-match b1
                   A aa $ :a aa
                   B bb $ :b bb
                   _ o (println |others) :other
-                assert= :other $ record-match c1
+                assert= :other $ struct-match c1
                   A aa $ :a aa
                   B bb $ :b bb
                   _ o (println |others) :other
@@ -179,34 +179,34 @@
             fn () (log-title "|Testing record methods")
               &let
                 kitty $ %{} Cat (:name |kitty) (:color :red)
-                assert= :Cat $ &record:get-name kitty
-                assert= :red $ &record:get kitty :color
-                assert= true $ = (record-struct kitty) Cat
-                assert= true $ struct? (record-struct kitty)
-                assert= true $ &record:matches? kitty
-                  %{} (record-struct kitty) (:name |kitty) (:color :red)
-                assert= (&record:to-map kitty) (&{} :name |kitty :color :red)
-                assert= 2 $ &record:count kitty
+                assert= :Cat $ &struct:get-name kitty
+                assert= :red $ &struct:get kitty :color
+                assert= true $ = (&struct:definition kitty) Cat
+                assert= true $ struct-def? (&struct:definition kitty)
+                assert= true $ &struct:matches? kitty
+                  %{} (&struct:definition kitty) (:name |kitty) (:color :red)
+                assert= (&struct:to-map kitty) (&{} :name |kitty :color :red)
+                assert= 2 $ &struct:count kitty
                 assert=
-                  &record:get kitty $ &record:field-tag kitty 0
-                  &record:nth kitty 0
+                  &struct:get kitty $ &struct:field-tag kitty 0
+                  &struct:nth kitty 0
                 assert=
-                  &record:get kitty $ &record:field-tag kitty 1
-                  &record:nth kitty 1
-                assert= true $ &record:contains? kitty (&record:field-tag kitty 0)
-                assert= true $ &record:contains? kitty (&record:field-tag kitty 1)
-                assert= true $ &record:contains? kitty :color
-                assert= false $ &record:contains? kitty :age
+                  &struct:get kitty $ &struct:field-tag kitty 1
+                  &struct:nth kitty 1
+                assert= true $ &struct:contains? kitty (&struct:field-tag kitty 0)
+                assert= true $ &struct:contains? kitty (&struct:field-tag kitty 1)
+                assert= true $ &struct:contains? kitty :color
+                assert= false $ &struct:contains? kitty :age
                 assert=
                   %{} Cat (:name |kitty) (:color :blue)
-                  &record:assoc kitty :color :blue
+                  &struct:assoc kitty :color :blue
                 assert=
-                  &record:from-map Cat $ &{} :name |kitty :color :red
+                  &struct:from-map Cat $ &{} :name |kitty :color :red
                   %{} Cat (:name |kitty) (:color :red)
                 &let
-                  persian $ &record:extend-as kitty :Persian :age 10
-                  assert= 10 $ &record:get persian :age
-                  assert= :Persian $ &record:get-name persian
+                  persian $ &struct:extend-as kitty :Persian :age 10
+                  assert= 10 $ &struct:get persian :age
+                  assert= :Persian $ &struct:get-name persian
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -218,13 +218,13 @@
                   p1 $ %{}? Person (:name |Chen)
                   p2 $ %{}? Person (:name |Chen) (:age 20) (:position :mainland)
                   p3 $ %{}? Person (:age 31)
-                assert= (%some |Chen) (get p1 :name)
-                assert= (%some nil) (get p1 :age)
-                assert= (%some nil) (get p1 :position)
-                assert= (%some 20) (get p2 :age)
-                assert= (%some nil) (get p3 :name)
-                assert= (%some 31) (get p3 :age)
-                assert= (%some nil) (get p3 :position)
+                assert= |Chen $ get p1 :name
+                assert= nil $ get p1 :age
+                assert= nil $ get p1 :position
+                assert= 20 $ get p2 :age
+                assert= nil $ get p3 :name
+                assert= 31 $ get p3 :age
+                assert= nil $ get p3 :position
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -246,7 +246,7 @@
                   println l1
                   l1t .show
                   l2t .show
-                  assert= (&record:impls l1) (&record:impls a1r)
+                  assert= (&struct:impls l1) (&struct:impls a1r)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -282,29 +282,28 @@
                   p0 $ &%{} Person :name nil :age nil :position nil
                   p3 $ &%{} Person :name |Chen :age 23 :position :mainland
                   c1 $ %{} City (:name |Shanghai) (:province |Shanghai)
-                assert= true $ = (record-struct p0) Person
-                assert= (%some nil) (get p0 :age)
-                assert= (%some nil) (get p0 :name)
-                assert= (%some nil) (get p0 :position)
-                assert= (%some 20) (get p1 :age)
-                assert= (%some 20) (get p2 :age)
-                assert= (%some 23) (get p3 :age)
-                assert= 23 $ &record:get p3 :age
-                assert= :record $ type-of p1
-                assert= (&record:to-map p1)
+                assert= true $ = (&struct:definition p0) Person
+                assert= nil $ get p0 :age
+                assert= nil $ get p0 :name
+                assert= nil $ get p0 :position
+                assert= 20 $ get p1 :age
+                assert= 20 $ get p2 :age
+                assert= 23 $ get p3 :age
+                assert= 23 $ &struct:get p3 :age
+                assert= :struct $ type-of p1
+                assert= (&struct:to-map p1)
                   {} (:name |Chen) (:age 20) (:position :mainland)
-                assert= (%some 21)
-                  get
-                    &record:from-map Person $ {} (:name |Chen) (:age 21) (:position :mainland)
-                    , :age
+                assert= 21 $ get
+                  &struct:from-map Person $ {} (:name |Chen) (:age 21) (:position :mainland)
+                  , :age
                 assert= (keys p2) (#{} :age :name :position)
-                assert-detect identity $ &record:matches? p1 p1
-                assert-detect identity $ &record:matches? p1 p2
-                assert-detect not $ &record:matches? p1 c1
+                assert-detect identity $ &struct:matches? p1 p1
+                assert-detect identity $ &struct:matches? p1 p2
+                assert-detect not $ &struct:matches? p1 c1
                 &let
                   p4 $ assoc p1 :age 30
-                  assert= (%some 20) (get p1 :age)
-                  assert= (%some 30) (get p4 :age)
+                  assert= 20 $ get p1 :age
+                  assert= 30 $ get p4 :age
                 inside-js: $ js/console.log (to-js-data p1)
                 assert-detect identity $ = p1 p1
                 assert-detect identity $ = p1 p2
@@ -319,11 +318,10 @@
                 assert-detect identity $ contains? p1 :name
                 assert-detect not $ contains? p1 :surname
                 assert= 3 $ count p1
-                assert= (%some 21)
-                  get
-                    update p1 :age $ fn (age)
-                      if (nil? age) 1 $ inc age
-                    , :age
+                assert= 21 $ get
+                  update p1 :age $ fn (age)
+                    if (nil? age) 1 $ inc age
+                  , :age
                 assert= 20 $ :age p1
           :examples $ []
           :schema $ :: 'Fn
@@ -335,13 +333,13 @@
             fn () (log-title "|Testing record-with")
               let
                   p1 $ %{} Person (:name |Chen) (:age 20) (:position :hangzhou)
-                  p2 $ record-with p1 (:age 21) (:position :shanghai)
+                  p2 $ struct-with p1 (:age 21) (:position :shanghai)
                 ; println |P2 p2
-                assert= (%some 20) (get p1 :age)
-                assert= (%some 21) (get p2 :age)
-                assert= (%some :hangzhou) (get p1 :position)
-                assert= (%some :shanghai) (get p2 :position)
-                assert= (%some |Chen) (get p2 :name)
+                assert= 20 $ get p1 :age
+                assert= 21 $ get p2 :age
+                assert= :hangzhou $ get p1 :position
+                assert= :shanghai $ get p2 :position
+                assert= |Chen $ get p2 :name
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/test-string.cirru
+++ b/calcit/test-string.cirru
@@ -194,7 +194,7 @@
               assert= (str-spaced nil nil |c 12) "|c 12"
               assert= (str-spaced |a nil |c 12 nil) "|a c 12"
               assert= (str 1 2 3) |123
-              assert= "|(:: :a |世界 \"|海 洋\")" $ str (:: :a "|世界" "|海 洋")
+              assert= "|(%:: _ :a |世界 \"|海 洋\")" $ str (:: :a "|世界" "|海 洋")
               assert=
                 type-of $ &str 1
                 , :string

--- a/calcit/test-sum-types.cirru
+++ b/calcit/test-sum-types.cirru
@@ -34,10 +34,10 @@
               let
                   ok-action $ make-ok 42
                   err-action $ make-err |boom
-                assert= true $ any? (&tuple:impls ok-action)
+                assert= true $ any? (&enum:impls ok-action)
                   fn (impl)
                     option:some? $ impl-origin impl
-                assert= "|(%:: :ok 42 (:enum Result))" $ str ok-action
+                assert= "|(%:: 'Result :ok 42)" $ str ok-action
                 assert= "|Action ok -> 42" $ ok-action .describe
                 assert= "|Action err -> boom" $ err-action .describe
                 assert= "|handled ok 42" $ summarize ok-action

--- a/calcit/test-tag-match-validation.cirru
+++ b/calcit/test-tag-match-validation.cirru
@@ -44,7 +44,7 @@
             defn test-invalid-tag () (println "|  Testing invalid tag detection...") (; Create a valid enum tuple then corrupt its tag)
               let
                   ok-tuple $ %:: Result :ok
-                  invalid-with-enum $ &tuple:assoc ok-tuple 0 :invalid
+                  invalid-with-enum $ &enum:assoc ok-tuple 0 :invalid
                 try
                   tag-match invalid-with-enum
                     (:invalid x) x
@@ -77,7 +77,7 @@
             defn test-wrong-arity () (println "|  Testing wrong arity detection...")
               let
                   err-tuple $ %:: Result :err |failed |reason
-                  wrong-arity $ &tuple:assoc err-tuple 0 :ok
+                  wrong-arity $ &enum:assoc err-tuple 0 :ok
                 println "|    Tuple:" wrong-arity
                 println "|    Testing enum arity mismatch..."
                 try

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -138,7 +138,7 @@
         |myfoo:foo $ %{} :CodeEntry (:doc "|method implementation for MyFoo/:foo")
           :code $ quote
             defn myfoo:foo (p)
-              str "|foo " $ &record:get p :name
+              str "|foo " $ &struct:get p :name
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -146,7 +146,7 @@
         |myfoo:foo2 $ %{} :CodeEntry (:doc "|method implementation for MyFooImpl2/:foo")
           :code $ quote
             defn myfoo:foo2 (p)
-              str "|foo2 " $ &record:get p :name
+              str "|foo2 " $ &struct:get p :name
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/test-tuple.cirru
+++ b/calcit/test-tuple.cirru
@@ -66,14 +66,14 @@
               assert= :many $ try-size (:: :dyn 1 2 3 4 5)
               let
                   ok $ %:: Result :ok 1
-                assert= (%some Result) (tuple-enum ok)
-                assert= "|(%:: :ok 1 (:enum Result))" $ str ok
-                assert= true $ &tuple:enum-has-variant? Result :ok
-                assert= 1 $ &tuple:enum-variant-arity Result :ok
-                assert= nil $ &tuple:validate-enum ok :ok
+                assert= (%some Result) (enum-definition ok)
+                assert= "|(%:: 'Result :ok 1)" $ str ok
+                assert= true $ &enum-def:has-variant? Result :ok
+                assert= 1 $ &enum-def:variant-arity Result :ok
+                assert= nil $ &enum:validate ok :ok
               let
                   plain $ :: :plain 1
-                assert= (%none) (tuple-enum plain)
+                assert= (%none) (enum-definition plain)
           :examples $ []
           :schema $ :: 'Dynamic
         |try-size $ %{} :CodeEntry (:doc |)

--- a/calcit/test-types-inference.cirru
+++ b/calcit/test-types-inference.cirru
@@ -285,22 +285,16 @@
               assert-type p $ :: Person
               &inspect-type p
               let
-                  name-v $ &record:get p :name
-                assert-type name-v $ :: 'Optional 'Dynamic
+                  name-v $ &struct:get p :name
+                assert-type name-v String
                 &inspect-type name-v
               let
                   top-name-v $ get p :name
-                  top-miss-v $ get p :email
                   city-v $ get-in p ([] :address :city)
-                  city-miss-v $ get-in p ([] :address :zip)
-                assert-type top-name-v $ :: 'Optional 'String
-                assert-type top-miss-v $ :: 'Optional 'Dynamic
+                assert-type top-name-v String
                 assert-type city-v $ :: 'Option 'String
-                assert-type city-miss-v $ :: 'Option 'Dynamic
                 &inspect-type top-name-v
-                &inspect-type top-miss-v
                 &inspect-type city-v
-                &inspect-type city-miss-v
           :examples $ []
           :schema $ :: 'Dynamic
         |test-ref-inference $ %{} :CodeEntry (:doc |)

--- a/calcit/test-types.cirru
+++ b/calcit/test-types.cirru
@@ -189,19 +189,19 @@
         |test-defstruct-defenum $ %{} :CodeEntry (:doc "|Smoke test for defstruct/defenum and %:: tuples")
           :code $ quote
             defn test-defstruct-defenum ()
-              assert= :struct $ type-of Person
-              assert= :enum $ type-of Result
-              assert= :struct $ type-of (impl-traits Person StructImpl)
+              assert= :struct-def $ type-of Person
+              assert= :enum-def $ type-of Result
+              assert= :struct-def $ type-of (impl-traits Person StructImpl)
               let
                   enum-with-impls $ impl-traits Result EnumImpl
                   enum-with-result-impls $ impl-traits enum-with-impls ResultImpl
                   ok $ %:: enum-with-result-impls :ok 1
-                assert= :enum $ type-of enum-with-impls
-                assert= true $ any? (&tuple:impls ok)
+                assert= :enum-def $ type-of enum-with-impls
+                assert= true $ any? (&enum:impls ok)
                   fn (impl)
                     = (impl-origin impl) (%some ResultTrait)
-                assert= (%some enum-with-result-impls) (tuple-enum ok)
-                assert= "|(%:: :ok 1 (:enum Result))" $ str ok
+                assert= (%some enum-with-result-impls) (enum-definition ok)
+                assert= "|(%:: 'Result :ok 1)" $ str ok
               , "|defstruct/defenum checks passed"
           :examples $ []
           :schema $ :: 'Dynamic

--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -789,7 +789,7 @@
             defn test-record-field-tag () $ &let
               point $ %{} Point (:x 1) (:y 2)
               if
-                &= (&record:field-tag point 0) :x
+                &= (&struct:field-tag point 0) :x
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
@@ -798,7 +798,7 @@
             defn test-record-get-name () $ &let
               point $ %{} Point (:x 1) (:y 2)
               if
-                &= (&record:get-name point) :Point
+                &= (&struct:get-name point) :Point
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
@@ -808,7 +808,7 @@
               a $ %{} Point (:x 1) (:y 2)
               &let
                 b $ %{} Point (:x 3) (:y 4)
-                if (&record:matches? a b) 1 0
+                if (&struct:matches? a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
         |test-record-struct-eq $ %{} :CodeEntry (:doc "|record struct equals source struct")
@@ -816,7 +816,7 @@
             defn test-record-struct-eq () $ &let
               point $ %{} Point (:x 1) (:y 2)
               if
-                &= (record-struct point) Point
+                &= (&struct:definition point) Point
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
@@ -825,7 +825,7 @@
             defn test-record-sum (x y)
               &let
                 p $ %{} Point (:x x) (:y y)
-                &+ (&record:nth p 0 :x) (&record:nth p 1 :y)
+                &+ (&struct:nth p 0 :x) (&struct:nth p 1 :y)
           :examples $ []
           :schema $ :: 'Dynamic
         |test-record-to-map $ %{} :CodeEntry (:doc "|record to-map exposes field values by tag")
@@ -833,7 +833,7 @@
             defn test-record-to-map () $ &let
               point $ %{} Point (:x 1) (:y 2)
               &let
-                m $ &record:to-map point
+                m $ &struct:to-map point
                 &+ (&map:get m :x) (&map:get m :y)
           :examples $ []
           :schema $ :: 'Dynamic
@@ -1112,22 +1112,22 @@
         |test-tuple-assoc $ %{} :CodeEntry (:doc "|Tuple assoc updates payload by index")
           :code $ quote
             defn test-tuple-assoc () $ &let
-              t $ &tuple:assoc (:: :pair 10 20) 1 9
-              &+ (&tuple:nth t 1) (&tuple:nth t 2)
+              t $ &enum:assoc (:: :pair 10 20) 1 9
+              &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
         |test-tuple-count $ %{} :CodeEntry (:doc "|Tuple count returns payload count")
           :code $ quote
             defn test-tuple-count () $ &let
               t $ :: :pair 10 20
-              &tuple:count t
+              &enum:count t
           :examples $ []
           :schema $ :: 'Dynamic
         |test-tuple-sum $ %{} :CodeEntry (:doc "|Tuple create + nth access: idx 1 and 2 are payloads")
           :code $ quote
             defn test-tuple-sum () $ &let
               t $ :: :pair 10 20
-              &+ (&tuple:nth t 1) (&tuple:nth t 2)
+              &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
         |test-type-of-list $ %{} :CodeEntry (:doc "|type-of list == :list tag")
@@ -1169,7 +1169,7 @@
             defn test-type-of-tuple () $ if
               &=
                 type-of $ :: :Pair 1 2
-                , :tuple
+                , :enum
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -72,7 +72,7 @@
             defimpl Num NumTrait
               .inc $ fn (x) (update x 1 inc)
               .show $ fn (x)
-                str $ &tuple:nth x 1
+                str $ &enum:nth x 1
           :examples $ []
           :schema $ :: 'Dynamic
         |NumBox $ %{} :CodeEntry (:doc |)
@@ -367,7 +367,7 @@
                     let
                         a0-tuple a0
                       assert-type a0-tuple 'Tuple
-                      assert= true $ any? (&tuple:impls a0-tuple)
+                      assert= true $ any? (&enum:impls a0-tuple)
                         fn (impl)
                           = (impl-origin impl) (%some NumTrait)
                 assert-traits a0 NumTrait calcit.core/Show
@@ -449,7 +449,7 @@
         |test-tuple $ %{} :CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing tuple")
-              assert= :tuple $ type-of (:: :a :b)
+              assert= :enum $ type-of (:: :a :b)
               assert= (%some :a)
                 nth (:: :a :b) 0
               assert= (%some :b)
@@ -477,20 +477,20 @@
               assert= (:: 0 0 1)
                 update (:: 0 0 0) 2 inc
               assert= 1 $ count (:: :none)
-              assert-detect tuple? $ parse-cirru-edn "|:: :none"
+              assert-detect enum? $ parse-cirru-edn "|:: :none"
               assert= false $ = (:: :t 1) (:: :t 2)
               assert= false $ = (:: :t 1) (:: :t 1 2)
               let
                   a $ :: :a 1
                   b $ %:: Demo :a 1
-                assert= true $ any? (&tuple:impls b)
+                assert= true $ any? (&enum:impls b)
                   fn (impl)
                     includes? (str impl) |DemoGetTrait
                 assert=
-                  &tuple:params $ :: :a 1 2 3
+                  &enum:params $ :: :a 1 2 3
                   [] 1 2 3
-                assert= "|(%:: :a 1 (:enum Demo))" $ str b
-              assert= "|(:: :a :b :c)" $ str (:: :a :b :c)
+                assert= "|(%:: 'Demo :a 1)" $ str b
+              assert= "|(%:: _ :a :b :c)" $ str (:: :a :b :c)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/docs/data.md
+++ b/docs/data.md
@@ -31,13 +31,13 @@ Calcit uses persistent values by default, with a small set of explicit stateful 
 
 ## Named Data
 
-- **Record / Struct**: `defstruct` declares a fixed field layout; `%{}` constructs a record value.
-- **Enum / Tuple**: `defenum` declares named alternatives. Enum instances use the tuple runtime representation and retain their enum identity.
-- **Tuple**: `::` creates lightweight tagged positional data when a full enum declaration is unnecessary.
+- **Struct**: `defstruct` creates a `StructDef`; `%{}` constructs a fixed-field struct value.
+- **Enum**: `defenum` creates an `EnumDef`; `%::` constructs a tagged enum value.
+- **Anonymous Struct / Enum**: `%{} _ ...` and `%:: _ ...` create short-lived values without named definitions.
 - **Option**: `Option T` has `%some T` and `%none` variants.
 - **Result**: `Result T E` has `%ok T` and `%err E` variants.
 
-Prefer records and enums at module boundaries: their declarations carry schemas, support trait attachment, and give static analysis more information than ad-hoc maps or tuples.
+Prefer named structs and enums at module boundaries: their definitions carry schemas, support trait attachment, and give static analysis more information than ad-hoc maps or anonymous values.
 
 ## Explicitly Stateful Values
 
@@ -56,7 +56,7 @@ Prefer records and enums at module boundaries: their declarations carry schemas,
 - **Rust runtime**: Uses [rpds](https://github.com/orium/rpds) for HashMap/HashSet and [ternary-tree](https://github.com/calcit-lang/ternary-tree.rs/) for vectors
 - **JavaScript runtime**: Uses [ternary-tree.ts](https://github.com/calcit-lang/ternary-tree.ts) for all collections
 
-Collection method availability is also expressed through built-in traits. `Countable` and `Contains` cover List, Map, Set, String, Record, and Tuple; `Compare` covers Number and String. See [Polymorphism](features/polymorphism.md) for the full matrix.
+Collection method availability is also expressed through built-in traits. `Countable` and `Contains` cover List, Map, Set, String, Struct, and Enum; `Compare` covers Number and String. See [Polymorphism](features/polymorphism.md) for the full matrix.
 
 For serialization fidelity and unsupported runtime values, see:
 

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -63,17 +63,17 @@ Map and Set iteration order is not a semantic guarantee. The formatter applies a
 | Map | Arbitrary EDN keys preserved | Keys must be Tag or String; parsed object keys become Tag |
 | Set | Preserved | Encoded as an array; Set identity is lost |
 | Buffer | Preserved | Encoded as a `0x...` string; Buffer identity is lost |
-| Tuple / enum value | Tag, fields, and enum name preserved | Encoded as an array; tuple and enum identity is lost |
-| Record | Record name and fields preserved | Encoded as an object; struct identity is lost |
+| Enum value | Variant, payloads, and enum name preserved | Encoded as an array; enum identity is lost |
+| Struct value | Struct name and fields preserved | Encoded as an object; struct identity is lost |
 | Cirru quote | Preserved | Encoded as nested strings and arrays |
 | Ref | Encoded as `atom`; parsing creates a new Ref | Unsupported |
 | AnyRef, function, trait/impl, mutable builder | Not portable; do not use as interchange data | Unsupported |
 
 `json-stringify` rejects unsupported values and Maps with non-Tag/non-String keys instead of silently inventing a representation. It also rejects non-finite numbers. `json-parse` maps JSON arrays to List and JSON objects to Maps whose keys are Tags.
 
-## Restoring declared record and enum identity
+## Restoring declared struct and enum identity
 
-Cirru EDN always retains the printed record or enum name. To reconnect parsed values to the exact `defstruct` or `defenum` object (including attached traits), pass an options Map keyed by that name:
+Cirru EDN always retains the printed struct or enum name. To reconnect parsed values to the exact `defstruct` or `defenum` object (including attached traits), pass an options Map keyed by that name:
 
 ```cirru
 let
@@ -83,7 +83,7 @@ let
     :Person $ %{} Person (:name |)
 ```
 
-Without this options Map, parsing still produces a structurally equivalent Record or Tuple, but it cannot recover declaration-attached trait implementations from text alone. The options Map does not validate field value types, container elements, enum payloads, generics, or constraints. Prefer `parse-cirru-edn-as` when those guarantees are required.
+Without this options Map, parsing still produces a structurally equivalent anonymous Struct or Enum, but it cannot recover declaration-attached trait implementations from text alone. The options Map does not validate field value types, container elements, enum payloads, generics, or constraints. Prefer `parse-cirru-edn-as` when those guarantees are required.
 
 ## Literals
 
@@ -165,7 +165,7 @@ also can be nested:
     :d 3
 ```
 
-Records retain their type name and fields:
+Structs retain their type name and fields:
 
 ```cirru
 let
@@ -175,10 +175,12 @@ let
     :a 1
 ```
 
-Enums use `%::`, while ordinary tagged tuples use `::`:
+Named enums use `%:: EnumDef ...`; anonymous enum values use `%:: _ ...` or the `::` shorthand:
 
 ```cirru.no-run
-%:: :Result :ok 1
+let
+    SampleResult $ defenum SampleResult (:ok 'Number) (:err 'String)
+  %:: SampleResult :ok 1
 :: :point 10 20
 ```
 
@@ -190,7 +192,7 @@ Quoted Cirru is preserved as syntax data. This is used by runtime snapshots (`ca
 quote $ def a 1
 ```
 
-at runtime, it's represented with tuples:
+at runtime, its syntax tree uses anonymous enum values:
 
 ```cirru
 :: 'quote $ [] |def |a |1
@@ -213,7 +215,7 @@ $ cr eval 'parse-cirru-edn "|quote $ def a 1"'
 took 0.011ms: (:: 'quote ([] |def |a |1))
 ```
 
-The runtime display may resemble a tuple, but Cirru EDN gives `quote` dedicated parsing and formatting semantics.
+The runtime display uses an anonymous enum shape, but Cirru EDN gives `quote` dedicated parsing and formatting semantics.
 
 ## Buffers
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -43,7 +43,7 @@ Calcit inherits most features from Clojure/ClojureScript while adding its own in
 - **Ternary tree collections** - Custom persistent data structures optimized for Rust
 - **Incremental compilation** - Fast hot reload with `.compact-inc.cirru` format
 - **Pattern matching** - Tagged unions with compile-time validation
-- **Record types** - Lightweight structs with field access validation
+- **Struct types** - Fixed-field values with required field access validation
 - **Traits & method dispatch** - Attach capability-based methods to values, with explicit disambiguation when needed
 
 ## Language Features
@@ -67,8 +67,8 @@ For detailed information about specific features:
 
 Use this section as a keyword index for `cr docs read`:
 
-- **Collections**: list, map, set, tuple, record
-- **Pattern Matching**: enum, match, legacy tag-match, tuple-match, result, exhaustiveness
+- **Collections**: list, map, set, struct, enum
+- **Pattern Matching**: enum, match, anonymous enum, tag-match, result, exhaustiveness
 - **Types**: static-analysis, assert-type, optional, variadic
 - **Methods**: trait, impl-traits, method dispatch, trait-call
 - **Interop**: js interop, async, promise, js-await
@@ -77,7 +77,7 @@ Use this section as a keyword index for `cr docs read`:
 Task-oriented jump map:
 
 - Data transforms → [List](features/list.md), [HashMap](features/hashmap.md), [Sets](features/sets.md)
-- Domain modeling → [Records](features/records.md), [Enums](features/enums.md), [Tuples](features/tuples.md)
+- Domain modeling → [Structs](features/records.md), [Enums](features/enums.md), [Anonymous Enums](features/tuples.md)
 - Type safety → [Static Analysis](features/static-analysis.md), [Error Handling](features/error-handling.md)
 - Extensibility → [Macros](features/macros.md), [Traits](features/traits.md), [Polymorphism](features/polymorphism.md)
 - Runtime integration → [JavaScript Interop](features/js-interop.md), [Imports](features/imports.md)
@@ -97,8 +97,8 @@ Task-oriented jump map:
 Calcit's static analysis provides:
 
 - **Function arity checking** - Validates argument counts at compile time
-- **Record field validation** - Checks field names exist in record types
-- **Tuple bounds checking** - Validates tuple index access
+- **Struct field validation** - Checks that required fields exist in struct definitions
+- **Enum bounds checking** - Validates positional enum payload access
 - **Enum variant validation** - Ensures correct enum construction
 - **Method existence checking** - Verifies methods exist for types
 - **Recur arity validation** - Checks recursive calls have correct arguments
@@ -110,6 +110,6 @@ Calcit's static analysis provides:
 - **Zero-cost abstractions** - Persistent data structures with minimal overhead
 - **Lazy sequences** - Efficient processing of large datasets
 - **Optimized compilation** - JavaScript output with tree-shaking support
-- **Type-directed optimizations** - Compile-time rewrites for record field access/update when types are known (e.g., `&record:assoc` → `&record:assoc-at`)
+- **Type-directed optimizations** - Compile-time rewrites for struct field access/update when types are known (e.g., `&struct:assoc` → `&struct:assoc-at`)
 
 Calcit is designed to be familiar to Clojure developers while providing modern tooling, type safety, and excellent development experience.

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -427,7 +427,7 @@ let
 
 1. **Use type annotations** for function parameters and return values
 2. **Prefer immutable data** - use `swap!` instead of manual mutation
-3. **Use pattern matching** (`match`, `record-match`) for control flow; `match` also works on plain tuples, while `tag-match` is mainly for legacy code
+3. **Use pattern matching** (`match`, `struct-match`) for control flow; `tag-match` also works on anonymous enums when no definition is available
 4. **Leverage threading macros** (`->`, `->>`) for data pipelines
 5. **Use enums for result types** instead of exceptions
 6. **Keep functions small** and focused on a single responsibility

--- a/docs/features/enums.md
+++ b/docs/features/enums.md
@@ -13,7 +13,7 @@ parent: core/features
 
 # Enums (defenum)
 
-Calcit enums are tagged unions — each variant has a tag (keyword) and zero or more typed payload fields. Under the hood enums are represented as tuples with a class reference.
+Calcit enums are tagged unions: each variant has a tag and zero or more typed payload values. `defenum` creates an enum definition; `%::` constructs enum values that retain that definition.
 
 ## Quick Recipes
 
@@ -21,7 +21,7 @@ Calcit enums are tagged unions — each variant has a tag (keyword) and zero or 
 - **Create**: `%:: Shape :circle 5`
 - **Match** (recommended): `match shape ((:circle r) ...) ((:rect w h) ...)`
 - **Legacy Fallback**: `tag-match shape ((:circle r) ...) ((:rect w h) ...)`
-- **Type Check**: `assert-type shape 'Enum`
+- **Type Check**: `assert-type shape 'Shape`
 
 ## Defining Enums
 
@@ -30,7 +30,7 @@ let
     Color $ defenum Color (:red) (:green) (:blue)
     c $ %:: Color :red
   println c
-  ; => $ %:: :red (:enum Color)
+  ; => $ %:: 'Color :red
 ```
 
 Variants with payloads:
@@ -41,9 +41,9 @@ let
     c $ %:: Shape :circle 5
     r $ %:: Shape :rect 3 4
   println c
-  ; => $ %:: :circle 5 (:enum Shape)
+  ; => $ %:: 'Shape :circle 5
   println r
-  ; => $ %:: :rect 3 4 (:enum Shape)
+  ; => $ %:: 'Shape :rect 3 4
 ```
 
 ## Generic Enums
@@ -57,8 +57,8 @@ let
     err $ %:: ResultX :err |oops
   assert-type ok $ :: 'ResultX 'Number 'String
   assert-type err $ :: 'ResultX 'Number 'String
-  assert= 1 $ &tuple:nth ok 1
-  assert= |oops $ &tuple:nth err 1
+  assert= 1 $ &enum:nth ok 1
+  assert= |oops $ &enum:nth err 1
 ```
 
 At the type level, `(:: 'ResultX 'Number 'String)` means the first slot is bound to `T` and the second slot is bound to `E`.
@@ -77,10 +77,10 @@ let
     none-val $ %:: ShownMaybe :none
   assert-type some-val $ :: 'ShownMaybe 'Number
   assert= |1 $ match some-val
-    (:some item) (item .show)
+    (:some item) (.show item)
     (:none) |none
   assert= |none $ match none-val
-    (:some item) (item .show)
+    (:some item) (.show item)
     (:none) |none
 ```
 
@@ -90,14 +90,14 @@ The `where` map uses type variables as keys and trait names as values. `%::` che
 
 Enum payload slots can reference named structs, not just primitive tags. Use the same applied named type syntax that `defstruct` uses in schemas.
 
-```cirru
+```cirru.no-check
 let
     Point $ defstruct Point (:x :number) (:y :number)
     Shape $ defenum Shape (:point Point) (:label :string)
     p $ %{} Point (:x 1) (:y 2)
     shape $ %:: Shape :point p
   assert-type shape Shape
-  assert= 1 $ option:unwrap $ get (&tuple:nth shape 1) :x
+  assert= 1 $ get (&enum:nth shape 1) :x
 ```
 
 Applied generic structs also work in enum payloads:
@@ -110,9 +110,9 @@ let
       :empty
     value $ %:: Wrapped :box
       %{} Box $ :value 1
-    boxed $ &tuple:nth value 1
+    boxed $ &enum:nth value 1
   assert-type value $ :: 'Wrapped :number
-  assert= 1 $ option:unwrap $ :value boxed
+  assert= 1 $ :value boxed
 ```
 
 When you annotate an enum payload with a struct type, `%::` validates both the variant tag and the payload value at runtime. Applied struct payload types must use the correct generic arity.
@@ -283,13 +283,13 @@ let
 
 ## Checking Enum Origin
 
-Use the Option-returning `tuple-enum` API to verify a tuple belongs to a specific enum:
+Use the Option-returning `enum-definition` API to inspect the definition behind an enum value:
 
 ```cirru
 let
     ApiResult $ defenum ApiResult (:ok :number) (:err :string)
     x $ %:: ApiResult :ok 1
-  println $ = (tuple-enum x) (%some ApiResult)
+  println $ = (enum-definition x) (%some ApiResult)
   ; => true
 ```
 
@@ -370,9 +370,9 @@ defenum Shape2 (:point Point) (:circle :number)
 
 Runtime type validation is enforced at instance creation — passing the wrong type to `%::` will raise an error.
 
-## Automatic Tuple-to-Enum Rewrite
+## Automatic Anonymous-to-Named Enum Rewrite
 
-When a function parameter is typed as an enum in its schema, the preprocessor automatically rewrites untyped tuple literal (`::`) arguments to typed enum tuple construction (`%::`). This lets you write shorter tuple syntax while still getting full enum type checking.
+When a function parameter is typed as an enum, the preprocessor can rewrite an anonymous enum (`%:: _`) to the expected named definition.
 
 ```cirru
 let
@@ -384,30 +384,30 @@ let
         (:ok) :ok
         (:err msg) msg
         _ :unknown
-  ; Write an untyped tuple "—" preprocessor rewrites to enum tuple automatically:
-  assert= :ok $ takes-result (:: :ok)
+  ; The anonymous enum is rewritten to the expected named enum:
+  assert= :ok $ takes-result (%:: _ :ok)
   ; Equivalent to:
   assert= :ok $ takes-result (%:: Result0 :ok)
 ```
 
 Requirements for the rewrite to trigger:
 
-- The function must have a schema with `:args` that references an enum type (via `TypeRef` like `'ns/EnumName`, `Enum`, or `Tuple`)
-- The argument at the call site must be an untyped tuple literal (`::`)
+- The function schema must reference a named enum type such as `'ns/EnumName`
+- The argument at the call site must be an anonymous enum literal (`%:: _`)
 - The enum definition must be resolvable at preprocess time
 
 If any condition is not met, the argument is left unchanged (no error is raised). This makes the rewrite safe to use alongside existing code.
 
 ## Notes
 
-- Enum instances are immutable tuples with a class reference.
+- Enum values are immutable and retain their enum definition.
 - `match` is the recommended pattern matching syntax with exhaustiveness checking.
 - `tag-match` is a legacy macro; keep it for legacy code paths or when you explicitly want the old syntax.
-- Use `&tuple:nth` to directly access payload values by index (0 = tag, 1+ = payloads).
-- Enums vs plain tuples: plain `:: :tag val` tuples have no class; `%:: Enum :tag val` tuples carry their enum class for origin checking.
+- Use `&enum:nth` to directly access payload values by index (0 = tag, 1+ = payloads).
+- `%:: _ :tag ...` constructs an anonymous enum; `%:: EnumDef :tag ...` constructs a named enum.
 
 ## See Also
 
-- [Tuples](tuples.md) — raw tagged tuples without a class
-- [Records](records.md) — named-field structs with `defstruct`
+- [Anonymous enums](tuples.md) — short-lived enum values without `defenum`
+- [Structs](records.md) — named-field structures with `defstruct`
 - [Static Analysis](static-analysis.md) — type checking for enum payloads and type slots

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -35,7 +35,7 @@ inferred as `JsNullish<JsObject>`:
   it is deliberately distinct from legacy `Optional` and nominal `Option`.
 - `JsObject` is an opaque host value. A `js-present?`/`js-nullish?` check proves only that the
   value is present; it does not prove that the payload is a Calcit `String`,
-  `Number`, record, or collection.
+  `Number`, struct, or collection.
 - Before passing the value into strongly typed Calcit code, validate/convert it
   with a boundary decoder. `unsafe-coerce` is available only when an external
   API contract is trusted and the unchecked conversion is intentional.

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -214,11 +214,11 @@ Core types provide origin-carrying built-in trait implementations registered con
 | Trait | Method | Built-in value categories |
 | --- | --- | --- |
 | `Compare` | `.compare` | Number, String |
-| `Countable` | `.count` | List, Map, Set, String, Record, Tuple/enum |
-| `Contains` | `.contains?` | List, Map, Set, String, Record, Tuple/enum |
+| `Countable` | `.count` | List, Map, Set, String, Struct, Enum |
+| `Contains` | `.contains?` | List, Map, Set, String, Struct, Enum |
 | `Mappable` | `.map` | List, Map, Set, Option, Result |
-| `Show` | `.show` | Number, String, Bool, Tag, Symbol, Nil, CirruQuote, List, Map, Set, Fn, Record, Tuple |
-| `Eq` | `.eq?` | The same scalar/collection/record/tuple categories registered for `Show` |
+| `Show` | `.show` | Number, String, Bool, Tag, Symbol, Nil, CirruQuote, List, Map, Set, Fn, Struct, Enum |
+| `Eq` | `.eq?` | The same scalar, collection, struct, and enum categories registered for `Show` |
 
 `Compare` returns a negative number, zero, or a positive number. It intentionally starts with Number and String; cross-category ordering is not defined.
 
@@ -245,14 +245,14 @@ Core lookup APIs that no longer need to preserve bootstrapping compatibility use
 - String `.find-index` and `str-find-index` return `Option<Number>`; the internal `&str:find-index` primitive retains its `-1` ABI sentinel.
 - `get-env` returns `Option<String>`; use `option:unwrap-or` for a default.
 - `parse-float` returns `Result<Number,String>`, with the invalid source in `:err`.
-- Reflection uses `tuple-enum: Tuple -> Option<Enum>` and `impl-origin: Impl -> Option<Trait>`; `record-struct: Record -> Struct` is total and does not invent absence.
+- Reflection uses `enum-definition: Enum -> Option<EnumDef>`, `struct-definition: Struct -> Option<StructDef>`, and `impl-origin: Impl -> Option<Trait>`.
 - `destruct-list`, `destruct-map`, `destruct-set`, and `destruct-str` return named `*Destruct` enums, preserving the familiar `:some`/`:none` branches with checked payloads.
-- Public collection methods follow the same contract: Map/Set `.destruct` return their named destruct enums. Record does not expose `.nth`, because field position is not stable across backends; use field-name `get` returning `Option<T>`.
+- Public collection methods follow the same contract: Map/Set `.destruct` return their named destruct enums. Struct does not expose `.nth`, because field position is not stable across backends; field-name `get` returns the field's declared type directly.
 - `when-let` consumes `Option<T>` and returns `Option<R>`; `update-in` passes `Option<T>` to its updater so a missing leaf is never represented by nil.
 
 Raw JavaScript property reads and native calls are different: they return `JsNullish<JsObject>`. Narrow them with `js-present?`/`js-nullish?`; `nil?`, `some?`, and generic `optionally` do not erase this host boundary. Use `js-nullish->option` only as an explicit conversion after accepting or validating the opaque payload contract.
 
-When a generic payload cannot be inferred, Calcit keeps the nominal wrapper and uses `Dynamic` only for the unknown payload—for example, `find` over a dynamically typed list is still `Option<Dynamic>`, not plain `Dynamic`. This makes migration mistakes visible. Using nullable predicates (`some?`/`nil?`), positional tuple access, or raw comparison on that Option reports `W_NOMINAL_ENUM_LEGACY_USE`; switch to Option methods, `option:unwrap-or`, or `tag-match`.
+When a generic payload cannot be inferred, Calcit keeps the nominal wrapper and uses `Dynamic` only for the unknown payload—for example, `find` over a dynamically typed list is still `Option<Dynamic>`, not plain `Dynamic`. This makes migration mistakes visible. Using nullable predicates (`some?`/`nil?`), positional enum access, or raw comparison on that Option reports `W_NOMINAL_ENUM_LEGACY_USE`; switch to Option methods, `option:unwrap-or`, or `tag-match`.
 
 The same operations are available as methods on enum values:
 

--- a/docs/features/records.md
+++ b/docs/features/records.md
@@ -1,5 +1,5 @@
 ---
-title: "Records"
+title: "Structs"
 scope: "core"
 kind: "reference"
 category: "features"
@@ -11,9 +11,9 @@ id: core/features/records
 parent: core/features
 ---
 
-# Records
+# Structs
 
-Calcit provides Records as a way to define structured data types with named fields, similar to structs in other languages. Records are defined with `defstruct` and instantiated with the `%{}` macro.
+Calcit structs are declared data types with a fixed set of named fields. Struct definitions are created with `defstruct`; struct values are constructed with `%{}`.
 
 ## Quick Recipes
 
@@ -21,7 +21,7 @@ Calcit provides Records as a way to define structured data types with named fiel
 - **Create**: `%{} Point (:x 1) (:y 2)`
 - **Access**: `get p :x` or `(:x p)`
 - **Update**: `assoc p :x 10` or `update p :x inc`
-- **Type Check**: `assert-type p 'Record`
+- **Type Check**: `assert-type p 'Point`
 
 ## Defining a Struct Type
 
@@ -72,9 +72,9 @@ let
   assert= |1 $ item .show
 ```
 
-Here `({} ('T Show))` means `T` must satisfy the `Show` trait. `%{}` enforces that bound when constructing a record instance, so the constraint lives on the data definition rather than on each individual function schema.
+Here `({} ('T Show))` means `T` must satisfy the `Show` trait. `%{}` enforces that bound when constructing a struct value, so the constraint lives on the data definition rather than on each individual function schema.
 
-## Creating Records
+## Creating Struct Values
 
 Use the `%{}` macro to instantiate a struct:
 
@@ -96,7 +96,7 @@ let
 
 ## Accessing Fields
 
-Use `get` (or `&record:get`) to read a field:
+Use `get` (or `&struct:get`) to read a field:
 
 ```cirru
 let
@@ -106,7 +106,9 @@ let
   ; => 1
 ```
 
-Standard collection functions like `keys`, `count`, and `contains?` also work on records:
+For a statically known struct, field access returns the field's declared type directly. A missing field is a type/checking error; struct access never produces `Option` merely because the field name might be absent.
+
+Standard collection functions like `keys`, `count`, and `contains?` also work on structs:
 
 ```cirru
 let
@@ -122,7 +124,7 @@ let
 
 ## Updating Fields
 
-Records are immutable. Use `assoc` or `record-with` to produce an updated copy:
+Struct values are immutable. Use `assoc` or `struct-with` to produce an updated copy:
 
 ```cirru
 let
@@ -139,23 +141,23 @@ let
 let
     Person $ defstruct Person (:name :string) (:age :number) (:position :tag)
     p $ %{} Person (:name |Chen) (:age 20) (:position :mainland)
-    p2 $ record-with p (:age 21) (:position :shanghai)
+    p2 $ struct-with p (:age 21) (:position :shanghai)
   println p2
   ; p2 has updated :age and :position, :name is unchanged
 ```
 
-`&record:assoc` is the low-level variant (no type checking):
+`&struct:assoc` is the low-level variant:
 
 ```cirru
 let
     Point $ defstruct Point (:x :number) (:y :number)
     p $ %{} Point (:x 1) (:y 2)
-  println $ &record:assoc p :x 100
+  println $ &struct:assoc p :x 100
 ```
 
-## Partial Records
+## Partial Struct Construction
 
-Use `%{}?` to create a record with only some fields set (others default to `nil`):
+Use `%{}?` to create a partial struct with only some fields set (others default to `nil`):
 
 ```cirru
 let
@@ -181,45 +183,43 @@ let
 let
     Point $ defstruct Point (:x :number) (:y :number)
     p $ %{} Point (:x 1) (:y 2)
-  ; check if a value is a record $ struct instance
-  println $ record? p
+  ; check if a value is a struct
+  println $ struct? p
   ; => true
   ; check if it matches a specific struct
-  println $ &record:matches? p Point
+  println $ &struct:matches? p Point
   ; => true
-  ; get the struct definition the record was created from
-  println $ record-struct p
-  ; compare structs directly for origin check
-  println $ = (record-struct p) Point
+  ; get the definition used to construct the value
+  println $ struct-definition p
+  ; compare definitions directly for an origin check
+  println $ = (option:unwrap $ struct-definition p) Point
   ; => true
-  ; struct? checks struct definitions, not instances
-  println $ struct? Point
+  ; struct-def? is the definition predicate
+  println $ struct-def? Point
   ; => true
-  println $ struct? p
+  println $ struct-def? p
   ; => false
 ```
 
 ## Pattern Matching
 
-Use `record-match` to branch on record types:
+Use `struct-match` to branch on struct definitions:
 
 ```cirru
 let
     Circle $ defstruct Circle (:radius :number)
-    Square $ defstruct Square (:side :number)
+    Square $ defstruct Square (:radius :number)
     shape $ %{} Circle (:radius 5)
-  record-match shape
+  struct-match shape
     Circle c $ * 3.14
-      * (option:unwrap $ get c :radius)
-        option:unwrap $ get c :radius
-    Square s $ * (option:unwrap $ get s :side)
-      option:unwrap $ get s :side
+      * (get c :radius) (get c :radius)
+    Square s $ * (get s :radius) (get s :radius)
     _ _ 0
 
 ; => 78.5
 ```
 
-## Converting Records
+## Converting Structs
 
 ### To Map
 
@@ -227,11 +227,11 @@ let
 let
     Point $ defstruct Point (:x :number) (:y :number)
     p $ %{} Point (:x 1) (:y 2)
-  println $ &record:to-map p
+  println $ &struct:to-map p
   ; => {} (:x 1) (:y 2)
 ```
 
-`merge` also works and returns a new record of the same struct:
+`merge` also works and returns a new value of the same struct definition:
 
 ```cirru
 let
@@ -241,22 +241,22 @@ let
     {} (:age 23) (:name |Ye)
 ```
 
-## Record Name and Struct Inspection
+## Struct Name and Definition Inspection
 
 ```cirru
 let
     Person $ defstruct Person (:name :string) (:age :number) (:position :tag)
     p $ %{} Person (:name |Chen) (:age 20) (:position :mainland)
-  ; get the tag name of the record
-  println $ &record:get-name p
+  ; get the tag name of the struct value
+  println $ &struct:get-name p
   ; => :Person
-  ; check the struct behind a record value
-  println $ record-struct p
+  ; inspect the definition behind a struct value
+  println $ struct-definition p
 ```
 
 ### Struct Origin Check
 
-Compare struct definitions directly when you need to confirm a record's origin:
+Compare struct definitions directly when you need to confirm a struct value's origin:
 
 ```cirru
 let
@@ -264,7 +264,7 @@ let
     Dog $ defstruct Dog (:name :string)
     v1 $ %{} Cat (:name |Mimi) (:color :white)
   if
-    = (record-struct v1) Cat
+    = (option:unwrap $ struct-definition v1) Cat
     println "|Handle Cat branch"
     println "|Not a Cat"
 ```
@@ -307,7 +307,7 @@ let
 let
     Config $ defstruct Config (:host :string) (:port :number) (:debug :bool)
     config $ %{} Config (:host |localhost) (:port 3000) (:debug false)
-  println $ option:unwrap $ get config :port
+  println $ get config :port
   ; => 3000
 ```
 
@@ -317,8 +317,7 @@ let
 let
     Product $ defstruct Product (:id :string) (:name :string) (:price :number) (:discount :number)
     product $ %{} Product (:id |P001) (:name |Widget) (:price 100) (:discount 0.9)
-  println $ * (option:unwrap $ get product :price)
-    option:unwrap $ get product :discount
+  println $ * (get product :price) (get product :discount)
   ; => 90
 ```
 
@@ -331,87 +330,89 @@ let
       hint-fn $ {}
         :args $ [] 'User
         :return :string
-      option:unwrap $ get user :name
+      &struct:get user :name
   println $ get-user-name
     %{} User (:name |John) (:age 30) (:email |john@example.com)
 
 ; => John
 ```
 
-## Automatic Map-to-Record Rewrite
+## Automatic Map-to-Struct Rewrite
 
-When a function parameter is typed as a struct in its schema, the preprocessor automatically rewrites hashmap literal (`{}`) arguments to record construction (`%{}`). This lets you write ergonomic hashmap syntax while still getting full record type checking at runtime.
+When a function parameter is typed as a struct in its schema, the preprocessor automatically rewrites hashmap literal (`{}`) arguments to struct construction (`%{}`). This keeps ergonomic literal syntax while retaining the nominal type.
 
-```cirru
-let
-    Point $ defstruct Point (:x :number) (:y :number)
-    sum-point $ fn (p)
-      :: :fn $ {} (:return :number)
-        :args $ [] 'app.main/Point
-      &+ (option:unwrap $ :x p) (option:unwrap $ :y p)
-  ; Write a hashmap "—" preprocessor rewrites to record automatically:
-  assert= 30 $ sum-point
-    {} (:x 10) (:y 20)
-  ; Equivalent to:
-  assert= 30 $ sum-point
-    %{} Point (:x 10) (:y 20)
+```cirru.no-check
+defstruct Point (:x :number) (:y :number)
+
+defn sum-point (p)
+  hint-fn $ {} (:return :number)
+    :args $ [] 'app.main/Point
+  &+ (:x p) (:y p)
+
+; The preprocessor rewrites this hashmap to the expected struct:
+assert= 30 $ sum-point
+  {} (:x 10) (:y 20)
+; Equivalent to:
+assert= 30 $ sum-point
+  %{} Point (:x 10) (:y 20)
 ```
 
 Requirements for the rewrite to trigger:
 
-- The function must have a schema with `:args` that references a struct type (via `TypeRef` like `'ns/StructName`, `Struct`, or `Record`)
+- The function must have a schema with `:args` that references a struct type (for example `'ns/StructName` or `'Struct`)
 - The argument at the call site must be a hashmap literal (`{}` with tag keys)
 - All keys in the hashmap must be tags (`:field-name`)
 - The struct definition must be resolvable at preprocess time
 
 If any condition is not met, the argument is left unchanged (no error is raised). This makes the rewrite safe to use alongside existing code.
 
-## Loose Records (`?{}`)
+## Anonymous Structs
 
-Loose records are records created without a declared struct definition, using the `?{}` syntax. This is analogous to how untyped tuples (`::`) work without requiring a `defenum` — loose records provide the same convenience for named fields.
+Use `_` as the definition marker when a short-lived struct does not need a named `defstruct` declaration.
 
-### Creating a Loose Record
+### Creating an Anonymous Struct
 
 ```cirru
-?{} :name |John :age 30
+%{} _ (:name |John) (:age 30)
 
-; => $ ?{} (:age 30) (:name |John)
+; => $ %{} _ (:age 30) (:name |John)
 ```
 
 Fields are automatically sorted alphabetically, matching the behavior of struct-backed records. All keys must be tags, and duplicate keys produce an error.
 
 ### Accessing Fields
 
-Loose records support the same field access operations as struct-backed records:
+Anonymous structs still have a fixed field set, so access is direct and missing fields are errors:
 
 ```cirru
 let
-    r $ ?{} :x 10 :y 20
-  println $ option:unwrap $ :x r
+    r $ %{} _ (:x 10) (:y 20)
+  println $ :x r
   ; => 10
   println $ type-of r
-  ; => :record
+  ; => :struct
 ```
 
-### Automatic Rewrite to Struct Record
+### Automatic Rewrite to a Named Struct
 
-When a loose record is passed to a function whose parameter is typed as a struct, the preprocessor automatically rewrites it to a struct-backed record — just like the map-to-record rewrite:
+When an anonymous struct is passed to a function whose parameter is a named struct, the preprocessor can rewrite it to the expected nominal definition:
 
-```cirru
-let
-    Point $ defstruct Point (:x :number) (:y :number)
-    sum-point $ fn (p)
-      :: :fn $ {} (:return :number)
-        :args $ [] 'app.main/Point
-      &+ (option:unwrap $ :x p) (option:unwrap $ :y p)
-  ; Loose record rewritten to struct record at compile time:
-  assert= 30 $ sum-point (?{} :x 10 :y 20)
-  ; Equivalent to:
-  assert= 30 $ sum-point
-    %{} Point (:x 10) (:y 20)
+```cirru.no-check
+defstruct Point (:x :number) (:y :number)
+
+defn sum-point (p)
+  hint-fn $ {} (:return :number)
+    :args $ [] 'app.main/Point
+  &+ (:x p) (:y p)
+
+; Anonymous struct rewritten to the expected named struct:
+assert= 30 $ sum-point (%{} _ (:x 10) (:y 20))
+; Equivalent to:
+assert= 30 $ sum-point
+  %{} Point (:x 10) (:y 20)
 ```
 
-The rewrite uses the same requirements as map-to-record rewrite. Fields not present in the loose record but defined in the struct are filled with `nil`.
+The rewrite uses the same requirements as the map-to-struct rewrite. Fields not present in the anonymous struct but defined in the target struct are filled with `nil`; their declared field types must therefore permit `nil`.
 
 ### Design Symmetry
 
@@ -420,29 +421,29 @@ The collection type system follows a consistent "precision increasing" pattern:
 | Positional (by index)            | Named (by field)                       |
 | -------------------------------- | -------------------------------------- |
 | `list` (dynamic)                 | `hashmap` (dynamic)                    |
-| `:: :tag ...` (untyped tuple)    | `?{} :field val` (loose record)        |
-| `%:: Enum :tag ...` (typed enum) | `%{} Struct :field val` (typed record) |
+| `%:: _ :tag ...` (anonymous enum) | `%{} _ (:field val)` (anonymous struct) |
+| `%:: Enum :tag ...` (named enum)  | `%{} Struct (:field val)` (named struct) |
 
-Both untyped tuples and loose records can be automatically rewritten to their typed counterparts when function parameter types are known at compile time.
+Both anonymous enums and anonymous structs can be rewritten to their named counterparts when function parameter types are known at compile time.
 
 ## Performance Notes
 
-- Records are immutable — updates create new records
+- Struct values are immutable — updates create new values
 - Field access is O(1) when the struct type is known at preprocess time (compile-time index resolution)
 - When the type is unknown, field access falls back to O(log n) binary search over sorted field names
-- Use `record-with` to update multiple fields at once and minimize intermediate allocations
+- Use `struct-with` to update multiple fields at once and minimize intermediate allocations
 
 ### Type-Directed Optimizations
 
 When the static analysis system knows a value's struct type, the preprocessor rewrites field operations to skip runtime name lookups:
 
-- **Field read** `(:field record)` → `&record:nth record <index>` — direct index access instead of name search
-- **Field update** `&record:assoc record :field value` → `&record:assoc-at record <index> value` — skips `index_of` binary search
-- **Batch update** `record-with record (:f1 v1) (:f2 v2)` → `&record:with-at record <indexes> <values>` — all indices pre-resolved
+- **Field read** `(:field value)` → `&struct:nth value <index>` — direct index access instead of name search
+- **Field update** `&struct:assoc value :field next` → `&struct:assoc-at value <index> next`
+- **Batch update** `struct-with value (:f1 v1) (:f2 v2)` → `&struct:with-at value <indexes> <values>`
 
 These rewrites are automatic and transparent. To benefit from them, provide type annotations via `:schema` or `hint-fn` so the preprocessor can resolve struct types.
 
-Record intentionally has no public `.nth` method: positional field order is not
-a cross-backend API contract. Use field-name `get`, which returns `Option<T>`.
-Only generated, statically checked field access uses internal `&record:nth`
-directly.
+Struct intentionally has no public `.nth` method: positional field order is not
+a cross-backend API contract. Use field-name `get`, which returns the declared
+field type directly. Only generated, statically checked access uses internal
+`&struct:nth`.

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -94,11 +94,11 @@ Both analysis commands run as static Snapshot readers: they load configured modu
 
 Use `--summary-only` when only aggregate counts are needed. Human output stops after the aggregate section; JSON keeps `data.summary` and the scope revision while returning an empty `data.definitions` array. `defstruct`, `defenum`, and `deftrait` carry type information in their declarations, so they are classified as data declarations instead of receiving a false top-level `schema-dynamic` finding.
 
-`check-examples` reports pass/fail and elapsed time without printing the final example value, which can be a very large function, record, or component tree. Output explicitly produced by an example is still shown.
+`check-examples` reports pass/fail and elapsed time without printing the final example value, which can be a very large function, struct, or component tree. Output explicitly produced by an example is still shown.
 
 ## Type Annotations
 
-Built-in types use **quoted symbols**: write `'String`, `'Number`, `'List`, `'Fn`, and `'Dynamic`. This keeps type syntax distinct from ordinary keyword/tag data. Lowercase tags such as `:string`, `:number`, and `:dynamic` remain load-compatible, but `cr edit format` rewrites type positions to the symbol form. It does not rewrite ordinary tags such as enum variants, record keys, `:return` schema keys, or `:kind` values.
+Built-in types use **quoted symbols**: write `'String`, `'Number`, `'List`, `'Fn`, and `'Dynamic`. This keeps type syntax distinct from ordinary keyword/tag data. Lowercase tags such as `:string`, `:number`, and `:dynamic` remain load-compatible, but `cr edit format` rewrites type positions to the symbol form. It does not rewrite ordinary tags such as enum variants, struct field keys, `:return` schema keys, or `:kind` values.
 
 ### Function Parameter Types
 
@@ -222,7 +222,8 @@ let
 | `'List` | List |
 | `'Map` | Hash Map |
 | `'Set` | Set |
-| `'Tuple` | Tuple (general) |
+| `'Enum` | Enum value (anonymous or named) |
+| `'Struct` | Struct value (anonymous or named) |
 | `'Fn` | Function |
 | `'Ref` | Atom / Ref |
 | `'Dynamic` | Unknown/unresolved type; static checks are disabled at this boundary |
@@ -298,7 +299,7 @@ If the body only needs a capability, add a trait bound rather than replacing `'T
 
 The same rule applies inside containers and callbacks: `:: :list 'T` preserves a homogeneous item relationship, while bare `:list` means `list<dynamic>`; a complete `:: :fn` callback schema preserves argument/return checking, while bare `:fn` does not.
 
-#### Record and Enum Types
+#### Struct and Enum Types
 
 Use the name defined by `defstruct` or `defenum`:
 
@@ -309,7 +310,7 @@ let
       hint-fn $ {}
         :args $ [] 'User
         :return :string
-      option:unwrap $ get u :name
+      &struct:get u :name
   get-name $ %{} User (:name |Alice)
 ```
 
@@ -327,24 +328,26 @@ defn greet (name age) (str "|Hello " name "|, you are " age)
 ; greet |Alice
 ```
 
-### Record Field Access
+### Struct Field Access
 
-Validates that record fields exist:
+Validates that struct fields exist. A known field has its declared type directly;
+an unknown field is a diagnostic rather than an `Option` result:
 
 ```cirru
 defstruct User (:name :string) (:age :number)
 
-defn get-user-email (user) (.-email user) (; Warning: field 'email' not found in record User) (; Available fields: name, age)
+defn get-user-email (user) (.-email user) (; Warning: field ':email' not found in struct User) (; Available fields: :name, :age)
 ```
 
-### Tuple Index Bounds
+### Enum Index Bounds
 
-Checks tuple index access at compile time:
+Enum positional access is bounds-checked at runtime and reports an ordinary
+diagnostic rather than panicking:
 
 ```cirru.no-check
 let
-    point $ %:: :Point 10 20 30
-  &tuple:nth point 5 ; Warning: index 5 out of bounds, tuple has 4 elements
+    point $ %:: _ :point 10 20 30
+  &enum:nth point 5 ; Error: index 5 is outside this enum value
 ```
 
 ### Enum Variant Validation
@@ -421,7 +424,7 @@ let
   [] n numbers
 ```
 
-### Record and Struct Types
+### Struct Types
 
 ```cirru
 let
@@ -495,7 +498,7 @@ Schema on the namespace definition:
 ```cirru.no-check
 :: :fn $ {}
   :args $ [] :dynamic
-  :return $ :: :optional :record
+  :return $ :: 'Optional 'Struct
 ```
 
 ## Variadic Types
@@ -554,13 +557,13 @@ Checks are automatically skipped for:
 
 Beyond warning about type errors, the static analysis system drives **compile-time performance optimizations**. When the preprocessor knows a value's type, it rewrites operations to skip runtime dispatches:
 
-### Record Field Operations
+### Struct Field Operations
 
-When a record's struct type is known:
+When a struct definition is known:
 
-- **Field read** `(:field record)` → `&record:nth record <index>` — O(1) direct access instead of O(log n) name lookup
-- **Field update** `&record:assoc record :field value` → `&record:assoc-at record <index> value` — pre-resolved field index
-- **Batch update** `record-with record (:f1 v1) (:f2 v2)` → `&record:with-at record <indexes> <values>` — all indices pre-resolved
+- **Field read** `(:field value)` → `&struct:nth value <index>` — O(1) direct access instead of a name lookup
+- **Field update** `&struct:assoc value :field next` → `&struct:assoc-at value <index> next`
+- **Batch update** `struct-with value (:f1 v1) (:f2 v2)` → `&struct:with-at value <indexes> <values>`
 
 ### Conditional Folding
 
@@ -756,7 +759,7 @@ Type check warnings include:
 Example warning:
 
 ```
-[Warn] Tuple index out of bounds: tuple has 3 element(s), but trying to access index 5, at my-app.core/process-point
+[Warn] Field `:email` does not exist in struct `User`. Available fields: [:age, :name]. Struct field access is required and never returns nil/Option for a missing field; use a declared field instead
 ```
 
 ## Advanced Topics

--- a/docs/features/traits.md
+++ b/docs/features/traits.md
@@ -40,7 +40,7 @@ deftrait MyFoo $ .foo
 
 ## Implement a trait
 
-Use `defimpl` to create an impl record for a trait.
+Use `defimpl` to create a nominal impl value for a trait.
 
 ```cirru
 let
@@ -67,7 +67,7 @@ let
 defimpl ImplName Trait ...
 ```
 
-- First argument is the **impl record name**.
+- First argument is the **impl value name**.
 - Second argument is the concrete **trait value** (normally a symbol). A tag is accepted only for the legacy method-bag form described below.
 
 Examples:
@@ -145,7 +145,7 @@ Implementation notes:
 Constraints:
 
 - `impl-traits` only accepts **struct/enum** values.
-- Record/tuple instances must be created from a struct/enum that already has impls attached (`%{}` or `%::`).
+- Struct/enum values must be created from a definition that already has impls attached (`%{}` or `%::`).
 
 Syntax:
 
@@ -237,7 +237,7 @@ When you want to **disambiguate** (or bypass `.method` resolution), use `&trait-
 
 Usage: `&trait-call Trait :method receiver & args`
 
-`&trait-call` matches by the impl record's trait origin, not just by trait name text. This avoids accidental dispatch when two different trait values share the same printed name.
+`&trait-call` matches by the impl value's trait origin, not just by trait name text. This avoids accidental dispatch when two different trait values share the same printed name.
 
 Example with two traits sharing the same method name:
 
@@ -297,10 +297,10 @@ let
     Shape0 $ defenum Shape (:point 'Number 'Number)
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (t)
-        str |shape: $ &tuple:nth t 0
+        str |shape: $ &enum:nth t 0
     Shape $ impl-traits Shape0 MyFooImpl
-    some-tuple $ %:: Shape :point 10 20
-    impls $ &tuple:impls some-tuple
+    shape $ %:: Shape :point 10 20
+    impls $ &enum:impls shape
   any? impls $ fn (impl)
     = (impl-origin impl) (%some MyFoo)
 ```

--- a/docs/features/tuples.md
+++ b/docs/features/tuples.md
@@ -1,294 +1,97 @@
 ---
-title: "Tuples"
+title: "Anonymous Enums"
 scope: "core"
 kind: "reference"
 category: "features"
 aliases:
-  - "tuple"
-  - "tagged tuple"
-  - "tuple match"
+  - "anonymous enum"
+  - "legacy tuple migration"
 id: core/features/tuples
 parent: core/features
 ---
 
-# Tuples
+# Anonymous Enums
 
-Tuples in Calcit are tagged unions that can hold multiple values with a tag. They are used for representing structured data and are the foundation for records and enums.
-
-## Quick Recipes
-
-- **Create**: `:: :point 10 20`
-- **Create Typed**: `%:: Shape :circle 5`
-- **Access**: `&tuple:nth t 1`
-- **Match Tuples**: `match t ((:point x y) ...)` (recommended for both plain tuples and enum-backed tuples)
-- **Legacy Match**: `tag-match t ((:point x y) ...)`
-- **Update**: `&tuple:assoc t 1 99`
-
-## Creating Tuples
-
-### Shorthand Syntax
-
-Use `::` to create a tuple with a tag:
+Anonymous enums are short-lived tagged values that do not need a named
+`defenum` declaration. Use `_` in the definition position:
 
 ```cirru
 let
-    result 42
-    message |error-occurred
-  do
-    :: :point 10 20
-    :: :ok result
-    :: :err message
+    value $ %:: _ :point 10 20
+  println value
+  ; => $ %:: _ :point 10 20
 ```
 
-### With Class Syntax
+The `_` marker makes the missing definition explicit. The old “tuple” name and
+`&tuple:*` native APIs have been removed; diagnostics point to their `enum`
+replacements.
 
-Use `%::` to create a typed tuple from an enum:
+## Accessing Values
+
+Use `&enum:nth` when positional access is genuinely appropriate. Index `0` is
+the variant tag and payload values begin at index `1`.
 
 ```cirru
 let
-    Shape $ defenum Shape (:point :number :number) (:circle :number)
-  %:: Shape :point 10 20
+    value $ %:: _ :point 10 20
+  assert= :point $ &enum:nth value 0
+  assert= 10 $ &enum:nth value 1
+  assert= 3 $ &enum:count value
 ```
 
-## Tuple Structure
+Anonymous enum access remains bounds-checked and reports ordinary diagnostics;
+it never relies on unchecked indexing.
 
-A tuple consists of:
+## Matching
 
-- **Tag**: A keyword identifying the tuple type (index 0)
-- **Class**: Optional class metadata (hidden)
-- **Parameters**: Zero or more values (indices 1+)
+`tag-match` can match an anonymous enum when there is no definition available
+for exhaustiveness analysis:
 
 ```cirru
 let
-    t $ :: :point 10 20
-  ; Index 0: :point, Index 1: 10, Index 2: 20
-  [] (&tuple:nth t 0) (&tuple:nth t 1) (&tuple:nth t 2)
+    value $ %:: _ :point 10 20
+  assert= 30 $ tag-match value
+    (:point x y) (+ x y)
+    _ 0
 ```
 
-## Accessing Tuple Elements
+For domain data, prefer a named enum and native `match`, which can validate
+variants, payload arity, and exhaustiveness:
 
 ```cirru
 let
-    t $ :: :point 10 20
-  &tuple:nth t 0
-  ; => :point
-
-  &tuple:nth t 1
-  ; => 10
-
-  &tuple:nth t 2
-  ; => 20
+    Shape $ defenum Shape (:point 'Number 'Number) (:none)
+    value $ %:: Shape :point 10 20
+  assert= 30 $ match value
+    (:point x y) (+ x y)
+    (:none) 0
 ```
 
-## Tuple Properties
+## Named Conversion
 
-```cirru
-let
-    t $ :: :point 10 20
-  do
-    ; count includes the tag
-    &tuple:count (:: :a 1 2 3)
-    ; => 4
-    &tuple:params t
-    ; => ([] 10 20)
-    tuple-enum t
-    ; => (%none) (plain tuple, not from enum)
-```
+When the expected function parameter type is a named enum, the preprocessor can
+rewrite `%:: _ :variant ...` to that named definition. Variant and payload
+validation then use the target `defenum` declaration.
 
-`tuple-enum` is the source-prototype API for tuples:
+## Migration
 
-- If a tuple is created from an enum (`%::`), it returns `%some` with that enum definition.
-- If a tuple is created as a plain tuple (`::`), it returns `%none`.
+Use these replacements when upgrading older code:
 
-The nullable `&tuple:enum` primitive remains internal for core bootstrapping.
+| Removed spelling | Replacement |
+| --- | --- |
+| tuple value / `:tuple` | enum value / `:enum` |
+| `tuple?` | `enum?` for values, `enum-def?` for definitions |
+| `tuple-enum` | `enum-definition` |
+| `&tuple:nth` | `&enum:nth` |
+| `&tuple:count` | `&enum:count` |
+| `&tuple:assoc` | `&enum:assoc` |
+| `&tuple:*` | corresponding `&enum:*` API |
 
-```cirru
-do
-  let
-      plain $ :: :point 10 20
-    option:none? $ tuple-enum plain
-    ; => true
-  let
-      ApiResult $ defenum ApiResult (:ok :number) (:err :string)
-      ok $ %:: ApiResult :ok 1
-    assert= (%some ApiResult) $ tuple-enum ok
-```
+Compatibility readers may still load historical snapshots, but newly written
+schemas and source should use `Enum`, `EnumDef`, `enum`, and `enum-def` names.
 
-### Accurate Origin Check (Enum Eq)
+## See Also
 
-```cirru
-let
-    ApiResult $ defenum ApiResult (:ok :number) (:err :string)
-    x $ %:: ApiResult :ok 1
-  assert= (tuple-enum x) (%some ApiResult)
-```
-
-### Complex Branching Example (Safe + Validation)
-
-```cirru
-do
-  defenum Result
-    :ok :number
-    :err :string
-  let
-      xs $ []
-        %:: Result :ok 1
-        %:: Result :err |bad
-        :: :plain 42
-    if (option:none? (tuple-enum (&list:nth xs 2)))
-      if (= (tuple-enum (&list:nth xs 0)) (%some Result))
-        , |result-and-plain
-        , |result-missing
-      , |unexpected
-```
-
-## Updating Tuples
-
-```cirru
-; Update element at index
-&tuple:assoc (:: :point 10 20) 1 100
-; => (:: :point 100 20)
-```
-
-## Pattern Matching with Tuples
-
-### match (recommended)
-
-`match` is the preferred pattern matching syntax. It is a native syntax (not a macro) and provides compile-time exhaustiveness checking for enum types:
-
-```cirru
-let
-    MyResult $ defenum MyResult (:ok :number) (:err :string)
-    result $ %:: MyResult :ok 42
-  match result
-    (:ok v) (str |Success: v)
-    (:err msg) (str |Error: msg)
-```
-
-See [Enums](enums.md) for full details on `match` including exhaustiveness checking and migration from `tag-match`.
-
-### tag-match (legacy)
-
-`tag-match` is a macro that also branches on enum/tuple tags. It works without a static enum type and accepts a `_` wildcard, but has no compile-time checks:
-
-```cirru
-let
-    MyResult $ defenum MyResult (:ok :number) (:err :string)
-    result $ %:: MyResult :ok 42
-  tag-match result
-    (:ok v) (str |Success: v)
-    (:err msg) (str |Error: msg)
-    _ |Unknown
-```
-
-`tag-match` remains available as a legacy alternative, but `match` also works on plain (untyped) tuples.
-
-### list-match
-
-For simple list-like destructuring:
-
-```cirru
-; list-match takes (head rest) branches — rest captures remaining elements as a list
-list-match ([] :point 10 20)
-  () |Empty
-  (h tl) ([] h tl)
-```
-
-The function forms `destruct-list`, `destruct-map`, `destruct-set`, and
-`destruct-str` return the nominal enums `ListDestruct<T>`,
-`MapDestruct<K,V>`, `SetDestruct<T>`, and `StringDestruct`. Their variants stay
-`:none` and `:some`, so existing `tag-match` branches keep the same shape while
-the schema now checks every payload.
-
-## Enums as Tuples
-
-Enums are specialized tuples with predefined variants:
-
-```cirru
-; Define enum
-defenum Option
-  :some :dynamic
-  :none
-
-; Create enum instances
-%:: Option :some 42
-%:: Option :none
-
-; Check variant
-&tuple:enum-has-variant? Option :some
-; => true
-
-; Get variant arity
-&tuple:enum-variant-arity Option :some
-; => 1
-```
-
-## Common Use Cases
-
-### Result Types
-
-```cirru
-let
-    MyResult $ defenum MyResult (:ok :number) (:err :string)
-    divide $ defn divide (a b)
-      if (= b 0)
-        %:: MyResult :err |Division-by-zero
-        %:: MyResult :ok (/ a b)
-    result $ divide 10 2
-  match result
-    (:ok value) (str |ok: value)
-    (:err msg) (str |err: msg)
-```
-
-### Optional Values
-
-```cirru
-let
-    MaybeInt $ defenum MaybeInt (:some :number) (:none)
-    find-item $ fn (items target)
-      reduce items (%:: MaybeInt :none)
-        fn (acc x)
-          if (= x target) (%:: MaybeInt :some x) acc
-    result $ find-item ([] 1 2 3) 2
-  match result
-    (:some v) v
-    (:none) |not-found
-```
-
-### Tagged Data
-
-```cirru
-; Represent different message types
-:: :greeting |Hello
-:: :number 42
-:: :list ([] 1 2 3)
-```
-
-## Type Annotations
-
-```cirru
-let
-    ApiResult $ defenum ApiResult (:ok :string) (:err :string)
-    process-result $ fn (r)
-      hint-fn $ {} (:args $ [] :dynamic) (:return :string)
-      match r
-        (:ok v) (str v)
-        (:err msg) msg
-  process-result $ %:: ApiResult :ok |done
-```
-
-## Tuple vs Record
-
-| Feature   | Tuple         | Record             |
-| --------- | ------------- | ------------------ |
-| Access    | By index      | By field name      |
-| Structure | Tag + params  | Named fields       |
-| Methods   | Via class     | Via traits         |
-| Use case  | Tagged unions | Structured objects |
-
-## Performance Notes
-
-- Tuples are immutable
-- Element access is O(1)
-- `&tuple:assoc` creates a new tuple
-- Use records for complex objects with named fields
+- [Enums](enums.md) — named enums declared with `defenum`
+- [Structs](records.md) — fixed named fields declared with `defstruct`
+- [Static Analysis](static-analysis.md) — enum payload and match checking

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -83,10 +83,10 @@ cr eval "echo |done"
 - **Lists**: `[] 1 2 3`
 - **HashMaps**: `{} (:a 1) (:b 2)`
 - **HashSets**: `#{} :a :b :c`
-- **Tuples**: `:: :tag 1 2` - tagged unions with class support
-- **Records**: `%{} RecordName (:key1 val1) (:key2 val2)`, similar to structs
-- **Structs**: `defstruct Point (:x 'Number) (:y 'Number)` - record type definitions
-- **Enums**: `defenum Result (:ok ..) (:err 'String)` - sum types
+- **Anonymous Enums**: `%:: _ :tag 1 2` (or `:: :tag 1 2`) - short-lived tagged values
+- **Anonymous Structs**: `%{} _ (:key1 val1) (:key2 val2)` - short-lived fixed-field values
+- **Structs**: `defstruct Point (:x 'Number) (:y 'Number)` and `%{} Point ...`
+- **Enums**: `defenum Result (:ok ..) (:err 'String)` and `%:: Result ...`
 - **Refs/Atoms**: `atom 0` - mutable references
 - **Buffers**: `&buffer 0x01 0x02` - binary data
 
@@ -162,7 +162,7 @@ defn add (a b) (+ a b)
 ### Built-in Types
 
 - `'Number`, `'String`, `'Bool`, `'Nil`, `'Dynamic`
-- `'List`, `'Map`, `'Set`, `'Record`, `'Fn`, `'Tuple`
+- `'List`, `'Map`, `'Set`, `'Struct`, `'Enum`, `'StructDef`, `'EnumDef`, `'Fn`
 - `'Dynamic` - wildcard type (default when no annotation)
 - Generic types (Cirru style):
 
@@ -180,8 +180,8 @@ let
 ### Static Checks (Compile-time)
 
 - **Arity checking**: Function call argument count validation
-- **Record field checking**: Validates field names in record access
-- **Tuple index bounds**: Ensures tuple indices are valid
+- **Struct field checking**: Validates required field names in struct access
+- **Enum index bounds**: Ensures enum payload indices are valid
 - **Enum tag matching**: Validates tags in `&case` and `&extract-case`
 - **Method validation**: Checks method names and class types
 - **Recur arity**: Validates recur argument count matches function params
@@ -268,51 +268,52 @@ let
 - `get-char-code`, `char-from-code` - character operations
 - `&str:escape` - escape string
 
-### Tuple Operations
+### Enum Operations
 
-- `::` - create tuple (shorthand)
-- `%::` - create tuple with class
-- `&tuple:nth` - access element by index
-- `&tuple:assoc` - update element
-- `&tuple:count` - get element count
-- `&tuple:class` - get class
-- `&tuple:params` - get parameters
-- `tuple-enum` - get an enum prototype as `Option<Enum>`
+- `defenum` - define a named enum
+- `%::` - create a named enum value, or an anonymous value with `%:: _ ...`
+- `::` - shorthand for an anonymous enum value
+- `&enum:nth` - access the variant tag or payload by index
+- `&enum:assoc` - update a payload position
+- `&enum:count` - count the variant tag and payload positions
+- `&enum:params` - get payload parameters
+- `enum-definition` - get the definition as `Option<EnumDef>`
 - `destruct-list`, `destruct-map`, `destruct-set`, `destruct-str` - split collections using nominal `*Destruct` enums
-- `&tuple:with-class` - change class
+- `enum?`, `enum-def?` - distinguish values from definitions
 
-### Record Operations
+### Struct Operations
 
 - `defstruct` - define a struct type with typed fields
-- `%{}` - create a record instance from a struct
-- `%{}?` - create a partial record (unset fields default to nil)
-- `&%{}` - low-level record constructor (flat key-value pairs, no type check)
-- `record-with` - update multiple fields, returns new record
-- `&record:get` - get field value
-- `&record:assoc` - set field value (low-level)
-- `record-struct` - get the struct definition the record was created from
-- `&record:matches?` - type check
-- `&record:from-map` - convert from map
-- `&record:to-map` - convert to map
-- `&record:get-name` - get tag name of the record's struct
-- `record?`, `struct?` - predicates
+- `%{}` - create a named struct value, or an anonymous value with `%{} _ ...`
+- `%{}?` - create a partial struct (unset fields default to nil)
+- `&%{}` - low-level struct constructor (flat key-value pairs, no type check)
+- `struct-with` - update multiple declared fields
+- `&struct:get` - get a required declared field
+- `&struct:assoc` - set a declared field (low-level)
+- `struct-definition` - get the definition as `Option<StructDef>`
+- `&struct:matches?` - type check
+- `&struct:from-map` - convert from map
+- `&struct:to-map` - convert to map
+- `&struct:get-name` - get the tag name of the struct definition
+- `struct?`, `struct-def?` - distinguish values from definitions
 
 ### Struct & Enum Operations
 
 - `defstruct` - define struct type
 - `defenum` - define enum type
-- `&struct::new`, `&enum::new` - create instances
-- `struct?`, `enum?` - predicates
-- `&tuple:enum-has-variant?` - check variant
-- `&tuple:enum-variant-arity` - get variant arity
-- `match` - native pattern matching on enums and tuples
-- `tag-match` - legacy enum/tuple matching syntax
+- `&struct-def:new`, `&enum-def:new` - internal definition constructors
+- `struct?`, `enum?` - value predicates
+- `struct-def?`, `enum-def?` - definition predicates
+- `&enum-def:has-variant?` - check a declared variant
+- `&enum-def:variant-arity` - get declared variant arity
+- `match` - native pattern matching on named enums
+- `tag-match` - fallback matching for anonymous enums
 
 ## Traits & Methods
 
 - `deftrait` - define a trait (method set + type signatures)
 - `impl-origin` - get an impl's trait origin as `Option<Trait>`
-- `defimpl` - define an impl record for a trait: `defimpl ImplName Trait ...`
+- `defimpl` - define a nominal impl value for a trait: `defimpl ImplName Trait ...`
 - `impl-traits` - attach impl records to a struct/enum definition (user impls: later impls override earlier ones for same method name)
 - `.method` - normal method dispatch
 - `&trait-call` - explicit trait method call: `&trait-call Trait :method receiver & args`
@@ -333,8 +334,8 @@ let
 
 - `nil?`, `some?` - nil checks
 - `number?`, `string?`, `tag?`, `symbol?`
-- `list?`, `map?`, `set?`, `tuple?`
-- `record?`, `struct?`, `enum?`, `ref?`
+- `list?`, `map?`, `set?`, `struct?`, `enum?`
+- `struct-def?`, `enum-def?`, `ref?`
 - `fn?`, `macro?`
 
 ### Control Flow
@@ -344,9 +345,9 @@ let
 - `cond` - multi-way conditional; requires a final `(true value)` branch
 - `case` - pattern matching on values; raises when no pattern matches
 - `&case` - internal case macro
-- `match` - preferred enum/tuple pattern matching
-- `tag-match` - legacy enum/tuple pattern matching
-- `record-match` - record pattern matching
+- `match` - preferred named-enum pattern matching
+- `tag-match` - fallback anonymous-enum pattern matching
+- `struct-match` - struct pattern matching
 - `list-match` - list destructuring match
 - `field-match` - map field matching
 - `if-let` - unwrap an `Option<T>` with explicit some/none branches
@@ -355,7 +356,9 @@ let
 Nested updates are nominal as well: `update-in` passes `Option<T>` to its
 updater, and `dissoc-in` treats an empty path as a no-op. Public lookup and
 positional APIs (`get`, `get-in`, `first`, `last`, and collection `nth`) return
-`Option<T>`. Record has no public positional `.nth`; use field-name `get`.
+`Option<T>`. Accessing a statically known struct field with `get`, `:field`, or
+`.field` returns the field's declared type directly; an undeclared field is a
+diagnostic, not `nil`. Struct has no public positional `.nth`.
 
 ### Threading Macros
 

--- a/docs/run/agent-advanced.md
+++ b/docs/run/agent-advanced.md
@@ -164,7 +164,7 @@ echo 'range 10' | cr exec
 
 - `&methods-of value` — 列出某值的可用方法名（返回字符串列表 `[] |.foo |.bar ...`）
 - `&inspect-methods value` — 打印方法与 impl 来源（调试 trait override 链，可临时插入 pipeline）
-- `impl-origin impl` — 以 `Option<Trait>` 读取 impl record 的 trait 来源
+- `impl-origin impl` — 以 `Option<Trait>` 读取 nominal impl 的 trait 来源
 - `&trait-call Trait :method receiver & args` — 显式消歧：只调用属于指定 trait 的方法实现
 
 > 📖 深入了解 trait 实现机制：`cr docs read traits.md` 或 `cr docs search 'trait-call'`
@@ -211,7 +211,7 @@ echo 'range 10' | cr exec
 详细内容已移入独立文件：
 
 - `Cirru 语法核心概念` → [cirru-syntax.md](../cirru-syntax.md)
-- `数据结构：Tuple vs Vector` → [features/tuples.md](../features/tuples.md)
+- `数据结构：Anonymous Enum vs List` → [features/tuples.md](../features/tuples.md)
 - `类型标注与检查` → [features/static-analysis.md](../features/static-analysis.md)
 
 ### 其他易错点
@@ -551,27 +551,27 @@ hello / "hello"   => symbol hello, not a string
 
 **不放心修改是否正确？** 每步后用 `cr tree show` 验证。
 
-**Tuple vs Vector：**
+**Anonymous Enum vs List：**
 
 ```cirru.no-check
-; ✅ Tuple - 用于事件、模式匹配
-:: :clipboard/read text
+; ✅ anonymous enum - 用于事件、模式匹配
+%:: _ :clipboard/read text
 
 ; ✅ Vector - 用于 DOM 列表
 [] (button) (div)
 
 ; ❌ 错误：用 vector 传事件
 send-to-component! $ [] :clipboard/read text
-; 报错：tag-match expected tuple
+; 报错：tag-match expected enum value
 
-; ✅ 正确：用 tuple
-send-to-component! $ :: :clipboard/read text
+; ✅ 正确：用 anonymous enum
+send-to-component! $ %:: _ :clipboard/read text
 ```
 
 **记忆规则：**
 
-- **`::` (tuple)**: 事件、模式匹配、不可变数据结构
-- **`[]` (vector)**: DOM 元素列表、动态集合
+- **`%:: _` (anonymous enum)**: 事件、模式匹配、短生命周期 tagged data；`::` 仍是简写
+- **`[]` (list)**: DOM 元素列表、动态集合
 
 ### 4. 输入大小限制 ⭐⭐⭐
 
@@ -736,7 +736,7 @@ cr tree replace 'app.core/checkout' --path @3.2.1 --code 'quote calculate-discou
 **其他差异：**
 
 - **宏系统**：Calcit 更简洁，缺少 Clojure 的 reader macro（如 `#()`）
-- **数据类型**：Calcit 的 Tuple (`::`) 和 Vector (`[]`) 有特定用途（见"Cirru 字符串和数据类型"）
+- **数据类型**：Calcit 的 Anonymous Enum (`%:: _`，`::` 为简写) 和 List (`[]`) 有不同用途（见"Cirru 字符串和数据类型"）
 
 ---
 
@@ -850,7 +850,7 @@ cr query error
 | `tree-replace: root path is not allowed` | 写操作传了空 path                             | 改用 `cr edit def --overwrite` 覆盖整段定义            |
 | `add-import: import rule already exists` | 重复添加相同 import                           | 跳过或先手动移除旧规则                                 |
 | `Definition 'xxx' already exists`        | `cr edit def` 未传 `--overwrite`              | 加 `--overwrite`                                       |
-| `tag-match expected tuple`               | 传入 vector 而非 tuple                        | 改用 `::` 语法，如 `:: :event-name data`               |
+| `tag-match expected enum value`          | 传入 list 而非 enum                           | 改用 `%:: _`，如 `%:: _ :event-name data`               |
 | `unknown symbol: xxx`                    | 符号未定义或未 import                         | `cr query find` 确认位置，`cr edit add-import` 引入    |
 | `expects pairs in list for let`          | `let` 绑定语法错误                            | 改为 `let ((x val)) body`（双层括号）                  |
 | `cannot be used as operator`             | 末尾符号被当作函数调用                        | 改用 `, acc` 前缀传递值，或用函数包裹                  |

--- a/docs/run/query.md
+++ b/docs/run/query.md
@@ -248,8 +248,8 @@ let
   do
     ; "Get all methods/traits implemented by a value"
     println $ &methods-of p
-    ; 'Get tag name of a record or enum'
-    println $ &record:get-name p
+    ; 'Get the definition tag name of a struct value'
+    println $ &struct:get-name p
     ; "Describe any value's internal type"
     println $ &inspect-type p
 ```

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -59,7 +59,7 @@ related:
 
 ### 类型标注语法迁移
 
-新版本把 schema 类型的推荐写法统一为 quoted symbol：`'String`、`'Number`、`'List`、`'Ref`、`'Fn` 和 `'Dynamic`。旧的 `:string`、`:number`、`:list`、`:ref`、`:fn`、`:dynamic` 仍可加载，以便平滑升级；普通 tag 数据（例如 enum variant `:ok`、record key 和 schema 的 `:return`/`:kind` key）不会被改变。
+新版本把 schema 类型的推荐写法统一为 quoted symbol：`'String`、`'Number`、`'List`、`'Ref`、`'Fn` 和 `'Dynamic`。旧的 `:string`、`:number`、`:list`、`:ref`、`:fn`、`:dynamic` 仍可加载，以便平滑升级；普通 tag 数据（例如 enum variant `:ok`、struct field key 和 schema 的 `:return`/`:kind` key）不会被改变。
 
 在完成依赖升级后执行：
 
@@ -69,6 +69,35 @@ cr calcit.cirru --check-only
 ```
 
 `edit format` 会只改写 schema、`hint-fn`、`assert-type`、`unsafe-coerce`、`defstruct` 和 `defenum` 等类型位置，并将 entry schema 重新序列化为 canonical symbols；它不会猜测或加强实际类型契约。提交前检查 diff，尤其是具有手写 tag 数据的宏或 DSL。
+
+### Struct / Enum 数据模型命名迁移
+
+新数据模型明确区分定义和值：`defstruct` 返回 `StructDef`，`defenum` 返回
+`EnumDef`；实例类型分别是 `Struct` 和 `Enum`。没有具名定义的临时值使用
+`%{} _ ...` 和 `%:: _ ...`。旧的 record / tuple 公开名称会产生
+`W_REMOVED_DATA_API`，诊断中同时给出替代写法；新 Snapshot 不再写出
+`:record`、`:tuple`、`Record` 或 `Tuple`。
+
+常用迁移如下：
+
+| 旧写法 | 新写法 |
+| --- | --- |
+| `record?` | `struct?`（值）或 `struct-def?`（定义） |
+| `tuple?` | `enum?`（值）或 `enum-def?`（定义） |
+| `record-struct` | `struct-definition` |
+| `tuple-enum` | `enum-definition` |
+| `record-with` / `record-match` | `struct-with` / `struct-match` |
+| `&record:*` / `&tuple:*` | 对应的 `&struct:*` / `&enum:*`；定义元数据使用 `&struct-def:*` / `&enum-def:*` |
+
+Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field` 和
+`.field` 直接返回字段声明类型，不再自动包装 `Option<T>`。不存在的字段会在
+静态检查阶段报告，运行期也会抛出普通错误；升级业务代码时应删除这类访问后的
+`option:unwrap`。Map 等动态容器的访问仍返回 `Option<T>`，`get-in` 也继续保留
+可失败路径语义，不能批量删除其 unwrap。
+
+推荐先执行 `cr calcit.cirru --check-only`，按诊断逐项替换，再运行完整 JS
+回归。不要先全局删除 `option:unwrap`；只处理接收者已被推断为 Struct 且字段在
+`defstruct` 中声明的访问。
 
 下面流程按“先确认版本，再对齐工具链，再更新依赖，最后按 CI 链路验证”的顺序执行。
 
@@ -262,7 +291,7 @@ let
 - concrete trait impl 必须完整实现声明的方法，且不能夹带 trait 未声明的方法；
 - trait method 的值必须可调用；native 预处理在签名信息可用时还会检查函数签名；
 - 同名方法不会跨 impl 拼接成一个 trait，也不会让两个独立 trait 互相冒充；
-- list/map/set/string/number/record/tuple 等内建能力现在由 native 与 JS 共用的 nominal core impl 表提供。
+- list/map/set/string/number/struct/enum 等内建能力现在由 native 与 JS 共用的 nominal core impl 表提供。
 
 建议在升级验证中显式覆盖两类负向用例：只有 `TraitA/.method` 时，`assert-traits value TraitB` 和 `&trait-call TraitB :method value` 都必须失败。
 

--- a/editing-history/202608061714-struct-enum-data-model-v2.md
+++ b/editing-history/202608061714-struct-enum-data-model-v2.md
@@ -1,0 +1,39 @@
+# Struct / Enum data model v2
+
+## Scope
+
+- Split runtime definitions from values: `StructDef` / `EnumDef` versus `Struct` / `Enum`.
+- Replaced outward `record` / `tuple` names with `struct` / `enum`; historical snapshot input remains readable, but new writes and old API calls receive migration diagnostics.
+- Added canonical anonymous forms `%{} _ ...` and `%:: _ ...`.
+- Render named data definitions with symbols, for example `(%{} 'TodoState ...)`, in Rust display and the TypeScript custom formatter.
+
+## Field access contract
+
+- A struct has a fixed declared field set. Known-field `get` and postfix access return the field's declared type directly rather than `Option<T>`.
+- Missing struct fields produce static diagnostics when type information is available and ordinary runtime errors otherwise; they never turn into silent `nil`/`Option` absence.
+- Map, list, string, and other genuinely fallible collection lookups retain `Option` behavior.
+
+## Migration surface
+
+- Native APIs moved from `&record:*` / `&tuple:*` to `&struct:*` / `&enum:*`; definition-only operations use `&struct-def:*` / `&enum-def:*`.
+- Public reflection is `struct-definition` / `enum-definition`; predicates distinguish values (`struct?`, `enum?`) from definitions (`struct-def?`, `enum-def?`).
+- Removed calls emit `W_REMOVED_DATA_API` with concrete replacements. Compatibility wrapper bodies also fail explicitly if checking is bypassed.
+- Documentation now presents structs, enums, anonymous structs, and anonymous enums as the public model and keeps old spellings only in the migration table.
+
+## Recursive types and regressions
+
+- Recursive nominal references stay finite while being resolved.
+- `Optional<Node>` accepts a `nil` leaf and nested non-`nil` nodes.
+- Required invalid recursion and unsupported recursive data-shape forms return normal diagnostics instead of overflowing the stack.
+
+## Cross-backend work
+
+- Rust, JS, IR, and WASM emitters and runtime tags use the new semantic categories.
+- TypeScript runtime files are separated into struct/enum definition and value modules.
+- Custom formatter headers embed named and anonymous definition markers as `CalcitSymbol`, including `_`.
+
+## Real-project validation
+
+- Respo was migrated from legacy data APIs and predicates using AST leaf replacements.
+- `Element` stays a struct through `purify-element`, allowing direct typed field access and removing obsolete `Option` unwraps.
+- Respo check-only and its full JS test suite pass when loaded against this repository's newly compiled `@calcit/procs` runtime.

--- a/history/202608061433-required-record-field-access.md
+++ b/history/202608061433-required-record-field-access.md
@@ -1,0 +1,32 @@
+# Required record field access
+
+## Background
+
+Struct-backed values and loose records both have a fixed runtime field set.
+Direct field syntax therefore must not inherit the optional semantics of the
+generic collection `get` API: a declared field returns its value directly and
+an absent field is an ordinary diagnostic.
+
+## Changes
+
+- Specialize postfix and tag-headed record access to indexed or required
+  record lookup during preprocessing.
+- Make missing native record fields fail consistently in the Rust, JavaScript,
+  and WASM runtimes instead of producing nil or undefined.
+- Keep the public collection `get` API optional by guarding required record
+  lookup with `record:contains?`.
+- Add Rust and JavaScript regression coverage for direct field specialization
+  and missing-field diagnostics.
+- Update the internal `&record:get` schema and documentation to describe the
+  required lookup contract.
+
+## Verification
+
+- `cargo fmt`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-all`
+- `yarn check-agent-interface`
+- Respo `cr calcit.cirru --check-only`
+- Respo `cr calcit.cirru js`

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -21,16 +21,20 @@ try {
   const todoName = runtimeA.newTag("TodoState");
   const todoField = runtimeA.newTag("draft");
   const todoType = new runtimeA.CalcitSymbol("String");
-  const todoRecord = new runtimeA.CalcitRecord(todoName, [todoField], [""]);
-  const todoStruct = new runtimeA.CalcitStruct(todoName, [todoField], [todoType]);
-  const todoEnum = new runtimeA.CalcitEnum(new runtimeA.CalcitRecord(todoName, [todoField], [todoType]));
+  const todoRecord = new runtimeA.CalcitStructValue(todoName, [todoField], [""]);
+  const todoStruct = new runtimeA.CalcitStructDef(todoName, [todoField], [todoType]);
+  const todoEnum = new runtimeA.CalcitEnumDef(new runtimeA.CalcitStructValue(todoName, [todoField], [todoType]));
+  const todoEnumValue = new runtimeA.CalcitEnumValue(todoField, [""], todoEnum);
+  const anonymousEnumValue = new runtimeA.CalcitEnumValue(todoField, [""]);
   assert.equal(todoRecord.toString(), "(%{} 'TodoState (:draft |))");
-  assert.equal(todoStruct.toString(), "(%struct 'TodoState (:draft 'String))");
-  assert.equal(todoEnum.toString(), "(%enum 'TodoState)");
+  assert.equal(todoStruct.toString(), "(%struct-def 'TodoState (:draft 'String))");
+  assert.equal(todoEnum.toString(), "(%enum-def 'TodoState)");
+  assert.equal(todoEnumValue.toString(), "(%:: 'TodoState :draft |)");
+  assert.equal(anonymousEnumValue.toString(), "(%:: _ :draft |)");
   assert.throws(
-    () => runtimeA._$n_record_$o_get(todoRecord, runtimeA.newTag("missing")),
+    () => runtimeA._$n_struct_$o_get(todoRecord, runtimeA.newTag("missing")),
     /does not define field :missing/,
-    "record field lookup must reject a missing field instead of returning nil"
+    "struct field lookup must reject a missing field instead of returning nil"
   );
 
   runtimeA.load_console_formatter_$x_();
@@ -48,13 +52,16 @@ try {
     const name = embeddedObjects(formatter.header(value)).find((item) => item?.value === "TodoState");
     assert.ok(name instanceof runtimeA.CalcitSymbol, `${kind} formatter should render its name as a symbol`);
   };
-  assertNominalNameIsSymbol(todoRecord, "record");
-  assertNominalNameIsSymbol(todoStruct, "struct");
-  assertNominalNameIsSymbol(todoEnum, "enum");
-  assert.ok(formatter.hasBody(todoStruct), "struct formatter should expose field types");
-  assert.ok(formatter.hasBody(todoEnum), "enum formatter should expose variants");
-  assert.ok(embeddedObjects(formatter.body(todoStruct)).includes(todoType), "struct formatter should embed field types");
-  assert.ok(embeddedObjects(formatter.body(todoEnum)).includes(todoType), "enum formatter should embed variant payload types");
+  assertNominalNameIsSymbol(todoRecord, "struct value");
+  assertNominalNameIsSymbol(todoStruct, "struct definition");
+  assertNominalNameIsSymbol(todoEnum, "enum definition");
+  assertNominalNameIsSymbol(todoEnumValue, "enum value");
+  const anonymousEnumName = embeddedObjects(formatter.header(anonymousEnumValue)).find((item) => item?.value === "_");
+  assert.ok(anonymousEnumName instanceof runtimeA.CalcitSymbol, "anonymous enum formatter should render `_` as a symbol");
+  assert.ok(formatter.hasBody(todoStruct), "struct definition formatter should expose field types");
+  assert.ok(formatter.hasBody(todoEnum), "enum definition formatter should expose variants");
+  assert.ok(embeddedObjects(formatter.body(todoStruct)).includes(todoType), "struct definition formatter should embed field types");
+  assert.ok(embeddedObjects(formatter.body(todoEnum)).includes(todoType), "enum definition formatter should embed variant payload types");
 
   const foreignField = runtimeA.newTag("show");
   const method = () => "demo";

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -27,6 +27,11 @@ try {
   assert.equal(todoRecord.toString(), "(%{} 'TodoState (:draft |))");
   assert.equal(todoStruct.toString(), "(%struct 'TodoState (:draft 'String))");
   assert.equal(todoEnum.toString(), "(%enum 'TodoState)");
+  assert.throws(
+    () => runtimeA._$n_record_$o_get(todoRecord, runtimeA.newTag("missing")),
+    /does not define field :missing/,
+    "record field lookup must reject a missing field instead of returning nil"
+  );
 
   runtimeA.load_console_formatter_$x_();
   const formatter = globalThis.devtoolsFormatters.at(-1);

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -1101,7 +1101,7 @@ mod type_query_tests {
     let result_type = CalcitTypeAnnotation::TypeRef(Arc::from("test-enum.main/Result0"), Arc::new(vec![]));
     assert!(result_type.resolve_to_enum().is_some(), "source-backed Result0 should resolve");
     assert!(
-      result_type.matches_annotation(&CalcitTypeAnnotation::DynTuple),
+      result_type.matches_annotation(&CalcitTypeAnnotation::AnonymousEnum),
       "a source-backed enum reference should satisfy tuple operations"
     );
     let person_symbol =

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -372,8 +372,8 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     NumberQuestion => meta::number_question(args),
     BoolQuestion => meta::bool_question(args),
     SetQuestion => meta::set_question(args),
-    TupleQuestion => meta::tuple_question(args),
-    RecordQuestion => meta::record_question(args),
+    EnumQuestion => meta::enum_question(args),
+    StructQuestion => meta::struct_question(args),
     FnQuestion => meta::fn_question(args),
     IsSpreadingMark => meta::is_spreading_mark(args),
     // tuple

--- a/src/builtins/json.rs
+++ b/src/builtins/json.rs
@@ -1,5 +1,5 @@
 use crate::builtins::{err_arity, err_arity_with_hint, meta::type_of};
-use crate::calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitProc, CalcitRecord, CalcitTuple, format_proc_examples_hint};
+use crate::calcit::{Calcit, CalcitEnumValue, CalcitErr, CalcitErrKind, CalcitProc, CalcitStructValue, format_proc_examples_hint};
 use crate::util::number::is_integer;
 use cirru_parser::Cirru;
 use serde_json::{Map, Number, Value};
@@ -112,7 +112,7 @@ fn calcit_to_json(value: &Calcit) -> Result<Value, CalcitErr> {
       }
       Ok(Value::Object(object))
     }
-    Calcit::Tuple(CalcitTuple { tag, extra, .. }) => {
+    Calcit::Enum(CalcitEnumValue { tag, extra, .. }) => {
       let mut items = Vec::with_capacity(extra.len() + 1);
       items.push(calcit_to_json(tag)?);
       for item in extra {
@@ -122,7 +122,7 @@ fn calcit_to_json(value: &Calcit) -> Result<Value, CalcitErr> {
     }
     Calcit::CirruQuote(code) => cirru_to_json(code),
     Calcit::Buffer(buffer) => Ok(Value::String(format!("0x{}", hex::encode(buffer)))),
-    Calcit::Record(CalcitRecord { struct_ref, values }) => {
+    Calcit::Struct(CalcitStructValue { struct_ref, values }) => {
       let mut object = Map::with_capacity(struct_ref.fields.len());
       for (idx, field) in struct_ref.fields.iter().enumerate() {
         object.insert(field.ref_str().to_owned(), calcit_to_json(&values[idx])?);
@@ -132,8 +132,8 @@ fn calcit_to_json(value: &Calcit) -> Result<Value, CalcitErr> {
     Calcit::Ref(..)
     | Calcit::Thunk(..)
     | Calcit::Recur(..)
-    | Calcit::Struct(..)
-    | Calcit::Enum(..)
+    | Calcit::StructDef(..)
+    | Calcit::EnumDef(..)
     | Calcit::Trait(..)
     | Calcit::Impl(..)
     | Calcit::Proc(..)

--- a/src/builtins/lists.rs
+++ b/src/builtins/lists.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use rpds::HashTrieSet;
 
-use crate::calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitTuple};
+use crate::calcit::{Calcit, CalcitEnumValue, CalcitErr, CalcitErrKind, CalcitList};
 use crate::util::number::f64_to_usize;
 
 use crate::builtins;
@@ -368,7 +368,7 @@ pub fn foldl_shortcut(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calci
         for x in xs.iter() {
           let pair = runner::run_fn(&[state.to_owned(), (*x).to_owned()], info, call_stack)?;
           match pair {
-            Calcit::Tuple(CalcitTuple { tag: x0, extra, .. }) => match &*x0 {
+            Calcit::Enum(CalcitEnumValue { tag: x0, extra, .. }) => match &*x0 {
               Calcit::Bool(b) => {
                 let x1 = extra.first().ok_or(CalcitErr::use_msg_stack_location(
                   CalcitErrKind::Arity,
@@ -408,7 +408,7 @@ pub fn foldl_shortcut(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calci
         for x in xs {
           let pair = runner::run_fn(&[state.to_owned(), x.to_owned()], info, call_stack)?;
           match pair {
-            Calcit::Tuple(CalcitTuple { tag: x0, extra, .. }) => match &*x0 {
+            Calcit::Enum(CalcitEnumValue { tag: x0, extra, .. }) => match &*x0 {
               Calcit::Bool(b) => {
                 let x1 = extra.first().ok_or(CalcitErr::use_msg_stack_location(
                   CalcitErrKind::Arity,
@@ -452,7 +452,7 @@ pub fn foldl_shortcut(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calci
             call_stack,
           )?;
           match pair {
-            Calcit::Tuple(CalcitTuple { tag: x0, extra, .. }) => match &*x0 {
+            Calcit::Enum(CalcitEnumValue { tag: x0, extra, .. }) => match &*x0 {
               Calcit::Bool(b) => {
                 let x1 = extra.first().ok_or(CalcitErr::use_msg_stack_location(
                   CalcitErrKind::Arity,
@@ -521,7 +521,7 @@ pub fn foldr_shortcut(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calci
           let x = xs[size - 1 - i].to_owned();
           let pair = runner::run_fn(&[state.to_owned(), x.to_owned()], info, call_stack)?;
           match pair {
-            Calcit::Tuple(CalcitTuple { tag: x0, extra, .. }) => match &*x0 {
+            Calcit::Enum(CalcitEnumValue { tag: x0, extra, .. }) => match &*x0 {
               Calcit::Bool(b) => {
                 let x1 = extra.first().ok_or(CalcitErr::use_msg_stack_location(
                   CalcitErrKind::Arity,

--- a/src/builtins/maps.rs
+++ b/src/builtins/maps.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::builtins::meta::type_of;
-use crate::calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitProc, CalcitRecord, format_proc_examples_hint};
+use crate::calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitProc, CalcitStructValue, format_proc_examples_hint};
 
 use crate::util::number::is_even;
 
@@ -101,7 +101,7 @@ pub fn call_merge(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         }
         Ok(Calcit::Map(zs))
       }
-      (Calcit::Record(record @ CalcitRecord { struct_ref, values }), Calcit::Map(ys)) => {
+      (Calcit::Struct(record @ CalcitStructValue { struct_ref, values }), Calcit::Map(ys)) => {
         let mut new_values = (**values).to_owned();
         for (k, v) in ys {
           match k {
@@ -110,7 +110,7 @@ pub fn call_merge(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               None => {
                 return CalcitErr::err_str(
                   CalcitErrKind::Type,
-                  format!("&map:merge invalid field `{s}` for record: {:?}", struct_ref.fields),
+                  format!("&map:merge invalid field `{s}` for struct: {:?}", struct_ref.fields),
                 );
               }
             },
@@ -119,14 +119,14 @@ pub fn call_merge(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               None => {
                 return CalcitErr::err_str(
                   CalcitErrKind::Type,
-                  format!("&map:merge invalid field `{s}` for record: {:?}", struct_ref.fields),
+                  format!("&map:merge invalid field `{s}` for struct: {:?}", struct_ref.fields),
                 );
               }
             },
             a => return CalcitErr::err_str(CalcitErrKind::Type, format!("&map:merge invalid field key, but received: {a}")),
           }
         }
-        Ok(Calcit::Record(CalcitRecord {
+        Ok(Calcit::Struct(CalcitStructValue {
           struct_ref: record.struct_ref.to_owned(),
           values: Arc::new(new_values),
         }))
@@ -150,7 +150,7 @@ pub fn to_pairs(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       }
       Ok(Calcit::Set(zs))
     }
-    Some(Calcit::Record(CalcitRecord { struct_ref, values, .. })) => {
+    Some(Calcit::Struct(CalcitStructValue { struct_ref, values, .. })) => {
       let mut zs: rpds::HashTrieSetSync<Calcit> = rpds::HashTrieSet::new_sync();
       for idx in 0..struct_ref.fields.len() {
         let chunk = vec![Calcit::Tag(struct_ref.fields[idx].to_owned()), values[idx].to_owned()];
@@ -160,7 +160,7 @@ pub fn to_pairs(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
     Some(a) => {
       let msg = format!(
-        "&map:to-pairs requires a map or record, but received: {}",
+        "&map:to-pairs requires a map or struct, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::ToPairs).unwrap_or_default();

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -2,9 +2,9 @@ use crate::calcit::type_annotation::{collect_runtime_type_bindings, validate_run
 use crate::{
   builtins,
   calcit::{
-    self, Calcit, CalcitEnum, CalcitErr, CalcitErrKind, CalcitImpl, CalcitImport, CalcitList, CalcitLocal, CalcitProc, CalcitRecord,
-    CalcitStruct, CalcitSymbolInfo, CalcitSyntax, CalcitTrait, CalcitTuple, CalcitTypeAnnotation, GEN_NS, GENERATED_DEF,
-    brief_type_of_value, format_proc_examples_hint, gen_core_id, register_type_slot, value_matches_type_annotation,
+    self, Calcit, CalcitEnumDef, CalcitEnumValue, CalcitErr, CalcitErrKind, CalcitImpl, CalcitImport, CalcitList, CalcitLocal,
+    CalcitProc, CalcitStructDef, CalcitStructValue, CalcitSymbolInfo, CalcitSyntax, CalcitTrait, CalcitTypeAnnotation, GEN_NS,
+    GENERATED_DEF, brief_type_of_value, format_proc_examples_hint, gen_core_id, register_type_slot, value_matches_type_annotation,
   },
   call_stack::{self, CallStackList},
   codegen::gen_ir::dump_code,
@@ -70,7 +70,7 @@ pub fn type_of(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     Str(..) => Ok(Calcit::tag("string")),
     Thunk(..) => Ok(Calcit::tag("thunk")), // internal
     Ref(..) => Ok(Calcit::tag("ref")),
-    Tuple { .. } => Ok(Calcit::tag("tuple")),
+    Enum { .. } => Ok(Calcit::tag("enum")),
     Buffer(..) => Ok(Calcit::tag("buffer")),
     BufList(..) => Ok(Calcit::tag("buf-list")),
     CirruQuote(..) => Ok(Calcit::tag("cirru-quote")),
@@ -78,9 +78,9 @@ pub fn type_of(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     List(..) => Ok(Calcit::tag("list")),
     Set(..) => Ok(Calcit::tag("set")),
     Map(..) => Ok(Calcit::tag("map")),
-    Record { .. } => Ok(Calcit::tag("record")),
     Struct { .. } => Ok(Calcit::tag("struct")),
-    Enum { .. } => Ok(Calcit::tag("enum")),
+    StructDef { .. } => Ok(Calcit::tag("struct-def")),
+    EnumDef { .. } => Ok(Calcit::tag("enum-def")),
     Proc(..) => Ok(Calcit::tag("fn")), // special kind proc, but also fn
     Macro { .. } => Ok(Calcit::tag("macro")),
     Fn { .. } => Ok(Calcit::tag("fn")),
@@ -416,7 +416,10 @@ pub fn turn_tag(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn new_tuple(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.is_empty() {
-    let msg = format!("tuple requires at least 1 argument (tag), but received: {} arguments", xs.len());
+    let msg = format!(
+      "anonymous enum requires at least 1 argument (tag), but received: {} arguments",
+      xs.len()
+    );
     CalcitErr::err_str(CalcitErrKind::Arity, msg)
   } else {
     let extra: Vec<Calcit> = if xs.len() == 1 {
@@ -428,7 +431,7 @@ pub fn new_tuple(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       }
       ys
     };
-    Ok(Calcit::Tuple(CalcitTuple {
+    Ok(Calcit::Enum(CalcitEnumValue {
       tag: Arc::new(xs[0].to_owned()),
       extra,
       sum_type: None,
@@ -445,8 +448,8 @@ pub fn new_enum_tuple_no_class(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   } else {
     let enum_value = xs[0].to_owned();
     match enum_value {
-      Calcit::Record(enum_record) => {
-        let enum_proto = match CalcitEnum::from_record(enum_record.clone()) {
+      Calcit::Struct(enum_record) => {
+        let enum_proto = match CalcitEnumDef::from_record(enum_record.clone()) {
           Ok(proto) => proto,
           Err(msg) => {
             return CalcitErr::err_str(CalcitErrKind::Type, format!("%:: expected a valid enum prototype, but {msg}"));
@@ -513,13 +516,13 @@ pub fn new_enum_tuple_no_class(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         }
 
         let extra: Vec<Calcit> = xs.iter().skip(2).cloned().collect();
-        Ok(Calcit::Tuple(CalcitTuple {
+        Ok(Calcit::Enum(CalcitEnumValue {
           tag: Arc::new(xs[1].to_owned()),
           extra,
           sum_type: Some(Arc::new(enum_proto)),
         }))
       }
-      Calcit::Enum(enum_def) => {
+      Calcit::EnumDef(enum_def) => {
         let enum_proto = enum_def.clone();
 
         let tag_value = &xs[1];
@@ -582,7 +585,7 @@ pub fn new_enum_tuple_no_class(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         }
 
         let extra: Vec<Calcit> = xs.iter().skip(2).cloned().collect();
-        Ok(Calcit::Tuple(CalcitTuple {
+        Ok(Calcit::Enum(CalcitEnumValue {
           tag: Arc::new(xs[1].to_owned()),
           extra,
           sum_type: Some(Arc::new(enum_proto)),
@@ -590,7 +593,7 @@ pub fn new_enum_tuple_no_class(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       }
       other => CalcitErr::err_str(
         CalcitErrKind::Type,
-        format!("%:: expected a record as enum prototype, but received: {other}"),
+        format!("%:: expected an EnumDef as prototype, but received: {other}"),
       ),
     }
   }
@@ -599,16 +602,16 @@ pub fn new_enum_tuple_no_class(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 /// Get the enum prototype from a tuple
 pub fn tuple_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:enum expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:definition expected 1 argument, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Tuple(t) => match &t.sum_type {
-      Some(enum_proto) => Ok(Calcit::Enum((**enum_proto).clone())),
+    Calcit::Enum(t) => match &t.sum_type {
+      Some(enum_proto) => Ok(Calcit::EnumDef((**enum_proto).clone())),
       None => Ok(Calcit::Nil),
     },
     a => {
       let msg = format!(
-        "&tuple:enum requires a tuple, but received: {}",
+        "&enum:definition requires an enum value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeTupleEnum).unwrap_or_default();
@@ -632,11 +635,11 @@ pub fn trait_new(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         }
         Calcit::List(Arc::new(CalcitList::from(items.as_slice())))
       }
-      Calcit::Tuple(tuple) => {
+      Calcit::Enum(tuple) => {
         let tag = tuple.tag.to_owned();
         let extra = tuple.extra.to_owned();
         let sum_type = tuple.sum_type.to_owned();
-        Calcit::Tuple(CalcitTuple { tag, extra, sum_type })
+        Calcit::Enum(CalcitEnumValue { tag, extra, sum_type })
       }
       _ => form.to_owned(),
     }
@@ -771,33 +774,33 @@ fn collect_trait_records(xs: &[Calcit], proc_name: &str) -> Result<Vec<Arc<Calci
 
 pub fn record_impl_traits(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() < 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:impl-traits expected 2+ arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:impl-traits expected 2+ arguments, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Record(record) => {
+    Calcit::Struct(record) => {
       let mut impls = record.struct_ref.impls.clone();
-      impls.extend(collect_trait_records(&xs[1..], "&record:impl-traits")?);
+      impls.extend(collect_trait_records(&xs[1..], "&struct:impl-traits")?);
       let mut next_struct = (*record.struct_ref).clone();
       next_struct.impls = impls;
 
-      Ok(Calcit::Record(CalcitRecord {
+      Ok(Calcit::Struct(CalcitStructValue {
         struct_ref: Arc::new(next_struct),
         values: record.values.to_owned(),
       }))
     }
     other => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&record:impl-traits expected a record, but received: {other}"),
+      format!("&struct:impl-traits expected a struct value, but received: {other}"),
     ),
   }
 }
 
 pub fn tuple_impl_traits(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() < 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:impl-traits expected 2+ arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:impl-traits expected 2+ arguments, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Tuple(tuple) => {
+    Calcit::Enum(tuple) => {
       let mut next_sum_type = match &tuple.sum_type {
         Some(s) => (**s).clone(),
         None => {
@@ -805,24 +808,24 @@ pub fn tuple_impl_traits(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
             Calcit::Tag(t) => t.to_owned(),
             _ => EdnTag::from("tag"),
           };
-          let record = CalcitRecord {
-            struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::from("anonymous-tuple"), vec![tag_name])),
+          let record = CalcitStructValue {
+            struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::from("_"), vec![tag_name])),
             values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::from(
               &vec![Calcit::tag("any"); tuple.extra.len()][..],
             )))]),
           };
-          CalcitEnum::from_record(record).map_err(|msg| {
+          CalcitEnumDef::from_record(record).map_err(|msg| {
             CalcitErr::use_msg_stack_location(
               CalcitErrKind::Type,
-              format!("failed to create anonymous enum for tuple, {msg}"),
+              format!("failed to create anonymous enum, {msg}"),
               &CallStackList::default(),
               tuple.tag.get_location(),
             )
           })?
         }
       };
-      next_sum_type.impls.extend(collect_trait_records(&xs[1..], "&tuple:impl-traits")?);
-      Ok(Calcit::Tuple(CalcitTuple {
+      next_sum_type.impls.extend(collect_trait_records(&xs[1..], "&enum:impl-traits")?);
+      Ok(Calcit::Enum(CalcitEnumValue {
         tag: tuple.tag.to_owned(),
         extra: tuple.extra.to_owned(),
         sum_type: Some(Arc::new(next_sum_type)),
@@ -830,53 +833,51 @@ pub fn tuple_impl_traits(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
     other => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&tuple:impl-traits expected a tuple, but received: {other}"),
+      format!("&enum:impl-traits expected an enum value, but received: {other}"),
     ),
   }
 }
 
 pub fn struct_impl_traits(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() < 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:impl-traits expected 2+ arguments, but received:", xs);
+    return CalcitErr::err_nodes(
+      CalcitErrKind::Arity,
+      "&struct-def:impl-traits expected 2+ arguments, but received:",
+      xs,
+    );
   }
   match &xs[0] {
-    Calcit::Struct(struct_def) => {
+    Calcit::StructDef(struct_def) => {
       let mut next = struct_def.to_owned();
       let mut next_impls = next.impls.clone();
-      next_impls.extend(collect_trait_records(&xs[1..], "&struct:impl-traits")?);
+      next_impls.extend(collect_trait_records(&xs[1..], "&struct-def:impl-traits")?);
       next.impls = next_impls;
-      Ok(Calcit::Struct(next))
+      Ok(Calcit::StructDef(next))
     }
     other => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&struct:impl-traits expected a struct, but received: {other}"),
+      format!("&struct-def:impl-traits expected a struct definition, but received: {other}"),
     ),
   }
 }
 
 pub fn enum_impl_traits(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() < 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:impl-traits expected 2+ arguments, but received:", xs);
+    return CalcitErr::err_nodes(
+      CalcitErrKind::Arity,
+      "&enum-def:impl-traits expected 2+ arguments, but received:",
+      xs,
+    );
   }
   match &xs[0] {
-    Calcit::Enum(enum_def) => {
+    Calcit::EnumDef(enum_def) => {
       let mut next = enum_def.to_owned();
-      next.impls.extend(collect_trait_records(&xs[1..], "&enum:impl-traits")?);
-      Ok(Calcit::Enum(next))
-    }
-    Calcit::Record(record) => {
-      let mut impls = record.struct_ref.impls.clone();
-      impls.extend(collect_trait_records(&xs[1..], "&enum:impl-traits")?);
-      let mut next_struct = (*record.struct_ref).clone();
-      next_struct.impls = impls;
-      Ok(Calcit::Record(CalcitRecord {
-        struct_ref: Arc::new(next_struct),
-        values: record.values.to_owned(),
-      }))
+      next.impls.extend(collect_trait_records(&xs[1..], "&enum-def:impl-traits")?);
+      Ok(Calcit::EnumDef(next))
     }
     other => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&enum:impl-traits expected an enum or enum record, but received: {other}"),
+      format!("&enum-def:impl-traits expected an enum definition, but received: {other}"),
     ),
   }
 }
@@ -950,12 +951,12 @@ pub fn impl_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
-fn parse_enum_record(enum_record: &CalcitRecord, proc_name: &str) -> Result<CalcitEnum, CalcitErr> {
-  match CalcitEnum::from_record(enum_record.to_owned()) {
+fn parse_enum_record(enum_record: &CalcitStructValue, proc_name: &str) -> Result<CalcitEnumDef, CalcitErr> {
+  match CalcitEnumDef::from_record(enum_record.to_owned()) {
     Ok(proto) => Ok(proto),
     Err(msg) => Err(CalcitErr::use_str(
       CalcitErrKind::Type,
-      format!("{proc_name} expected a valid enum record, but {msg}"),
+      format!("{proc_name} expected a valid EnumDef, but {msg}"),
     )),
   }
 }
@@ -965,23 +966,23 @@ pub fn tuple_enum_has_variant(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 2 {
     return CalcitErr::err_nodes(
       CalcitErrKind::Arity,
-      "&tuple:enum-has-variant? expected 2 arguments, but received:",
+      "&enum-def:has-variant? expected 2 arguments, but received:",
       xs,
     );
   }
   match (&xs[0], &xs[1]) {
-    (Calcit::Record(enum_record), Calcit::Tag(tag)) => {
-      let enum_proto = parse_enum_record(enum_record, "&tuple:enum-has-variant?")?;
+    (Calcit::Struct(enum_record), Calcit::Tag(tag)) => {
+      let enum_proto = parse_enum_record(enum_record, "&enum-def:has-variant?")?;
       Ok(Calcit::Bool(enum_proto.find_variant(tag).is_some()))
     }
-    (Calcit::Enum(enum_def), Calcit::Tag(tag)) => Ok(Calcit::Bool(enum_def.find_variant(tag).is_some())),
-    (Calcit::Record(_) | Calcit::Enum(_), other) => CalcitErr::err_str(
+    (Calcit::EnumDef(enum_def), Calcit::Tag(tag)) => Ok(Calcit::Bool(enum_def.find_variant(tag).is_some())),
+    (Calcit::Struct(_) | Calcit::EnumDef(_), other) => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&tuple:enum-has-variant? expected a tag as second argument, but received: {other}"),
+      format!("&enum-def:has-variant? expected a tag as second argument, but received: {other}"),
     ),
     (other, _) => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&tuple:enum-has-variant? expected an enum as first argument, but received: {other}"),
+      format!("&enum-def:has-variant? expected an enum as first argument, but received: {other}"),
     ),
   }
 }
@@ -991,43 +992,43 @@ pub fn tuple_enum_variant_arity(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 2 {
     return CalcitErr::err_nodes(
       CalcitErrKind::Arity,
-      "&tuple:enum-variant-arity expected 2 arguments, but received:",
+      "&enum-def:variant-arity expected 2 arguments, but received:",
       xs,
     );
   }
   match (&xs[0], &xs[1]) {
-    (Calcit::Record(enum_record), Calcit::Tag(tag)) => {
-      let enum_proto = parse_enum_record(enum_record, "&tuple:enum-variant-arity")?;
+    (Calcit::Struct(enum_record), Calcit::Tag(tag)) => {
+      let enum_proto = parse_enum_record(enum_record, "&enum-def:variant-arity")?;
       match enum_proto.find_variant(tag) {
         Some(variant) => Ok(Calcit::Number(variant.arity() as f64)),
         None => CalcitErr::err_str(
           CalcitErrKind::Type,
           format!(
-            "&tuple:enum-variant-arity: enum `{}` does not have variant `{}`",
+            "&enum-def:variant-arity: enum `{}` does not have variant `{}`",
             enum_proto.name(),
             tag
           ),
         ),
       }
     }
-    (Calcit::Enum(enum_def), Calcit::Tag(tag)) => match enum_def.find_variant(tag) {
+    (Calcit::EnumDef(enum_def), Calcit::Tag(tag)) => match enum_def.find_variant(tag) {
       Some(variant) => Ok(Calcit::Number(variant.arity() as f64)),
       None => CalcitErr::err_str(
         CalcitErrKind::Type,
         format!(
-          "&tuple:enum-variant-arity: enum `{}` does not have variant `{}`",
+          "&enum-def:variant-arity: enum `{}` does not have variant `{}`",
           enum_def.name(),
           tag
         ),
       ),
     },
-    (Calcit::Record(_) | Calcit::Enum(_), other) => CalcitErr::err_str(
+    (Calcit::Struct(_) | Calcit::EnumDef(_), other) => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&tuple:enum-variant-arity expected a tag as second argument, but received: {other}"),
+      format!("&enum-def:variant-arity expected a tag as second argument, but received: {other}"),
     ),
     (other, _) => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&tuple:enum-variant-arity expected an enum as first argument, but received: {other}"),
+      format!("&enum-def:variant-arity expected an enum as first argument, but received: {other}"),
     ),
   }
 }
@@ -1035,11 +1036,11 @@ pub fn tuple_enum_variant_arity(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 /// Validate enum tuple tag and arity if enum metadata exists
 pub fn tuple_validate_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:validate-enum expected 2 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:validate expected 2 arguments, but received:", xs);
   }
   match (&xs[0], &xs[1]) {
-    (Calcit::Tuple(tuple), Calcit::Tag(tag)) => {
-      let tuple_value = Calcit::Tuple(tuple.to_owned());
+    (Calcit::Enum(tuple), Calcit::Tag(tag)) => {
+      let tuple_value = Calcit::Enum(tuple.to_owned());
       if let Some(enum_proto) = &tuple.sum_type {
         match enum_proto.find_variant(tag) {
           Some(variant) => {
@@ -1059,13 +1060,13 @@ pub fn tuple_validate_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       }
       Ok(Calcit::Nil)
     }
-    (Calcit::Tuple(_), other) => CalcitErr::err_str(
+    (Calcit::Enum(_), other) => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&tuple:validate-enum expected a tag as second argument, but received: {other}"),
+      format!("&enum:validate expected a tag as second argument, but received: {other}"),
     ),
     (other, _) => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&tuple:validate-enum expected a tuple as first argument, but received: {other}"),
+      format!("&enum:validate expected an enum value as first argument, but received: {other}"),
     ),
   }
 }
@@ -1091,23 +1092,23 @@ pub fn invoke_method(name: &str, method_args: &[Calcit], call_stack: &CallStackL
   use Calcit::*;
   match v0 {
     // user-defined values: impl-traits appends, so later impls override earlier ones
-    Tuple(tuple) => {
+    Enum(tuple) => {
       let user_impls = tuple.impls();
       let has_user_method = user_impls.iter().any(|imp| imp.get(name).is_some());
       if has_user_method {
         method_call_impls(user_impls, v0, name, method_args, call_stack, true)
       } else {
-        let impls_value = runner::evaluate_symbol_from_program("&core-tuple-impls", calcit::CORE_NS, None, call_stack)?;
+        let impls_value = runner::evaluate_symbol_from_program("&core-enum-impls", calcit::CORE_NS, None, call_stack)?;
         method_call(&impls_value, v0, name, method_args, call_stack)
       }
     }
-    Record(record) => {
+    Struct(record) => {
       let user_impls = &record.struct_ref.impls;
       let has_user_method = user_impls.iter().any(|imp| imp.get(name).is_some());
       if has_user_method {
         method_call_impls(user_impls, v0, name, method_args, call_stack, true)
       } else {
-        let impls_value = runner::evaluate_symbol_from_program("&core-record-impls", calcit::CORE_NS, None, call_stack)?;
+        let impls_value = runner::evaluate_symbol_from_program("&core-struct-impls", calcit::CORE_NS, None, call_stack)?;
         method_call(&impls_value, v0, name, method_args, call_stack)
       }
     }
@@ -1278,10 +1279,10 @@ pub fn native_compare(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn tuple_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:nth expected 2 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:nth expected 2 arguments, but received:", xs);
   }
   match (&xs[0], &xs[1]) {
-    (Calcit::Tuple(CalcitTuple { tag, extra, .. }), Calcit::Number(n)) => match f64_to_usize(*n) {
+    (Calcit::Enum(CalcitEnumValue { tag, extra, .. }), Calcit::Number(n)) => match f64_to_usize(*n) {
       Ok(0) => Ok((**tag).to_owned()) as Result<Calcit, CalcitErr>,
       Ok(m) => {
         if m - 1 < extra.len() {
@@ -1290,15 +1291,15 @@ pub fn tuple_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           let size = extra.len() + 1;
           CalcitErr::err_str(
             CalcitErrKind::Arity,
-            format!("&tuple:nth index out of range. Tuple has {size} elements, but trying to index with {m}"),
+            format!("&enum:nth index out of range. Tuple has {size} elements, but trying to index with {m}"),
           )
         }
       }
-      Err(e) => CalcitErr::err_str(CalcitErrKind::Type, format!("&tuple:nth expected a valid index, {e}")),
+      Err(e) => CalcitErr::err_str(CalcitErrKind::Type, format!("&enum:nth expected a valid index, {e}")),
     },
     (a, b) => {
       let msg = format!(
-        "&tuple:nth requires a tuple and an index, but received: {} and {}",
+        "&enum:nth requires an enum value and an index, but received: {} and {}",
         type_of(std::slice::from_ref(a))?.lisp_str(),
         type_of(std::slice::from_ref(b))?.lisp_str()
       );
@@ -1310,13 +1311,13 @@ pub fn tuple_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 3 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:assoc expected 3 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:assoc expected 3 arguments, but received:", xs);
   }
   match (&xs[0], &xs[1]) {
-    (Calcit::Tuple(CalcitTuple { tag, extra, sum_type }), Calcit::Number(n)) => match f64_to_usize(*n) {
+    (Calcit::Enum(CalcitEnumValue { tag, extra, sum_type }), Calcit::Number(n)) => match f64_to_usize(*n) {
       Ok(idx) => {
         if idx == 0 {
-          Ok(Calcit::Tuple(CalcitTuple {
+          Ok(Calcit::Enum(CalcitEnumValue {
             tag: Arc::new(xs[2].to_owned()),
             extra: extra.to_owned(),
             sum_type: sum_type.to_owned(),
@@ -1324,7 +1325,7 @@ pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         } else if idx - 1 < extra.len() {
           let mut new_extra = extra.to_owned();
           xs[2].clone_into(&mut new_extra[idx - 1]);
-          Ok(Calcit::Tuple(CalcitTuple {
+          Ok(Calcit::Enum(CalcitEnumValue {
             tag: tag.to_owned(),
             extra: new_extra,
             sum_type: sum_type.to_owned(),
@@ -1332,7 +1333,7 @@ pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         } else {
           CalcitErr::err_str(
             CalcitErrKind::Arity,
-            format!("&tuple:assoc index out of range. Tuple only has fields at index 0, 1, but received unknown index: {idx}"),
+            format!("&enum:assoc index out of range. Tuple only has fields at index 0, 1, but received unknown index: {idx}"),
           )
         }
       }
@@ -1340,7 +1341,7 @@ pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     },
     (a, b, ..) => {
       let msg = format!(
-        "&tuple:assoc requires a tuple and an index, but received: {} and {}",
+        "&enum:assoc requires an enum value and an index, but received: {} and {}",
         type_of(std::slice::from_ref(a))?.lisp_str(),
         type_of(std::slice::from_ref(b))?.lisp_str()
       );
@@ -1352,13 +1353,13 @@ pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn tuple_count(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:count expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:count expected 1 argument, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Tuple(CalcitTuple { extra, .. }) => Ok(Calcit::Number((extra.len() + 1) as f64)),
+    Calcit::Enum(CalcitEnumValue { extra, .. }) => Ok(Calcit::Number((extra.len() + 1) as f64)),
     x => {
       let msg = format!(
-        "&tuple:count requires a tuple, but received: {}",
+        "&enum:count requires an enum value, but received: {}",
         type_of(std::slice::from_ref(x))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeTupleCount).unwrap_or_default();
@@ -1369,15 +1370,15 @@ pub fn tuple_count(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn tuple_impls(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:impls expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:impls expected 1 argument, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Tuple(tuple) => Ok(Calcit::from(
+    Calcit::Enum(tuple) => Ok(Calcit::from(
       tuple.impls().iter().map(|imp| Calcit::Impl((**imp).to_owned())).collect::<Vec<_>>(),
     )),
     x => {
       let msg = format!(
-        "&tuple:impls requires a tuple, but received: {}",
+        "&enum:impls requires an enum value, but received: {}",
         type_of(std::slice::from_ref(x))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeTupleImpls).unwrap_or_default();
@@ -1388,10 +1389,10 @@ pub fn tuple_impls(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn tuple_params(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&tuple:params expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&enum:params expected 1 argument, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Tuple(CalcitTuple { extra, .. }) => {
+    Calcit::Enum(CalcitEnumValue { extra, .. }) => {
       // Ok(Calcit::List(extra.iter().map(|x| Arc::new(x.to_owned())).collect_into(vec![])))
       let mut ys = vec![];
       for x in extra {
@@ -1401,7 +1402,7 @@ pub fn tuple_params(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
     x => {
       let msg = format!(
-        "&tuple:params requires a tuple, but received: {}",
+        "&enum:params requires an enum value, but received: {}",
         type_of(std::slice::from_ref(x))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeTupleParams).unwrap_or_default();
@@ -1422,26 +1423,26 @@ fn collect_optional_core_impl_records(name: &str, call_stack: &CallStackList) ->
 
 fn collect_impl_records_for_value(value: &Calcit, call_stack: &CallStackList) -> Result<Vec<Arc<CalcitImpl>>, CalcitErr> {
   match value {
-    Calcit::Tuple(tuple) => {
-      let mut impls = collect_optional_core_impl_records("&core-tuple-impls", call_stack)?;
+    Calcit::Enum(tuple) => {
+      let mut impls = collect_optional_core_impl_records("&core-enum-impls", call_stack)?;
       impls.extend(tuple.impls().iter().cloned());
       Ok(impls)
     }
-    Calcit::Record(record) => {
-      let mut impls = collect_optional_core_impl_records("&core-record-impls", call_stack)?;
+    Calcit::Struct(record) => {
+      let mut impls = collect_optional_core_impl_records("&core-struct-impls", call_stack)?;
       impls.extend(record.struct_ref.impls.iter().cloned());
       Ok(impls)
     }
     // Bare type definitions (not yet instantiated) carry their own attached impls,
     // so introspection tools like `&methods-of` can answer "what methods will
     // instances of this type have" without needing a concrete instance first.
-    Calcit::Struct(struct_def) => {
-      let mut impls = collect_optional_core_impl_records("&core-record-impls", call_stack)?;
+    Calcit::StructDef(struct_def) => {
+      let mut impls = collect_optional_core_impl_records("&core-struct-impls", call_stack)?;
       impls.extend(struct_def.impls.iter().cloned());
       Ok(impls)
     }
-    Calcit::Enum(enum_def) => {
-      let mut impls = collect_optional_core_impl_records("&core-tuple-impls", call_stack)?;
+    Calcit::EnumDef(enum_def) => {
+      let mut impls = collect_optional_core_impl_records("&core-enum-impls", call_stack)?;
       impls.extend(enum_def.impls().iter().cloned());
       Ok(impls)
     }
@@ -1471,7 +1472,7 @@ fn iter_impls_in_precedence_order<'a>(
     // user values are last-wins, so higher precedence is later entries.
     // Bare struct/enum definitions attach impls the same way (via `.extend`
     // in `&struct:impl-traits`/`&enum:impl-traits`), so they share this order.
-    Calcit::Tuple(..) | Calcit::Record(..) | Calcit::Struct(..) | Calcit::Enum(..) => Box::new(impls.iter().rev()),
+    Calcit::Enum(..) | Calcit::Struct(..) | Calcit::StructDef(..) | Calcit::EnumDef(..) => Box::new(impls.iter().rev()),
     // builtin core impl lists are first-wins and order-sensitive
     _ => Box::new(impls.iter()),
   }
@@ -2017,18 +2018,30 @@ pub fn set_question(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   Ok(Calcit::Bool(matches!(&xs[0], Calcit::Set(_))))
 }
 
-pub fn tuple_question(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+pub fn enum_question(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "tuple? expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "enum? expected 1 argument, but received:", xs);
   }
-  Ok(Calcit::Bool(matches!(&xs[0], Calcit::Tuple { .. })))
+  if matches!(&xs[0], Calcit::EnumDef(_)) {
+    return CalcitErr::err_str(
+      CalcitErrKind::Type,
+      "`enum?` now checks enum values; use `enum-def?` for a value produced by `defenum`",
+    );
+  }
+  Ok(Calcit::Bool(matches!(&xs[0], Calcit::Enum { .. })))
 }
 
-pub fn record_question(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+pub fn struct_question(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "record? expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "struct? expected 1 argument, but received:", xs);
   }
-  Ok(Calcit::Bool(matches!(&xs[0], Calcit::Record { .. })))
+  if matches!(&xs[0], Calcit::StructDef(_)) {
+    return CalcitErr::err_str(
+      CalcitErrKind::Type,
+      "`struct?` now checks struct values; use `struct-def?` for a value produced by `defstruct`",
+    );
+  }
+  Ok(Calcit::Bool(matches!(&xs[0], Calcit::Struct { .. })))
 }
 
 pub fn fn_question(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
@@ -2092,9 +2105,9 @@ mod tests {
     }
   }
 
-  fn shown_maybe_enum(show_trait: Arc<CalcitTrait>) -> CalcitEnum {
-    CalcitEnum::from_record(CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct {
+  fn shown_maybe_enum(show_trait: Arc<CalcitTrait>) -> CalcitEnumDef {
+    CalcitEnumDef::from_record(CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef {
         name: EdnTag::new("ShownMaybe"),
         fields: Arc::new(vec![EdnTag::new("none"), EdnTag::new("some")]),
         field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
@@ -2114,14 +2127,14 @@ mod tests {
   }
 
   fn value_with_trait(trait_def: Arc<CalcitTrait>) -> Calcit {
-    let mut struct_def = CalcitStruct::from_fields(EdnTag::new("ShownValue"), vec![]);
+    let mut struct_def = CalcitStructDef::from_fields(EdnTag::new("ShownValue"), vec![]);
     struct_def.impls.push(Arc::new(CalcitImpl {
       name: trait_def.name.clone(),
       origin: Some(trait_def),
       fields: Arc::new(vec![]),
       values: Arc::new(vec![]),
     }));
-    Calcit::Record(CalcitRecord {
+    Calcit::Struct(CalcitStructValue {
       struct_ref: Arc::new(struct_def),
       values: Arc::new(vec![]),
     })
@@ -2131,7 +2144,7 @@ mod tests {
   fn generic_enum_where_bounds_accept_nominal_trait_values() {
     let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
     let result = new_enum_tuple_no_class(&[
-      Calcit::Enum(shown_maybe_enum(show_trait.clone())),
+      Calcit::EnumDef(shown_maybe_enum(show_trait.clone())),
       Calcit::tag("some"),
       value_with_trait(show_trait),
     ]);
@@ -2143,7 +2156,7 @@ mod tests {
   fn generic_enum_where_bounds_reject_missing_nominal_trait() {
     let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
     let err = new_enum_tuple_no_class(&[
-      Calcit::Enum(shown_maybe_enum(show_trait)),
+      Calcit::EnumDef(shown_maybe_enum(show_trait)),
       Calcit::tag("some"),
       Calcit::Proc(CalcitProc::NativeResetGenSymIndex),
     ])

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -8,8 +8,8 @@ use crate::builtins::meta::type_of;
 use crate::calcit::CORE_NS;
 use crate::calcit::type_annotation::{collect_runtime_type_bindings, validate_runtime_generic_where_bounds};
 use crate::calcit::{
-  Calcit, CalcitEnum, CalcitErr, CalcitErrKind, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitRecord, CalcitStruct,
-  CalcitSyntax, CalcitTypeAnnotation, brief_type_of_value, format_proc_examples_hint, value_matches_type_annotation,
+  Calcit, CalcitEnumDef, CalcitErr, CalcitErrKind, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitStructDef,
+  CalcitStructValue, CalcitSyntax, CalcitTypeAnnotation, brief_type_of_value, format_proc_examples_hint, value_matches_type_annotation,
 };
 
 fn mark_fn_used_in_impl(value: &Calcit) -> Calcit {
@@ -230,7 +230,7 @@ pub fn new_impl(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           return CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint);
         }
       },
-      Calcit::Tuple(tuple) => match (tuple.extra.first(), tuple.extra.get(1)) {
+      Calcit::Enum(tuple) => match (tuple.extra.first(), tuple.extra.get(1)) {
         (Some(value), None) => (tuple.tag.as_ref(), value),
         _ => {
           let msg = format!("&impl::new expects (field value) pairs, but received: {item}");
@@ -289,7 +289,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     let hint = format_proc_examples_hint(&CalcitProc::NativeStructNew).unwrap_or_default();
     return CalcitErr::err_nodes_with_hint(
       CalcitErrKind::Arity,
-      "&struct::new expects a name and field definitions, but received none:",
+      "&struct-def:new expects a name and field definitions, but received none:",
       xs,
       hint,
     );
@@ -300,7 +300,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     Calcit::Tag(k) => k.to_owned(),
     a => {
       let msg = format!(
-        "&struct::new expects a name (symbol or tag), but received: {}",
+        "&struct-def:new expects a name (symbol or tag), but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeStructNew).unwrap_or_default();
@@ -329,7 +329,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
             Calcit::Symbol { sym, .. } | Calcit::Str(sym) => EdnTag(sym.to_owned()),
             Calcit::Tag(tag) => tag.to_owned(),
             other => {
-              let msg = format!("&struct::new field expects a tag/symbol, but received: {other}");
+              let msg = format!("&struct-def:new field expects a tag/symbol, but received: {other}");
               let hint = format_proc_examples_hint(&CalcitProc::NativeStructNew).unwrap_or_default();
               return CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint);
             }
@@ -339,7 +339,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
             let hint = format_proc_examples_hint(&CalcitProc::NativeStructNew).unwrap_or_default();
             return CalcitErr::err_str_with_hint(
               CalcitErrKind::Type,
-              format!("&struct::new field `{field_name}` has invalid type annotation: {e}"),
+              format!("&struct-def:new field `{field_name}` has invalid type annotation: {e}"),
               hint,
             );
           }
@@ -349,18 +349,18 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           let hint = format_proc_examples_hint(&CalcitProc::NativeStructNew).unwrap_or_default();
           return CalcitErr::err_str_with_hint(
             CalcitErrKind::Arity,
-            "&struct::new field expects a pair (field type), but received only a field name",
+            "&struct-def:new field expects a pair (field type), but received only a field name",
             hint,
           );
         }
         _ => {
-          let msg = format!("&struct::new field expects a pair list, but received: {item}");
+          let msg = format!("&struct-def:new field expects a pair list, but received: {item}");
           let hint = format_proc_examples_hint(&CalcitProc::NativeStructNew).unwrap_or_default();
           return CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint);
         }
       },
       other => {
-        let msg = format!("&struct::new expects field entries as lists, but received: {other}");
+        let msg = format!("&struct-def:new expects field entries as lists, but received: {other}");
         let hint = format_proc_examples_hint(&CalcitProc::NativeStructNew).unwrap_or_default();
         return CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint);
       }
@@ -372,7 +372,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     if fields[idx - 1].0 == fields[idx].0 {
       return CalcitErr::err_str(
         CalcitErrKind::Unexpected,
-        format!("&struct::new duplicated field: {}", fields[idx].0),
+        format!("&struct-def:new duplicated field: {}", fields[idx].0),
       );
     }
   }
@@ -383,7 +383,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let field_names: Vec<EdnTag> = fields.iter().map(|(name, _)| name.to_owned()).collect();
   let field_types: Vec<Arc<CalcitTypeAnnotation>> = fields.iter().map(|(_, t)| t.to_owned()).collect();
 
-  Ok(Calcit::Struct(CalcitStruct {
+  Ok(Calcit::StructDef(CalcitStructDef {
     name: name_id,
     fields: Arc::new(field_names),
     field_types: Arc::new(field_types),
@@ -398,7 +398,7 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     let hint = format_proc_examples_hint(&CalcitProc::NativeEnumNew).unwrap_or_default();
     return CalcitErr::err_nodes_with_hint(
       CalcitErrKind::Arity,
-      "&enum::new expects a name and variants, but received none:",
+      "&enum-def:new expects a name and variants, but received none:",
       xs,
       hint,
     );
@@ -409,7 +409,7 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     Calcit::Tag(k) => k.to_owned(),
     a => {
       let msg = format!(
-        "&enum::new expects a name (symbol or tag), but received: {}",
+        "&enum-def:new expects a name (symbol or tag), but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeEnumNew).unwrap_or_default();
@@ -437,7 +437,7 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           Some(Calcit::Symbol { sym, .. }) => EdnTag(sym.to_owned()),
           Some(Calcit::Tag(k)) => k.to_owned(),
           Some(other) => {
-            let msg = format!("&enum::new variant expects a tag, but received: {other}");
+            let msg = format!("&enum-def:new variant expects a tag, but received: {other}");
             let hint = format_proc_examples_hint(&CalcitProc::NativeEnumNew).unwrap_or_default();
             return CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint);
           }
@@ -445,7 +445,7 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
             let hint = format_proc_examples_hint(&CalcitProc::NativeEnumNew).unwrap_or_default();
             return CalcitErr::err_str_with_hint(
               CalcitErrKind::Arity,
-              "&enum::new variant expects a tag and payload types, but received an empty list",
+              "&enum-def:new variant expects a tag and payload types, but received an empty list",
               hint,
             );
           }
@@ -456,7 +456,7 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         variants.push((tag, payload_list));
       }
       other => {
-        let msg = format!("&enum::new expects variants as lists, but received: {other}");
+        let msg = format!("&enum-def:new expects variants as lists, but received: {other}");
         let hint = format_proc_examples_hint(&CalcitProc::NativeEnumNew).unwrap_or_default();
         return CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint);
       }
@@ -468,7 +468,7 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     if variants[idx - 1].0 == variants[idx].0 {
       return CalcitErr::err_str(
         CalcitErrKind::Unexpected,
-        format!("&enum::new duplicated variant: {}", variants[idx].0),
+        format!("&enum-def:new duplicated variant: {}", variants[idx].0),
       );
     }
   }
@@ -476,21 +476,21 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let fields: Vec<EdnTag> = variants.iter().map(|(tag, _)| tag.to_owned()).collect();
   let values: Vec<Calcit> = variants.iter().map(|(_, value)| value.to_owned()).collect();
 
-  let mut struct_ref = CalcitStruct::from_fields(name_id, fields);
+  let mut struct_ref = CalcitStructDef::from_fields(name_id, fields);
   generics.sort();
   generics.dedup();
   struct_ref.generics = Arc::new(generics);
   struct_ref.where_bounds = Arc::new(where_bounds);
   struct_ref.impls = vec![Arc::new(enum_prototype_marker())];
 
-  let record = CalcitRecord {
+  let record = CalcitStructValue {
     struct_ref: Arc::new(struct_ref),
     values: Arc::new(values),
   };
 
-  match CalcitEnum::from_record(record) {
-    Ok(enum_def) => Ok(Calcit::Enum(enum_def)),
-    Err(msg) => CalcitErr::err_str(CalcitErrKind::Type, format!("&enum::new failed to build enum: {msg}")),
+  match CalcitEnumDef::from_record(record) {
+    Ok(enum_def) => Ok(Calcit::EnumDef(enum_def)),
+    Err(msg) => CalcitErr::err_str(CalcitErrKind::Type, format!("&enum-def:new failed to build enum: {msg}")),
   }
 }
 
@@ -504,7 +504,7 @@ fn enum_prototype_marker() -> CalcitImpl {
 }
 
 /// Partial record constructor — missing fields default to nil.
-/// Proto must be a `Calcit::Struct` from `defstruct`.
+/// Proto must be a `Calcit::StructDef` from `defstruct`.
 pub fn call_record_partial(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let args_size = xs.len();
   if args_size < 1 {
@@ -513,8 +513,8 @@ pub fn call_record_partial(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if (args_size - 1).rem(2) != 0 {
     return CalcitErr::err_nodes(CalcitErrKind::Arity, "&%{}? expected pairs after prototype, but received:", xs);
   }
-  let (base_struct, mut base_values): (Arc<CalcitStruct>, Vec<Calcit>) = match &xs[0] {
-    Calcit::Struct(s) => {
+  let (base_struct, mut base_values): (Arc<CalcitStructDef>, Vec<Calcit>) = match &xs[0] {
+    Calcit::StructDef(s) => {
       let vals = vec![Calcit::Nil; s.fields.len()];
       (Arc::new(s.to_owned()), vals)
     }
@@ -576,7 +576,7 @@ pub fn call_record_partial(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       None => {
         return CalcitErr::err_str(
           CalcitErrKind::Type,
-          format!("&%{{}}? unexpected field `{field_name}` for record: {:?}", base_struct.fields),
+          format!("&%{{}}? unexpected field `{field_name}` for struct: {:?}", base_struct.fields),
         );
       }
     }
@@ -587,7 +587,7 @@ pub fn call_record_partial(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       format!("&%{{}}? failed generic where-bound validation for `{}`: {msg}", base_struct.name),
     );
   }
-  Ok(Calcit::Record(CalcitRecord {
+  Ok(Calcit::Struct(CalcitStructValue {
     struct_ref: base_struct,
     values: Arc::new(base_values),
   }))
@@ -628,19 +628,19 @@ pub fn call_loose_record(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
   let fields: Vec<EdnTag> = pairs.iter().map(|(f, _)| f.to_owned()).collect();
   let values: Vec<Calcit> = pairs.into_iter().map(|(_, v)| v).collect();
-  Ok(Calcit::Record(CalcitRecord::from_loose_pairs(fields, values)))
+  Ok(Calcit::Struct(CalcitStructValue::from_anonymous_pairs(fields, values)))
 }
 
-/// Direct indexed access to a record field: `&record:nth record index`
+/// Direct indexed access to a struct field: `&struct:nth record index`
 /// This is the optimized path emitted by the preprocessor when the field index is known at compile time.
 pub fn record_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
-  // Accept 2 or 3 args: (record, idx) or (record, idx, :field-tag)
+  // Accept 2 or 3 args: (struct, idx) or (struct, idx, :field-tag)
   // The 3rd arg (field tag) is only used by JS codegen; Rust runtime ignores it.
   if xs.len() < 2 || xs.len() > 3 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:nth expected 2-3 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:nth expected 2-3 arguments, but received:", xs);
   }
   match (&xs[0], &xs[1]) {
-    (Calcit::Record(CalcitRecord { values, struct_ref }), Calcit::Number(n)) => {
+    (Calcit::Struct(CalcitStructValue { values, struct_ref }), Calcit::Number(n)) => {
       let idx = *n as usize;
       if idx < values.len() {
         Ok(values[idx].to_owned())
@@ -648,7 +648,7 @@ pub fn record_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         CalcitErr::err_str(
           CalcitErrKind::Arity,
           format!(
-            "&record:nth index {} out of range for record `{}` with {} fields",
+            "&struct:nth index {} out of range for struct `{}` with {} fields",
             idx,
             struct_ref.name,
             values.len()
@@ -659,7 +659,7 @@ pub fn record_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     (a, b) => CalcitErr::err_str(
       CalcitErrKind::Type,
       format!(
-        "&record:nth expected (record, number), but received: {} {}",
+        "&struct:nth expected (struct, number), but received: {} {}",
         a.lisp_str(),
         b.lisp_str()
       ),
@@ -667,13 +667,13 @@ pub fn record_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
-/// Get the field tag (name) at a given index: `&record:field-tag record index`
+/// Get the field tag (name) at a given index: `&struct:field-tag record index`
 pub fn record_field_tag(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:field-tag expected 2 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:field-tag expected 2 arguments, but received:", xs);
   }
   match (&xs[0], &xs[1]) {
-    (Calcit::Record(CalcitRecord { struct_ref, .. }), Calcit::Number(n)) => {
+    (Calcit::Struct(CalcitStructValue { struct_ref, .. }), Calcit::Number(n)) => {
       let idx = *n as usize;
       if idx < struct_ref.fields.len() {
         Ok(Calcit::Tag(struct_ref.fields[idx].to_owned()))
@@ -681,7 +681,7 @@ pub fn record_field_tag(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         CalcitErr::err_str(
           CalcitErrKind::Arity,
           format!(
-            "&record:field-tag index {} out of range for record `{}` with {} fields",
+            "&struct:field-tag index {} out of range for struct `{}` with {} fields",
             idx,
             struct_ref.name,
             struct_ref.fields.len()
@@ -692,7 +692,7 @@ pub fn record_field_tag(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     (a, b) => CalcitErr::err_str(
       CalcitErrKind::Type,
       format!(
-        "&record:field-tag expected (record, number), but received: {} {}",
+        "&struct:field-tag expected (struct, number), but received: {} {}",
         a.lisp_str(),
         b.lisp_str()
       ),
@@ -700,24 +700,24 @@ pub fn record_field_tag(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
-/// Direct indexed assoc on a record field: `&record:assoc-at record index :field value`
+/// Direct indexed assoc on a struct field: `&struct:assoc-at record index :field value`
 /// This is the optimized path emitted by the preprocessor when the field index is known at compile time.
 pub fn record_assoc_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
-  // 4 args: (record, idx, :field-tag, value)
+  // 4 args: (struct, idx, :field-tag, value)
   // Keep the field tag as a runtime consistency check so a stale index cannot
   // silently update an adjacent field after schema drift.
   if xs.len() != 4 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:assoc-at expected 4 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:assoc-at expected 4 arguments, but received:", xs);
   }
   match (&xs[0], &xs[1], &xs[2]) {
-    (Calcit::Record(CalcitRecord { struct_ref, values }), Calcit::Number(n), Calcit::Tag(field_tag)) => {
-      let idx = checked_record_index(*n, "&record:assoc-at")?;
+    (Calcit::Struct(CalcitStructValue { struct_ref, values }), Calcit::Number(n), Calcit::Tag(field_tag)) => {
+      let idx = checked_record_index(*n, "&struct:assoc-at")?;
       if idx < values.len() {
         let Some(expected_tag) = struct_ref.fields.get(idx) else {
           return CalcitErr::err_str(
             CalcitErrKind::Arity,
             format!(
-              "&record:assoc-at record `{}` is missing field metadata at index {idx}",
+              "&struct:assoc-at struct `{}` is missing field metadata at index {idx}",
               struct_ref.name
             ),
           );
@@ -725,12 +725,12 @@ pub fn record_assoc_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         if expected_tag != field_tag {
           return CalcitErr::err_str(
             CalcitErrKind::Type,
-            format!("&record:assoc-at index {idx} expects field `:{expected_tag}`, but received `:{field_tag}`"),
+            format!("&struct:assoc-at index {idx} expects field `:{expected_tag}`, but received `:{field_tag}`"),
           );
         }
         let mut new_values = (**values).to_owned();
         xs[3].clone_into(&mut new_values[idx]);
-        Ok(Calcit::Record(CalcitRecord {
+        Ok(Calcit::Struct(CalcitStructValue {
           struct_ref: struct_ref.to_owned(),
           values: Arc::new(new_values),
         }))
@@ -738,7 +738,7 @@ pub fn record_assoc_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         CalcitErr::err_str(
           CalcitErrKind::Arity,
           format!(
-            "&record:assoc-at index {} out of range for record `{}` with {} fields",
+            "&struct:assoc-at index {} out of range for struct `{}` with {} fields",
             idx,
             struct_ref.name,
             values.len()
@@ -749,7 +749,7 @@ pub fn record_assoc_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     (a, b, field) => CalcitErr::err_str(
       CalcitErrKind::Type,
       format!(
-        "&record:assoc-at expected (record, number, tag), but received: {} {} {}",
+        "&struct:assoc-at expected (struct, number, tag), but received: {} {} {}",
         a.lisp_str(),
         b.lisp_str(),
         field.lisp_str()
@@ -758,32 +758,32 @@ pub fn record_assoc_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
-/// Optimized `&record:with` — field indices pre-resolved at compile time.
-/// Args: (record, idx1, :tag1, val1, idx2, :tag2, val2, ...)
+/// Optimized `&struct:with` — field indices pre-resolved at compile time.
+/// Args: (struct, idx1, :tag1, val1, idx2, :tag2, val2, ...)
 /// Tags are carried for JS codegen; Rust runtime uses indices directly.
 pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.is_empty() || !(xs.len() - 1).is_multiple_of(3) {
     return CalcitErr::err_nodes(
       CalcitErrKind::Arity,
-      "&record:with-at expected (record, idx, tag, val, ...) triples, but received:",
+      "&struct:with-at expected (struct, idx, tag, val, ...) triples, but received:",
       xs,
     );
   }
   match &xs[0] {
-    Calcit::Record(CalcitRecord { struct_ref, values }) => {
+    Calcit::Struct(CalcitStructValue { struct_ref, values }) => {
       let mut new_values = (**values).to_owned();
       let triple_count = (xs.len() - 1) / 3;
       for i in 0..triple_count {
         let base = 1 + i * 3;
         match (&xs[base], &xs[base + 1]) {
           (Calcit::Number(n), Calcit::Tag(field_tag)) => {
-            let idx = checked_record_index(*n, "&record:with-at")?;
+            let idx = checked_record_index(*n, "&struct:with-at")?;
             if idx < new_values.len() {
               let Some(expected_tag) = struct_ref.fields.get(idx) else {
                 return CalcitErr::err_str(
                   CalcitErrKind::Arity,
                   format!(
-                    "&record:with-at record `{}` is missing field metadata at index {idx}",
+                    "&struct:with-at struct `{}` is missing field metadata at index {idx}",
                     struct_ref.name
                   ),
                 );
@@ -791,7 +791,7 @@ pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               if expected_tag != field_tag {
                 return CalcitErr::err_str(
                   CalcitErrKind::Type,
-                  format!("&record:with-at index {idx} expects field `:{expected_tag}`, but received `:{field_tag}`"),
+                  format!("&struct:with-at index {idx} expects field `:{expected_tag}`, but received `:{field_tag}`"),
                 );
               }
               xs[base + 2].clone_into(&mut new_values[idx]);
@@ -799,7 +799,7 @@ pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               return CalcitErr::err_str(
                 CalcitErrKind::Arity,
                 format!(
-                  "&record:with-at index {} out of range for record `{}` with {} fields",
+                  "&struct:with-at index {} out of range for struct `{}` with {} fields",
                   idx,
                   struct_ref.name,
                   new_values.len()
@@ -811,7 +811,7 @@ pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
             return CalcitErr::err_str(
               CalcitErrKind::Type,
               format!(
-                "&record:with-at expected number index and tag, but received: {} {}",
+                "&struct:with-at expected number index and tag, but received: {} {}",
                 index.lisp_str(),
                 field.lisp_str()
               ),
@@ -819,14 +819,14 @@ pub fn record_with_at(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           }
         }
       }
-      Ok(Calcit::Record(CalcitRecord {
+      Ok(Calcit::Struct(CalcitStructValue {
         struct_ref: struct_ref.to_owned(),
         values: Arc::new(new_values),
       }))
     }
     a => CalcitErr::err_str(
       CalcitErrKind::Type,
-      format!("&record:with-at expected a record, but received: {}", a.lisp_str()),
+      format!("&struct:with-at expected a struct value, but received: {}", a.lisp_str()),
     ),
   }
 }
@@ -847,16 +847,16 @@ pub fn call_record(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     return CalcitErr::err_nodes(CalcitErrKind::Arity, "&%{{}} expected at least 2 arguments, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Struct(struct_def) => {
-      let record = CalcitRecord {
+    Calcit::StructDef(struct_def) => {
+      let record = CalcitStructValue {
         struct_ref: Arc::new(struct_def.to_owned()),
         values: Arc::new(vec![Calcit::Nil; struct_def.fields.len()]),
       };
       call_record_with_prototype(&record, xs)
     }
-    Calcit::Record(_) => CalcitErr::err_str(
+    Calcit::Struct(_) => CalcitErr::err_str(
       CalcitErrKind::Type,
-      "&%{} requires a struct (from defstruct) as prototype, not a record instance; use defstruct to define the type",
+      "&%{} requires a struct (from defstruct) as prototype, not a struct instance; use defstruct to define the type",
     ),
     a => {
       let msg = format!(
@@ -869,9 +869,9 @@ pub fn call_record(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
-fn call_record_with_prototype(record: &CalcitRecord, xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+fn call_record_with_prototype(record: &CalcitStructValue, xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let args_size = xs.len();
-  let CalcitRecord { struct_ref, values: v0 } = record;
+  let CalcitStructValue { struct_ref, values: v0 } = record;
   if (args_size - 1).rem(2) != 0 {
     return CalcitErr::err_nodes(CalcitErrKind::Arity, "&%{{}} expected pairs, but received:", xs);
   }
@@ -923,7 +923,7 @@ fn call_record_with_prototype(record: &CalcitRecord, xs: &[Calcit]) -> Result<Ca
         None => {
           return CalcitErr::err_str(
             CalcitErrKind::Type,
-            format!("&%{{}} unexpected field `{s}` for record: {:?}", struct_ref.fields),
+            format!("&%{{}} unexpected field `{s}` for struct: {:?}", struct_ref.fields),
           );
         }
       },
@@ -952,7 +952,7 @@ fn call_record_with_prototype(record: &CalcitRecord, xs: &[Calcit]) -> Result<Ca
         None => {
           return CalcitErr::err_str(
             CalcitErrKind::Type,
-            format!("&%{{}} unexpected field `{s}` for record: {:?}", struct_ref.fields),
+            format!("&%{{}} unexpected field `{s}` for struct: {:?}", struct_ref.fields),
           );
         }
       },
@@ -974,7 +974,7 @@ fn call_record_with_prototype(record: &CalcitRecord, xs: &[Calcit]) -> Result<Ca
     );
   }
 
-  Ok(Calcit::Record(CalcitRecord {
+  Ok(Calcit::Struct(CalcitStructValue {
     struct_ref: struct_ref.to_owned(),
     values: Arc::new(values),
   }))
@@ -986,12 +986,12 @@ pub fn record_with(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if args_size < 3 {
     return CalcitErr::err_nodes(
       CalcitErrKind::Arity,
-      "&record:with expected at least 3 arguments, but received:",
+      "&struct:with expected at least 3 arguments, but received:",
       xs,
     );
   }
   match &xs[0] {
-    Calcit::Record(record @ CalcitRecord { struct_ref, values: v0 }) => {
+    Calcit::Struct(record @ CalcitStructValue { struct_ref, values: v0 }) => {
       if (args_size - 1).rem(2) == 0 {
         let size = (args_size - 1) / 2;
         let mut values: Vec<Calcit> = (**v0).to_owned();
@@ -1010,7 +1010,7 @@ pub fn record_with(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
                   return CalcitErr::err_str(
                     CalcitErrKind::Type,
                     format!(
-                      "&record:with field `{}` expects type `{}`, but received `{}` ({})",
+                      "&struct:with field `{}` expects type `{}`, but received `{}` ({})",
                       s.ref_str(),
                       expected_type.to_brief_string(),
                       brief_type_of_value(&xs[v_idx]),
@@ -1023,7 +1023,7 @@ pub fn record_with(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               None => {
                 return CalcitErr::err_str(
                   CalcitErrKind::Type,
-                  format!("&record:with unexpected field `{s}` for record: {:?}", struct_ref.fields),
+                  format!("&struct:with unexpected field `{s}` for struct: {:?}", struct_ref.fields),
                 );
               }
             },
@@ -1037,7 +1037,7 @@ pub fn record_with(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
                   return CalcitErr::err_str(
                     CalcitErrKind::Type,
                     format!(
-                      "&record:with field `{}` expects type `{}`, but received `{}` ({})",
+                      "&struct:with field `{}` expects type `{}`, but received `{}` ({})",
                       s,
                       expected_type.to_brief_string(),
                       brief_type_of_value(&xs[v_idx]),
@@ -1050,13 +1050,13 @@ pub fn record_with(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               None => {
                 return CalcitErr::err_str(
                   CalcitErrKind::Type,
-                  format!("&record:with unexpected field `{s}` for record: {:?}", struct_ref.fields),
+                  format!("&struct:with unexpected field `{s}` for struct: {:?}", struct_ref.fields),
                 );
               }
             },
             a => {
               let msg = format!(
-                "&record:with requires field in string/tag, but received: {}",
+                "&struct:with requires field in string/tag, but received: {}",
                 type_of(std::slice::from_ref(a))?.lisp_str()
               );
               let hint = format_proc_examples_hint(&CalcitProc::NativeRecordWith).unwrap_or_default();
@@ -1065,17 +1065,17 @@ pub fn record_with(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           }
         }
 
-        Ok(Calcit::Record(CalcitRecord {
+        Ok(Calcit::Struct(CalcitStructValue {
           struct_ref: struct_ref.to_owned(),
           values: Arc::new(values),
         }))
       } else {
-        CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:with expected pairs, but received:", xs)
+        CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:with expected pairs, but received:", xs)
       }
     }
     a => {
       let msg = format!(
-        "&record:with requires a record as prototype, but received: {}",
+        "&struct:with requires a struct value as prototype, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordWith).unwrap_or_default();
@@ -1087,10 +1087,10 @@ pub fn record_with(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 pub fn get_impls(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let args_size = xs.len();
   if args_size != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:impls expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:impls expected 1 argument, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Record(record) => Ok(Calcit::from(
+    Calcit::Struct(record) => Ok(Calcit::from(
       record
         .struct_ref
         .impls
@@ -1098,12 +1098,12 @@ pub fn get_impls(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         .map(|x| Calcit::Impl((**x).to_owned()))
         .collect::<Vec<Calcit>>(),
     )),
-    Calcit::Tuple(tuple) => Ok(Calcit::from(
+    Calcit::Enum(tuple) => Ok(Calcit::from(
       tuple.impls().iter().map(|c| Calcit::Impl((**c).to_owned())).collect::<Vec<_>>(),
     )),
     a => {
       let msg = format!(
-        "&record:impls requires a record as prototype, but received: {}",
+        "&struct:impls requires a struct value as prototype, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordImpls).unwrap_or_default();
@@ -1114,14 +1114,14 @@ pub fn get_impls(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn record_from_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:from-map expected 2 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:from-map expected 2 arguments, but received:", xs);
   }
   // first argument must be a Struct prototype
-  let (struct_ref, base_values): (Arc<CalcitStruct>, Vec<Calcit>) = match &xs[0] {
-    Calcit::Struct(s) => (Arc::new(s.to_owned()), vec![Calcit::Nil; s.fields.len()]),
+  let (struct_ref, base_values): (Arc<CalcitStructDef>, Vec<Calcit>) = match &xs[0] {
+    Calcit::StructDef(s) => (Arc::new(s.to_owned()), vec![Calcit::Nil; s.fields.len()]),
     a => {
       let msg = format!(
-        "&record:from-map requires a struct as prototype, but received: {}",
+        "&struct:from-map requires a struct as prototype, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordFromMap).unwrap_or_default();
@@ -1137,7 +1137,7 @@ pub fn record_from_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           Calcit::Tag(s) => s.ref_str().to_owned().into(),
           a => {
             let msg = format!(
-              "&record:from-map requires field in string/tag, but received: {}",
+              "&struct:from-map requires field in string/tag, but received: {}",
               type_of(std::slice::from_ref(a))?.lisp_str()
             );
             let hint = format_proc_examples_hint(&CalcitProc::NativeRecordFromMap).unwrap_or_default();
@@ -1154,7 +1154,7 @@ pub fn record_from_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
               return CalcitErr::err_str(
                 CalcitErrKind::Type,
                 format!(
-                  "&record:from-map field `{}` expects type `{}`, but received `{}` ({})",
+                  "&struct:from-map field `{}` expects type `{}`, but received `{}` ({})",
                   key,
                   expected_type.to_brief_string(),
                   brief_type_of_value(v),
@@ -1167,19 +1167,19 @@ pub fn record_from_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
           None => {
             return CalcitErr::err_str(
               CalcitErrKind::Type,
-              format!("&record:from-map invalid field {k} for record {:?}", struct_ref.fields),
+              format!("&struct:from-map invalid field {k} for struct {:?}", struct_ref.fields),
             );
           }
         }
       }
-      Ok(Calcit::Record(CalcitRecord {
+      Ok(Calcit::Struct(CalcitStructValue {
         struct_ref,
         values: Arc::new(new_values),
       }))
     }
     b => {
       let msg = format!(
-        "&record:from-map requires a map as second argument, but received: {}",
+        "&struct:from-map requires a map as second argument, but received: {}",
         type_of(std::slice::from_ref(b))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordFromMap).unwrap_or_default();
@@ -1190,13 +1190,13 @@ pub fn record_from_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn get_record_name(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:get-name expected a record, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:get-name expected a struct value, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Record(CalcitRecord { struct_ref, .. }) => Ok(Calcit::Tag(struct_ref.name.to_owned())),
+    Calcit::Struct(CalcitStructValue { struct_ref, .. }) => Ok(Calcit::Tag(struct_ref.name.to_owned())),
     a => {
       let msg = format!(
-        "&record:get-name requires a record, but received: {}",
+        "&struct:get-name requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGetName).unwrap_or_default();
@@ -1207,13 +1207,18 @@ pub fn get_record_name(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn get_record_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:struct expected a record, but received:", xs);
+    return CalcitErr::err_nodes(
+      CalcitErrKind::Arity,
+      "&struct:definition expected a struct value, but received:",
+      xs,
+    );
   }
   match &xs[0] {
-    Calcit::Record(CalcitRecord { struct_ref, .. }) => Ok(Calcit::Struct(struct_ref.as_ref().to_owned())),
+    Calcit::Struct(value) if value.is_anonymous() => Ok(Calcit::Nil),
+    Calcit::Struct(CalcitStructValue { struct_ref, .. }) => Ok(Calcit::StructDef(struct_ref.as_ref().to_owned())),
     a => {
       let msg = format!(
-        "&record:struct requires a record, but received: {}",
+        "&struct:definition requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordStruct).unwrap_or_default();
@@ -1224,10 +1229,10 @@ pub fn get_record_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn turn_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:to-map expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:to-map expected 1 argument, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Record(CalcitRecord { struct_ref, values, .. }) => {
+    Calcit::Struct(CalcitStructValue { struct_ref, values, .. }) => {
       let mut ys: rpds::HashTrieMapSync<Calcit, Calcit> = rpds::HashTrieMap::new_sync();
       for idx in 0..struct_ref.fields.len() {
         ys.insert_mut(Calcit::Tag(struct_ref.fields[idx].to_owned()), values[idx].to_owned());
@@ -1236,7 +1241,7 @@ pub fn turn_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
     a => {
       let msg = format!(
-        "&record:to-map requires a record, but received: {}",
+        "&struct:to-map requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordToMap).unwrap_or_default();
@@ -1247,15 +1252,15 @@ pub fn turn_map(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn matches(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 2 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:matches? expected 2 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:matches? expected 2 arguments, but received:", xs);
   }
   // second argument is the target shape to compare against
-  let right_struct: &CalcitStruct = match &xs[1] {
-    Calcit::Record(CalcitRecord { struct_ref, .. }) => struct_ref,
-    Calcit::Struct(struct_ref) => struct_ref,
+  let right_struct: &CalcitStructDef = match &xs[1] {
+    Calcit::Struct(CalcitStructValue { struct_ref, .. }) => struct_ref,
+    Calcit::StructDef(struct_ref) => struct_ref,
     b => {
       let msg = format!(
-        "&record:matches? second argument requires a record or struct, but received: {}",
+        "&struct:matches? second argument requires a struct value or struct, but received: {}",
         type_of(std::slice::from_ref(b))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordMatches).unwrap_or_default();
@@ -1263,14 +1268,14 @@ pub fn matches(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
   };
   match &xs[0] {
-    Calcit::Record(CalcitRecord {
+    Calcit::Struct(CalcitStructValue {
       struct_ref: left_struct, ..
     }) => Ok(Calcit::Bool(
       left_struct.name == right_struct.name && left_struct.fields == right_struct.fields,
     )),
     a => {
       let msg = format!(
-        "&record:matches? first argument requires a record, but received: {}",
+        "&struct:matches? first argument requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordMatches).unwrap_or_default();
@@ -1281,13 +1286,13 @@ pub fn matches(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn count(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:count expected 1 argument, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:count expected 1 argument, but received:", xs);
   }
   match &xs[0] {
-    Calcit::Record(CalcitRecord { struct_ref, .. }) => Ok(Calcit::Number(struct_ref.fields.len() as f64)),
+    Calcit::Struct(CalcitStructValue { struct_ref, .. }) => Ok(Calcit::Number(struct_ref.fields.len() as f64)),
     a => {
       let msg = format!(
-        "&record:count requires a record, but received: {}",
+        "&struct:count requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordCount).unwrap_or_default();
@@ -1298,12 +1303,12 @@ pub fn count(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn contains_ques(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match (xs.first(), xs.get(1)) {
-    (Some(Calcit::Record(record)), Some(a)) => match a {
+    (Some(Calcit::Struct(record)), Some(a)) => match a {
       Calcit::Str(k) | Calcit::Symbol { sym: k, .. } => Ok(Calcit::Bool(record.index_of(k).is_some())),
       Calcit::Tag(k) => Ok(Calcit::Bool(record.index_of(k.ref_str()).is_some())),
       a => {
         let msg = format!(
-          "&record:contains? requires a field in string/tag, but received: {}",
+          "&struct:contains? requires a field in string/tag, but received: {}",
           type_of(std::slice::from_ref(a))?.lisp_str()
         );
         let hint = format_proc_examples_hint(&CalcitProc::NativeRecordContains).unwrap_or_default();
@@ -1314,14 +1319,14 @@ pub fn contains_ques(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordContains).unwrap_or_default();
       CalcitErr::err_nodes_with_hint(
         CalcitErrKind::Arity,
-        "&record:contains? expected 2 arguments, but received:",
+        "&struct:contains? expected 2 arguments, but received:",
         xs,
         hint,
       )
     }
     (Some(a), Some(_)) => {
       let msg = format!(
-        "&record:contains? requires a record, but received: {}",
+        "&struct:contains? requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordContains).unwrap_or_default();
@@ -1331,7 +1336,7 @@ pub fn contains_ques(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordContains).unwrap_or_default();
       CalcitErr::err_nodes_with_hint(
         CalcitErrKind::Arity,
-        "&record:contains? expected 2 arguments, but received:",
+        "&struct:contains? expected 2 arguments, but received:",
         xs,
         hint,
       )
@@ -1341,13 +1346,13 @@ pub fn contains_ques(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn get(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match (xs.first(), xs.get(1)) {
-    (Some(Calcit::Record(record @ CalcitRecord { values, struct_ref })), Some(a)) => {
+    (Some(Calcit::Struct(record @ CalcitStructValue { values, struct_ref })), Some(a)) => {
       let field_name = match a {
         Calcit::Str(k) | Calcit::Symbol { sym: k, .. } => k.as_ref(),
         Calcit::Tag(k) => k.ref_str(),
         a => {
           let msg = format!(
-            "&record:get requires a field in string/tag, but received: {}",
+            "&struct:get requires a field in string/tag, but received: {}",
             type_of(std::slice::from_ref(a))?.lisp_str()
           );
           let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGet).unwrap_or_default();
@@ -1358,17 +1363,17 @@ pub fn get(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         Some(idx) => Ok(values[idx].to_owned()),
         None => CalcitErr::err_str(
           CalcitErrKind::Type,
-          format!("&record:get record `{}` does not define field `:{field_name}`", struct_ref.name),
+          format!("&struct:get struct `{}` does not define field `:{field_name}`", struct_ref.name),
         ),
       }
     }
     (Some(_), None) => {
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGet).unwrap_or_default();
-      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&record:get expected 2 arguments, but received:", xs, hint)
+      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&struct:get expected 2 arguments, but received:", xs, hint)
     }
     (Some(a), Some(_)) => {
       let msg = format!(
-        "&record:get requires a record, but received: {}",
+        "&struct:get requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGet).unwrap_or_default();
@@ -1376,45 +1381,45 @@ pub fn get(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
     (None, ..) => {
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGet).unwrap_or_default();
-      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&record:get expected 2 arguments, but received:", xs, hint)
+      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&struct:get expected 2 arguments, but received:", xs, hint)
     }
   }
 }
 
 pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match (xs.first(), xs.get(1), xs.get(2)) {
-    (Some(Calcit::Record(record @ CalcitRecord { struct_ref, values })), Some(a), Some(b)) => match a {
+    (Some(Calcit::Struct(record @ CalcitStructValue { struct_ref, values })), Some(a), Some(b)) => match a {
       Calcit::Str(s) | Calcit::Symbol { sym: s, .. } => match record.index_of(s) {
         Some(pos) => {
           let mut new_values = (**values).to_owned();
           b.clone_into(&mut new_values[pos]);
-          Ok(Calcit::Record(CalcitRecord {
+          Ok(Calcit::Struct(CalcitStructValue {
             struct_ref: struct_ref.to_owned(),
             values: Arc::new(new_values),
           }))
         }
         None => CalcitErr::err_str(
           CalcitErrKind::Type,
-          format!("&record:assoc invalid field `{s}` for record: {:?}", struct_ref.fields),
+          format!("&struct:assoc invalid field `{s}` for struct: {:?}", struct_ref.fields),
         ),
       },
       Calcit::Tag(s) => match record.index_of(s.ref_str()) {
         Some(pos) => {
           let mut new_values = (**values).to_owned();
           b.clone_into(&mut new_values[pos]);
-          Ok(Calcit::Record(CalcitRecord {
+          Ok(Calcit::Struct(CalcitStructValue {
             struct_ref: struct_ref.to_owned(),
             values: Arc::new(new_values),
           }))
         }
         None => CalcitErr::err_str(
           CalcitErrKind::Type,
-          format!("&record:assoc invalid field `{s}` for record: {:?}", struct_ref.fields),
+          format!("&struct:assoc invalid field `{s}` for struct: {:?}", struct_ref.fields),
         ),
       },
       a => {
         let msg = format!(
-          "&record:assoc requires a field in string/tag, but received: {} for record: {:?}",
+          "&struct:assoc requires a field in string/tag, but received: {} for struct: {:?}",
           type_of(std::slice::from_ref(a))?.lisp_str(),
           struct_ref.fields
         );
@@ -1424,11 +1429,11 @@ pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     },
     (Some(_), None, _) | (Some(_), Some(_), None) => {
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordAssoc).unwrap_or_default();
-      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&record:assoc expected 3 arguments, but received:", xs, hint)
+      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&struct:assoc expected 3 arguments, but received:", xs, hint)
     }
     (Some(a), Some(_), Some(_)) => {
       let msg = format!(
-        "&record:assoc requires a record, but received: {}",
+        "&struct:assoc requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordAssoc).unwrap_or_default();
@@ -1436,34 +1441,34 @@ pub fn assoc(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
     (None, ..) => {
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordAssoc).unwrap_or_default();
-      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&record:assoc expected 3 arguments, but received:", xs, hint)
+      CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&struct:assoc expected 3 arguments, but received:", xs, hint)
     }
   }
 }
 
 pub fn extend_as(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 4 {
-    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:extend-as expected 4 arguments, but received:", xs);
+    return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:extend-as expected 4 arguments, but received:", xs);
   }
   match (xs.first(), xs.get(1), xs.get(2), xs.get(3)) {
-    (Some(Calcit::Record(record)), Some(n), Some(a), Some(new_value)) => match a {
+    (Some(Calcit::Struct(record)), Some(n), Some(a), Some(new_value)) => match a {
       Calcit::Str(s) | Calcit::Symbol { sym: s, .. } => match record.index_of(s) {
-        Some(_pos) => CalcitErr::err_str(CalcitErrKind::Unexpected, format!("&record:extend-as field `{s}` already existed")),
+        Some(_pos) => CalcitErr::err_str(CalcitErrKind::Unexpected, format!("&struct:extend-as field `{s}` already existed")),
         None => match record.extend_field(&EdnTag(s.to_owned()), n, new_value) {
-          Ok(new_record) => Ok(Calcit::Record(new_record)),
+          Ok(new_record) => Ok(Calcit::Struct(new_record)),
           Err(e) => Err(CalcitErr::use_str(CalcitErrKind::Unexpected, e)),
         },
       },
       Calcit::Tag(s) => match record.index_of(s.ref_str()) {
-        Some(_pos) => CalcitErr::err_str(CalcitErrKind::Unexpected, format!("&record:extend-as field `{s}` already existed")),
+        Some(_pos) => CalcitErr::err_str(CalcitErrKind::Unexpected, format!("&struct:extend-as field `{s}` already existed")),
         None => match record.extend_field(s, n, new_value) {
-          Ok(new_record) => Ok(Calcit::Record(new_record)),
+          Ok(new_record) => Ok(Calcit::Struct(new_record)),
           Err(e) => Err(CalcitErr::use_str(CalcitErrKind::Unexpected, e)),
         },
       },
       a => {
         let msg = format!(
-          "&record:extend-as requires a field in string/tag, but received: {} for record: {:?}",
+          "&struct:extend-as requires a field in string/tag, but received: {} for struct: {:?}",
           type_of(std::slice::from_ref(a))?.lisp_str(),
           record.struct_ref.fields
         );
@@ -1473,13 +1478,13 @@ pub fn extend_as(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     },
     (Some(a), ..) => {
       let msg = format!(
-        "&record:extend-as requires a record, but received: {}",
+        "&struct:extend-as requires a struct value, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordExtendAs).unwrap_or_default();
       CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint)
     }
-    (None, ..) => CalcitErr::err_nodes(CalcitErrKind::Arity, "&record:extend-as expected 4 arguments, but received:", xs),
+    (None, ..) => CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:extend-as expected 4 arguments, but received:", xs),
   }
 }
 
@@ -1505,8 +1510,8 @@ mod tests {
   }
 
   fn indexed_record_fixture() -> Calcit {
-    Calcit::Record(CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    Calcit::Struct(CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::new("Point"),
         vec![EdnTag::new("x"), EdnTag::new("y")],
       )),
@@ -1516,7 +1521,7 @@ mod tests {
 
   #[test]
   fn required_recursive_field_returns_a_type_error_without_recursing() {
-    let struct_def = CalcitStruct {
+    let struct_def = CalcitStructDef {
       name: EdnTag::new("RequiredNode"),
       fields: Arc::new(vec![EdnTag::new("next")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeRef(
@@ -1528,7 +1533,7 @@ mod tests {
       impls: vec![],
     };
 
-    let err = call_record(&[Calcit::Struct(struct_def), Calcit::tag("next"), Calcit::Nil])
+    let err = call_record(&[Calcit::StructDef(struct_def), Calcit::tag("next"), Calcit::Nil])
       .expect_err("a required recursive field must reject nil instead of recursing");
 
     assert!(err.msg.contains("expects type `'RequiredNode`"), "unexpected error: {err:?}");
@@ -1537,7 +1542,7 @@ mod tests {
   #[test]
   fn record_get_rejects_missing_fields_instead_of_returning_nil() {
     let record = indexed_record_fixture();
-    let err = get(&[record, Calcit::tag("missing")]).expect_err("missing record field must not become nil");
+    let err = get(&[record, Calcit::tag("missing")]).expect_err("missing struct field must not become nil");
 
     assert_eq!(err.kind, CalcitErrKind::Type);
     assert!(err.msg.contains("does not define field `:missing`"), "unexpected error: {err:?}");
@@ -1564,7 +1569,7 @@ mod tests {
 
     let updated =
       record_assoc_at(&[record, Calcit::Number(0.0), Calcit::tag("x"), Calcit::Number(3.0)]).expect("matching index/tag update");
-    let Calcit::Record(updated) = updated else {
+    let Calcit::Struct(updated) = updated else {
       panic!("updated value must remain a record");
     };
     assert_eq!(updated.values.as_ref(), &[Calcit::Number(3.0), Calcit::Number(2.0)]);
@@ -1628,8 +1633,8 @@ mod tests {
     assert!(promoted.get("render").is_some());
   }
 
-  fn shown_box_struct(show_trait: Arc<CalcitTrait>) -> CalcitStruct {
-    CalcitStruct {
+  fn shown_box_struct(show_trait: Arc<CalcitTrait>) -> CalcitStructDef {
+    CalcitStructDef {
       name: EdnTag::new("ShownBox"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
@@ -1643,14 +1648,14 @@ mod tests {
   }
 
   fn value_with_trait(trait_def: Arc<CalcitTrait>) -> Calcit {
-    let mut struct_def = CalcitStruct::from_fields(EdnTag::new("ShownValue"), vec![]);
+    let mut struct_def = CalcitStructDef::from_fields(EdnTag::new("ShownValue"), vec![]);
     struct_def.impls.push(Arc::new(CalcitImpl {
       name: trait_def.name.clone(),
       origin: Some(trait_def),
       fields: Arc::new(vec![]),
       values: Arc::new(vec![]),
     }));
-    Calcit::Record(CalcitRecord {
+    Calcit::Struct(CalcitStructValue {
       struct_ref: Arc::new(struct_def),
       values: Arc::new(vec![]),
     })
@@ -1660,7 +1665,7 @@ mod tests {
   fn generic_struct_where_bounds_accept_nominal_trait_values() {
     let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
     let result = call_record(&[
-      Calcit::Struct(shown_box_struct(show_trait.clone())),
+      Calcit::StructDef(shown_box_struct(show_trait.clone())),
       Calcit::tag("value"),
       value_with_trait(show_trait),
     ]);
@@ -1672,7 +1677,7 @@ mod tests {
   fn generic_struct_where_bounds_reject_missing_nominal_trait() {
     let show_trait = Arc::new(CalcitTrait::new(EdnTag::new("Renderable"), vec![], vec![]));
     let err = call_record(&[
-      Calcit::Struct(shown_box_struct(show_trait)),
+      Calcit::StructDef(shown_box_struct(show_trait)),
       Calcit::tag("value"),
       Calcit::Proc(CalcitProc::NativeResetGenSymIndex),
     ])

--- a/src/builtins/records.rs
+++ b/src/builtins/records.rs
@@ -1341,24 +1341,27 @@ pub fn contains_ques(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn get(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match (xs.first(), xs.get(1)) {
-    (Some(Calcit::Record(record @ CalcitRecord { values, .. })), Some(a)) => match a {
-      Calcit::Str(k) | Calcit::Symbol { sym: k, .. } => match record.index_of(k) {
+    (Some(Calcit::Record(record @ CalcitRecord { values, struct_ref })), Some(a)) => {
+      let field_name = match a {
+        Calcit::Str(k) | Calcit::Symbol { sym: k, .. } => k.as_ref(),
+        Calcit::Tag(k) => k.ref_str(),
+        a => {
+          let msg = format!(
+            "&record:get requires a field in string/tag, but received: {}",
+            type_of(std::slice::from_ref(a))?.lisp_str()
+          );
+          let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGet).unwrap_or_default();
+          return CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint);
+        }
+      };
+      match record.index_of(field_name) {
         Some(idx) => Ok(values[idx].to_owned()),
-        None => Ok(Calcit::Nil),
-      },
-      Calcit::Tag(k) => match record.index_of(k.ref_str()) {
-        Some(idx) => Ok(values[idx].to_owned()),
-        None => Ok(Calcit::Nil),
-      },
-      a => {
-        let msg = format!(
-          "&record:get requires a field in string/tag, but received: {}",
-          type_of(std::slice::from_ref(a))?.lisp_str()
-        );
-        let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGet).unwrap_or_default();
-        CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint)
+        None => CalcitErr::err_str(
+          CalcitErrKind::Type,
+          format!("&record:get record `{}` does not define field `:{field_name}`", struct_ref.name),
+        ),
       }
-    },
+    }
     (Some(_), None) => {
       let hint = format_proc_examples_hint(&CalcitProc::NativeRecordGet).unwrap_or_default();
       CalcitErr::err_nodes_with_hint(CalcitErrKind::Arity, "&record:get expected 2 arguments, but received:", xs, hint)
@@ -1529,6 +1532,15 @@ mod tests {
       .expect_err("a required recursive field must reject nil instead of recursing");
 
     assert!(err.msg.contains("expects type `'RequiredNode`"), "unexpected error: {err:?}");
+  }
+
+  #[test]
+  fn record_get_rejects_missing_fields_instead_of_returning_nil() {
+    let record = indexed_record_fixture();
+    let err = get(&[record, Calcit::tag("missing")]).expect_err("missing record field must not become nil");
+
+    assert_eq!(err.kind, CalcitErrKind::Type);
+    assert!(err.msg.contains("does not define field `:missing`"), "unexpected error: {err:?}");
   }
 
   #[test]

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -14,7 +14,7 @@ use crate::calcit::{
   self, CalcitArgLabel, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitList, CalcitLocal, CalcitMacro,
   CalcitSymbolInfo, CalcitSyntax, CalcitTypeAnnotation, LocatedWarning,
 };
-use crate::calcit::{Calcit, CalcitErr, CalcitScope, CalcitTuple, gen_core_id};
+use crate::calcit::{Calcit, CalcitEnumValue, CalcitErr, CalcitScope, gen_core_id};
 use crate::call_stack::CallStackList;
 use crate::runner::{self, call_expr, evaluate_expr};
 
@@ -218,7 +218,7 @@ fn collect_param_symbols(args: &CalcitList) -> Result<Vec<Arc<str>>, String> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitRecord, CalcitStruct, CalcitTrait};
+  use crate::calcit::{CalcitStructDef, CalcitStructValue, CalcitTrait};
   use crate::call_stack::CallStackList;
   use cirru_edn::EdnTag;
 
@@ -361,7 +361,7 @@ mod tests {
     let sym = Arc::from("x");
     let idx = CalcitLocal::track_sym(&sym);
     let empty_trait_def = Arc::new(CalcitTrait::new(EdnTag::from("Noop"), vec![], vec![]));
-    let mut person_struct = CalcitStruct::from_fields(EdnTag::from("Person"), vec![]);
+    let mut person_struct = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![]);
     person_struct.impls.push(Arc::new(crate::calcit::CalcitImpl {
       name: empty_trait_def.name.clone(),
       origin: Some(empty_trait_def.clone()),
@@ -370,7 +370,7 @@ mod tests {
     }));
     scope.insert_mut(
       idx,
-      Calcit::Record(CalcitRecord {
+      Calcit::Struct(CalcitStructValue {
         struct_ref: Arc::new(person_struct),
         values: Arc::new(vec![]),
       }),
@@ -391,7 +391,7 @@ mod tests {
       empty_trait,
     ]);
     let result = assert_traits(&expr, &scope, "tests.assert", &CallStackList::default()).expect("assert-traits should pass");
-    assert!(matches!(result, Calcit::Record(_)));
+    assert!(matches!(result, Calcit::Struct(_)));
   }
 
   #[test]
@@ -1111,12 +1111,12 @@ pub fn syntax_match(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_
   let value = evaluate_expr(&expr[0], scope, file_ns, call_stack)?;
 
   let (tag, extra) = match &value {
-    Calcit::Tuple(CalcitTuple { tag, extra, .. }) => match tag.as_ref() {
+    Calcit::Enum(CalcitEnumValue { tag, extra, .. }) => match tag.as_ref() {
       Calcit::Tag(t) => (t.to_owned(), extra),
       _ => {
         return Err(CalcitErr::use_msg_stack_location(
           CalcitErrKind::Type,
-          format!("match expected tuple with tag as first element, got: {tag}"),
+          format!("match expected enum with tag as first element, got: {tag}"),
           call_stack,
           expr[0].get_location(),
         ));
@@ -1125,7 +1125,7 @@ pub fn syntax_match(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_
     _ => {
       return Err(CalcitErr::use_msg_stack_location(
         CalcitErrKind::Type,
-        format!("match expected a tuple value, got: {}", calcit::brief_type_of_value(&value)),
+        format!("match expected an enum value, got: {}", calcit::brief_type_of_value(&value)),
         call_stack,
         expr[0].get_location(),
       ));

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -35,18 +35,18 @@ use cirru_parser::Cirru;
 use im_ternary_tree::TernaryTreeList;
 
 pub use calcit_impl::CalcitImpl;
-pub use calcit_struct::CalcitStruct;
+pub use calcit_struct::CalcitStructDef;
 pub use calcit_trait::CalcitTrait;
 pub use fns::{CalcitArgLabel, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitMacro, CalcitScope};
 pub use list::CalcitList;
 pub use local::CalcitLocal;
 pub use proc_name::{CalcitProc, ProcArity, ProcTypeSignature};
-pub use record::CalcitRecord;
-pub use sum_type::{CalcitEnum, EnumVariant};
+pub use record::CalcitStructValue;
+pub use sum_type::{CalcitEnumDef, EnumVariant};
 pub use symbol::{CalcitImport, CalcitSymbolInfo, ImportInfo};
 pub use syntax_name::{CalcitSyntax, SyntaxTypeSignature};
 pub use thunk::{CalcitThunk, CalcitThunkInfo};
-pub use tuple::CalcitTuple;
+pub use tuple::CalcitEnumValue;
 pub use type_annotation::{
   CalcitFnTypeAnnotation, CalcitGenericBound, CalcitTypeAnnotation, DYNAMIC_TYPE, SchemaKind, brief_type_of_value, clear_type_slots,
   configure_entry_type_slots, pop_type_slot_override, push_type_slot_override, register_program_lookups, register_type_slot,
@@ -90,8 +90,8 @@ pub enum Calcit {
   Thunk(CalcitThunk), // code, value
   /// atom, holding a path to its state, data inside remains during hot code swapping
   Ref(Arc<str>, Arc<Mutex<ValueAndListeners>>),
-  /// more tagged union type, more like an internal structure
-  Tuple(CalcitTuple),
+  /// Enum value. `definition` is absent for anonymous enum values.
+  Enum(CalcitEnumValue),
   /// binary data, to be used by FFIs
   Buffer(Vec<u8>),
   /// mutable append-only list, for performance-sensitive accumulation patterns.
@@ -104,13 +104,12 @@ pub enum Calcit {
   List(Arc<CalcitList>),
   Set(rpds::HashTrieSetSync<Calcit>),
   Map(rpds::HashTrieMapSync<Calcit, Calcit>),
-  /// with only static and limited keys, for performance and checking
-  /// size of keys are values should be kept consistent
-  Record(CalcitRecord),
-  /// struct definition value, carries field types and names
-  Struct(CalcitStruct),
-  /// enum definition value, wraps enum prototype and variants
-  Enum(CalcitEnum),
+  /// Struct value with a fixed field set.
+  Struct(CalcitStructValue),
+  /// `defstruct` definition value, carries field types and names.
+  StructDef(CalcitStructDef),
+  /// `defenum` definition value, wraps the closed variant set.
+  EnumDef(CalcitEnumDef),
   /// trait definition value, carries method signatures
   Trait(CalcitTrait),
   /// trait implementation value, carries methods and target trait name
@@ -174,27 +173,20 @@ impl fmt::Display for Calcit {
       },
       CirruQuote(code) => f.write_str(&format!("(&cirru-quote {code})")),
       Ref(name, _locked_pair) => f.write_str(&format!("(&ref {name} ...)")),
-      Tuple(tuple) => match &tuple.sum_type {
-        Some(sum_type) => {
-          f.write_str("(%:: ")?;
-          f.write_str(&tuple.tag.to_string())?;
-          for item in &tuple.extra {
-            f.write_char(' ')?;
-            f.write_str(&item.to_string())?;
-          }
-          f.write_str(&format!(" (:enum {})", sum_type.name()))?;
-          f.write_str(")")
+      Enum(value) => {
+        f.write_str("(%:: ")?;
+        match &value.sum_type {
+          Some(enum_def) => f.write_str(&format!("'{}", enum_def.name()))?,
+          None => f.write_char('_')?,
         }
-        None => {
-          f.write_str("(:: ")?;
-          f.write_str(&tuple.tag.to_string())?;
-          for item in &tuple.extra {
-            f.write_char(' ')?;
-            f.write_str(&item.to_string())?;
-          }
-          f.write_str(")")
+        f.write_char(' ')?;
+        f.write_str(&value.tag.to_string())?;
+        for item in &value.extra {
+          f.write_char(' ')?;
+          f.write_str(&item.to_string())?;
         }
-      },
+        f.write_char(')')
+      }
       Buffer(buf) => {
         f.write_str("(&buffer")?;
         if buf.len() > 8 {
@@ -252,9 +244,9 @@ impl fmt::Display for Calcit {
         f.write_str(")")?;
         Ok(())
       }
-      Record(CalcitRecord { struct_ref, values, .. }) => {
-        if record::LOOSE_RECORD_NAME == struct_ref.name.ref_str() {
-          f.write_str("(?{}")?;
+      Struct(CalcitStructValue { struct_ref, values, .. }) => {
+        if record::ANONYMOUS_STRUCT_NAME == struct_ref.name.ref_str() {
+          f.write_str("(%{} _")?;
         } else {
           f.write_str(&format!("(%{{}} '{}", struct_ref.name))?;
         }
@@ -263,10 +255,10 @@ impl fmt::Display for Calcit {
         }
         f.write_str(")")
       }
-      Struct(CalcitStruct {
+      StructDef(CalcitStructDef {
         name, fields, field_types, ..
       }) => {
-        f.write_str("(%struct ")?;
+        f.write_str("(%struct-def ")?;
         f.write_str(&format!("'{name}"))?;
         for (k, t) in fields.iter().zip(field_types.iter()) {
           f.write_char(' ')?;
@@ -274,8 +266,8 @@ impl fmt::Display for Calcit {
         }
         f.write_char(')')
       }
-      Enum(enum_def) => {
-        f.write_str("(%enum ")?;
+      EnumDef(enum_def) => {
+        f.write_str("(%enum-def ")?;
         f.write_str(&format!("'{}", enum_def.name()))?;
         for variant in enum_def.variants() {
           f.write_char(' ')?;
@@ -465,7 +457,7 @@ impl Hash for Calcit {
         "ref:".hash(_state);
         name.hash(_state);
       }
-      Tuple(CalcitTuple { tag, extra, sum_type: _ }) => {
+      Enum(CalcitEnumValue { tag, extra, sum_type: _ }) => {
         "tuple:".hash(_state);
         tag.hash(_state);
         extra.hash(_state);
@@ -510,13 +502,13 @@ impl Hash for Calcit {
           x.hash(_state)
         }
       }
-      Record(CalcitRecord { struct_ref, values, .. }) => {
+      Struct(CalcitStructValue { struct_ref, values, .. }) => {
         "record:".hash(_state);
         struct_ref.name.hash(_state);
         struct_ref.fields.hash(_state);
         values.hash(_state);
       }
-      Struct(CalcitStruct {
+      StructDef(CalcitStructDef {
         name,
         fields,
         field_types,
@@ -538,7 +530,7 @@ impl Hash for Calcit {
           imp.values.hash(_state);
         }
       }
-      Enum(enum_def) => {
+      EnumDef(enum_def) => {
         "enum:".hash(_state);
         enum_def.name().hash(_state);
         enum_def.generics().hash(_state);
@@ -658,18 +650,18 @@ impl Ord for Calcit {
       (_, Ref(_, _)) => Greater,
 
       (
-        Tuple(CalcitTuple {
+        Enum(CalcitEnumValue {
           tag: a0, extra: extra0, ..
         }),
-        Tuple(CalcitTuple {
+        Enum(CalcitEnumValue {
           tag: a1, extra: extra1, ..
         }),
       ) => match a0.cmp(a1) {
         Equal => extra0.cmp(extra1),
         v => v,
       },
-      (Tuple { .. }, _) => Less,
-      (_, Tuple { .. }) => Greater,
+      (Enum { .. }, _) => Less,
+      (_, Enum { .. }) => Greater,
 
       (Buffer(buf1), Buffer(buf2)) => buf1.cmp(buf2),
       (Buffer(..), _) => Less,
@@ -699,17 +691,17 @@ impl Ord for Calcit {
       (Map(_), _) => Less,
       (_, Map(_)) => Greater,
 
-      (Record(a), Record(b)) => compare_record_values(a, b),
-      (Record { .. }, _) => Less,
-      (_, Record { .. }) => Greater,
-
-      (Struct(a), Struct(b)) => compare_calcit_struct_values(a, b),
+      (Struct(a), Struct(b)) => compare_record_values(a, b),
       (Struct { .. }, _) => Less,
       (_, Struct { .. }) => Greater,
 
-      (Enum(a), Enum(b)) => compare_calcit_enum_values(a, b),
-      (Enum { .. }, _) => Less,
-      (_, Enum { .. }) => Greater,
+      (StructDef(a), StructDef(b)) => compare_calcit_struct_values(a, b),
+      (StructDef { .. }, _) => Less,
+      (_, StructDef { .. }) => Greater,
+
+      (EnumDef(a), EnumDef(b)) => compare_calcit_enum_values(a, b),
+      (EnumDef { .. }, _) => Less,
+      (_, EnumDef { .. }) => Greater,
 
       (Trait(a), Trait(b)) => compare_calcit_trait_values(a, b),
       (Trait { .. }, _) => Less,
@@ -775,7 +767,7 @@ impl PartialEq for Calcit {
       (Str(a), Str(b)) => a == b,
       (Thunk(a), Thunk(b)) => a == b,
       (Ref(a, _), Ref(b, _)) => a == b,
-      (Tuple(a), Tuple(b)) => a == b,
+      (Enum(a), Enum(b)) => a == b,
       (Buffer(b), Buffer(d)) => b == d,
       (BufList(a), BufList(b)) => {
         let a = a.lock().expect("BufList lock");
@@ -786,9 +778,9 @@ impl PartialEq for Calcit {
       (List(a), List(b)) => a == b,
       (Set(a), Set(b)) => a == b,
       (Map(a), Map(b)) => a == b,
-      (Record(a), Record(b)) => a == b,
       (Struct(a), Struct(b)) => a == b,
-      (Enum(a), Enum(b)) => a.name() == b.name() && a.variants() == b.variants(),
+      (StructDef(a), StructDef(b)) => a == b,
+      (EnumDef(a), EnumDef(b)) => a.name() == b.name() && a.variants() == b.variants(),
       (Trait(a), Trait(b)) => a == b,
       (Impl(a), Impl(b)) => a == b,
       (Proc(a), Proc(b)) => a == b,
@@ -910,8 +902,8 @@ impl Calcit {
       }
       Thunk(_) => "**Calcit thunk** — a delayed-evaluation expression".to_string(),
       Ref(name, _) => format!("**Calcit atom/ref** (`{name}`) — a mutable state container"),
-      Tuple(tuple) => {
-        format!("**Calcit tuple** (`{}`) — a tagged union", tuple.tag)
+      Enum(tuple) => {
+        format!("**Calcit enum value** (`{}`) — a tagged union variant", tuple.tag)
       }
       Buffer(buf) => format!("**Calcit buffer** ({} bytes) — binary data", buf.len()),
       BufList(items) => {
@@ -925,9 +917,9 @@ impl Calcit {
       List(xs) => format!("**Calcit list** ({} items) — vector/list", xs.len()),
       Set(xs) => format!("**Calcit set** ({} items) — unique values set", xs.size()),
       Map(xs) => format!("**Calcit map** ({} pairs) — key-value map", xs.size()),
-      Record(record) => format!("**Calcit record** (`{}`) — typed struct", record.name()),
-      Struct(strukt) => format!("**Calcit struct** (`{}`) — struct definition", strukt.name),
-      Enum(enm) => format!("**Calcit enum** (`{}`) — enum/sum-type definition", enm.name()),
+      Struct(record) => format!("**Calcit struct value** (`{}`)", record.name()),
+      StructDef(strukt) => format!("**Calcit struct definition** (`{}`)", strukt.name),
+      EnumDef(enm) => format!("**Calcit enum definition** (`{}`)", enm.name()),
       Trait(trt) => format!("**Calcit trait** (`{}`) — trait definition", trt.name),
       Impl(imp) => format!("**Calcit impl** (`{}`) — trait implementation", imp.name),
       Proc(p) => format!("**Calcit procedure** (`{p}`) — native function"),
@@ -1467,12 +1459,12 @@ mod tests {
 
   #[test]
   fn cmp_records_compares_values_when_same_name() {
-    let struct_ref = Arc::new(CalcitStruct::from_fields(EdnTag::new("Person"), vec![EdnTag::new("age")]));
-    let left = Calcit::Record(CalcitRecord {
+    let struct_ref = Arc::new(CalcitStructDef::from_fields(EdnTag::new("Person"), vec![EdnTag::new("age")]));
+    let left = Calcit::Struct(CalcitStructValue {
       struct_ref: struct_ref.clone(),
       values: Arc::new(vec![Calcit::Number(1.0)]),
     });
-    let right = Calcit::Record(CalcitRecord {
+    let right = Calcit::Struct(CalcitStructValue {
       struct_ref,
       values: Arc::new(vec![Calcit::Number(2.0)]),
     });
@@ -1558,7 +1550,7 @@ mod tests {
     assert_ne!(impl_left, impl_right);
     assert_ne!(impl_left.cmp(&impl_right), Equal);
 
-    let struct_left = Calcit::Struct(CalcitStruct {
+    let struct_left = Calcit::StructDef(CalcitStructDef {
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("age")]),
       field_types: Arc::new(vec![DYNAMIC_TYPE.clone()]),
@@ -1566,7 +1558,7 @@ mod tests {
       where_bounds: Arc::new(vec![]),
       impls: vec![],
     });
-    let struct_right = Calcit::Struct(CalcitStruct {
+    let struct_right = Calcit::StructDef(CalcitStructDef {
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("age")]),
       field_types: Arc::new(vec![DYNAMIC_TYPE.clone()]),
@@ -1577,24 +1569,24 @@ mod tests {
     assert_ne!(struct_left, struct_right);
     assert_ne!(struct_left.cmp(&struct_right), Equal);
 
-    let enum_left_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("Result"), vec![EdnTag::new("ok")])),
+    let enum_left_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("Result"), vec![EdnTag::new("ok")])),
       values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::Vector(vec![])))]),
     };
-    let enum_right_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("Result"), vec![EdnTag::new("ok")])),
+    let enum_right_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("Result"), vec![EdnTag::new("ok")])),
       values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::Vector(vec![Calcit::tag("string")])))]),
     };
-    let enum_left = Calcit::Enum(CalcitEnum::from_record(enum_left_record).expect("valid enum"));
-    let enum_right = Calcit::Enum(CalcitEnum::from_record(enum_right_record).expect("valid enum"));
+    let enum_left = Calcit::EnumDef(CalcitEnumDef::from_record(enum_left_record).expect("valid enum"));
+    let enum_right = Calcit::EnumDef(CalcitEnumDef::from_record(enum_right_record).expect("valid enum"));
     assert_ne!(enum_left, enum_right);
     assert_ne!(enum_left.cmp(&enum_right), Equal);
   }
 
   #[test]
   fn enum_display_includes_variants() {
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::new("Result"),
         vec![EdnTag::new("ok"), EdnTag::new("err")],
       )),
@@ -1603,23 +1595,23 @@ mod tests {
         Calcit::List(Arc::new(CalcitList::Vector(vec![Calcit::tag("string")]))),
       ]),
     };
-    let enum_value = Calcit::Enum(CalcitEnum::from_record(enum_record).expect("valid enum"));
+    let enum_value = Calcit::EnumDef(CalcitEnumDef::from_record(enum_record).expect("valid enum"));
     let text = enum_value.to_string();
-    assert!(text.starts_with("(%enum 'Result"), "unexpected display: {text}");
+    assert!(text.starts_with("(%enum-def 'Result"), "unexpected display: {text}");
     assert!(text.contains(":ok)"), "missing zero-payload variant: {text}");
     assert!(text.contains(":err :string)"), "missing payload variant: {text}");
   }
 
   #[test]
   fn named_data_display_uses_symbol_name() {
-    let record = Calcit::Record(CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("TodoState"), vec![EdnTag::new("draft")])),
+    let record = Calcit::Struct(CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("TodoState"), vec![EdnTag::new("draft")])),
       values: Arc::new(vec![Calcit::Str(Arc::from(""))]),
     });
-    let struct_def = Calcit::Struct(CalcitStruct::from_fields(EdnTag::new("TodoState"), vec![EdnTag::new("draft")]));
+    let struct_def = Calcit::StructDef(CalcitStructDef::from_fields(EdnTag::new("TodoState"), vec![EdnTag::new("draft")]));
 
     assert_eq!(record.to_string(), "(%{} 'TodoState (:draft |))");
-    assert!(struct_def.to_string().starts_with("(%struct 'TodoState"));
+    assert!(struct_def.to_string().starts_with("(%struct-def 'TodoState"));
   }
 
   #[test]
@@ -1655,7 +1647,7 @@ mod tests {
         }),
       }]),
     });
-    let struct_value = Calcit::Struct(CalcitStruct {
+    let struct_value = Calcit::StructDef(CalcitStructDef {
       name: EdnTag::new("S"),
       fields: Arc::new(vec![EdnTag::new("v")]),
       field_types: Arc::new(vec![DYNAMIC_TYPE.clone()]),

--- a/src/calcit/calcit_impl.rs
+++ b/src/calcit/calcit_impl.rs
@@ -13,7 +13,7 @@ pub struct CalcitImpl {
 }
 
 impl CalcitImpl {
-  pub fn from_record(record: &crate::calcit::CalcitRecord) -> Self {
+  pub fn from_record(record: &crate::calcit::CalcitStructValue) -> Self {
     CalcitImpl {
       name: record.struct_ref.name.to_owned(),
       origin: None,

--- a/src/calcit/calcit_struct.rs
+++ b/src/calcit/calcit_struct.rs
@@ -6,7 +6,7 @@ use cirru_edn::EdnTag;
 use super::{CalcitGenericBound, CalcitImpl, CalcitTypeAnnotation};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CalcitStruct {
+pub struct CalcitStructDef {
   pub name: EdnTag,
   pub fields: Arc<Vec<EdnTag>>,
   pub field_types: Arc<Vec<Arc<CalcitTypeAnnotation>>>,
@@ -16,11 +16,11 @@ pub struct CalcitStruct {
   pub impls: Vec<Arc<CalcitImpl>>,
 }
 
-impl CalcitStruct {
+impl CalcitStructDef {
   pub fn from_fields(name: EdnTag, fields: Vec<EdnTag>) -> Self {
     let field_types = vec![super::DYNAMIC_TYPE.clone(); fields.len()];
     let generics = Arc::new(vec![]);
-    CalcitStruct {
+    CalcitStructDef {
       name,
       fields: Arc::new(fields),
       field_types: Arc::new(field_types),
@@ -36,7 +36,7 @@ impl CalcitStruct {
   }
 }
 
-impl Hash for CalcitStruct {
+impl Hash for CalcitStructDef {
   fn hash<H: Hasher>(&self, state: &mut H) {
     self.name.hash(state);
     self.fields.hash(state);

--- a/src/calcit/compare.rs
+++ b/src/calcit/compare.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use cirru_edn::EdnAnyRef;
 
-use super::{Calcit, CalcitEnum, CalcitFn, CalcitImpl, CalcitRecord, CalcitStruct, CalcitTrait};
+use super::{Calcit, CalcitEnumDef, CalcitFn, CalcitImpl, CalcitStructDef, CalcitStructValue, CalcitTrait};
 
 pub(super) fn compare_calcit_trait_values(a: &CalcitTrait, b: &CalcitTrait) -> Ordering {
   match (a.runtime_id, b.runtime_id) {
@@ -104,7 +104,7 @@ fn compare_impl_origin(a: Option<&Arc<CalcitTrait>>, b: Option<&Arc<CalcitTrait>
   }
 }
 
-pub(super) fn compare_calcit_struct_values(a: &CalcitStruct, b: &CalcitStruct) -> Ordering {
+pub(super) fn compare_calcit_struct_values(a: &CalcitStructDef, b: &CalcitStructDef) -> Ordering {
   match a.name.cmp(&b.name) {
     Equal => match a.fields.cmp(&b.fields) {
       Equal => match a.field_types.cmp(&b.field_types) {
@@ -138,7 +138,7 @@ fn compare_struct_impls(a: &[Arc<CalcitImpl>], b: &[Arc<CalcitImpl>]) -> Orderin
   }
 }
 
-pub(super) fn compare_calcit_enum_values(a: &CalcitEnum, b: &CalcitEnum) -> Ordering {
+pub(super) fn compare_calcit_enum_values(a: &CalcitEnumDef, b: &CalcitEnumDef) -> Ordering {
   match a.name().cmp(b.name()) {
     Equal => a
       .generics()
@@ -208,7 +208,7 @@ pub(super) fn compare_map_values(a: &rpds::HashTrieMapSync<Calcit, Calcit>, b: &
   }
 }
 
-pub(super) fn compare_record_values(a: &CalcitRecord, b: &CalcitRecord) -> Ordering {
+pub(super) fn compare_record_values(a: &CalcitStructValue, b: &CalcitStructValue) -> Ordering {
   match a.struct_ref.name.cmp(&b.struct_ref.name) {
     Equal => match a.struct_ref.fields.cmp(&b.struct_ref.fields) {
       Equal => a.values.cmp(&b.values),

--- a/src/calcit/data_patch.rs
+++ b/src/calcit/data_patch.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use cirru_edn::EdnTag;
 
 use super::data_shape::{DataShapeGraph, DataShapeNode};
-use super::{Calcit, CalcitRecord, CalcitTuple};
+use super::{Calcit, CalcitEnumValue, CalcitStructValue};
 
 const MAX_PATCH_DEPTH: usize = 1024;
 
@@ -230,7 +230,7 @@ fn apply_patch_node(
       let DataShapeNode::Struct { fields, .. } = &shape.nodes[*node] else {
         return Err(DataPatchError::at(path, "StructFields reached a non-struct shape node"));
       };
-      let Calcit::Record(record) = base else {
+      let Calcit::Struct(record) = base else {
         return Err(DataPatchError::at(path, "StructFields base is not a record"));
       };
       let mut values = record.values.as_ref().clone();
@@ -254,7 +254,7 @@ fn apply_patch_node(
           .map_err(|error| DataPatchError::at(error.path, error.message))?;
         values[*field_index] = next;
       }
-      Ok(Calcit::Record(CalcitRecord {
+      Ok(Calcit::Struct(CalcitStructValue {
         struct_ref: record.struct_ref.clone(),
         values: Arc::new(values),
       }))
@@ -267,7 +267,7 @@ fn apply_patch_node(
       let DataShapeNode::Enum { variants, .. } = &shape.nodes[*node] else {
         return Err(DataPatchError::at(path, "EnumPayload reached a non-enum shape node"));
       };
-      let Calcit::Tuple(tuple) = base else {
+      let Calcit::Enum(tuple) = base else {
         return Err(DataPatchError::at(path, "EnumPayload base is not an enum tuple"));
       };
       let (expected_tag, payload_nodes) = variants
@@ -294,7 +294,7 @@ fn apply_patch_node(
           .map_err(|error| DataPatchError::at(error.path, error.message))?;
         payloads[*payload_index] = next;
       }
-      Ok(Calcit::Tuple(CalcitTuple {
+      Ok(Calcit::Enum(CalcitEnumValue {
         tag: tuple.tag.clone(),
         extra: payloads,
         sum_type: tuple.sum_type.clone(),
@@ -306,15 +306,15 @@ fn apply_patch_node(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitEnum, CalcitList, CalcitStruct, CalcitTypeAnnotation};
+  use crate::calcit::{CalcitEnumDef, CalcitList, CalcitStructDef, CalcitTypeAnnotation};
 
-  fn point_fixture() -> (DataShapeGraph, Arc<CalcitStruct>, Calcit) {
-    let mut nominal = CalcitStruct::from_fields(EdnTag::new("Point"), vec![EdnTag::new("x"), EdnTag::new("label")]);
+  fn point_fixture() -> (DataShapeGraph, Arc<CalcitStructDef>, Calcit) {
+    let mut nominal = CalcitStructDef::from_fields(EdnTag::new("Point"), vec![EdnTag::new("x"), EdnTag::new("label")]);
     nominal.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]);
     let nominal = Arc::new(nominal);
     let shape =
       DataShapeGraph::build(&CalcitTypeAnnotation::Struct(nominal.clone(), Arc::new(vec![])), "tests.patch").expect("point data shape");
-    let value = Calcit::Record(CalcitRecord {
+    let value = Calcit::Struct(CalcitStructValue {
       struct_ref: nominal.clone(),
       values: Arc::new(vec![Calcit::Number(1.0), Calcit::Str(Arc::from("old"))]),
     });
@@ -345,7 +345,7 @@ mod tests {
     .expect("valid point patch");
 
     let value = patch.apply(&shape, &base).expect("apply point patch");
-    let (Calcit::Record(before), Calcit::Record(after)) = (&base, &value) else {
+    let (Calcit::Struct(before), Calcit::Struct(after)) = (&base, &value) else {
       panic!("point values must be records");
     };
     assert!(Arc::ptr_eq(&before.struct_ref, &after.struct_ref));
@@ -401,8 +401,8 @@ mod tests {
 
   #[test]
   fn applies_payload_patch_only_to_the_declared_enum_variant() {
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::new("Outcome"),
         vec![EdnTag::new("none"), EdnTag::new("score")],
       )),
@@ -411,7 +411,7 @@ mod tests {
         Calcit::List(Arc::new(CalcitList::from([CalcitTypeAnnotation::Number.to_calcit()].as_slice()))),
       ]),
     };
-    let nominal = Arc::new(CalcitEnum::from_record(enum_record).expect("outcome enum"));
+    let nominal = Arc::new(CalcitEnumDef::from_record(enum_record).expect("outcome enum"));
     let shape =
       DataShapeGraph::build(&CalcitTypeAnnotation::Enum(nominal.clone(), Arc::new(vec![])), "tests.patch").expect("outcome shape");
     let DataShapeNode::Enum { variants, .. } = &shape.nodes[shape.root] else {
@@ -419,7 +419,7 @@ mod tests {
     };
     let variant = variants.iter().position(|(tag, _)| tag.ref_str() == "score").unwrap();
     let score_node = variants[variant].1[0];
-    let base = Calcit::Tuple(CalcitTuple {
+    let base = Calcit::Enum(CalcitEnumValue {
       tag: Arc::new(Calcit::Tag(EdnTag::new("score"))),
       extra: vec![Calcit::Number(1.0)],
       sum_type: Some(nominal),
@@ -441,7 +441,7 @@ mod tests {
     .expect("valid enum payload patch");
 
     let value = patch.apply(&shape, &base).expect("apply enum patch");
-    let Calcit::Tuple(tuple) = value else {
+    let Calcit::Enum(tuple) = value else {
       panic!("patched outcome must remain an enum tuple");
     };
     assert_eq!(tuple.extra, vec![Calcit::Number(2.0)]);

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -6,7 +6,7 @@ use cirru_edn::EdnTag;
 use md5::{Digest, Md5};
 
 use super::type_annotation::{TypeBindings, validate_runtime_generic_where_bounds};
-use super::{Calcit, CalcitEnum, CalcitStruct, CalcitTypeAnnotation};
+use super::{Calcit, CalcitEnumDef, CalcitStructDef, CalcitTypeAnnotation};
 use crate::program;
 
 const DATA_SHAPE_ABI_VERSION: u16 = 1;
@@ -43,13 +43,13 @@ pub(crate) enum DataShapeNode {
   },
   Ref(usize),
   Struct {
-    nominal: Arc<CalcitStruct>,
+    nominal: Arc<CalcitStructDef>,
     nominal_path: Option<(Arc<str>, Arc<str>)>,
     type_args: Arc<Vec<Arc<CalcitTypeAnnotation>>>,
     fields: Vec<(EdnTag, usize)>,
   },
   Enum {
-    nominal: Arc<CalcitEnum>,
+    nominal: Arc<CalcitEnumDef>,
     nominal_path: Option<(Arc<str>, Arc<str>)>,
     type_args: Arc<Vec<Arc<CalcitTypeAnnotation>>>,
     variants: Vec<(EdnTag, Vec<usize>)>,
@@ -250,20 +250,20 @@ impl DataShapeGraph {
         self.validate_node_value(*inner, &inner_value, &format!("{path}.value"), depth + 1)
       }
       DataShapeNode::Struct { nominal, fields, .. } => {
-        let Calcit::Record(record) = value else {
-          return Err(shape_kind_mismatch(path, &format!("record :{}", nominal.name), value));
+        let Calcit::Struct(record) = value else {
+          return Err(shape_kind_mismatch(path, &format!("struct :{}", nominal.name), value));
         };
         if !Arc::ptr_eq(&record.struct_ref, nominal) {
           return Err(DataShapeValueError::at(
             path,
-            format!("expected nominal record :{}, got :{}", nominal.name, record.struct_ref.name),
+            format!("expected nominal struct :{}, got :{}", nominal.name, record.struct_ref.name),
           ));
         }
         if record.values.len() != fields.len() {
           return Err(DataShapeValueError::at(
             path,
             format!(
-              "record :{} expects {} value(s), got {}",
+              "struct :{} expects {} value(s), got {}",
               nominal.name,
               fields.len(),
               record.values.len()
@@ -274,7 +274,7 @@ impl DataShapeGraph {
           if record.struct_ref.fields.get(idx) != Some(field) {
             return Err(DataShapeValueError::at(
               path,
-              format!("record :{} field #{idx} does not match :{field}", nominal.name),
+              format!("struct :{} field #{idx} does not match :{field}", nominal.name),
             ));
           }
           self.validate_node_value(*child, item, &format!("{path}.{}", field.ref_str()), depth + 1)?;
@@ -282,13 +282,13 @@ impl DataShapeGraph {
         Ok(())
       }
       DataShapeNode::Enum { nominal, variants, .. } => {
-        let Calcit::Tuple(tuple) = value else {
+        let Calcit::Enum(tuple) = value else {
           return Err(shape_kind_mismatch(path, &format!("enum :{}", nominal.name()), value));
         };
         let Some(actual_enum) = tuple.sum_type.as_ref() else {
           return Err(DataShapeValueError::at(
             path,
-            format!("expected enum :{}, got ordinary tuple", nominal.name()),
+            format!("expected nominal enum :{}, got anonymous enum", nominal.name()),
           ));
         };
         if !Arc::ptr_eq(actual_enum, nominal) {
@@ -353,7 +353,7 @@ impl DataShapeNode {
       Self::Set(_) => "set",
       Self::Map { .. } => "map",
       Self::Ref(_) => "ref",
-      Self::Struct { .. } => "record",
+      Self::Struct { .. } => "struct",
       Self::Enum { .. } => "enum",
     }
   }
@@ -408,7 +408,7 @@ impl GraphBuilder {
         let path = infer_nominal_path(default_ns, nominal.name.ref_str());
         self.build_struct(nominal.clone(), args, path, default_ns)
       }
-      CalcitTypeAnnotation::Record(nominal) => {
+      CalcitTypeAnnotation::StructValue(nominal) => {
         let path = infer_nominal_path(default_ns, nominal.name.ref_str());
         self.build_struct(nominal.clone(), &Arc::new(vec![]), path, default_ns)
       }
@@ -416,10 +416,13 @@ impl GraphBuilder {
         let path = infer_nominal_path(default_ns, nominal.name().ref_str());
         self.build_enum(nominal.clone(), args, path, default_ns)
       }
-      CalcitTypeAnnotation::Tuple(nominal) => {
+      CalcitTypeAnnotation::EnumValue(nominal) => {
         let path = infer_nominal_path(default_ns, nominal.name().ref_str());
         self.build_enum(nominal.clone(), &Arc::new(vec![]), path, default_ns)
       }
+      CalcitTypeAnnotation::StructDef(_) | CalcitTypeAnnotation::EnumDef(_) => Err(unsupported_type(
+        "type-definition values are not closed application data; use the corresponding Struct or Enum instance type",
+      )),
       CalcitTypeAnnotation::TypeRef(name, args) => self.build_named(name, args, default_ns),
       CalcitTypeAnnotation::TypeSlot(name) => match super::resolve_type_slot(name) {
         Some(resolved) => {
@@ -435,7 +438,7 @@ impl GraphBuilder {
       },
       CalcitTypeAnnotation::Dynamic => Err(unsupported_type("Dynamic is forbidden in a closed data shape")),
       CalcitTypeAnnotation::TypeVar(name) => Err(unsupported_type(&format!("generic variable '{name} is not bound"))),
-      CalcitTypeAnnotation::DynTuple => Err(unsupported_type("ordinary tuple has no declared enum schema")),
+      CalcitTypeAnnotation::AnonymousEnum => Err(unsupported_type("anonymous enum has no declared enum schema")),
       CalcitTypeAnnotation::DynFn | CalcitTypeAnnotation::Fn(_) => Err(unsupported_type("function values are not closed data")),
       CalcitTypeAnnotation::Trait(_) | CalcitTypeAnnotation::TraitSet(_) => {
         Err(unsupported_type("trait constraints are not data shapes"))
@@ -482,7 +485,7 @@ impl GraphBuilder {
 
   fn build_struct(
     &mut self,
-    nominal: Arc<CalcitStruct>,
+    nominal: Arc<CalcitStructDef>,
     args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
     nominal_path: Option<(Arc<str>, Arc<str>)>,
     default_ns: &str,
@@ -528,7 +531,7 @@ impl GraphBuilder {
 
   fn build_enum(
     &mut self,
-    nominal: Arc<CalcitEnum>,
+    nominal: Arc<CalcitEnumDef>,
     args: &Arc<Vec<Arc<CalcitTypeAnnotation>>>,
     nominal_path: Option<(Arc<str>, Arc<str>)>,
     default_ns: &str,
@@ -695,10 +698,10 @@ fn update_nominal_fingerprint(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitGenericBound, CalcitImpl, CalcitList, CalcitRecord, CalcitTrait, CalcitTuple};
+  use crate::calcit::{CalcitEnumValue, CalcitGenericBound, CalcitImpl, CalcitList, CalcitStructValue, CalcitTrait};
 
-  fn phantom_box() -> Arc<CalcitStruct> {
-    Arc::new(CalcitStruct {
+  fn phantom_box() -> Arc<CalcitStructDef> {
+    Arc::new(CalcitStructDef {
       name: EdnTag::new("PhantomBox"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -736,7 +739,7 @@ mod tests {
     let dynamic = DataShapeGraph::build(&CalcitTypeAnnotation::Dynamic, "tests.shape").expect_err("dynamic must fail");
     assert!(dynamic.to_string().contains("Dynamic is forbidden"));
 
-    let generic = Arc::new(CalcitStruct {
+    let generic = Arc::new(CalcitStructDef {
       name: EdnTag::new("Box"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
@@ -762,26 +765,26 @@ mod tests {
 
   #[test]
   fn rejects_structurally_equal_but_distinct_nominal_declarations() {
-    let nominal = Arc::new(CalcitStruct::from_fields(EdnTag::new("Point"), vec![]));
+    let nominal = Arc::new(CalcitStructDef::from_fields(EdnTag::new("Point"), vec![]));
     let shape =
       DataShapeGraph::build(&CalcitTypeAnnotation::Struct(nominal.clone(), Arc::new(vec![])), "tests.shape").expect("point shape");
     let impostor = Arc::new((*nominal).clone());
-    let record = Calcit::Record(CalcitRecord {
+    let record = Calcit::Struct(CalcitStructValue {
       struct_ref: impostor,
       values: Arc::new(vec![]),
     });
 
     let error = shape.validate_value(&record).expect_err("distinct struct declaration must fail");
-    assert!(error.message.contains("expected nominal record"), "unexpected error: {error}");
+    assert!(error.message.contains("expected nominal struct"), "unexpected error: {error}");
 
-    let enum_prototype = || CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("Outcome"), vec![EdnTag::new("none")])),
+    let enum_prototype = || CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("Outcome"), vec![EdnTag::new("none")])),
       values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::default()))]),
     };
-    let nominal = Arc::new(CalcitEnum::from_record(enum_prototype()).expect("outcome enum"));
+    let nominal = Arc::new(CalcitEnumDef::from_record(enum_prototype()).expect("outcome enum"));
     let shape = DataShapeGraph::build(&CalcitTypeAnnotation::Enum(nominal, Arc::new(vec![])), "tests.shape").expect("outcome shape");
-    let impostor = Arc::new(CalcitEnum::from_record(enum_prototype()).expect("impostor outcome enum"));
-    let tuple = Calcit::Tuple(CalcitTuple {
+    let impostor = Arc::new(CalcitEnumDef::from_record(enum_prototype()).expect("impostor outcome enum"));
+    let tuple = Calcit::Enum(CalcitEnumValue {
       tag: Arc::new(Calcit::Tag(EdnTag::new("none"))),
       extra: vec![],
       sum_type: Some(impostor),
@@ -794,7 +797,7 @@ mod tests {
   #[test]
   fn enforces_generic_where_bounds_while_deriving() {
     let marker = Arc::new(CalcitTrait::new(EdnTag::new("DataMarker"), vec![], vec![]));
-    let bounded = Arc::new(CalcitStruct {
+    let bounded = Arc::new(CalcitStructDef {
       name: EdnTag::new("MarkedBox"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
@@ -813,7 +816,7 @@ mod tests {
     .expect_err("Number does not implement the nominal marker trait");
     assert!(rejected.to_string().contains("does not satisfy"));
 
-    let mut marked_value = CalcitStruct::from_fields(EdnTag::new("MarkedValue"), vec![]);
+    let mut marked_value = CalcitStructDef::from_fields(EdnTag::new("MarkedValue"), vec![]);
     marked_value.impls.push(Arc::new(CalcitImpl {
       name: EdnTag::new("MarkedValueDataMarker"),
       origin: Some(marker),

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -52,33 +52,33 @@ pub enum CalcitProc {
   NativeTuple,
   #[strum(serialize = "%::")]
   NativeEnumTupleNew,
-  #[strum(serialize = "&tuple:nth")]
+  #[strum(serialize = "&enum:nth")]
   NativeTupleNth,
-  #[strum(serialize = "&tuple:assoc")]
+  #[strum(serialize = "&enum:assoc")]
   NativeTupleAssoc,
-  #[strum(serialize = "&tuple:count")]
+  #[strum(serialize = "&enum:count")]
   NativeTupleCount,
-  #[strum(serialize = "&tuple:impls")]
+  #[strum(serialize = "&enum:impls")]
   NativeTupleImpls,
-  #[strum(serialize = "&tuple:params")]
+  #[strum(serialize = "&enum:params")]
   NativeTupleParams,
-  #[strum(serialize = "&tuple:enum")]
+  #[strum(serialize = "&enum:definition")]
   NativeTupleEnum,
-  #[strum(serialize = "&struct::new")]
+  #[strum(serialize = "&struct-def:new")]
   NativeStructNew,
-  #[strum(serialize = "&enum::new")]
+  #[strum(serialize = "&enum-def:new")]
   NativeEnumNew,
   #[strum(serialize = "&trait::new")]
   NativeTraitNew,
   #[strum(serialize = "&impl::new")]
   NativeImplNew,
-  #[strum(serialize = "&record:impl-traits")]
-  NativeRecordImplTraits,
-  #[strum(serialize = "&tuple:impl-traits")]
-  NativeTupleImplTraits,
   #[strum(serialize = "&struct:impl-traits")]
-  NativeStructImplTraits,
+  NativeRecordImplTraits,
   #[strum(serialize = "&enum:impl-traits")]
+  NativeTupleImplTraits,
+  #[strum(serialize = "&struct-def:impl-traits")]
+  NativeStructImplTraits,
+  #[strum(serialize = "&enum-def:impl-traits")]
   NativeEnumImplTraits,
   #[strum(serialize = "&impl:origin")]
   NativeImplOrigin,
@@ -86,11 +86,11 @@ pub enum CalcitProc {
   NativeImplGet,
   #[strum(serialize = "&impl:nth")]
   NativeImplNth,
-  #[strum(serialize = "&tuple:enum-has-variant?")]
+  #[strum(serialize = "&enum-def:has-variant?")]
   NativeTupleEnumHasVariant,
-  #[strum(serialize = "&tuple:enum-variant-arity")]
+  #[strum(serialize = "&enum-def:variant-arity")]
   NativeTupleEnumVariantArity,
-  #[strum(serialize = "&tuple:validate-enum")]
+  #[strum(serialize = "&enum:validate")]
   NativeTupleValidateEnum,
   #[strum(serialize = "&display-stack")]
   NativeDisplayStack,
@@ -140,10 +140,10 @@ pub enum CalcitProc {
   BoolQuestion,
   #[strum(serialize = "set?")]
   SetQuestion,
-  #[strum(serialize = "tuple?")]
-  TupleQuestion,
-  #[strum(serialize = "record?")]
-  RecordQuestion,
+  #[strum(serialize = "enum?")]
+  EnumQuestion,
+  #[strum(serialize = "struct?")]
+  StructQuestion,
   #[strum(serialize = "fn?")]
   FnQuestion,
   /// to detect syntax `&`
@@ -443,37 +443,37 @@ pub enum CalcitProc {
   NativeRecord,
   #[strum(serialize = "&%{}?")]
   NativeRecordPartial,
-  #[strum(serialize = "&record:with")]
+  #[strum(serialize = "&struct:with")]
   NativeRecordWith,
-  #[strum(serialize = "&record:impls")]
+  #[strum(serialize = "&struct:impls")]
   NativeRecordImpls,
-  #[strum(serialize = "&record:matches?")]
+  #[strum(serialize = "&struct:matches?")]
   NativeRecordMatches,
-  #[strum(serialize = "&record:from-map")]
+  #[strum(serialize = "&struct:from-map")]
   NativeRecordFromMap,
-  #[strum(serialize = "&record:get-name")]
+  #[strum(serialize = "&struct:get-name")]
   NativeRecordGetName,
-  #[strum(serialize = "&record:struct")]
+  #[strum(serialize = "&struct:definition")]
   NativeRecordStruct,
-  #[strum(serialize = "&record:to-map")]
+  #[strum(serialize = "&struct:to-map")]
   NativeRecordToMap,
-  #[strum(serialize = "&record:count")]
+  #[strum(serialize = "&struct:count")]
   NativeRecordCount,
-  #[strum(serialize = "&record:contains?")]
+  #[strum(serialize = "&struct:contains?")]
   NativeRecordContains,
-  #[strum(serialize = "&record:get")]
+  #[strum(serialize = "&struct:get")]
   NativeRecordGet,
-  #[strum(serialize = "&record:nth")]
+  #[strum(serialize = "&struct:nth")]
   NativeRecordNth,
-  #[strum(serialize = "&record:field-tag")]
+  #[strum(serialize = "&struct:field-tag")]
   NativeRecordFieldTag,
-  #[strum(serialize = "&record:assoc")]
+  #[strum(serialize = "&struct:assoc")]
   NativeRecordAssoc,
-  #[strum(serialize = "&record:assoc-at")]
+  #[strum(serialize = "&struct:assoc-at")]
   NativeRecordAssocAt,
-  #[strum(serialize = "&record:with-at")]
+  #[strum(serialize = "&struct:with-at")]
   NativeRecordWithAt,
-  #[strum(serialize = "&record:extend-as")]
+  #[strum(serialize = "&struct:extend-as")]
   NativeRecordExtendAs,
   // type slots
   #[strum(serialize = "deftype-slot")]
@@ -725,11 +725,11 @@ impl CalcitProc {
         return_type: some_tag("bool"),
         arg_types: vec![dynamic_tag()],
       }),
-      TupleQuestion => Some(ProcTypeSignature {
+      EnumQuestion => Some(ProcTypeSignature {
         return_type: some_tag("bool"),
         arg_types: vec![dynamic_tag()],
       }),
-      RecordQuestion => Some(ProcTypeSignature {
+      StructQuestion => Some(ProcTypeSignature {
         return_type: some_tag("bool"),
         arg_types: vec![dynamic_tag()],
       }),
@@ -1115,45 +1115,45 @@ impl CalcitProc {
         arg_types: vec![set_of(type_var("T"))],
       }),
 
-      // === Tuple operations ===
+      // === Enum value operations ===
       NativeTuple => Some(ProcTypeSignature {
-        return_type: some_tag("tuple"),
+        return_type: some_tag("enum"),
         arg_types: vec![dynamic_tag(), variadic_dynamic()],
       }),
       NativeEnumTupleNew => Some(ProcTypeSignature {
-        return_type: some_tag("tuple"),
-        arg_types: vec![some_tag("enum"), some_tag("tag"), variadic_dynamic()],
+        return_type: some_tag("enum"),
+        arg_types: vec![some_tag("enum-def"), some_tag("tag"), variadic_dynamic()],
       }),
       NativeTupleNth => Some(ProcTypeSignature {
         return_type: dynamic_tag(),
-        arg_types: vec![some_tag("tuple"), some_tag("number")],
+        arg_types: vec![some_tag("enum"), some_tag("number")],
       }),
       NativeTupleAssoc => Some(ProcTypeSignature {
-        return_type: some_tag("tuple"),
-        arg_types: vec![some_tag("tuple"), some_tag("number"), dynamic_tag()],
+        return_type: some_tag("enum"),
+        arg_types: vec![some_tag("enum"), some_tag("number"), dynamic_tag()],
       }),
       NativeTupleCount => Some(ProcTypeSignature {
         return_type: some_tag("number"),
-        arg_types: vec![some_tag("tuple")],
+        arg_types: vec![some_tag("enum")],
       }),
       NativeTupleImpls => Some(ProcTypeSignature {
         return_type: some_tag("list"),
-        arg_types: vec![some_tag("tuple")],
+        arg_types: vec![some_tag("enum")],
       }),
       NativeTupleParams => Some(ProcTypeSignature {
         return_type: some_tag("list"),
-        arg_types: vec![some_tag("tuple")],
+        arg_types: vec![some_tag("enum")],
       }),
       NativeTupleEnum => Some(ProcTypeSignature {
-        return_type: optional_tag("enum"),
-        arg_types: vec![some_tag("tuple")],
+        return_type: optional_tag("enum-def"),
+        arg_types: vec![some_tag("enum")],
       }),
       NativeStructNew => Some(ProcTypeSignature {
-        return_type: some_tag("struct"),
+        return_type: some_tag("struct-def"),
         arg_types: vec![some_tag("tag"), variadic_dynamic()],
       }),
       NativeEnumNew => Some(ProcTypeSignature {
-        return_type: some_tag("enum"),
+        return_type: some_tag("enum-def"),
         arg_types: vec![some_tag("tag"), variadic_dynamic()],
       }),
       NativeTraitNew => Some(ProcTypeSignature {
@@ -1177,64 +1177,64 @@ impl CalcitProc {
         arg_types: vec![some_tag("impl"), some_tag("number")],
       }),
       NativeRecordImplTraits => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("record"), variadic_dynamic()],
-      }),
-      NativeTupleImplTraits => Some(ProcTypeSignature {
-        return_type: some_tag("tuple"),
-        arg_types: vec![some_tag("tuple"), variadic_dynamic()],
-      }),
-      NativeStructImplTraits => Some(ProcTypeSignature {
         return_type: some_tag("struct"),
         arg_types: vec![some_tag("struct"), variadic_dynamic()],
       }),
-      NativeEnumImplTraits => Some(ProcTypeSignature {
+      NativeTupleImplTraits => Some(ProcTypeSignature {
         return_type: some_tag("enum"),
         arg_types: vec![some_tag("enum"), variadic_dynamic()],
       }),
+      NativeStructImplTraits => Some(ProcTypeSignature {
+        return_type: some_tag("struct-def"),
+        arg_types: vec![some_tag("struct-def"), variadic_dynamic()],
+      }),
+      NativeEnumImplTraits => Some(ProcTypeSignature {
+        return_type: some_tag("enum-def"),
+        arg_types: vec![some_tag("enum-def"), variadic_dynamic()],
+      }),
       NativeTupleEnumHasVariant => Some(ProcTypeSignature {
         return_type: some_tag("bool"),
-        arg_types: vec![some_tag("enum"), some_tag("tag")],
+        arg_types: vec![some_tag("enum-def"), some_tag("tag")],
       }),
       NativeTupleEnumVariantArity => Some(ProcTypeSignature {
         return_type: some_tag("number"),
-        arg_types: vec![some_tag("enum"), some_tag("tag")],
+        arg_types: vec![some_tag("enum-def"), some_tag("tag")],
       }),
       NativeTupleValidateEnum => Some(ProcTypeSignature {
         return_type: some_tag("nil"),
-        arg_types: vec![some_tag("tuple"), some_tag("tag")],
+        arg_types: vec![some_tag("enum"), some_tag("tag")],
       }),
 
-      // === Record operations ===
+      // === Struct value operations ===
       NativeLooseRecord => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
+        return_type: some_tag("struct"),
         arg_types: vec![variadic_dynamic()],
       }),
       NativeRecord => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("struct"), variadic_dynamic()],
+        return_type: some_tag("struct"),
+        arg_types: vec![some_tag("struct-def"), variadic_dynamic()],
       }),
       NativeRecordPartial => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("struct"), variadic_dynamic()],
+        return_type: some_tag("struct"),
+        arg_types: vec![some_tag("struct-def"), variadic_dynamic()],
       }),
       NativeRecordWith => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("record"), dynamic_tag(), dynamic_tag(), variadic_dynamic()],
+        return_type: some_tag("struct"),
+        arg_types: vec![some_tag("struct"), dynamic_tag(), dynamic_tag(), variadic_dynamic()],
       }),
       NativeRecordAssoc => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("record"), dynamic_tag(), dynamic_tag()],
+        return_type: some_tag("struct"),
+        arg_types: vec![some_tag("struct"), dynamic_tag(), dynamic_tag()],
       }),
       NativeRecordAssocAt => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("record"), some_tag("number"), some_tag("tag"), dynamic_tag()],
+        return_type: some_tag("struct"),
+        arg_types: vec![some_tag("struct"), some_tag("number"), some_tag("tag"), dynamic_tag()],
       }),
       NativeRecordWithAt => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
+        return_type: some_tag("struct"),
         // (record, idx, tag, value, ...) — variadic triples after first arg
         arg_types: vec![
-          some_tag("record"),
+          some_tag("struct"),
           some_tag("number"),
           some_tag("tag"),
           dynamic_tag(),
@@ -1243,51 +1243,51 @@ impl CalcitProc {
       }),
       NativeRecordGet => Some(ProcTypeSignature {
         return_type: dynamic_tag(),
-        arg_types: vec![some_tag("record"), some_tag("tag")],
+        arg_types: vec![some_tag("struct"), some_tag("tag")],
       }),
       NativeRecordNth => Some(ProcTypeSignature {
         return_type: dynamic_tag(),
-        arg_types: vec![some_tag("record"), some_tag("number"), some_tag("tag")],
+        arg_types: vec![some_tag("struct"), some_tag("number"), some_tag("tag")],
       }),
       NativeRecordFieldTag => Some(ProcTypeSignature {
         return_type: some_tag("tag"),
-        arg_types: vec![some_tag("record"), some_tag("number")],
+        arg_types: vec![some_tag("struct"), some_tag("number")],
       }),
       NativeRecordCount => Some(ProcTypeSignature {
         return_type: some_tag("number"),
-        arg_types: vec![some_tag("record")],
+        arg_types: vec![some_tag("struct")],
       }),
       NativeRecordContains => Some(ProcTypeSignature {
         return_type: some_tag("bool"),
-        arg_types: vec![some_tag("record"), dynamic_tag()],
+        arg_types: vec![some_tag("struct"), dynamic_tag()],
       }),
       NativeRecordMatches => Some(ProcTypeSignature {
         return_type: some_tag("bool"),
-        arg_types: vec![some_tag("record"), dynamic_tag()],
+        arg_types: vec![some_tag("struct"), dynamic_tag()],
       }),
       NativeRecordToMap => Some(ProcTypeSignature {
         return_type: map_of(some_tag("tag"), dynamic_tag()),
-        arg_types: vec![some_tag("record")],
+        arg_types: vec![some_tag("struct")],
       }),
       NativeRecordFromMap => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("struct"), some_tag("map")],
+        return_type: some_tag("struct"),
+        arg_types: vec![some_tag("struct-def"), some_tag("map")],
       }),
       NativeRecordGetName => Some(ProcTypeSignature {
         return_type: some_tag("tag"),
-        arg_types: vec![some_tag("record")],
+        arg_types: vec![some_tag("struct")],
       }),
       NativeRecordStruct => Some(ProcTypeSignature {
-        return_type: some_tag("struct"),
-        arg_types: vec![some_tag("record")],
+        return_type: optional_tag("struct-def"),
+        arg_types: vec![some_tag("struct")],
       }),
       NativeRecordImpls => Some(ProcTypeSignature {
         return_type: some_tag("list"),
-        arg_types: vec![some_tag("record")],
+        arg_types: vec![some_tag("struct")],
       }),
       NativeRecordExtendAs => Some(ProcTypeSignature {
-        return_type: some_tag("record"),
-        arg_types: vec![some_tag("record"), some_tag("tag"), some_tag("tag"), dynamic_tag()],
+        return_type: some_tag("struct"),
+        arg_types: vec![some_tag("struct"), some_tag("tag"), some_tag("tag"), dynamic_tag()],
       }),
 
       // === Refs/Atoms ===
@@ -1532,13 +1532,15 @@ mod tests {
     let record_struct = CalcitProc::NativeRecordStruct
       .get_type_signature()
       .expect("record-struct signature");
-    assert_eq!(record_struct.return_type, some_tag("struct"));
+    assert_eq!(record_struct.return_type, optional_tag("struct-def"));
   }
 
   #[test]
   fn nullable_primitives_do_not_shadow_their_typed_public_wrappers() {
     assert_eq!(CalcitProc::from_str("&parse-float"), Ok(CalcitProc::ParseFloat));
     assert_eq!(CalcitProc::from_str("&get-env"), Ok(CalcitProc::GetEnv));
+    assert_eq!(CalcitProc::from_str("&struct:nth"), Ok(CalcitProc::NativeRecordNth));
+    assert_eq!(CalcitProc::from_str("&enum:nth"), Ok(CalcitProc::NativeTupleNth));
     assert!(CalcitProc::from_str("parse-float").is_err());
     assert!(CalcitProc::from_str("get-env").is_err());
   }

--- a/src/calcit/record.rs
+++ b/src/calcit/record.rs
@@ -4,36 +4,36 @@ use cirru_edn::EdnTag;
 
 use crate::Calcit;
 
-use super::CalcitStruct;
+use super::CalcitStructDef;
 
-/// Sentinel name for loose records (records without a declared struct).
-/// Analogous to how CalcitTuple has sum_type: None for untyped tuples.
-pub const LOOSE_RECORD_NAME: &str = "?";
+/// Display-only sentinel for anonymous structs (values without a `StructDef`).
+/// Code must use `is_anonymous` rather than treating `_` as nominal identity.
+pub const ANONYMOUS_STRUCT_NAME: &str = "_";
 
 #[derive(Debug, Clone)]
-pub struct CalcitRecord {
-  pub struct_ref: Arc<CalcitStruct>,
+pub struct CalcitStructValue {
+  pub struct_ref: Arc<CalcitStructDef>,
   pub values: Arc<Vec<Calcit>>,
 }
 
-impl PartialEq for CalcitRecord {
+impl PartialEq for CalcitStructValue {
   fn eq(&self, other: &Self) -> bool {
     self.struct_ref.name == other.struct_ref.name && self.struct_ref.fields == other.struct_ref.fields && self.values == other.values
   }
 }
 
-impl Eq for CalcitRecord {}
+impl Eq for CalcitStructValue {}
 
-impl Default for CalcitRecord {
-  fn default() -> CalcitRecord {
-    CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("record"), vec![])),
+impl Default for CalcitStructValue {
+  fn default() -> CalcitStructValue {
+    CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("record"), vec![])),
       values: Arc::new(vec![]),
     }
   }
 }
 
-impl CalcitRecord {
+impl CalcitStructValue {
   pub fn name(&self) -> &EdnTag {
     &self.struct_ref.name
   }
@@ -42,16 +42,16 @@ impl CalcitRecord {
     &self.struct_ref.fields
   }
 
-  /// Returns true if this record was created with `?{}` (no declared struct).
-  pub fn is_loose(&self) -> bool {
-    self.struct_ref.name.ref_str() == LOOSE_RECORD_NAME
+  /// Returns true when the value has no declared struct definition.
+  pub fn is_anonymous(&self) -> bool {
+    self.struct_ref.name.ref_str() == ANONYMOUS_STRUCT_NAME
   }
 
-  /// Create a loose record from sorted field-value pairs.
+  /// Create an anonymous struct from sorted field-value pairs.
   /// Fields must already be sorted alphabetically.
-  pub fn from_loose_pairs(fields: Vec<EdnTag>, values: Vec<Calcit>) -> Self {
-    CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new(LOOSE_RECORD_NAME), fields)),
+  pub fn from_anonymous_pairs(fields: Vec<EdnTag>, values: Vec<Calcit>) -> Self {
+    CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new(ANONYMOUS_STRUCT_NAME), fields)),
       values: Arc::new(values),
     }
   }
@@ -89,7 +89,7 @@ impl CalcitRecord {
     }
   }
 
-  pub fn extend_field(&self, new_field: &EdnTag, new_tag: &Calcit, new_value: &Calcit) -> Result<CalcitRecord, String> {
+  pub fn extend_field(&self, new_field: &EdnTag, new_tag: &Calcit, new_value: &Calcit) -> Result<CalcitStructValue, String> {
     let mut next_fields: Vec<EdnTag> = Vec::with_capacity(self.struct_ref.fields.len());
     let mut next_values: Vec<Calcit> = Vec::with_capacity(self.struct_ref.fields.len());
     let mut inserted: bool = false;
@@ -129,11 +129,11 @@ impl CalcitRecord {
     let new_name_id: EdnTag = match new_tag {
       Calcit::Str(s) | Calcit::Symbol { sym: s, .. } => EdnTag(s.to_owned()),
       Calcit::Tag(s) => s.to_owned(),
-      _ => return Err("extend-field expected a record name, but received an invalid type".to_string()),
+      _ => return Err("extend-field expected a struct name, but received an invalid type".to_string()),
     };
 
-    Ok(CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(new_name_id, next_fields)),
+    Ok(CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(new_name_id, next_fields)),
       values: Arc::new(next_values),
     })
   }
@@ -145,8 +145,8 @@ mod tests {
 
   #[test]
   fn extend_field_returns_err_on_duplicate_field() {
-    let record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("Person"), vec![EdnTag::new("age")])),
+    let record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("Person"), vec![EdnTag::new("age")])),
       values: Arc::new(vec![Calcit::Number(1.0)]),
     };
 

--- a/src/calcit/sum_type.rs
+++ b/src/calcit/sum_type.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use cirru_edn::EdnTag;
 
-use crate::calcit::{Calcit, CalcitGenericBound, CalcitImpl, CalcitList, CalcitRecord, CalcitStruct, CalcitTypeAnnotation};
+use crate::calcit::{Calcit, CalcitGenericBound, CalcitImpl, CalcitList, CalcitStructDef, CalcitStructValue, CalcitTypeAnnotation};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumVariant {
@@ -22,7 +22,7 @@ impl EnumVariant {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CalcitEnum {
+pub struct CalcitEnumDef {
   name: EdnTag,
   generics: Arc<Vec<Arc<str>>>,
   where_bounds: Arc<Vec<CalcitGenericBound>>,
@@ -33,14 +33,14 @@ pub struct CalcitEnum {
   variant_index: Arc<HashMap<String, usize>>,
 }
 
-impl CalcitEnum {
-  /// Create from a `CalcitRecord` using the old-style enum definition format.
+impl CalcitEnumDef {
+  /// Create from a `CalcitStructValue` using the old-style enum definition format.
   /// The record's fields are variant tags and values are payload type lists.
-  pub fn from_record(record: CalcitRecord) -> Result<Self, String> {
+  pub fn from_record(record: CalcitStructValue) -> Result<Self, String> {
     Self::from_arc(Arc::new(record))
   }
 
-  pub fn from_arc(record: Arc<CalcitRecord>) -> Result<Self, String> {
+  pub fn from_arc(record: Arc<CalcitStructValue>) -> Result<Self, String> {
     let (variants, variant_index) = Self::collect_variants(&record)?;
     let name = record.name().to_owned();
     let generics = record.struct_ref.generics.clone();
@@ -68,9 +68,9 @@ impl CalcitEnum {
     self.where_bounds.as_ref()
   }
 
-  /// Reconstruct a `CalcitRecord` prototype from the enum's data.
+  /// Reconstruct a `CalcitStructValue` prototype from the enum's data.
   /// Used for serialization and backwards-compatibility paths that expect a record.
-  pub fn to_record_prototype(&self) -> CalcitRecord {
+  pub fn to_record_prototype(&self) -> CalcitStructValue {
     let fields: Vec<EdnTag> = self.variants.iter().map(|v| v.tag.clone()).collect();
     let values: Vec<Calcit> = self
       .variants
@@ -84,7 +84,7 @@ impl CalcitEnum {
         }
       })
       .collect();
-    let struct_def = CalcitStruct {
+    let struct_def = CalcitStructDef {
       name: self.name.clone(),
       fields: Arc::new(fields),
       field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); values.len()]),
@@ -92,7 +92,7 @@ impl CalcitEnum {
       where_bounds: self.where_bounds.clone(),
       impls: self.impls.clone(),
     };
-    CalcitRecord {
+    CalcitStructValue {
       struct_ref: Arc::new(struct_def),
       values: Arc::new(values),
     }
@@ -118,7 +118,7 @@ impl CalcitEnum {
     self.variant_index.get(name).map(|idx| &self.variants[*idx])
   }
 
-  fn collect_variants(record: &CalcitRecord) -> Result<(Vec<EnumVariant>, HashMap<String, usize>), String> {
+  fn collect_variants(record: &CalcitStructValue) -> Result<(Vec<EnumVariant>, HashMap<String, usize>), String> {
     let mut variants: Vec<EnumVariant> = Vec::with_capacity(record.fields().len());
     let mut index: HashMap<String, usize> = HashMap::with_capacity(record.fields().len());
     let generics = record.struct_ref.generics.as_ref();
@@ -173,7 +173,7 @@ impl CalcitEnum {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitList, CalcitStruct, CalcitSymbolInfo, CalcitTuple, CalcitTypeAnnotation};
+  use crate::calcit::{CalcitEnumValue, CalcitList, CalcitStructDef, CalcitSymbolInfo, CalcitTypeAnnotation};
 
   fn symbol(name: &str) -> Calcit {
     Calcit::Symbol {
@@ -194,9 +194,9 @@ mod tests {
     Calcit::List(Arc::new(CalcitList::Vector(items)))
   }
 
-  fn sample_enum_record() -> CalcitRecord {
-    CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+  fn sample_enum_record() -> CalcitStructValue {
+    CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::new("Result"),
         vec![EdnTag::new("err"), EdnTag::new("ok")],
       )),
@@ -207,7 +207,7 @@ mod tests {
   #[test]
   fn parses_enum_prototype() {
     let record = sample_enum_record();
-    let enum_proto = CalcitEnum::from_record(record).expect("valid enum");
+    let enum_proto = CalcitEnumDef::from_record(record).expect("valid enum");
 
     assert_eq!(enum_proto.name(), &EdnTag::new("Result"));
     let err_variant = enum_proto.find_variant_by_name("err").expect("err variant");
@@ -221,8 +221,8 @@ mod tests {
 
   #[test]
   fn parses_generic_enum_prototype() {
-    let record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct {
+    let record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef {
         name: EdnTag::new("Result"),
         fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
         field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
@@ -233,7 +233,7 @@ mod tests {
       values: Arc::new(vec![list_from(vec![symbol("E")]), list_from(vec![symbol("T")])]),
     };
 
-    let enum_proto = CalcitEnum::from_record(record).expect("valid generic enum");
+    let enum_proto = CalcitEnumDef::from_record(record).expect("valid generic enum");
     assert_eq!(enum_proto.generics(), &[Arc::from("T"), Arc::from("E")]);
     assert!(matches!(
       enum_proto.find_variant_by_name("ok").and_then(|v| v.payload_types().first()).map(|t| t.as_ref()),
@@ -247,18 +247,18 @@ mod tests {
 
   #[test]
   fn rejects_non_generic_struct_type_args_in_payloads() {
-    let pair = CalcitStruct::from_fields(EdnTag::new("Pair"), vec![EdnTag::new("left"), EdnTag::new("right")]);
-    let applied_pair = Calcit::Tuple(CalcitTuple {
-      tag: Arc::new(Calcit::Struct(pair)),
+    let pair = CalcitStructDef::from_fields(EdnTag::new("Pair"), vec![EdnTag::new("left"), EdnTag::new("right")]);
+    let applied_pair = Calcit::Enum(CalcitEnumValue {
+      tag: Arc::new(Calcit::StructDef(pair)),
       extra: vec![Calcit::tag("number"), Calcit::tag("string")],
       sum_type: None,
     });
-    let record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::new("Wrapped"), vec![EdnTag::new("pair")])),
+    let record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("Wrapped"), vec![EdnTag::new("pair")])),
       values: Arc::new(vec![list_from(vec![applied_pair])]),
     };
 
-    let err = CalcitEnum::from_record(record).expect_err("non-generic struct should reject type args in enum payloads");
+    let err = CalcitEnumDef::from_record(record).expect_err("non-generic struct should reject type args in enum payloads");
     assert!(
       err.contains("enum variant `pair` has invalid payload type annotation")
         && err.contains("struct `Pair` is not generic but received 2 type argument(s)"),

--- a/src/calcit/tuple.rs
+++ b/src/calcit/tuple.rs
@@ -2,16 +2,16 @@ use std::sync::Arc;
 
 use crate::Calcit;
 
-use super::{CalcitEnum, CalcitImpl};
+use super::{CalcitEnumDef, CalcitImpl};
 
 #[derive(Debug, Clone)]
-pub struct CalcitTuple {
+pub struct CalcitEnumValue {
   pub tag: Arc<Calcit>,
   pub extra: Vec<Calcit>,
-  pub sum_type: Option<Arc<CalcitEnum>>,
+  pub sum_type: Option<Arc<CalcitEnumDef>>,
 }
 
-impl CalcitTuple {
+impl CalcitEnumValue {
   pub fn impls(&self) -> &[Arc<CalcitImpl>] {
     match &self.sum_type {
       Some(s) => s.impls(),
@@ -20,10 +20,10 @@ impl CalcitTuple {
   }
 }
 
-impl PartialEq for CalcitTuple {
+impl PartialEq for CalcitEnumValue {
   fn eq(&self, other: &Self) -> bool {
     self.tag == other.tag && self.extra == other.extra
   }
 }
 
-impl Eq for CalcitTuple {}
+impl Eq for CalcitEnumValue {}

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -12,8 +12,8 @@ use std::thread_local;
 use cirru_edn::{Edn, EdnListView, EdnMapView, EdnSetView, EdnTag};
 
 use super::{
-  CORE_NS, Calcit, CalcitEnum, CalcitFn, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitRecord, CalcitStruct,
-  CalcitSymbolInfo, CalcitSyntax, CalcitTrait, CalcitTuple,
+  CORE_NS, Calcit, CalcitEnumDef, CalcitEnumValue, CalcitFn, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitStructDef,
+  CalcitStructValue, CalcitSymbolInfo, CalcitSyntax, CalcitTrait,
 };
 use std::sync::{LazyLock, OnceLock};
 
@@ -268,12 +268,12 @@ pub enum CalcitTypeAnnotation {
   List(Arc<CalcitTypeAnnotation>),
   /// Map type with key and value type annotations
   Map(Arc<CalcitTypeAnnotation>, Arc<CalcitTypeAnnotation>),
-  /// A record value's type, identified by its struct definition
-  Record(Arc<CalcitStruct>),
-  /// A tuple value's type, optionally identified by its sum type enum
-  Tuple(Arc<CalcitEnum>),
-  /// Any tuple type (when specific structure is not known)
-  DynTuple,
+  /// A struct value's inferred type, identified by its struct definition.
+  StructValue(Arc<CalcitStructDef>),
+  /// An enum value's inferred type, identified by its enum definition.
+  EnumValue(Arc<CalcitEnumDef>),
+  /// An anonymous/open enum value whose closed variant set is unknown.
+  AnonymousEnum,
   /// function type without a known signature
   DynFn,
   Fn(Arc<CalcitFnTypeAnnotation>),
@@ -296,9 +296,13 @@ pub enum CalcitTypeAnnotation {
   JsNullish(Arc<CalcitTypeAnnotation>),
   /// Struct type definition, optionally with applied generic arguments.
   /// `args` is empty when used as a bare type annotation (no generics applied).
-  Struct(Arc<CalcitStruct>, Arc<Vec<Arc<CalcitTypeAnnotation>>>),
+  Struct(Arc<CalcitStructDef>, Arc<Vec<Arc<CalcitTypeAnnotation>>>),
   /// Enum type definition, optionally with applied generic arguments.
-  Enum(Arc<CalcitEnum>, Arc<Vec<Arc<CalcitTypeAnnotation>>>),
+  Enum(Arc<CalcitEnumDef>, Arc<Vec<Arc<CalcitTypeAnnotation>>>),
+  /// First-class definition value produced by `defstruct`.
+  StructDef(Arc<CalcitStructDef>),
+  /// First-class definition value produced by `defenum`.
+  EnumDef(Arc<CalcitEnumDef>),
   /// Generic type variable, e.g. 'T
   TypeVar(Arc<str>),
   /// Named type reference kept as source-level syntax, e.g. `'Result` or `(:: 'Result 'T 'E)`.
@@ -404,13 +408,19 @@ impl CalcitTypeAnnotation {
         }
         Ok(())
       }
-      Self::Record(_) | Self::Tuple(_) | Self::Trait(_) | Self::TraitSet(_) | Self::Custom(_) => Ok(()),
+      Self::StructValue(_)
+      | Self::EnumValue(_)
+      | Self::StructDef(_)
+      | Self::EnumDef(_)
+      | Self::Trait(_)
+      | Self::TraitSet(_)
+      | Self::Custom(_) => Ok(()),
       Self::Bool
       | Self::Number
       | Self::String
       | Self::Symbol
       | Self::Tag
-      | Self::DynTuple
+      | Self::AnonymousEnum
       | Self::DynFn
       | Self::Buffer
       | Self::CirruQuote
@@ -443,7 +453,7 @@ impl CalcitTypeAnnotation {
       "list" => Some(Self::List(DYNAMIC_TYPE.clone())),
       "map" => Some(Self::Map(DYNAMIC_TYPE.clone(), DYNAMIC_TYPE.clone())),
       "set" => Some(Self::Set(DYNAMIC_TYPE.clone())),
-      "tuple" => Some(Self::DynTuple),
+      "tuple" | "enum" => Some(Self::AnonymousEnum),
       "fn" => Some(Self::DynFn),
       "ref" => Some(Self::Ref(DYNAMIC_TYPE.clone())),
       "buffer" => Some(Self::Buffer),
@@ -466,7 +476,7 @@ impl CalcitTypeAnnotation {
       Self::Map(_, _) => Some("map"),
       Self::DynFn => Some("fn"),
       Self::Set(_) => Some("set"),
-      Self::DynTuple => Some("tuple"),
+      Self::AnonymousEnum => Some("enum"),
       Self::Ref(_) => Some("ref"),
       Self::Buffer => Some("buffer"),
       Self::CirruQuote => Some("cirru-quote"),
@@ -496,7 +506,9 @@ impl CalcitTypeAnnotation {
       "set" | "Set" => Some("Set"),
       "fn" | "Fn" => Some("Fn"),
       "macro" | "Macro" => Some("Macro"),
-      "tuple" | "Tuple" => Some("Tuple"),
+      // Record/Tuple are accepted only as legacy input spellings. Writers and
+      // diagnostics always use the Struct/Enum value model.
+      "tuple" | "Tuple" | "enum" | "Enum" => Some("Enum"),
       "ref" | "Ref" => Some("Ref"),
       "buffer" | "Buffer" => Some("Buffer"),
       "cirru-quote" | "CirruQuote" => Some("CirruQuote"),
@@ -504,9 +516,9 @@ impl CalcitTypeAnnotation {
       "optional" | "Optional" => Some("Optional"),
       "js-nullish" | "JsNullish" => Some("JsNullish"),
       "&" | "variadic" | "Variadic" => Some("Variadic"),
-      "record" | "Record" => Some("Record"),
-      "struct" | "Struct" => Some("Struct"),
-      "enum" | "Enum" => Some("Enum"),
+      "record" | "Record" | "struct" | "Struct" => Some("Struct"),
+      "struct-def" | "StructDef" => Some("StructDef"),
+      "enum-def" | "EnumDef" => Some("EnumDef"),
       "trait" | "Trait" => Some("Trait"),
       "impl" | "Impl" => Some("Impl"),
       _ => None,
@@ -526,15 +538,16 @@ impl CalcitTypeAnnotation {
       "Map" => Some(Self::Map(DYNAMIC_TYPE.clone(), DYNAMIC_TYPE.clone())),
       "Set" => Some(Self::Set(DYNAMIC_TYPE.clone())),
       "Fn" | "Macro" => Some(Self::DynFn),
-      "Tuple" => Some(Self::DynTuple),
+      "Enum" => Some(Self::AnonymousEnum),
       "Ref" => Some(Self::Ref(DYNAMIC_TYPE.clone())),
       "Buffer" => Some(Self::Buffer),
       "CirruQuote" => Some(Self::CirruQuote),
       "JsObject" => Some(Self::JsObject),
-      "Record" | "Struct" | "Enum" | "Trait" | "Impl" => {
-        let legacy_name = name.trim_start_matches(':').to_ascii_lowercase();
-        Some(Self::Custom(Arc::new(Calcit::tag(&legacy_name))))
-      }
+      "Struct" => Some(Self::Custom(Arc::new(Calcit::tag("struct")))),
+      "StructDef" => Some(Self::Custom(Arc::new(Calcit::tag("struct-def")))),
+      "EnumDef" => Some(Self::Custom(Arc::new(Calcit::tag("enum-def")))),
+      "Trait" => Some(Self::Custom(Arc::new(Calcit::tag("trait")))),
+      "Impl" => Some(Self::Custom(Arc::new(Calcit::tag("impl")))),
       // These forms require a payload and are handled by the type-expression parser.
       "Optional" | "JsNullish" | "Variadic" => None,
       _ => None,
@@ -1217,7 +1230,7 @@ impl CalcitTypeAnnotation {
         }
         Calcit::Map(ys)
       }
-      Edn::Tuple(view) => Calcit::Tuple(CalcitTuple {
+      Edn::Tuple(view) => Calcit::Enum(CalcitEnumValue {
         tag: Arc::new(Self::edn_type_to_calcit(view.tag.as_ref())),
         extra: view.extra.iter().map(Self::edn_type_to_calcit).collect(),
         sum_type: None,
@@ -1654,6 +1667,19 @@ impl CalcitTypeAnnotation {
       return DYNAMIC_TYPE.clone();
     }
 
+    // A definition value used in a type-expression position denotes its
+    // instance type. Runtime expression inference still classifies the same
+    // value as StructDef/EnumDef; this branch is deliberately schema-only.
+    match form {
+      Calcit::StructDef(struct_def) => {
+        return Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def.to_owned()), Arc::new(vec![])));
+      }
+      Calcit::EnumDef(enum_def) => {
+        return Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def.to_owned()), Arc::new(vec![])));
+      }
+      _ => {}
+    }
+
     if let Some(name) = Self::parse_type_var_form(form) {
       if let Some(builtin) = Self::builtin_type_from_symbol_name(&name) {
         return Arc::new(builtin);
@@ -1693,7 +1719,7 @@ impl CalcitTypeAnnotation {
       }
     }
 
-    if let Calcit::Tuple(tuple) = form {
+    if let Calcit::Enum(tuple) = form {
       if let Some(struct_def) = resolve_struct_def(tuple.tag.as_ref()) {
         let args = tuple.extra.iter().map(parse_nested).collect::<Vec<_>>();
         return Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(args)));
@@ -2079,10 +2105,10 @@ impl CalcitTypeAnnotation {
     if let Some(resolved) = resolve_calcit_value(form) {
       match resolved {
         Calcit::Trait(trait_def) => return Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def))),
-        Calcit::Struct(struct_def) if !strict_named_refs => {
+        Calcit::StructDef(struct_def) if !strict_named_refs => {
           return Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(vec![])));
         }
-        Calcit::Enum(enum_def) if !strict_named_refs => {
+        Calcit::EnumDef(enum_def) if !strict_named_refs => {
           return Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def), Arc::new(vec![])));
         }
         _ => {}
@@ -2142,8 +2168,10 @@ impl CalcitTypeAnnotation {
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
-      Self::Record(struct_def) => format!("record {}", struct_def.name),
-      Self::Tuple(enum_def) => format!("enum {}", enum_def.name()),
+      Self::StructDef(struct_def) => format!("struct-def {}", struct_def.name),
+      Self::EnumDef(enum_def) => format!("enum-def {}", enum_def.name()),
+      Self::StructValue(struct_def) => format!("struct {}", struct_def.name),
+      Self::EnumValue(enum_def) => format!("enum {}", enum_def.name()),
       Self::Dynamic => "dynamic".to_string(),
       Self::TypeSlot(name) => format!("type-slot({name})"),
       _ => "unknown".to_string(),
@@ -2211,20 +2239,20 @@ impl CalcitTypeAnnotation {
     }
   }
 
-  /// Try to resolve this type annotation to a concrete `CalcitStruct` definition.
+  /// Try to resolve this type annotation to a concrete `CalcitStructDef` definition.
   /// Works for `Struct(def, _)`, `Record(def)`, and `TypeRef("ns/name", _)` that can be
   /// looked up from the program registry.
-  pub fn resolve_to_struct(&self) -> Option<CalcitStruct> {
+  pub fn resolve_to_struct(&self) -> Option<CalcitStructDef> {
     self.resolve_to_struct_with_ref().map(|(s, _)| s)
   }
 
   /// Resolve to struct, also returning the (ns, def) path when available from a TypeRef.
   /// The path can be used to construct an Import reference for JS codegen compatibility.
   #[allow(clippy::type_complexity)]
-  pub fn resolve_to_struct_with_ref(&self) -> Option<(CalcitStruct, Option<(Arc<str>, Arc<str>)>)> {
+  pub fn resolve_to_struct_with_ref(&self) -> Option<(CalcitStructDef, Option<(Arc<str>, Arc<str>)>)> {
     match self {
       Self::Struct(base, _) => Some((base.as_ref().clone(), None)),
-      Self::Record(base) => Some((base.as_ref().clone(), None)),
+      Self::StructValue(base) => Some((base.as_ref().clone(), None)),
       Self::TypeRef(name, _) => {
         // TypeRef name may be "ns/def" or just "def" — try to split on '/'
         let stripped = name.trim_start_matches('\'').trim_start_matches(':');
@@ -2239,20 +2267,20 @@ impl CalcitTypeAnnotation {
     }
   }
 
-  /// Try to resolve this type annotation to a concrete `CalcitEnum` definition.
+  /// Try to resolve this type annotation to a concrete `CalcitEnumDef` definition.
   /// Works for `Enum(def, _)`, `Tuple(def)`, and `TypeRef("ns/name", _)` that can be
   /// looked up from the program registry.
-  pub fn resolve_to_enum(&self) -> Option<CalcitEnum> {
+  pub fn resolve_to_enum(&self) -> Option<CalcitEnumDef> {
     self.resolve_to_enum_with_ref().map(|(e, _)| e)
   }
 
   /// Resolve to enum, also returning the (ns, def) path when available from a TypeRef.
   /// The path can be used to construct an Import reference for JS codegen compatibility.
   #[allow(clippy::type_complexity)]
-  pub fn resolve_to_enum_with_ref(&self) -> Option<(CalcitEnum, Option<(Arc<str>, Arc<str>)>)> {
+  pub fn resolve_to_enum_with_ref(&self) -> Option<(CalcitEnumDef, Option<(Arc<str>, Arc<str>)>)> {
     match self {
       Self::Enum(base, _) => Some((base.as_ref().clone(), None)),
-      Self::Tuple(base) => Some((base.as_ref().clone(), None)),
+      Self::EnumValue(base) => Some((base.as_ref().clone(), None)),
       Self::TypeRef(name, _) => {
         let stripped = name.trim_start_matches('\'').trim_start_matches(':');
         if let Some((ns, def)) = stripped.rsplit_once('/') {
@@ -2368,8 +2396,8 @@ impl CalcitTypeAnnotation {
 
   fn collect_static_impls(&self) -> Option<Vec<Arc<CalcitImpl>>> {
     match self {
-      Self::Struct(struct_def, _) | Self::Record(struct_def) => Some(struct_def.impls.to_vec()),
-      Self::Enum(enum_def, _) | Self::Tuple(enum_def) => Some(enum_def.impls().to_vec()),
+      Self::Struct(struct_def, _) | Self::StructValue(struct_def) => Some(struct_def.impls.to_vec()),
+      Self::Enum(enum_def, _) | Self::EnumValue(enum_def) => Some(enum_def.impls().to_vec()),
       Self::Optional(inner) => inner.collect_static_impls(),
       Self::TypeRef(name, _) => resolve_type_ref_as_schema(name).and_then(|schema| schema.collect_static_impls()),
       Self::TypeSlot(name) => resolve_type_slot(name).and_then(|bound| bound.collect_static_impls()),
@@ -2394,10 +2422,10 @@ impl CalcitTypeAnnotation {
   /// origins from calcit-core; this table prevents preprocessing order from
   /// changing whether an otherwise identical core call emits a warning.
   fn builtin_core_trait_names(&self) -> &'static [&'static str] {
-    if matches!(self, Self::Record(_) | Self::Struct(_, _)) {
+    if matches!(self, Self::StructValue(_) | Self::Struct(_, _)) {
       return &["Show", "Eq", "Countable", "Contains"];
     }
-    if matches!(self, Self::DynTuple | Self::Tuple(_) | Self::Enum(_, _)) {
+    if matches!(self, Self::AnonymousEnum | Self::EnumValue(_) | Self::Enum(_, _)) {
       return &["Show", "Eq", "Countable", "Contains"];
     }
     match self.core_impl_list_symbol() {
@@ -2563,13 +2591,13 @@ impl CalcitTypeAnnotation {
           (false, true) => Self::bind_declared_generics_from_applied_args(base.generics(), args.as_ref(), bindings),
         }
       }
-      (Self::TypeRef(name, _), Self::Record(base)) | (Self::Record(base), Self::TypeRef(name, _)) => {
+      (Self::TypeRef(name, _), Self::StructValue(base)) | (Self::StructValue(base), Self::TypeRef(name, _)) => {
         // Records are structurally map-like (field name -> value), so procs typed as
         // accepting a generic "map" (e.g. `to-pairs`/`keys`) should also accept records,
         // in addition to matching the record's own type name.
         Self::type_ref_name_matches(name, base.name.ref_str()) || Self::type_ref_name_matches(name, "map")
       }
-      (Self::TypeRef(name, _), Self::Tuple(base)) | (Self::Tuple(base), Self::TypeRef(name, _)) => {
+      (Self::TypeRef(name, _), Self::EnumValue(base)) | (Self::EnumValue(base), Self::TypeRef(name, _)) => {
         Self::type_ref_name_matches(name, base.name().ref_str())
       }
       (Self::Struct(a, a_args), Self::Struct(b, b_args)) => {
@@ -2603,8 +2631,20 @@ impl CalcitTypeAnnotation {
       (Self::TraitSet(actual), Self::TraitSet(expected)) => expected.iter().all(|t| actual.iter().any(|a| a == t)),
       (actual, Self::Trait(expected)) => actual.satisfies_trait_bound(expected.as_ref()),
       (actual, Self::TraitSet(expected)) => actual.satisfies_trait_bounds(expected.as_ref()),
-      (Self::Struct(_, _), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "struct") => true,
-      (Self::Enum(_, _), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "enum") => true,
+      (Self::Struct(_, _), Self::Custom(expected))
+        if Self::custom_keyword_matches(expected, "struct") || Self::custom_keyword_matches(expected, "record") =>
+      {
+        true
+      }
+      (Self::Enum(_, _), Self::Custom(expected))
+        if Self::custom_keyword_matches(expected, "enum") || Self::custom_keyword_matches(expected, "tuple") =>
+      {
+        true
+      }
+      (Self::StructDef(actual), Self::StructDef(expected)) => actual.name == expected.name,
+      (Self::EnumDef(actual), Self::EnumDef(expected)) => actual.name() == expected.name(),
+      (Self::StructDef(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "struct-def") => true,
+      (Self::EnumDef(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "enum-def") => true,
       (Self::Trait(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "trait") => true,
       (Self::TraitSet(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "trait") => true,
       (Self::Custom(actual), Self::Custom(expected))
@@ -2612,8 +2652,8 @@ impl CalcitTypeAnnotation {
       {
         true
       }
-      // DynTuple matches any other DynTuple
-      (Self::DynTuple, Self::DynTuple) => true,
+      // AnonymousEnum matches any other AnonymousEnum
+      (Self::AnonymousEnum, Self::AnonymousEnum) => true,
       // Function type matching: DynFn matches any Fn, specific Fn must match signature
       (Self::Fn(_), Self::DynFn) | (Self::DynFn, Self::Fn(_)) => true,
       // Tags are callable in Calcit (as map key accessors), so they satisfy :fn requirements
@@ -2621,17 +2661,26 @@ impl CalcitTypeAnnotation {
       (Self::Fn(a), Self::Fn(b)) => a.matches_signature(b.as_ref()),
       (Self::Variadic(a), Self::Variadic(b)) => a.matches_with_bindings(b, bindings),
       (Self::Custom(a), Self::Custom(b)) => a.as_ref() == b.as_ref(),
-      (Self::Record(a), Self::Record(b)) => a.name == b.name,
-      (Self::Record(a), Self::Struct(b, _)) => a.name == b.name,
-      (Self::Record(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "record") => true,
-      (Self::Tuple(a), Self::Tuple(b)) => a.name() == b.name(),
-      (Self::Tuple(a), Self::Enum(b, _)) | (Self::Enum(b, _), Self::Tuple(a)) => a.name() == b.name(),
-      (Self::Tuple(_), Self::DynTuple) | (Self::DynTuple, Self::Tuple(_)) => true,
+      (Self::StructValue(a), Self::StructValue(b)) => a.name == b.name,
+      (Self::StructValue(a), Self::Struct(b, _)) => a.name == b.name,
+      (Self::StructValue(_), Self::Custom(expected))
+        if Self::custom_keyword_matches(expected, "record") || Self::custom_keyword_matches(expected, "struct") =>
+      {
+        true
+      }
+      (Self::EnumValue(a), Self::EnumValue(b)) => a.name() == b.name(),
+      (Self::EnumValue(a), Self::Enum(b, _)) | (Self::Enum(b, _), Self::EnumValue(a)) => a.name() == b.name(),
+      (Self::EnumValue(_), Self::Custom(expected))
+        if Self::custom_keyword_matches(expected, "tuple") || Self::custom_keyword_matches(expected, "enum") =>
+      {
+        true
+      }
+      (Self::EnumValue(_), Self::AnonymousEnum) | (Self::AnonymousEnum, Self::EnumValue(_)) => true,
       // Enum values use the tuple runtime representation, so a concrete named
       // enum is safe wherever a builtin proc accepts a dynamic tuple. Keep the
       // relation directional: a dynamic tuple cannot satisfy a named enum.
-      (Self::Enum(_, _), Self::DynTuple) => true,
-      (type_ref @ Self::TypeRef(_, _), Self::DynTuple) => type_ref.resolve_to_enum().is_some(),
+      (Self::Enum(_, _), Self::AnonymousEnum) => true,
+      (type_ref @ Self::TypeRef(_, _), Self::AnonymousEnum) => type_ref.resolve_to_enum().is_some(),
       (type_ref @ Self::TypeRef(_, _), Self::Custom(expected)) | (Self::Custom(expected), type_ref @ Self::TypeRef(_, _))
         if Self::custom_keyword_matches(expected, "record") || Self::custom_keyword_matches(expected, "struct") =>
       {
@@ -2683,10 +2732,10 @@ impl CalcitTypeAnnotation {
       Calcit::List(_) => Self::List(Arc::new(Self::Dynamic)),
       Calcit::Map(_) => Self::Map(Arc::new(Self::Dynamic), Arc::new(Self::Dynamic)),
       Calcit::Set(_) => Self::Set(Arc::new(Self::Dynamic)),
-      Calcit::Record(record) => Self::Record(record.struct_ref.clone()),
-      Calcit::Enum(enum_def) => Self::Enum(Arc::new(enum_def.to_owned()), Arc::new(vec![])),
-      Calcit::Struct(struct_def) => Self::Struct(Arc::new(struct_def.to_owned()), Arc::new(vec![])),
-      Calcit::Tuple(tuple) => {
+      Calcit::Struct(record) => Self::StructValue(record.struct_ref.clone()),
+      Calcit::EnumDef(enum_def) => Self::EnumDef(Arc::new(enum_def.to_owned())),
+      Calcit::StructDef(struct_def) => Self::StructDef(Arc::new(struct_def.to_owned())),
+      Calcit::Enum(tuple) => {
         // Check for special tuple patterns
         if let Calcit::Tag(tag) = tuple.tag.as_ref() {
           let tag_name = tag.ref_str().trim_start_matches(':');
@@ -2701,8 +2750,8 @@ impl CalcitTypeAnnotation {
           }
         }
         match &tuple.sum_type {
-          Some(enum_def) => Self::Tuple(enum_def.clone()),
-          None => Self::DynTuple,
+          Some(enum_def) => Self::EnumValue(enum_def.clone()),
+          None => Self::AnonymousEnum,
         }
       }
       Calcit::Fn { info, .. } => Self::from_calcit_fn(info),
@@ -2728,10 +2777,9 @@ impl CalcitTypeAnnotation {
     if tag_name == "dynamic" {
       Self::Dynamic
     } else {
-      Self::builtin_type_from_tag_name(tag_name).unwrap_or_else(|| match tag_name {
-        "record" | "struct" | "enum" | "trait" | "impl" => Self::Custom(Arc::new(Calcit::tag(tag_name))),
-        _ => Self::Tag,
-      })
+      Self::builtin_type_from_tag_name(tag_name)
+        .or_else(|| Self::builtin_type_from_symbol_name(tag_name))
+        .unwrap_or_else(|| Self::Tag)
     }
   }
 
@@ -2843,25 +2891,25 @@ impl CalcitTypeAnnotation {
 
     match self {
       Self::Fn(_) => Calcit::Tag(EdnTag::from("fn")),
-      Self::Variadic(inner) => Calcit::Tuple(CalcitTuple {
+      Self::Variadic(inner) => Calcit::Enum(CalcitEnumValue {
         tag: Arc::new(Calcit::Tag(EdnTag::from("&"))),
         extra: vec![inner.to_calcit()],
         sum_type: None,
       }),
       Self::Custom(value) => value.as_ref().to_owned(),
-      Self::Optional(inner) => Calcit::Tuple(CalcitTuple {
+      Self::Optional(inner) => Calcit::Enum(CalcitEnumValue {
         tag: Arc::new(Calcit::Tag(EdnTag::from("optional"))),
         extra: vec![inner.to_calcit()],
         sum_type: None,
       }),
-      Self::JsNullish(inner) => Calcit::Tuple(CalcitTuple {
+      Self::JsNullish(inner) => Calcit::Enum(CalcitEnumValue {
         tag: Arc::new(Calcit::Tag(EdnTag::from("js-nullish"))),
         extra: vec![inner.to_calcit()],
         sum_type: None,
       }),
       Self::Struct(struct_def, args) => {
         if args.is_empty() {
-          Calcit::Struct((**struct_def).clone())
+          Calcit::StructDef((**struct_def).clone())
         } else {
           let mut items = Vec::with_capacity(args.len() + 2);
           items.push(Self::make_symbol("::"));
@@ -2887,7 +2935,9 @@ impl CalcitTypeAnnotation {
           Calcit::List(Arc::new(CalcitList::from(items.as_slice())))
         }
       }
-      Self::Enum(enum_def, _) => Calcit::Enum((**enum_def).clone()),
+      Self::Enum(enum_def, _) => Calcit::EnumDef((**enum_def).clone()),
+      Self::StructDef(struct_def) => Calcit::StructDef((**struct_def).clone()),
+      Self::EnumDef(enum_def) => Calcit::EnumDef((**enum_def).clone()),
       Self::Trait(trait_def) => Calcit::Trait((**trait_def).clone()),
       Self::TraitSet(_) => Calcit::Nil,
       Self::Dynamic => Calcit::Tag(EdnTag::from("dynamic")),
@@ -2908,7 +2958,7 @@ impl CalcitTypeAnnotation {
       Self::Symbol => Edn::Symbol(Arc::from("Symbol")),
       Self::Tag => Edn::Symbol(Arc::from("Tag")),
       Self::DynFn => Edn::Symbol(Arc::from("Fn")),
-      Self::DynTuple => Edn::Symbol(Arc::from("Tuple")),
+      Self::AnonymousEnum => Edn::Symbol(Arc::from("Enum")),
       Self::Buffer => Edn::Symbol(Arc::from("Buffer")),
       Self::CirruQuote => Edn::Symbol(Arc::from("CirruQuote")),
       Self::JsObject => Edn::Symbol(Arc::from("JsObject")),
@@ -2982,8 +3032,10 @@ impl CalcitTypeAnnotation {
       Self::Custom(value) => calcit_type_to_edn(value.as_ref()),
       // Enum / Trait variants – use the name as a symbol
       Self::Enum(e, _) => Edn::Symbol(Arc::from(e.name().ref_str())),
-      Self::Record(struct_def) => Edn::Symbol(Arc::from(struct_def.name.ref_str())),
-      Self::Tuple(enum_def) => Edn::Symbol(Arc::from(enum_def.name().ref_str())),
+      Self::StructDef(_) => Edn::Symbol(Arc::from("StructDef")),
+      Self::EnumDef(_) => Edn::Symbol(Arc::from("EnumDef")),
+      Self::StructValue(struct_def) => Edn::Symbol(Arc::from(struct_def.name.ref_str())),
+      Self::EnumValue(enum_def) => Edn::Symbol(Arc::from(enum_def.name().ref_str())),
       Self::Trait(trait_def) => Edn::Symbol(Arc::from(trait_def.name.ref_str())),
       Self::TypeSlot(name) => Edn::Symbol(Arc::from(format!("*{name}"))),
       // Anything else falls back to dynamic
@@ -2991,26 +3043,26 @@ impl CalcitTypeAnnotation {
     }
   }
 
-  pub fn as_record(&self) -> Option<&CalcitStruct> {
+  pub fn as_record(&self) -> Option<&CalcitStructDef> {
     self.as_struct()
   }
 
-  pub fn as_tuple(&self) -> Option<&CalcitEnum> {
+  pub fn as_tuple(&self) -> Option<&CalcitEnumDef> {
     match self {
-      Self::Tuple(enum_def) => Some(enum_def),
+      Self::EnumValue(enum_def) => Some(enum_def),
       Self::Enum(enum_def, _) => Some(enum_def),
       Self::Optional(inner) => inner.as_tuple(),
       _ => None,
     }
   }
 
-  pub fn as_struct(&self) -> Option<&CalcitStruct> {
+  pub fn as_struct(&self) -> Option<&CalcitStructDef> {
     match self {
-      Self::Record(struct_def) => Some(struct_def),
+      Self::StructValue(struct_def) => Some(struct_def),
       Self::Struct(struct_def, _) => Some(struct_def),
       Self::Custom(value) => match value.as_ref() {
-        Calcit::Record(record) => Some(record.struct_ref.as_ref()),
-        Calcit::Struct(struct_def) => Some(struct_def),
+        Calcit::Struct(record) => Some(record.struct_ref.as_ref()),
+        Calcit::StructDef(struct_def) => Some(struct_def),
         _ => None,
       },
       Self::Optional(inner) => inner.as_struct(),
@@ -3098,8 +3150,8 @@ impl CalcitTypeAnnotation {
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
-      Self::Record(struct_def) => format!("record {}", struct_def.name),
-      Self::Tuple(enum_def) => format!("enum {}", enum_def.name()),
+      Self::StructValue(struct_def) => format!("struct {}", struct_def.name),
+      Self::EnumValue(enum_def) => format!("enum {}", enum_def.name()),
       Self::Dynamic => "dynamic".to_string(),
       Self::TypeSlot(name) => format!("type-slot({name})"),
       _ => "unknown".to_string(),
@@ -3119,9 +3171,9 @@ impl CalcitTypeAnnotation {
       Self::Ref(_) => 9,
       Self::Buffer => 10,
       Self::CirruQuote => 11,
-      Self::Record(_) => 12,
-      Self::Tuple(_) => 13,
-      Self::DynTuple => 14,
+      Self::StructValue(_) => 12,
+      Self::EnumValue(_) => 13,
+      Self::AnonymousEnum => 14,
       Self::Fn(_) => 15,
       Self::Set(_) => 16,
       Self::Variadic(_) => 17,
@@ -3138,11 +3190,13 @@ impl CalcitTypeAnnotation {
       Self::Unit => 28,
       Self::JsObject => 29,
       Self::TypeSlot(_) => 30,
+      Self::StructDef(_) => 31,
+      Self::EnumDef(_) => 32,
     }
   }
 }
 
-fn resolve_struct_annotation(struct_form: &Calcit, class_form: Option<&Calcit>) -> Option<CalcitStruct> {
+fn resolve_struct_annotation(struct_form: &Calcit, class_form: Option<&Calcit>) -> Option<CalcitStructDef> {
   let mut struct_def = resolve_struct_def(struct_form)?;
   if let Some(class_record) = class_form.and_then(resolve_record_def) {
     struct_def.impls = vec![Arc::new(CalcitImpl::from_record(&class_record))];
@@ -3150,7 +3204,7 @@ fn resolve_struct_annotation(struct_form: &Calcit, class_form: Option<&Calcit>) 
   Some(struct_def)
 }
 
-fn resolve_enum_annotation(enum_form: &Calcit, class_form: Option<&Calcit>) -> Option<CalcitEnum> {
+fn resolve_enum_annotation(enum_form: &Calcit, class_form: Option<&Calcit>) -> Option<CalcitEnumDef> {
   let mut enum_def = resolve_enum_def(enum_form)?;
   if let Some(class_record) = class_form.and_then(resolve_record_def) {
     enum_def.set_impls(vec![Arc::new(CalcitImpl::from_record(&class_record))]);
@@ -3158,13 +3212,13 @@ fn resolve_enum_annotation(enum_form: &Calcit, class_form: Option<&Calcit>) -> O
   Some(enum_def)
 }
 
-fn resolve_struct_def(form: &Calcit) -> Option<CalcitStruct> {
+fn resolve_struct_def(form: &Calcit) -> Option<CalcitStructDef> {
   match form {
-    Calcit::Struct(struct_def) => Some(struct_def.to_owned()),
-    Calcit::Record(record) => Some(record.struct_ref.as_ref().to_owned()),
+    Calcit::StructDef(struct_def) => Some(struct_def.to_owned()),
+    Calcit::Struct(record) => Some(record.struct_ref.as_ref().to_owned()),
     _ => resolve_calcit_value(form).and_then(|value| match value {
-      Calcit::Struct(struct_def) => Some(struct_def),
-      Calcit::Record(record) => Some(record.struct_ref.as_ref().to_owned()),
+      Calcit::StructDef(struct_def) => Some(struct_def),
+      Calcit::Struct(record) => Some(record.struct_ref.as_ref().to_owned()),
       _ => None,
     }),
   }
@@ -3172,19 +3226,19 @@ fn resolve_struct_def(form: &Calcit) -> Option<CalcitStruct> {
 
 /// Resolve a struct definition by namespace and definition name from the program registry.
 /// Used by `CalcitTypeAnnotation::resolve_to_struct` to look up `TypeRef("ns/def")` at compile time.
-fn resolve_struct_from_program(ns: &str, def: &str) -> Option<CalcitStruct> {
+fn resolve_struct_from_program(ns: &str, def: &str) -> Option<CalcitStructDef> {
   lookup_runtime_ready_registered(ns, def)
     .and_then(|value| match &value {
-      Calcit::Struct(s) => Some(s.to_owned()),
+      Calcit::StructDef(s) => Some(s.to_owned()),
       _ => resolve_type_def_from_code(&value).and_then(|resolved| match resolved {
-        Calcit::Struct(s) => Some(s),
+        Calcit::StructDef(s) => Some(s),
         _ => None,
       }),
     })
     .or_else(|| {
       lookup_def_code_registered(ns, def).and_then(|code| {
         resolve_type_def_from_code(&code).and_then(|resolved| match resolved {
-          Calcit::Struct(s) => Some(s),
+          Calcit::StructDef(s) => Some(s),
           _ => None,
         })
       })
@@ -3193,45 +3247,45 @@ fn resolve_struct_from_program(ns: &str, def: &str) -> Option<CalcitStruct> {
 
 /// Resolve an enum definition by namespace and definition name from the program registry.
 /// Used by `CalcitTypeAnnotation::resolve_to_enum` to look up `TypeRef("ns/def")` at compile time.
-fn resolve_enum_from_program(ns: &str, def: &str) -> Option<CalcitEnum> {
+fn resolve_enum_from_program(ns: &str, def: &str) -> Option<CalcitEnumDef> {
   lookup_runtime_ready_registered(ns, def)
     .and_then(|value| match &value {
-      Calcit::Enum(e) => Some(e.to_owned()),
-      Calcit::Record(record) => CalcitEnum::from_record(record.to_owned()).ok(),
+      Calcit::EnumDef(e) => Some(e.to_owned()),
+      Calcit::Struct(record) => CalcitEnumDef::from_record(record.to_owned()).ok(),
       _ => resolve_type_def_from_code(&value).and_then(|resolved| match resolved {
-        Calcit::Enum(e) => Some(e),
-        Calcit::Record(record) => CalcitEnum::from_record(record).ok(),
+        Calcit::EnumDef(e) => Some(e),
+        Calcit::Struct(record) => CalcitEnumDef::from_record(record).ok(),
         _ => None,
       }),
     })
     .or_else(|| {
       lookup_def_code_registered(ns, def).and_then(|code| {
         resolve_type_def_from_code(&code).and_then(|resolved| match resolved {
-          Calcit::Enum(e) => Some(e),
-          Calcit::Record(record) => CalcitEnum::from_record(record).ok(),
+          Calcit::EnumDef(e) => Some(e),
+          Calcit::Struct(record) => CalcitEnumDef::from_record(record).ok(),
           _ => None,
         })
       })
     })
 }
 
-fn resolve_enum_def(form: &Calcit) -> Option<CalcitEnum> {
+fn resolve_enum_def(form: &Calcit) -> Option<CalcitEnumDef> {
   match form {
-    Calcit::Enum(enum_def) => Some(enum_def.to_owned()),
-    Calcit::Record(record) => CalcitEnum::from_record(record.to_owned()).ok(),
+    Calcit::EnumDef(enum_def) => Some(enum_def.to_owned()),
+    Calcit::Struct(record) => CalcitEnumDef::from_record(record.to_owned()).ok(),
     _ => resolve_calcit_value(form).and_then(|value| match value {
-      Calcit::Enum(enum_def) => Some(enum_def),
-      Calcit::Record(record) => CalcitEnum::from_record(record).ok(),
+      Calcit::EnumDef(enum_def) => Some(enum_def),
+      Calcit::Struct(record) => CalcitEnumDef::from_record(record).ok(),
       _ => None,
     }),
   }
 }
 
-fn resolve_record_def(form: &Calcit) -> Option<CalcitRecord> {
+fn resolve_record_def(form: &Calcit) -> Option<CalcitStructValue> {
   match form {
-    Calcit::Record(record) => Some(record.to_owned()),
+    Calcit::Struct(record) => Some(record.to_owned()),
     _ => resolve_calcit_value(form).and_then(|value| match value {
-      Calcit::Record(record) => Some(record),
+      Calcit::Struct(record) => Some(record),
       _ => None,
     }),
   }
@@ -3245,7 +3299,7 @@ fn calcit_type_to_edn(form: &Calcit) -> Edn {
     Calcit::Tag(t) => Edn::Tag(t.clone()),
     Calcit::Symbol { sym, .. } => Edn::Symbol(sym.clone()),
     Calcit::List(xs) => Edn::List(EdnListView(xs.iter().map(calcit_type_to_edn).collect())),
-    Calcit::Tuple(t) => Edn::tuple(calcit_type_to_edn(t.tag.as_ref()), t.extra.iter().map(calcit_type_to_edn).collect()),
+    Calcit::Enum(t) => Edn::tuple(calcit_type_to_edn(t.tag.as_ref()), t.extra.iter().map(calcit_type_to_edn).collect()),
     _ => Edn::Nil,
   }
 }
@@ -3281,10 +3335,10 @@ fn resolve_type_def_from_code(code: &Calcit) -> Option<Calcit> {
     return resolve_type_def_from_code(value);
   }
   if is_defstruct_head(head) || is_struct_new_head(head) {
-    return parse_defstruct_code(items.as_ref()).map(Calcit::Struct);
+    return parse_defstruct_code(items.as_ref()).map(Calcit::StructDef);
   }
   if is_defenum_head(head) || is_enum_new_head(head) {
-    return parse_defenum_code(items.as_ref()).map(Calcit::Enum);
+    return parse_defenum_code(items.as_ref()).map(Calcit::EnumDef);
   }
   None
 }
@@ -3311,14 +3365,14 @@ fn is_defenum_head(head: &Calcit) -> bool {
 
 fn is_struct_new_head(head: &Calcit) -> bool {
   matches!(head, Calcit::Proc(CalcitProc::NativeStructNew))
-    || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "&struct::new")
-    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "&struct::new")
+    || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "&struct-def:new")
+    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "&struct-def:new")
 }
 
 fn is_enum_new_head(head: &Calcit) -> bool {
   matches!(head, Calcit::Proc(CalcitProc::NativeEnumNew))
-    || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "&enum::new")
-    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "&enum::new")
+    || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "&enum-def:new")
+    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "&enum-def:new")
 }
 
 fn parse_type_name(form: &Calcit) -> Option<EdnTag> {
@@ -3335,7 +3389,7 @@ fn is_list_literal_head(head: &Calcit) -> bool {
     || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "[]")
 }
 
-fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStruct> {
+fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStructDef> {
   let name_form = items.get(1)?;
   let name = parse_type_name(name_form)?;
   let mut generics: Vec<Arc<str>> = vec![];
@@ -3387,7 +3441,7 @@ fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStruct> {
   let field_names: Vec<EdnTag> = fields.iter().map(|(name, _)| name.to_owned()).collect();
   let field_types: Vec<Arc<CalcitTypeAnnotation>> = fields.iter().map(|(_, t)| t.to_owned()).collect();
 
-  Some(CalcitStruct {
+  Some(CalcitStructDef {
     name,
     fields: Arc::new(field_names),
     field_types: Arc::new(field_types),
@@ -3397,7 +3451,7 @@ fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStruct> {
   })
 }
 
-fn parse_defenum_code(items: &CalcitList) -> Option<CalcitEnum> {
+fn parse_defenum_code(items: &CalcitList) -> Option<CalcitEnumDef> {
   let name_form = items.get(1)?;
   let name = parse_type_name(name_form)?;
   let mut generics: Vec<Arc<str>> = vec![];
@@ -3448,14 +3502,14 @@ fn parse_defenum_code(items: &CalcitList) -> Option<CalcitEnum> {
   let values: Vec<Calcit> = variants.iter().map(|(_, value)| value.to_owned()).collect();
   generics.sort();
   generics.dedup();
-  let mut struct_ref = CalcitStruct::from_fields(name, fields);
+  let mut struct_ref = CalcitStructDef::from_fields(name, fields);
   struct_ref.generics = Arc::new(generics);
   struct_ref.where_bounds = Arc::new(where_bounds);
-  let record = CalcitRecord {
+  let record = CalcitStructValue {
     struct_ref: Arc::new(struct_ref),
     values: Arc::new(values),
   };
-  CalcitEnum::from_record(record).ok()
+  CalcitEnumDef::from_record(record).ok()
 }
 
 fn resolve_calcit_value(form: &Calcit) -> Option<Calcit> {
@@ -3611,10 +3665,10 @@ mod tests {
     );
   }
 
-  fn generic_result_enum() -> Arc<CalcitEnum> {
+  fn generic_result_enum() -> Arc<CalcitEnumDef> {
     Arc::new(
-      CalcitEnum::from_record(CalcitRecord {
-        struct_ref: Arc::new(CalcitStruct {
+      CalcitEnumDef::from_record(CalcitStructValue {
+        struct_ref: Arc::new(CalcitStructDef {
           name: EdnTag::new("Result"),
           fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
           field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
@@ -3629,6 +3683,40 @@ mod tests {
       })
       .expect("valid generic enum"),
     )
+  }
+
+  #[test]
+  fn struct_and_enum_definitions_do_not_match_instance_types() {
+    let person = Arc::new(CalcitStructDef::from_fields(EdnTag::new("Person"), vec![EdnTag::new("name")]));
+    let result = generic_result_enum();
+
+    let person_def = CalcitTypeAnnotation::StructDef(person.clone());
+    let person_value = CalcitTypeAnnotation::StructValue(person.clone());
+    let result_def = CalcitTypeAnnotation::EnumDef(result.clone());
+    let result_value = CalcitTypeAnnotation::EnumValue(result.clone());
+
+    assert!(!person_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Struct")));
+    assert!(person_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("StructDef")));
+    assert!(person_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Struct")));
+    assert!(!person_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("StructDef")));
+
+    assert!(!result_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Enum")));
+    assert!(result_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("EnumDef")));
+    assert!(result_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Enum")));
+    assert!(!result_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("EnumDef")));
+
+    assert_eq!(person_def.to_brief_string(), "struct-def Person");
+    assert_eq!(result_def.to_brief_string(), "enum-def Result");
+
+    let person_definition = Calcit::StructDef(person.as_ref().clone());
+    let person_instance = Calcit::Struct(CalcitStructValue {
+      struct_ref: person.clone(),
+      values: Arc::new(vec![Calcit::Str(Arc::from("Ada"))]),
+    });
+    assert!(value_matches_type_annotation(&person_definition, &person_def));
+    assert!(!value_matches_type_annotation(&person_definition, &person_value));
+    assert!(value_matches_type_annotation(&person_instance, &person_value));
+    assert!(!value_matches_type_annotation(&person_instance, &person_def));
   }
 
   #[test]
@@ -3669,8 +3757,8 @@ mod tests {
     // Records are field-name -> value, structurally map-like, so a proc typed
     // as accepting a generic "map" (e.g. `to-pairs`/`keys`) should not warn
     // when called with a record. See RFC 07-19-type-introspection-consistency.
-    let record_struct = CalcitStruct::from_fields(EdnTag::new("Person"), vec![EdnTag::new("name")]);
-    let record_type = CalcitTypeAnnotation::Record(Arc::new(record_struct));
+    let record_struct = CalcitStructDef::from_fields(EdnTag::new("Person"), vec![EdnTag::new("name")]);
+    let record_type = CalcitTypeAnnotation::StructValue(Arc::new(record_struct));
     let map_type = CalcitTypeAnnotation::TypeRef(Arc::from("map"), Arc::new(vec![]));
 
     let mut bindings = TypeBindings::new();
@@ -4242,7 +4330,7 @@ mod tests {
     let Some(Edn::Map(map)) = view.extra.first() else {
       panic!("wrapped schema payload should be a map");
     };
-    assert!(matches!(map.tag_get("return"), Some(Edn::Symbol(name)) if name.as_ref() == "Record"));
+    assert!(matches!(map.tag_get("return"), Some(Edn::Symbol(name)) if name.as_ref() == "Struct"));
   }
 
   #[test]
@@ -4287,7 +4375,7 @@ mod tests {
 
   #[test]
   fn rejects_type_args_on_non_generic_struct_annotation() {
-    let pair = CalcitStruct {
+    let pair = CalcitStructDef {
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -4308,7 +4396,7 @@ mod tests {
 
   #[test]
   fn rejects_wrong_arity_on_generic_struct_annotation() {
-    let pair = CalcitStruct {
+    let pair = CalcitStructDef {
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -4329,7 +4417,7 @@ mod tests {
 
   #[test]
   fn matching_named_struct_ref_binds_generic_args_from_struct_annotation() {
-    let pair = Arc::new(CalcitStruct {
+    let pair = Arc::new(CalcitStructDef {
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -4351,7 +4439,7 @@ mod tests {
 
   #[test]
   fn matching_bare_struct_annotation_binds_generic_args_from_named_struct_ref() {
-    let pair = Arc::new(CalcitStruct {
+    let pair = Arc::new(CalcitStructDef {
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -4407,7 +4495,7 @@ mod tests {
       generic_result_enum(),
       Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
     );
-    let tuple = CalcitTypeAnnotation::DynTuple;
+    let tuple = CalcitTypeAnnotation::AnonymousEnum;
 
     assert!(named.matches_annotation(&tuple));
     assert!(!tuple.matches_annotation(&named));
@@ -4432,7 +4520,7 @@ mod tests {
       Calcit::from(vec![symbol("impl-traits"), enum_form, symbol("ResultMethods")]),
     ]);
 
-    assert!(matches!(resolve_type_def_from_code(&wrapped), Some(Calcit::Enum(_))));
+    assert!(matches!(resolve_type_def_from_code(&wrapped), Some(Calcit::EnumDef(_))));
   }
 
   #[test]
@@ -4509,7 +4597,7 @@ mod tests {
   #[test]
   fn concrete_struct_matches_struct_category() {
     let actual = CalcitTypeAnnotation::Struct(
-      Arc::new(CalcitStruct::from_fields(EdnTag::new("Person"), vec![EdnTag::new("name")])),
+      Arc::new(CalcitStructDef::from_fields(EdnTag::new("Person"), vec![EdnTag::new("name")])),
       Arc::new(vec![]),
     );
     let expected = CalcitTypeAnnotation::from_tag_name("struct");
@@ -4541,16 +4629,16 @@ impl Hash for CalcitTypeAnnotation {
         k.hash(state);
         v.hash(state);
       }
-      Self::Record(struct_def) => {
+      Self::StructValue(struct_def) => {
         "record".hash(state);
         struct_def.name.hash(state);
         struct_def.fields.hash(state);
       }
-      Self::Tuple(enum_def) => {
-        "tuple".hash(state);
+      Self::EnumValue(enum_def) => {
+        "enum-value".hash(state);
         enum_def.name().hash(state);
       }
-      Self::DynTuple => "dyntuple".hash(state),
+      Self::AnonymousEnum => "dyntuple".hash(state),
       Self::DynFn => "dynfn".hash(state),
       Self::Fn(signature) => {
         "function".hash(state);
@@ -4593,6 +4681,13 @@ impl Hash for CalcitTypeAnnotation {
         struct_def.generics.hash(state);
         args.hash(state);
       }
+      Self::StructDef(struct_def) => {
+        "struct-def".hash(state);
+        struct_def.name.hash(state);
+        struct_def.fields.hash(state);
+        struct_def.field_types.hash(state);
+        struct_def.generics.hash(state);
+      }
       Self::TypeVar(name) => {
         "typevar".hash(state);
         name.hash(state);
@@ -4606,6 +4701,10 @@ impl Hash for CalcitTypeAnnotation {
         "enum".hash(state);
         enum_def.name().hash(state);
         args.hash(state);
+      }
+      Self::EnumDef(enum_def) => {
+        "enum-def".hash(state);
+        enum_def.name().hash(state);
       }
       Self::Trait(trait_def) => {
         "trait".hash(state);
@@ -4651,8 +4750,8 @@ impl Ord for CalcitTypeAnnotation {
       | (Self::CirruQuote, Self::CirruQuote) => Ordering::Equal,
       (Self::List(a), Self::List(b)) => a.cmp(b),
       (Self::Map(ak, av), Self::Map(bk, bv)) => ak.cmp(bk).then_with(|| av.cmp(bv)),
-      (Self::Record(a), Self::Record(b)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
-      (Self::Tuple(a), Self::Tuple(b)) => a.name().cmp(b.name()),
+      (Self::StructValue(a), Self::StructValue(b)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
+      (Self::EnumValue(a), Self::EnumValue(b)) => a.name().cmp(b.name()),
       (Self::Fn(a), Self::Fn(b)) => a
         .generics
         .cmp(&b.generics)
@@ -4669,6 +4768,8 @@ impl Ord for CalcitTypeAnnotation {
       (Self::TypeRef(a_name, a_args), Self::TypeRef(b_name, b_args)) => a_name.cmp(b_name).then_with(|| a_args.cmp(b_args)),
       (Self::Struct(a, _), Self::Struct(b, _)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
       (Self::Enum(a, _), Self::Enum(b, _)) => a.name().cmp(b.name()),
+      (Self::StructDef(a), Self::StructDef(b)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
+      (Self::EnumDef(a), Self::EnumDef(b)) => a.name().cmp(b.name()),
       (Self::Trait(a), Self::Trait(b)) => a.name.cmp(&b.name),
       (Self::TraitSet(a), Self::TraitSet(b)) => a.iter().map(|t| &t.name).cmp(b.iter().map(|t| &t.name)),
       _ => Ordering::Equal, // other variants already separated by kind order
@@ -4989,50 +5090,54 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
     CalcitTypeAnnotation::Ref(_) => matches!(value, Calcit::Ref(..)),
     CalcitTypeAnnotation::Buffer => matches!(value, Calcit::Buffer(_)),
     CalcitTypeAnnotation::CirruQuote => matches!(value, Calcit::CirruQuote(_)),
-    CalcitTypeAnnotation::DynTuple => matches!(value, Calcit::Tuple(_)),
+    CalcitTypeAnnotation::AnonymousEnum => matches!(value, Calcit::Enum(_)),
     CalcitTypeAnnotation::DynFn | CalcitTypeAnnotation::Fn(_) => matches!(value, Calcit::Fn { .. } | Calcit::Proc(_)),
     CalcitTypeAnnotation::Struct(expected_struct, _) => match value {
-      Calcit::Struct(s) => s.name == expected_struct.name,
-      Calcit::Record(r) => r.struct_ref.name == expected_struct.name,
+      Calcit::Struct(r) => r.struct_ref.name == expected_struct.name,
       _ => false,
     },
     CalcitTypeAnnotation::Enum(expected_enum, _) => match value {
-      Calcit::Enum(e) => e.name() == expected_enum.name(),
-      Calcit::Tuple(t) => t.sum_type.as_ref().is_some_and(|st| st.name() == expected_enum.name()),
+      Calcit::Enum(t) => t.sum_type.as_ref().is_some_and(|st| st.name() == expected_enum.name()),
       _ => false,
     },
     CalcitTypeAnnotation::TypeRef(expected_name, _) => match value {
-      Calcit::Struct(s) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, s.name.ref_str()),
-      Calcit::Record(r) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, r.struct_ref.name.ref_str()),
-      Calcit::Enum(e) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, e.name().ref_str()),
-      Calcit::Tuple(t) => t
+      Calcit::Struct(r) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, r.struct_ref.name.ref_str()),
+      Calcit::Enum(t) => t
         .sum_type
         .as_ref()
         .is_some_and(|st| CalcitTypeAnnotation::type_ref_name_matches(expected_name, st.name().ref_str())),
       _ => false,
     },
-    CalcitTypeAnnotation::Record(expected_struct) => match value {
-      Calcit::Record(r) => r.struct_ref.name == expected_struct.name,
+    CalcitTypeAnnotation::StructDef(expected_struct) => match value {
+      Calcit::StructDef(struct_def) => struct_def.name == expected_struct.name,
       _ => false,
     },
-    CalcitTypeAnnotation::Tuple(expected_enum) => match value {
-      Calcit::Tuple(t) => t.sum_type.as_ref().is_some_and(|st| st.name() == expected_enum.name()),
+    CalcitTypeAnnotation::EnumDef(expected_enum) => match value {
+      Calcit::EnumDef(enum_def) => enum_def.name() == expected_enum.name(),
+      _ => false,
+    },
+    CalcitTypeAnnotation::StructValue(expected_struct) => match value {
+      Calcit::Struct(r) => r.struct_ref.name == expected_struct.name,
+      _ => false,
+    },
+    CalcitTypeAnnotation::EnumValue(expected_enum) => match value {
+      Calcit::Enum(t) => t.sum_type.as_ref().is_some_and(|st| st.name() == expected_enum.name()),
       _ => false,
     },
     CalcitTypeAnnotation::Trait(expected_trait) => match value {
-      Calcit::Record(r) => r
+      Calcit::Struct(r) => r
         .struct_ref
         .impls
         .iter()
         .any(|imp| imp.matches_trait_reference(expected_trait.as_ref())),
-      Calcit::Tuple(t) => t.impls().iter().any(|imp| imp.matches_trait_reference(expected_trait.as_ref())),
+      Calcit::Enum(t) => t.impls().iter().any(|imp| imp.matches_trait_reference(expected_trait.as_ref())),
       _ => false,
     },
     CalcitTypeAnnotation::TraitSet(traits) => match value {
-      Calcit::Record(r) => traits
+      Calcit::Struct(r) => traits
         .iter()
         .all(|trait_def| r.struct_ref.impls.iter().any(|imp| imp.matches_trait_reference(trait_def.as_ref()))),
-      Calcit::Tuple(t) => traits
+      Calcit::Enum(t) => traits
         .iter()
         .all(|trait_def| t.impls().iter().any(|imp| imp.matches_trait_reference(trait_def.as_ref()))),
       _ => false,
@@ -5041,9 +5146,10 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
       Calcit::Tag(tag) => match tag.ref_str() {
         "any" => true,
         "nil" => matches!(value, Calcit::Nil),
-        "record" => matches!(value, Calcit::Record(_)),
-        "struct" => matches!(value, Calcit::Struct(_)),
-        "enum" => matches!(value, Calcit::Enum(_)),
+        "record" | "struct" => matches!(value, Calcit::Struct(_)),
+        "tuple" | "enum" => matches!(value, Calcit::Enum(_)),
+        "struct-def" => matches!(value, Calcit::StructDef(_)),
+        "enum-def" => matches!(value, Calcit::EnumDef(_)),
         _ => true, // unknown custom types: be permissive
       },
       _ => true,
@@ -5062,7 +5168,7 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
   }
 }
 
-fn infer_runtime_struct_applied_args(struct_def: &CalcitStruct, values: &[Calcit]) -> Vec<Arc<CalcitTypeAnnotation>> {
+fn infer_runtime_struct_applied_args(struct_def: &CalcitStructDef, values: &[Calcit]) -> Vec<Arc<CalcitTypeAnnotation>> {
   if struct_def.generics.is_empty() {
     return vec![];
   }
@@ -5079,7 +5185,7 @@ fn infer_runtime_struct_applied_args(struct_def: &CalcitStruct, values: &[Calcit
     .collect()
 }
 
-fn infer_runtime_enum_applied_args(enum_def: &CalcitEnum, tuple: &CalcitTuple) -> Vec<Arc<CalcitTypeAnnotation>> {
+fn infer_runtime_enum_applied_args(enum_def: &CalcitEnumDef, tuple: &CalcitEnumValue) -> Vec<Arc<CalcitTypeAnnotation>> {
   if enum_def.generics().is_empty() {
     return vec![];
   }
@@ -5130,9 +5236,9 @@ pub fn infer_runtime_value_type(value: &Calcit) -> Arc<CalcitTypeAnnotation> {
         ))
       })
       .unwrap_or_else(|| Arc::new(CalcitTypeAnnotation::DynFn)),
-    Calcit::Record(record) => {
+    Calcit::Struct(record) => {
       if record.struct_ref.generics.is_empty() {
-        Arc::new(CalcitTypeAnnotation::Record(record.struct_ref.clone()))
+        Arc::new(CalcitTypeAnnotation::StructValue(record.struct_ref.clone()))
       } else {
         Arc::new(CalcitTypeAnnotation::Struct(
           record.struct_ref.clone(),
@@ -5143,16 +5249,16 @@ pub fn infer_runtime_value_type(value: &Calcit) -> Arc<CalcitTypeAnnotation> {
         ))
       }
     }
-    Calcit::Struct(struct_def) => Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def.to_owned()), Arc::new(vec![]))),
-    Calcit::Tuple(tuple) => match &tuple.sum_type {
-      Some(enum_def) if enum_def.generics().is_empty() => Arc::new(CalcitTypeAnnotation::Tuple(enum_def.clone())),
+    Calcit::StructDef(struct_def) => Arc::new(CalcitTypeAnnotation::StructDef(Arc::new(struct_def.to_owned()))),
+    Calcit::Enum(tuple) => match &tuple.sum_type {
+      Some(enum_def) if enum_def.generics().is_empty() => Arc::new(CalcitTypeAnnotation::EnumValue(enum_def.clone())),
       Some(enum_def) => Arc::new(CalcitTypeAnnotation::Enum(
         enum_def.clone(),
         Arc::new(infer_runtime_enum_applied_args(enum_def.as_ref(), tuple)),
       )),
-      None => Arc::new(CalcitTypeAnnotation::DynTuple),
+      None => Arc::new(CalcitTypeAnnotation::AnonymousEnum),
     },
-    Calcit::Enum(enum_def) => Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def.to_owned()), Arc::new(vec![]))),
+    Calcit::EnumDef(enum_def) => Arc::new(CalcitTypeAnnotation::EnumDef(Arc::new(enum_def.to_owned()))),
     _ => Arc::new(CalcitTypeAnnotation::from_calcit(value)),
   }
 }
@@ -5202,10 +5308,10 @@ pub fn brief_type_of_value(value: &Calcit) -> &'static str {
     Calcit::Ref(..) => "ref",
     Calcit::Buffer(_) => "buffer",
     Calcit::CirruQuote(_) => "cirru-quote",
-    Calcit::Tuple(_) => "tuple",
-    Calcit::Record(_) => "record",
-    Calcit::Struct(_) => "struct",
     Calcit::Enum(_) => "enum",
+    Calcit::Struct(_) => "struct",
+    Calcit::StructDef(_) => "struct-def",
+    Calcit::EnumDef(_) => "enum-def",
     Calcit::Fn { .. } | Calcit::Proc(_) => "fn",
     Calcit::Macro { .. } => "macro",
     Calcit::Syntax(..) => "syntax",

--- a/src/call_tree.rs
+++ b/src/call_tree.rs
@@ -381,7 +381,7 @@ impl CallTreeAnalyzer {
           Self::extract_calls_recursive(code, current_ns, calls);
         }
       },
-      Calcit::Tuple(tuple) => {
+      Calcit::Enum(tuple) => {
         for item in &tuple.extra {
           Self::extract_calls_recursive(item, current_ns, calls);
         }

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -16,12 +16,12 @@
               :generics $ [] 'T
               :return $ :: 'Set 'T
           :tags $ #{} :builtin :internal
-        |%:: $ %{} :CodeEntry (:doc "|internal function for creating enum tuples\nSyntax: (%:: enum tag & values)\nParams: enum (record/enum), tag (tag), values (any, variable number)\nReturns: tuple with enum metadata\nCreates a tagged tuple that carries enum metadata for validation (use &tuple:impl-traits to attach impls)")
+        |%:: $ %{} :CodeEntry (:doc "|Construct an enum value. Use an EnumDef for nominal values or `_` for an anonymous/open enum.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Tuple)
-              :args $ [] 'Enum 'Tag
+            {} (:return 'Enum)
+              :args $ [] 'Dynamic 'Tag
           :tags $ #{} :builtin :internal
         |%<- $ %{} :CodeEntry (:doc "|pass value as `%` into several expressions, in reversed order")
           :code $ quote
@@ -68,7 +68,7 @@
               :args $ [] 'T
               :generics $ [] 'T
               :return $ :: 'Option 'T
-        |%{} $ %{} :CodeEntry (:doc "|Macro for constructing struct-based records\nSyntax: (%{} StructName & field-value-pairs)\nParams: StructName (struct from defstruct), field-value-pairs (key-value list pairs, variadic)\nReturns: record")
+        |%{} $ %{} :CodeEntry (:doc "|Construct a struct value. Use a StructDef for nominal values or `_` for an anonymous struct.")
           :code $ quote
             defmacro %{} (R & xs)
               if
@@ -76,17 +76,19 @@
                 raise $ str-spaced "|%{} expects field entries in list, got:" xs
               &let
                 args $ &list:concat & xs
-                quasiquote $ &%{} ~R ~@args
+                if (&= R '_)
+                  quasiquote $ ?{} ~@args
+                  quasiquote $ &%{} ~R ~@args
           :examples $ []
             quote $ let
                 Point $ defstruct Point (:x 'Number) (:y 'Number)
                 rec $ %{} Point ([] :x 1) ([] :y 2)
               assert= 1 $ :x rec
           :schema $ :: 'Macro
-            {} (:return 'Record)
-              :args $ [] 'Struct
+            {} (:return 'Struct)
+              :args $ [] 'Dynamic
           :tags $ #{} :macro
-        |%{}? $ %{} :CodeEntry (:doc "|Partial record constructor — allows omitting optional fields\nOmitted fields default to nil when using a struct prototype.\nSyntax: (%{}? R & field-value-pairs)\nParams: R (struct), field-value-pairs (key-value list pairs, variadic)\nReturns: record")
+        |%{}? $ %{} :CodeEntry (:doc "|Partial struct constructor. It allows declared Optional fields to be omitted and fills them with nil.")
           :code $ quote
             defmacro %{}? (R & xs)
               if
@@ -101,7 +103,7 @@
                 p $ %{}? Point (:x 1)
               assert= nil $ :y p
           :schema $ :: 'Macro
-            {} (:return 'Record)
+            {} (:return 'Struct)
               :args $ [] 'Struct
           :tags $ #{} :macro
         |& $ %{} :CodeEntry (:doc "|internal syntax for spreading in function definition and call\nSyntax: (& rest-args) in params or (f & args) in calls\nParams: varies based on context\nReturns: varies based on context\nMarks rest parameters or argument spreading")
@@ -109,18 +111,18 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal :syntax
-        |&%{} $ %{} :CodeEntry (:doc "|internal function for native record creation\nSyntax: (&%{} name & key-value-pairs)\nParams: name (keyword), key-value-pairs (any, variadic)\nReturns: record\nCreates native record with name and fields")
+        |&%{} $ %{} :CodeEntry (:doc "|Internal native constructor for a struct value from a StructDef and field/value pairs.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Record)
+            {} (:return 'Struct)
               :args $ [] 'Struct
           :tags $ #{} :builtin :internal
-        |&%{}? $ %{} :CodeEntry (:doc "|internal function for partial record construction\nSyntax: (&%{}? proto & key-value-pairs)\nParams: proto (struct), key-value-pairs (any, variadic)\nReturns: record\nMissing fields default to nil.")
+        |&%{}? $ %{} :CodeEntry (:doc "|Internal partial struct constructor; omitted declared Optional fields default to nil.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Record)
+            {} (:return 'Struct)
               :args $ [] 'Struct
           :tags $ #{} :builtin :internal
         |&* $ %{} :CodeEntry (:doc "|internal function for multiplication\nSyntax: (&* a b)\nParams: a (number), b (number)\nReturns: number\nMultiplies two numbers together, supports integers and floats")
@@ -322,6 +324,24 @@
             {} (:return 'Number)
               :args $ [] 'Dynamic 'Dynamic
           :tags $ #{} :builtin :internal
+        |&core-enum-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for enum values.")
+          :code $ quote
+            def &core-enum-impls $ [] &core-enum-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Countable internal/&core-countable-enum-impl) (&impl::new Contains internal/&core-contains-enum-impl)
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :internal
+        |&core-enum-methods $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-enum-methods $ &impl::new :&core-enum-methods (:: :count &enum:count) (:: :nth nth) (:: :get get) (:: :assoc &enum:assoc) (:: :first first)
+              :: :empty? $ defn &enum:empty?-impl (x)
+                &= 0 $ &enum:count x
+              :: :contains? $ defn &enum:contains?-impl (x k)
+                if (&>= k 0)
+                  &< k $ &enum:count x
+                  , false
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :internal
         |&core-fn-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for fn")
           :code $ quote
             def &core-fn-impls $ [] &core-fn-methods (&impl::new Show internal/&core-show-impl)
@@ -376,20 +396,6 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
-        |&core-record-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for record")
-          :code $ quote
-            def &core-record-impls $ [] &core-record-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Countable internal/&core-countable-record-impl) (&impl::new Contains internal/&core-contains-record-impl)
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :internal
-        |&core-record-methods $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            def &core-record-methods $ &impl::new :&core-record-methods (:: :count &record:count) (:: :contains? &record:contains?) (:: :get get) (:: :assoc &record:assoc) (:: :to-map &record:to-map)
-              :: :empty? $ defn &record:empty?-impl (x)
-                &= 0 $ &record:count x
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :internal
         |&core-scalar-impls $ %{} :CodeEntry (:doc "|Built-in nominal Show/Eq implementation list for scalar literals")
           :code $ quote
             def &core-scalar-impls $ [] (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl)
@@ -420,21 +426,17 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
-        |&core-tuple-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for tuple")
+        |&core-struct-impls $ %{} :CodeEntry (:doc "|Built-in implementation list for struct values.")
           :code $ quote
-            def &core-tuple-impls $ [] &core-tuple-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Countable internal/&core-countable-tuple-impl) (&impl::new Contains internal/&core-contains-tuple-impl)
+            def &core-struct-impls $ [] &core-struct-methods (&impl::new Show internal/&core-show-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Countable internal/&core-countable-struct-impl) (&impl::new Contains internal/&core-contains-struct-impl)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
-        |&core-tuple-methods $ %{} :CodeEntry (:doc |)
+        |&core-struct-methods $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def &core-tuple-methods $ &impl::new :&core-tuple-methods (:: :count &tuple:count) (:: :nth nth) (:: :get get) (:: :assoc &tuple:assoc) (:: :first first)
-              :: :empty? $ defn &tuple:empty?-impl (x)
-                &= 0 $ &tuple:count x
-              :: :contains? $ defn &tuple:contains?-impl (x k)
-                if (&>= k 0)
-                  &< k $ &tuple:count x
-                  , false
+            def &core-struct-methods $ &impl::new :&core-struct-methods (:: :count &struct:count) (:: :contains? &struct:contains?) (:: :get get) (:: :assoc &struct:assoc) (:: :to-map &struct:to-map)
+              :: :empty? $ defn &struct:empty?-impl (x)
+                &= 0 $ &struct:count x
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -482,20 +484,92 @@
             {} (:return 'Unit)
               :args $ [] 'Dynamic
           :tags $ #{} :effect :internal :macro
-        |&enum::new $ %{} :CodeEntry (:doc "|internal function for creating enum definitions\nSyntax: (&enum::new name (variant type...) ...)\nParams: name (tag), variant entries (list)\nReturns: enum prototype value\nCreates enum variants and payload type annotations")
+        |&enum-def:has-variant? $ %{} :CodeEntry (:doc "|Test whether an EnumDef declares a variant.")
           :code $ quote &runtime-implementation
           :examples $ []
-            quote $ &enum::new :Result ([] :ok :number) ([] :err :string)
           :schema $ :: 'Fn
-            {} (:return 'Enum)
+            {} (:return 'Bool)
+              :args $ [] 'Tag 'Tag
+          :tags $ #{} :builtin :internal
+        |&enum-def:impl-traits $ %{} :CodeEntry (:doc "|Attach implementations to an EnumDef.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Tag)
               :args $ [] 'Tag
           :tags $ #{} :builtin :internal
-        |&enum:impl-traits $ %{} :CodeEntry (:doc "|internal function for enum trait impl attachment\nSyntax: (&enum:impl-traits enum impls)\nParams: enum (enum), impls (record)\nReturns: enum value with trait implementations\nAttaches impls info to an enum prototype")
+        |&enum-def:new $ %{} :CodeEntry (:doc "|Create an EnumDef from a name and declared variants.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+            quote $ &enum-def:new :Result ([] :ok :number) ([] :err :string)
+          :schema $ :: 'Fn
+            {} (:return 'Tag)
+              :args $ [] 'Tag
+          :tags $ #{} :builtin :internal
+        |&enum-def:variant-arity $ %{} :CodeEntry (:doc "|Read the payload arity of an EnumDef variant.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'Tag 'Tag
+          :tags $ #{} :builtin :internal
+        |&enum:assoc $ %{} :CodeEntry (:doc "|Associate a payload position on an enum value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Enum)
+              :args $ [] 'Enum 'Number 'Tag
+          :tags $ #{} :builtin :internal
+        |&enum:count $ %{} :CodeEntry (:doc "|Count tag and payload positions in an enum value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'Enum
+          :tags $ #{} :builtin :internal
+        |&enum:definition $ %{} :CodeEntry (:doc "|Return the EnumDef of a nominal enum value, or nil for an anonymous enum.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Enum
+              :return $ :: 'Optional 'Tag
+          :tags $ #{} :builtin :internal
+        |&enum:impl-traits $ %{} :CodeEntry (:doc "|Attach implementations to an enum value.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Enum)
               :args $ [] 'Enum
+          :tags $ #{} :builtin :internal
+        |&enum:impls $ %{} :CodeEntry (:doc "|Return implementations attached to an enum value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Enum
+              :return $ :: 'List 'Impl
+          :tags $ #{} :builtin :internal
+        |&enum:nth $ %{} :CodeEntry (:doc "|Read a tag or payload position from an enum value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Tag)
+              :args $ [] 'Enum 'Number
+          :tags $ #{} :builtin :internal
+        |&enum:params $ %{} :CodeEntry (:doc "|Return enum payload parameters as a list.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'List)
+              :args $ [] 'Enum
+          :tags $ #{} :builtin :internal
+        |&enum:validate $ %{} :CodeEntry (:doc "|Validate an enum value against its definition.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] 'Enum 'Tag
           :tags $ #{} :builtin :internal
         |&exclude $ %{} :CodeEntry (:doc "|internal function for excluding from set\nSyntax: (&exclude set element)\nParams: set (set), element (any)\nReturns: set\nReturns new set with element excluded")
           :code $ quote &runtime-implementation
@@ -612,7 +686,7 @@
           :code $ quote &runtime-implementation
           :examples $ []
             quote $ assert= :fn
-              &tuple:nth (&get-def-schema |calcit.core/map) 0
+              &enum:nth (&get-def-schema |calcit.core/map) 0
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
@@ -657,9 +731,9 @@
                   &list:nth base k
                 (map? base) (&map:get base k)
                 (string? base) (&str:nth base k)
-                (tuple? base) (&tuple:nth base k)
-                (record? base) (&record:get base k)
-                true $ raise (str-spaced |&get-raw |expected |a |collection |or |record, |got: base)
+                (enum? base) (&enum:nth base k)
+                (struct? base) (&struct:get base k)
+                true $ raise (str-spaced |&get-raw |expected |a |collection |or |struct, |got: base)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -721,10 +795,10 @@
           :tags $ #{} :builtin :internal
         |&init-builtin-impls! $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn &init-builtin-impls! () (; "this function to make sure builtin impls are loaded") (identity &core-number-impls) (identity &core-string-impls) (identity &core-set-impls) (identity &core-list-impls) (identity &core-map-impls) (identity &core-fn-impls) (identity &core-tuple-impls) (identity &core-record-impls) (identity &core-scalar-impls) (identity Add) (identity Eq) (identity Len) (identity Mappable) (identity Multiply) (identity Show)
+            defn &init-builtin-impls! () (; "this function to make sure builtin impls are loaded") (identity &core-number-impls) (identity &core-string-impls) (identity &core-set-impls) (identity &core-list-impls) (identity &core-map-impls) (identity &core-fn-impls) (identity &core-enum-impls) (identity &core-struct-impls) (identity &core-scalar-impls) (identity Add) (identity Eq) (identity Len) (identity Mappable) (identity Multiply) (identity Show)
               if
                 &= (&get-calcit-backend) :js
-                register-calcit-builtin-impls $ &js-object :number &core-number-impls :string &core-string-impls :set &core-set-impls :list &core-list-impls :map &core-map-impls :fn &core-fn-impls :tuple &core-tuple-impls :record &core-record-impls :scalar &core-scalar-impls
+                register-calcit-builtin-impls $ &js-object :number &core-number-impls :string &core-string-impls :set &core-set-impls :list &core-list-impls :map &core-map-impls :fn &core-fn-impls :enum &core-enum-impls :struct &core-struct-impls :scalar &core-scalar-impls
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -1241,7 +1315,7 @@
             {}
               :args $ [] (:: 'Map 'K 'V)
               :generics $ [] 'K 'V
-              :return $ :: 'Optional 'Tuple
+              :return $ :: 'Optional 'Enum
           :tags $ #{} :builtin :internal
         |&map:diff-keys $ %{} :CodeEntry (:doc "|internal function for map diff keys\nSyntax: (&map:diff-keys map1 map2)\nParams: map1 (map), map2 (map)\nReturns: set\nReturns keys that differ between maps")
           :code $ quote &runtime-implementation
@@ -1275,7 +1349,7 @@
                 common-triples $ nth triple 2
               list drop-keys new-diff common-triples
           :schema $ :: 'Fn
-            {} (:return 'Tuple)
+            {} (:return 'Enum)
               :args $ [] (:: 'Map 'K 'V) (:: 'Map 'K 'W)
               :generics $ [] 'K 'V 'W
           :tags $ #{} :builtin :internal
@@ -1422,7 +1496,7 @@
             {}
               :args $ [] (:: 'Map 'K 'V)
               :generics $ [] 'K 'V
-              :return $ :: 'List 'Tuple
+              :return $ :: 'List 'Enum
           :tags $ #{} :builtin :internal
         |&map:vals $ %{} :CodeEntry (:doc |)
           :code $ quote (&runtime-implementation)
@@ -1516,123 +1590,6 @@
               :args $ [] 'String
               :return $ :: 'Optional 'Number
           :tags $ #{} :builtin :internal
-        |&record-match-internal $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            defmacro &record-match-internal (value & body)
-              if (&list:empty? body)
-                quasiquote $ eprintln "|[Warn] record-match found no matched case, missing `_` case?" ~value
-                &let
-                  pair $ &list:nth body 0
-                  if
-                    not $ list? pair
-                    raise $ str-spaced "|record-match expected arm in list, got:" pair
-                  let
-                      pattern $ &list:nth pair 0
-                    assert "|expected record or symbol as pattern" $ or (record? pattern) (symbol? pattern)
-                    if (&= pattern '_)
-                      &let ()
-                        assert "|record-match expected a branch after `_`" $ &<= 3 (&list:count pair)
-                        quasiquote $ &let
-                            ~ $ &list:nth pair 1
-                            , ~value
-                          ~@ $ &list:slice pair 2
-                      &let ()
-                        assert "|record-match expected an with (proto new-name & body)" $ &<= 3 (&list:count pair)
-                        quasiquote $ if (&record:matches? ~value ~pattern)
-                          &let
-                              ~ $ &list:nth pair 1
-                              , ~value
-                            ~@ $ &list:slice pair 2
-                          &record-match-internal ~value $ ~@ (&list:rest body)
-          :examples $ []
-          :schema $ :: 'Macro
-            {} $ :args ([] 'Record)
-          :tags $ #{} :internal :macro
-        |&record:assoc $ %{} :CodeEntry (:doc "|internal function for record field association\nSyntax: (&record:assoc record key value & key-values)\nParams: record (record), key (any), value (any), key-values (any, variadic)\nReturns: record\nReturns new record with field associations")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :builtin :internal
-        |&record:contains? $ %{} :CodeEntry (:doc "|internal function for checking if record contains field\nSyntax: (&record:contains? record key)\nParams: record (record), key (any)\nReturns: boolean\nReturns true if record contains field")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :builtin :internal
-        |&record:count $ %{} :CodeEntry (:doc "|internal function for counting record fields\nSyntax: (&record:count record)\nParams: record (record)\nReturns: number\nReturns number of fields in record")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Number)
-              :args $ [] 'Tag
-          :tags $ #{} :builtin :internal
-        |&record:extend-as $ %{} :CodeEntry (:doc "|internal function for extending record as new type\nSyntax: (&record:extend-as record new-name)\nParams: record (record), new-name (keyword)\nReturns: record\nExtends record as new type with different name")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :builtin :internal
-        |&record:from-map $ %{} :CodeEntry (:doc "|internal function for creating record from map\nSyntax: (&record:from-map name map)\nParams: name (keyword), map (map)\nReturns: record\nCreates record from map with specified name")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :builtin :internal
-        |&record:get $ %{} :CodeEntry (:doc "|Internal required record field lookup. Syntax: (&record:get record key). Returns the declared field value; raises when the field is not defined.")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Dynamic)
-              :args $ [] 'Record 'Tag
-          :tags $ #{} :builtin :internal
-        |&record:get-name $ %{} :CodeEntry (:doc "|internal function for getting record name\nSyntax: (&record:get-name record)\nParams: record (record)\nReturns: keyword\nReturns name of record")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Tag)
-              :args $ [] 'Tag
-          :tags $ #{} :builtin :internal
-        |&record:impl-traits $ %{} :CodeEntry (:doc "|internal function for record trait impl attachment\nSyntax: (&record:impl-traits record impls)\nParams: record (record), impls (any)\nReturns: record\nReturns new record with specified impls")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Record)
-              :args $ [] 'Record
-          :tags $ #{} :builtin :internal
-        |&record:impls $ %{} :CodeEntry (:doc "|internal function for getting record impls\nSyntax: (&record:impls record)\nParams: record (record)\nReturns: any\nReturns impls of record")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {}
-              :args $ [] 'Record
-              :return $ :: 'List 'Impl
-          :tags $ #{} :builtin :internal
-        |&record:matches? $ %{} :CodeEntry (:doc "|internal function for checking record matches\nSyntax: (&record:matches? record pattern)\nParams: record (record), pattern (any)\nReturns: boolean\nReturns true if record matches pattern")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :builtin :internal
-        |&record:struct $ %{} :CodeEntry (:doc "|internal function for getting record source struct\nSyntax: (&record:struct record)\nParams: record (record)\nReturns: struct or nil\nReturns source struct definition of record, or nil when unavailable")
-          :code $ quote &runtime-implementation
-          :examples $ []
-            quote $ let
-                User $ defstruct User (:name 'String)
-                u $ %{} User (:name |Alice)
-              assert= User $ &record:struct u
-          :schema $ :: 'Fn
-            {} (:return 'Struct)
-              :args $ [] 'Record
-          :tags $ #{} :builtin :internal
-        |&record:to-map $ %{} :CodeEntry (:doc "|internal function for converting record to map\nSyntax: (&record:to-map record)\nParams: record (record)\nReturns: map\nConverts record to map")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {}
-              :args $ [] 'Record
-              :return $ :: 'Map 'Tag 'Dynamic
-          :tags $ #{} :builtin :internal
-        |&record:with $ %{} :CodeEntry (:doc "|internal function for record with operation\nSyntax: (&record:with record key value & key-values)\nParams: record (record), key (any), value (any), key-values (any, variadic)\nReturns: record\nReturns new record with updated fields")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :builtin :internal
         |&reset-gensym-index! $ %{} :CodeEntry (:doc "|internal function for resetting gensym index\nSyntax: (&reset-gensym-index!)\nParams: none\nReturns: nil\nResets the global gensym counter to 0 for deterministic symbol generation")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -1655,7 +1612,7 @@
             {}
               :args $ [] (:: 'Set 'T)
               :generics $ [] 'T
-              :return $ :: 'Optional 'Tuple
+              :return $ :: 'Optional 'Enum
           :tags $ #{} :builtin :internal
         |&set:empty $ %{} :CodeEntry (:doc "|internal helper for set :empty method entry")
           :code $ quote
@@ -1894,96 +1851,143 @@
             {} (:return 'String)
               :args $ [] 'String 'Number 'Number
           :tags $ #{} :builtin :internal
-        |&struct::new $ %{} :CodeEntry (:doc "|internal function for creating struct definitions\nSyntax: (&struct::new name (field type) ...)\nParams: name (tag), field pairs (list)\nReturns: struct definition value\nCreates a struct definition with fields and type annotations")
+        |&struct-def:impl-traits $ %{} :CodeEntry (:doc "|Attach implementations to a StructDef.")
           :code $ quote &runtime-implementation
           :examples $ []
-            quote $ &struct::new :Person ([] :name :string) ([] :age :number)
           :schema $ :: 'Fn
-            {} (:return 'Struct)
+            {} (:return 'Tag)
               :args $ [] 'Tag
           :tags $ #{} :builtin :internal
-        |&struct:impl-traits $ %{} :CodeEntry (:doc "|internal function for struct trait impl attachment\nSyntax: (&struct:impl-traits struct impls)\nParams: struct (struct), impls (record)\nReturns: struct with trait implementations\nAttaches impls info to a struct definition")
+        |&struct-def:new $ %{} :CodeEntry (:doc "|Create a StructDef from a name and declared field types.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+            quote $ &struct-def:new :Person ([] :name :string) ([] :age :number)
+          :schema $ :: 'Fn
+            {} (:return 'Tag)
+              :args $ [] 'Tag
+          :tags $ #{} :builtin :internal
+        |&struct-match-internal $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            defmacro &struct-match-internal (value & body)
+              if (&list:empty? body)
+                quasiquote $ eprintln "|[Warn] struct-match found no matched case, missing `_` case?" ~value
+                &let
+                  pair $ &list:nth body 0
+                  if
+                    not $ list? pair
+                    raise $ str-spaced "|struct-match expected arm in list, got:" pair
+                  let
+                      pattern $ &list:nth pair 0
+                    assert "|expected struct or symbol as pattern" $ or (struct? pattern) (symbol? pattern)
+                    if (&= pattern '_)
+                      &let ()
+                        assert "|struct-match expected a branch after `_`" $ &<= 3 (&list:count pair)
+                        quasiquote $ &let
+                            ~ $ &list:nth pair 1
+                            , ~value
+                          ~@ $ &list:slice pair 2
+                      &let ()
+                        assert "|struct-match expected (StructDef binding & body)" $ &<= 3 (&list:count pair)
+                        quasiquote $ if (&struct:matches? ~value ~pattern)
+                          &let
+                              ~ $ &list:nth pair 1
+                              , ~value
+                            ~@ $ &list:slice pair 2
+                          &struct-match-internal ~value $ ~@ (&list:rest body)
+          :examples $ []
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Struct)
+          :tags $ #{} :internal :macro
+        |&struct:assoc $ %{} :CodeEntry (:doc "|Associate a declared field on a struct value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :builtin :internal
+        |&struct:contains? $ %{} :CodeEntry (:doc "|Test whether a struct value declares a field.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :builtin :internal
+        |&struct:count $ %{} :CodeEntry (:doc "|Count fields in a struct value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'Struct
+          :tags $ #{} :builtin :internal
+        |&struct:definition $ %{} :CodeEntry (:doc "|Return the StructDef of a nominal struct value, or nil for an anonymous struct.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+            quote $ let
+                User $ defstruct User (:name 'String)
+                user $ %{} User (:name |Alice)
+              assert= User $ &struct:definition user
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Struct
+              :return $ :: 'Optional 'Tag
+          :tags $ #{} :builtin :internal
+        |&struct:extend-as $ %{} :CodeEntry (:doc "|Extend a struct value with a declared field.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :builtin :internal
+        |&struct:from-map $ %{} :CodeEntry (:doc "|Construct a struct value from a StructDef and map.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :builtin :internal
+        |&struct:get $ %{} :CodeEntry (:doc "|Read a required declared field from a struct value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] 'Struct 'Tag
+          :tags $ #{} :builtin :internal
+        |&struct:get-name $ %{} :CodeEntry (:doc "|Return the name tag of a struct value.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Tag)
+              :args $ [] 'Tag
+          :tags $ #{} :builtin :internal
+        |&struct:impl-traits $ %{} :CodeEntry (:doc "|Attach implementations to a struct value.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Struct)
               :args $ [] 'Struct
           :tags $ #{} :builtin :internal
-        |&trait::new $ %{} :CodeEntry (:doc "|internal function for creating trait values\nSyntax: (&trait::new name methods)\nParams: name (tag/symbol), methods (list of tags)\nReturns: trait\nCreates a trait definition value")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :builtin :internal
-        |&tuple:assoc $ %{} :CodeEntry (:doc "|internal function for tuple assoc operation\nSyntax: (&tuple:assoc tuple index value)\nParams: tuple (tuple), index (number), value (any)\nReturns: new tuple with updated value\nReturns new tuple with value at index updated")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Tuple)
-              :args $ [] 'Tuple 'Number 'Tag
-          :tags $ #{} :builtin :internal
-        |&tuple:count $ %{} :CodeEntry (:doc "|internal function for tuple count operation\nSyntax: (&tuple:count tuple)\nParams: tuple (tuple)\nReturns: number of elements\nReturns the number of elements in the tuple")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Number)
-              :args $ [] 'Tuple
-          :tags $ #{} :builtin :internal
-        |&tuple:enum $ %{} :CodeEntry (:doc "|Get the enum prototype from a tuple\nSyntax: (&tuple:enum tuple)\nParams: tuple (tuple)\nReturns: enum value or nil if not an enum tuple")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Tag)
-              :args $ [] 'Tuple
-          :tags $ #{} :builtin :internal
-        |&tuple:enum-has-variant? $ %{} :CodeEntry (:doc "|Check if an enum has a specific variant\nSyntax: (&tuple:enum-has-variant? enum tag)\nParams: enum (enum), tag (tag)\nReturns: bool - true if variant exists")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Bool)
-              :args $ [] 'Enum 'Tag
-          :tags $ #{} :builtin :internal
-        |&tuple:enum-variant-arity $ %{} :CodeEntry (:doc "|Get the arity of a variant in an enum\nSyntax: (&tuple:enum-variant-arity enum tag)\nParams: enum (enum), tag (tag)\nReturns: number - number of payload fields for the variant")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Number)
-              :args $ [] 'Enum 'Tag
-          :tags $ #{} :builtin :internal
-        |&tuple:impl-traits $ %{} :CodeEntry (:doc "|internal function for tuple trait impl attachment\nSyntax: (&tuple:impl-traits tuple new-impls)\nParams: tuple (tuple), new-impls (any)\nReturns: new tuple with updated impls\nReturns new tuple with same values but different impls")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Tuple)
-              :args $ [] 'Tuple
-          :tags $ #{} :builtin :internal
-        |&tuple:impls $ %{} :CodeEntry (:doc "|internal function for getting tuple impls\nSyntax: (&tuple:impls tuple)\nParams: tuple (tuple)\nReturns: impls of the tuple\nReturns the impls/type identifier of the tuple")
+        |&struct:impls $ %{} :CodeEntry (:doc "|Return implementations attached to a struct value.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
             {}
-              :args $ [] 'Tuple
+              :args $ [] 'Struct
               :return $ :: 'List 'Impl
           :tags $ #{} :builtin :internal
-        |&tuple:nth $ %{} :CodeEntry (:doc "|internal function for tuple nth operation\nSyntax: (&tuple:nth tuple index)\nParams: tuple (tuple), index (number)\nReturns: value at index or nil\nGets the value at specified index in tuple, returns nil if out of bounds")
+        |&struct:matches? $ %{} :CodeEntry (:doc "|Test whether a struct value matches a struct pattern.")
           :code $ quote &runtime-implementation
           :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Tag)
-              :args $ [] 'Tuple 'Number
+          :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal
-        |&tuple:params $ %{} :CodeEntry (:doc "|internal function for getting tuple params\nSyntax: (&tuple:params tuple)\nParams: tuple (tuple)\nReturns: list of parameter values\nReturns the parameter values of the tuple as a list")
+        |&struct:to-map $ %{} :CodeEntry (:doc "|Convert a struct value to a map.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'List)
-              :args $ [] 'Tuple
+            {}
+              :args $ [] 'Struct
+              :return $ :: 'Map 'Tag 'Dynamic
           :tags $ #{} :builtin :internal
-        |&tuple:validate-enum $ %{} :CodeEntry (:doc "|Validate enum tuple tag/arity if enum metadata exists\nSyntax: (&tuple:validate-enum tuple tag)\nParams: tuple (tuple), tag (tag)\nReturns: nil\nRaises error on invalid tag or arity")
+        |&struct:with $ %{} :CodeEntry (:doc "|Return a struct value with updated fields.")
           :code $ quote &runtime-implementation
           :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Unit)
-              :args $ [] 'Tuple 'Tag
+          :schema $ :: 'Dynamic
+          :tags $ #{} :builtin :internal
+        |&trait::new $ %{} :CodeEntry (:doc "|internal function for creating trait values\nSyntax: (&trait::new name methods)\nParams: name (tag/symbol), methods (list of tags)\nReturns: trait\nCreates a trait definition value")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal
         |&union $ %{} :CodeEntry (:doc "|internal function for set union\nSyntax: (&union set1 set2 & sets)\nParams: set1 (set), set2 (set), sets (set, variadic)\nReturns: set\nReturns union of all sets")
           :code $ quote &runtime-implementation
@@ -2118,7 +2122,7 @@
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] 'Dynamic 'Dynamic
-        |: $ %{} :CodeEntry (:doc "|Macro sugar for tagged tuples\nExpands to `::` while passing the tag through `turn-tag`, so both keywords and bare symbols may be used.")
+        |: $ %{} :CodeEntry (:doc "|Macro sugar for anonymous enums. Expands to `::` and normalizes the variant tag with `turn-tag`.")
           :code $ quote
             defmacro : (tag & args)
               if
@@ -2133,7 +2137,7 @@
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic)
           :tags $ #{} :macro
-        |:: $ %{} :CodeEntry (:doc "|internal function for creating tuples\nSyntax: (:: impls & values)\nParams: impls (any), values (any, variable number)\nReturns: tuple with impls and values\nCreates a tuple with specified impls and values")
+        |:: $ %{} :CodeEntry (:doc "|Construct an anonymous enum value. The implicit enum definition is `_`.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Dynamic
@@ -2654,7 +2658,7 @@
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic 'Dynamic)
           :tags $ #{} :control :log :macro
-        |assoc $ %{} :CodeEntry (:doc "|associates a key-value pair to a collection, works on maps, lists, tuples, and records")
+        |assoc $ %{} :CodeEntry (:doc "|Associate a key or index in maps, lists, enums, and structs.")
           :code $ quote
             defn assoc (x k v)
               if (nil? x)
@@ -2957,7 +2961,7 @@
               :args $ [] (:: 'List 'T) 'T
               :generics $ [] 'T
               :return $ :: 'List 'T
-        |contains-in? $ %{} :CodeEntry (:doc "|Checks whether a nested path exists within maps, records, tuples, or lists. Returns true only when every hop succeeds.")
+        |contains-in? $ %{} :CodeEntry (:doc "|Check whether every hop in a nested path exists across maps, structs, enums, or lists.")
           :code $ quote
             defn contains-in? (xs path)
               list-match path
@@ -2973,15 +2977,15 @@
                       if (&map:contains? xs p0)
                         recur (&map:get xs p0) ps
                         , false
-                    (record? xs)
-                      if (&record:contains? xs p0)
-                        recur (&record:get xs p0) ps
+                    (struct? xs)
+                      if (&struct:contains? xs p0)
+                        recur (&struct:get xs p0) ps
                         , false
-                    (tuple? xs)
+                    (enum? xs)
                       if
                         and (&>= p0 0)
-                          &< p0 $ &tuple:count xs
-                        recur (&tuple:nth xs p0) ps
+                          &< p0 $ &enum:count xs
+                        recur (&enum:nth xs p0) ps
                         , false
                     true false
           :examples $ []
@@ -3146,7 +3150,7 @@
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic 'Dynamic
           :tags $ #{} :builtin :internal :state :syntax
-        |defenum $ %{} :CodeEntry (:doc "|macro for defining enums\nSyntax: (defenum Name [('T 'E)] (:variant type...) ...)\nParams: Name (symbol/tag), optional generics list, variants (tag + payload types)\nReturns: enum prototype value\nExpands to &enum::new")
+        |defenum $ %{} :CodeEntry (:doc "|Define an EnumDef with a closed set of variants.")
           :code $ quote
             defmacro defenum (name & variants)
               assert "|defenum expects name as tag/symbol" $ or (tag? name) (symbol? name)
@@ -3203,20 +3207,20 @@
                                       quasiquote $ [] (~ variant-tag) (~@ payload-forms)
                             if (empty? generics)
                               if has-where-form?
-                                quasiquote $ &enum::new
+                                quasiquote $ &enum-def:new
                                   ~ $ turn-tag name
                                   ~ where-form
                                   ~@ normalized
-                                quasiquote $ &enum::new
+                                quasiquote $ &enum-def:new
                                   ~ $ turn-tag name
                                   ~@ normalized
                               if has-where-form?
-                                quasiquote $ &enum::new
+                                quasiquote $ &enum-def:new
                                   ~ $ turn-tag name
                                   [] ~@generics
                                   ~ where-form
                                   ~@ normalized
-                                quasiquote $ &enum::new
+                                quasiquote $ &enum-def:new
                                   ~ $ turn-tag name
                                   [] ~@generics
                                   ~@ normalized
@@ -3358,7 +3362,7 @@
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic 'Dynamic)
           :tags $ #{} :macro
-        |defstruct $ %{} :CodeEntry (:doc "|macro for defining record structs\nSyntax: (defstruct Name [('T 'S)] :field :type ...)\nParams: Name (symbol/tag), optional generics list, field pairs (tag + type)\nReturns: struct definition value\nExpands to &struct::new")
+        |defstruct $ %{} :CodeEntry (:doc "|Define a StructDef with fixed fields and field types.")
           :code $ quote
             defmacro defstruct (name & pairs)
               assert "|defstruct expects name as tag/symbol" $ or (tag? name) (symbol? name)
@@ -3420,20 +3424,20 @@
                                         quasiquote $ [] (~ field-name) (~ type-form)
                             if (empty? generics)
                               if has-where-form?
-                                quasiquote $ &struct::new
+                                quasiquote $ &struct-def:new
                                   ~ $ turn-tag name
                                   ~ where-form
                                   ~@ normalized
-                                quasiquote $ &struct::new
+                                quasiquote $ &struct-def:new
                                   ~ $ turn-tag name
                                   ~@ normalized
                               if has-where-form?
-                                quasiquote $ &struct::new
+                                quasiquote $ &struct-def:new
                                   ~ $ turn-tag name
                                   [] ~@generics
                                   ~ where-form
                                   ~@ normalized
-                                quasiquote $ &struct::new
+                                quasiquote $ &struct-def:new
                                   ~ $ turn-tag name
                                   [] ~@generics
                                   ~@ normalized
@@ -3710,19 +3714,44 @@
             {} (:return 'Bool)
               :args $ [] 'String 'String
           :tags $ #{} :builtin :internal
-        |enum? $ %{} :CodeEntry (:doc "|Predicate that checks whether a value is an enum definition.")
+        |enum-def? $ %{} :CodeEntry (:doc "|Predicate that checks whether a value is an enum definition.")
           :code $ quote
-            defn enum? (x)
-              &= (type-of x) :enum
+            defn enum-def? (x)
+              &= (type-of x) :enum-def
           :examples $ []
             quote $ assert= true
-              enum? $ defenum Result (:ok) (:err 'String)
+              enum-def? $ defenum Result (:ok) (:err 'String)
             quote $ assert= false
-              enum? $ :: :ok 1
+              enum-def? $ %:: _ :ok 1
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] 'T
               :generics $ [] 'T
+        |enum-definition $ %{} :CodeEntry (:doc "|Return Option<EnumDef> for an enum value.")
+          :code $ quote
+            defn enum-definition (tuple)
+              optionally $ &enum:definition tuple
+          :examples $ []
+            quote $ assert= (%some Option)
+              enum-definition $ %some 1
+            quote $ assert= (%none)
+              enum-definition $ :: :plain 1
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Enum
+              :return $ :: 'Option 'Tag
+        |enum? $ %{} :CodeEntry (:doc "|Predicate that checks nominal and anonymous enum values. Passing an EnumDef reports a migration error.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+            quote $ assert= true
+              enum? $ %:: _ :ok 1
+            quote $ assert= false
+              enum? $ {} (:ok 1)
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'T
+              :generics $ [] 'T
+          :tags $ #{} :builtin :internal
         |eval $ %{} :CodeEntry (:doc "|internal syntax for evaluating code at runtime\nSyntax: (eval expr)\nParams: expr (quoted code)\nReturns: result of evaluation\nEvaluates quoted code in current environment")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -3867,12 +3896,12 @@
                 (string? x)
                   if (&str:empty? x) (%none)
                     %some $ &str:first x
-                (tuple? x)
+                (enum? x)
                   if
-                    &= 0 $ &tuple:count x
+                    &= 0 $ &enum:count x
                     %none
-                    %some $ &tuple:nth x 0
-                true $ raise (str-spaced |first |expected |a |list, |string, |or |tuple, |got: x)
+                    %some $ &enum:nth x 0
+                true $ raise (str-spaced |first |expected |a |list, |string, |or |enum, |got: x)
           :examples $ []
             quote $ assert= (%some 1)
               first $ [] 1 2 3
@@ -4056,7 +4085,7 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal :syntax
-        |get $ %{} :CodeEntry (:doc "|Return a keyed or indexed value as Option<T>; missing entries produce none.")
+        |get $ %{} :CodeEntry (:doc "|Lookup by key or index. Struct fields return their declared value directly and unknown fields raise; maps and indexed collections return Option<T>.")
           :code $ quote
             defn get (base k)
               cond
@@ -4064,13 +4093,10 @@
                   if (&map:contains? base k)
                     %some $ &map:get base k
                     %none
-                (record? base)
-                  if (&record:contains? base k)
-                    %some $ &record:get base k
-                    %none
-                (or (list? base) (string? base) (tuple? base))
+                (struct? base) (&struct:get base k)
+                (or (list? base) (string? base) (enum? base))
                   if (number? k) (nth base k) (%none)
-                true $ raise (str-spaced |get |expected |a |collection |or |record, |got: base)
+                true $ raise (str-spaced |get |expected |a |collection |or |struct, |got: base)
           :examples $ []
             quote $ assert= (%some 2)
               get ([] 0 2 4) 1
@@ -4113,9 +4139,11 @@
                 list-match path
                   () $ %some base
                   (y0 ys)
-                    tag-match (get base y0)
-                      (:some value) (recur value ys)
-                      (:none) (%none)
+                    if (struct? base)
+                      recur (&struct:get base y0) ys
+                      tag-match (get base y0)
+                        (:some value) (recur value ys)
+                        (:none) (%none)
           :examples $ []
             quote $ assert= (%some 1)
               get-in
@@ -4261,8 +4289,8 @@
                   fn (trait)
                     = :impl $ type-of trait
                 raise "|impl-traits misuse. Expected: impl arguments are :impl values. Actual: found non-impl argument. Fix: pass values created by `defimpl`."
-              if (struct? x) (&struct:impl-traits x & traits)
-                if (enum? x) (&enum:impl-traits x & traits)
+              if (struct-def? x) (&struct-def:impl-traits x & traits)
+                if (enum-def? x) (&enum-def:impl-traits x & traits)
                   raise $ str-spaced "|impl-traits misuse. Expected: first argument is struct/enum definition. Actual:" (type-of x) "|Fix: attach impls to `defstruct`/`defenum` result, then construct instances from that definition."
           :examples $ []
           :schema $ :: 'Fn
@@ -4542,13 +4570,13 @@
                   if (&str:empty? xs) (%none)
                     %some $ &str:nth xs
                       &- (&str:count xs) 1
-                (tuple? xs)
+                (enum? xs)
                   if
-                    &= 0 $ &tuple:count xs
+                    &= 0 $ &enum:count xs
                     %none
-                    %some $ &tuple:nth xs
-                      &- (&tuple:count xs) 1
-                true $ raise (str-spaced |last |expected |a |list, |string, |or |tuple, |got: xs)
+                    %some $ &enum:nth xs
+                      &- (&enum:count xs) 1
+                true $ raise (str-spaced |last |expected |a |list, |string, |or |enum, |got: xs)
           :examples $ []
             quote $ assert= (%some 3)
               last $ [] 1 2 3
@@ -4872,7 +4900,7 @@
                         assert "|expected pair returned when mapping hashmap" $ &= 2 (&list:count result)
                         &map:assoc acc (&list:nth result 0) (&list:nth result 1)
                       if
-                        or (nil? result) (tuple? result)
+                        or (nil? result) (enum? result)
                         , acc $ raise (str-spaced "|map-kv expected list or nil, got:" result)
           :examples $ []
           :schema $ :: 'Fn
@@ -5009,7 +5037,7 @@
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic 'Dynamic)
           :tags $ #{} :macro
-        |nth $ %{} :CodeEntry (:doc "|Return the indexed item from a list, string, or tuple as Option<T>; invalid indexes produce none. Records use field-name get because positional order is not a cross-backend contract.")
+        |nth $ %{} :CodeEntry (:doc "|Return an indexed item from a list, string, or enum as Option<T>. Struct fields are accessed by their declared names.")
           :code $ quote
             defn nth (x i)
               cond
@@ -5027,13 +5055,13 @@
                       &< i $ &str:count x
                     %some $ &str:nth x i
                     %none
-                (tuple? x)
+                (enum? x)
                   if
                     and (&>= i 0)
-                      &< i $ &tuple:count x
-                    %some $ &tuple:nth x i
+                      &< i $ &enum:count x
+                    %some $ &enum:nth x i
                     %none
-                true $ raise (str-spaced |nth |expected |a |list, |string, |or |tuple, |got: x)
+                true $ raise (str-spaced |nth |expected |a |list, |string, |or |enum, |got: x)
           :examples $ []
             quote $ assert= (%some 2)
               nth ([] 1 2 3) 1
@@ -5061,7 +5089,7 @@
               tag-match opt
                 (:some value) (f value)
                 (:none)
-                  %:: (&tuple:enum opt) :none
+                  %:: (&enum:definition opt) :none
           :examples $ []
             quote $ assert= (%some 4)
               option:and-then (%some 2)
@@ -5103,9 +5131,9 @@
             defn option:map (opt f)
               tag-match opt
                 (:some value)
-                  %:: (&tuple:enum opt) :some $ f value
+                  %:: (&enum:definition opt) :some $ f value
                 (:none)
-                  %:: (&tuple:enum opt) :none
+                  %:: (&enum:definition opt) :none
           :examples $ []
           :schema $ :: 'Fn
             {}
@@ -5174,7 +5202,7 @@
             quote $ assert= (%some 1) (optionally 1)
             quote $ assert= (%none) (optionally nil)
             quote $ assert= Option
-              &tuple:enum $ optionally 1
+              &enum:definition $ optionally 1
           :schema $ :: 'Fn
             {}
               :args $ [] (:: 'Optional 'T)
@@ -5338,60 +5366,31 @@
             {} (:return 'String)
               :args $ [] 'String
           :tags $ #{} :builtin :file :internal :io
-        |record-match $ %{} :CodeEntry (:doc |)
+        |record-match $ %{} :CodeEntry (:doc "|Removed legacy macro. Use struct-match.")
           :code $ quote
-            defmacro record-match (value & body)
-              if (&list:empty? body) (raise "|record-match expected patterns for matching")
-                if (list? value)
-                  &let
-                    v# $ gensym |v
-                    quasiquote $ &let (~v# ~value)
-                      assert "|expected record to match" $ record? ~v#
-                      &record-match-internal ~v# ~@body
-                  quasiquote $ &let ()
-                    assert "|expected record to match" $ record? ~value
-                    &record-match-internal ~value ~@body
+            defmacro record-match (& _args) (raise "|`record-match` was removed; use `struct-match`")
           :examples $ []
-          :schema $ :: 'Macro
-            {} $ :args ([] 'Record)
-          :tags $ #{} :macro
-        |record-struct $ %{} :CodeEntry (:doc "|Return the struct definition that owns a record value.")
+          :schema $ :: 'Dynamic
+        |record-struct $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn record-struct (record) (&record:struct record)
+            defn record-struct (_value) (raise "|`record-struct` was removed; use `struct-definition`, which returns Option<StructDef>")
           :examples $ []
-            quote $ let
-                User $ defstruct User (:name 'String)
-                user $ %{} User (:name |Ada)
-              assert= User $ record-struct user
           :schema $ :: 'Fn
-            {} (:return 'Struct)
-              :args $ [] 'Record
-        |record-with $ %{} :CodeEntry (:doc "|macro to extend existing record with new values in pairs, internally using &record:with which takes flattern items")
+            {}
+              :args $ [] 'Dynamic
+              :return $ :: 'Option 'Tag
+        |record-with $ %{} :CodeEntry (:doc "|Removed legacy macro. Use struct-with.")
           :code $ quote
-            defmacro record-with (record & pairs) (; "check if args are in pairs")
-              if
-                not $ and (list? pairs)
-                  every? pairs $ fn (xs)
-                    and (list? xs)
-                      &= 2 $ count xs
-                raise $ str-spaced "|record-with expects a list of pairs (each with exactly two elements), got:" pairs
-              ; "call &record:with"
-              quasiquote $ &record:with ~record
-                ~@ $ &list:concat & pairs
+            defmacro record-with (& _args) (raise "|`record-with` was removed; use `struct-with`")
           :examples $ []
-          :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
-          :tags $ #{} :macro
-        |record? $ %{} :CodeEntry (:doc "|Predicate that checks whether a value is a struct-based record (created with defstruct + %{}).")
-          :code $ quote &runtime-implementation
+          :schema $ :: 'Dynamic
+        |record? $ %{} :CodeEntry (:doc "|Removed legacy predicate. Use struct? for values or struct-def? for definitions.")
+          :code $ quote
+            defn record? (_value) (raise "|`record?` was removed; use `struct?` for struct values or `struct-def?` for definitions")
           :examples $ []
-            quote $ assert= false
-              record? $ {} (:x 1)
           :schema $ :: 'Fn
             {} (:return 'Bool)
-              :args $ [] 'T
-              :generics $ [] 'T
-          :tags $ #{} :builtin :internal
+              :args $ [] 'Dynamic
         |recur $ %{} :CodeEntry (:doc "|internal function for tail recursion\nSyntax: (recur args...)\nParams: args (any, variable number)\nReturns: recur structure for tail call optimization\nEnables tail call optimization by marking recursive calls")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -5477,7 +5476,7 @@
               tag-match res
                 (:ok value) (f value)
                 (:err err)
-                  %:: (&tuple:enum res) :err err
+                  %:: (&enum:definition res) :err err
           :examples $ []
             quote $ assert= (%ok 4)
               result:and-then (%ok 2)
@@ -5509,9 +5508,9 @@
             defn result:map (res f)
               tag-match res
                 (:ok value)
-                  %:: (&tuple:enum res) :ok $ f value
+                  %:: (&enum:definition res) :ok $ f value
                 (:err err)
-                  %:: (&tuple:enum res) :err err
+                  %:: (&enum:definition res) :err err
           :examples $ []
           :schema $ :: 'Fn
             {}
@@ -5525,9 +5524,9 @@
             defn result:map-err (res f)
               tag-match res
                 (:ok value)
-                  %:: (&tuple:enum res) :ok value
+                  %:: (&enum:definition res) :ok value
                 (:err err)
-                  %:: (&tuple:enum res) :err $ f err
+                  %:: (&enum:definition res) :err $ f err
           :examples $ []
             quote $ assert= (%err |failed!)
               result:map-err (%err |failed)
@@ -5796,18 +5795,76 @@
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String 'String
-        |struct? $ %{} :CodeEntry (:doc "|Predicate that checks whether a value is a struct definition.")
+        |struct-def? $ %{} :CodeEntry (:doc "|Predicate that checks whether a value is a struct definition.")
           :code $ quote
-            defn struct? (x)
-              &= (type-of x) :struct
+            defn struct-def? (x)
+              &= (type-of x) :struct-def
           :examples $ []
             quote $ assert= true
-              struct? $ defstruct Person (:name 'String)
+              struct-def? $ defstruct Person (:name 'String)
+            quote $ assert= false
+              struct-def? $ %{} _ (:x 1)
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'Dynamic
+        |struct-definition $ %{} :CodeEntry (:doc "|Return Option<StructDef> for a struct value.")
+          :code $ quote
+            defn struct-definition (value)
+              optionally $ &struct:definition value
+          :examples $ []
+            quote $ let
+                User $ defstruct User (:name 'String)
+                user $ %{} User (:name |Ada)
+              assert= (%some User) (struct-definition user)
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Struct
+              :return $ :: 'Option 'Tag
+        |struct-match $ %{} :CodeEntry (:doc "|Pattern-match a struct value by StructDef and fields.")
+          :code $ quote
+            defmacro struct-match (value & body)
+              if (&list:empty? body) (raise "|struct-match expected patterns for matching")
+                if (list? value)
+                  &let
+                    v# $ gensym |v
+                    quasiquote $ &let (~v# ~value)
+                      assert "|expected struct value to match" $ struct? ~v#
+                      &struct-match-internal ~v# ~@body
+                  quasiquote $ &let ()
+                    assert "|expected struct value to match" $ struct? ~value
+                    &struct-match-internal ~value ~@body
+          :examples $ []
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Struct)
+          :tags $ #{} :macro
+        |struct-with $ %{} :CodeEntry (:doc "|Construct a new struct value by replacing declared fields.")
+          :code $ quote
+            defmacro struct-with (record & pairs) (; "check if args are in pairs")
+              if
+                not $ and (list? pairs)
+                  every? pairs $ fn (xs)
+                    and (list? xs)
+                      &= 2 $ count xs
+                raise $ str-spaced "|struct-with expects a list of pairs (each with exactly two elements), got:" pairs
+              ; "|call &struct:with"
+              quasiquote $ &struct:with ~record
+                ~@ $ &list:concat & pairs
+          :examples $ []
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic)
+          :tags $ #{} :macro
+        |struct? $ %{} :CodeEntry (:doc "|Predicate that checks struct values, including nominal and anonymous structs. Passing a StructDef reports a migration error.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+            quote $ assert= true
+              struct? $ %{} _ (:x 1)
             quote $ assert= false
               struct? $ {} (:x 1)
           :schema $ :: 'Fn
             {} (:return 'Bool)
-              :args $ [] 'Dynamic
+              :args $ [] 'T
+              :generics $ [] 'T
+          :tags $ #{} :builtin :internal
         |swap! $ %{} :CodeEntry (:doc "|Atomically updates a reference by applying a function to its current value and storing the result.")
           :code $ quote
             defmacro swap! (a f & args)
@@ -5841,7 +5898,7 @@
             {} (:return 'Bool)
               :args $ [] 'T
               :generics $ [] 'T
-        |tag-match $ %{} :CodeEntry (:doc "|Pattern matching on tagged tuples, dispatches based on the first element of the tuple")
+        |tag-match $ %{} :CodeEntry (:doc "|Pattern-match an enum value by its variant tag.")
           :code $ quote
             defmacro tag-match (value & body)
               if (&list:empty? body) (raise "|tag-match expected some patterns and matches")
@@ -5851,11 +5908,11 @@
                     v# $ gensym |v
                     quasiquote $ &let (~v# ~value)
                       if
-                        not $ tuple? ~v#
-                        raise $ str "|tag-match expected tuple, got" ~v#
+                        not $ enum? ~v#
+                        raise $ str "|tag-match expected enum value, got" ~v#
                       &let
-                        ~t# $ &tuple:nth ~v# 0
-                        &tuple:validate-enum ~v# ~t#
+                        ~t# $ &enum:nth ~v# 0
+                        &enum:validate ~v# ~t#
                         internal/&tag-match-internal ~v# ~t# $ ~@ body
           :examples $ []
             quote $ assert= 11
@@ -5972,7 +6029,7 @@
             {}
               :args $ [] (:: 'Map 'K 'V)
               :generics $ [] 'K 'V
-              :return $ :: 'Set 'Tuple
+              :return $ :: 'Set 'Enum
           :tags $ #{} :builtin :internal
         |trim $ %{} :CodeEntry (:doc "|internal function for trimming strings\nSyntax: (trim s)\nParams: s (string)\nReturns: string\nRemoves whitespace from beginning and end of string")
           :code $ quote &runtime-implementation
@@ -5986,31 +6043,21 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :control :internal :syntax
-        |tuple-enum $ %{} :CodeEntry (:doc "|Return the source enum prototype as Option<Enum>; plain tuples produce none.")
+        |tuple-enum $ %{} :CodeEntry (:doc |)
           :code $ quote
-            defn tuple-enum (tuple)
-              optionally $ &tuple:enum tuple
+            defn tuple-enum (_value) (raise "|`tuple-enum` was removed; use `enum-definition`, which returns Option<EnumDef>")
           :examples $ []
-            quote $ assert= (%some Option)
-              tuple-enum $ %some 1
-            quote $ assert= (%none)
-              tuple-enum $ :: :plain 1
           :schema $ :: 'Fn
             {}
-              :args $ [] 'Tuple
-              :return $ :: 'Option 'Enum
-        |tuple? $ %{} :CodeEntry (:doc "|Predicate that checks whether a value is a tuple literal created with the `::` form.")
-          :code $ quote &runtime-implementation
+              :args $ [] 'Dynamic
+              :return $ :: 'Option 'Tag
+        |tuple? $ %{} :CodeEntry (:doc "|Removed legacy predicate. Use enum? for values or enum-def? for definitions.")
+          :code $ quote
+            defn tuple? (_value) (raise "|`tuple?` was removed; use `enum?` for enum values or `enum-def?` for definitions")
           :examples $ []
-            quote $ assert= true
-              tuple? $ :: :a :b
-            quote $ assert= false
-              tuple? $ [] :a :b
           :schema $ :: 'Fn
             {} (:return 'Bool)
-              :args $ [] 'T
-              :generics $ [] 'T
-          :tags $ #{} :builtin :internal
+              :args $ [] 'Dynamic
         |turn-str $ %{} :CodeEntry (:doc |)
           :code $ quote
             defn turn-str (x) (turn-string x)
@@ -6103,11 +6150,11 @@
                   if (&list:contains? x k)
                     assoc x k $ f (&list:nth x k)
                     , x
-                  if (tuple? x)
-                    assoc x k $ f (&tuple:nth x k)
-                    if (record? x)
+                  if (enum? x)
+                    assoc x k $ f (&enum:nth x k)
+                    if (struct? x)
                       if (contains? x k)
-                        assoc x k $ f (&record:get x k)
+                        assoc x k $ f (&struct:get x k)
                         , x
                       raise $ &str:concat "|Cannot update key on item: " (to-lispy-string x)
           :examples $ []
@@ -6442,6 +6489,15 @@
             def &core-compare-string-impl $ &impl::new :&core-compare-string-impl (:: :compare &str:compare)
           :examples $ []
           :schema $ :: 'Dynamic
+        |&core-contains-enum-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-contains-enum-impl $ &impl::new :&core-contains-enum-impl
+              :: :contains? $ fn (x k)
+                if (&>= k 0)
+                  &< k $ &enum:count x
+                  , false
+          :examples $ []
+          :schema $ :: 'Dynamic
         |&core-contains-list-impl $ %{} :CodeEntry (:doc |)
           :code $ quote
             def &core-contains-list-impl $ &impl::new :&core-contains-list-impl (:: :contains? &list:contains?)
@@ -6450,11 +6506,6 @@
         |&core-contains-map-impl $ %{} :CodeEntry (:doc |)
           :code $ quote
             def &core-contains-map-impl $ &impl::new :&core-contains-map-impl (:: :contains? &map:contains?)
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |&core-contains-record-impl $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            def &core-contains-record-impl $ &impl::new :&core-contains-record-impl (:: :contains? &record:contains?)
           :examples $ []
           :schema $ :: 'Dynamic
         |&core-contains-set-impl $ %{} :CodeEntry (:doc |)
@@ -6467,13 +6518,14 @@
             def &core-contains-string-impl $ &impl::new :&core-contains-string-impl (:: :contains? &str:contains?)
           :examples $ []
           :schema $ :: 'Dynamic
-        |&core-contains-tuple-impl $ %{} :CodeEntry (:doc |)
+        |&core-contains-struct-impl $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def &core-contains-tuple-impl $ &impl::new :&core-contains-tuple-impl
-              :: :contains? $ fn (x k)
-                if (&>= k 0)
-                  &< k $ &tuple:count x
-                  , false
+            def &core-contains-struct-impl $ &impl::new :&core-contains-struct-impl (:: :contains? &struct:contains?)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |&core-countable-enum-impl $ %{} :CodeEntry (:doc |)
+          :code $ quote
+            def &core-countable-enum-impl $ &impl::new :&core-countable-enum-impl (:: :count &enum:count)
           :examples $ []
           :schema $ :: 'Dynamic
         |&core-countable-list-impl $ %{} :CodeEntry (:doc |)
@@ -6486,11 +6538,6 @@
             def &core-countable-map-impl $ &impl::new :&core-countable-map-impl (:: :count &map:count)
           :examples $ []
           :schema $ :: 'Dynamic
-        |&core-countable-record-impl $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            def &core-countable-record-impl $ &impl::new :&core-countable-record-impl (:: :count &record:count)
-          :examples $ []
-          :schema $ :: 'Dynamic
         |&core-countable-set-impl $ %{} :CodeEntry (:doc |)
           :code $ quote
             def &core-countable-set-impl $ &impl::new :&core-countable-set-impl (:: :count &set:count)
@@ -6501,9 +6548,9 @@
             def &core-countable-string-impl $ &impl::new :&core-countable-string-impl (:: :count &str:count)
           :examples $ []
           :schema $ :: 'Dynamic
-        |&core-countable-tuple-impl $ %{} :CodeEntry (:doc |)
+        |&core-countable-struct-impl $ %{} :CodeEntry (:doc |)
           :code $ quote
-            def &core-countable-tuple-impl $ &impl::new :&core-countable-tuple-impl (:: :count &tuple:count)
+            def &core-countable-struct-impl $ &impl::new :&core-countable-struct-impl (:: :count &struct:count)
           :examples $ []
           :schema $ :: 'Dynamic
         |&core-eq-impl $ %{} :CodeEntry (:doc "|Core trait impl for Eq")
@@ -6609,13 +6656,13 @@
                           size $ &list:count pattern
                           quasiquote $ if
                             if (identical? ~t ~k)
-                              identical? ~size $ &tuple:count ~value
+                              identical? ~size $ &enum:count ~value
                               , false
                             let
                               ~ $ map-indexed (&list:rest pattern)
                                 defn %tag-match (idx x)
                                   [] x $ quasiquote
-                                    &tuple:nth ~value $ ~ (inc idx)
+                                    &enum:nth ~value $ ~ (inc idx)
                               , ~branch
                             &tag-match-internal ~value ~t $ ~@ (&list:rest body)
                       if (&= pattern '_) branch $ raise (str-spaced "|unknown supported pattern:" pair)

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1575,13 +1575,12 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal
-        |&record:get $ %{} :CodeEntry (:doc "|internal function for getting record field\nSyntax: (&record:get record key) or (&record:get record key default)\nParams: record (record), key (any), default (any, optional)\nReturns: any\nGets field value, returns default if field not found")
+        |&record:get $ %{} :CodeEntry (:doc "|Internal required record field lookup. Syntax: (&record:get record key). Returns the declared field value; raises when the field is not defined.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
-            {}
+            {} (:return 'Dynamic)
               :args $ [] 'Record 'Tag
-              :return $ :: 'Optional 'Dynamic
           :tags $ #{} :builtin :internal
         |&record:get-name $ %{} :CodeEntry (:doc "|internal function for getting record name\nSyntax: (&record:get-name record)\nParams: record (record)\nReturns: keyword\nReturns name of record")
           :code $ quote &runtime-implementation

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -91,8 +91,8 @@ fn is_preferred_js_proc(name: &str) -> bool {
       | "fn?"
       | "bool?"
       | "ref?"
-      | "record?"
-      | "tuple?"
+      | "struct?"
+      | "enum?"
       | "starts-with?"
       | "ends-with?"
   )
@@ -496,8 +496,8 @@ fn gen_call_code(
     // deftype-slot is preprocessing-only; it has no JS runtime effect.
     Calcit::Proc(CalcitProc::DeftypeSlot) => Ok(format!("{return_code}null")),
     Calcit::Proc(CalcitProc::WithTypeSlot) => Err("internal compiler error: with-type-slot escaped preprocessing".to_owned()),
-    // &record:nth: with 3 args (record, idx, :field-tag), use record.getRequired(tag) for JS
-    // because JS CalcitRecord fields are sorted by tag.idx (registration order), not alphabetically.
+    // &struct:nth: with 3 args (record, idx, :field-tag), use record.getRequired(tag) for JS
+    // because JS CalcitStructValue fields are sorted by tag.idx (registration order), not alphabetically.
     // With 2 args (record, idx), fall back to record.values[idx] (only valid when index matches).
     Calcit::Proc(CalcitProc::NativeRecordNth) => {
       if body.len() == 3 {
@@ -509,10 +509,10 @@ fn gen_call_code(
         let idx_code = to_js_code(&body[1], ns, local_defs, file_imports, tags, None)?;
         Ok(format!("{return_code}{record_code}.values[{idx_code}]"))
       } else {
-        Err(format!("&record:nth expected 2-3 arguments, got: {body}"))
+        Err(format!("&struct:nth expected 2-3 arguments, got: {body}"))
       }
     }
-    // &record:assoc-at: optimized assoc with pre-resolved index.
+    // &struct:assoc-at: optimized assoc with pre-resolved index.
     // JS uses record.assoc(tag, value) since JS field ordering differs from Rust.
     Calcit::Proc(CalcitProc::NativeRecordAssocAt) => {
       if body.len() == 4 {
@@ -521,10 +521,10 @@ fn gen_call_code(
         let value_code = to_js_code(&body[3], ns, local_defs, file_imports, tags, None)?;
         Ok(format!("{return_code}{record_code}.assoc({tag_code}, {value_code})"))
       } else {
-        Err(format!("&record:assoc-at expected 4 arguments, got: {body}"))
+        Err(format!("&struct:assoc-at expected 4 arguments, got: {body}"))
       }
     }
-    // &record:with-at: optimized with pre-resolved indices.
+    // &struct:with-at: optimized with pre-resolved indices.
     // JS ignores indices and calls the same _$n_record_$o_with(proto, tag, val, ...) function.
     Calcit::Proc(CalcitProc::NativeRecordWithAt) => {
       if body.len() >= 3 && (body.len() - 1).is_multiple_of(3) {
@@ -542,12 +542,12 @@ fn gen_call_code(
         }
         Ok(format!(
           "{return_code}{proc_prefix}{}({})",
-          escape_var("&record:with"),
+          escape_var("&struct:with"),
           all_args.join(", ")
         ))
       } else {
         Err(format!(
-          "&record:with-at expected (record, idx, tag, val, ...) triples, got: {body}"
+          "&struct:with-at expected (record, idx, tag, val, ...) triples, got: {body}"
         ))
       }
     }
@@ -1037,7 +1037,7 @@ fn gen_let_code(
 
 /// Generate JS code for `match` syntax.
 /// After preprocessing, `body` is: [<value>, (<pattern1> <body1>), (<pattern2> <body2>), ...]
-/// Generated JS is an IIFE with if-else chain checking tuple tag and arity.
+/// Generated JS is an IIFE with if-else chain checking enum tag and arity.
 fn gen_match_code(
   body: &CalcitList,
   local_defs: &HashSet<Arc<str>>,
@@ -1061,7 +1061,7 @@ fn gen_match_code(
 
   let mut chunk = String::new();
   writeln!(chunk, "let {val_var} = {value_code};").expect("write");
-  writeln!(chunk, "let {tag_var} = {proc_prefix}_$n_tuple_$o_nth({val_var}, 0);").expect("write");
+  writeln!(chunk, "let {tag_var} = {proc_prefix}_$n_enum_$o_nth({val_var}, 0);").expect("write");
 
   let mut first = true;
   for branch_idx in 1..body.len() {
@@ -1102,12 +1102,12 @@ fn gen_match_code(
 
         tags.borrow_mut().insert(tag_name.to_owned());
         let tag_code = tags::tag_access(tag_name.ref_str());
-        let arity = pat_xs.len(); // includes tag, so total tuple count
+        let arity = pat_xs.len(); // includes tag, so total enum item count
 
         let else_mark = if first { "" } else { " else " };
         write!(
           chunk,
-          "{else_mark}if ({tag_var} === {tag_code} && {proc_prefix}_$n_tuple_$o_count({val_var}) === {arity}) {{"
+          "{else_mark}if ({tag_var} === {tag_code} && {proc_prefix}_$n_enum_$o_count({val_var}) === {arity}) {{"
         )
         .expect("write");
 
@@ -1122,7 +1122,7 @@ fn gen_match_code(
           if let Calcit::Local(CalcitLocal { sym, .. }) | Calcit::Symbol { sym, .. } = binding {
             scoped_defs.insert(sym.to_owned());
           }
-          write!(chunk, "\nlet {bind_name} = {proc_prefix}_$n_tuple_$o_nth({val_var}, {});", i + 1).expect("write");
+          write!(chunk, "\nlet {bind_name} = {proc_prefix}_$n_enum_$o_nth({val_var}, {});", i + 1).expect("write");
         }
 
         let body_code = to_js_code(branch_body, ns, &scoped_defs, file_imports, tags, Some(return_label))?;

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -496,14 +496,14 @@ fn gen_call_code(
     // deftype-slot is preprocessing-only; it has no JS runtime effect.
     Calcit::Proc(CalcitProc::DeftypeSlot) => Ok(format!("{return_code}null")),
     Calcit::Proc(CalcitProc::WithTypeSlot) => Err("internal compiler error: with-type-slot escaped preprocessing".to_owned()),
-    // &record:nth: with 3 args (record, idx, :field-tag), use record.get(tag) for JS
+    // &record:nth: with 3 args (record, idx, :field-tag), use record.getRequired(tag) for JS
     // because JS CalcitRecord fields are sorted by tag.idx (registration order), not alphabetically.
     // With 2 args (record, idx), fall back to record.values[idx] (only valid when index matches).
     Calcit::Proc(CalcitProc::NativeRecordNth) => {
       if body.len() == 3 {
         let record_code = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
         let tag_code = to_js_code(&body[2], ns, local_defs, file_imports, tags, None)?;
-        Ok(format!("{return_code}{record_code}.get({tag_code})"))
+        Ok(format!("{return_code}{record_code}.getRequired({tag_code})"))
       } else if body.len() == 2 {
         let record_code = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
         let idx_code = to_js_code(&body[1], ns, local_defs, file_imports, tags, None)?;

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -115,8 +115,8 @@ $procs.register_calcit_builtin_impls({{
   set: _$n_core_set_impls,
   string: _$n_core_string_impls,
   fn: _$n_core_fn_impls,
-  tuple: _$n_core_tuple_impls,
-  record: _$n_core_record_impls,
+  enum: _$n_core_enum_impls,
+  struct: _$n_core_struct_impls,
   scalar: _$n_core_scalar_impls,
 }});
 

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -9,8 +9,8 @@
 //! - `recur` (tail recursion via WASM loop)
 //! - Number literals, Bool literals, Nil (→ 0.0)
 //! - Tag values (compiled to f64 integer constants)
-//! - Record creation (`&%{}`) and field access (`&record:nth`, `&record:get`)
-//! - Tuple creation (`::`) and field access (`&tuple:nth`)
+//! - Record creation (`&%{}`) and field access (`&struct:nth`, `&struct:get`)
+//! - Tuple creation (`::`) and field access (`&enum:nth`)
 //!
 //! All values are represented as f64 (matching Calcit's single numeric type).
 //! Booleans: true → 1.0, false/nil → 0.0.
@@ -29,7 +29,7 @@ use wasm_encoder::{
 
 use crate::builtins::syntax::get_raw_args_fn;
 use crate::calcit::{
-  Calcit, CalcitArgLabel, CalcitFnArgs, CalcitImport, CalcitLocal, CalcitProc, CalcitStruct, CalcitSyntax, MethodKind,
+  Calcit, CalcitArgLabel, CalcitFnArgs, CalcitImport, CalcitLocal, CalcitProc, CalcitStructDef, CalcitSyntax, MethodKind,
 };
 use crate::program;
 
@@ -887,7 +887,7 @@ fn emit_expr(ctx: &mut WasmGenCtx, expr: &Calcit) -> Result<(), String> {
         .ok_or_else(|| format!("unknown tag in WASM codegen: {tag_str}"))?;
       ctx.emit(f64_const(id as f64));
     }
-    Calcit::Struct(s) => {
+    Calcit::StructDef(s) => {
       let tag_str = s.name.to_string();
       let id = *ctx
         .tag_index
@@ -951,8 +951,8 @@ fn emit_expr(ctx: &mut WasmGenCtx, expr: &Calcit) -> Result<(), String> {
         .ok_or_else(|| format!("string literal not found in pool: {s}"))?;
       ctx.emit(f64_const(*ptr as f64));
     }
-    Calcit::Record(_) => return Err("Record literals not supported in WASM codegen (use constructor)".into()),
-    Calcit::Tuple(_) => return Err("Tuple literals not supported in WASM codegen (use constructor)".into()),
+    Calcit::Struct(_) => return Err("Record literals not supported in WASM codegen (use constructor)".into()),
+    Calcit::Enum(_) => return Err("Tuple literals not supported in WASM codegen (use constructor)".into()),
     // Function value (Fn with def_ref) — encode as f64 table slot index for call_indirect.
     Calcit::Fn { info, .. } => {
       if let Some(def_ref) = &info.def_ref {
@@ -1067,6 +1067,13 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
       // High-level set wrappers (union/difference/include) use reduce+lambda which can't be
       // compiled to WASM directly. Intercept and inline native 2+ arg set operations.
       if import.ns.as_ref() == "calcit.core" {
+        // Native placeholders may remain imports when WASM consumes a source
+        // form instead of the fully lowered expression. Resolve their current
+        // public names through CalcitProc so ABI renames do not silently turn
+        // supported operations into skipped functions.
+        if let Ok(proc) = import.def.parse::<CalcitProc>() {
+          return emit_proc_call(ctx, &proc, &args_list);
+        }
         match import.def.as_ref() {
           "union" => return emit_set_op_variadic(ctx, &args_list, SetOpKind::Union),
           "difference" => return emit_set_op_variadic(ctx, &args_list, SetOpKind::Difference),
@@ -1099,8 +1106,6 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
           "slice" if args_list.len() >= 2 && args_list.len() <= 3 => return emit_list_slice(ctx, &args_list),
           // `dissoc` — delegated to map dissoc for 2-arg calls.
           "dissoc" if args_list.len() == 2 => return emit_map_dissoc(ctx, &args_list),
-          // Public reflection wrapper around the native record metadata operation.
-          "record-struct" if args_list.len() == 1 => return emit_record_struct(ctx, &args_list),
           // `conj` — append one or more elements to a list.
           "conj" if args_list.len() >= 2 => return emit_conj(ctx, &args_list),
           // `update` — map update: new map with key set to f(old value).
@@ -1163,6 +1168,9 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
         ctx.emit(f64_const(0.0)); // nil
         return Ok(());
       }
+      if let Ok(proc) = name.parse::<CalcitProc>() {
+        return emit_proc_call(ctx, &proc, &args_list);
+      }
       // HOF interceptors — Symbol-head calls appear when preprocessor doesn't resolve
       // intra-namespace references to Import nodes (e.g. calcit.core internal calls).
       match name {
@@ -1179,7 +1187,6 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
         "reduce" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
         "foldl'" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
         "update" if args_list.len() == 3 => return emit_update(ctx, &args_list),
-        "record-struct" if args_list.len() == 1 => return emit_record_struct(ctx, &args_list),
         _ => {}
       }
       // Check if this symbol refers to an inline lambda captured in this scope.
@@ -1254,7 +1261,6 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
           "reduce" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
           "foldl'" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
           "update" if args_list.len() == 3 => return emit_update(ctx, &args_list),
-          "record-struct" if args_list.len() == 1 => return emit_record_struct(ctx, &args_list),
           _ => {}
         }
       }
@@ -1355,9 +1361,6 @@ fn emit_call_spread(ctx: &mut WasmGenCtx, args_list: &[Calcit]) -> Result<(), St
 
   match head {
     Calcit::Import(import) => {
-      if import.ns.as_ref() == "calcit.core" && import.def.as_ref() == "record-struct" && call_args.len() == 1 {
-        return emit_record_struct(ctx, call_args);
-      }
       let qualified = format!("{}/{}", import.ns, import.def);
       let fn_idx = ctx
         .fn_index
@@ -1382,9 +1385,6 @@ fn emit_call_spread(ctx: &mut WasmGenCtx, args_list: &[Calcit]) -> Result<(), St
     }
     Calcit::Symbol { sym, .. } => {
       let name = sym.as_ref();
-      if name == "record-struct" && call_args.len() == 1 {
-        return emit_record_struct(ctx, call_args);
-      }
       let fn_idx = *ctx
         .fn_index
         .get(name)
@@ -1402,9 +1402,6 @@ fn emit_call_spread(ctx: &mut WasmGenCtx, args_list: &[Calcit]) -> Result<(), St
           info.def_ns, info.name
         )
       })?;
-      if def_ref.def_ns.as_ref() == "calcit.core" && def_ref.def_name.as_ref() == "record-struct" && call_args.len() == 1 {
-        return emit_record_struct(ctx, call_args);
-      }
       let qualified = format!("{}/{}", def_ref.def_ns, def_ref.def_name);
       let fn_idx = ctx
         .fn_index
@@ -1705,8 +1702,10 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     CalcitProc::NumberQuestion => emit_type_predicate(ctx, "number", args),
     CalcitProc::BoolQuestion => emit_type_predicate(ctx, "bool", args),
     CalcitProc::SetQuestion => emit_type_predicate(ctx, "set", args),
-    CalcitProc::TupleQuestion => emit_type_predicate(ctx, "tuple", args),
-    CalcitProc::RecordQuestion => emit_type_predicate(ctx, "record", args),
+    // The current WASM heap ABI keeps its legacy storage tag numbers; these
+    // strings are not exposed as Calcit language type names.
+    CalcitProc::EnumQuestion => emit_type_predicate(ctx, "enum", args),
+    CalcitProc::StructQuestion => emit_type_predicate(ctx, "struct", args),
     CalcitProc::FnQuestion => emit_type_predicate(ctx, "fn", args),
 
     // Recur
@@ -2926,7 +2925,7 @@ fn emit_match(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
 /// Builtin type tags always registered in tag_index, so `type-of` can return them
 /// and heap objects can carry them in their header slot.
 const BUILTIN_TYPE_TAGS: &[&str] = &[
-  "buf-list", "list", "map", "set", "tuple", "record", "number", "bool", "nil", "tag", "fn", "string", "symbol",
+  "buf-list", "list", "map", "set", "enum", "struct", "number", "bool", "nil", "tag", "fn", "string", "symbol",
 ];
 
 fn collect_all_tags_from(fn_defs: &[(String, String, CalcitFnArgs, Vec<Calcit>)]) -> HashMap<String, u32> {
@@ -2955,7 +2954,7 @@ fn collect_tags_from_expr(expr: &Calcit, tags: &mut Vec<String>) {
         collect_tags_from_expr(x, tags);
       }
     }
-    Calcit::Struct(s) => {
+    Calcit::StructDef(s) => {
       tags.push(s.name.to_string());
       for f in s.fields.iter() {
         tags.push(f.to_string());

--- a/src/codegen/emit_wasm/heap.rs
+++ b/src/codegen/emit_wasm/heap.rs
@@ -156,7 +156,7 @@ pub(super) fn emit_option_tuple(ctx: &mut WasmGenCtx, payload_local: Option<u32>
     .ok_or_else(|| format!("Option tag missing from WASM tag index: {tag_name}"))? as f64;
   let payload_count = usize::from(payload_local.is_some());
   let ptr_local = ctx.alloc_local_typed(ValType::I32);
-  emit_bump_alloc(ctx, ((2 + payload_count) * 8) as i32, ptr_local, "tuple");
+  emit_bump_alloc(ctx, ((2 + payload_count) * 8) as i32, ptr_local, "enum");
 
   ctx.emit(Instruction::LocalGet(ptr_local));
   ctx.emit(f64_const(payload_count as f64));

--- a/src/codegen/emit_wasm/methods.rs
+++ b/src/codegen/emit_wasm/methods.rs
@@ -800,8 +800,8 @@ fn emit_method_empty_question(ctx: &mut WasmGenCtx, receiver_local: u32) -> Resu
   let map_tag = get_type_tag(ctx, "map");
   let set_tag = get_type_tag(ctx, "set");
   let string_tag = get_type_tag(ctx, "string");
-  let tuple_tag = get_type_tag(ctx, "tuple");
-  let record_tag = get_type_tag(ctx, "record");
+  let tuple_tag = get_type_tag(ctx, "enum");
+  let record_tag = get_type_tag(ctx, "struct");
   let type_local = ctx.alloc_local();
   emit_type_of_local(ctx, receiver_local);
   ctx.emit(Instruction::LocalSet(type_local));
@@ -1039,7 +1039,7 @@ fn emit_tuple_assoc_from_local(ctx: &mut WasmGenCtx, receiver_local: u32, index_
   ctx.emit(Instruction::LocalSet(size));
 
   let dst = ctx.alloc_local_typed(ValType::I32);
-  super::emit_bump_alloc_dynamic(ctx, size, dst, "tuple");
+  super::emit_bump_alloc_dynamic(ctx, size, dst, "enum");
 
   let dst_base = super::emit_addr_offset(ctx, dst, 0);
   let src_base = super::emit_addr_offset(ctx, ptr_local, 0);
@@ -1061,7 +1061,7 @@ fn emit_tuple_assoc_from_local(ctx: &mut WasmGenCtx, receiver_local: u32, index_
 fn emit_method_assoc(ctx: &mut WasmGenCtx, receiver_local: u32, key_local: u32, val_local: u32) -> Result<(), String> {
   let list_tag = super::get_type_tag(ctx, "list");
   let map_tag = super::get_type_tag(ctx, "map");
-  let tuple_tag = super::get_type_tag(ctx, "tuple");
+  let tuple_tag = super::get_type_tag(ctx, "enum");
   let type_local = ctx.alloc_local();
   emit_type_of_local(ctx, receiver_local);
   ctx.emit(Instruction::LocalSet(type_local));
@@ -1098,8 +1098,8 @@ fn emit_method_count(ctx: &mut WasmGenCtx, receiver_local: u32) -> Result<(), St
   let map_tag = get_type_tag(ctx, "map");
   let set_tag = get_type_tag(ctx, "set");
   let string_tag = get_type_tag(ctx, "string");
-  let tuple_tag = get_type_tag(ctx, "tuple");
-  let record_tag = get_type_tag(ctx, "record");
+  let tuple_tag = get_type_tag(ctx, "enum");
+  let record_tag = get_type_tag(ctx, "struct");
   let type_local = ctx.alloc_local();
   emit_type_of_local(ctx, receiver_local);
   ctx.emit(Instruction::LocalSet(type_local));
@@ -1130,7 +1130,7 @@ fn emit_method_count(ctx: &mut WasmGenCtx, receiver_local: u32) -> Result<(), St
 
 fn emit_method_nth(ctx: &mut WasmGenCtx, receiver_local: u32, index_local: u32) -> Result<(), String> {
   let list_tag = get_type_tag(ctx, "list");
-  let tuple_tag = get_type_tag(ctx, "tuple");
+  let tuple_tag = get_type_tag(ctx, "enum");
   let string_tag = get_type_tag(ctx, "string");
   let type_local = ctx.alloc_local();
   emit_type_of_local(ctx, receiver_local);
@@ -1163,7 +1163,7 @@ fn emit_method_nth(ctx: &mut WasmGenCtx, receiver_local: u32, index_local: u32) 
 
 fn emit_method_first(ctx: &mut WasmGenCtx, receiver_local: u32) -> Result<(), String> {
   let list_tag = get_type_tag(ctx, "list");
-  let tuple_tag = get_type_tag(ctx, "tuple");
+  let tuple_tag = get_type_tag(ctx, "enum");
   let string_tag = get_type_tag(ctx, "string");
   let type_local = ctx.alloc_local();
   emit_type_of_local(ctx, receiver_local);
@@ -1217,7 +1217,7 @@ fn emit_method_rest(ctx: &mut WasmGenCtx, receiver_local: u32) -> Result<(), Str
 fn emit_method_get(ctx: &mut WasmGenCtx, receiver_local: u32, key_local: u32) -> Result<(), String> {
   let map_tag = get_type_tag(ctx, "map");
   let list_tag = get_type_tag(ctx, "list");
-  let tuple_tag = get_type_tag(ctx, "tuple");
+  let tuple_tag = get_type_tag(ctx, "enum");
   let type_local = ctx.alloc_local();
   emit_type_of_local(ctx, receiver_local);
   ctx.emit(Instruction::LocalSet(type_local));

--- a/src/codegen/emit_wasm/records.rs
+++ b/src/codegen/emit_wasm/records.rs
@@ -185,7 +185,8 @@ pub(super) fn emit_record_nth(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
 /// Emit `&record:get record :field_tag` — dynamic field access by tag name.
 ///
 /// Performs a compile-time dispatch table: for each known struct type, scans
-/// field tags and returns the matching field value. Returns nil (0.0) if tag not found.
+/// field tags and returns the matching field value. A missing tag traps instead
+/// of silently returning the numeric representation of nil.
 pub(super) fn emit_record_get(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
   expect_arity(2, args, "&record:get requires 2 args (record, tag)")?;
 
@@ -216,7 +217,7 @@ pub(super) fn emit_record_get(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
     ctx.emit(Instruction::F64Eq);
     ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
 
-    // Nested if-chain: return field value for matching tag, else 0.0 (nil)
+    // Nested if-chain: return field value for matching tag, else trap.
     for (field_idx, field_tag_id) in field_tag_ids.iter().enumerate() {
       ctx.emit(Instruction::LocalGet(key_tag_local));
       ctx.emit(f64_const(*field_tag_id as f64));
@@ -227,7 +228,7 @@ pub(super) fn emit_record_get(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
       ctx.emit(Instruction::F64Load(mem_arg_f64(((2 + field_idx) * 8) as u64)));
       ctx.emit(Instruction::Else);
     }
-    ctx.emit(f64_const(0.0)); // field tag not found → nil
+    ctx.emit(Instruction::Unreachable);
     for _ in field_tag_ids {
       ctx.emit(Instruction::End);
     }
@@ -235,7 +236,7 @@ pub(super) fn emit_record_get(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
     ctx.emit(Instruction::Else);
   }
 
-  ctx.emit(f64_const(0.0)); // unknown struct type → nil
+  ctx.emit(Instruction::Unreachable);
   for _ in &struct_entries {
     ctx.emit(Instruction::End);
   }

--- a/src/codegen/emit_wasm/records.rs
+++ b/src/codegen/emit_wasm/records.rs
@@ -32,7 +32,7 @@ pub(super) fn emit_record_new(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
 
   // Allocate: save i32 pointer to a temporary local
   let ptr_local = ctx.alloc_local_typed(ValType::I32);
-  emit_bump_alloc(ctx, total_size, ptr_local, "record");
+  emit_bump_alloc(ctx, total_size, ptr_local, "struct");
 
   // Store field count at offset 0
   ctx.emit(Instruction::LocalGet(ptr_local));
@@ -59,21 +59,21 @@ pub(super) fn emit_record_new(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
   Ok(())
 }
 
-/// Resolve a struct reference (either inline Calcit::Struct or Calcit::Import) to a CalcitStruct.
-pub(super) fn resolve_struct_ref(node: &Calcit) -> Result<CalcitStruct, String> {
+/// Resolve a struct reference (either inline Calcit::StructDef or Calcit::Import) to a CalcitStructDef.
+pub(super) fn resolve_struct_ref(node: &Calcit) -> Result<CalcitStructDef, String> {
   match node {
-    Calcit::Struct(s) => Ok(s.clone()),
+    Calcit::StructDef(s) => Ok(s.clone()),
     Calcit::Import(CalcitImport { ns, def, .. }) => {
       // Try runtime first
-      if let Some(Calcit::Struct(s)) = program::lookup_runtime_ready(ns, def) {
+      if let Some(Calcit::StructDef(s)) = program::lookup_runtime_ready(ns, def) {
         return Ok(s);
       }
       // Try compiled def
       if let Some(compiled) = program::lookup_compiled_def(ns, def) {
-        if let Calcit::Struct(s) = &compiled.codegen_form {
+        if let Calcit::StructDef(s) = &compiled.codegen_form {
           return Ok(s.clone());
         }
-        if let Calcit::Struct(s) = &compiled.preprocessed_code {
+        if let Calcit::StructDef(s) = &compiled.preprocessed_code {
           return Ok(s.clone());
         }
         // Try to extract struct from defrecord form: (defrecord Name :field1 :field2 ...)
@@ -97,8 +97,8 @@ pub(super) fn resolve_struct_ref(node: &Calcit) -> Result<CalcitStruct, String> 
   }
 }
 
-/// Try to extract a CalcitStruct from a `(defrecord Name :field1 :field2 ...)` form.
-pub(super) fn try_parse_defrecord_form(code: &Calcit) -> Option<CalcitStruct> {
+/// Try to extract a CalcitStructDef from a `(defrecord Name :field1 :field2 ...)` form.
+pub(super) fn try_parse_defrecord_form(code: &Calcit) -> Option<CalcitStructDef> {
   let Calcit::List(xs) = code else { return None };
   if xs.len() < 2 {
     return None;
@@ -130,7 +130,7 @@ pub(super) fn try_parse_defrecord_form(code: &Calcit) -> Option<CalcitStruct> {
     }
   }
   fields.sort();
-  Some(CalcitStruct {
+  Some(CalcitStructDef {
     name,
     fields: std::sync::Arc::new(fields),
     field_types: std::sync::Arc::new(vec![]),
@@ -140,13 +140,13 @@ pub(super) fn try_parse_defrecord_form(code: &Calcit) -> Option<CalcitStruct> {
   })
 }
 
-/// Emit `&record:nth record idx_literal tag_literal` — O(1) field access by index.
+/// Emit `&struct:nth record idx_literal tag_literal` — O(1) field access by index.
 ///
 /// `idx` must be a compile-time Number constant.
 pub(super) fn emit_record_nth(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
   // args: [record_expr, idx_expr, tag_expr]
   if args.len() < 2 {
-    return Err("&record:nth requires at least 2 args (record, index)".into());
+    return Err("&struct:nth requires at least 2 args (record, index)".into());
   }
   // Layout: [count:f64][struct_tag:f64][field0:f64]...
   // Field at byte offset (2 + idx) * 8 from the record pointer
@@ -182,13 +182,13 @@ pub(super) fn emit_record_nth(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
   Ok(())
 }
 
-/// Emit `&record:get record :field_tag` — dynamic field access by tag name.
+/// Emit `&struct:get record :field_tag` — dynamic field access by tag name.
 ///
 /// Performs a compile-time dispatch table: for each known struct type, scans
 /// field tags and returns the matching field value. A missing tag traps instead
 /// of silently returning the numeric representation of nil.
 pub(super) fn emit_record_get(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(2, args, "&record:get requires 2 args (record, tag)")?;
+  expect_arity(2, args, "&struct:get requires 2 args (record, tag)")?;
 
   let record_ptr = emit_ptr_to_i32(ctx, &args[0])?;
 
@@ -243,12 +243,12 @@ pub(super) fn emit_record_get(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
   Ok(())
 }
 
-/// Emit `&record:count record` — returns the number of fields.
+/// Emit `&struct:count record` — returns the number of fields.
 /// Layout: [count:f64][struct_tag:f64][fields...]
 /// Count is at offset 0 from the record pointer.
 pub(super) fn emit_record_count(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
   if args.is_empty() {
-    return Err("&record:count requires 1 arg (record)".into());
+    return Err("&struct:count requires 1 arg (record)".into());
   }
   emit_expr(ctx, &args[0])?;
   ctx.emit(Instruction::I32TruncF64U);
@@ -257,7 +257,7 @@ pub(super) fn emit_record_count(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result
 }
 
 pub(super) fn emit_record_field_tag(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(2, args, "&record:field-tag requires 2 args (record, index)")?;
+  expect_arity(2, args, "&struct:field-tag requires 2 args (record, index)")?;
 
   emit_expr(ctx, &args[0])?;
   ctx.emit(Instruction::I32TruncF64U);
@@ -321,7 +321,7 @@ pub(super) fn emit_record_field_tag(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Re
 }
 
 pub(super) fn emit_record_get_name(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(1, args, "&record:get-name requires 1 arg (record)")?;
+  expect_arity(1, args, "&struct:get-name requires 1 arg (record)")?;
 
   emit_expr(ctx, &args[0])?;
   ctx.emit(Instruction::I32TruncF64U);
@@ -330,7 +330,7 @@ pub(super) fn emit_record_get_name(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Res
 }
 
 pub(super) fn emit_record_struct(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(1, args, "&record:struct requires 1 arg (record)")?;
+  expect_arity(1, args, "&struct:definition requires 1 arg (record)")?;
 
   emit_expr(ctx, &args[0])?;
   ctx.emit(Instruction::I32TruncF64U);
@@ -339,7 +339,7 @@ pub(super) fn emit_record_struct(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Resul
 }
 
 pub(super) fn emit_record_to_map(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(1, args, "&record:to-map requires 1 arg (record)")?;
+  expect_arity(1, args, "&struct:to-map requires 1 arg (record)")?;
 
   let record_ptr = emit_ptr_to_i32(ctx, &args[0])?;
   let struct_tag_local = ctx.alloc_local();
@@ -387,12 +387,12 @@ pub(super) fn emit_record_to_map(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Resul
   Ok(())
 }
 
-/// Emit `&record:matches? a b` — check if two records have the same struct type.
+/// Emit `&struct:matches? a b` — check if two records have the same struct type.
 ///
 /// Record layout: [count: f64] [struct_tag: f64] [field0: f64] ...
 /// Compares the struct_tag (offset 0) of both records.
 pub(super) fn emit_record_matches(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(2, args, "&record:matches? expects 2 args")?;
+  expect_arity(2, args, "&struct:matches? expects 2 args")?;
   // Load struct_tag of first record (at offset 8, after count)
   emit_expr(ctx, &args[0])?;
   ctx.emit(Instruction::I32TruncF64U);
@@ -413,12 +413,12 @@ pub(super) fn emit_record_matches(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Resu
   Ok(())
 }
 
-/// Emit `&record:contains? record key_tag` — check if a field tag exists in a record.
+/// Emit `&struct:contains? record key_tag` — check if a field tag exists in a record.
 ///
 /// Layout: [count:f64][struct_tag:f64][field0:f64]...
 /// Field tags are compile-time known via ctx.record_field_tags.
 pub(super) fn emit_record_contains(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(2, args, "&record:contains? requires 2 args (record, key_tag)")?;
+  expect_arity(2, args, "&struct:contains? requires 2 args (record, key_tag)")?;
   let record_ptr = emit_ptr_to_i32(ctx, &args[0])?;
 
   // Load struct_tag from record at offset 8
@@ -509,7 +509,7 @@ pub(super) fn emit_tuple_new(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<()
   let total_size = ((2 + payload.len()) * 8) as i32;
 
   let ptr_local = ctx.alloc_local_typed(ValType::I32);
-  emit_bump_alloc(ctx, total_size, ptr_local, "tuple");
+  emit_bump_alloc(ctx, total_size, ptr_local, "enum");
 
   // Store count at offset 0
   ctx.emit(Instruction::LocalGet(ptr_local));
@@ -562,7 +562,7 @@ pub(super) fn emit_enum_tuple_new(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Resu
   let total_size = ((2 + payload.len()) * 8) as i32;
 
   let ptr_local = ctx.alloc_local_typed(ValType::I32);
-  emit_bump_alloc(ctx, total_size, ptr_local, "tuple");
+  emit_bump_alloc(ctx, total_size, ptr_local, "enum");
 
   ctx.emit(Instruction::LocalGet(ptr_local));
   ctx.emit(f64_const(payload.len() as f64));
@@ -583,13 +583,13 @@ pub(super) fn emit_enum_tuple_new(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Resu
   Ok(())
 }
 
-/// Emit `&tuple:nth tuple idx` — O(1) payload access by index.
+/// Emit `&enum:nth tuple idx` — O(1) payload access by index.
 ///
 /// Tuple layout: [count:f64][tag:f64][payload0:f64]...
 /// idx 0 returns tag, idx 1+ returns payloads.
 /// Offset = (1 + idx) * 8  (skip count slot).
 pub(super) fn emit_tuple_nth(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(2, args, "&tuple:nth requires 2 args (tuple, index)")?;
+  expect_arity(2, args, "&enum:nth requires 2 args (tuple, index)")?;
   let ptr = emit_ptr_to_i32(ctx, &args[0])?;
   let idx_local = ctx.alloc_local_typed(ValType::I32);
   emit_expr(ctx, &args[1])?;
@@ -607,14 +607,14 @@ pub(super) fn emit_tuple_nth(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<()
   Ok(())
 }
 
-/// Emit `&tuple:count tuple` — matches interpreter semantics: payload count + 1 (includes tag).
+/// Emit `&enum:count tuple` — matches interpreter semantics: payload count + 1 (includes tag).
 ///
 /// Tuple layout: [count:f64][tag:f64][payload0:f64]...
 /// Stored count at offset 0 is the raw payload count; the interpreter returns `extra.len() + 1`.
 /// The +1 is required for `&tag-match-internal` which compares `(&list:count pattern)` (tag + bindings)
-/// against `(&tuple:count value)`.
+/// against `(&enum:count value)`.
 pub(super) fn emit_tuple_count(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(1, args, "&tuple:count expects 1 arg")?;
+  expect_arity(1, args, "&enum:count expects 1 arg")?;
   emit_expr(ctx, &args[0])?;
   ctx.emit(Instruction::I32TruncF64U);
   ctx.emit(Instruction::F64Load(mem_arg_f64(0)));
@@ -625,7 +625,7 @@ pub(super) fn emit_tuple_count(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<
 }
 
 pub(super) fn emit_tuple_assoc(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(3, args, "&tuple:assoc expects 3 args")?;
+  expect_arity(3, args, "&enum:assoc expects 3 args")?;
   let src = emit_ptr_to_i32(ctx, &args[0])?;
   let count = emit_load_count_i32(ctx, src);
   let idx = ctx.alloc_local_typed(ValType::I32);
@@ -649,7 +649,7 @@ pub(super) fn emit_tuple_assoc(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<
   ctx.emit(Instruction::LocalSet(size));
 
   let dst = ctx.alloc_local_typed(ValType::I32);
-  emit_bump_alloc_dynamic(ctx, size, dst, "tuple");
+  emit_bump_alloc_dynamic(ctx, size, dst, "enum");
 
   let dst_base = emit_addr_offset(ctx, dst, 0);
   let src_base = emit_addr_offset(ctx, src, 0);

--- a/src/codegen/gen_ir.rs
+++ b/src/codegen/gen_ir.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use cirru_edn::{Edn, EdnListView, format};
 
 use crate::calcit::{
-  Calcit, CalcitArgLabel, CalcitEnum, CalcitFnArgs, CalcitImpl, CalcitImport, CalcitLocal, CalcitRecord, CalcitStruct, CalcitTuple,
-  CalcitTypeAnnotation, ImportInfo, MethodKind,
+  Calcit, CalcitArgLabel, CalcitEnumDef, CalcitEnumValue, CalcitFnArgs, CalcitImpl, CalcitImport, CalcitLocal, CalcitStructDef,
+  CalcitStructValue, CalcitTypeAnnotation, ImportInfo, MethodKind,
 };
 use crate::program;
 
@@ -247,11 +247,11 @@ pub(crate) fn dump_code(code: &Calcit) -> Edn {
       });
       Edn::from(ys)
     }
-    Calcit::Tuple(tuple) => dump_tuple_code(tuple),
-    Calcit::Record(record) => dump_record_code(record),
+    Calcit::Enum(tuple) => dump_tuple_code(tuple),
+    Calcit::Struct(record) => dump_record_code(record),
     Calcit::Impl(impl_def) => dump_impl_code(impl_def),
-    Calcit::Struct(struct_def) => dump_struct_code(struct_def),
-    Calcit::Enum(enum_def) => dump_enum_code(enum_def),
+    Calcit::StructDef(struct_def) => dump_struct_code(struct_def),
+    Calcit::EnumDef(enum_def) => dump_enum_code(enum_def),
     Calcit::Method(method, kind) => {
       let mut entries = vec![
         (Edn::tag("kind"), Edn::tag("method")),
@@ -352,7 +352,7 @@ fn dump_type_annotation(type_info: &CalcitTypeAnnotation) -> Edn {
   type_info.to_type_edn()
 }
 
-fn dump_tuple_code(tuple: &CalcitTuple) -> Edn {
+fn dump_tuple_code(tuple: &CalcitEnumValue) -> Edn {
   let mut entries = tuple_metadata_entries(tuple);
   let mut values = EdnListView::default();
   for value in &tuple.extra {
@@ -363,7 +363,7 @@ fn dump_tuple_code(tuple: &CalcitTuple) -> Edn {
   Edn::map_from_iter(entries)
 }
 
-fn tuple_metadata_entries(tuple: &CalcitTuple) -> Vec<(Edn, Edn)> {
+fn tuple_metadata_entries(tuple: &CalcitEnumValue) -> Vec<(Edn, Edn)> {
   let mut entries = vec![
     (Edn::tag("kind"), Edn::tag("tuple")),
     (Edn::tag("tag"), Edn::Str(tuple.tag.to_string().into())),
@@ -374,7 +374,7 @@ fn tuple_metadata_entries(tuple: &CalcitTuple) -> Vec<(Edn, Edn)> {
   entries
 }
 
-fn dump_record_code(record: &CalcitRecord) -> Edn {
+fn dump_record_code(record: &CalcitStructValue) -> Edn {
   let mut entries = record_metadata(record);
   let mut fields = EdnListView::default();
   for (field, value) in record.struct_ref.fields.iter().zip(record.values.iter()) {
@@ -409,7 +409,7 @@ fn dump_impl_code(impl_def: &CalcitImpl) -> Edn {
   Edn::map_from_iter(entries)
 }
 
-fn dump_struct_code(struct_def: &CalcitStruct) -> Edn {
+fn dump_struct_code(struct_def: &CalcitStructDef) -> Edn {
   let mut entries = vec![
     (Edn::tag("kind"), Edn::tag("struct")),
     (Edn::tag("name"), Edn::Str(struct_def.name.ref_str().into())),
@@ -435,7 +435,7 @@ fn dump_struct_code(struct_def: &CalcitStruct) -> Edn {
   Edn::map_from_iter(entries)
 }
 
-fn dump_enum_code(enum_def: &CalcitEnum) -> Edn {
+fn dump_enum_code(enum_def: &CalcitEnumDef) -> Edn {
   let mut entries = vec![
     (Edn::tag("kind"), Edn::tag("enum")),
     (Edn::tag("name"), Edn::Str(enum_def.name().ref_str().into())),
@@ -466,7 +466,7 @@ fn dump_enum_code(enum_def: &CalcitEnum) -> Edn {
   Edn::map_from_iter(entries)
 }
 
-fn record_metadata(record: &CalcitRecord) -> Vec<(Edn, Edn)> {
+fn record_metadata(record: &CalcitStructValue) -> Vec<(Edn, Edn)> {
   let entries = vec![
     (Edn::tag("kind"), Edn::tag("record")),
     (Edn::tag("name"), Edn::Str(record.name().ref_str().into())),

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
   Calcit,
-  calcit::{CalcitList, CalcitProc, CalcitRecord, CalcitStruct, CalcitSyntax, CalcitTuple},
+  calcit::{CalcitEnumValue, CalcitList, CalcitProc, CalcitStructDef, CalcitStructValue, CalcitSyntax},
 };
 
 pub mod cirru;
@@ -91,7 +91,7 @@ pub fn data_to_calcit(x: &Calcit, ns: &str, at_def: &str) -> Result<Calcit, Stri
     ]))),
     Registered(s) => Ok(Calcit::Registered(s.to_owned())),
     Nil => Ok(Calcit::Nil),
-    Tuple(CalcitTuple { tag: t, extra, .. }) => {
+    Enum(CalcitEnumValue { tag: t, extra, .. }) => {
       let mut ys = vec![Calcit::Proc(CalcitProc::NativeTuple), data_to_calcit(t, ns, at_def)?];
       for x in extra {
         ys.push(data_to_calcit(x, ns, at_def)?);
@@ -122,7 +122,7 @@ pub fn data_to_calcit(x: &Calcit, ns: &str, at_def: &str) -> Result<Calcit, Stri
       }
       Ok(Calcit::from(ys))
     }
-    Record(CalcitRecord { struct_ref, values, .. }) => {
+    Struct(CalcitStructValue { struct_ref, values, .. }) => {
       let mut ys = vec![Calcit::Symbol {
         sym: "%{}".into(),
         info: Arc::new(crate::calcit::CalcitSymbolInfo {
@@ -148,7 +148,7 @@ pub fn data_to_calcit(x: &Calcit, ns: &str, at_def: &str) -> Result<Calcit, Stri
       }
       Ok(Calcit::from(ys))
     }
-    Struct(CalcitStruct {
+    StructDef(CalcitStructDef {
       name,
       fields,
       field_types,
@@ -205,7 +205,7 @@ pub fn data_to_calcit(x: &Calcit, ns: &str, at_def: &str) -> Result<Calcit, Stri
         Ok(struct_value)
       }
     }
-    Enum(enum_def) => {
+    EnumDef(enum_def) => {
       let mut ys = vec![Calcit::Symbol {
         sym: "defenum".into(),
         info: Arc::new(crate::calcit::CalcitSymbolInfo {

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use bisection_key::LexiconKey;
 use cirru_parser::Cirru;
 
-use crate::calcit::{self, CalcitEnum, CalcitImpl, CalcitImport, CalcitList, CalcitLocal, CalcitStruct, CalcitTuple};
-use crate::calcit::{Calcit, CalcitRecord};
+use crate::calcit::{self, CalcitEnumDef, CalcitEnumValue, CalcitImpl, CalcitImport, CalcitList, CalcitLocal, CalcitStructDef};
+use crate::calcit::{Calcit, CalcitStructValue};
 use crate::{calcit::MethodKind, data::cirru};
 
 use cirru_edn::{Edn, EdnListView, EdnMapView, EdnRecordView, EdnSetView, EdnTag, EdnTupleView};
@@ -45,7 +45,7 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
       }
       Ok(ys.into())
     }
-    Record(CalcitRecord { struct_ref, values, .. }) => {
+    Struct(CalcitStructValue { struct_ref, values, .. }) => {
       let mut entries = EdnRecordView::new(struct_ref.name.to_owned());
       for idx in 0..struct_ref.fields.len() {
         entries.insert(struct_ref.fields[idx].to_owned(), calcit_to_edn(&values[idx])?);
@@ -62,7 +62,7 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
     }
     Proc(name) => Ok(Edn::Symbol(name.as_ref().into())),
     Syntax(name, _ns) => Ok(Edn::sym(name.as_ref())),
-    Tuple(CalcitTuple { tag, extra, sum_type, .. }) => {
+    Enum(CalcitEnumValue { tag, extra, sum_type, .. }) => {
       let enum_tag = sum_type.as_ref().map(|enum_def| Edn::Tag(enum_def.name().to_owned()));
       match &**tag {
         Symbol { sym, .. } => {
@@ -76,7 +76,7 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
             Err(format!("unknown tag for EDN: {sym}")) // TODO more types to handle
           }
         }
-        Record(CalcitRecord { struct_ref, .. }) => {
+        Struct(CalcitStructValue { struct_ref, .. }) => {
           let mut extra_values = vec![];
           for item in extra {
             extra_values.push(calcit_to_edn(item)?);
@@ -416,7 +416,7 @@ pub fn edn_to_calcit(x: &Edn, options: &Calcit) -> Calcit {
     Edn::Quote(nodes) => Calcit::CirruQuote(nodes.to_owned()),
     Edn::Tuple(EdnTupleView { tag, enum_tag, extra }) => {
       let sum_type = enum_tag.as_ref().and_then(|enum_tag| resolve_enum_tag(enum_tag, options));
-      Calcit::Tuple(CalcitTuple {
+      Calcit::Enum(CalcitEnumValue {
         tag: Arc::new(edn_to_calcit(tag, options)),
         extra: extra.iter().map(|x| edn_to_calcit(x, options)).collect(),
         sum_type,
@@ -454,10 +454,10 @@ pub fn edn_to_calcit(x: &Edn, options: &Calcit) -> Calcit {
       }
 
       let struct_ref = match find_record_in_options(&name.arc_str(), options) {
-        Some(Calcit::Record(record)) if fields == *record.struct_ref.fields => Arc::clone(&record.struct_ref),
-        _ => Arc::new(CalcitStruct::from_fields(name.to_owned(), fields)),
+        Some(Calcit::Struct(record)) if fields == *record.struct_ref.fields => Arc::clone(&record.struct_ref),
+        _ => Arc::new(CalcitStructDef::from_fields(name.to_owned(), fields)),
       };
-      Calcit::Record(CalcitRecord {
+      Calcit::Struct(CalcitStructValue {
         struct_ref,
         values: Arc::new(values),
       })
@@ -482,7 +482,7 @@ fn find_enum_in_options<'a>(name: &str, options: &'a Calcit) -> Option<&'a Calci
   }
 }
 
-fn resolve_enum_tag(enum_tag: &Edn, options: &Calcit) -> Option<Arc<CalcitEnum>> {
+fn resolve_enum_tag(enum_tag: &Edn, options: &Calcit) -> Option<Arc<CalcitEnumDef>> {
   let enum_name = match enum_tag {
     Edn::Tag(tag) => tag.ref_str(),
     Edn::Symbol(sym) => sym.as_ref(),
@@ -490,7 +490,7 @@ fn resolve_enum_tag(enum_tag: &Edn, options: &Calcit) -> Option<Arc<CalcitEnum>>
     _ => return None,
   };
   match find_enum_in_options(enum_name, options) {
-    Some(Calcit::Enum(enum_def)) => Some(Arc::new(enum_def.to_owned())),
+    Some(Calcit::EnumDef(enum_def)) => Some(Arc::new(enum_def.to_owned())),
     _ => None,
   }
 }
@@ -541,11 +541,11 @@ mod tests {
 
   #[test]
   fn dynamic_record_options_do_not_panic_on_field_mismatch() {
-    let declared = Arc::new(CalcitStruct::from_fields(
+    let declared = Arc::new(CalcitStructDef::from_fields(
       EdnTag::new("Person"),
       vec![EdnTag::new("age"), EdnTag::new("name")],
     ));
-    let prototype = Calcit::Record(CalcitRecord {
+    let prototype = Calcit::Struct(CalcitStructValue {
       struct_ref: declared.clone(),
       values: Arc::new(vec![Calcit::Nil, Calcit::Nil]),
     });
@@ -555,7 +555,7 @@ mod tests {
     let mut input = EdnRecordView::new(EdnTag::new("Person"));
     input.insert(EdnTag::new("name"), Edn::str("Ada"));
     let decoded = edn_to_calcit(&Edn::Record(input), &Calcit::Map(options));
-    let Calcit::Record(record) = decoded else {
+    let Calcit::Struct(record) = decoded else {
       panic!("expected record");
     };
     assert!(!Arc::ptr_eq(&record.struct_ref, &declared));

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -6,7 +6,7 @@ use cirru_edn::{Edn, EdnRecordView, EdnTupleView};
 
 use crate::builtins::quick_build_atom;
 use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
-use crate::calcit::{self, Calcit, CalcitList, CalcitRecord, CalcitTuple};
+use crate::calcit::{self, Calcit, CalcitEnumValue, CalcitList, CalcitStructValue};
 
 const MAX_DECODE_DEPTH: usize = 1024;
 
@@ -189,7 +189,7 @@ impl Decoder<'_> {
               .expect("record field sets were checked");
             values.push(self.decode_node(*field_node, raw_value, &format!("{path}.{}", field.ref_str()), depth + 1)?);
           }
-          Ok(Calcit::Record(CalcitRecord {
+          Ok(Calcit::Struct(CalcitStructValue {
             struct_ref: nominal.clone(),
             values: Arc::new(values),
           }))
@@ -235,7 +235,7 @@ impl Decoder<'_> {
           for (idx, (payload_node, raw_value)) in payload_nodes.iter().zip(extra.iter()).enumerate() {
             values.push(self.decode_node(*payload_node, raw_value, &format!("{path}.payload[{idx}]"), depth + 1)?);
           }
-          Ok(Calcit::Tuple(CalcitTuple {
+          Ok(Calcit::Enum(CalcitEnumValue {
             tag: Arc::new(Calcit::Tag(variant_tag.clone())),
             extra: values,
             sum_type: Some(nominal.clone()),
@@ -303,11 +303,11 @@ fn sorted_duplicate_names<'a>(values: impl IntoIterator<Item = &'a str>) -> Vec<
 mod tests {
   use super::*;
   use crate::calcit::data_shape::DataShapeGraph;
-  use crate::calcit::{CalcitEnum, CalcitStruct, CalcitTypeAnnotation, EnumVariant};
+  use crate::calcit::{CalcitEnumDef, CalcitStructDef, CalcitTypeAnnotation, EnumVariant};
   use cirru_edn::EdnTag;
 
-  fn person_struct() -> Arc<CalcitStruct> {
-    Arc::new(CalcitStruct {
+  fn person_struct() -> Arc<CalcitStructDef> {
+    Arc::new(CalcitStructDef {
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("age"), EdnTag::new("name")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
@@ -324,7 +324,7 @@ mod tests {
       DataShapeGraph::build(&CalcitTypeAnnotation::Struct(person.clone(), Arc::new(vec![])), "tests.edn").expect("derive person shape");
     let input = cirru_edn::parse("%{} :Person (:age 23) (:name |Ada)").expect("parse edn");
     let decoded = decode(&shape, &input).expect("decode person");
-    let Calcit::Record(record) = decoded else {
+    let Calcit::Struct(record) = decoded else {
       panic!("expected record");
     };
     assert!(Arc::ptr_eq(&record.struct_ref, &person));
@@ -402,8 +402,8 @@ mod tests {
 
   #[test]
   fn decodes_enum_and_checks_payload_arity() {
-    let prototype = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct {
+    let prototype = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef {
         name: EdnTag::new("ResultText"),
         fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
         field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),
@@ -416,13 +416,13 @@ mod tests {
         Calcit::List(Arc::new(CalcitList::Vector(vec![]))),
       ]),
     };
-    let enum_def = Arc::new(CalcitEnum::from_record(prototype).expect("enum prototype"));
+    let enum_def = Arc::new(CalcitEnumDef::from_record(prototype).expect("enum prototype"));
     assert!(matches!(enum_def.variants(), [EnumVariant { .. }, EnumVariant { .. }]));
     let shape =
       DataShapeGraph::build(&CalcitTypeAnnotation::Enum(enum_def.clone(), Arc::new(vec![])), "tests.edn").expect("derive enum shape");
     let input = cirru_edn::parse("%:: :ResultText :err |oops").expect("parse edn");
     let decoded = decode(&shape, &input).expect("decode enum");
-    let Calcit::Tuple(tuple) = decoded else {
+    let Calcit::Enum(tuple) = decoded else {
       panic!("expected tuple");
     };
     assert!(tuple.sum_type.as_ref().is_some_and(|actual| Arc::ptr_eq(actual, &enum_def)));

--- a/src/effects_graph.rs
+++ b/src/effects_graph.rs
@@ -2,7 +2,7 @@
 
 use crate::builtins;
 use crate::calcit::CalcitTypeAnnotation;
-use crate::calcit::{Calcit, CalcitFnArgs, CalcitLocal, CalcitProc, CalcitStruct, CalcitSyntax};
+use crate::calcit::{Calcit, CalcitFnArgs, CalcitLocal, CalcitProc, CalcitStructDef, CalcitSyntax};
 use crate::program::{
   ImportRule, PROGRAM_CODE_DATA, lookup_codegen_type_hint, lookup_def_code, lookup_def_schema, lookup_ns_target_in_import,
 };
@@ -383,7 +383,7 @@ impl EffectsGraphAnalyzer {
       Calcit::Thunk(crate::calcit::CalcitThunk::Code { code, .. }) => {
         self.walk_expr(code, current_ns, out, depth);
       }
-      Calcit::Tuple(tuple) => {
+      Calcit::Enum(tuple) => {
         for item in &tuple.extra {
           self.walk_expr(item, current_ns, out, depth);
         }
@@ -590,7 +590,7 @@ fn extract_call_targets_recursive(code: &Calcit, current_ns: &str, calls: &mut V
     Calcit::Thunk(crate::calcit::CalcitThunk::Code { code, .. }) => {
       extract_call_targets_recursive(code, current_ns, calls);
     }
-    Calcit::Tuple(tuple) => {
+    Calcit::Enum(tuple) => {
       for item in &tuple.extra {
         extract_call_targets_recursive(item, current_ns, calls);
       }
@@ -891,7 +891,7 @@ fn format_schema_annotation(schema: &std::sync::Arc<CalcitTypeAnnotation>, conte
   }
 }
 
-fn format_struct_fields(st: &CalcitStruct, context_ns: &str, depth: usize) -> String {
+fn format_struct_fields(st: &CalcitStructDef, context_ns: &str, depth: usize) -> String {
   let fields: Vec<String> = st
     .fields
     .iter()
@@ -947,7 +947,7 @@ fn walk_for_record_templates(code: &Calcit, best: &mut Option<Vec<(String, Strin
       }
     }
     Calcit::Thunk(crate::calcit::CalcitThunk::Code { code, .. }) => walk_for_record_templates(code, best),
-    Calcit::Record(record) => {
+    Calcit::Struct(record) => {
       if let Some(fields) = record_fields_from_calcit(record)
         && fields.len() >= 2
         && best.as_ref().is_none_or(|current| current.len() < fields.len())
@@ -981,7 +981,7 @@ fn format_record_fields(fields: &[(String, String)], context_ns: &str, depth: us
 }
 
 fn parse_record_field_pairs(expr: &Calcit) -> Option<Vec<(String, String)>> {
-  if let Calcit::Record(record) = expr {
+  if let Calcit::Struct(record) = expr {
     return record_fields_from_calcit(record);
   }
   let Calcit::List(list) = expr else {
@@ -1022,7 +1022,7 @@ fn parse_nested_record_entries(list: &crate::calcit::CalcitList, start: usize) -
   if fields.is_empty() { None } else { Some(fields) }
 }
 
-fn record_fields_from_calcit(record: &crate::calcit::CalcitRecord) -> Option<Vec<(String, String)>> {
+fn record_fields_from_calcit(record: &crate::calcit::CalcitStructValue) -> Option<Vec<(String, String)>> {
   let fields = record.fields();
   let values = record.values.as_ref();
   if fields.is_empty() || fields.len() != values.len() {

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
-use crate::calcit::{CalcitImport, CalcitStruct, CalcitSyntax, ImportInfo};
+use crate::calcit::{CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo};
 use crate::call_stack::CallStackList;
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
@@ -32,7 +32,7 @@ fn strict_edn_decoder_nominals_are_compiled_dependencies() {
   let graph = DataShapeGraph::from_nodes(
     0,
     vec![DataShapeNode::Struct {
-      nominal: Arc::new(CalcitStruct::from_fields(EdnTag::new("Person"), vec![])),
+      nominal: Arc::new(CalcitStructDef::from_fields(EdnTag::new("Person"), vec![])),
       nominal_path: Some((ns.clone(), def.clone())),
       type_args: Arc::new(vec![]),
       fields: vec![],

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -331,7 +331,14 @@ pub fn call_expr(
             Some(value) => Ok(value.to_owned()),
             None => Ok(Calcit::Nil),
           },
-          Calcit::Record(record) => Ok(record.get(k.ref_str()).cloned().unwrap_or(Calcit::Nil)),
+          Calcit::Record(record) => record.get(k.ref_str()).cloned().ok_or_else(|| {
+            CalcitErr::use_msg_stack_location(
+              CalcitErrKind::Type,
+              format!("record `{}` does not define field `:{k}`", record.struct_ref.name),
+              call_stack,
+              v.get_location(),
+            )
+          }),
           _ => Err(CalcitErr::use_msg_stack_location(
             CalcitErrKind::Type,
             format!("expected a hashmap or record, got: {v}"),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -117,15 +117,15 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_sta
     | Tag(_)
     | Str(_)
     | Ref(..)
-    | Tuple { .. }
+    | Enum { .. }
     | Buffer(..)
     | BufList(..)
     | CirruQuote(..)
     | Proc(_)
     | Macro { .. }
     | Fn { .. }
-    | Struct { .. }
-    | Enum { .. }
+    | StructDef { .. }
+    | EnumDef { .. }
     | Trait { .. }
     | Impl { .. }
     | Syntax(_, _)
@@ -172,9 +172,9 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_sta
       call_stack,
       expr.get_location(),
     )),
-    Record { .. } => Err(CalcitErr::use_msg_stack_location(
+    Struct { .. } => Err(CalcitErr::use_msg_stack_location(
       CalcitErrKind::Unexpected,
-      "unexpected record for expr",
+      "unexpected struct value for expr",
       call_stack,
       expr.get_location(),
     )),
@@ -331,7 +331,7 @@ pub fn call_expr(
             Some(value) => Ok(value.to_owned()),
             None => Ok(Calcit::Nil),
           },
-          Calcit::Record(record) => record.get(k.ref_str()).cloned().ok_or_else(|| {
+          Calcit::Struct(record) => record.get(k.ref_str()).cloned().ok_or_else(|| {
             CalcitErr::use_msg_stack_location(
               CalcitErrKind::Type,
               format!("record `{}` does not define field `:{k}`", record.struct_ref.name),

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -120,6 +120,18 @@ pub(crate) fn tag_annotation(name: &str) -> Arc<CalcitTypeAnnotation> {
   Arc::new(CalcitTypeAnnotation::from_tag_name(name))
 }
 
+/// A loose record has a runtime field set but no nominal declaration from which
+/// the preprocessor can derive an index. It is still a record: postfix access
+/// must use the required record lookup rather than the Option-producing
+/// collection `get` API.
+fn is_unshaped_record_type(type_info: &CalcitTypeAnnotation) -> bool {
+  matches!(
+    type_info,
+    CalcitTypeAnnotation::Custom(value)
+      if matches!(value.as_ref(), Calcit::Tag(tag) if tag.ref_str().trim_start_matches(':') == "record")
+  )
+}
+
 /// Extract type information from a Calcit definition
 /// Functions and procs are converted into `CalcitTypeAnnotation::Function` to retain argument/return hints
 /// Other values fall back to their concrete annotation (tag/record/tuple/custom)
@@ -1006,19 +1018,34 @@ fn preprocess_list_call(
     let first_arg = &args[0];
     match first_arg {
       Calcit::Tag(field_tag) if args.len() == 1 => {
-        if let Some(type_info) = resolve_type_value(&head_form, scope_types)
-          && let Some(struct_def) = type_info.as_ref().resolve_to_struct()
-          && let Some(idx) = struct_def.index_of(field_tag.ref_str())
-        {
-          // Rewrite to (&record:nth expr idx :field-tag) — same as the existing
-          // `(:tag expr)` rewrite, works in both Rust runtime and JS codegen.
-          let items: Vec<Calcit> = vec![
-            Calcit::Proc(CalcitProc::NativeRecordNth),
-            head_form,
-            Calcit::Number(idx as f64),
-            Calcit::Tag(field_tag.to_owned()),
-          ];
-          return Ok(Calcit::from(CalcitList::from(items.as_slice())));
+        if let Some(type_info) = resolve_type_value(&head_form, scope_types) {
+          if let Some(struct_def) = type_info.as_ref().resolve_to_struct()
+            && let Some(idx) = struct_def.index_of(field_tag.ref_str())
+          {
+            // Rewrite to (&record:nth expr idx :field-tag) — same as the existing
+            // `(:tag expr)` rewrite, works in both Rust runtime and JS codegen.
+            // A nominal struct has a fixed field set, so this returns the field
+            // directly rather than wrapping it in Option.
+            let items: Vec<Calcit> = vec![
+              Calcit::Proc(CalcitProc::NativeRecordNth),
+              head_form,
+              Calcit::Number(idx as f64),
+              Calcit::Tag(field_tag.to_owned()),
+            ];
+            return Ok(Calcit::from(CalcitList::from(items.as_slice())));
+          }
+
+          // A record field is never an optional collection lookup. For a
+          // nominal record this path means the tag was not declared; for a
+          // loose record the field set is known only at runtime. Both use the
+          // required record lookup and report a normal error when absent.
+          if type_info.as_ref().resolve_to_struct().is_some() || is_unshaped_record_type(type_info.as_ref()) {
+            return Ok(Calcit::from(CalcitList::from(&[
+              Calcit::Proc(CalcitProc::NativeRecordGet),
+              head_form,
+              first_arg.to_owned(),
+            ])));
+          }
         }
         // For non-record types (Dynamic, Fn, etc.), silently fall through —
         // `:tag` is a normal argument like `(list :a)` or `(f :a)`.
@@ -1253,6 +1280,15 @@ fn preprocess_list_call(
             ];
             let nth_call = Calcit::from(CalcitList::from(items.as_slice()));
             return Ok(nth_call);
+          }
+          if let Some(type_info) = resolve_type_value(&processed_arg, scope_types)
+            && (type_info.as_ref().resolve_to_struct().is_some() || is_unshaped_record_type(type_info.as_ref()))
+          {
+            return Ok(Calcit::from(CalcitList::from(&[
+              Calcit::Proc(CalcitProc::NativeRecordGet),
+              processed_arg,
+              head.to_owned(),
+            ])));
           }
           // Fallback: rewrite to (get arg :tag) and re-preprocess
           let get_method = Calcit::Import(CalcitImport {
@@ -6044,6 +6080,70 @@ mod tests {
 
     // Currently no warnings expected for valid field access
     // In future, we'll check warnings.borrow().is_empty()
+  }
+
+  #[test]
+  fn postfix_nominal_record_access_uses_direct_field_lookup() {
+    let expr = Cirru::List(vec![Cirru::leaf("person"), Cirru::leaf(":name")]);
+    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse postfix field access");
+    let mut scope_defs = HashSet::new();
+    scope_defs.insert(Arc::from("person"));
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(
+      Arc::from("person"),
+      Arc::new(CalcitTypeAnnotation::Record(Arc::new(CalcitStruct::from_fields(
+        EdnTag::from("Person"),
+        vec![EdnTag::from("name")],
+      )))),
+    );
+
+    let warnings = RefCell::new(vec![]);
+    let resolved = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut scope_types,
+      "tests.record",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess nominal postfix field access");
+
+    let Calcit::List(items) = resolved else {
+      panic!("expected specialized field access call");
+    };
+    assert!(
+      matches!(items.first(), Some(Calcit::Proc(CalcitProc::NativeRecordNth))),
+      "nominal field access should bypass Option-producing get: {items}"
+    );
+  }
+
+  #[test]
+  fn postfix_loose_record_access_uses_required_record_get() {
+    let expr = Cirru::List(vec![Cirru::leaf("record"), Cirru::leaf(":name")]);
+    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse postfix field access");
+    let mut scope_defs = HashSet::new();
+    scope_defs.insert(Arc::from("record"));
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(Arc::from("record"), tag_annotation("record"));
+
+    let warnings = RefCell::new(vec![]);
+    let resolved = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut scope_types,
+      "tests.record",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess loose record postfix field access");
+
+    let Calcit::List(items) = resolved else {
+      panic!("expected required record get call");
+    };
+    assert!(
+      matches!(items.first(), Some(Calcit::Proc(CalcitProc::NativeRecordGet))),
+      "loose record access should never use Option-producing get: {items}"
+    );
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6,9 +6,9 @@ use crate::{
   builtins::{self, is_js_syntax_procs, is_proc_name, is_registered_proc},
   calcit::{
     self, Calcit, CalcitArgLabel, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnTypeAnnotation, CalcitImpl, CalcitImport,
-    CalcitList, CalcitLocal, CalcitProc, CalcitScope, CalcitStruct, CalcitSymbolInfo, CalcitSyntax, CalcitTrait, CalcitTypeAnnotation,
-    GENERATED_DEF, ImportInfo, LocatedWarning, NodeLocation, RawCodeType, SchemaKind, brief_type_of_value, pop_type_slot_override,
-    push_type_slot_override, register_type_slot,
+    CalcitList, CalcitLocal, CalcitProc, CalcitScope, CalcitStructDef, CalcitSymbolInfo, CalcitSyntax, CalcitTrait,
+    CalcitTypeAnnotation, GENERATED_DEF, ImportInfo, LocatedWarning, NodeLocation, RawCodeType, SchemaKind, brief_type_of_value,
+    pop_type_slot_override, push_type_slot_override, register_type_slot,
   },
   call_stack::{CallStackList, StackKind},
   codegen, program, runner,
@@ -51,7 +51,7 @@ thread_local! {
   /// When set, the hashmap literal preprocessor uses this struct definition to look up
   /// field types and inject EXPECTED_FN_TYPE for Fn-typed fields.
   /// This enables type propagation through record literals (e.g., `:on-click $ fn (e d!) ...` in DomProps).
-  static EXPECTED_STRUCT_TYPE: RefCell<Option<CalcitStruct>> = const { RefCell::new(None) };
+  static EXPECTED_STRUCT_TYPE: RefCell<Option<CalcitStructDef>> = const { RefCell::new(None) };
   /// Feature flags of the current function being preprocessed.
   /// Used to check whether js-ffi calls are permitted.
   static CURRENT_FN_FEATURES: RefCell<Option<Arc<HashSet<EdnTag>>>> = const { RefCell::new(None) };
@@ -120,21 +120,63 @@ pub(crate) fn tag_annotation(name: &str) -> Arc<CalcitTypeAnnotation> {
   Arc::new(CalcitTypeAnnotation::from_tag_name(name))
 }
 
-/// A loose record has a runtime field set but no nominal declaration from which
-/// the preprocessor can derive an index. It is still a record: postfix access
-/// must use the required record lookup rather than the Option-producing
+fn removed_data_api_replacement(name: &str) -> Option<String> {
+  match name {
+    "record?" => Some("struct? (values) or struct-def? (definitions)".to_owned()),
+    "tuple?" => Some("enum? (values) or enum-def? (definitions)".to_owned()),
+    "record-struct" => Some("struct-definition".to_owned()),
+    "tuple-enum" => Some("enum-definition".to_owned()),
+    "record-with" => Some("struct-with".to_owned()),
+    "record-match" => Some("struct-match".to_owned()),
+    "&record:struct" => Some("&struct:definition".to_owned()),
+    "&tuple:enum" => Some("&enum:definition".to_owned()),
+    "&tuple:enum-has-variant?" => Some("&enum-def:has-variant?".to_owned()),
+    "&tuple:enum-variant-arity" => Some("&enum-def:variant-arity".to_owned()),
+    "&tuple:validate-enum" => Some("&enum:validate".to_owned()),
+    _ if name.starts_with("&record:") => Some(name.replacen("&record:", "&struct:", 1)),
+    _ if name.starts_with("&tuple:") => Some(name.replacen("&tuple:", "&enum:", 1)),
+    _ => None,
+  }
+}
+
+fn warn_on_removed_data_api_call(
+  head: &Calcit,
+  call_location: Option<NodeLocation>,
+  file_ns: &str,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  let Calcit::Import(CalcitImport { ns, def, .. }) = head else {
+    return;
+  };
+  if ns.as_ref() != calcit::CORE_NS {
+    return;
+  }
+  let Some(replacement) = removed_data_api_replacement(def) else {
+    return;
+  };
+  let message = format!("[Warn] `{def}` was removed by the struct/enum data-model migration; use `{replacement}`");
+  if let Some(location) = call_location {
+    gen_check_warning_with_location_code(message, "W_REMOVED_DATA_API", location, check_warnings);
+  } else {
+    gen_check_warning_code(message, "W_REMOVED_DATA_API", file_ns, check_warnings);
+  }
+}
+
+/// An anonymous struct has a runtime field set but no nominal declaration from
+/// which the preprocessor can derive an index. Postfix access must use the
+/// required struct lookup rather than the Option-producing
 /// collection `get` API.
-fn is_unshaped_record_type(type_info: &CalcitTypeAnnotation) -> bool {
+fn is_anonymous_struct_type(type_info: &CalcitTypeAnnotation) -> bool {
   matches!(
     type_info,
     CalcitTypeAnnotation::Custom(value)
-      if matches!(value.as_ref(), Calcit::Tag(tag) if tag.ref_str().trim_start_matches(':') == "record")
+      if matches!(value.as_ref(), Calcit::Tag(tag) if matches!(tag.ref_str().trim_start_matches(':'), "record" | "struct"))
   )
 }
 
 /// Extract type information from a Calcit definition
 /// Functions and procs are converted into `CalcitTypeAnnotation::Function` to retain argument/return hints
-/// Other values fall back to their concrete annotation (tag/record/tuple/custom)
+/// Other values fall back to their concrete annotation.
 pub struct PreprocessContext<'a> {
   scope_defs: &'a HashSet<Arc<str>>,
   scope_types: &'a mut ScopeTypes,
@@ -340,10 +382,10 @@ fn preprocess_with_type_slot_block(
 
   let type_annotation: Arc<CalcitTypeAnnotation> = if let Some((ns, def)) = &import_path {
     match &resolved {
-      Calcit::Enum(_) | Calcit::Struct(_) => {
+      Calcit::EnumDef(_) | Calcit::StructDef(_) => {
         Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), Arc::new(vec![])))
       }
-      Calcit::Record(record) => Arc::new(CalcitTypeAnnotation::Record(record.struct_ref.clone())),
+      Calcit::Struct(record) => Arc::new(CalcitTypeAnnotation::StructValue(record.struct_ref.clone())),
       other => {
         return Err(CalcitErr::use_msg_stack_location(
           CalcitErrKind::Unexpected,
@@ -358,14 +400,14 @@ fn preprocess_with_type_slot_block(
     }
   } else {
     match &resolved {
-      Calcit::Enum(enum_def) => Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def.to_owned()), Arc::new(vec![]))),
-      Calcit::Struct(struct_def) => Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def.to_owned()), Arc::new(vec![]))),
-      Calcit::Record(record) => Arc::new(CalcitTypeAnnotation::Record(record.struct_ref.clone())),
+      Calcit::EnumDef(enum_def) => Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def.to_owned()), Arc::new(vec![]))),
+      Calcit::StructDef(struct_def) => Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def.to_owned()), Arc::new(vec![]))),
+      Calcit::Struct(record) => Arc::new(CalcitTypeAnnotation::StructValue(record.struct_ref.clone())),
       other => match infer_type_from_expr(other, scope_types) {
         Some(inferred)
           if matches!(
             inferred.as_ref(),
-            CalcitTypeAnnotation::Enum(_, _) | CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::Record(_)
+            CalcitTypeAnnotation::Enum(_, _) | CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::StructValue(_)
           ) =>
         {
           inferred
@@ -589,10 +631,10 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
       let short_name = name.rsplit('/').next().unwrap_or(name.as_ref());
       let local_type = scope_types.get(name).or_else(|| scope_types.get(short_name));
       match local_type.map(AsRef::as_ref) {
-        Some(CalcitTypeAnnotation::Struct(struct_def, _)) | Some(CalcitTypeAnnotation::Record(struct_def)) => {
+        Some(CalcitTypeAnnotation::Struct(struct_def, _)) | Some(CalcitTypeAnnotation::StructValue(struct_def)) => {
           Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args))
         }
-        Some(CalcitTypeAnnotation::Enum(enum_def, _)) | Some(CalcitTypeAnnotation::Tuple(enum_def)) => {
+        Some(CalcitTypeAnnotation::Enum(enum_def, _)) | Some(CalcitTypeAnnotation::EnumValue(enum_def)) => {
           Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args))
         }
         Some(CalcitTypeAnnotation::Trait(trait_def)) if resolved_args.is_empty() => {
@@ -938,11 +980,21 @@ pub fn preprocess_expr(
                   for def in scope_defs {
                     names.push(def.to_owned());
                   }
-                  gen_check_warning_with_location(
-                    format!("[Warn] unknown `{def}` in {def_ns}/{at_def}, locals {{{}}}", names.join(" ")),
-                    NodeLocation::new(def_ns.to_owned(), at_def.to_owned(), location.to_owned().unwrap_or_default()),
-                    check_warnings,
-                  );
+                  let node_location = NodeLocation::new(def_ns.to_owned(), at_def.to_owned(), location.to_owned().unwrap_or_default());
+                  if let Some(replacement) = removed_data_api_replacement(def) {
+                    gen_check_warning_with_location_code(
+                      format!("[Warn] `{def}` was removed by the struct/enum data-model migration; use `{replacement}`"),
+                      "W_REMOVED_DATA_API",
+                      node_location,
+                      check_warnings,
+                    );
+                  } else {
+                    gen_check_warning_with_location(
+                      format!("[Warn] unknown `{def}` in {def_ns}/{at_def}, locals {{{}}}", names.join(" ")),
+                      node_location,
+                      check_warnings,
+                    );
+                  }
                   Ok(expr.to_owned())
                 }
               }
@@ -966,9 +1018,9 @@ pub fn preprocess_expr(
     | Calcit::Bool(..)
     | Calcit::Tag(..)
     | Calcit::CirruQuote(..)
-    | Calcit::Struct(..)
-    | Calcit::Enum(..)
-    | Calcit::Record(..) => Ok(expr.to_owned()),
+    | Calcit::StructDef(..)
+    | Calcit::EnumDef(..)
+    | Calcit::Struct(..) => Ok(expr.to_owned()),
     Calcit::Method(..) => Ok(expr.to_owned()),
     Calcit::Proc(..) => Ok(expr.to_owned()),
     Calcit::Syntax(..) => Ok(expr.to_owned()),
@@ -1003,6 +1055,59 @@ fn preprocess_list_call(
     def_name: &def_name,
     call_location: call_location.clone(),
   };
+  warn_on_removed_data_api_call(&head_form, call_location.clone(), file_ns, check_warnings);
+
+  let has_anonymous_definition_marker = matches!(args.first(), Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "_");
+  let is_constructor_named = |name: &str| {
+    matches!(&head_form, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == name)
+      || matches!(&head_form, Calcit::Symbol { sym, .. } if sym.as_ref() == name)
+  };
+
+  // `%{} _ (:field value) ...` is the canonical anonymous-struct
+  // constructor. Lower it before macro arguments are preprocessed so `_`
+  // cannot be mistaken for a normal unresolved symbol.
+  if has_anonymous_definition_marker && is_constructor_named("%{}") {
+    let mut items = vec![Calcit::Proc(CalcitProc::NativeLooseRecord)];
+    for entry in args.iter().skip(1) {
+      let Calcit::List(pair) = entry else {
+        return CalcitErr::err_str(
+          CalcitErrKind::Type,
+          format!("%{{}} _ expects (:field value) entries, but received: {entry}"),
+        );
+      };
+      if pair.len() != 2 {
+        return CalcitErr::err_str(
+          CalcitErrKind::Arity,
+          format!("%{{}} _ expects (:field value) entries, but received: {entry}"),
+        );
+      }
+      items.extend(pair.iter().cloned());
+    }
+    return preprocess_expr(
+      &Calcit::from(CalcitList::from(items.as_slice())),
+      scope_defs,
+      scope_types,
+      file_ns,
+      check_warnings,
+      call_stack,
+    );
+  }
+
+  // `%:: _ :variant ...` is the canonical anonymous-enum constructor.
+  if has_anonymous_definition_marker
+    && (matches!(&head_form, Calcit::Proc(CalcitProc::NativeEnumTupleNew)) || is_constructor_named("%::"))
+  {
+    let mut items = vec![Calcit::Proc(CalcitProc::NativeTuple)];
+    items.extend(args.iter().skip(1).cloned());
+    return preprocess_expr(
+      &Calcit::from(CalcitList::from(items.as_slice())),
+      scope_defs,
+      scope_types,
+      file_ns,
+      check_warnings,
+      call_stack,
+    );
+  }
 
   // === Postfix record field access / method call detection ===
   // Pattern: (expr :field) where expr has a known record type → rewrite to (.-field expr)
@@ -1022,7 +1127,7 @@ fn preprocess_list_call(
           if let Some(struct_def) = type_info.as_ref().resolve_to_struct()
             && let Some(idx) = struct_def.index_of(field_tag.ref_str())
           {
-            // Rewrite to (&record:nth expr idx :field-tag) — same as the existing
+            // Rewrite to (&struct:nth expr idx :field-tag) — same as the existing
             // `(:tag expr)` rewrite, works in both Rust runtime and JS codegen.
             // A nominal struct has a fixed field set, so this returns the field
             // directly rather than wrapping it in Option.
@@ -1039,7 +1144,7 @@ fn preprocess_list_call(
           // nominal record this path means the tag was not declared; for a
           // loose record the field set is known only at runtime. Both use the
           // required record lookup and report a normal error when absent.
-          if type_info.as_ref().resolve_to_struct().is_some() || is_unshaped_record_type(type_info.as_ref()) {
+          if type_info.as_ref().resolve_to_struct().is_some() || is_anonymous_struct_type(type_info.as_ref()) {
             return Ok(Calcit::from(CalcitList::from(&[
               Calcit::Proc(CalcitProc::NativeRecordGet),
               head_form,
@@ -1205,6 +1310,9 @@ fn preprocess_list_call(
       }
       if !has_spread {
         let mut current_args = CalcitList::from(ys.drop_left());
+        // Core helpers such as `get` resolve to ordinary functions, so validate
+        // their statically known struct fields in this branch as well.
+        check_record_field_access(&head_form, &current_args, scope_types, file_ns, check_warnings);
         warn_on_nominal_enum_legacy_absence_use(head, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         warn_on_legacy_js_nullish_predicate(head, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         let mut any_rewritten = false;
@@ -1270,7 +1378,7 @@ fn preprocess_list_call(
             && let Some(struct_def) = type_info.as_ref().resolve_to_struct()
             && let Some(idx) = struct_def.index_of(tag.ref_str())
           {
-            // Emit (&record:nth processed_arg idx :field-tag)
+            // Emit (&struct:nth processed_arg idx :field-tag)
             // The 3rd arg (field tag) is used by JS codegen where field order differs from Rust
             let items: Vec<Calcit> = vec![
               Calcit::Proc(CalcitProc::NativeRecordNth),
@@ -1282,7 +1390,7 @@ fn preprocess_list_call(
             return Ok(nth_call);
           }
           if let Some(type_info) = resolve_type_value(&processed_arg, scope_types)
-            && (type_info.as_ref().resolve_to_struct().is_some() || is_unshaped_record_type(type_info.as_ref()))
+            && (type_info.as_ref().resolve_to_struct().is_some() || is_anonymous_struct_type(type_info.as_ref()))
           {
             return Ok(Calcit::from(CalcitList::from(&[
               Calcit::Proc(CalcitProc::NativeRecordGet),
@@ -1407,10 +1515,14 @@ fn preprocess_list_call(
       | Calcit::List(..)
       | Calcit::RawCode(..)
       | Calcit::Symbol { .. }
-      | Calcit::Struct(..)
-      | Calcit::Enum(..) => {
-        // Check if the head (the thing being called) is actually callable
-        check_callable_type(&head_form, scope_types, file_ns, &def_name, check_warnings);
+      | Calcit::StructDef(..)
+      | Calcit::EnumDef(..) => {
+        // Postfix method syntax is represented as `(receiver .method ...)` at
+        // this stage. The receiver is deliberately not callable; the method
+        // rewrite below validates and resolves the actual call target.
+        if !matches!(args.first(), Some(Calcit::Method(..))) {
+          check_callable_type(&head_form, scope_types, file_ns, &def_name, check_warnings);
+        }
 
         let mut ys = CalcitList::new_inner_from(std::slice::from_ref(&head_form));
         let mut has_spread = false;
@@ -1475,7 +1587,7 @@ fn preprocess_list_call(
         check_record_update_fields(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
         check_record_method_args(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
 
-        // Optimize &record:get to &record:nth when field index can be resolved at compile time
+        // Optimize &struct:get to &struct:nth when field index can be resolved at compile time
         if matches!(&head_form, Calcit::Proc(CalcitProc::NativeRecordGet))
           && processed_args.len() == 2
           && let (Some(record_arg), Some(Calcit::Tag(field_tag))) = (processed_args.first(), processed_args.get(1))
@@ -1491,7 +1603,7 @@ fn preprocess_list_call(
           ]);
         }
 
-        // Optimize &record:assoc to &record:assoc-at when field index can be resolved at compile time
+        // Optimize &struct:assoc to &struct:assoc-at when field index can be resolved at compile time
         if matches!(&head_form, Calcit::Proc(CalcitProc::NativeRecordAssoc))
           && processed_args.len() == 3
           && let (Some(record_arg), Some(Calcit::Tag(field_tag)), Some(value_arg)) =
@@ -1509,7 +1621,7 @@ fn preprocess_list_call(
           ]);
         }
 
-        // Optimize &record:with to &record:with-at when all field indices can be resolved at compile time
+        // Optimize &struct:with to &struct:with-at when all field indices can be resolved at compile time
         if matches!(&head_form, Calcit::Proc(CalcitProc::NativeRecordWith))
           && processed_args.len() >= 3
           && (processed_args.len() - 1) % 2 == 0
@@ -1728,8 +1840,8 @@ fn try_rewrite_struct_enum_constructor_head_call(
   // A record instance and its struct prototype intentionally share most type
   // information, so `resolve_type_value` alone cannot distinguish them.
   let constructor_kind = match head_form {
-    Calcit::Struct(_) => Some("defstruct"),
-    Calcit::Enum(_) => Some("defenum"),
+    Calcit::StructDef(_) => Some("defstruct"),
+    Calcit::EnumDef(_) => Some("defenum"),
     Calcit::Import(CalcitImport { ns, def, .. }) => data_definition_kind(ns, def),
     Calcit::Symbol { sym, info, .. } => data_definition_kind(&info.at_ns, sym),
     _ => None,
@@ -1739,8 +1851,12 @@ fn try_rewrite_struct_enum_constructor_head_call(
     return Ok(None);
   };
 
+  let resolved_struct_definition = match type_info.as_ref() {
+    CalcitTypeAnnotation::StructDef(struct_def) => Some((struct_def.as_ref().clone(), None)),
+    other => other.resolve_to_struct_with_ref(),
+  };
   if constructor_kind == Some("defstruct")
-    && let Some((struct_def, ns_def_path)) = type_info.as_ref().resolve_to_struct_with_ref()
+    && let Some((struct_def, ns_def_path)) = resolved_struct_definition
   {
     // Only attempt constructor-style rewriting for tag/value-style positional args.
     // Method-call syntax (expr .method ...) is represented as `Method` in the first arg
@@ -1873,8 +1989,12 @@ fn try_rewrite_struct_enum_constructor_head_call(
     return Ok(Some(Calcit::from(record_items)));
   }
 
+  let resolved_enum_definition = match type_info.as_ref() {
+    CalcitTypeAnnotation::EnumDef(enum_def) => Some((enum_def.as_ref().clone(), None)),
+    other => other.resolve_to_enum_with_ref(),
+  };
   if constructor_kind == Some("defenum")
-    && let Some((enum_def, ns_def_path)) = type_info.as_ref().resolve_to_enum_with_ref()
+    && let Some((enum_def, ns_def_path)) = resolved_enum_definition
   {
     let Some(first_arg) = args.first() else {
       gen_check_warning(
@@ -2250,19 +2370,19 @@ fn check_record_field_access(
   file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
-  // Check if this is a call to &record:get
+  // Check if this is a call to &struct:get
   if let Calcit::Proc(CalcitProc::NativeRecordGet) = head {
-    // &record:get takes 2 args: (record, field)
+    // &struct:get takes 2 args: (record, field)
     if args.len() >= 2
       && let (Some(record_arg), Some(field_arg)) = (args.first(), args.get(1))
     {
       check_field_in_record(record_arg, field_arg, scope_types, file_ns, check_warnings);
     }
   }
-  // Also check for Import of &record:get from calcit.core
+  // Also check calcit.core imports that perform required struct field access.
   else if let Calcit::Import(CalcitImport { ns, def, .. }) = head {
     if &**ns == calcit::CORE_NS
-      && (&**def == "record-get" || &**def == "&record:get")
+      && (&**def == "get" || &**def == "record-get" || &**def == "&struct:get")
       && args.len() >= 2
       && let (Some(record_arg), Some(field_arg)) = (args.first(), args.get(1))
     {
@@ -2377,17 +2497,21 @@ fn check_field_in_record(
   let available_fields: Vec<&str> = struct_def.fields.iter().map(|f| f.ref_str()).collect();
   gen_check_warning(
     format!(
-      "[Warn] Field `{field_name}` does not exist in record `{}`. Available fields: [{}]",
+      "[Warn] Field `:{field_name}` does not exist in struct `{}`. Available fields: [{}]. Struct field access is required and never returns nil/Option for a missing field; use a declared field instead",
       struct_def.name,
-      available_fields.join(", ")
+      available_fields
+        .iter()
+        .map(|field| format!(":{field}"))
+        .collect::<Vec<_>>()
+        .join(", ")
     ),
     file_ns,
     check_warnings,
   );
 }
 
-/// Check tuple index bounds for &tuple:nth operations.
-/// NOTE: Static bounds checking is not available for `Tuple(Arc<CalcitEnum>)` since
+/// Check tuple index bounds for &enum:nth operations.
+/// NOTE: Static bounds checking is not available for `Tuple(Arc<CalcitEnumDef>)` since
 /// the enum definition does not carry the per-variant payload sizes. This function is
 /// a no-op: bounds errors will be caught at runtime instead.
 pub(crate) fn check_tuple_nth_bounds(
@@ -2856,8 +2980,6 @@ fn warn_on_nominal_enum_legacy_absence_use(
       | "list?"
       | "map?"
       | "set?"
-      | "record?"
-      | "tuple?"
       | "tag?"
       | "number?"
       | "string?"
@@ -2917,8 +3039,8 @@ fn warn_on_nominal_enum_legacy_absence_use(
     }
     "=" | "&=" => "compare values of the same nominal enum, or pattern-match before comparing a payload",
     "&compare" if enum_name == "Option" => "unwrap or pattern-match the Option before comparing its payload",
-    "list?" | "map?" | "set?" | "record?" | "tuple?" | "tag?" | "number?" | "string?" | "keyword?" | "symbol?" | "fn?" | "bool?"
-    | "buffer?" | "cirru-quote?" | "ref?" | "macro?" | "syntax?" | "enum?" | "struct?" => {
+    "list?" | "map?" | "set?" | "struct?" | "enum?" | "struct-def?" | "enum-def?" | "tag?" | "number?" | "string?" | "keyword?"
+    | "symbol?" | "fn?" | "bool?" | "buffer?" | "cirru-quote?" | "ref?" | "macro?" | "syntax?" => {
       "pattern-match the nominal enum before applying a payload type predicate"
     }
     _ if enum_name == "Option" => "use `tag-match`, `option:unwrap-or`, or an Option method to access the payload",
@@ -3173,8 +3295,10 @@ fn try_specialize_polymorphic_call(
       | ("bool?", T::Bool)
       | ("tag?", T::Tag)
       | ("fn?", T::Fn(_) | T::DynFn)
-      | ("tuple?", T::Tuple(_) | T::DynTuple)
-      | ("record?", T::Record(_) | T::Struct(_, _))
+      | ("enum?", T::EnumValue(_) | T::AnonymousEnum | T::Enum(_, _))
+      | ("struct?", T::StructValue(_) | T::Struct(_, _))
+      | ("struct-def?", T::StructDef(_))
+      | ("enum-def?", T::EnumDef(_))
   );
   if predicate_true {
     return Some(Calcit::Bool(true));
@@ -3210,8 +3334,8 @@ fn try_specialize_polymorphic_call(
     ("count", T::Map(_, _)) => NativeMapCount,
     ("count", T::Set(_)) => NativeSetCount,
     ("count", T::String) => NativeStrCount,
-    ("count", T::Tuple(_) | T::DynTuple) => NativeTupleCount,
-    ("count", T::Record(_)) => NativeRecordCount,
+    ("count", T::EnumValue(_) | T::AnonymousEnum) => NativeTupleCount,
+    ("count", T::StructValue(_)) => NativeRecordCount,
     // empty?
     ("empty?", T::List(_)) => NativeListEmpty,
     ("empty?", T::Map(_, _)) => NativeMapEmpty,
@@ -3222,14 +3346,14 @@ fn try_specialize_polymorphic_call(
     ("contains?", T::Map(_, _)) => NativeMapContains,
     ("contains?", T::Set(_)) => NativeSetIncludes,
     ("contains?", T::String) => NativeStrContains,
-    ("contains?", T::Record(_)) => NativeRecordContains,
+    ("contains?", T::StructValue(_)) => NativeRecordContains,
     // rest
     ("rest", T::List(_)) => NativeListRest,
     // assoc
     ("assoc", T::List(_)) => NativeListAssoc,
     ("assoc", T::Map(_, _)) => NativeMapAssoc,
-    ("assoc", T::Tuple(_) | T::DynTuple) => NativeTupleAssoc,
-    ("assoc", T::Record(_)) => NativeRecordAssoc,
+    ("assoc", T::EnumValue(_) | T::AnonymousEnum) => NativeTupleAssoc,
+    ("assoc", T::StructValue(_)) => NativeRecordAssoc,
     // includes?
     ("includes?", T::List(_)) => NativeListIncludes,
     ("includes?", T::Map(_, _)) => NativeMapIncludes,
@@ -3512,7 +3636,7 @@ fn collect_impl_records_from_value(value: &Calcit) -> Option<Vec<Arc<CalcitImpl>
 fn get_impl_records_from_type(type_value: &CalcitTypeAnnotation) -> Option<Vec<Arc<CalcitImpl>>> {
   if let Some(struct_def) = type_value.resolve_to_struct() {
     // Prepend core record impls; user impls come after and win (last_wins=true)
-    let mut impls = resolve_core_impl_records("&core-record-impls").unwrap_or_default();
+    let mut impls = resolve_core_impl_records("&core-struct-impls").unwrap_or_default();
     impls.extend(struct_def.impls.iter().cloned());
     return Some(impls);
   }
@@ -3523,14 +3647,14 @@ fn get_impl_records_from_type(type_value: &CalcitTypeAnnotation) -> Option<Vec<A
 
   if let Some(enum_def) = type_value.resolve_to_enum() {
     // Prepend core tuple impls; user impls come after and win (last_wins=true)
-    let mut impls = resolve_core_impl_records("&core-tuple-impls").unwrap_or_default();
+    let mut impls = resolve_core_impl_records("&core-enum-impls").unwrap_or_default();
     impls.extend(enum_def.impls.iter().cloned());
     return Some(impls);
   }
 
-  if let CalcitTypeAnnotation::DynTuple = type_value {
+  if let CalcitTypeAnnotation::AnonymousEnum = type_value {
     // Untyped tuple: only core impls
-    if let Some(core_impls) = resolve_core_impl_records("&core-tuple-impls") {
+    if let Some(core_impls) = resolve_core_impl_records("&core-enum-impls") {
       return Some(core_impls);
     }
   }
@@ -3880,7 +4004,10 @@ fn extract_predicate_bindings(cond_form: &Calcit, scope_types: &ScopeTypes) -> P
     "set?" => Some(tag_annotation("set")),
     "string?" => Some(tag_annotation("string")),
     "number?" => Some(tag_annotation("number")),
-    "tuple?" => Some(tag_annotation("tuple")),
+    "enum?" => Some(tag_annotation("enum")),
+    "struct?" => Some(tag_annotation("struct")),
+    "enum-def?" => Some(tag_annotation("enum-def")),
+    "struct-def?" => Some(tag_annotation("struct-def")),
     "tag?" => Some(tag_annotation("tag")),
     "bool?" => Some(tag_annotation("bool")),
     "symbol?" => Some(tag_annotation("symbol")),
@@ -3952,7 +4079,11 @@ fn extract_predicate_bindings(cond_form: &Calcit, scope_types: &ScopeTypes) -> P
   }
 }
 
-fn resolve_enum_type_for_match(type_ref: &CalcitTypeAnnotation, file_ns: &str, scope_types: &ScopeTypes) -> Option<calcit::CalcitEnum> {
+fn resolve_enum_type_for_match(
+  type_ref: &CalcitTypeAnnotation,
+  file_ns: &str,
+  scope_types: &ScopeTypes,
+) -> Option<calcit::CalcitEnumDef> {
   if let Some(enum_def) = type_ref.resolve_to_enum() {
     return Some(enum_def);
   }
@@ -3976,8 +4107,8 @@ fn resolve_enum_type_for_match(type_ref: &CalcitTypeAnnotation, file_ns: &str, s
     (Arc::from(calcit::CORE_NS), Arc::from(stripped))
   };
   match resolve_program_value_for_preprocess(&target_ns, &target_def, None) {
-    Some(Calcit::Enum(enum_def)) => Some(enum_def),
-    Some(Calcit::Record(record)) => calcit::CalcitEnum::from_record(record).ok(),
+    Some(Calcit::EnumDef(enum_def)) => Some(enum_def),
+    Some(Calcit::Struct(record)) => calcit::CalcitEnumDef::from_record(record).ok(),
     _ => None,
   }
 }
@@ -4026,14 +4157,14 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
   // can be specialized instead of falling back to Dynamic.
   let inferred_match_type = infer_type_from_expr(&value_form, ctx.scope_types);
   let enum_match = inferred_match_type.and_then(|t| match t.as_ref() {
-    CalcitTypeAnnotation::Tuple(enum_ref) => Some((enum_ref.as_ref().to_owned(), Arc::new(vec![]))),
+    CalcitTypeAnnotation::EnumValue(enum_ref) => Some((enum_ref.as_ref().to_owned(), Arc::new(vec![]))),
     CalcitTypeAnnotation::Enum(enum_ref, args) => Some((enum_ref.as_ref().to_owned(), args.clone())),
     CalcitTypeAnnotation::TypeRef(_, args) => {
       resolve_enum_type_for_match(t.as_ref(), ctx.file_ns, ctx.scope_types).map(|enum_ref| (enum_ref, args.clone()))
     }
     CalcitTypeAnnotation::TypeSlot(name) => calcit::resolve_type_slot(name).and_then(|resolved| match resolved.as_ref() {
       CalcitTypeAnnotation::Enum(e, args) => Some((e.as_ref().to_owned(), args.clone())),
-      CalcitTypeAnnotation::Tuple(e) => Some((e.as_ref().to_owned(), Arc::new(vec![]))),
+      CalcitTypeAnnotation::EnumValue(e) => Some((e.as_ref().to_owned(), Arc::new(vec![]))),
       _ => None,
     }),
     _ => None,
@@ -5124,7 +5255,7 @@ fn validate_def_schema_during_preprocess(
 mod tests {
   use super::*;
   use crate::calcit::{
-    CalcitFn, CalcitFnArgs, CalcitFnUsageMeta, CalcitImport, CalcitMacro, CalcitRecord, CalcitScope, CalcitStruct, ImportInfo,
+    CalcitFn, CalcitFnArgs, CalcitFnUsageMeta, CalcitImport, CalcitMacro, CalcitScope, CalcitStructDef, CalcitStructValue, ImportInfo,
   };
   use crate::data::cirru::code_to_calcit;
   use cirru_parser::Cirru;
@@ -5134,6 +5265,50 @@ mod tests {
 
   fn lock_preprocess_test_state() -> std::sync::MutexGuard<'static, ()> {
     PREPROCESS_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+  }
+
+  #[test]
+  fn removed_data_apis_point_to_their_struct_enum_replacements() {
+    let cases = [
+      ("record?", "struct? (values) or struct-def? (definitions)"),
+      ("tuple?", "enum? (values) or enum-def? (definitions)"),
+      ("record-struct", "struct-definition"),
+      ("tuple-enum", "enum-definition"),
+      ("record-with", "struct-with"),
+      ("record-match", "struct-match"),
+      ("&record:get", "&struct:get"),
+      ("&record:struct", "&struct:definition"),
+      ("&tuple:nth", "&enum:nth"),
+      ("&tuple:enum", "&enum:definition"),
+      ("&tuple:enum-has-variant?", "&enum-def:has-variant?"),
+      ("&tuple:enum-variant-arity", "&enum-def:variant-arity"),
+      ("&tuple:validate-enum", "&enum:validate"),
+    ];
+
+    for (legacy, replacement) in cases {
+      assert_eq!(removed_data_api_replacement(legacy).as_deref(), Some(replacement));
+    }
+    assert_eq!(removed_data_api_replacement("&map:get"), None);
+  }
+
+  #[test]
+  fn removed_core_data_api_calls_emit_migration_diagnostics() {
+    let head = Calcit::Import(CalcitImport {
+      ns: Arc::from(calcit::CORE_NS),
+      def: Arc::from("record?"),
+      info: Arc::new(ImportInfo::Core {
+        at_ns: Arc::from("tests.migration"),
+      }),
+      def_id: None,
+    });
+    let warnings = RefCell::new(vec![]);
+
+    warn_on_removed_data_api_call(&head, None, "tests.migration", &warnings);
+
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].code(), Some("W_REMOVED_DATA_API"));
+    assert!(warnings[0].message().contains("struct? (values) or struct-def? (definitions)"));
   }
 
   #[test]
@@ -5237,7 +5412,7 @@ mod tests {
     });
     let args = CalcitList::from(std::slice::from_ref(&option_value));
 
-    for operation in ["some?", "get", "&compare", "record?"] {
+    for operation in ["some?", "get", "&compare", "struct?"] {
       let head = core_head(operation);
       let warnings = RefCell::new(vec![]);
       warn_on_nominal_enum_legacy_absence_use(&head, &args, &ScopeTypes::new(), "tests.option-migration", "demo", &warnings);
@@ -5374,7 +5549,7 @@ mod tests {
       values: Arc::new(vec![Calcit::Nil, Calcit::Nil]),
     });
     let type_value = CalcitTypeAnnotation::Struct(
-      Arc::new(CalcitStruct {
+      Arc::new(CalcitStructDef {
         name: EdnTag::new("Demo"),
         fields: Arc::new(vec![]),
         field_types: Arc::new(vec![]),
@@ -6047,12 +6222,12 @@ mod tests {
     use cirru_edn::EdnTag;
 
     // Create a test record type with fields: name, age
-    let test_record = Arc::new(CalcitTypeAnnotation::Record(Arc::new(CalcitStruct::from_fields(
+    let test_record = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
       EdnTag::from("Person"),
       vec![EdnTag::from("age"), EdnTag::from("name")],
     ))));
 
-    // Test expression: (assert-type user <record-type>) (&record:get user :name)
+    // Test expression: (assert-type user <record-type>) (&struct:get user :name)
     let expr = Cirru::List(vec![
       Cirru::leaf("&let"),
       Cirru::List(vec![Cirru::leaf("user"), Cirru::leaf("nil")]),
@@ -6061,7 +6236,7 @@ mod tests {
         Cirru::leaf("user"),
         Cirru::leaf("record-type"), // placeholder, will be replaced
       ]),
-      Cirru::List(vec![Cirru::leaf("&record:get"), Cirru::leaf("user"), Cirru::leaf(":name")]),
+      Cirru::List(vec![Cirru::leaf("&struct:get"), Cirru::leaf("user"), Cirru::leaf(":name")]),
     ]);
 
     let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse cirru");
@@ -6083,6 +6258,47 @@ mod tests {
   }
 
   #[test]
+  fn common_get_reports_missing_known_struct_field_during_preprocess() {
+    let struct_type = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
+      EdnTag::from("Person"),
+      vec![EdnTag::from("name")],
+    ))));
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(Arc::from("person"), struct_type);
+
+    let head = Calcit::Import(CalcitImport {
+      ns: Arc::from(calcit::CORE_NS),
+      def: Arc::from("get"),
+      info: Arc::new(ImportInfo::Core {
+        at_ns: Arc::from("tests.struct"),
+      }),
+      def_id: None,
+    });
+    let args = CalcitList::from(
+      &[
+        Calcit::Symbol {
+          sym: Arc::from("person"),
+          info: Arc::new(CalcitSymbolInfo {
+            at_ns: Arc::from("tests.struct"),
+            at_def: Arc::from("demo"),
+          }),
+          location: None,
+        },
+        Calcit::Tag(EdnTag::from("missing")),
+      ][..],
+    );
+    let warnings = RefCell::new(vec![]);
+
+    check_record_field_access(&head, &args, &scope_types, "tests.struct", &warnings);
+
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    let message = warnings[0].message();
+    assert!(message.contains("Field `:missing` does not exist in struct `Person`"));
+    assert!(message.contains("never returns nil/Option"));
+  }
+
+  #[test]
   fn postfix_nominal_record_access_uses_direct_field_lookup() {
     let expr = Cirru::List(vec![Cirru::leaf("person"), Cirru::leaf(":name")]);
     let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse postfix field access");
@@ -6091,7 +6307,7 @@ mod tests {
     let mut scope_types = ScopeTypes::new();
     scope_types.insert(
       Arc::from("person"),
-      Arc::new(CalcitTypeAnnotation::Record(Arc::new(CalcitStruct::from_fields(
+      Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Person"),
         vec![EdnTag::from("name")],
       )))),
@@ -6152,7 +6368,7 @@ mod tests {
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let person_struct = CalcitStruct::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
+    let person_struct = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
 
     let expr = Cirru::List(vec![
       Cirru::leaf("Person"),
@@ -6167,7 +6383,7 @@ mod tests {
       panic!("expected parsed call");
     };
     let mut code_items = parsed_items.to_vec();
-    code_items[0] = Calcit::Struct(person_struct.clone());
+    code_items[0] = Calcit::StructDef(person_struct.clone());
     let code = Calcit::from(code_items);
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -6192,7 +6408,7 @@ mod tests {
 
     assert!(matches!(items.first(), Some(Calcit::Proc(CalcitProc::NativeRecord))));
     match items.get(1) {
-      Some(Calcit::Struct(struct_def)) => assert_eq!(struct_def.name, person_struct.name),
+      Some(Calcit::StructDef(struct_def)) => assert_eq!(struct_def.name, person_struct.name),
       other => panic!("expected struct prototype at position 1, got {other:?}"),
     }
     assert_eq!(*items.get(2).expect("name field key"), Calcit::Tag(EdnTag::from("name")));
@@ -6203,13 +6419,13 @@ mod tests {
 
   #[test]
   fn rewrites_enum_head_call_to_enum_tuple_ctor() {
-    use crate::calcit::CalcitEnum;
+    use crate::calcit::CalcitEnumDef;
     use crate::data::cirru::code_to_calcit;
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Result"),
         vec![EdnTag::from("ok"), EdnTag::from("err")],
       )),
@@ -6218,7 +6434,7 @@ mod tests {
         Calcit::List(Arc::new(CalcitList::default())),
       ]),
     };
-    let result_enum = CalcitEnum::from_record(enum_record.clone()).expect("valid result enum");
+    let result_enum = CalcitEnumDef::from_record(enum_record.clone()).expect("valid result enum");
 
     let expr = Cirru::List(vec![Cirru::leaf("Result"), Cirru::leaf(":ok")]);
 
@@ -6227,7 +6443,7 @@ mod tests {
       panic!("expected parsed call");
     };
     let mut code_items = parsed_items.to_vec();
-    code_items[0] = Calcit::Enum(result_enum.clone());
+    code_items[0] = Calcit::EnumDef(result_enum.clone());
     let code = Calcit::from(code_items);
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -6252,7 +6468,7 @@ mod tests {
 
     assert!(matches!(items.first(), Some(Calcit::Proc(CalcitProc::NativeEnumTupleNew))));
     match items.get(1) {
-      Some(Calcit::Record(enum_record)) => assert_eq!(enum_record.struct_ref.name, *result_enum.name()),
+      Some(Calcit::Struct(enum_record)) => assert_eq!(enum_record.struct_ref.name, *result_enum.name()),
       other => panic!("expected enum prototype at position 1, got {other:?}"),
     }
     assert_eq!(*items.get(2).expect("tag key"), Calcit::Tag(EdnTag::from("ok")));
@@ -6265,7 +6481,7 @@ mod tests {
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let person_struct = CalcitStruct::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
+    let person_struct = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
 
     let expr = Cirru::List(vec![Cirru::leaf("Person"), Cirru::leaf(":name")]);
 
@@ -6274,7 +6490,7 @@ mod tests {
       panic!("expected parsed call");
     };
     let mut code_items = parsed_items.to_vec();
-    code_items[0] = Calcit::Struct(person_struct.clone());
+    code_items[0] = Calcit::StructDef(person_struct.clone());
     let code = Calcit::from(code_items);
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -6316,7 +6532,7 @@ mod tests {
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let person_struct = CalcitStruct::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
+    let person_struct = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
 
     let expr = Cirru::List(vec![
       Cirru::leaf("Person"),
@@ -6331,7 +6547,7 @@ mod tests {
       panic!("expected parsed call");
     };
     let mut code_items = parsed_items.to_vec();
-    code_items[0] = Calcit::Struct(person_struct.clone());
+    code_items[0] = Calcit::StructDef(person_struct.clone());
     let code = Calcit::from(code_items);
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -6371,7 +6587,7 @@ mod tests {
   fn rejects_struct_head_call_with_duplicate_or_missing_required_field() {
     use cirru_edn::EdnTag;
 
-    let person_struct = CalcitStruct::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
+    let person_struct = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("age")]);
     let warnings = RefCell::new(vec![]);
     let scope_types = ScopeTypes::new();
     let stack = CallStackList::default();
@@ -6386,7 +6602,7 @@ mod tests {
       .as_slice(),
     );
     let duplicate_result = try_rewrite_struct_enum_constructor_head_call(
-      &Calcit::Struct(person_struct.clone()),
+      &Calcit::StructDef(person_struct.clone()),
       &duplicate_args,
       &scope_types,
       "tests.record",
@@ -6406,7 +6622,7 @@ mod tests {
     warnings.borrow_mut().clear();
     let missing_args = CalcitList::from(vec![Calcit::Tag(EdnTag::from("name")), Calcit::Str(Arc::from("Alice"))].as_slice());
     let missing_result = try_rewrite_struct_enum_constructor_head_call(
-      &Calcit::Struct(person_struct),
+      &Calcit::StructDef(person_struct),
       &missing_args,
       &scope_types,
       "tests.record",
@@ -6426,20 +6642,20 @@ mod tests {
 
   #[test]
   fn record_and_enum_instances_are_not_constructor_heads() {
-    use crate::calcit::{CalcitEnum, CalcitTuple};
+    use crate::calcit::{CalcitEnumDef, CalcitEnumValue};
     use cirru_edn::EdnTag;
 
-    let person_struct = CalcitStruct::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name")]);
-    let person = Calcit::Record(CalcitRecord {
+    let person_struct = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name")]);
+    let person = Calcit::Struct(CalcitStructValue {
       struct_ref: Arc::new(person_struct),
       values: Arc::new(vec![Calcit::Str(Arc::from("Alice"))]),
     });
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(EdnTag::from("Result"), vec![EdnTag::from("ok")])),
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::from("Result"), vec![EdnTag::from("ok")])),
       values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::default()))]),
     };
-    let result_enum = CalcitEnum::from_record(enum_record).expect("valid enum");
-    let enum_value = Calcit::Tuple(CalcitTuple {
+    let result_enum = CalcitEnumDef::from_record(enum_record).expect("valid enum");
+    let enum_value = Calcit::Enum(CalcitEnumValue {
       tag: Arc::new(Calcit::Tag(EdnTag::from("ok"))),
       extra: vec![],
       sum_type: Some(Arc::new(result_enum)),
@@ -6466,12 +6682,12 @@ mod tests {
   fn warns_on_record_constructor_field_type_mismatch() {
     use cirru_edn::EdnTag;
 
-    let mut point_struct = CalcitStruct::from_fields(EdnTag::from("Point"), vec![EdnTag::from("x")]);
+    let mut point_struct = CalcitStructDef::from_fields(EdnTag::from("Point"), vec![EdnTag::from("x")]);
     point_struct.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]);
     let args = CalcitList::from(vec![Calcit::Tag(EdnTag::from("x")), Calcit::Str(Arc::from("wrong"))].as_slice());
     let warnings = RefCell::new(vec![]);
     let result = try_rewrite_struct_enum_constructor_head_call(
-      &Calcit::Struct(point_struct),
+      &Calcit::StructDef(point_struct),
       &args,
       &ScopeTypes::new(),
       "tests.record",
@@ -6493,7 +6709,7 @@ mod tests {
     use cirru_edn::EdnTag;
 
     let generic: Arc<str> = Arc::from("T");
-    let mut box_struct = CalcitStruct::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]);
+    let mut box_struct = CalcitStructDef::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]);
     box_struct.generics = Arc::new(vec![generic.clone()]);
     box_struct.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(generic))]);
     let receiver = Calcit::Local(CalcitLocal {
@@ -6534,7 +6750,7 @@ mod tests {
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let cat_struct = CalcitStruct::from_fields(EdnTag::from("Cat"), vec![EdnTag::from("name"), EdnTag::from("color")]);
+    let cat_struct = CalcitStructDef::from_fields(EdnTag::from("Cat"), vec![EdnTag::from("name"), EdnTag::from("color")]);
 
     let expr = Cirru::List(vec![Cirru::leaf("kitty"), Cirru::leaf(".rename"), Cirru::leaf("|LagopusB")]);
     let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse struct method call");
@@ -6543,7 +6759,10 @@ mod tests {
     scope_defs.insert(Arc::from("kitty"));
 
     let mut scope_types: ScopeTypes = ScopeTypes::new();
-    scope_types.insert(Arc::from("kitty"), Arc::new(CalcitTypeAnnotation::Record(Arc::new(cat_struct))));
+    scope_types.insert(
+      Arc::from("kitty"),
+      Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(cat_struct))),
+    );
 
     let warnings = RefCell::new(vec![]);
     let stack = CallStackList::default();
@@ -6569,13 +6788,13 @@ mod tests {
 
   #[test]
   fn rejects_enum_head_call_with_missing_tag() {
-    use crate::calcit::{CalcitEnum, CalcitRecord};
+    use crate::calcit::{CalcitEnumDef, CalcitStructValue};
     use crate::data::cirru::code_to_calcit;
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Result"),
         vec![EdnTag::from("ok"), EdnTag::from("err")],
       )),
@@ -6584,7 +6803,7 @@ mod tests {
         Calcit::List(Arc::new(CalcitList::default())),
       ]),
     };
-    let result_enum = CalcitEnum::from_record(enum_record.clone()).expect("valid result enum");
+    let result_enum = CalcitEnumDef::from_record(enum_record.clone()).expect("valid result enum");
 
     let expr = Cirru::List(vec![Cirru::leaf("Result")]);
 
@@ -6593,7 +6812,7 @@ mod tests {
       panic!("expected parsed call");
     };
     let mut code_items = parsed_items.to_vec();
-    code_items[0] = Calcit::Enum(result_enum.clone());
+    code_items[0] = Calcit::EnumDef(result_enum.clone());
     let code = Calcit::from(code_items);
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -6631,13 +6850,13 @@ mod tests {
 
   #[test]
   fn rejects_enum_head_call_with_invalid_tag() {
-    use crate::calcit::{CalcitEnum, CalcitRecord};
+    use crate::calcit::{CalcitEnumDef, CalcitStructValue};
     use crate::data::cirru::code_to_calcit;
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Result"),
         vec![EdnTag::from("ok"), EdnTag::from("err")],
       )),
@@ -6646,7 +6865,7 @@ mod tests {
         Calcit::List(Arc::new(CalcitList::default())),
       ]),
     };
-    let result_enum = CalcitEnum::from_record(enum_record.clone()).expect("valid result enum");
+    let result_enum = CalcitEnumDef::from_record(enum_record.clone()).expect("valid result enum");
 
     let expr = Cirru::List(vec![Cirru::leaf("Result"), Cirru::leaf(":bad")]);
 
@@ -6655,7 +6874,7 @@ mod tests {
       panic!("expected parsed call");
     };
     let mut code_items = parsed_items.to_vec();
-    code_items[0] = Calcit::Enum(result_enum.clone());
+    code_items[0] = Calcit::EnumDef(result_enum.clone());
     let code = Calcit::from(code_items);
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -6693,13 +6912,13 @@ mod tests {
 
   #[test]
   fn rejects_enum_head_call_with_non_tag_first_arg() {
-    use crate::calcit::{CalcitEnum, CalcitRecord};
+    use crate::calcit::{CalcitEnumDef, CalcitStructValue};
     use crate::data::cirru::code_to_calcit;
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Mode"),
         vec![EdnTag::from("dark"), EdnTag::from("light")],
       )),
@@ -6708,7 +6927,7 @@ mod tests {
         Calcit::List(Arc::new(CalcitList::default())),
       ]),
     };
-    let mode_enum = CalcitEnum::from_record(enum_record.clone()).expect("valid mode enum");
+    let mode_enum = CalcitEnumDef::from_record(enum_record.clone()).expect("valid mode enum");
 
     let expr = Cirru::List(vec![Cirru::leaf("Mode"), Cirru::leaf("dark")]);
 
@@ -6717,7 +6936,7 @@ mod tests {
       panic!("expected parsed call");
     };
     let mut code_items = parsed_items.to_vec();
-    code_items[0] = Calcit::Enum(mode_enum.clone());
+    code_items[0] = Calcit::EnumDef(mode_enum.clone());
     let code = Calcit::from(code_items);
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -6760,14 +6979,14 @@ mod tests {
     use cirru_edn::EdnTag;
 
     // Create a test record type with fields: name, age
-    let test_record = Arc::new(CalcitTypeAnnotation::Record(Arc::new(CalcitStruct::from_fields(
+    let test_record = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
       EdnTag::from("Person"),
       vec![EdnTag::from("age"), EdnTag::from("name")],
     ))));
 
-    // Test expression: (&record:get user :email) with user already typed
+    // Test expression: (&struct:get user :email) with user already typed
     let expr = Cirru::List(vec![
-      Cirru::leaf("&record:get"),
+      Cirru::leaf("&struct:get"),
       Cirru::leaf("user"),
       Cirru::leaf(":email"), // invalid field
     ]);
@@ -6827,8 +7046,8 @@ mod tests {
       values: Arc::new(vec![method_import.clone()]),
     };
 
-    let class_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct {
+    let class_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef {
         name: EdnTag::from("Greeter"),
         fields: Arc::new(vec![EdnTag::from("greet")]),
         field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone()]),
@@ -6840,7 +7059,7 @@ mod tests {
     };
     scope_types.insert(
       Arc::from("user"),
-      Arc::new(CalcitTypeAnnotation::Record(class_record.struct_ref.clone())),
+      Arc::new(CalcitTypeAnnotation::StructValue(class_record.struct_ref.clone())),
     );
 
     let warnings = RefCell::new(vec![]);
@@ -6866,7 +7085,7 @@ mod tests {
     use cirru_edn::EdnTag;
 
     // Create a test record type with fields: name, age
-    let test_record = Arc::new(CalcitTypeAnnotation::Record(Arc::new(CalcitStruct::from_fields(
+    let test_record = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
       EdnTag::from("Person"),
       vec![EdnTag::from("age"), EdnTag::from("name")],
     ))));
@@ -7090,7 +7309,7 @@ mod tests {
     use cirru_edn::EdnTag;
 
     // Create a test record type with fields: name, age
-    let test_record = Arc::new(CalcitTypeAnnotation::Record(Arc::new(CalcitStruct::from_fields(
+    let test_record = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
       EdnTag::from("Person"),
       vec![EdnTag::from("age"), EdnTag::from("name")],
     ))));
@@ -7134,7 +7353,7 @@ mod tests {
     use cirru_edn::EdnTag;
 
     // Create a test record type with limited methods
-    let test_record = Arc::new(CalcitTypeAnnotation::Record(Arc::new(CalcitStruct::from_fields(
+    let test_record = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
       EdnTag::from("Person"),
       vec![EdnTag::from("age"), EdnTag::from("name")],
     ))));
@@ -7408,14 +7627,14 @@ mod tests {
     });
     let args = CalcitList::from(&[arg_local] as &[Calcit]);
 
-    let mut shown_struct = crate::calcit::CalcitStruct::from_fields(EdnTag::new("Shown"), vec![EdnTag::new("name")]);
+    let mut shown_struct = crate::calcit::CalcitStructDef::from_fields(EdnTag::new("Shown"), vec![EdnTag::new("name")]);
     shown_struct.impls = vec![Arc::new(crate::calcit::CalcitImpl {
       name: EdnTag::new("ShowImpl"),
       origin: Some(show_trait.clone()),
       fields: Arc::new(vec![EdnTag::new("show")]),
       values: Arc::new(vec![Calcit::Nil]),
     })];
-    let plain_struct = crate::calcit::CalcitStruct::from_fields(EdnTag::new("Plain"), vec![EdnTag::new("name")]);
+    let plain_struct = crate::calcit::CalcitStructDef::from_fields(EdnTag::new("Plain"), vec![EdnTag::new("name")]);
 
     let mut ok_scope_types: ScopeTypes = ScopeTypes::new();
     ok_scope_types.insert(
@@ -7507,14 +7726,14 @@ mod tests {
     });
     let args = CalcitList::from(&[arg_local] as &[Calcit]);
 
-    let mut shown_struct = crate::calcit::CalcitStruct::from_fields(EdnTag::new("Shown"), vec![EdnTag::new("name")]);
+    let mut shown_struct = crate::calcit::CalcitStructDef::from_fields(EdnTag::new("Shown"), vec![EdnTag::new("name")]);
     shown_struct.impls = vec![Arc::new(CalcitImpl {
       name: EdnTag::new("ShowImpl"),
       origin: Some(show_trait.clone()),
       fields: Arc::new(vec![EdnTag::new("show")]),
       values: Arc::new(vec![Calcit::Nil]),
     })];
-    let plain_struct = crate::calcit::CalcitStruct::from_fields(EdnTag::new("Plain"), vec![EdnTag::new("name")]);
+    let plain_struct = crate::calcit::CalcitStructDef::from_fields(EdnTag::new("Plain"), vec![EdnTag::new("name")]);
 
     let call_info = CallTypeCheckInfo {
       file_ns: "tests.where",
@@ -7697,8 +7916,8 @@ mod tests {
       values: Arc::new(vec![method_value.clone()]),
     };
 
-    let class_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct {
+    let class_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef {
         name: EdnTag::from("Person"),
         fields: Arc::new(vec![EdnTag::from("greet")]),
         field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone()]),
@@ -7724,7 +7943,7 @@ mod tests {
     let mut scope_types: ScopeTypes = ScopeTypes::new();
     scope_types.insert(
       Arc::from("user"),
-      Arc::new(CalcitTypeAnnotation::Record(class_record.struct_ref.clone())),
+      Arc::new(CalcitTypeAnnotation::StructValue(class_record.struct_ref.clone())),
     );
 
     let warnings = RefCell::new(vec![]);
@@ -7749,12 +7968,12 @@ mod tests {
 
   #[test]
   fn checks_enum_tuple_invalid_variant() {
-    use crate::calcit::CalcitEnum;
+    use crate::calcit::CalcitEnumDef;
     use cirru_edn::EdnTag;
 
     // Create a test enum: Result with :ok and :err variants
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Result"),
         vec![EdnTag::from("err"), EdnTag::from("ok")],
       )),
@@ -7764,13 +7983,13 @@ mod tests {
         Calcit::from(CalcitList::default()),       // :ok payload types (empty)
       ]),
     };
-    let enum_proto = CalcitEnum::from_record(enum_record.clone()).expect("valid enum");
+    let enum_proto = CalcitEnumDef::from_record(enum_record.clone()).expect("valid enum");
 
     // Test: create enum tuple with invalid variant :invalid
     let args = CalcitList::from(
       &vec![
-        Calcit::Enum(enum_proto), // enum prototype
-        Calcit::tag("invalid"),   // invalid variant tag
+        Calcit::EnumDef(enum_proto), // enum prototype
+        Calcit::tag("invalid"),      // invalid variant tag
       ][..],
     );
 
@@ -7794,12 +8013,12 @@ mod tests {
 
   #[test]
   fn checks_enum_tuple_wrong_arity() {
-    use crate::calcit::CalcitEnum;
+    use crate::calcit::CalcitEnumDef;
     use cirru_edn::EdnTag;
 
     // Create a test enum: Result with :ok (0 payloads) and :err (1 payload)
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Result"),
         vec![EdnTag::from("err"), EdnTag::from("ok")],
       )),
@@ -7808,14 +8027,14 @@ mod tests {
         Calcit::from(CalcitList::default()),       // :ok expects 0 payloads
       ]),
     };
-    let enum_proto = CalcitEnum::from_record(enum_record.clone()).expect("valid enum");
+    let enum_proto = CalcitEnumDef::from_record(enum_record.clone()).expect("valid enum");
 
     // Test: create :err tuple but without the required payload
     let args = CalcitList::from(
       &vec![
-        Calcit::Enum(enum_proto), // enum prototype
-        Calcit::tag("err"),       // :err variant expects 1 payload
-                                  // missing payload!
+        Calcit::EnumDef(enum_proto), // enum prototype
+        Calcit::tag("err"),          // :err variant expects 1 payload
+                                     // missing payload!
       ][..],
     );
 
@@ -7839,12 +8058,12 @@ mod tests {
 
   #[test]
   fn checks_enum_tuple_payload_type() {
-    use crate::calcit::CalcitEnum;
+    use crate::calcit::CalcitEnumDef;
     use cirru_edn::EdnTag;
 
     // Create a test enum: Result with :err (string payload)
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::from("Result"),
         vec![EdnTag::from("err"), EdnTag::from("ok")],
       )),
@@ -7853,14 +8072,14 @@ mod tests {
         Calcit::from(CalcitList::default()),       // :ok expects no payloads
       ]),
     };
-    let enum_proto = CalcitEnum::from_record(enum_record.clone()).expect("valid enum");
+    let enum_proto = CalcitEnumDef::from_record(enum_record.clone()).expect("valid enum");
 
     // Test: create :err tuple with number instead of string
     let args = CalcitList::from(
       &vec![
-        Calcit::Enum(enum_proto), // enum prototype
-        Calcit::tag("err"),       // :err variant
-        Calcit::Number(42.0),     // should be string, not number!
+        Calcit::EnumDef(enum_proto), // enum prototype
+        Calcit::tag("err"),          // :err variant
+        Calcit::Number(42.0),        // should be string, not number!
       ][..],
     );
 
@@ -7887,10 +8106,10 @@ mod tests {
     use cirru_edn::EdnTag;
     let _ = EdnTag::from("point"); // tag retained for documentation
 
-    // With Arc<CalcitEnum> typed tuples, size is not statically known;
-    // bounds checking falls through (same as DynTuple). Verify no warning.
+    // With Arc<CalcitEnumDef> typed tuples, size is not statically known;
+    // bounds checking falls through (same as AnonymousEnum). Verify no warning.
     let mut scope_types: ScopeTypes = ScopeTypes::new();
-    scope_types.insert(Arc::from("my-tuple"), Arc::new(CalcitTypeAnnotation::DynTuple));
+    scope_types.insert(Arc::from("my-tuple"), Arc::new(CalcitTypeAnnotation::AnonymousEnum));
 
     let args = CalcitList::from(
       &vec![
@@ -7913,7 +8132,7 @@ mod tests {
     let warnings_vec = warnings.borrow();
     assert!(
       warnings_vec.is_empty(),
-      "DynTuple: no static bounds checking, should have no warning"
+      "AnonymousEnum: no static bounds checking, should have no warning"
     );
   }
 
@@ -7922,9 +8141,9 @@ mod tests {
     use cirru_edn::EdnTag;
     let _ = EdnTag::from("point"); // tag retained for documentation
 
-    // DynTuple: bounds checking not performed, no warning expected
+    // AnonymousEnum: bounds checking not performed, no warning expected
     let mut scope_types: ScopeTypes = ScopeTypes::new();
-    scope_types.insert(Arc::from("my-tuple"), Arc::new(CalcitTypeAnnotation::DynTuple));
+    scope_types.insert(Arc::from("my-tuple"), Arc::new(CalcitTypeAnnotation::AnonymousEnum));
 
     let args = CalcitList::from(
       &vec![
@@ -7953,9 +8172,9 @@ mod tests {
     use cirru_edn::EdnTag;
     let _ = EdnTag::from("point"); // tag retained for documentation
 
-    // DynTuple: dynamic index - should skip checking
+    // AnonymousEnum: dynamic index - should skip checking
     let mut scope_types: ScopeTypes = ScopeTypes::new();
-    scope_types.insert(Arc::from("my-tuple"), Arc::new(CalcitTypeAnnotation::DynTuple));
+    scope_types.insert(Arc::from("my-tuple"), Arc::new(CalcitTypeAnnotation::AnonymousEnum));
 
     // Test: dynamic index (variable) - should skip checking
     let args = CalcitList::from(

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -567,7 +567,7 @@ pub(crate) fn check_function_return_type(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitLocal, CalcitStruct, CalcitSymbolInfo};
+  use crate::calcit::{CalcitLocal, CalcitStructDef, CalcitSymbolInfo};
   use cirru_edn::EdnTag;
 
   fn make_local(name: &str, type_info: Arc<CalcitTypeAnnotation>) -> Calcit {
@@ -593,7 +593,7 @@ mod tests {
 
   #[test]
   fn specialize_update_uses_record_field_type_for_callback() {
-    let task_struct = Arc::new(CalcitStruct {
+    let task_struct = Arc::new(CalcitStructDef {
       name: EdnTag::new("Task"),
       fields: Arc::new(vec![EdnTag::new("done?")]),
       field_types: Arc::new(vec![tag_annotation("bool")]),
@@ -614,7 +614,7 @@ mod tests {
       where_bounds: Arc::new(vec![]),
       return_type: crate::calcit::DYNAMIC_TYPE.clone(),
       arg_types: vec![
-        Arc::new(CalcitTypeAnnotation::Record(task_struct.clone())),
+        Arc::new(CalcitTypeAnnotation::StructValue(task_struct.clone())),
         crate::calcit::DYNAMIC_TYPE.clone(),
         Arc::new(CalcitTypeAnnotation::from_function_parts(
           vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))],
@@ -625,7 +625,7 @@ mod tests {
     };
 
     let args = CalcitList::from(&[
-      make_local("task", Arc::new(CalcitTypeAnnotation::Record(task_struct))),
+      make_local("task", Arc::new(CalcitTypeAnnotation::StructValue(task_struct))),
       Calcit::Tag(EdnTag::new("done?")),
       make_local(
         "not",

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -18,8 +18,8 @@ use std::{
 use crate::{
   builtins,
   calcit::{
-    self, Calcit, CalcitEnum, CalcitFnTypeAnnotation, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitRecord, CalcitStruct,
-    CalcitSyntax, CalcitTrait, CalcitTypeAnnotation, ImportInfo, SchemaKind, resolve_type_slot,
+    self, Calcit, CalcitEnumDef, CalcitFnTypeAnnotation, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitStructDef,
+    CalcitStructValue, CalcitSyntax, CalcitTrait, CalcitTypeAnnotation, ImportInfo, SchemaKind, resolve_type_slot,
   },
   call_stack::CallStackList,
   program, runner,
@@ -303,14 +303,22 @@ fn infer_core_get_in_return_type(call_expr: &CalcitList, scope_types: &ScopeType
 }
 
 fn infer_get_return_type_from_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&Calcit>) -> Option<Arc<CalcitTypeAnnotation>> {
-  infer_lookup_payload_type_from_type(base_type, key_arg).map(|payload| core_type_ref("Option", vec![payload]))
+  let payload = infer_lookup_payload_type_from_type(base_type, key_arg)?;
+  if base_type.resolve_to_struct().is_some() {
+    // Struct fields are declared and always present. Runtime `get` delegates
+    // to the required lookup and reports an unknown field instead of returning
+    // Option/nil, so the static type must expose the declared field directly.
+    Some(payload)
+  } else {
+    Some(core_type_ref("Option", vec![payload]))
+  }
 }
 
 fn infer_sequence_payload_type(base_type: &CalcitTypeAnnotation) -> Option<Arc<CalcitTypeAnnotation>> {
   match base_type {
     CalcitTypeAnnotation::List(element_type) => Some(element_type.clone()),
     CalcitTypeAnnotation::String => Some(tag_annotation("string")),
-    CalcitTypeAnnotation::Tuple(_) | CalcitTypeAnnotation::DynTuple => Some(calcit::DYNAMIC_TYPE.clone()),
+    CalcitTypeAnnotation::EnumValue(_) | CalcitTypeAnnotation::AnonymousEnum => Some(calcit::DYNAMIC_TYPE.clone()),
     _ => None,
   }
 }
@@ -323,8 +331,8 @@ fn infer_lookup_payload_type_from_type(
     CalcitTypeAnnotation::List(element_type) => Some(element_type.clone()),
     CalcitTypeAnnotation::Map(_, value_type) => Some(value_type.clone()),
     CalcitTypeAnnotation::String => Some(tag_annotation("string")),
-    CalcitTypeAnnotation::Tuple(_) | CalcitTypeAnnotation::DynTuple => Some(calcit::DYNAMIC_TYPE.clone()),
-    CalcitTypeAnnotation::Record(_) | CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::TypeRef(_, _) => {
+    CalcitTypeAnnotation::EnumValue(_) | CalcitTypeAnnotation::AnonymousEnum => Some(calcit::DYNAMIC_TYPE.clone()),
+    CalcitTypeAnnotation::StructValue(_) | CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::TypeRef(_, _) => {
       if let Some(field_name) = key_arg.and_then(extract_field_name)
         && let Some(field_type) = resolve_struct_field_type(base_type, field_name)
       {
@@ -415,13 +423,13 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
       values.iter(),
       scope_types,
     )))),
-    Calcit::Tuple(tuple) => match &tuple.sum_type {
-      Some(enum_def) => Some(Arc::new(CalcitTypeAnnotation::Tuple(enum_def.clone()))),
-      None => Some(Arc::new(CalcitTypeAnnotation::DynTuple)),
+    Calcit::Enum(tuple) => match &tuple.sum_type {
+      Some(enum_def) => Some(Arc::new(CalcitTypeAnnotation::EnumValue(enum_def.clone()))),
+      None => Some(Arc::new(CalcitTypeAnnotation::AnonymousEnum)),
     },
-    Calcit::Record(record) => {
+    Calcit::Struct(record) => {
       if record.struct_ref.generics.is_empty() {
-        Some(Arc::new(CalcitTypeAnnotation::Record(record.struct_ref.clone())))
+        Some(Arc::new(CalcitTypeAnnotation::StructValue(record.struct_ref.clone())))
       } else {
         let applied_args = infer_struct_applied_args(record.struct_ref.as_ref(), record.values.iter(), scope_types);
         Some(Arc::new(CalcitTypeAnnotation::Struct(
@@ -430,14 +438,8 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
         )))
       }
     }
-    Calcit::Struct(struct_def) => Some(Arc::new(CalcitTypeAnnotation::Struct(
-      Arc::new(struct_def.to_owned()),
-      Arc::new(vec![]),
-    ))),
-    Calcit::Enum(enum_def) => Some(Arc::new(CalcitTypeAnnotation::Enum(
-      Arc::new(enum_def.to_owned()),
-      Arc::new(vec![]),
-    ))),
+    Calcit::StructDef(struct_def) => Some(Arc::new(CalcitTypeAnnotation::StructDef(Arc::new(struct_def.to_owned())))),
+    Calcit::EnumDef(enum_def) => Some(Arc::new(CalcitTypeAnnotation::EnumDef(Arc::new(enum_def.to_owned())))),
     Calcit::Trait(trait_def) => Some(Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def.to_owned())))),
     // Impl values carry useful compile-time method metadata. `Custom` is the
     // existing annotation representation for first-class runtime metadata;
@@ -513,7 +515,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
         // Import: could be a function, try to get its return type
         Calcit::Import(CalcitImport { ns, def, .. }) => {
           if &**ns == calcit::CORE_NS
-            && (&**def == "record-get" || &**def == "&record:get")
+            && (&**def == "record-get" || &**def == "&struct:get")
             && let Some(field_type) = infer_record_get_type(xs, scope_types)
           {
             return Some(field_type);
@@ -746,7 +748,7 @@ fn is_list_constructor(value: &Calcit) -> bool {
 
 fn extract_impl_pair(value: &Calcit) -> Option<(&Calcit, &Calcit)> {
   match value {
-    Calcit::Tuple(tuple) if tuple.extra.len() == 1 => Some((tuple.tag.as_ref(), tuple.extra.first()?)),
+    Calcit::Enum(tuple) if tuple.extra.len() == 1 => Some((tuple.tag.as_ref(), tuple.extra.first()?)),
     Calcit::List(items) if items.len() == 2 => Some((items.first()?, items.get(1)?)),
     Calcit::List(items)
       if items.len() == 3
@@ -849,15 +851,27 @@ fn infer_impl_attachment_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Opti
   }
 
   match base.as_ref() {
+    CalcitTypeAnnotation::StructDef(struct_def) => {
+      let mut attached = struct_def.as_ref().to_owned();
+      attached.impls.extend(impl_values);
+      Some(Arc::new(CalcitTypeAnnotation::StructDef(Arc::new(attached))))
+    }
+    CalcitTypeAnnotation::EnumDef(enum_def) => {
+      let mut attached = enum_def.as_ref().to_owned();
+      let mut impls = attached.impls().to_vec();
+      impls.extend(impl_values);
+      attached.set_impls(impls);
+      Some(Arc::new(CalcitTypeAnnotation::EnumDef(Arc::new(attached))))
+    }
     CalcitTypeAnnotation::Struct(struct_def, args) => {
       let mut attached = struct_def.as_ref().to_owned();
       attached.impls.extend(impl_values);
       Some(Arc::new(CalcitTypeAnnotation::Struct(Arc::new(attached), args.clone())))
     }
-    CalcitTypeAnnotation::Record(struct_def) => {
+    CalcitTypeAnnotation::StructValue(struct_def) => {
       let mut attached = struct_def.as_ref().to_owned();
       attached.impls.extend(impl_values);
-      Some(Arc::new(CalcitTypeAnnotation::Record(Arc::new(attached))))
+      Some(Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(attached))))
     }
     CalcitTypeAnnotation::Enum(enum_def, args) => {
       let mut attached = enum_def.as_ref().to_owned();
@@ -866,12 +880,12 @@ fn infer_impl_attachment_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Opti
       attached.set_impls(impls);
       Some(Arc::new(CalcitTypeAnnotation::Enum(Arc::new(attached), args.clone())))
     }
-    CalcitTypeAnnotation::Tuple(enum_def) => {
+    CalcitTypeAnnotation::EnumValue(enum_def) => {
       let mut attached = enum_def.as_ref().to_owned();
       let mut impls = attached.impls().to_vec();
       impls.extend(impl_values);
       attached.set_impls(impls);
-      Some(Arc::new(CalcitTypeAnnotation::Tuple(Arc::new(attached))))
+      Some(Arc::new(CalcitTypeAnnotation::EnumValue(Arc::new(attached))))
     }
     CalcitTypeAnnotation::TypeRef(_, args) => {
       if let Some(mut attached) = base.resolve_to_struct() {
@@ -1127,15 +1141,20 @@ fn infer_definition_value_type(ns: &str, def: &str) -> Option<Arc<CalcitTypeAnno
 
 fn infer_definition_value_type_inner(ns: &str, def: &str) -> Option<Arc<CalcitTypeAnnotation>> {
   // Static data/trait/impl declarations carry richer metadata in their
-  // preprocessed value than in the intentionally broad top-level schema
-  // (`'Struct`, `'Enum`, `'Trait`, or `'Impl`). Prefer that concrete metadata so
+  // preprocessed value than in the intentionally broad top-level schema.
+  // Prefer that concrete metadata so definition values stay distinct from
+  // their instance types and imported `impl-traits` calls retain their method table.
   // imported `impl-traits` calls keep their nominal type and method table.
   if let Some(compiled) = program::lookup_compiled_def(ns, def)
     && let Some(inferred) = infer_type_from_expr(&compiled.preprocessed_code, &ScopeTypes::new())
   {
     let is_concrete_metadata = matches!(
       inferred.as_ref(),
-      CalcitTypeAnnotation::Struct(..) | CalcitTypeAnnotation::Enum(..) | CalcitTypeAnnotation::Trait(..)
+      CalcitTypeAnnotation::Struct(..)
+        | CalcitTypeAnnotation::Enum(..)
+        | CalcitTypeAnnotation::StructDef(..)
+        | CalcitTypeAnnotation::EnumDef(..)
+        | CalcitTypeAnnotation::Trait(..)
     ) || matches!(inferred.as_ref(), CalcitTypeAnnotation::Custom(value) if matches!(value.as_ref(), Calcit::Impl(_)));
     if is_concrete_metadata {
       return Some(inferred);
@@ -1187,7 +1206,7 @@ fn infer_enum_tuple_annotation(xs: &CalcitList, scope_types: &ScopeTypes) -> Opt
   let enum_proto = resolve_enum_value(enum_arg, scope_types)?;
 
   if enum_proto.generics().is_empty() {
-    return Some(Arc::new(CalcitTypeAnnotation::Tuple(Arc::new(enum_proto))));
+    return Some(Arc::new(CalcitTypeAnnotation::EnumValue(Arc::new(enum_proto))));
   }
 
   let applied_args = infer_enum_tuple_applied_args(&enum_proto, tag_arg, xs.iter().skip(3), scope_types).unwrap_or_else(|| {
@@ -1201,7 +1220,7 @@ fn infer_enum_tuple_annotation(xs: &CalcitList, scope_types: &ScopeTypes) -> Opt
 }
 
 fn infer_enum_tuple_applied_args<'a>(
-  enum_proto: &CalcitEnum,
+  enum_proto: &CalcitEnumDef,
   tag_arg: Option<&Calcit>,
   payload_args: impl Iterator<Item = &'a Calcit>,
   scope_types: &ScopeTypes,
@@ -1241,7 +1260,7 @@ fn infer_record_get_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Option<Ar
   infer_record_field_type(record_arg, field_name, scope_types)
 }
 
-/// Infer the return type of `&record:nth record idx` by looking up the field type at the given index.
+/// Infer the return type of `&struct:nth record idx` by looking up the field type at the given index.
 fn infer_record_nth_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
   if xs.len() < 3 {
     return None;
@@ -1263,7 +1282,7 @@ fn infer_record_literal_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Optio
   let proto_arg = xs.get(1)?;
   let record = resolve_record_value(proto_arg, scope_types)?;
   if record.struct_ref.generics.is_empty() {
-    return Some(Arc::new(CalcitTypeAnnotation::Record(record.struct_ref.clone())));
+    return Some(Arc::new(CalcitTypeAnnotation::StructValue(record.struct_ref.clone())));
   }
 
   let field_values = collect_record_literal_values(xs, &record)?;
@@ -1277,7 +1296,7 @@ fn infer_record_literal_type(xs: &CalcitList, scope_types: &ScopeTypes) -> Optio
 fn infer_struct_literal_type(xs: &CalcitList) -> Option<Arc<CalcitTypeAnnotation>> {
   let args = xs.iter().skip(1).map(normalize_static_metadata_form).collect::<Vec<_>>();
   match builtins::records::new_struct(&args).ok()? {
-    Calcit::Struct(struct_def) => Some(Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(vec![])))),
+    Calcit::StructDef(struct_def) => Some(Arc::new(CalcitTypeAnnotation::StructDef(Arc::new(struct_def)))),
     _ => None,
   }
 }
@@ -1285,7 +1304,7 @@ fn infer_struct_literal_type(xs: &CalcitList) -> Option<Arc<CalcitTypeAnnotation
 fn infer_enum_literal_type(xs: &CalcitList) -> Option<Arc<CalcitTypeAnnotation>> {
   let args = xs.iter().skip(1).map(normalize_static_metadata_form).collect::<Vec<_>>();
   match builtins::records::new_enum(&args).ok()? {
-    Calcit::Enum(enum_def) => Some(Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def), Arc::new(vec![])))),
+    Calcit::EnumDef(enum_def) => Some(Arc::new(CalcitTypeAnnotation::EnumDef(Arc::new(enum_def)))),
     _ => None,
   }
 }
@@ -1307,7 +1326,7 @@ fn resolve_struct_field_type(type_info: &CalcitTypeAnnotation, field_name: &str)
 fn resolve_struct_field_type_by_index(type_info: &CalcitTypeAnnotation, idx: usize) -> Option<Arc<CalcitTypeAnnotation>> {
   match type_info {
     CalcitTypeAnnotation::Optional(inner) => resolve_struct_field_type_by_index(inner.as_ref(), idx),
-    CalcitTypeAnnotation::Record(struct_def) => struct_def.field_types.get(idx).cloned(),
+    CalcitTypeAnnotation::StructValue(struct_def) => struct_def.field_types.get(idx).cloned(),
     CalcitTypeAnnotation::Struct(struct_def, args) => {
       let field_type = struct_def.field_types.get(idx)?.clone();
       Some(substitute_declared_generics(
@@ -1346,7 +1365,7 @@ fn substitute_declared_generics(
 }
 
 fn infer_struct_applied_args<'a>(
-  struct_def: &CalcitStruct,
+  struct_def: &CalcitStructDef,
   values: impl Iterator<Item = &'a Calcit>,
   scope_types: &ScopeTypes,
 ) -> Vec<Arc<CalcitTypeAnnotation>> {
@@ -1367,7 +1386,7 @@ fn infer_struct_applied_args<'a>(
     .collect()
 }
 
-fn collect_record_literal_values(xs: &CalcitList, record: &CalcitRecord) -> Option<Vec<Calcit>> {
+fn collect_record_literal_values(xs: &CalcitList, record: &CalcitStructValue) -> Option<Vec<Calcit>> {
   if xs.len() < 2 {
     return None;
   }
@@ -1410,18 +1429,18 @@ pub(crate) fn resolve_program_value_for_preprocess(ns: &str, def: &str, def_id: 
   runner::evaluate_symbol_from_program(def, ns, def_id, &call_stack).ok()
 }
 
-pub(crate) fn resolve_enum_value(target: &Calcit, scope_types: &ScopeTypes) -> Option<CalcitEnum> {
+pub(crate) fn resolve_enum_value(target: &Calcit, scope_types: &ScopeTypes) -> Option<CalcitEnumDef> {
   match target {
-    Calcit::Enum(enum_def) => Some(enum_def.to_owned()),
-    Calcit::Record(record) => CalcitEnum::from_record(record.to_owned()).ok(),
+    Calcit::EnumDef(enum_def) => Some(enum_def.to_owned()),
+    Calcit::Struct(record) => CalcitEnumDef::from_record(record.to_owned()).ok(),
     Calcit::Symbol { sym, info, .. } => match resolve_program_value_for_preprocess(&info.at_ns, sym, None) {
-      Some(Calcit::Enum(enum_def)) => Some(enum_def),
-      Some(Calcit::Record(record)) => CalcitEnum::from_record(record).ok(),
+      Some(Calcit::EnumDef(enum_def)) => Some(enum_def),
+      Some(Calcit::Struct(record)) => CalcitEnumDef::from_record(record).ok(),
       _ => None,
     },
     Calcit::Import(CalcitImport { ns, def, def_id, .. }) => match resolve_program_value_for_preprocess(ns, def, *def_id) {
-      Some(Calcit::Enum(enum_def)) => Some(enum_def),
-      Some(Calcit::Record(record)) => CalcitEnum::from_record(record).ok(),
+      Some(Calcit::EnumDef(enum_def)) => Some(enum_def),
+      Some(Calcit::Struct(record)) => CalcitEnumDef::from_record(record).ok(),
       _ => None,
     },
     _ => resolve_type_value(target, scope_types)
@@ -1429,35 +1448,33 @@ pub(crate) fn resolve_enum_value(target: &Calcit, scope_types: &ScopeTypes) -> O
         CalcitTypeAnnotation::TypeSlot(name) => resolve_type_slot(name),
         _ => Some(t),
       })
-      .and_then(|t| t.resolve_to_struct())
-      .and_then(|struct_def| {
-        let len = struct_def.fields.len();
-        let record = CalcitRecord {
-          struct_ref: Arc::new(struct_def),
-          values: Arc::new(vec![Calcit::Nil; len]),
-        };
-        CalcitEnum::from_record(record).ok()
+      .and_then(|t| match t.as_ref() {
+        // Definition values stay distinct from enum instances in ordinary type
+        // matching. Constructor inference is the one context that deliberately
+        // unwraps the definition metadata into its resulting instance type.
+        CalcitTypeAnnotation::EnumDef(enum_def) => Some(enum_def.as_ref().to_owned()),
+        _ => t.resolve_to_enum(),
       }),
   }
 }
 
-pub(crate) fn resolve_record_value(target: &Calcit, scope_types: &ScopeTypes) -> Option<CalcitRecord> {
+pub(crate) fn resolve_record_value(target: &Calcit, scope_types: &ScopeTypes) -> Option<CalcitStructValue> {
   match target {
-    Calcit::Record(record) => Some(record.to_owned()),
-    Calcit::Enum(enum_def) => Some(enum_def.to_record_prototype()),
-    Calcit::Struct(struct_def) => {
+    Calcit::Struct(record) => Some(record.to_owned()),
+    Calcit::EnumDef(enum_def) => Some(enum_def.to_record_prototype()),
+    Calcit::StructDef(struct_def) => {
       let values = vec![Calcit::Nil; struct_def.fields.len()];
-      Some(CalcitRecord {
+      Some(CalcitStructValue {
         struct_ref: Arc::new(struct_def.to_owned()),
         values: Arc::new(values),
       })
     }
     Calcit::Symbol { sym, info, .. } => match resolve_program_value_for_preprocess(&info.at_ns, sym, None) {
-      Some(Calcit::Record(record)) => Some(record),
-      Some(Calcit::Enum(enum_def)) => Some(enum_def.to_record_prototype()),
-      Some(Calcit::Struct(struct_def)) => {
+      Some(Calcit::Struct(record)) => Some(record),
+      Some(Calcit::EnumDef(enum_def)) => Some(enum_def.to_record_prototype()),
+      Some(Calcit::StructDef(struct_def)) => {
         let values = vec![Calcit::Nil; struct_def.fields.len()];
-        Some(CalcitRecord {
+        Some(CalcitStructValue {
           struct_ref: Arc::new(struct_def.to_owned()),
           values: Arc::new(values),
         })
@@ -1467,11 +1484,11 @@ pub(crate) fn resolve_record_value(target: &Calcit, scope_types: &ScopeTypes) ->
     Calcit::Import(CalcitImport { ns, def, def_id, .. }) => {
       let runtime_value = resolve_program_value_for_preprocess(ns, def, *def_id);
       match runtime_value {
-        Some(Calcit::Record(record)) => Some(record),
-        Some(Calcit::Enum(enum_def)) => Some(enum_def.to_record_prototype()),
-        Some(Calcit::Struct(struct_def)) => {
+        Some(Calcit::Struct(record)) => Some(record),
+        Some(Calcit::EnumDef(enum_def)) => Some(enum_def.to_record_prototype()),
+        Some(Calcit::StructDef(struct_def)) => {
           let values = vec![Calcit::Nil; struct_def.fields.len()];
-          Some(CalcitRecord {
+          Some(CalcitStructValue {
             struct_ref: Arc::new(struct_def.to_owned()),
             values: Arc::new(values),
           })
@@ -1480,7 +1497,13 @@ pub(crate) fn resolve_record_value(target: &Calcit, scope_types: &ScopeTypes) ->
       }
     }
     _ => resolve_type_value(target, scope_types).and_then(|t| {
-      t.resolve_to_struct().map(|struct_def| CalcitRecord {
+      let struct_def = match t.as_ref() {
+        // As above, only the explicit struct-construction path unwraps a
+        // StructDef into the nominal metadata of the instance being created.
+        CalcitTypeAnnotation::StructDef(struct_def) => struct_def.as_ref().to_owned(),
+        _ => t.resolve_to_struct()?,
+      };
+      Some(CalcitStructValue {
         struct_ref: Arc::new(struct_def.clone()),
         values: Arc::new(vec![Calcit::Nil; struct_def.fields.len()]),
       })
@@ -1595,7 +1618,7 @@ mod tests {
 
   #[test]
   fn strict_edn_decode_expression_has_declared_closed_type() {
-    let target = Calcit::Tuple(calcit::CalcitTuple {
+    let target = Calcit::Enum(calcit::CalcitEnumValue {
       tag: Arc::new(Calcit::tag("list")),
       extra: vec![Calcit::tag("number")],
       sum_type: None,
@@ -1666,17 +1689,15 @@ mod tests {
   }
 
   #[test]
-  fn known_struct_get_wraps_required_field_type_in_nominal_option() {
-    let mut struct_def = CalcitStruct::from_fields(EdnTag::from("User"), vec![EdnTag::from("name")]);
+  fn known_struct_get_returns_the_required_field_type_directly() {
+    let mut struct_def = CalcitStructDef::from_fields(EdnTag::from("User"), vec![EdnTag::from("name")]);
     struct_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]);
     let user_type = CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(vec![]));
     let key = Calcit::Tag(EdnTag::from("name"));
 
     assert!(matches!(
       infer_get_return_type_from_type(&user_type, Some(&key)).as_deref(),
-      Some(CalcitTypeAnnotation::TypeRef(name, args))
-        if name.as_ref() == "calcit.core/Option"
-          && matches!(args.first().map(AsRef::as_ref), Some(CalcitTypeAnnotation::String))
+      Some(CalcitTypeAnnotation::String)
     ));
     assert!(
       infer_get_return_type_from_type(&CalcitTypeAnnotation::Optional(Arc::new(user_type)), Some(&key)).is_none(),
@@ -1687,7 +1708,7 @@ mod tests {
   #[test]
   fn typed_record_updates_preserve_the_receiver_type() {
     let generic: Arc<str> = Arc::from("T");
-    let mut struct_def = CalcitStruct::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]);
+    let mut struct_def = CalcitStructDef::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]);
     struct_def.generics = Arc::new(vec![generic.clone()]);
     struct_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(generic))]);
     let receiver_type = Arc::new(CalcitTypeAnnotation::Struct(
@@ -1740,7 +1761,7 @@ mod tests {
   #[test]
   fn enum_constructor_keeps_nominal_type_without_payload_evidence() {
     let generic: Arc<str> = Arc::from("T");
-    let struct_def = CalcitStruct {
+    let struct_def = CalcitStructDef {
       name: EdnTag::from("MaybeX"),
       fields: Arc::new(vec![EdnTag::from("none"), EdnTag::from("some")]),
       field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),
@@ -1748,7 +1769,7 @@ mod tests {
       where_bounds: Arc::new(vec![]),
       impls: vec![],
     };
-    let enum_def = CalcitEnum::from_record(CalcitRecord {
+    let enum_def = CalcitEnumDef::from_record(CalcitStructValue {
       struct_ref: Arc::new(struct_def),
       values: Arc::new(vec![
         Calcit::from(CalcitList::default()),
@@ -1759,7 +1780,7 @@ mod tests {
 
     let none_call = CalcitList::from(&[
       Calcit::Proc(CalcitProc::NativeEnumTupleNew),
-      Calcit::Enum(enum_def.clone()),
+      Calcit::EnumDef(enum_def.clone()),
       Calcit::Tag(EdnTag::from("none")),
     ] as &[Calcit]);
     assert!(matches!(
@@ -1771,7 +1792,7 @@ mod tests {
 
     let some_call = CalcitList::from(&[
       Calcit::Proc(CalcitProc::NativeEnumTupleNew),
-      Calcit::Enum(enum_def.clone()),
+      Calcit::EnumDef(enum_def.clone()),
       Calcit::Tag(EdnTag::from("some")),
       Calcit::Number(1.0),
     ] as &[Calcit]);
@@ -1791,32 +1812,32 @@ mod tests {
       fields: Arc::new(vec![EdnTag::from("show")]),
       values: Arc::new(vec![Calcit::Nil]),
     };
-    let struct_def = CalcitStruct::from_fields(cirru_edn::EdnTag::from("Bird"), vec![cirru_edn::EdnTag::from("name")]);
+    let struct_def = CalcitStructDef::from_fields(cirru_edn::EdnTag::from("Bird"), vec![cirru_edn::EdnTag::from("name")]);
     let struct_call = proc_call(
       CalcitProc::NativeStructImplTraits,
-      vec![Calcit::Struct(struct_def.clone()), Calcit::Impl(method_impl.clone())],
+      vec![Calcit::StructDef(struct_def.clone()), Calcit::Impl(method_impl.clone())],
     );
     assert!(matches!(
       infer_static_type_from_expr(&struct_call).as_deref(),
-      Some(CalcitTypeAnnotation::Struct(inferred, _))
+      Some(CalcitTypeAnnotation::StructDef(inferred))
         if inferred.name == struct_def.name && inferred.impls.iter().any(|item| item.get("show").is_some())
     ));
 
-    let enum_record = CalcitRecord {
-      struct_ref: Arc::new(CalcitStruct::from_fields(
+    let enum_record = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
         cirru_edn::EdnTag::from("Outcome"),
         vec![cirru_edn::EdnTag::from("ok")],
       )),
       values: Arc::new(vec![Calcit::List(Arc::new(CalcitList::default()))]),
     };
-    let enum_def = CalcitEnum::from_record(enum_record).expect("valid enum fixture");
+    let enum_def = CalcitEnumDef::from_record(enum_record).expect("valid enum fixture");
     let enum_call = proc_call(
       CalcitProc::NativeEnumImplTraits,
-      vec![Calcit::Enum(enum_def.clone()), Calcit::Impl(method_impl)],
+      vec![Calcit::EnumDef(enum_def.clone()), Calcit::Impl(method_impl)],
     );
     assert!(matches!(
       infer_static_type_from_expr(&enum_call).as_deref(),
-      Some(CalcitTypeAnnotation::Enum(inferred, _))
+      Some(CalcitTypeAnnotation::EnumDef(inferred))
         if inferred.name() == enum_def.name() && inferred.impls().iter().any(|item| item.get("show").is_some())
     ));
   }

--- a/src/runner/preprocess/type_rewriting.rs
+++ b/src/runner/preprocess/type_rewriting.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use cirru_edn::EdnTag;
 
 use crate::calcit::{
-  Calcit, CalcitEnum, CalcitFn, CalcitFnTypeAnnotation, CalcitImport, CalcitList, CalcitProc, CalcitStruct, CalcitTypeAnnotation,
+  Calcit, CalcitEnumDef, CalcitFn, CalcitFnTypeAnnotation, CalcitImport, CalcitList, CalcitProc, CalcitStructDef, CalcitTypeAnnotation,
   ImportInfo, LocatedWarning,
 };
 
@@ -341,7 +341,7 @@ fn try_rewrite_single_tuple_to_enum_tuple(
 
 /// Build a Calcit node referencing a struct definition, using Import when ns/def is known.
 pub(crate) fn build_struct_ref_node(
-  struct_def: &CalcitStruct,
+  struct_def: &CalcitStructDef,
   ns_def_path: Option<(Arc<str>, Arc<str>)>,
   file_ns: &str,
   def_name: &str,
@@ -364,13 +364,13 @@ pub(crate) fn build_struct_ref_node(
       def_id: None,
     })
   } else {
-    Calcit::Struct(struct_def.clone())
+    Calcit::StructDef(struct_def.clone())
   }
 }
 
 /// Build a Calcit node referencing an enum definition, using Import when ns/def is known.
 pub(crate) fn build_enum_ref_node(
-  enum_def: CalcitEnum,
+  enum_def: CalcitEnumDef,
   ns_def_path: Option<(Arc<str>, Arc<str>)>,
   file_ns: &str,
   def_name: &str,
@@ -393,6 +393,6 @@ pub(crate) fn build_enum_ref_node(
       def_id: None,
     })
   } else {
-    Calcit::Record(enum_def.to_record_prototype())
+    Calcit::Struct(enum_def.to_record_prototype())
   }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -516,10 +516,10 @@ pub fn schema_annotation_to_edn(schema: &CalcitTypeAnnotation) -> Edn {
         .unwrap_or_else(|| Edn::Symbol(Arc::from("Dynamic"))),
       _ => Edn::Symbol(Arc::from("Dynamic")),
     },
-    CalcitTypeAnnotation::Record(_) => Edn::Symbol(Arc::from("Record")),
+    CalcitTypeAnnotation::StructValue(_) => Edn::Symbol(Arc::from("Struct")),
     CalcitTypeAnnotation::Struct(..) => Edn::Symbol(Arc::from("Struct")),
     CalcitTypeAnnotation::Enum(..) => Edn::Symbol(Arc::from("Enum")),
-    CalcitTypeAnnotation::Tuple(_) => Edn::Symbol(Arc::from("Tuple")),
+    CalcitTypeAnnotation::EnumValue(_) => Edn::Symbol(Arc::from("Enum")),
     CalcitTypeAnnotation::Trait(_) => Edn::Symbol(Arc::from("Trait")),
     other => other.to_type_edn(),
   };
@@ -1077,11 +1077,31 @@ fn looks_like_undeclared_type_var(name: &str) -> bool {
 
 /// Allowed primitive tag types usable as a bare leaf schema (e.g. `:string`, `:number`).
 pub const PRIMITIVE_SCHEMA_TAGS: &[&str] = &[
-  "any", "bool", "number", "string", "symbol", "tag", "list", "map", "set", "fn", "tuple", "ref", "buffer", "dynamic", "unit",
-  "record", "struct", "enum", "trait", "impl",
+  "any",
+  "bool",
+  "number",
+  "string",
+  "symbol",
+  "tag",
+  "list",
+  "map",
+  "set",
+  "fn",
+  "tuple",
+  "ref",
+  "buffer",
+  "dynamic",
+  "unit",
+  "record",
+  "struct",
+  "enum",
+  "struct-def",
+  "enum-def",
+  "trait",
+  "impl",
 ];
 
-const PARAMETERIZED_SCHEMA_TAGS: &[&str] = &["list", "map", "set", "fn", "tuple", "ref"];
+const PARAMETERIZED_SCHEMA_TAGS: &[&str] = &["list", "map", "set", "fn", "ref"];
 
 fn canonical_schema_symbol_from_cirru(node: &Cirru) -> Option<&'static str> {
   let Cirru::Leaf(value) = node else {
@@ -1100,10 +1120,46 @@ fn is_qualified_nominal_schema_ref(value: &str) -> bool {
   !namespace.is_empty() && !definition.is_empty()
 }
 
+fn check_no_legacy_data_type_names(schema: &Cirru) -> Result<(), String> {
+  match schema {
+    Cirru::Leaf(value) => {
+      let name = value.trim_start_matches(['\'', ':']);
+      let replacement = match name {
+        "record" | "Record" => Some("Struct"),
+        "tuple" | "Tuple" => Some("Enum"),
+        _ => None,
+      };
+      if let Some(replacement) = replacement {
+        return Err(format!(
+          "Legacy type name `{name}` was removed by the struct/enum data-model migration; use `'{replacement}`."
+        ));
+      }
+      Ok(())
+    }
+    Cirru::List(items) => {
+      for item in items {
+        check_no_legacy_data_type_names(item)?;
+      }
+      Ok(())
+    }
+  }
+}
+
 fn validate_standalone_type_schema(schema: &Cirru) -> Result<(), String> {
   parse_schema_data(schema)?;
   check_no_nil_type(schema)?;
   check_no_excess_quotes(schema)?;
+
+  if let Cirru::List(items) = schema
+    && matches!(items.first(), Some(Cirru::Leaf(head)) if head.as_ref() == "::")
+    && let Some(Cirru::Leaf(type_name)) = items.get(1)
+    && canonical_schema_symbol_from_cirru(&items[1]).is_none()
+    && !is_qualified_nominal_schema_ref(type_name)
+  {
+    return Err(format!(
+      "Unknown standalone type `{type_name}`. Use a built-in type name or a fully qualified nominal type such as `'app.schema/Store`."
+    ));
+  }
 
   let schema_edn = schema_cirru_to_edn(schema.clone());
   if matches!(schema_edn, Edn::Nil) {
@@ -1115,10 +1171,7 @@ fn validate_standalone_type_schema(schema: &Cirru) -> Result<(), String> {
   {
     return Ok(());
   }
-  if matches!(
-    annotation.as_ref(),
-    CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::Tag | CalcitTypeAnnotation::DynTuple
-  ) {
+  if matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::Tag) {
     return Err(format!(
       "Unsupported standalone type schema: {}",
       cirru_parser::format(std::slice::from_ref(schema), true.into()).unwrap_or_else(|_| format!("{schema:?}"))
@@ -1132,12 +1185,13 @@ fn validate_standalone_type_schema(schema: &Cirru) -> Result<(), String> {
 /// `(:: :fn ({} ...))` / `(:: :macro ({} ...))` callable schemas. Loading
 /// existing snapshots remains deliberately more permissive.
 pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
+  check_no_legacy_data_type_names(schema)?;
   let raw_items = match schema {
     Cirru::List(items) => items,
     Cirru::Leaf(s) => {
       let tag_name = s.trim_start_matches(':');
       if let Some(canonical) = canonical_schema_symbol_from_cirru(schema) {
-        let parameterized = matches!(canonical, "List" | "Map" | "Set" | "Fn" | "Tuple" | "Ref");
+        let parameterized = matches!(canonical, "List" | "Map" | "Set" | "Fn" | "Ref");
         if !parameterized {
           return Ok(());
         }
@@ -1162,7 +1216,6 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
         let example = match tag_name {
           "map" => ":: :map :tag :bool",
           "fn" => ":: :fn $ {} (:args $ []) (:return :unit)",
-          "tuple" => ":: :tuple :bool",
           other => {
             return Err(format!(
               "Bare `:{other}` leaves its nested type dynamic. Use an explicit type expression such as `:: :{other} :bool`; write `:dynamic` as the nested type only when the boundary is intentionally dynamic."
@@ -2623,6 +2676,21 @@ mod tests {
     let quoted_string = Cirru::Leaf(Arc::from("'String"));
     let parsed_quoted_string = parse_schema_annotation_for_write(&quoted_string).expect("'String leaf should parse");
     assert!(matches!(parsed_quoted_string.as_ref(), CalcitTypeAnnotation::String));
+
+    for (legacy, replacement) in [
+      ("'Record", "'Struct"),
+      ("'Tuple", "'Enum"),
+      (":record", "'Struct"),
+      (":tuple", "'Enum"),
+    ] {
+      let error =
+        validate_schema_for_write(&Cirru::Leaf(Arc::from(legacy))).expect_err("legacy data type names must be rejected on write");
+      assert!(error.contains(replacement), "error should point to {replacement}: {error}");
+    }
+
+    let nested_legacy = parse_one(":: 'List 'Record");
+    let error = validate_schema_for_write(&nested_legacy).expect_err("nested legacy data type names must be rejected on write");
+    assert!(error.contains("'Struct"), "nested error should point to 'Struct: {error}");
     let leaf_fn = Cirru::Leaf(Arc::from(":fn"));
     assert!(validate_schema_for_write(&leaf_fn).is_err(), "bare :fn should require a signature");
     let leaf_ref = Cirru::Leaf(Arc::from(":ref"));
@@ -2636,13 +2704,11 @@ mod tests {
     assert!(validate_schema_for_write(&leaf_trait).is_ok(), ":trait leaf should pass");
     let leaf_enum = Cirru::Leaf(Arc::from(":enum"));
     assert!(validate_schema_for_write(&leaf_enum).is_ok(), ":enum leaf should pass");
-    let leaf_record = Cirru::Leaf(Arc::from(":record"));
-    assert!(validate_schema_for_write(&leaf_record).is_ok(), ":record leaf should pass");
     let leaf_struct = Cirru::Leaf(Arc::from(":struct"));
     assert!(validate_schema_for_write(&leaf_struct).is_ok(), ":struct leaf should pass");
     let leaf_impl = Cirru::Leaf(Arc::from(":impl"));
     assert!(validate_schema_for_write(&leaf_impl).is_ok(), ":impl leaf should pass");
-    for kind in ["record", "struct", "enum", "trait", "impl"] {
+    for kind in ["struct", "enum", "trait", "impl"] {
       let schema = Cirru::Leaf(Arc::from(format!(":{kind}")));
       let annotation = parse_schema_annotation_for_write(&schema).unwrap_or_else(|error| panic!(":{kind} should parse: {error}"));
       assert!(
@@ -3159,7 +3225,7 @@ mod tests {
     let Some(Edn::Map(map)) = view.extra.first() else {
       panic!("wrapped schema payload should be a map");
     };
-    assert!(matches!(map.tag_get("return"), Some(Edn::Symbol(name)) if name.as_ref() == "Record"));
+    assert!(matches!(map.tag_get("return"), Some(Edn::Symbol(name)) if name.as_ref() == "Struct"));
   }
 
   #[test]

--- a/ts-src/calcit-data.mts
+++ b/ts-src/calcit-data.mts
@@ -3,16 +3,16 @@ import { overwriteComparator, initTernaryTreeMap } from "@calcit/ternary-tree";
 import { overwriteMapComparator } from "./js-map.mjs";
 import { disableListStructureCheck } from "@calcit/ternary-tree";
 
-import { CalcitRecord, fieldsEqual } from "./js-record.mjs";
+import { CalcitStructValue, fieldsEqual } from "./js-struct-value.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
-import { CalcitStruct } from "./js-struct.mjs";
-import { CalcitEnum } from "./js-enum.mjs";
+import { CalcitStructDef } from "./js-struct-def.mjs";
+import { CalcitEnumDef } from "./js-enum-def.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 
 import { CalcitValue, _$n_compare } from "./js-primes.mjs";
 import { CalcitList, CalcitSliceList } from "./js-list.mjs";
 import { CalcitSet, overwriteSetComparator } from "./js-set.mjs";
-import { CalcitTuple } from "./js-tuple.mjs";
+import { CalcitEnumValue } from "./js-enum-value.mjs";
 import { CalcitTrait } from "./js-trait.mjs";
 import { CalcitCirruQuote, cirru_deep_equal } from "./js-cirru.mjs";
 import { CirruWriterNode } from "@cirru/writer.ts";
@@ -80,7 +80,7 @@ export let isNestedCalcitData = (x: CalcitValue): boolean => {
   if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     return x.len() > 0;
   }
-  if (x instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
     return x.fields.length > 0;
   }
   if (x instanceof CalcitImpl) {
@@ -99,7 +99,7 @@ export let tipNestedCalcitData = (x: CalcitValue): string => {
   if (x instanceof CalcitMap || x instanceof CalcitSliceMap) {
     return "'{}...";
   }
-  if (x instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
     return "'%{}...";
   }
   if (x instanceof CalcitImpl) {
@@ -256,7 +256,7 @@ export let hashFunction = (x: CalcitValue): Hash => {
     x.cachedHash = h;
     return h;
   }
-  if (x instanceof CalcitTuple) {
+  if (x instanceof CalcitEnumValue) {
     let base = defaultHash_tuple;
     base = mergeValueHash(base, hashFunction(x.tag));
     for (let idx = 0; idx < x.extra.length; idx++) {
@@ -322,7 +322,7 @@ export let hashFunction = (x: CalcitValue): Hash => {
     x.cachedHash = base;
     return base;
   }
-  if (x instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
     let base = defaultHash_record;
     for (let idx = 0; idx < x.fields.length; idx++) {
       base = mergeValueHash(base, hashFunction(x.fields[idx]));
@@ -344,7 +344,7 @@ export let hashFunction = (x: CalcitValue): Hash => {
     x.cachedHash = base;
     return base;
   }
-  if (x instanceof CalcitStruct) {
+  if (x instanceof CalcitStructDef) {
     let base = defaultHash_struct;
     base = mergeValueHash(base, hashFunction(x.name));
     for (let idx = 0; idx < x.fields.length; idx++) {
@@ -357,7 +357,7 @@ export let hashFunction = (x: CalcitValue): Hash => {
     x.cachedHash = base;
     return base;
   }
-  if (x instanceof CalcitEnum) {
+  if (x instanceof CalcitEnumDef) {
     let base = defaultHash_enum;
     base = mergeValueHash(base, hashFunction(x.prototype));
     for (let impl of x.impls) {
@@ -441,16 +441,16 @@ export let toString = (x: CalcitValue, escaped: boolean, disableJsDataWarning: b
   if (x instanceof CalcitSet) {
     return x.toString(disableJsDataWarning);
   }
-  if (x instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
     return x.toString(disableJsDataWarning);
   }
   if (x instanceof CalcitImpl) {
     return x.toString(disableJsDataWarning);
   }
-  if (x instanceof CalcitStruct) {
+  if (x instanceof CalcitStructDef) {
     return x.toString(disableJsDataWarning);
   }
-  if (x instanceof CalcitEnum) {
+  if (x instanceof CalcitEnumDef) {
     return x.toString();
   }
   if (x instanceof CalcitTrait) {
@@ -459,7 +459,7 @@ export let toString = (x: CalcitValue, escaped: boolean, disableJsDataWarning: b
   if (x instanceof CalcitRef) {
     return x.toString();
   }
-  if (x instanceof CalcitTuple) {
+  if (x instanceof CalcitEnumValue) {
     return x.toString(disableJsDataWarning);
   }
   if (x instanceof CalcitCirruQuote) {
@@ -532,7 +532,7 @@ let to_js_data_inner = (x: CalcitValue, addColon: boolean): any => {
     }
     return Symbol(x.value);
   }
-  if (x instanceof CalcitTuple) {
+  if (x instanceof CalcitEnumValue) {
     var result: any[] = [to_js_data_inner(x.tag, false)];
     for (let i = 0; i < x.extra.length; i++) {
       let item = x.extra[i];
@@ -565,7 +565,7 @@ let to_js_data_inner = (x: CalcitValue, addColon: boolean): any => {
     });
     return result;
   }
-  if (x instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
     let result: Record<string, CalcitValue> = {};
     for (let idx = 0; idx < x.fields.length; idx++) {
       result[x.fields[idx].value] = to_js_data_inner(x.values[idx], false);
@@ -693,8 +693,8 @@ export let _$n__$e_ = (x: CalcitValue, y: CalcitValue): boolean => {
     }
     return false;
   }
-  if (x instanceof CalcitTuple) {
-    if (y instanceof CalcitTuple) {
+  if (x instanceof CalcitEnumValue) {
+    if (y instanceof CalcitEnumValue) {
       return x.eq(y);
     }
     return false;
@@ -743,8 +743,8 @@ export let _$n__$e_ = (x: CalcitValue, y: CalcitValue): boolean => {
     }
     return false;
   }
-  if (x instanceof CalcitRecord) {
-    if (y instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
+    if (y instanceof CalcitStructValue) {
       if (x.name !== y.name) {
         return false;
       }
@@ -789,14 +789,14 @@ export let _$n__$e_ = (x: CalcitValue, y: CalcitValue): boolean => {
     }
     return false;
   }
-  if (x instanceof CalcitStruct) {
-    if (y instanceof CalcitStruct) {
+  if (x instanceof CalcitStructDef) {
+    if (y instanceof CalcitStructDef) {
       return x.name === y.name && fieldsEqual(x.fields, y.fields);
     }
     return false;
   }
-  if (x instanceof CalcitEnum) {
-    if (y instanceof CalcitEnum) {
+  if (x instanceof CalcitEnumDef) {
+    if (y instanceof CalcitEnumDef) {
       return x.name === y.name;
     }
     return false;

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -22,22 +22,22 @@ import {
 } from "./calcit-data.mjs";
 
 import { CalcitRef, atom } from "./js-ref.mjs";
-import { CalcitRecord } from "./js-record.mjs";
+import { CalcitStructValue } from "./js-struct-value.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
-import { CalcitStruct } from "./js-struct.mjs";
-import { CalcitEnum } from "./js-enum.mjs";
+import { CalcitStructDef } from "./js-struct-def.mjs";
+import { CalcitEnumDef } from "./js-enum-def.mjs";
 import { CalcitTrait } from "./js-trait.mjs";
 
 export * from "./calcit-data.mjs";
-export * from "./js-record.mjs";
+export * from "./js-struct-value.mjs";
 export * from "./js-impl.mjs";
-export * from "./js-struct.mjs";
-export * from "./js-enum.mjs";
+export * from "./js-struct-def.mjs";
+export * from "./js-enum-def.mjs";
 export * from "./js-map.mjs";
 export * from "./js-list.mjs";
 export * from "./js-set.mjs";
 export * from "./js-primes.mjs";
-export * from "./js-tuple.mjs";
+export * from "./js-enum-value.mjs";
 export * from "./js-trait.mjs";
 export * from "./custom-formatter.mjs";
 export * from "./js-cirru.mjs";
@@ -49,7 +49,7 @@ export { _$n_compare } from "./js-primes.mjs";
 import { CalcitList, CalcitSliceList, foldl } from "./js-list.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet } from "./js-set.mjs";
-import { CalcitTuple } from "./js-tuple.mjs";
+import { CalcitEnumValue } from "./js-enum-value.mjs";
 import { to_calcit_data, extract_cirru_edn, extract_cirru_edn_for_typed, CalcitCirruQuote } from "./js-cirru.mjs";
 import { TypedEdnSetView } from "./typed-edn.mjs";
 
@@ -77,8 +77,8 @@ export let type_of = (x: any): CalcitTag => {
   if (x instanceof CalcitRef) {
     return newTag("ref");
   }
-  if (x instanceof CalcitTuple) {
-    return newTag("tuple");
+  if (x instanceof CalcitEnumValue) {
+    return newTag("enum");
   }
   if (x instanceof CalcitSymbol) {
     return newTag("symbol");
@@ -86,17 +86,17 @@ export let type_of = (x: any): CalcitTag => {
   if (x instanceof CalcitSet) {
     return newTag("set");
   }
-  if (x instanceof CalcitRecord) {
-    return newTag("record");
+  if (x instanceof CalcitStructValue) {
+    return newTag("struct");
   }
   if (x instanceof CalcitImpl) {
     return newTag("impl");
   }
-  if (x instanceof CalcitStruct) {
-    return newTag("struct");
+  if (x instanceof CalcitStructDef) {
+    return newTag("struct-def");
   }
-  if (x instanceof CalcitEnum) {
-    return newTag("enum");
+  if (x instanceof CalcitEnumDef) {
+    return newTag("enum-def");
   }
   if (x instanceof CalcitTrait) {
     return newTag("trait");
@@ -212,7 +212,7 @@ export let _$n_assert_traits = function (value: CalcitValue, traitDef: CalcitVal
   }
   const impls = pair[0];
   const reverse =
-    value instanceof CalcitRecord || value instanceof CalcitTuple || value instanceof CalcitStruct || value instanceof CalcitEnum;
+    value instanceof CalcitStructValue || value instanceof CalcitEnumValue || value instanceof CalcitStructDef || value instanceof CalcitEnumDef;
   const ordered = reverse ? [...impls].reverse() : impls;
   const selected = ordered.find((impl) => impl != null && impl.origin === traitDef);
   if (selected == null) {
@@ -237,7 +237,7 @@ export let _$n_assert_traits = function (value: CalcitValue, traitDef: CalcitVal
   return value;
 };
 
-export let defstruct = (name: CalcitValue, ...entries: CalcitValue[]): CalcitStruct => {
+export let defstruct = (name: CalcitValue, ...entries: CalcitValue[]): CalcitStructDef => {
   const structName = castTag(name);
   const fields: Array<{ tag: CalcitTag; type: CalcitValue }> = [];
   const fieldEntries = trimDataDefinitionEntries(entries);
@@ -261,10 +261,10 @@ export let defstruct = (name: CalcitValue, ...entries: CalcitValue[]): CalcitStr
 
   const fieldTags = fields.map((entry) => entry.tag);
   const fieldTypes = fields.map((entry) => entry.type);
-  return new CalcitStruct(structName, fieldTags, fieldTypes, null);
+  return new CalcitStructDef(structName, fieldTags, fieldTypes, null);
 };
 
-export let defenum = (name: CalcitValue, ...variants: CalcitValue[]): CalcitEnum => {
+export let defenum = (name: CalcitValue, ...variants: CalcitValue[]): CalcitEnumDef => {
   const enumName = castTag(name);
   const entries: Array<{ tag: CalcitTag; payload: CalcitSliceList }> = [];
   const variantEntries = trimDataDefinitionEntries(variants);
@@ -288,8 +288,8 @@ export let defenum = (name: CalcitValue, ...variants: CalcitValue[]): CalcitEnum
 
   const tags = entries.map((entry) => entry.tag);
   const values = entries.map((entry) => entry.payload);
-  const prototype = new CalcitRecord(enumName, tags, values, null);
-  return new CalcitEnum(prototype);
+  const prototype = new CalcitStructValue(enumName, tags, values, null);
+  return new CalcitEnumDef(prototype);
 };
 
 export let _$n_impl_$o__$o_new = (name: CalcitValue, ...pairs: CalcitValue[]): CalcitImpl => {
@@ -301,14 +301,14 @@ export let _$n_impl_$o__$o_new = (name: CalcitValue, ...pairs: CalcitValue[]): C
   if (pairs.length === 1 && pairs[0] instanceof CalcitImpl) {
     const sourceImpl = pairs[0];
     sourcePairs = sourceImpl.fields.map(
-      (field, idx) => new CalcitTuple(newTag(field.value), [sourceImpl.values[idx]], null)
+      (field, idx) => new CalcitEnumValue(newTag(field.value), [sourceImpl.values[idx]], null)
     );
   }
   for (let idx = 0; idx < sourcePairs.length; idx++) {
     const pairValue = sourcePairs[idx];
     let fieldTag: CalcitTag;
     let value: CalcitValue;
-    if (pairValue instanceof CalcitTuple) {
+    if (pairValue instanceof CalcitEnumValue) {
       if (pairValue.extra.length !== 1) {
         throw new Error(`&impl::new expects (field value) pairs, got: ${toString(pairValue, true)}`);
       }
@@ -350,11 +350,11 @@ export let _$n_impl_$o__$o_new = (name: CalcitValue, ...pairs: CalcitValue[]): C
   return new CalcitImpl(implName, fields, values, origin);
 };
 
-export let _$n_struct_$o__$o_new = (name: CalcitValue, ...entries: CalcitValue[]): CalcitStruct => {
+export let _$n_struct_def_$o_new = (name: CalcitValue, ...entries: CalcitValue[]): CalcitStructDef => {
   return defstruct(name, ...entries);
 };
 
-export let _$n_enum_$o__$o_new = (name: CalcitValue, ...variants: CalcitValue[]): CalcitEnum => {
+export let _$n_enum_def_$o_new = (name: CalcitValue, ...variants: CalcitValue[]): CalcitEnumDef => {
   return defenum(name, ...variants);
 };
 
@@ -378,23 +378,23 @@ export function _$n_map_$o_count(x: CalcitValue): number {
 
   throw new Error(`expected a map ${x}`);
 }
-export function _$n_record_$o_count(x: CalcitValue): number {
-  if (x instanceof CalcitRecord) return x.fields.length;
+export function _$n_struct_$o_count(x: CalcitValue): number {
+  if (x instanceof CalcitStructValue) return x.fields.length;
 
-  throw new Error(`expected a record ${x}`);
+  throw new Error(`expected a struct value ${x}`);
 }
 
-export function _$n_record_$o_field_tag(x: CalcitValue, idx: CalcitValue): CalcitTag {
-  if (!(x instanceof CalcitRecord)) throw new Error(`&record:field-tag expected a record, got ${x}`);
+export function _$n_struct_$o_field_tag(x: CalcitValue, idx: CalcitValue): CalcitTag {
+  if (!(x instanceof CalcitStructValue)) throw new Error(`&struct:field-tag expected a struct value, got ${x}`);
   const i = idx as number;
-  if (i < 0 || i >= x.fields.length) throw new Error(`&record:field-tag index ${i} out of bounds (${x.fields.length})`);
+  if (i < 0 || i >= x.fields.length) throw new Error(`&struct:field-tag index ${i} out of bounds (${x.fields.length})`);
   return x.fields[i];
 }
 
-export function _$n_record_$o_nth(x: CalcitValue, idx: CalcitValue): CalcitValue {
-  if (!(x instanceof CalcitRecord)) throw new Error(`&record:nth expected a record, got ${x}`);
+export function _$n_struct_$o_nth(x: CalcitValue, idx: CalcitValue): CalcitValue {
+  if (!(x instanceof CalcitStructValue)) throw new Error(`&struct:nth expected a struct value, got ${x}`);
   const i = idx as number;
-  if (i < 0 || i >= x.values.length) throw new Error(`&record:nth index ${i} out of range for record with ${x.values.length} fields`);
+  if (i < 0 || i >= x.values.length) throw new Error(`&struct:nth index ${i} out of range for struct with ${x.values.length} fields`);
   return x.values[i];
 }
 
@@ -494,10 +494,10 @@ export let _$n_map_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean 
   throw new Error("map `contains?` expected a map");
 };
 
-export let _$n_record_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
-  if (xs instanceof CalcitRecord) return xs.contains(x);
+export let _$n_struct_$o_contains_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
+  if (xs instanceof CalcitStructValue) return xs.contains(x);
 
-  throw new Error("record `contains?` expected a record");
+  throw new Error("struct `contains?` expected a struct value");
 };
 
 export let _$n_str_$o_includes_$q_ = (xs: CalcitValue, x: CalcitValue): boolean => {
@@ -566,18 +566,18 @@ export let _$n_list_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
   throw new Error("Does not support `nth` on this type");
 };
 
-export let _$n_tuple_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
+export let _$n_enum_$o_nth = function (xs: CalcitValue, k: CalcitValue) {
   if (arguments.length !== 2) throw new Error("nth takes 2 arguments");
   if (typeof k !== "number") throw new Error("Expected number index for a list");
 
-  if (xs instanceof CalcitTuple) return xs.get(k);
+  if (xs instanceof CalcitEnumValue) return xs.get(k);
 
   throw new Error("Does not support `nth` on this type");
 };
-export let _$n_tuple_$o_count = function (xs: CalcitValue) {
-  if (arguments.length !== 1) throw new Error("&tuple:count takes 1 arguments");
+export let _$n_enum_$o_count = function (xs: CalcitValue) {
+  if (arguments.length !== 1) throw new Error("&enum:count takes 1 arguments");
 
-  if (xs instanceof CalcitTuple) return xs.count();
+  if (xs instanceof CalcitEnumValue) return xs.count();
 
   throw new Error("Does not support `count` on this type");
 };
@@ -589,65 +589,62 @@ const coerce_impl = (value: CalcitValue, procName: string): CalcitImpl => {
   throw new Error(`${procName} expects trait impls as impls`);
 };
 
-export let _$n_tuple_$o_impls = function (x: CalcitTuple) {
-  if (arguments.length !== 1) throw new Error("&tuple:impls takes 1 argument");
+export let _$n_enum_$o_impls = function (x: CalcitEnumValue) {
+  if (arguments.length !== 1) throw new Error("&enum:impls takes 1 argument");
   return new CalcitSliceList(x.impls);
 };
 
-export let _$n_tuple_$o_params = function (x: CalcitTuple) {
-  if (arguments.length !== 1) throw new Error("&tuple:params takes 1 argument");
+export let _$n_enum_$o_params = function (x: CalcitEnumValue) {
+  if (arguments.length !== 1) throw new Error("&enum:params takes 1 argument");
   return new CalcitSliceList(x.extra);
 };
 
-export let _$n_tuple_$o_with_impls = function (x: CalcitTuple, y: CalcitValue) {
-  if (arguments.length !== 2) throw new Error("&tuple:with-impls takes 2 arguments");
-  if (!(x instanceof CalcitTuple)) throw new Error("&tuple:with-impls expects a tuple");
-  const impl = coerce_impl(y, "&tuple:with-impls");
+export let _$n_enum_$o_with_impls = function (x: CalcitEnumValue, y: CalcitValue) {
+  if (arguments.length !== 2) throw new Error("&enum:with-impls takes 2 arguments");
+  if (!(x instanceof CalcitEnumValue)) throw new Error("&enum:with-impls expects an enum value");
+  const impl = coerce_impl(y, "&enum:with-impls");
   let proto = x.enumPrototype;
   if (proto == null) {
-    proto = new CalcitEnum(new CalcitRecord(newTag("anonymous-tuple"), [], [], new CalcitStruct(newTag("anonymous-tuple"), [], [])));
+    proto = new CalcitEnumDef(new CalcitStructValue(newTag("_"), [], [], new CalcitStructDef(newTag("_"), [], [])));
   }
-  return new CalcitTuple(x.tag, x.extra, proto.withImpls(impl));
+  return new CalcitEnumValue(x.tag, x.extra, proto.withImpls(impl));
 };
 
-export let _$n_tuple_$o_impl_traits = function (x: CalcitValue, ...traits: CalcitValue[]) {
-  if (traits.length < 1) throw new Error("&tuple:impl-traits takes 2+ arguments");
-  if (!(x instanceof CalcitTuple)) throw new Error("&tuple:impl-traits expects a tuple");
-  const impls = traits.map((trait) => coerce_impl(trait, "&tuple:impl-traits"));
+export let _$n_enum_$o_impl_traits = function (x: CalcitValue, ...traits: CalcitValue[]) {
+  if (traits.length < 1) throw new Error("&enum:impl-traits takes 2+ arguments");
+  if (!(x instanceof CalcitEnumValue)) throw new Error("&enum:impl-traits expects an enum value");
+  const impls = traits.map((trait) => coerce_impl(trait, "&enum:impl-traits"));
   let proto = x.enumPrototype;
   if (proto == null) {
     const tagName = x.tag instanceof CalcitTag ? x.tag : newTag("tag");
     const anyTypes = new CalcitSliceList(new Array(x.extra.length).fill(newTag("any")));
-    proto = new CalcitEnum(
-      new CalcitRecord(newTag("anonymous-tuple"), [tagName], [anyTypes], new CalcitStruct(newTag("anonymous-tuple"), [tagName], [anyTypes]))
+    proto = new CalcitEnumDef(
+      new CalcitStructValue(newTag("_"), [tagName], [anyTypes], new CalcitStructDef(newTag("_"), [tagName], [anyTypes]))
     );
   }
-  return new CalcitTuple(x.tag, x.extra, proto.withImpls(impls));
+  return new CalcitEnumValue(x.tag, x.extra, proto.withImpls(impls));
 };
 
-export let _$n_tuple_$o_enum = function (x: CalcitTuple) {
-  if (arguments.length !== 1) throw new Error("&tuple:enum takes 1 argument");
-  if (!(x instanceof CalcitTuple)) throw new Error("&tuple:enum expects a tuple");
+export let _$n_enum_$o_definition = function (x: CalcitEnumValue) {
+  if (arguments.length !== 1) throw new Error("&enum:definition takes 1 argument");
+  if (!(x instanceof CalcitEnumValue)) throw new Error("&enum:definition expects an enum value");
   if (x.enumPrototype == null) {
     return null;
   }
-  if (x.enumPrototype instanceof CalcitEnum) {
-    return x.enumPrototype;
-  }
-  return new CalcitEnum(x.enumPrototype as CalcitRecord);
+  return x.enumPrototype;
 };
 
-const unwrap_enum_prototype = (enumPrototype: CalcitValue, procName: string): CalcitRecord => {
-  if (enumPrototype instanceof CalcitEnum) {
+const unwrap_enum_prototype = (enumPrototype: CalcitValue, procName: string): CalcitStructValue => {
+  if (enumPrototype instanceof CalcitEnumDef) {
     return enumPrototype.prototype;
   }
-  if (enumPrototype instanceof CalcitRecord) {
-    return enumPrototype;
+  if (enumPrototype instanceof CalcitStructValue) {
+    throw new Error(`${procName} no longer accepts a struct prototype; pass an EnumDef produced by defenum`);
   }
-  throw new Error(`${procName} expects enum prototype as first argument`);
+  throw new Error(`${procName} expects an EnumDef as first argument`);
 };
 
-const assert_enum_tag_args = (procName: string, enumPrototype: CalcitValue, variantTag: CalcitTag): CalcitRecord => {
+const assert_enum_tag_args = (procName: string, enumPrototype: CalcitValue, variantTag: CalcitTag): CalcitStructValue => {
   const proto = unwrap_enum_prototype(enumPrototype, procName);
   if (!(variantTag instanceof CalcitTag)) {
     throw new Error(`${procName} expects tag as second argument`);
@@ -655,17 +652,17 @@ const assert_enum_tag_args = (procName: string, enumPrototype: CalcitValue, vari
   return proto;
 };
 
-export let _$n_tuple_$o_enum_has_variant_$q_ = function (enumPrototype: CalcitValue, variantTag: CalcitTag) {
-  if (arguments.length !== 2) throw new Error("&tuple:enum-has-variant? takes 2 arguments");
-  const proto = assert_enum_tag_args("&tuple:enum-has-variant?", enumPrototype, variantTag);
+export let _$n_enum_def_$o_has_variant_$q_ = function (enumPrototype: CalcitValue, variantTag: CalcitTag) {
+  if (arguments.length !== 2) throw new Error("&enum-def:has-variant? takes 2 arguments");
+  const proto = assert_enum_tag_args("&enum-def:has-variant?", enumPrototype, variantTag);
   return proto.contains(variantTag);
 };
 
-export let _$n_tuple_$o_enum_has_variant = _$n_tuple_$o_enum_has_variant_$q_;
+export let _$n_enum_def_$o_has_variant = _$n_enum_def_$o_has_variant_$q_;
 
-export let _$n_tuple_$o_enum_variant_arity = function (enumPrototype: CalcitValue, variantTag: CalcitTag) {
-  if (arguments.length !== 2) throw new Error("&tuple:enum-variant-arity takes 2 arguments");
-  const proto = assert_enum_tag_args("&tuple:enum-variant-arity", enumPrototype, variantTag);
+export let _$n_enum_def_$o_variant_arity = function (enumPrototype: CalcitValue, variantTag: CalcitTag) {
+  if (arguments.length !== 2) throw new Error("&enum-def:variant-arity takes 2 arguments");
+  const proto = assert_enum_tag_args("&enum-def:variant-arity", enumPrototype, variantTag);
 
   const variant = proto.getOrNil(variantTag);
   if (variant === undefined) {
@@ -678,26 +675,26 @@ export let _$n_tuple_$o_enum_variant_arity = function (enumPrototype: CalcitValu
   throw new Error("Expected variant to be a list");
 };
 
-export let _$n_tuple_$o_validate_enum = function (tuple: CalcitValue, tag: CalcitValue): CalcitValue {
-  if (arguments.length !== 2) throw new Error("&tuple:validate-enum takes 2 arguments");
-  if (!(tuple instanceof CalcitTuple)) throw new Error("&tuple:validate-enum expects a tuple as first argument");
-  if (tuple.enumPrototype == null) {
+export let _$n_enum_$o_validate = function (enumValue: CalcitValue, tag: CalcitValue): CalcitValue {
+  if (arguments.length !== 2) throw new Error("&enum:validate takes 2 arguments");
+  if (!(enumValue instanceof CalcitEnumValue)) throw new Error("&enum:validate expects an enum value as first argument");
+  if (enumValue.enumPrototype == null) {
     return null;
   }
 
-  const proto = assert_enum_tag_args("&tuple:validate-enum", tuple.enumPrototype as CalcitValue, tag as CalcitTag);
+  const proto = assert_enum_tag_args("&enum:validate", enumValue.enumPrototype as CalcitValue, tag as CalcitTag);
 
   const tagValue = tag as CalcitTag;
   const variant = proto.getOrNil(tagValue);
   if (variant === undefined) {
-    throw new Error(`enum does not have variant ${tagValue.value} for ${tuple}`);
+    throw new Error(`enum does not have variant ${tagValue.value} for ${enumValue}`);
   }
 
   if (variant instanceof CalcitSliceList) {
     const expected = variant.len();
-    const actual = tuple.extra.length;
+    const actual = enumValue.extra.length;
     if (expected !== actual) {
-      throw new Error(`enum variant expects ${expected} payload(s), got ${actual} for ${tuple}`);
+      throw new Error(`enum variant expects ${expected} payload(s), got ${actual} for ${enumValue}`);
     }
     return null;
   }
@@ -705,12 +702,12 @@ export let _$n_tuple_$o_validate_enum = function (tuple: CalcitValue, tag: Calci
   throw new Error("Expected variant to be a list");
 };
 
-export let _$n_record_$o_get = function (xs: CalcitValue, k: CalcitTag) {
+export let _$n_struct_$o_get = function (xs: CalcitValue, k: CalcitTag) {
   if (arguments.length !== 2) {
-    throw new Error("record &get takes 2 arguments");
+    throw new Error("&struct:get takes 2 arguments");
   }
 
-  if (xs instanceof CalcitRecord) return xs.getRequired(k);
+  if (xs instanceof CalcitStructValue) return xs.getRequired(k);
 
   throw new Error("Does not support `&get` on this type");
 };
@@ -726,17 +723,17 @@ export let _$n_list_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: Cal
   }
   throw new Error("list `assoc` expected a list");
 };
-export let _$n_tuple_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
+export let _$n_enum_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
   if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
-  if (xs instanceof CalcitTuple) {
+  if (xs instanceof CalcitEnumValue) {
     if (typeof k !== "number") {
       throw new Error("Expected number index for lists");
     }
     return xs.assoc(k, v);
   }
 
-  throw new Error("tuple `assoc` expected a tuple");
+  throw new Error("enum `assoc` expected an enum value");
 };
 export let _$n_map_$o_assoc = function (xs: CalcitValue, ...args: CalcitValue[]) {
   if (arguments.length < 3) throw new Error("assoc takes at least 3 arguments");
@@ -746,47 +743,43 @@ export let _$n_map_$o_assoc = function (xs: CalcitValue, ...args: CalcitValue[])
 
   throw new Error("map `assoc` expected a map");
 };
-export let _$n_record_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
+export let _$n_struct_$o_assoc = function (xs: CalcitValue, k: CalcitValue, v: CalcitValue) {
   if (arguments.length !== 3) throw new Error("assoc takes 3 arguments");
 
-  if (xs instanceof CalcitRecord) return xs.assoc(k, v);
+  if (xs instanceof CalcitStructValue) return xs.assoc(k, v);
 
-  throw new Error("record `assoc` expected a record");
+  throw new Error("struct `assoc` expected a struct value");
 };
 
-export let _$n_record_$o_impls = function (xs: CalcitValue) {
-  if (arguments.length !== 1) throw new Error("&record:impls takes 1 argument");
-  if (xs instanceof CalcitRecord) return new CalcitSliceList(xs.structRef.impls);
-  throw new Error("&record:impls expected a record");
-};
-
-export let _$n_record_$o_impl_traits = function (xs: CalcitValue, ...traits: CalcitValue[]) {
-  if (traits.length < 1) throw new Error("&record:impl-traits takes 2+ arguments");
-  if (!(xs instanceof CalcitRecord)) throw new Error("&record:impl-traits expected a record");
-  const impls = traits.map((trait) => coerce_impl(trait, "&record:impl-traits"));
-  const nextStruct = new CalcitStruct(xs.name, xs.fields, xs.structRef.fieldTypes, xs.structRef.impls.concat(impls));
-  return new CalcitRecord(xs.name, xs.fields, xs.values, nextStruct);
+export let _$n_struct_$o_impls = function (xs: CalcitValue) {
+  if (arguments.length !== 1) throw new Error("&struct:impls takes 1 argument");
+  if (xs instanceof CalcitStructValue) return new CalcitSliceList(xs.structRef.impls);
+  throw new Error("&struct:impls expected a struct value");
 };
 
 export let _$n_struct_$o_impl_traits = function (xs: CalcitValue, ...traits: CalcitValue[]) {
   if (traits.length < 1) throw new Error("&struct:impl-traits takes 2+ arguments");
-  if (!(xs instanceof CalcitStruct)) throw new Error("&struct:impl-traits expected a struct");
-  const addedImpls = traits.map((trait) => coerce_impl(trait, "&struct:impl-traits"));
-  const baseImpls = xs.impls ?? [];
-  return new CalcitStruct(xs.name, xs.fields, xs.fieldTypes, baseImpls.concat(addedImpls));
+  if (!(xs instanceof CalcitStructValue)) throw new Error("&struct:impl-traits expected a struct value");
+  const impls = traits.map((trait) => coerce_impl(trait, "&struct:impl-traits"));
+  const nextStruct = new CalcitStructDef(xs.name, xs.fields, xs.structRef.fieldTypes, xs.structRef.impls.concat(impls));
+  return new CalcitStructValue(xs.name, xs.fields, xs.values, nextStruct);
 };
 
-export let _$n_enum_$o_impl_traits = function (xs: CalcitValue, ...traits: CalcitValue[]) {
-  if (traits.length < 1) throw new Error("&enum:impl-traits takes 2+ arguments");
-  const addedImpls = traits.map((trait) => coerce_impl(trait, "&enum:impl-traits"));
-  if (xs instanceof CalcitEnum) {
+export let _$n_struct_def_$o_impl_traits = function (xs: CalcitValue, ...traits: CalcitValue[]) {
+  if (traits.length < 1) throw new Error("&struct-def:impl-traits takes 2+ arguments");
+  if (!(xs instanceof CalcitStructDef)) throw new Error("&struct-def:impl-traits expected a struct definition");
+  const addedImpls = traits.map((trait) => coerce_impl(trait, "&struct-def:impl-traits"));
+  const baseImpls = xs.impls ?? [];
+  return new CalcitStructDef(xs.name, xs.fields, xs.fieldTypes, baseImpls.concat(addedImpls));
+};
+
+export let _$n_enum_def_$o_impl_traits = function (xs: CalcitValue, ...traits: CalcitValue[]) {
+  if (traits.length < 1) throw new Error("&enum-def:impl-traits takes 2+ arguments");
+  const addedImpls = traits.map((trait) => coerce_impl(trait, "&enum-def:impl-traits"));
+  if (xs instanceof CalcitEnumDef) {
     return xs.withImpls(addedImpls);
   }
-  if (xs instanceof CalcitRecord) {
-    const nextStruct = new CalcitStruct(xs.name, xs.fields, xs.structRef.fieldTypes, xs.structRef.impls.concat(addedImpls));
-    return new CalcitRecord(xs.name, xs.fields, xs.values, nextStruct);
-  }
-  throw new Error("&enum:impl-traits expected an enum or enum record");
+  throw new Error("&enum-def:impl-traits expected an enum definition");
 };
 
 export let _$n_impl_$o_origin = function (impl: CalcitValue): CalcitValue {
@@ -1194,7 +1187,7 @@ export let _$n_merge = (a: CalcitValue, b: CalcitMap | CalcitSliceMap): CalcitVa
       throw new Error("Expected an argument of map");
     }
   }
-  if (a instanceof CalcitRecord) {
+  if (a instanceof CalcitStructValue) {
     if (b instanceof CalcitMap || b instanceof CalcitSliceMap) {
       let values = [];
       for (let idx = 0; idx < a.values.length; idx++) {
@@ -1217,10 +1210,10 @@ export let _$n_merge = (a: CalcitValue, b: CalcitMap | CalcitSliceMap): CalcitVa
           throw new Error(`Cannot find field ${field} among (${a.fields.join(", ")})`);
         }
       }
-      return new CalcitRecord(a.name, a.fields, values);
+      return new CalcitStructValue(a.name, a.fields, values);
     }
   }
-  throw new Error("Expected map or record");
+  throw new Error("Expected map or struct value");
 };
 
 export let _$n_merge_non_nil = (a: CalcitMap | CalcitSliceMap, b: CalcitMap | CalcitSliceMap): CalcitMap | CalcitSliceMap => {
@@ -1248,7 +1241,7 @@ export let to_pairs = (xs: CalcitValue): CalcitValue | CalcitSliceList => {
       result.push(new CalcitSliceList(pairs[idx]));
     }
     return new CalcitSet(result);
-  } else if (xs instanceof CalcitRecord) {
+  } else if (xs instanceof CalcitStructValue) {
     let arr_result: Array<CalcitSliceList> = [];
     for (let idx = 0; idx < xs.fields.length; idx++) {
       arr_result.push(new CalcitSliceList([xs.fields[idx], xs.values[idx]]));
@@ -1626,11 +1619,17 @@ export let fn_$q_ = (x: CalcitValue): boolean => {
 export let ref_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitRef;
 };
-export let record_$q_ = (x: CalcitValue): boolean => {
-  return x instanceof CalcitRecord;
+export let struct_$q_ = (x: CalcitValue): boolean => {
+  if (x instanceof CalcitStructDef) {
+    throw new Error("`struct?` now checks struct values; use `struct-def?` for a value produced by `defstruct`");
+  }
+  return x instanceof CalcitStructValue;
 };
-export let tuple_$q_ = (x: CalcitValue): boolean => {
-  return x instanceof CalcitTuple;
+export let enum_$q_ = (x: CalcitValue): boolean => {
+  if (x instanceof CalcitEnumDef) {
+    throw new Error("`enum?` now checks enum values; use `enum-def?` for a value produced by `defenum`");
+  }
+  return x instanceof CalcitEnumValue;
 };
 export let buffer_$q_ = (x: CalcitValue): boolean => {
   console.warn("TODO, detecting buffer");
@@ -1680,8 +1679,8 @@ type DataShapeNode =
   | { kind: "unit" | "bool" | "number" | "string" | "symbol" | "tag" | "buffer" | "cirru-quote" }
   | { kind: "optional" | "list" | "set" | "ref"; inner: number }
   | { kind: "map"; key: number; value: number }
-  | { kind: "struct"; nominal: CalcitStruct; fields: Array<[string, number]> }
-  | { kind: "enum"; nominal: CalcitEnum; variants: Array<{ tag: string; payload: number[] }> };
+  | { kind: "struct"; nominal: CalcitStructDef; fields: Array<[string, number]> }
+  | { kind: "enum"; nominal: CalcitEnumDef; variants: Array<{ tag: string; payload: number[] }> };
 
 type DataShapeGraph = {
   version: number;
@@ -1700,8 +1699,8 @@ const typed_edn_kind = (value: any): string => {
   if (value instanceof CalcitList || value instanceof CalcitSliceList) return "list";
   if (value instanceof CalcitMap || value instanceof CalcitSliceMap) return "map";
   if (value instanceof CalcitSet || value instanceof TypedEdnSetView) return "set";
-  if (value instanceof CalcitRecord) return "record";
-  if (value instanceof CalcitTuple) return value.enumPrototype == null ? "tuple" : "enum";
+  if (value instanceof CalcitStructValue) return "struct";
+  if (value instanceof CalcitEnumValue) return "enum";
   if (value instanceof CalcitRef) return "atom";
   if (value instanceof CalcitCirruQuote) return "cirru-quote";
   if (value instanceof Uint8Array) return "buffer";
@@ -1712,8 +1711,8 @@ const typed_edn_error = (path: string, message: string): never => {
   throw new Error(`parse-cirru-edn-as failed at ${path}: ${message}`);
 };
 
-const enum_prototype_name = (value: CalcitEnum | CalcitRecord): string => {
-  return value instanceof CalcitEnum ? value.name() : value.name.value;
+const enum_prototype_name = (value: CalcitEnumDef | CalcitStructValue): string => {
+  return value instanceof CalcitEnumDef ? value.name() : value.name.value;
 };
 
 const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any, path: string, depth: number): any => {
@@ -1795,11 +1794,11 @@ const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any
       if (!(input instanceof CalcitRef)) return typed_edn_error(path, `expected atom, got ${typed_edn_kind(input)}`);
       return atom(decode_typed_edn_node(graph, node.inner, input.value, `${path}.value`, depth + 1));
     case "struct": {
-      if (!(input instanceof CalcitRecord)) {
-        return typed_edn_error(path, `expected record :${node.nominal.name.value}, got ${typed_edn_kind(input)}`);
+      if (!(input instanceof CalcitStructValue)) {
+        return typed_edn_error(path, `expected struct :${node.nominal.name.value}, got ${typed_edn_kind(input)}`);
       }
       if (input.name.value !== node.nominal.name.value) {
-        return typed_edn_error(path, `expected record :${node.nominal.name.value}, got record :${input.name.value}`);
+        return typed_edn_error(path, `expected struct :${node.nominal.name.value}, got struct :${input.name.value}`);
       }
       const expectedNames = node.fields.map(([name]) => name);
       const actualNames = input.fields.map((field) => field.value);
@@ -1808,7 +1807,7 @@ const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any
       if (missing.length > 0 || unknown.length > 0 || expectedNames.length !== actualNames.length) {
         return typed_edn_error(
           path,
-          `record :${node.nominal.name.value} fields mismatch; missing [${missing.join(", ")}], unknown [${unknown.join(", ")}]`
+          `struct :${node.nominal.name.value} fields mismatch; missing [${missing.join(", ")}], unknown [${unknown.join(", ")}]`
         );
       }
       const decodedFields = new Map<string, CalcitValue>();
@@ -1819,18 +1818,18 @@ const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any
       // Native declarations use lexical field order while the JS runtime keeps
       // its interned-tag order. Re-align values to the nominal JS declaration.
       if (decodedFields.size !== node.nominal.fields.length) {
-        return typed_edn_error(path, `record :${node.nominal.name.value} decoder fields do not match its nominal declaration`);
+        return typed_edn_error(path, `struct :${node.nominal.name.value} decoder fields do not match its nominal declaration`);
       }
       const values = node.nominal.fields.map((field) => {
         if (!decodedFields.has(field.value)) {
-          return typed_edn_error(path, `record :${node.nominal.name.value} is missing declared field :${field.value}`);
+          return typed_edn_error(path, `struct :${node.nominal.name.value} is missing declared field :${field.value}`);
         }
         return decodedFields.get(field.value)!;
       });
-      return new CalcitRecord(node.nominal.name, node.nominal.fields, values, node.nominal);
+      return new CalcitStructValue(node.nominal.name, node.nominal.fields, values, node.nominal);
     }
     case "enum": {
-      if (!(input instanceof CalcitTuple) || input.enumPrototype == null) {
+      if (!(input instanceof CalcitEnumValue) || input.enumPrototype == null) {
         return typed_edn_error(path, `expected enum :${node.nominal.name()}, got ${typed_edn_kind(input)}`);
       }
       const actualEnumName = enum_prototype_name(input.enumPrototype);
@@ -1854,7 +1853,7 @@ const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any
       const values = variant.payload.map((payloadNode, idx) =>
         decode_typed_edn_node(graph, payloadNode, input.extra[idx], `${path}.payload[${idx}]`, depth + 1)
       );
-      return new CalcitTuple(newTag(variant.tag), values, node.nominal);
+      return new CalcitEnumValue(newTag(variant.tag), values, node.nominal);
     }
     default:
       return typed_edn_error(path, `invalid data shape node kind: ${(node as any).kind}`);
@@ -1937,13 +1936,13 @@ const calcit_to_json = (value: CalcitValue): any => {
     }
     return result;
   }
-  if (value instanceof CalcitTuple) {
+  if (value instanceof CalcitEnumValue) {
     return [calcit_to_json(value.tag), ...value.extra.map(calcit_to_json)];
   }
   if (value instanceof CalcitCirruQuote) {
     return cirru_quote_to_json(value.value as ICirruNode);
   }
-  if (value instanceof CalcitRecord) {
+  if (value instanceof CalcitStructValue) {
     const result: Record<string, any> = {};
     for (let idx = 0; idx < value.fields.length; idx++) {
       result[value.fields[idx].value] = calcit_to_json(value.values[idx]);
@@ -2054,11 +2053,11 @@ export let _$n_js_object = (...xs: CalcitValue[]): Record<string, CalcitValue> =
   return ret;
 };
 
-export let _$o__$o_ = (tagName: CalcitValue, ...extra: CalcitValue[]): CalcitTuple => {
-  return new CalcitTuple(tagName, extra, null);
+export let _$o__$o_ = (tagName: CalcitValue, ...extra: CalcitValue[]): CalcitEnumValue => {
+  return new CalcitEnumValue(tagName, extra, null);
 };
 
-export let _PCT__$o__$o_ = (enumPrototype: CalcitValue, tag: CalcitValue, ...extra: CalcitValue[]): CalcitTuple => {
+export let _PCT__$o__$o_ = (enumPrototype: CalcitValue, tag: CalcitValue, ...extra: CalcitValue[]): CalcitEnumValue => {
   const proto = assert_enum_tag_args("%::", enumPrototype, tag as CalcitTag);
   const tagValue = tag as CalcitTag;
 
@@ -2077,11 +2076,10 @@ export let _PCT__$o__$o_ = (enumPrototype: CalcitValue, tag: CalcitValue, ...ext
     throw new Error(`Expected variant definition to be a list, got ${variantDefinition}`);
   }
 
-  const tupleEnumPrototype = enumPrototype instanceof CalcitEnum ? enumPrototype : proto;
-  return new CalcitTuple(tag, extra, tupleEnumPrototype);
+  return new CalcitEnumValue(tag, extra, enumPrototype as CalcitEnumDef);
 };
 
-export let _PCT__PCT__$o__$o_ = (impl: CalcitValue, enumPrototype: CalcitValue, tag: CalcitValue, ...extra: CalcitValue[]): CalcitTuple => {
+export let _PCT__PCT__$o__$o_ = (impl: CalcitValue, enumPrototype: CalcitValue, tag: CalcitValue, ...extra: CalcitValue[]): CalcitEnumValue => {
   // Runtime validation: check if tag exists in enum and arity matches
   const proto = assert_enum_tag_args("%%::", enumPrototype, tag as CalcitTag);
   const tagValue = tag as CalcitTag;
@@ -2101,9 +2099,8 @@ export let _PCT__PCT__$o__$o_ = (impl: CalcitValue, enumPrototype: CalcitValue, 
     throw new Error(`Expected variant definition to be a list, got ${variantDefinition}`);
   }
 
-  const tupleEnumPrototype = enumPrototype instanceof CalcitEnum ? enumPrototype : (proto as any);
   const implValue = coerce_impl(impl, "%:: with impl");
-  return new CalcitTuple(tag, extra, tupleEnumPrototype.withImpls(implValue));
+  return new CalcitEnumValue(tag, extra, (enumPrototype as CalcitEnumDef).withImpls(implValue));
 };
 
 // mutable place for core to register
@@ -2116,8 +2113,8 @@ let calcit_builtin_impls = {
   list: null as CalcitImplEntry,
   map: null as CalcitImplEntry,
   fn: null as CalcitImplEntry,
-  tuple: null as CalcitImplEntry,
-  record: null as CalcitImplEntry,
+  enum: null as CalcitImplEntry,
+  struct: null as CalcitImplEntry,
   scalar: null as CalcitImplEntry,
 };
 
@@ -2156,10 +2153,10 @@ function lookup_impls(obj: CalcitValue): [CalcitImpl[], string] {
   } else if (obj instanceof CalcitMap || obj instanceof CalcitSliceMap) {
     tag = "&core-map-methods";
     impls = normalize_builtin_impls(calcit_builtin_impls.map);
-  } else if (obj instanceof CalcitRecord) {
+  } else if (obj instanceof CalcitStructValue) {
     tag = obj.name.toString();
     let instanceImpls = obj.structRef.impls;
-    let builtinRecordImpls = normalize_builtin_impls(calcit_builtin_impls.record);
+    let builtinRecordImpls = normalize_builtin_impls(calcit_builtin_impls.struct);
     if (builtinRecordImpls && instanceImpls && instanceImpls.length > 0) {
       impls = [...builtinRecordImpls, ...instanceImpls];
     } else if (builtinRecordImpls) {
@@ -2167,10 +2164,10 @@ function lookup_impls(obj: CalcitValue): [CalcitImpl[], string] {
     } else {
       impls = instanceImpls;
     }
-  } else if (obj instanceof CalcitTuple) {
+  } else if (obj instanceof CalcitEnumValue) {
     tag = obj.tag.toString();
     let instanceImpls = obj.impls;
-    let builtinTupleImpls = normalize_builtin_impls(calcit_builtin_impls.tuple);
+    let builtinTupleImpls = normalize_builtin_impls(calcit_builtin_impls.enum);
     if (builtinTupleImpls && instanceImpls && instanceImpls.length > 0) {
       impls = [...builtinTupleImpls, ...instanceImpls];
     } else if (builtinTupleImpls) {
@@ -2181,16 +2178,16 @@ function lookup_impls(obj: CalcitValue): [CalcitImpl[], string] {
   } else if (obj instanceof CalcitSet) {
     tag = "&core-set-methods";
     impls = normalize_builtin_impls(calcit_builtin_impls.set);
-  } else if (obj instanceof CalcitStruct) {
+  } else if (obj instanceof CalcitStructDef) {
     // Bare type definitions (not yet instantiated) carry their own attached
     // impls, so introspection tools like `&methods-of` can answer "what
     // methods will instances of this type have" without a concrete instance.
     tag = obj.name.toString();
-    const builtinRecordImpls = normalize_builtin_impls(calcit_builtin_impls.record) ?? [];
+    const builtinRecordImpls = normalize_builtin_impls(calcit_builtin_impls.struct) ?? [];
     impls = [...builtinRecordImpls, ...(obj.impls ?? [])];
-  } else if (obj instanceof CalcitEnum) {
+  } else if (obj instanceof CalcitEnumDef) {
     tag = obj.name();
-    const builtinTupleImpls = normalize_builtin_impls(calcit_builtin_impls.tuple) ?? [];
+    const builtinTupleImpls = normalize_builtin_impls(calcit_builtin_impls.enum) ?? [];
     impls = [...builtinTupleImpls, ...(obj.impls ?? [])];
   } else if (typeof obj === "number") {
     tag = "&core-number-methods";
@@ -2226,7 +2223,7 @@ export function invoke_method(p: string, obj: CalcitValue, ...args: CalcitValue[
   let tag = pair[1];
   // builtin impl lists are ordered by priority in calcit-core.
   // user-defined values use impl-traits append, so later impls override earlier ones.
-  let reverse = obj instanceof CalcitRecord || obj instanceof CalcitTuple || obj instanceof CalcitStruct || obj instanceof CalcitEnum;
+  let reverse = obj instanceof CalcitStructValue || obj instanceof CalcitEnumValue || obj instanceof CalcitStructDef || obj instanceof CalcitEnumDef;
   let idx = reverse ? impls.length - 1 : 0;
   while (reverse ? idx >= 0 : idx < impls.length) {
     let klass = impls[idx];
@@ -2255,7 +2252,7 @@ export function _$n_methods_of(obj: CalcitValue): CalcitSliceList {
     throw new Error(`&methods-of cannot resolve impls for: ${toString(obj, true)}`);
   }
   let impls = pair[0];
-  let reverse = obj instanceof CalcitRecord || obj instanceof CalcitTuple || obj instanceof CalcitStruct || obj instanceof CalcitEnum;
+  let reverse = obj instanceof CalcitStructValue || obj instanceof CalcitEnumValue || obj instanceof CalcitStructDef || obj instanceof CalcitEnumDef;
   let seen = new Set<string>();
   let ys: CalcitValue[] = [];
 
@@ -2298,7 +2295,7 @@ export function _$n_inspect_methods(obj: CalcitValue, note: CalcitValue): Calcit
     throw new Error(`&inspect-methods cannot resolve impls for: ${toString(obj, true)}`);
   }
   let impls = pair[0];
-  let reverse = obj instanceof CalcitRecord || obj instanceof CalcitTuple || obj instanceof CalcitStruct || obj instanceof CalcitEnum;
+  let reverse = obj instanceof CalcitStructValue || obj instanceof CalcitEnumValue || obj instanceof CalcitStructDef || obj instanceof CalcitEnumDef;
 
   console.log("\n&inspect-methods");
   console.log(`Note: ${toString(note, true)}`);
@@ -2352,7 +2349,7 @@ export function _$n_trait_call(traitDef: CalcitValue, method: CalcitValue, obj: 
     throw new Error(`&trait-call cannot resolve impls for: ${toString(obj, true)}`);
   }
   const impls = pair[0];
-  const reverse = obj instanceof CalcitRecord || obj instanceof CalcitTuple || obj instanceof CalcitStruct || obj instanceof CalcitEnum;
+  const reverse = obj instanceof CalcitStructValue || obj instanceof CalcitEnumValue || obj instanceof CalcitStructDef || obj instanceof CalcitEnumDef;
   let idx = reverse ? impls.length - 1 : 0;
   while (reverse ? idx >= 0 : idx < impls.length) {
     const impl = impls[idx];

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -710,7 +710,7 @@ export let _$n_record_$o_get = function (xs: CalcitValue, k: CalcitTag) {
     throw new Error("record &get takes 2 arguments");
   }
 
-  if (xs instanceof CalcitRecord) return xs.get(k);
+  if (xs instanceof CalcitRecord) return xs.getRequired(k);
 
   throw new Error("Does not support `&get` on this type");
 };

--- a/ts-src/custom-formatter.mts
+++ b/ts-src/custom-formatter.mts
@@ -2,13 +2,13 @@ import { CalcitValue, isLiteral } from "./js-primes.mjs";
 import { CalcitSymbol, CalcitTag } from "./calcit-data.mjs";
 import { CalcitRef } from "./js-ref.mjs";
 
-import { CalcitRecord } from "./js-record.mjs";
-import { CalcitStruct } from "./js-struct.mjs";
-import { CalcitEnum } from "./js-enum.mjs";
+import { CalcitStructValue } from "./js-struct-value.mjs";
+import { CalcitStructDef } from "./js-struct-def.mjs";
+import { CalcitEnumDef } from "./js-enum-def.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitList, CalcitSliceList } from "./js-list.mjs";
 import { CalcitSet } from "./js-set.mjs";
-import { CalcitTuple } from "./js-tuple.mjs";
+import { CalcitEnumValue } from "./js-enum-value.mjs";
 import { CalcitCirruQuote } from "./js-cirru.mjs";
 
 declare global {
@@ -181,66 +181,38 @@ export let load_console_formatter_$x_ = () => {
               preview
             );
           }
-          if (obj instanceof CalcitRecord) {
-            let name = new CalcitSymbol(obj.name.value);
-            if (obj.structRef.impls.length > 0) {
-              let ret: any[] = div(
-                { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
-                span({}, "%{}"),
-                span({ marginLeft: "6px" }, embedObject(obj.structRef.impls[0])),
-                span({ marginLeft: "6px" }, embedObject(name)),
-                span({ marginLeft: "6px" }, `...`)
-              );
-              return ret;
-            } else {
-              let ret: any[] = div(
-                { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
-                "%{} ",
-                embedObject(name),
-                " ..."
-              );
-              return ret;
-            }
+          if (obj instanceof CalcitStructValue) {
+            const name = new CalcitSymbol(obj.name.value);
+            return div({ color: hsl(280, 80, 60, 0.4), maxWidth: "100%" }, "%{} ", embedObject(name), " ...");
           }
-          if (obj instanceof CalcitStruct) {
+          if (obj instanceof CalcitStructDef) {
             return div(
               { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
-              "%struct ",
+              "%struct-def ",
               embedObject(new CalcitSymbol(obj.name.value)),
               " ..."
             );
           }
-          if (obj instanceof CalcitEnum) {
+          if (obj instanceof CalcitEnumDef) {
             return div(
               { color: hsl(280, 80, 60, 0.4), maxWidth: "100%" },
-              "%enum ",
+              "%enum-def ",
               embedObject(new CalcitSymbol(obj.prototype.name.value)),
               " ..."
             );
           }
-          if (obj instanceof CalcitTuple) {
-            if (obj.impls.length > 0) {
-              let ret: any[] = div(
-                { marginRight: "16px" },
-                div({ display: "inline-block", color: hsl(300, 100, 40) }, "%::"),
-                div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.impls[0])),
-                div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.tag))
-              );
-              for (let idx = 0; idx < obj.extra.length; idx++) {
-                ret.push(div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.extra[idx])));
-              }
-              return ret;
-            } else {
-              let ret: any[] = div(
-                { marginRight: "16px" },
-                div({ display: "inline-block", color: hsl(300, 100, 40) }, "::"),
-                div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.tag))
-              );
-              for (let idx = 0; idx < obj.extra.length; idx++) {
-                ret.push(div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.extra[idx])));
-              }
-              return ret;
+          if (obj instanceof CalcitEnumValue) {
+            const enumName = obj.enumPrototype == null ? "_" : obj.enumPrototype.name();
+            let ret: any[] = div(
+              { marginRight: "16px" },
+              div({ display: "inline-block", color: hsl(300, 100, 40) }, "%::"),
+              div({ marginLeft: "6px", display: "inline-block" }, embedObject(new CalcitSymbol(enumName))),
+              div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.tag))
+            );
+            for (let idx = 0; idx < obj.extra.length; idx++) {
+              ret.push(div({ marginLeft: "6px", display: "inline-block" }, embedObject(obj.extra[idx])));
             }
+            return ret;
           }
           if (obj instanceof CalcitRef) {
             return div(
@@ -276,11 +248,11 @@ export let load_console_formatter_$x_ = () => {
             let hasCollection = obj.nestedDataInChildren();
             return obj.len() > 0 && hasCollection;
           }
-          if (obj instanceof CalcitRecord) {
+          if (obj instanceof CalcitStructValue) {
             return obj.fields.length > 0;
           }
-          if (obj instanceof CalcitStruct || obj instanceof CalcitEnum) {
-            return obj instanceof CalcitStruct ? obj.fields.length > 0 : obj.prototype.fields.length > 0;
+          if (obj instanceof CalcitStructDef || obj instanceof CalcitEnumDef) {
+            return obj instanceof CalcitStructDef ? obj.fields.length > 0 : obj.prototype.fields.length > 0;
           }
           return false;
         },
@@ -344,7 +316,7 @@ export let load_console_formatter_$x_ = () => {
             }
             return ret;
           }
-          if (obj instanceof CalcitRecord) {
+          if (obj instanceof CalcitStructValue) {
             let ret: any[] = table({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
             for (let idx = 0; idx < obj.fields.length; idx++) {
               ret.push(
@@ -357,7 +329,7 @@ export let load_console_formatter_$x_ = () => {
             }
             return ret;
           }
-          if (obj instanceof CalcitStruct) {
+          if (obj instanceof CalcitStructDef) {
             let ret: any[] = table({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
             for (let idx = 0; idx < obj.fields.length; idx++) {
               ret.push(
@@ -370,7 +342,7 @@ export let load_console_formatter_$x_ = () => {
             }
             return ret;
           }
-          if (obj instanceof CalcitEnum) {
+          if (obj instanceof CalcitEnumDef) {
             let ret: any[] = table({ color: hsl(280, 80, 60), borderLeft: "1px solid #eee" });
             for (let idx = 0; idx < obj.prototype.fields.length; idx++) {
               ret.push(

--- a/ts-src/js-cirru.mts
+++ b/ts-src/js-cirru.mts
@@ -3,12 +3,12 @@ import { CirruWriterNode, writeCirruCode, writeCirruOneLiner } from "@cirru/writ
 
 import { CalcitValue, isLiteral, _$n_compare } from "./js-primes.mjs";
 import { CalcitList, CalcitSliceList } from "./js-list.mjs";
-import { CalcitRecord } from "./js-record.mjs";
+import { CalcitStructValue } from "./js-struct-value.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet } from "./js-set.mjs";
 import { CalcitTag, CalcitSymbol, CalcitRecur, newTag } from "./calcit-data.mjs";
-import { CalcitTuple } from "./js-tuple.mjs";
-import { CalcitEnum } from "./js-enum.mjs";
+import { CalcitEnumValue } from "./js-enum-value.mjs";
+import { CalcitEnumDef } from "./js-enum-def.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
 import { CalcitRef } from "./js-ref.mjs";
 import { deepEqual } from "@calcit/ternary-tree/lib/utils.mjs";
@@ -151,7 +151,7 @@ export let to_cirru_edn = (x: CalcitValue): CirruEdnFormat => {
     }
     return buffer;
   }
-  if (x instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
     let buffer: [string, CirruEdnFormat][] = [];
     for (let idx = 0; idx < x.fields.length; idx++) {
       buffer.push([x.fields[idx].toString(), to_cirru_edn(x.values[idx])]);
@@ -174,7 +174,7 @@ export let to_cirru_edn = (x: CalcitValue): CirruEdnFormat => {
     }
     return buffer;
   }
-  if (x instanceof CalcitTuple) {
+  if (x instanceof CalcitEnumValue) {
     if (x.tag instanceof CalcitSymbol && x.tag.value === "quote") {
       // turn `x.snd` with CalcitList into raw Cirru nodes, which is in plain Array
       return ["quote", toWriterNode(x.get(1) as any)] as CirruEdnFormat;
@@ -182,7 +182,7 @@ export let to_cirru_edn = (x: CalcitValue): CirruEdnFormat => {
       let enumTag = unwrap_enum_prototype_local(x.enumPrototype).name.toString();
       if (x.tag instanceof CalcitTag) {
         return ["%::", enumTag, x.tag.toString(), ...x.extra.map(to_cirru_edn)];
-      } else if (x.tag instanceof CalcitRecord) {
+      } else if (x.tag instanceof CalcitStructValue) {
         return ["%::", enumTag, x.tag.name.toString(), ...x.extra.map(to_cirru_edn)];
       } else if (x.tag instanceof CalcitImpl) {
         return ["%::", enumTag, x.tag.name.toString(), ...x.extra.map(to_cirru_edn)];
@@ -191,7 +191,7 @@ export let to_cirru_edn = (x: CalcitValue): CirruEdnFormat => {
       }
     } else if (x.tag instanceof CalcitTag) {
       return ["::", x.tag.toString(), ...x.extra.map(to_cirru_edn)];
-    } else if (x.tag instanceof CalcitRecord) {
+    } else if (x.tag instanceof CalcitStructValue) {
       return ["::", x.tag.name.toString(), ...x.extra.map(to_cirru_edn)];
     } else if (x.tag instanceof CalcitImpl) {
       return ["::", x.tag.name.toString(), ...x.extra.map(to_cirru_edn)];
@@ -230,8 +230,11 @@ let extractFieldTag = (x: string) => {
 let resolveEnumPrototype = (enumName: string, options: CalcitValue) => {
   if (options instanceof CalcitMap || options instanceof CalcitSliceMap) {
     let value = options.get(extractFieldTag(enumName));
-    if (value instanceof CalcitEnum || value instanceof CalcitRecord) {
+    if (value instanceof CalcitEnumDef) {
       return value;
+    }
+    if (value instanceof CalcitStructValue) {
+      throw new Error(`Enum ${enumName} uses a legacy struct prototype; provide an EnumDef produced by defenum`);
     }
     if (value != null) {
       throw new Error(`Expected enum prototype for ${enumName}, got: ${value}`);
@@ -240,20 +243,17 @@ let resolveEnumPrototype = (enumName: string, options: CalcitValue) => {
   return null;
 };
 
-// local helper to unwrap an enum prototype value to a CalcitRecord prototype
-const unwrap_enum_prototype_local = (enumPrototype: CalcitValue): CalcitRecord => {
-  if (enumPrototype instanceof CalcitEnum) {
+// local helper to inspect an EnumDef's variant prototype
+const unwrap_enum_prototype_local = (enumPrototype: CalcitValue): CalcitStructValue => {
+  if (enumPrototype instanceof CalcitEnumDef) {
     return enumPrototype.prototype;
   }
-  if (enumPrototype instanceof CalcitRecord) {
-    return enumPrototype;
-  }
-  throw new Error(`expected enum prototype`);
+  throw new Error(`expected an EnumDef produced by defenum`);
 };
 
 const tag_to_string = (tag: CalcitValue): string => {
   if (tag instanceof CalcitTag) return tag.toString();
-  if (tag instanceof CalcitRecord) return tag.name.toString();
+  if (tag instanceof CalcitStructValue) return tag.name.toString();
   throw new Error(`Unsupported tag for EDN: ${tag}`);
 };
 
@@ -321,7 +321,7 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
     if (x[0] === "%{}") {
       let name = x[1];
       if (typeof name != "string") {
-        throw new Error(`Expected string for record name, got: ${name}`);
+        throw new Error(`Expected string for struct name, got: ${name}`);
       }
       // put to entries first, sort and then...
       let entries: Array<[CalcitTag, CalcitValue]> = [];
@@ -344,7 +344,7 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
             throw new Error(`Expected pair of size 2, got: ${pair}`);
           }
         } else {
-          throw new Error(`Expected pairs for record, got: ${pair}`);
+          throw new Error(`Expected field pairs for struct, got: ${pair}`);
         }
       });
       entries.sort((a, b) => {
@@ -360,14 +360,14 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
 
       if (options instanceof CalcitMap || options instanceof CalcitSliceMap) {
         let v = options.get(extractFieldTag(name));
-        if (v != null && v instanceof CalcitRecord) {
+        if (v != null && v instanceof CalcitStructValue) {
           if (deepEqual(v.fields, fields)) {
-            return new CalcitRecord(extractFieldTag(name), fields, values, v.structRef);
+            return new CalcitStructValue(extractFieldTag(name), fields, values, v.structRef);
           }
         }
       }
 
-      return new CalcitRecord(extractFieldTag(name), fields, values);
+      return new CalcitStructValue(extractFieldTag(name), fields, values);
     }
     let notComment = (x: any) => {
       if (x instanceof Array && x[0] === ";") {
@@ -402,9 +402,9 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
     }
     if (x[0] === "::") {
       if (x.length < 2) {
-        throw new Error(`tuple expects at least 1 value, got: ${x}`);
+        throw new Error(`anonymous enum expects at least 1 value, got: ${x}`);
       }
-      return new CalcitTuple(
+      return new CalcitEnumValue(
         extract_cirru_edn_inner(x[1], options, preserveSourceEntries),
         x
           .slice(2)
@@ -424,7 +424,7 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
       // unwrap prototype to record then extract name
       const proto = enumPrototype != null ? unwrap_enum_prototype_local(enumPrototype) : null;
       const enumTag = proto != null ? proto.name.toString() : enumName;
-      return new CalcitTuple(
+      return new CalcitEnumValue(
         extract_cirru_edn_inner(x[2], options, preserveSourceEntries),
         x
           .slice(3)
@@ -505,12 +505,12 @@ export let to_calcit_data = (x: any, noKeyword: boolean = false): CalcitValue =>
   if (x instanceof CalcitList || x instanceof CalcitSliceList) return x;
   if (x instanceof CalcitMap || x instanceof CalcitSliceMap) return x;
   if (x instanceof CalcitSet) return x;
-  if (x instanceof CalcitRecord) return x;
+  if (x instanceof CalcitStructValue) return x;
   if (x instanceof CalcitRecur) return x;
   if (x instanceof CalcitRef) return x;
   if (x instanceof CalcitTag) return x;
   if (x instanceof CalcitSymbol) return x;
-  if (x instanceof CalcitTuple) return x;
+  if (x instanceof CalcitEnumValue) return x;
 
   // detects object
   if (x === Object(x)) {

--- a/ts-src/js-enum-def.mts
+++ b/ts-src/js-enum-def.mts
@@ -1,11 +1,11 @@
-import { CalcitRecord } from "./js-record.mjs";
+import { CalcitStructValue } from "./js-struct-value.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
 
-export class CalcitEnum {
-  prototype: CalcitRecord;
+export class CalcitEnumDef {
+  prototype: CalcitStructValue;
   cachedHash: number;
 
-  constructor(prototype: CalcitRecord) {
+  constructor(prototype: CalcitStructValue) {
     this.prototype = prototype;
     this.cachedHash = null;
   }
@@ -18,7 +18,7 @@ export class CalcitEnum {
     return this.prototype.structRef.impls;
   }
 
-  withImpls(impls: CalcitImpl | CalcitImpl[]): CalcitEnum {
+  withImpls(impls: CalcitImpl | CalcitImpl[]): CalcitEnumDef {
     let nextImpls: CalcitImpl[];
     if (impls instanceof CalcitImpl) {
       nextImpls = [impls];
@@ -27,10 +27,10 @@ export class CalcitEnum {
     } else {
       throw new Error("Expected an impl as implementation");
     }
-    return new CalcitEnum(this.prototype.withImpls(nextImpls));
+    return new CalcitEnumDef(this.prototype.withImpls(nextImpls));
   }
 
   toString(): string {
-    return `(%enum '${this.prototype.name.value})`;
+    return `(%enum-def '${this.prototype.name.value})`;
   }
 }

--- a/ts-src/js-enum-value.mts
+++ b/ts-src/js-enum-value.mts
@@ -3,15 +3,14 @@ import { Hash } from "@calcit/ternary-tree";
 import { CalcitValue } from "./js-primes.mjs";
 import { _$n__$e_, newTag, toString } from "./calcit-data.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
-import { CalcitRecord } from "./js-record.mjs";
-import { CalcitEnum } from "./js-enum.mjs";
+import { CalcitEnumDef } from "./js-enum-def.mjs";
 
-export class CalcitTuple {
+export class CalcitEnumValue {
   tag: CalcitValue;
   extra: CalcitValue[];
-  enumPrototype: CalcitRecord | CalcitEnum;
+  enumPrototype: CalcitEnumDef;
   cachedHash: Hash;
-  constructor(tagName: CalcitValue, extra: CalcitValue[], enumPrototype: CalcitRecord | CalcitEnum = null) {
+  constructor(tagName: CalcitValue, extra: CalcitValue[], enumPrototype: CalcitEnumDef = null) {
     this.tag = tagName;
     this.extra = extra;
     this.enumPrototype = enumPrototype;
@@ -22,10 +21,7 @@ export class CalcitTuple {
     if (this.enumPrototype == null) {
       return [];
     }
-    if (this.enumPrototype instanceof CalcitEnum) {
-      return this.enumPrototype.impls;
-    }
-    return this.enumPrototype.structRef.impls;
+    return this.enumPrototype.impls;
   }
 
   get(n: number) {
@@ -34,24 +30,24 @@ export class CalcitTuple {
     } else if (n - 1 < this.extra.length) {
       return this.extra[n - 1];
     } else {
-      throw new Error(`Tuple only have ${this.extra.length + 1} elements`);
+      throw new Error(`Enum value only has ${this.extra.length + 1} elements`);
     }
   }
   assoc(n: number, v: CalcitValue) {
     if (n === 0) {
-      return new CalcitTuple(v, this.extra, this.enumPrototype);
+      return new CalcitEnumValue(v, this.extra, this.enumPrototype);
     } else if (n - 1 < this.extra.length) {
       let next_extra = this.extra.slice();
       next_extra[n - 1] = v;
-      return new CalcitTuple(this.tag, next_extra, this.enumPrototype);
+      return new CalcitEnumValue(this.tag, next_extra, this.enumPrototype);
     } else {
-      throw new Error(`Tuple only have ${this.extra.length} elements`);
+      throw new Error(`Enum value only has ${this.extra.length} elements`);
     }
   }
   count() {
     return 1 + this.extra.length;
   }
-  eq(y: CalcitTuple): boolean {
+  eq(y: CalcitEnumValue): boolean {
     if (!_$n__$e_(this.tag, y.tag)) {
       return false;
     }
@@ -75,11 +71,8 @@ export class CalcitTuple {
       content += toString(args[i], true, disableJsDataWarning);
     }
     const hasEnum = this.enumPrototype != null;
-    const enumName = hasEnum ? (this.enumPrototype instanceof CalcitEnum ? this.enumPrototype.prototype.name.value : this.enumPrototype.name.value) : null;
+    const enumName = hasEnum ? this.enumPrototype.name() : null;
 
-    if (hasEnum) {
-      return `(%:: ${content} (:enum ${enumName}))`;
-    }
-    return `(:: ${content})`;
+    return `(%:: ${hasEnum ? `'${enumName}` : "_"} ${content})`;
   }
 }

--- a/ts-src/js-list.mts
+++ b/ts-src/js-list.mts
@@ -18,7 +18,7 @@ import {
 
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet } from "./js-set.mjs";
-import { CalcitTuple } from "./js-tuple.mjs";
+import { CalcitEnumValue } from "./js-enum-value.mjs";
 
 import { isNestedCalcitData, tipNestedCalcitData, toString, CalcitFn } from "./calcit-data.mjs";
 
@@ -349,7 +349,7 @@ export let foldl_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     for (let idx = 0; idx < size; idx++) {
       let item = xs.get(idx);
       let pair = f(state, item);
-      if (pair instanceof CalcitTuple) {
+      if (pair instanceof CalcitEnumValue) {
         if (typeof pair.tag === "boolean") {
           if (pair.tag) {
             return pair.get(1);
@@ -369,7 +369,7 @@ export let foldl_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     for (let idx = 0; idx < values.length; idx++) {
       let item = values[idx];
       let pair = f(state, item);
-      if (pair instanceof CalcitTuple) {
+      if (pair instanceof CalcitEnumValue) {
         if (typeof pair.tag === "boolean") {
           if (pair.tag) {
             return pair.get(1);
@@ -390,7 +390,7 @@ export let foldl_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     for (let i = 0; i < size; i++) {
       let pos = i << 1;
       let pair = f(state, new CalcitSliceList([xs.chunk[pos], xs.chunk[pos + 1]]));
-      if (pair instanceof CalcitTuple) {
+      if (pair instanceof CalcitEnumValue) {
         if (typeof pair.tag === "boolean") {
           if (pair.tag) {
             return pair.get(1);
@@ -410,7 +410,7 @@ export let foldl_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     for (let idx = 0; idx < pairs.length; idx++) {
       let item = pairs[idx];
       let pair = f(state, new CalcitSliceList(item));
-      if (pair instanceof CalcitTuple) {
+      if (pair instanceof CalcitEnumValue) {
         if (typeof pair.tag === "boolean") {
           if (pair.tag) {
             return pair.get(1);
@@ -440,7 +440,7 @@ export let foldr_shortcut = function (xs: CalcitValue, acc: CalcitValue, v0: Cal
     for (let idx = xs.len() - 1; idx >= 0; idx--) {
       let item = xs.get(idx);
       let pair = f(state, item);
-      if (pair instanceof CalcitTuple) {
+      if (pair instanceof CalcitEnumValue) {
         if (typeof pair.tag === "boolean") {
           if (pair.tag) {
             return pair.get(1);

--- a/ts-src/js-primes.mts
+++ b/ts-src/js-primes.mts
@@ -1,13 +1,13 @@
 import { CalcitTag, CalcitSymbol, CalcitFn, CalcitRecur } from "./calcit-data.mjs";
 import { CalcitRef } from "./js-ref.mjs";
 import { CalcitList, CalcitSliceList } from "./js-list.mjs";
-import { CalcitRecord } from "./js-record.mjs";
+import { CalcitStructValue } from "./js-struct-value.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
-import { CalcitStruct } from "./js-struct.mjs";
-import { CalcitEnum } from "./js-enum.mjs";
+import { CalcitStructDef } from "./js-struct-def.mjs";
+import { CalcitEnumDef } from "./js-enum-def.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet as CalcitSet } from "./js-set.mjs";
-import { CalcitTuple } from "./js-tuple.mjs";
+import { CalcitEnumValue } from "./js-enum-value.mjs";
 import { CalcitCirruQuote, cirru_deep_equal } from "./js-cirru.mjs";
 import { CalcitTrait } from "./js-trait.mjs";
 
@@ -23,14 +23,14 @@ export type CalcitValue =
   | CalcitTag
   | CalcitSymbol
   | CalcitRef
-  | CalcitTuple
+  | CalcitEnumValue
   | CalcitFn
   | CalcitRecur // should not be exposed to function
-  | CalcitRecord
+  | CalcitStructValue
   | CalcitImpl
   | CalcitTrait
-  | CalcitStruct
-  | CalcitEnum
+  | CalcitStructDef
+  | CalcitEnumDef
   | CalcitCirruQuote
   | null;
 
@@ -52,15 +52,15 @@ enum PseudoTypeIndex {
   tag,
   string,
   ref,
-  tuple,
+  enum_value,
   recur,
   list,
   set,
   map,
-  record,
+  struct_value,
   impl,
-  struct,
-  enum_type,
+  struct_def,
+  enum_def,
   fn,
   cirru_quote,
 }
@@ -75,15 +75,15 @@ let typeAsInt = (x: CalcitValue): number => {
   if (x instanceof CalcitTag) return PseudoTypeIndex.tag;
   if (t === "string") return PseudoTypeIndex.string;
   if (x instanceof CalcitRef) return PseudoTypeIndex.ref;
-  if (x instanceof CalcitTuple) return PseudoTypeIndex.tuple;
+  if (x instanceof CalcitEnumValue) return PseudoTypeIndex.enum_value;
   if (x instanceof CalcitRecur) return PseudoTypeIndex.recur;
   if (x instanceof CalcitList || x instanceof CalcitSliceList) return PseudoTypeIndex.list;
   if (x instanceof CalcitSet) return PseudoTypeIndex.set;
   if (x instanceof CalcitMap || x instanceof CalcitSliceMap) return PseudoTypeIndex.map;
-  if (x instanceof CalcitRecord) return PseudoTypeIndex.record;
+  if (x instanceof CalcitStructValue) return PseudoTypeIndex.struct_value;
   if (x instanceof CalcitImpl) return PseudoTypeIndex.impl;
-  if (x instanceof CalcitStruct) return PseudoTypeIndex.struct;
-  if (x instanceof CalcitEnum) return PseudoTypeIndex.enum_type;
+  if (x instanceof CalcitStructDef) return PseudoTypeIndex.struct_def;
+  if (x instanceof CalcitEnumDef) return PseudoTypeIndex.enum_def;
   if (x instanceof CalcitCirruQuote) return PseudoTypeIndex.cirru_quote;
   // proc, fn, macro, syntax, not distinguished
   if (t === "function") return PseudoTypeIndex.fn;

--- a/ts-src/js-record.mts
+++ b/ts-src/js-record.mts
@@ -37,6 +37,11 @@ export class CalcitRecord {
       return undefined;
     }
   }
+  getRequired(k: CalcitValue): CalcitValue {
+    const value = this.get(k);
+    if (value !== undefined) return value;
+    throw new Error(`record '${this.name.value}' does not define field ${castTag(k).toString()}`);
+  }
   getOrNil(k: CalcitValue) {
     let field = castTag(k);
     let idx = findInFields(this.fields, field);

--- a/ts-src/js-struct-def.mts
+++ b/ts-src/js-struct-def.mts
@@ -2,7 +2,7 @@ import { CalcitTag, toString } from "./calcit-data.mjs";
 import { CalcitValue } from "./js-primes.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
 
-export class CalcitStruct {
+export class CalcitStructDef {
   name: CalcitTag;
   fields: CalcitTag[];
   fieldTypes: CalcitValue[];
@@ -11,7 +11,7 @@ export class CalcitStruct {
 
   constructor(name: CalcitTag, fields: CalcitTag[], fieldTypes: CalcitValue[], impls: CalcitImpl[] = []) {
     if (fields.length !== fieldTypes.length) {
-      throw new Error("CalcitStruct: fields and fieldTypes length mismatch");
+      throw new Error("CalcitStructDef: fields and fieldTypes length mismatch");
     }
     this.name = name;
     this.fields = fields;
@@ -20,20 +20,20 @@ export class CalcitStruct {
     this.cachedHash = null;
   }
 
-  withImpls(impls: CalcitImpl | CalcitImpl[]): CalcitStruct {
+  withImpls(impls: CalcitImpl | CalcitImpl[]): CalcitStructDef {
     if (impls instanceof CalcitImpl) {
-      return new CalcitStruct(this.name, this.fields, this.fieldTypes, [impls]);
+      return new CalcitStructDef(this.name, this.fields, this.fieldTypes, [impls]);
     } else if (Array.isArray(impls)) {
-      return new CalcitStruct(this.name, this.fields, this.fieldTypes, impls);
+      return new CalcitStructDef(this.name, this.fields, this.fieldTypes, impls);
     }
     throw new Error("Expected an impl as implementation");
   }
 
   toString(disableJsDataWarning: boolean = false): string {
     if (this.fields.length !== this.fieldTypes.length) {
-      throw new Error("CalcitStruct: fields and fieldTypes length mismatch");
+      throw new Error("CalcitStructDef: fields and fieldTypes length mismatch");
     }
-    const parts: string[] = ["(%struct '", this.name.value];
+    const parts: string[] = ["(%struct-def '", this.name.value];
     for (let idx = 0; idx < this.fields.length; idx++) {
       const field = this.fields[idx];
       const fieldType = this.fieldTypes[idx];

--- a/ts-src/js-struct-value.mts
+++ b/ts-src/js-struct-value.mts
@@ -5,15 +5,15 @@ import { newTag, castTag, toString, CalcitTag, getStringName, findInFields } fro
 
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 
-import { CalcitStruct } from "./js-struct.mjs";
+import { CalcitStructDef } from "./js-struct-def.mjs";
 
-export class CalcitRecord {
+export class CalcitStructValue {
   name: CalcitTag;
   fields: Array<CalcitTag>;
   values: Array<CalcitValue>;
-  structRef: CalcitStruct;
+  structRef: CalcitStructDef;
   cachedHash: Hash;
-  constructor(name: CalcitTag, fields: Array<CalcitTag>, values?: Array<CalcitValue>, structRef?: CalcitStruct) {
+  constructor(name: CalcitTag, fields: Array<CalcitTag>, values?: Array<CalcitValue>, structRef?: CalcitStructDef) {
     this.name = name;
     let fieldNames = fields.map(castTag);
     this.fields = fields;
@@ -26,7 +26,7 @@ export class CalcitRecord {
       this.values = new Array(fieldNames.length);
     }
     this.cachedHash = null;
-    this.structRef = structRef || new CalcitStruct(name, fields, new Array(fields.length).fill(null));
+    this.structRef = structRef || new CalcitStructDef(name, fields, new Array(fields.length).fill(null));
   }
   get(k: CalcitValue) {
     let field = castTag(k);
@@ -40,7 +40,7 @@ export class CalcitRecord {
   getRequired(k: CalcitValue): CalcitValue {
     const value = this.get(k);
     if (value !== undefined) return value;
-    throw new Error(`record '${this.name.value}' does not define field ${castTag(k).toString()}`);
+    throw new Error(`struct '${this.name.value}' does not define field ${castTag(k).toString()}`);
   }
   getOrNil(k: CalcitValue) {
     let field = castTag(k);
@@ -51,7 +51,7 @@ export class CalcitRecord {
       return undefined;
     }
   }
-  assoc(k: CalcitValue, v: CalcitValue): CalcitRecord {
+  assoc(k: CalcitValue, v: CalcitValue): CalcitStructValue {
     let values: Array<CalcitValue> = new Array(this.fields.length);
     let k_id = castTag(k);
     for (let idx = 0; idx < this.fields.length; idx++) {
@@ -61,7 +61,7 @@ export class CalcitRecord {
         values[idx] = this.values[idx];
       }
     }
-    return new CalcitRecord(this.name, this.fields, values, this.structRef);
+    return new CalcitStructValue(this.name, this.fields, values, this.structRef);
   }
   /** return -1 for missing */
   findIndex(k: CalcitValue) {
@@ -75,14 +75,14 @@ export class CalcitRecord {
   }
   toString(disableJsDataWarning: boolean = false): string {
     // Optimize string building using array join instead of concatenation
-    const parts = ["(%{} '", this.name.value];
+    const parts = this.name.value === "_" ? ["(%{} _"] : ["(%{} '", this.name.value];
     for (let idx = 0; idx < this.fields.length; idx++) {
       parts.push(" (", this.fields[idx].toString(), " ", toString(this.values[idx], true, disableJsDataWarning), ")");
     }
     parts.push(")");
     return parts.join("");
   }
-  withImpls(impl: CalcitValue | CalcitImpl[]): CalcitRecord {
+  withImpls(impl: CalcitValue | CalcitImpl[]): CalcitStructValue {
     let nextImpls: CalcitImpl[];
     if (impl instanceof CalcitImpl) {
       nextImpls = [impl];
@@ -91,37 +91,37 @@ export class CalcitRecord {
     } else {
       throw new Error("Expected an impl or array of impls");
     }
-    let nextStruct = new CalcitStruct(this.name, this.fields, this.structRef.fieldTypes, this.structRef.impls.concat(nextImpls));
-    return new CalcitRecord(this.name, this.fields, this.values, nextStruct);
+    let nextStruct = new CalcitStructDef(this.name, this.fields, this.structRef.fieldTypes, this.structRef.impls.concat(nextImpls));
+    return new CalcitStructValue(this.name, this.fields, this.values, nextStruct);
   }
 }
 
-export let new_record = (name: CalcitValue, ...fields: Array<CalcitValue>): CalcitValue => {
+export let new_struct_value = (name: CalcitValue, ...fields: Array<CalcitValue>): CalcitValue => {
   let fieldNames = fields.map(castTag).sort((x, y) => {
     if (x.idx < y.idx) {
       return -1;
     } else if (x.idx > y.idx) {
       return 1;
     } else {
-      throw new Error(`Unexpected duplication in record fields: ${x.toString()}`);
+      throw new Error(`Unexpected duplication in struct fields: ${x.toString()}`);
     }
   });
-  return new CalcitRecord(castTag(name), fieldNames);
+  return new CalcitStructValue(castTag(name), fieldNames);
 };
 
-export let new_impl_record = (impl: CalcitImpl, name: CalcitValue, ...fields: Array<CalcitValue>): CalcitValue => {
+export let new_impl_struct_value = (impl: CalcitImpl, name: CalcitValue, ...fields: Array<CalcitValue>): CalcitValue => {
   let fieldNames = fields.map(castTag).sort((x, y) => {
     if (x.idx < y.idx) {
       return -1;
     } else if (x.idx > y.idx) {
       return 1;
     } else {
-      throw new Error(`Unexpected duplication in record fields: ${x.toString()}`);
+      throw new Error(`Unexpected duplication in struct fields: ${x.toString()}`);
     }
   });
   let nameTag = castTag(name);
-  let structRef = new CalcitStruct(nameTag, fieldNames, new Array(fieldNames.length).fill(null), [impl]);
-  return new CalcitRecord(nameTag, fieldNames, undefined, structRef);
+  let structRef = new CalcitStructDef(nameTag, fieldNames, new Array(fieldNames.length).fill(null), [impl]);
+  return new CalcitStructValue(nameTag, fieldNames, undefined, structRef);
 };
 
 /** Loose record: `?{} :field1 val1 :field2 val2` – record without a declared struct.
@@ -143,8 +143,8 @@ export let _$q__$M_ = (...xs: Array<CalcitValue>): CalcitValue => {
   }
   let fieldNames = pairs.map((p) => p[0]);
   let values = pairs.map((p) => p[1]);
-  let looseTag = newTag("?");
-  return new CalcitRecord(looseTag, fieldNames, values);
+  let looseTag = newTag("_");
+  return new CalcitStructValue(looseTag, fieldNames, values);
 };
 
 export let fieldsEqual = (xs: Array<CalcitTag>, ys: Array<CalcitTag>): boolean => {
@@ -163,13 +163,13 @@ export let fieldsEqual = (xs: Array<CalcitTag>, ys: Array<CalcitTag>): boolean =
 };
 
 export let _$n__PCT__$M_ = (proto: CalcitValue, ...xs: Array<CalcitValue>): CalcitValue => {
-  let recordProto: CalcitRecord;
-  if (proto instanceof CalcitRecord) {
+  let recordProto: CalcitStructValue;
+  if (proto instanceof CalcitStructValue) {
     recordProto = proto;
-  } else if (proto instanceof CalcitStruct) {
-    recordProto = new CalcitRecord(proto.name, proto.fields, new Array(proto.fields.length).fill(null), proto);
+  } else if (proto instanceof CalcitStructDef) {
+    recordProto = new CalcitStructValue(proto.name, proto.fields, new Array(proto.fields.length).fill(null), proto);
   } else {
-    throw new Error("Expected prototype to be a record");
+    throw new Error("Expected prototype to be a StructDef");
   }
   {
     if (xs.length % 2 !== 0) {
@@ -192,23 +192,23 @@ export let _$n__PCT__$M_ = (proto: CalcitValue, ...xs: Array<CalcitValue>): Calc
       }
 
       if (idx < 0) {
-        throw new Error("invalid field name for this record");
+        throw new Error("invalid field name for this struct");
       }
       if (values[i] != null) {
-        throw new Error("record field already has value, probably duplicated key");
+        throw new Error("struct field already has value, probably duplicated key");
       }
       values[i] = xs[idx * 2 + 1];
     }
 
-    return new CalcitRecord(recordProto.name, recordProto.fields, values, recordProto.structRef);
+    return new CalcitStructValue(recordProto.name, recordProto.fields, values, recordProto.structRef);
   }
 };
 
 export let _$n__PCT__$M__$q_ = (proto: CalcitValue, ...xs: Array<CalcitValue>): CalcitValue => {
-  let recordProto: CalcitRecord;
+  let recordProto: CalcitStructValue;
   let values: Array<CalcitValue>;
-  if (proto instanceof CalcitStruct) {
-    recordProto = new CalcitRecord(proto.name, proto.fields, new Array(proto.fields.length).fill(null), proto);
+  if (proto instanceof CalcitStructDef) {
+    recordProto = new CalcitStructValue(proto.name, proto.fields, new Array(proto.fields.length).fill(null), proto);
     values = recordProto.values.slice();
   } else {
     throw new Error("Expected prototype to be a struct");
@@ -226,18 +226,18 @@ export let _$n__PCT__$M__$q_ = (proto: CalcitValue, ...xs: Array<CalcitValue>): 
       throw new Error(`Cannot find field ${k} among ${recordProto.fields}`);
     }
     if (touched.has(idx)) {
-      throw new Error(`record field already has value, probably duplicated key: ${k}`);
+      throw new Error(`struct field already has value, probably duplicated key: ${k}`);
     }
     touched.add(idx);
     values[idx] = xs[i + 1];
   }
 
-  return new CalcitRecord(recordProto.name, recordProto.fields, values, recordProto.structRef);
+  return new CalcitStructValue(recordProto.name, recordProto.fields, values, recordProto.structRef);
 };
 
 /// update record with new values
-export let _$n_record_$o_with = (proto: CalcitValue, ...xs: Array<CalcitValue>): CalcitValue => {
-  if (proto instanceof CalcitRecord) {
+export let _$n_struct_$o_with = (proto: CalcitValue, ...xs: Array<CalcitValue>): CalcitValue => {
+  if (proto instanceof CalcitStructValue) {
     if (xs.length % 2 !== 0) {
       throw new Error("Expected even number of key/value");
     }
@@ -251,39 +251,40 @@ export let _$n_record_$o_with = (proto: CalcitValue, ...xs: Array<CalcitValue>):
       }
       values[idx] = v;
     }
-    return new CalcitRecord(proto.name, proto.fields, values, proto.structRef);
+    return new CalcitStructValue(proto.name, proto.fields, values, proto.structRef);
   } else {
-    throw new Error("Expected prototype to be a record");
+    throw new Error("Expected prototype to be a StructDef");
   }
 };
 
-export let _$n_record_$o_get_name = (x: CalcitValue): CalcitTag => {
-  if (x instanceof CalcitRecord) {
+export let _$n_struct_$o_get_name = (x: CalcitValue): CalcitTag => {
+  if (x instanceof CalcitStructValue) {
     return x.name;
   } else {
-    throw new Error("Expected a record");
+    throw new Error("Expected a struct value");
   }
 };
 
-export let _$n_record_$o_struct = (x: CalcitValue): CalcitValue => {
-  if (x instanceof CalcitRecord) {
+export let _$n_struct_$o_definition = (x: CalcitValue): CalcitValue => {
+  if (x instanceof CalcitStructValue) {
+    if (x.name.value === "_") return null;
     return x.structRef ?? null;
   } else {
-    throw new Error("Expected a record");
+    throw new Error("Expected a struct value");
   }
 };
 
-export let _$n_record_$o_from_map = (proto: CalcitValue, data: CalcitValue): CalcitValue => {
-  let recordProto: CalcitRecord;
-  if (proto instanceof CalcitStruct) {
-    recordProto = new CalcitRecord(proto.name, proto.fields, new Array(proto.fields.length).fill(null), proto);
+export let _$n_struct_$o_from_map = (proto: CalcitValue, data: CalcitValue): CalcitValue => {
+  let recordProto: CalcitStructValue;
+  if (proto instanceof CalcitStructDef) {
+    recordProto = new CalcitStructValue(proto.name, proto.fields, new Array(proto.fields.length).fill(null), proto);
   } else {
     throw new Error("Expected prototype to be struct");
   }
 
-  if (data instanceof CalcitRecord) {
+  if (data instanceof CalcitStructValue) {
     if (fieldsEqual(recordProto.fields, data.fields)) {
-      return new CalcitRecord(recordProto.name, recordProto.fields, data.values, recordProto.structRef);
+      return new CalcitStructValue(recordProto.name, recordProto.fields, data.values, recordProto.structRef);
     } else {
       let values: Array<CalcitValue> = [];
       for (let i = 0; i < recordProto.fields.length; i++) {
@@ -294,7 +295,7 @@ export let _$n_record_$o_from_map = (proto: CalcitValue, data: CalcitValue): Cal
         }
         values.push(data.values[idx]);
       }
-      return new CalcitRecord(recordProto.name, recordProto.fields, values, recordProto.structRef);
+      return new CalcitStructValue(recordProto.name, recordProto.fields, values, recordProto.structRef);
     }
   } else if (data instanceof CalcitMap || data instanceof CalcitSliceMap) {
     let pairs_buffer: Array<[CalcitTag, CalcitValue]> = [];
@@ -319,47 +320,47 @@ export let _$n_record_$o_from_map = (proto: CalcitValue, data: CalcitValue): Cal
       }
       throw new Error(`Cannot find field ${field} among ${pairs_buffer}`);
     }
-    return new CalcitRecord(recordProto.name, recordProto.fields, values, recordProto.structRef);
+    return new CalcitStructValue(recordProto.name, recordProto.fields, values, recordProto.structRef);
   } else {
-    throw new Error("Expected record or data for making a record");
+    throw new Error("Expected a struct value or data for making a struct");
   }
 };
 
-export let _$n_record_$o_to_map = (x: CalcitValue): CalcitValue => {
-  if (x instanceof CalcitRecord) {
+export let _$n_struct_$o_to_map = (x: CalcitValue): CalcitValue => {
+  if (x instanceof CalcitStructValue) {
     var dict: Array<CalcitValue> = [];
     for (let idx = 0; idx < x.fields.length; idx++) {
       dict.push(x.fields[idx], x.values[idx]);
     }
     return new CalcitSliceMap(dict);
   } else {
-    throw new Error("Expected record");
+    throw new Error("Expected a struct value");
   }
 };
 
-export let _$n_record_$o_matches_$q_ = (x: CalcitValue, y: CalcitValue): boolean => {
-  let targetStruct: CalcitStruct;
-  if (y instanceof CalcitRecord) {
+export let _$n_struct_$o_matches_$q_ = (x: CalcitValue, y: CalcitValue): boolean => {
+  let targetStruct: CalcitStructDef;
+  if (y instanceof CalcitStructValue) {
     targetStruct = y.structRef;
-  } else if (y instanceof CalcitStruct) {
+  } else if (y instanceof CalcitStructDef) {
     targetStruct = y;
   } else {
-    throw new Error("Expected second argument to be record or struct");
+    throw new Error("Expected second argument to be a struct value or StructDef");
   }
 
-  if (x instanceof CalcitRecord) {
+  if (x instanceof CalcitStructValue) {
     if (x.name !== targetStruct.name) {
       return false;
     }
     return fieldsEqual(x.fields, targetStruct.fields);
   } else {
-    throw new Error("Expected first argument to be record");
+    throw new Error("Expected first argument to be a struct value");
   }
 };
 
-export function _$n_record_$o_extend_as(obj: CalcitValue, new_name: CalcitValue, new_key: CalcitValue, new_value: CalcitValue) {
+export function _$n_struct_$o_extend_as(obj: CalcitValue, new_name: CalcitValue, new_key: CalcitValue, new_value: CalcitValue) {
   if (arguments.length !== 4) throw new Error(`Expected 4 arguments, got ${arguments.length}`);
-  if (!(obj instanceof CalcitRecord)) throw new Error("Expected record");
+  if (!(obj instanceof CalcitStructValue)) throw new Error("Expected a struct value");
   let field = castTag(new_key);
   let new_name_tag = castTag(new_name);
   let new_fields: CalcitTag[] = [];
@@ -383,7 +384,7 @@ export function _$n_record_$o_extend_as(obj: CalcitValue, new_name: CalcitValue,
         new_fields.push(k);
         new_values.push(obj.values[i]);
       } else {
-        throw new Error("Does not extend existed record field");
+        throw new Error("Cannot extend an existing struct field");
       }
     }
   }
@@ -392,5 +393,5 @@ export function _$n_record_$o_extend_as(obj: CalcitValue, new_name: CalcitValue,
     new_values.push(new_value);
   }
 
-  return new CalcitRecord(new_name_tag, new_fields, new_values);
+  return new CalcitStructValue(new_name_tag, new_fields, new_values);
 }


### PR DESCRIPTION
## Summary

- split nominal definitions from values as StructDef / EnumDef and Struct / Enum
- replace outward record / tuple APIs with struct / enum APIs, while emitting W_REMOVED_DATA_API migration diagnostics
- make known struct field access return the declared field type directly and reject undeclared fields
- render nominal names as symbols in Rust and TypeScript custom formatters, including anonymous underscore markers
- align Rust, JavaScript, IR, WASM, snapshot serialization, tests, and upgrade documentation

## Migration

- old snapshot input remains readable, but new writes reject legacy Record / Tuple and record / tuple tags
- removed API diagnostics provide concrete replacements
- Struct field unwraps should be removed only for statically known declared fields; Map access and get-in remain Optional

## Validation

- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-agent-interface
- yarn check-all
- executable Markdown checks for updated data-model documentation
- Respo check-only and full JS regression against the locally compiled runtime

## Notes

This is intentionally a breaking public terminology cleanup. Internal Rust module and historical test names are retained where renaming would add churn without changing the public model.