### PR TITLE
chore: release 0.13.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/20260808-1020-release-0.13.3.md
+++ b/editing-history/20260808-1020-release-0.13.3.md
@@ -1,0 +1,7 @@
+# Release 0.13.3
+
+在合并 Struct/Enum terminology migration、deprecated API analysis 与跨后端
+canonical EDN formatting 修复后，将 Rust crate 与 npm package 版本从 `0.13.2`
+同步升级至 `0.13.3`。
+
+验证：`cargo update --workspace`、`cargo test`、`yarn compile`。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Release 0.13.3

- Sync Cargo and npm package versions to `0.13.3`.
- Refresh `Cargo.lock` with `cargo update --workspace`.

Validation:
- `cargo test`
- `yarn compile`
- `cargo fmt --check`