### PR TITLE
fix: preprocess and validate generic enum methods

### DIFF
--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -357,6 +357,18 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
+        |test-enum-impl-precedence-order $ %{} :CodeEntry (:doc "|Test enum impl precedence order")
+          :code $ quote
+            defn test-enum-impl-precedence-order () (println "|Testing enum impl precedence order...")
+              let
+                  t $ %:: DemoBar :demo 1
+                assert-traits t MyBar
+                assert= |bar2 $ t .bar
+              println "|  tuple precedence: ✓"
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
         |test-eq-trait $ %{} :CodeEntry (:doc "|Test Eq trait")
           :code $ quote
             defn test-eq-trait () (println "|Testing Eq trait...") (; Value equality)
@@ -472,6 +484,8 @@
                 assert= (%none) (opt-none .map step)
                 assert= (%ok 2) (res-ok .map step)
                 assert= (%err |oops) (res-err .map step)
+                assert= (%some 2)
+                  opt-some .map $ fn (x) (inc x)
               let
                   opt-some $ %some 1
                   opt-none $ %none
@@ -523,18 +537,6 @@
                 {} $ :a 1
               ; assert= "|(#{} 1 2)" $ str (#{} 1 2)
               println "|  Show trait: ✓"
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Dynamic)
-              :args $ []
-        |test-enum-impl-precedence-order $ %{} :CodeEntry (:doc "|Test enum impl precedence order")
-          :code $ quote
-            defn test-enum-impl-precedence-order () (println "|Testing enum impl precedence order...")
-              let
-                  t $ %:: DemoBar :demo 1
-                assert-traits t MyBar
-                assert= |bar2 $ t .bar
-              println "|  tuple precedence: ✓"
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -11,6 +11,7 @@
 - `cargo run --bin cr -- calcit/type-fail/schema-rest-unexpected.cirru --check-only`
 - `cargo run --bin cr -- calcit/type-fail/schema-kind-mismatch.cirru --check-only`
 - `cargo run --bin cr -- calcit/type-fail/schema-call-arg-type-mismatch.cirru --check-only`
+- `cargo run --bin cr -- calcit/type-fail/trait-method-generic-receiver-mismatch.cirru --check-only`
 - `cargo run --bin cr -- calcit/type-fail/generic-where-bound-mismatch.cirru --check-only`
 - `cargo run --bin cr -- calcit/type-fail/type-slot-record-call-arg-type-mismatch.cirru --check-only`
 - `cargo run --bin cr -- calcit/type-fail/type-slot-bind-unknown.cirru --check-only`
@@ -20,6 +21,7 @@
 
 - 前 4 个会触发 `schema mismatch while preprocessing definition`（定义时校验）。
 - `schema-call-arg-type-mismatch.cirru` 会触发基于 schema 的函数参数类型告警，并在 `--check-only` 下被当作错误处理。
+- `trait-method-generic-receiver-mismatch.cirru` 会验证泛型方法根据 receiver 的 `Option<String>` 绑定其 fallback 类型，并拒绝 `Number` fallback。
 - `generic-where-bound-mismatch.cirru` 会触发 `W_GENERIC_WHERE_BOUND_MISMATCH`，验证泛型 `:where` 约束在调用点能被发现，并在 `--check-only` 下被当作错误处理。
 - `type-slot-record-call-arg-type-mismatch.cirru` 会验证 `bind-type` 绑定 record 实例后，`*slot` 参与调用点类型检查。
 - `type-slot-bind-unknown.cirru` 会验证未声明 slot 的 `bind-type` 会直接失败。
@@ -45,6 +47,7 @@
 
 - `E_SCHEMA_DEF_MISMATCH`：定义与 `:schema` 的 `:kind` / `:args` / `:rest` 不匹配
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配
+- `W_METHOD_ARG_TYPE_MISMATCH`：静态方法调用参数类型不匹配
 - `W_PROC_ARG_TYPE_MISMATCH`：内建 proc 参数类型不匹配
 - `W_CORE_FN_ARG_TYPE_MISMATCH`：`calcit.core` 函数参数类型不匹配
 - `W_FN_RETURN_TYPE_MISMATCH`：函数声明返回类型与函数体实际返回类型不匹配

