### PR TITLE
chore: release 0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608061731-release-0.13.2.md
+++ b/editing-history/202608061731-release-0.13.2.md
@@ -1,0 +1,18 @@
+# Release 0.13.2
+
+## Scope
+
+- Release the struct / enum data model cleanup merged by PR #301.
+- Publish direct required Struct field access and migration diagnostics for removed record / tuple APIs.
+- Publish symbol-based nominal formatting and matching TypeScript runtime modules.
+
+## Version synchronization
+
+- `Cargo.toml`: `0.13.2`
+- `package.json`: `0.13.2`
+- `Cargo.lock`: refreshed with `cargo update --workspace`
+
+## Release gates
+
+- The feature PR passed Test and all CodeQL jobs before merge.
+- The release commit must pass the same GitHub Actions checks before tag `0.13.2` is created.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Release

- bump Cargo crate version to 0.13.2
- bump npm package version to 0.13.2
- refresh Cargo.lock
- record the release history

## Included change

This patch releases the struct / enum data model cleanup from merged PR #301, including required Struct field access, migration diagnostics, and TypeScript formatter/runtime alignment.

## Local validation

- cargo fmt -- --check
- cargo test
- yarn compile

The tag and GitHub release will be created only after this release PR passes all required checks and is merged.