--- a/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
+++ b/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
@@ -1,0 +1,32 @@
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |type-fail-schema-call-arg-type) (:version |0.0.0)
+  :entries $ {}
+    :default $ {} (:description |) (:init-fn 'type-fail-schema-call-arg-type.main/main!) (:mode :native) (:reload-fn 'type-fail-schema-call-arg-type.main/reload!)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    |type-fail-schema-call-arg-type.main $ %{} :FileEntry
+      :defs $ {}
+        |main! $ %{} :CodeEntry (:doc "|Entry for type-fail schema call-site arg type mismatch")
+          :code $ quote
+            defn main! (option) (option .unwrap-or 0)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] (:: 'Option 'String)
+        |plus1 $ %{} :CodeEntry (:doc "|Schema expects :number, call-site passes :string")
+          :code $ quote
+            defn plus1 (x) (&+ x 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'Number
+        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+          :code $ quote
+            defn reload! () nil
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
+      :ns $ %{} :NsEntry (:doc "|Namespace for schema call-site mismatch")
+        :code $ quote (ns type-fail-schema-call-arg-type.main)

--- a/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
+++ b/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
@@ -1,13 +1,13 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |type-fail-schema-call-arg-type) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |type-fail-trait-method-generic-receiver) (:version |0.0.0)
   :entries $ {}
-    :default $ {} (:description |) (:init-fn 'type-fail-schema-call-arg-type.main/main!) (:mode :native) (:reload-fn 'type-fail-schema-call-arg-type.main/reload!)
+    :default $ {} (:description |) (:init-fn 'type-fail-trait-method-generic-receiver.main/main!) (:mode :native) (:reload-fn 'type-fail-trait-method-generic-receiver.main/reload!)
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-schema-call-arg-type.main $ %{} :FileEntry
+    |type-fail-trait-method-generic-receiver.main $ %{} :FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Entry for type-fail schema call-site arg type mismatch")
+        |main! $ %{} :CodeEntry (:doc "|Entry for generic Option receiver method argument mismatch")
           :code $ quote
             defn main! (option) (option .unwrap-or 0)
           :examples $ []
@@ -28,5 +28,5 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for schema call-site mismatch")
-        :code $ quote (ns type-fail-schema-call-arg-type.main)
+      :ns $ %{} :NsEntry (:doc "|Namespace for generic method receiver mismatch")
+        :code $ quote (ns type-fail-trait-method-generic-receiver.main)

--- a/editing-history/202608071848-static-method-generic-validation.md
+++ b/editing-history/202608071848-static-method-generic-validation.md
@@ -1,0 +1,5 @@
+# Static Method Generic Validation
+
+- Postfix method rewrites now preprocess their receiver and arguments before static method validation and code generation.
+- Static implementation methods use their declared schemas, binding generic variables from the receiver before validating other arguments.
+- Added regressions for `Option<String>.unwrap-or Number` and an inline anonymous callback passed to `Option.map`.

--- a/editing-history/202608080132-pr-309-review-fixes.md
+++ b/editing-history/202608080132-pr-309-review-fixes.md
@@ -1,0 +1,5 @@
+# PR #309 Review Fixes
+
+- Reused the already-preprocessed postfix receiver and run static method argument validation for every statically known receiver.
+- Guard receiver-generic binding when a trait or enum method schema has no declared argument types, preventing an empty-list index panic.
+- Renamed the generic receiver mismatch fixture package, namespace, entry points, and documentation to match its purpose.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -152,6 +152,29 @@ fn type_fail_call_arg_fixture_reports_warning_code() {
 }
 
 #[test]
+fn type_fail_trait_method_generic_receiver_fixture_reports_warning_code() {
+  run_with_large_stack(|| {
+    let entries = load_fixture_entries("calcit/type-fail/trait-method-generic-receiver-mismatch.cirru");
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("trait method fixture should preprocess with warnings, not hard errors");
+
+    let warnings = warnings.borrow();
+    let matched: Vec<&LocatedWarning> = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_METHOD_ARG_TYPE_MISMATCH"))
+      .collect();
+    assert_eq!(matched.len(), 1, "expected one method argument warning, got: {warnings:?}");
+    assert!(
+      matched[0].message().contains(".unwrap-or") && matched[0].message().contains("expects type `:string`, but got `:number`"),
+      "warning message was: {}",
+      matched[0].message()
+    );
+  });
+}
+
+#[test]
 fn type_fail_generic_where_bound_fixture_reports_warning_code() {
   run_with_large_stack(|| {
     let entries = load_fixture_entries("calcit/type-fail/generic-where-bound-mismatch.cirru");

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1186,22 +1186,12 @@ fn preprocess_list_call(
           if is_nominal_or_trait || has_known_method {
             // Rewrite to (.method expr remaining_args...) — already handled by codegen
             let typed_method = Calcit::Method(method_name.clone(), calcit::MethodKind::Invoke(type_info.clone()));
-            let mut processed_args = CalcitList::new_inner_from(&[]);
-            processed_args = processed_args.push(preprocess_expr(
-              &head_form,
-              scope_defs,
-              scope_types,
-              file_ns,
-              check_warnings,
-              call_stack,
-            )?);
+            let mut processed_args = CalcitList::new_inner_from(&[head_form]);
             for arg in args.iter().skip(1) {
               processed_args = processed_args.push(preprocess_expr(arg, scope_defs, scope_types, file_ns, check_warnings, call_stack)?);
             }
             let processed_args = CalcitList::from(processed_args);
-            if type_info.as_ref().resolve_to_enum().is_some() {
-              check_record_method_args(&typed_method, &processed_args, scope_types, file_ns, &def_name, check_warnings);
-            }
+            check_record_method_args(&typed_method, &processed_args, scope_types, file_ns, &def_name, check_warnings);
 
             let mut ys = CalcitList::new_inner_from(&[typed_method]);
             for arg in processed_args.iter() {
@@ -2186,7 +2176,7 @@ fn check_fn_args(
   }
 }
 
-// TODO this native implementation only handles symbols
+// Retrieves the definition name from a symbol or local receiver.
 fn grab_def_name(x: &Calcit) -> Arc<str> {
   match x {
     Calcit::Symbol { info, .. } | Calcit::Local(CalcitLocal { info, .. }) => info.at_def.to_owned(),
@@ -2693,10 +2683,12 @@ fn check_record_method_args(
     }
 
     let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
-    if let Some(receiver_type) = resolve_type_value(receiver, scope_types) {
+    if let Some(expected_receiver) = signature.arg_types.first()
+      && let Some(receiver_type) = resolve_type_value(receiver, scope_types)
+    {
       receiver_type
         .as_ref()
-        .matches_with_bindings(signature.arg_types[0].as_ref(), &mut bindings);
+        .matches_with_bindings(expected_receiver.as_ref(), &mut bindings);
     }
     let arg_types_without_receiver = signature.arg_types.iter().skip(1);
     for (idx, (arg, expected_type)) in method_args.iter().zip(arg_types_without_receiver).enumerate() {
@@ -2770,9 +2762,9 @@ fn check_record_method_args(
     }
 
     let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
-    type_value
-      .as_ref()
-      .matches_with_bindings(signature.arg_types[0].as_ref(), &mut bindings);
+    if let Some(expected_receiver) = signature.arg_types.first() {
+      type_value.as_ref().matches_with_bindings(expected_receiver.as_ref(), &mut bindings);
+    }
     for (idx, (arg, expected_type)) in method_args.iter().zip(signature.arg_types.iter().skip(1)).enumerate() {
       if matches!(**expected_type, CalcitTypeAnnotation::Dynamic) {
         continue;

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1020,7 +1020,8 @@ pub fn preprocess_expr(
     | Calcit::CirruQuote(..)
     | Calcit::StructDef(..)
     | Calcit::EnumDef(..)
-    | Calcit::Struct(..) => Ok(expr.to_owned()),
+    | Calcit::Struct(..)
+    | Calcit::Local(..) => Ok(expr.to_owned()),
     Calcit::Method(..) => Ok(expr.to_owned()),
     Calcit::Proc(..) => Ok(expr.to_owned()),
     Calcit::Syntax(..) => Ok(expr.to_owned()),
@@ -1049,7 +1050,12 @@ fn preprocess_list_call(
   let call_location = derive_call_expr_location(head);
   let head_form = preprocess_expr(head, scope_defs, scope_types, file_ns, check_warnings, call_stack)?;
   let args = xs.drop_left();
-  let def_name = grab_def_name(head);
+  let mut def_name = grab_def_name(head);
+  if def_name.as_ref() == "??"
+    && let Some(receiver) = args.first()
+  {
+    def_name = grab_def_name(receiver);
+  }
   let call_info = CallTypeCheckInfo {
     file_ns,
     def_name: &def_name,
@@ -1180,8 +1186,25 @@ fn preprocess_list_call(
           if is_nominal_or_trait || has_known_method {
             // Rewrite to (.method expr remaining_args...) — already handled by codegen
             let typed_method = Calcit::Method(method_name.clone(), calcit::MethodKind::Invoke(type_info.clone()));
-            let mut ys = CalcitList::new_inner_from(&[typed_method, head_form]);
+            let mut processed_args = CalcitList::new_inner_from(&[]);
+            processed_args = processed_args.push(preprocess_expr(
+              &head_form,
+              scope_defs,
+              scope_types,
+              file_ns,
+              check_warnings,
+              call_stack,
+            )?);
             for arg in args.iter().skip(1) {
+              processed_args = processed_args.push(preprocess_expr(arg, scope_defs, scope_types, file_ns, check_warnings, call_stack)?);
+            }
+            let processed_args = CalcitList::from(processed_args);
+            if type_info.as_ref().resolve_to_enum().is_some() {
+              check_record_method_args(&typed_method, &processed_args, scope_types, file_ns, &def_name, check_warnings);
+            }
+
+            let mut ys = CalcitList::new_inner_from(&[typed_method]);
+            for arg in processed_args.iter() {
               ys = ys.push(arg.to_owned());
             }
             return Ok(Calcit::from(CalcitList::from(ys)));
@@ -2166,7 +2189,7 @@ fn check_fn_args(
 // TODO this native implementation only handles symbols
 fn grab_def_name(x: &Calcit) -> Arc<str> {
   match x {
-    Calcit::Symbol { info, .. } => info.at_def.to_owned(),
+    Calcit::Symbol { info, .. } | Calcit::Local(CalcitLocal { info, .. }) => info.at_def.to_owned(),
     _ => String::from("??").into(),
   }
 }
@@ -2645,11 +2668,9 @@ fn check_record_method_args(
     return; // No type info, skip check
   };
 
-  if let Some(traits) = trait_list_from_type(type_value.as_ref()) {
-    let Some((trait_def, method_type)) = find_trait_method_type(&traits, method_name.as_ref()) else {
-      return;
-    };
-
+  if let Some(traits) = trait_list_from_type(type_value.as_ref())
+    && let Some((trait_def, method_type)) = find_trait_method_type(&traits, method_name.as_ref())
+  {
     let Some(signature) = method_type.as_function() else {
       return;
     };
@@ -2672,6 +2693,11 @@ fn check_record_method_args(
     }
 
     let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
+    if let Some(receiver_type) = resolve_type_value(receiver, scope_types) {
+      receiver_type
+        .as_ref()
+        .matches_with_bindings(signature.arg_types[0].as_ref(), &mut bindings);
+    }
     let arg_types_without_receiver = signature.arg_types.iter().skip(1);
     for (idx, (arg, expected_type)) in method_args.iter().zip(arg_types_without_receiver).enumerate() {
       if matches!(**expected_type, CalcitTypeAnnotation::Dynamic) {
@@ -2681,7 +2707,7 @@ fn check_record_method_args(
       if let Some(actual_type) = resolve_type_value(arg, scope_types)
         && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
       {
-        let expected_str = expected_type.as_ref().to_brief_string();
+        let expected_str = expected_type.substitute_type_vars(&bindings).to_brief_string();
         let actual_str = actual_type.as_ref().to_brief_string();
         gen_check_warning(
           format!(
@@ -2709,13 +2735,69 @@ fn check_record_method_args(
   };
 
   // Get function info from method entry
-  let fn_info: Option<&CalcitFn> = match method_entry {
-    Calcit::Fn { info, .. } => Some(info.as_ref()),
-    Calcit::Import(_import) => {
-      // Imports will be inlined and checked by check_proc_arg_types later
-      // Skip checking here to avoid duplicate warnings
+  let declared_schema = match method_entry {
+    Calcit::Import(import) => Some((
+      program::lookup_def_schema(&import.ns, &import.def),
+      format!("{} / {}", import.ns, import.def),
+    )),
+    Calcit::Fn { info, .. } if info.def_ref.is_some() => Some((
+      program::lookup_def_schema(&info.def_ns, &info.name),
+      format!("{} / {}", info.def_ns, info.name),
+    )),
+    _ => None,
+  };
+  if let Some((schema, implementation_name)) = declared_schema
+    && schema.contains_type_var()
+    && type_value.as_ref().resolve_to_enum().is_some()
+  {
+    let Some(signature) = schema.as_function() else {
+      return;
+    };
+    let Ok(method_args) = args.skip(1) else {
+      return;
+    };
+    let expected_count = signature.arg_types.len();
+    let actual_with_receiver = method_args.len() + 1;
+    if expected_count != 0 && expected_count != actual_with_receiver {
+      gen_check_warning(
+        format!(
+          "[Warn] Method `.{method_name}` expects {expected_count} args (including receiver), got {actual_with_receiver} in call at {file_ns}/{def_name}"
+        ),
+        file_ns,
+        check_warnings,
+      );
       return;
     }
+
+    let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
+    type_value
+      .as_ref()
+      .matches_with_bindings(signature.arg_types[0].as_ref(), &mut bindings);
+    for (idx, (arg, expected_type)) in method_args.iter().zip(signature.arg_types.iter().skip(1)).enumerate() {
+      if matches!(**expected_type, CalcitTypeAnnotation::Dynamic) {
+        continue;
+      }
+      if let Some(actual_type) = resolve_type_value(arg, scope_types)
+        && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
+      {
+        let expected_str = expected_type.substitute_type_vars(&bindings).to_brief_string();
+        let actual_str = actual_type.as_ref().to_brief_string();
+        gen_check_warning_code(
+          format!(
+            "[Warn] Method `.{method_name}` arg {} expects type `{expected_str}`, but got `{actual_str}` in call at {file_ns}/{def_name} (implementation {implementation_name})",
+            idx + 2,
+          ),
+          "W_METHOD_ARG_TYPE_MISMATCH",
+          file_ns,
+          check_warnings,
+        );
+      }
+    }
+    return;
+  }
+
+  let fn_info: Option<&CalcitFn> = match method_entry {
+    Calcit::Fn { info, .. } => Some(info.as_ref()),
     Calcit::Proc(_proc) => {
       // Procs will be inlined and checked by check_proc_arg_types later
       // Skip checking here to avoid duplicate warnings


### PR DESCRIPTION
Fixes #307
Fixes #308

## Summary
- preprocess postfix method arguments before lowering, so inline callbacks are compiled for JS
- validate generic nominal-enum implementation methods using bindings inferred from their receiver
- report stable `W_METHOD_ARG_TYPE_MISMATCH` diagnostics for invalid specialized fallback values
- add Option callback and type-fail regressions

## Validation
- cargo test
- cargo clippy -- -D warnings
- yarn compile
- yarn check-agent-interface
- cargo run --bin cr -- calcit/test-traits.cirru
- cargo run --bin cr -- calcit/test-traits.cirru js