### PR TITLE
feat: prefer inferred Option and Result methods

### DIFF
--- a/calcit/add.cirru
+++ b/calcit/add.cirru
@@ -5,13 +5,13 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ + 1 2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require

--- a/calcit/debug/check-args.cirru
+++ b/calcit/debug/check-args.cirru
@@ -5,14 +5,14 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |check-args.main $ %{} :FileEntry
+    |check-args.main $ %{} 'FileEntry
       :defs $ {}
-        |f1 $ %{} :CodeEntry (:doc |)
+        |f1 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn f1 (a) (:: 'Unit)
           :examples $ []
           :schema $ :: 'Dynamic
-        |f2 $ %{} :CodeEntry (:doc |)
+        |f2 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn f2 (a ? b)
               hint-fn $ {}
@@ -21,17 +21,17 @@
               :: :unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |f3 $ %{} :CodeEntry (:doc |)
+        |f3 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn f3 (a & b) (:: 'Unit)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (; "bad case examples for args checking") (f1 1 4) (f2 1) (f2 1 2) (f2 1 2 4) (f2) (f3 1) (f3 1 2) (f3 1 2 3) (f3)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns check-args.main $ :require
             [] util.core :refer $ [] log-title inside-eval:

--- a/calcit/debug/debug-overflow.cirru
+++ b/calcit/debug/debug-overflow.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |debug-overflow.main $ %{} :FileEntry
+    |debug-overflow.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println |TODO) (; rec 1 2 3 4 5 6 7 8 9)
               println $ my-cond
@@ -17,7 +17,7 @@
                 true 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |my-cond $ %{} :CodeEntry (:doc |)
+        |my-cond $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro my-cond (pair & else)
               &let
@@ -31,7 +31,7 @@
                         ~@ $ rest else
           :examples $ []
           :schema $ :: 'Dynamic
-        |rec $ %{} :CodeEntry (:doc |)
+        |rec $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro rec (x0 & xs)
               quasiquote $ if (&> ~x0 10) "|Too large"
@@ -41,7 +41,7 @@
                     rec $ ~@ xs
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns debug-overflow.main $ :require
             [] util.core :refer $ [] log-title inside-eval:

--- a/calcit/debug/macro-ns.cirru
+++ b/calcit/debug/macro-ns.cirru
@@ -5,30 +5,30 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |macro-ns.lib $ %{} :FileEntry
+    |macro-ns.lib $ %{} 'FileEntry
       :defs $ {}
-        |expand-1 $ %{} :CodeEntry (:doc |)
+        |expand-1 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro expand-1 (n) (println "|local data" v)
               quasiquote $ println ~n ~v
           :examples $ []
           :schema $ :: 'Dynamic
-        |v $ %{} :CodeEntry (:doc |)
+        |v $ %{} 'CodeEntry (:doc |)
           :code $ quote (def v 100)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns macro-ns.lib $ :require
             [] util.core :refer $ [] log-title inside-eval:
-    |macro-ns.main $ %{} :FileEntry
+    |macro-ns.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ expand-1 1
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns macro-ns.main $ :require
             macro-ns.lib :refer $ expand-1

--- a/calcit/debug/var-shadow.cirru
+++ b/calcit/debug/var-shadow.cirru
@@ -5,15 +5,15 @@
       :modules $ [] |./check-args.cirru
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ let
                 f1 "|local function"
               println check/f1
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require ([] check-args.main :as check)

--- a/calcit/fibo.cirru
+++ b/calcit/fibo.cirru
@@ -8,9 +8,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |fibo $ %{} :CodeEntry (:doc |)
+        |fibo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn fibo (x)
               if (< x 2) 1 $ +
@@ -18,17 +18,17 @@
                 fibo $ - x 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|Loaded program!") (try-fibo)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |sieve-primes $ %{} :CodeEntry (:doc |)
+        |sieve-primes $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sieve-primes (acc n limit)
               if (&> n limit) acc $ if
@@ -38,19 +38,19 @@
                 recur acc (inc n) limit
           :examples $ []
           :schema $ :: 'Dynamic
-        |try-fibo $ %{} :CodeEntry (:doc |)
+        |try-fibo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-fibo () $ let
                 n 22
               println "|fibo result:" n $ fibo n
           :examples $ []
           :schema $ :: 'Dynamic
-        |try-prime $ %{} :CodeEntry (:doc |)
+        |try-prime $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-prime () $ println
               sieve-primes ([] 2 3 5 7 11 13) 17 400
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require

--- a/calcit/scripts/bundle-calcit.cirru
+++ b/calcit/scripts/bundle-calcit.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Bundle indentation-based Calcit source files into a runnable snapshot.")
+        |main! $ %{} 'CodeEntry (:doc "|Bundle indentation-based Calcit source files into a runnable snapshot.")
           :code $ quote
             defn main! () $ let
                 CodeEntry $ defstruct CodeEntry (:doc 'String) (:code 'Dynamic) (:examples 'List)
@@ -61,10 +61,10 @@
               println $ str-spaced |wrote output-path |with (count files) |namespaces
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.main)

--- a/calcit/scripts/sync-calcit.cirru
+++ b/calcit/scripts/sync-calcit.cirru
@@ -5,9 +5,9 @@
       :modules $ [] |bisection-key/
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Synchronize a compact snapshot into a detailed calcit.cirru snapshot.")
+        |main! $ %{} 'CodeEntry (:doc "|Synchronize a compact snapshot into a detailed calcit.cirru snapshot.")
           :code $ quote
             defn main! () $ let
                 Leaf $ defstruct Leaf (:at 'Number) (:by 'String) (:text 'String)
@@ -109,12 +109,12 @@
               println $ str-spaced |synced compact-path |to calcit-path
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require
             bisection-key.util :refer $ assoc-append val-nth

--- a/calcit/test-algebra.cirru
+++ b/calcit/test-algebra.cirru
@@ -5,29 +5,29 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-algebra.main $ %{} :FileEntry
+    |test-algebra.main $ %{} 'FileEntry
       :defs $ {}
-        |AlgebraApply $ %{} :CodeEntry (:doc |)
+        |AlgebraApply $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait AlgebraApply $ .apply :fn
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraBind $ %{} :CodeEntry (:doc |)
+        |AlgebraBind $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait AlgebraBind $ .bind :fn
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraBox $ %{} :CodeEntry (:doc |)
+        |AlgebraBox $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def AlgebraBox $ impl-traits AlgebraBox0 AlgebraBoxMapImpl AlgebraBoxBindImpl AlgebraBoxApplyImpl AlgebraBoxMappendImpl
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraBox0 $ %{} :CodeEntry (:doc |)
+        |AlgebraBox0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct AlgebraBox0 $ :value 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraBoxApplyImpl $ %{} :CodeEntry (:doc |)
+        |AlgebraBoxApplyImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl AlgebraBoxApplyImpl AlgebraApply $ .apply
               fn (box fs)
@@ -36,52 +36,52 @@
                   assoc box :value $ f (&struct:get box :value)
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraBoxBindImpl $ %{} :CodeEntry (:doc |)
+        |AlgebraBoxBindImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl AlgebraBoxBindImpl AlgebraBind $ .bind
               fn (box f)
                 f $ &struct:get box :value
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraBoxMapImpl $ %{} :CodeEntry (:doc |)
+        |AlgebraBoxMapImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl AlgebraBoxMapImpl AlgebraMap $ .map
               fn (box f)
                 assoc box :value $ f (&struct:get box :value)
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraBoxMappendImpl $ %{} :CodeEntry (:doc |)
+        |AlgebraBoxMappendImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl AlgebraBoxMappendImpl AlgebraMappend $ .mappend
               fn (a b)
                 assoc a :value $ + (&struct:get a :value) (&struct:get b :value)
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraMap $ %{} :CodeEntry (:doc |)
+        |AlgebraMap $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait AlgebraMap $ .map :fn
           :examples $ []
           :schema $ :: 'Dynamic
-        |AlgebraMappend $ %{} :CodeEntry (:doc |)
+        |AlgebraMappend $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait AlgebraMappend $ .mappend :fn
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing algebra") (; "|Experimental code, to simulate usages like Monad") (test-map) (test-bind) (test-apply) (test-mappend)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-apply $ %{} :CodeEntry (:doc |)
+        |test-apply $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-apply () $ let
                 b1 $ %{} AlgebraBox (:value 3)
@@ -96,7 +96,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-bind $ %{} :CodeEntry (:doc |)
+        |test-bind $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-bind () $ let
                 b1 $ %{} AlgebraBox (:value 5)
@@ -110,7 +110,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-map $ %{} :CodeEntry (:doc |)
+        |test-map $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-map () $ let
                 b1 $ %{} AlgebraBox (:value 2)
@@ -123,7 +123,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-mappend $ %{} :CodeEntry (:doc |)
+        |test-mappend $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-mappend () $ let
                 b1 $ %{} AlgebraBox (:value 3)
@@ -137,7 +137,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-algebra $ :require
             util.core :refer $ log-title inside-eval:

--- a/calcit/test-anonymous-enum.cirru
+++ b/calcit/test-anonymous-enum.cirru
@@ -5,14 +5,14 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-anonymous-enum.main $ %{} :FileEntry
+    |test-anonymous-enum.main $ %{} 'FileEntry
       :defs $ {}
-        |Result $ %{} :CodeEntry (:doc |)
+        |Result $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Result (:ok 'Number) (:err 'String)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing anonymous enum")
               assert= (:: :parts |1 |23)
@@ -76,7 +76,7 @@
                 assert= (%none) (enum-definition plain)
           :examples $ []
           :schema $ :: 'Dynamic
-        |try-size $ %{} :CodeEntry (:doc |)
+        |try-size $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-size (x)
               tag-match x
@@ -89,7 +89,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-anonymous-enum.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-cond.cirru
+++ b/calcit/test-cond.cirru
@@ -5,14 +5,14 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-cond.main $ %{} :FileEntry
+    |test-cond.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing cond") (test-when) (test-cond) (test-or) (test-and) (test-either) (test-case) (test-tag-match) (test-field-match) true
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-and $ %{} :CodeEntry (:doc |)
+        |test-and $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing and")
               assert= (and 1) 1
@@ -34,7 +34,7 @@
                 , false
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-case $ %{} :CodeEntry (:doc |)
+        |test-case $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-case ()
               let
@@ -57,7 +57,7 @@
                 assert= (detect-x 2) |two
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-cond $ %{} :CodeEntry (:doc |)
+        |test-cond $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-cond () $ let
                 compare-x $ fn (x)
@@ -72,7 +72,7 @@
               assert= (compare-x 4) |<=5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-either $ %{} :CodeEntry (:doc |)
+        |test-either $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing either")
               assert= 1 $ either nil 1
@@ -82,7 +82,7 @@
               assert= 1 $ either (do nil) (do 1) (do nil)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-field-match $ %{} :CodeEntry (:doc |)
+        |test-field-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing field-match")
               &let
@@ -100,7 +100,7 @@
                 assert= :other $ match-ab (&{} :tag :c)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-or $ %{} :CodeEntry (:doc |)
+        |test-or $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing or")
               assert= (or 1) 1
@@ -123,7 +123,7 @@
                 , false
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tag-match $ %{} :CodeEntry (:doc |)
+        |test-tag-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing tag-match")
               ; println |EXPANDED $ format-to-cirru
@@ -158,7 +158,7 @@
                   [] "|no match"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-when $ %{} :CodeEntry (:doc |)
+        |test-when $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing when")
               assert= 1 $ when true 1
@@ -167,7 +167,7 @@
               assert= 1 $ when-not false 2 1
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-cond.main $ :require
             util.core :refer $ inside-eval: log-title

--- a/calcit/test-def-meta.cirru
+++ b/calcit/test-def-meta.cirru
@@ -5,26 +5,26 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-def-meta.main $ %{} :FileEntry
+    |test-def-meta.main $ %{} 'FileEntry
       :defs $ {}
-        |MetaSample $ %{} :CodeEntry (:doc "|Sample definition for def metadata lookup tests")
+        |MetaSample $ %{} 'CodeEntry (:doc "|Sample definition for def metadata lookup tests")
           :code $ quote
             defn MetaSample (x) (+ x 1)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-        |main! $ %{} :CodeEntry (:doc "|Run def metadata lookup tests")
+        |main! $ %{} 'CodeEntry (:doc "|Run def metadata lookup tests")
           :code $ quote
             defn main! () (log-title "|Testing def metadata") (test-local-def) (test-core-def) (test-missing-doc)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-core-def $ %{} :CodeEntry (:doc "|lookup calcit.core definitions")
+        |test-core-def $ %{} 'CodeEntry (:doc "|lookup calcit.core definitions")
           :code $ quote
             defn test-core-def () $ inside-eval:
               let
@@ -36,7 +36,7 @@
                   get (&enum:nth schema 1) :args
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-local-def $ %{} :CodeEntry (:doc "|lookup local definition metadata")
+        |test-local-def $ %{} 'CodeEntry (:doc "|lookup local definition metadata")
           :code $ quote
             defn test-local-def () $ inside-eval:
               let
@@ -48,13 +48,13 @@
                   get (&enum:nth schema 1) :return
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-missing-doc $ %{} :CodeEntry (:doc "|missing definition returns empty doc string")
+        |test-missing-doc $ %{} 'CodeEntry (:doc "|missing definition returns empty doc string")
           :code $ quote
             defn test-missing-doc () $ inside-eval:
               assert= | $ &get-def-doc |test-def-meta.main/not-a-real-def
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-def-meta.main $ :require
             util.core :refer $ log-title inside-eval:

--- a/calcit/test-doc-smoke.cirru
+++ b/calcit/test-doc-smoke.cirru
@@ -5,41 +5,41 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-doc-smoke.main $ %{} :FileEntry
+    |test-doc-smoke.main $ %{} 'FileEntry
       :defs $ {}
-        |DocEnum0 $ %{} :CodeEntry (:doc "|Doc smoke enum")
+        |DocEnum0 $ %{} 'CodeEntry (:doc "|Doc smoke enum")
           :code $ quote
             defenum DocEnum $ :ok 'String
           :examples $ []
           :schema $ :: 'Dynamic
-        |DocPerson0 $ %{} :CodeEntry (:doc "|Doc smoke struct")
+        |DocPerson0 $ %{} 'CodeEntry (:doc "|Doc smoke struct")
           :code $ quote
             defstruct DocPerson $ :name 'String
           :examples $ []
           :schema $ :: 'Dynamic
-        |DocTrait $ %{} :CodeEntry (:doc "|Doc smoke trait")
+        |DocTrait $ %{} 'CodeEntry (:doc "|Doc smoke trait")
           :code $ quote
             deftrait DocTrait $ .label :fn
           :examples $ []
           :schema $ :: 'Dynamic
-        |DocTraitImpl $ %{} :CodeEntry (:doc "|Doc smoke impl")
+        |DocTraitImpl $ %{} 'CodeEntry (:doc "|Doc smoke impl")
           :code $ quote
             defimpl DocTraitImpl DocTrait $ .label
               fn (x)
                 str-spaced |doc $ &struct:get x :name
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc "|Run docs smoke cases")
+        |main! $ %{} 'CodeEntry (:doc "|Run docs smoke cases")
           :code $ quote
             defn main! () (println "|Testing doc smoke cases...") (test-defimpl-order) (test-native-impl-new-dot-method) (test-assert-traits-local) (test-impl-traits-struct-enum-only) (println "|Doc smoke cases passed")
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-assert-traits-local $ %{} :CodeEntry (:doc "|assert-traits local first arg smoke")
+        |test-assert-traits-local $ %{} 'CodeEntry (:doc "|assert-traits local first arg smoke")
           :code $ quote
             defn test-assert-traits-local () $ let
                 DocPerson $ impl-traits DocPerson0 DocTraitImpl
@@ -48,12 +48,12 @@
               assert= "|doc Alice" $ p .label
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-defimpl-order $ %{} :CodeEntry (:doc "|defimpl arg order smoke")
+        |test-defimpl-order $ %{} 'CodeEntry (:doc "|defimpl arg order smoke")
           :code $ quote
             defn test-defimpl-order () $ assert= (%some DocTrait) (impl-origin DocTraitImpl)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-impl-traits-struct-enum-only $ %{} :CodeEntry (:doc "|impl-traits only accepts struct/enum definitions")
+        |test-impl-traits-struct-enum-only $ %{} 'CodeEntry (:doc "|impl-traits only accepts struct/enum definitions")
           :code $ quote
             defn test-impl-traits-struct-enum-only ()
               let
@@ -74,7 +74,7 @@
                   assert= true $ includes? msg |Fix:
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-native-impl-new-dot-method $ %{} :CodeEntry (:doc "|&impl::new accepts .method field keys")
+        |test-native-impl-new-dot-method $ %{} 'CodeEntry (:doc "|&impl::new accepts .method field keys")
           :code $ quote
             defn test-native-impl-new-dot-method () $ let
                 DotImpl $ &impl::new DocTrait
@@ -86,7 +86,7 @@
               assert= "|native-dot Bob" $ p .label
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-doc-smoke.main $ :require
             util.core :refer $ inside-eval:

--- a/calcit/test-edn.cirru
+++ b/calcit/test-edn.cirru
@@ -5,39 +5,39 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-edn.main $ %{} :FileEntry
+    |test-edn.main $ %{} 'FileEntry
       :defs $ {}
-        |A $ %{} :CodeEntry (:doc |)
+        |A $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct A $ :a 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |A-typed-person $ %{} :CodeEntry (:doc |)
+        |A-typed-person $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def A-typed-person $ parse-cirru-edn-as "|%{} :Person (:age 23) (:name |Top)" Person
           :examples $ []
           :schema $ :: 'Dynamic
-        |Box $ %{} :CodeEntry (:doc |)
+        |Box $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Box ([] 'T) (:value 'T)
           :examples $ []
           :schema $ :: 'Dynamic
-        |DemoEnum $ %{} :CodeEntry (:doc |)
+        |DemoEnum $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum DemoEnum (:ok) (:err 'String)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Person $ %{} :CodeEntry (:doc |)
+        |Person $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Person (:name 'String) (:age 'Number)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Team $ %{} :CodeEntry (:doc |)
+        |Team $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Team $ :members (:: 'List Person)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing edn") (test-edn) (test-edn-comment)
               inside-eval: $ test-symbol
@@ -47,14 +47,14 @@
               test-top-level-typed-edn
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-atom $ %{} :CodeEntry (:doc |)
+        |test-atom $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-atom () (log-title "|Testing atom to edn")
               let
@@ -65,7 +65,7 @@
                 assert= "|atom 1" $ trim (format-cirru-edn a)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-edn $ %{} :CodeEntry (:doc |)
+        |test-edn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-edn () $ let
                 edn-demo "|%{} :Person (:age 23) (:name |Chen)"
@@ -139,7 +139,7 @@
               assert= "|do |hello" $ trim (format-cirru-edn |hello)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-edn-comment $ %{} :CodeEntry (:doc |)
+        |test-edn-comment $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-edn-comment () (log-title "|Testing edn comment")
               assert=
@@ -151,14 +151,14 @@
               assert= (:: :a 1) (parse-cirru-edn "|:: :a (; comment) 1")
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-imported-typed-edn $ %{} :CodeEntry (:doc |)
+        |test-imported-typed-edn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-imported-typed-edn () $ assert=
               %{} External $ :label |linked
               parse-cirru-edn-as "|%{} :External (:label |linked)" External
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-symbol $ %{} :CodeEntry (:doc |)
+        |test-symbol $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-symbol () (log-title "|Testing symbol to edn")
               assert= (&extract-code-into-edn 'aa)
@@ -182,14 +182,14 @@
                 assert= code $ eval (&data-to-code code)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-top-level-typed-edn $ %{} :CodeEntry (:doc |)
+        |test-top-level-typed-edn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-top-level-typed-edn () $ assert=
               %{} Person (:name |Top) (:age 23)
               , A-typed-person
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-typed-edn $ %{} :CodeEntry (:doc |)
+        |test-typed-edn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-typed-edn () $ let
                 person $ parse-cirru-edn-as "|%{} :Person (:age 23) (:name |Ada)" Person
@@ -233,17 +233,17 @@
                 parse-cirru-edn-as "|{} (:a |first) (:a |second)" $ :: 'Map 'Tag 'String
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-edn.main $ :require
             util.core :refer $ inside-eval: log-title
             test-edn.schema :refer $ External
-    |test-edn.schema $ %{} :FileEntry
+    |test-edn.schema $ %{} 'FileEntry
       :defs $ {}
-        |External $ %{} :CodeEntry (:doc |)
+        |External $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct External $ :label 'String
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-edn.schema)

--- a/calcit/test-effects-graph.cirru
+++ b/calcit/test-effects-graph.cirru
@@ -5,28 +5,28 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-effects-graph.main $ %{} :FileEntry
+    |test-effects-graph.main $ %{} 'FileEntry
       :defs $ {}
-        |io-helper $ %{} :CodeEntry (:doc "|reads a file path")
+        |io-helper $ %{} 'CodeEntry (:doc "|reads a file path")
           :code $ quote
             defn io-helper (path) (read-file path)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc "|entry with io and state effects")
+        |main! $ %{} 'CodeEntry (:doc "|entry with io and state effects")
           :code $ quote
             defn main! () (println "|effects-graph smoke") (state-helper) (io-helper |README.md)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |state-helper $ %{} :CodeEntry (:doc "|defines and mutates an atom")
+        |state-helper $ %{} 'CodeEntry (:doc "|defines and mutates an atom")
           :code $ quote
             defn state-helper () (defatom *counter 0) (reset! *counter 1) (swap! *counter inc)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-effects-graph.main $

--- a/calcit/test-enum.cirru
+++ b/calcit/test-enum.cirru
@@ -5,30 +5,30 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-enum.main $ %{} :FileEntry
+    |test-enum.main $ %{} 'FileEntry
       :defs $ {}
-        |Duo $ %{} :CodeEntry (:doc "|Generic enum with 2 type variables")
+        |Duo $ %{} 'CodeEntry (:doc "|Generic enum with 2 type variables")
           :code $ quote
             defenum Duo ('T 'U) (:pair 'T 'U) (:swapped 'U 'T)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Maybe1 $ %{} :CodeEntry (:doc "|Generic enum with 1 type variable")
+        |Maybe1 $ %{} 'CodeEntry (:doc "|Generic enum with 1 type variable")
           :code $ quote
             defenum Maybe1 ('T) (:some 'T) (:none)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Result0 $ %{} :CodeEntry (:doc |)
+        |Result0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Result0 (:err 'String) (:ok)
           :examples $ []
           :schema $ :: 'Dynamic
-        |ResultImpl $ %{} :CodeEntry (:doc |)
+        |ResultImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl ResultImpl ResultTrait $ .dummy
               fn $ _x
           :examples $ []
           :schema $ :: 'Dynamic
-        |ResultTrait $ %{} :CodeEntry (:doc |)
+        |ResultTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait ResultTrait $ .dummy
               :: :fn $ {}
@@ -37,14 +37,14 @@
                 :return 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |ShownBox $ %{} :CodeEntry (:doc "|Generic struct with where-bound on payload type")
+        |ShownBox $ %{} 'CodeEntry (:doc "|Generic struct with where-bound on payload type")
           :code $ quote
             defstruct ShownBox ('T)
               ({} ('T Show))
               (:value 'T)
           :examples $ []
           :schema $ :: 'Dynamic
-        |ShownMaybe $ %{} :CodeEntry (:doc "|Generic enum with where-bound on payload type")
+        |ShownMaybe $ %{} 'CodeEntry (:doc "|Generic enum with where-bound on payload type")
           :code $ quote
             defenum ShownMaybe ('T)
               ({} ('T Show))
@@ -52,7 +52,7 @@
               (:none)
           :examples $ []
           :schema $ :: 'Dynamic
-        |check-result-type $ %{} :CodeEntry (:doc "|Check if value has enum origin")
+        |check-result-type $ %{} 'CodeEntry (:doc "|Check if value has enum origin")
           :code $ quote
             defn check-result-type (r)
               option:some? $ enum-definition r
@@ -60,21 +60,21 @@
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] 'test-enum.main/Result0
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ do (println "|Testing enum runtime validation...") (test-enum-creation) (test-generic-enum-creation) (test-generic-enum-where-bounds) (test-where-bound-definitions) (test-tag-match-validation) (test-anonymous-enum-to-named) (test-match) (println "|All tests passed!")
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ println |Reloaded
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |takes-result $ %{} :CodeEntry (:doc "|Function accepting Result0 enum type")
+        |takes-result $ %{} 'CodeEntry (:doc "|Function accepting Result0 enum type")
           :code $ quote
             defn takes-result (r)
               tag-match r
@@ -85,7 +85,20 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'test-enum.main/Result0
-        |test-enum-creation $ %{} :CodeEntry (:doc |)
+        |test-anonymous-enum-to-named $ %{} 'CodeEntry (:doc "|Test automatic anonymous-enum-to-named rewrite")
+          :code $ quote
+            defn test-anonymous-enum-to-named () $ do (println "|Testing anonymous-enum-to-named rewrite...") (; Untyped anonymous enum :: :ok gets rewritten to %:: Result0 :ok)
+              assert= :ok $ takes-result (:: :ok)
+              ; Untyped tuple with payload
+              assert= |error-msg $ takes-result (:: :err |error-msg)
+              ; Verify the rewritten value has enum origin
+              assert= true $ check-result-type (:: :ok)
+              println "|✓ Tuple-to-enum rewrite passed"
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        |test-enum-creation $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-enum-creation () $ do (println "|Testing enum tuple creation...")
               let
@@ -115,7 +128,7 @@
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-generic-enum-creation $ %{} :CodeEntry (:doc "|Exercise defenum generic variables in runtime creation and matching")
+        |test-generic-enum-creation $ %{} 'CodeEntry (:doc "|Exercise defenum generic variables in runtime creation and matching")
           :code $ quote
             defn test-generic-enum-creation () $ do (println "|Testing generic enum creation...")
               let
@@ -139,7 +152,7 @@
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-generic-enum-where-bounds $ %{} :CodeEntry (:doc "|Exercise where-bounds with generic enum payloads")
+        |test-generic-enum-where-bounds $ %{} 'CodeEntry (:doc "|Exercise where-bounds with generic enum payloads")
           :code $ quote
             defn test-generic-enum-where-bounds () $ let
                 render-maybe $ fn (v)
@@ -174,7 +187,7 @@
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-match $ %{} :CodeEntry (:doc |)
+        |test-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-match ()
               let
@@ -199,7 +212,7 @@
               println "|✓ match syntax passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tag-match-validation $ %{} :CodeEntry (:doc |)
+        |test-tag-match-validation $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-tag-match-validation () $ do (println "|Testing tag-match runtime validation...")
               let
@@ -213,20 +226,7 @@
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-anonymous-enum-to-named $ %{} :CodeEntry (:doc "|Test automatic anonymous-enum-to-named rewrite")
-          :code $ quote
-            defn test-anonymous-enum-to-named () $ do (println "|Testing anonymous-enum-to-named rewrite...") (; Untyped anonymous enum :: :ok gets rewritten to %:: Result0 :ok)
-              assert= :ok $ takes-result (:: :ok)
-              ; Untyped tuple with payload
-              assert= |error-msg $ takes-result (:: :err |error-msg)
-              ; Verify the rewritten value has enum origin
-              assert= true $ check-result-type (:: :ok)
-              println "|✓ Tuple-to-enum rewrite passed"
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Unit)
-              :args $ []
-        |test-where-bound-definitions $ %{} :CodeEntry (:doc "|Exercise defstruct/defenum where-map syntax on generic data types")
+        |test-where-bound-definitions $ %{} 'CodeEntry (:doc "|Exercise defstruct/defenum where-map syntax on generic data types")
           :code $ quote
             defn test-where-bound-definitions () $ do (println "|Testing data definition where-bounds...")
               let
@@ -248,7 +248,7 @@
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |unwrap-maybe $ %{} :CodeEntry (:doc "|Convert Maybe1<T> into nominal Option<T>.")
+        |unwrap-maybe $ %{} 'CodeEntry (:doc "|Convert Maybe1<T> into nominal Option<T>.")
           :code $ quote
             defn unwrap-maybe (v)
               match v
@@ -260,5 +260,5 @@
               :args $ [] (:: 'test-enum.main/Maybe1 'T)
               :generics $ [] 'T
               :return $ :: 'Option 'T
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-enum.main)

--- a/calcit/test-fn.cirru
+++ b/calcit/test-fn.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-fn.main $ %{} :FileEntry
+    |test-fn.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing fn")
               let
@@ -25,7 +25,7 @@
                 assert= 3 $ apply f2 ([] 1 2)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-fn.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-generics.cirru
+++ b/calcit/test-generics.cirru
@@ -5,37 +5,37 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-generics.main $ %{} :FileEntry
+    |test-generics.main $ %{} 'FileEntry
       :defs $ {}
-        |Box $ %{} :CodeEntry (:doc "|Generic box struct")
+        |Box $ %{} 'CodeEntry (:doc "|Generic box struct")
           :code $ quote
             defstruct Box ([] 'T) (:value 'T)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Holder $ %{} :CodeEntry (:doc "|Generic holder wrapping Box")
+        |Holder $ %{} 'CodeEntry (:doc "|Generic holder wrapping Box")
           :code $ quote
             defstruct Holder ([] 'T)
               :box $ :: 'Box 'T
           :examples $ []
           :schema $ :: 'Dynamic
-        |Node $ %{} :CodeEntry (:doc |)
+        |Node $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Node
               :next $ :: 'Optional Node
               :value 'Number
           :examples $ []
           :schema $ :: 'Dynamic
-        |Pair $ %{} :CodeEntry (:doc "|Generic pair struct")
+        |Pair $ %{} 'CodeEntry (:doc "|Generic pair struct")
           :code $ quote
             defstruct Pair ([] 'T 'U) (:left 'T) (:right 'U)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ do (println "|Testing generics...") (println "|  - generic structs") (test-struct-generics) (println "|  - function generics and where-bounds") (test-recursive-struct) (test-fn-generics) (println "|Generics tests passed")
           :examples $ []
           :schema $ :: 'Dynamic
-        |pair-right $ %{} :CodeEntry (:doc "|Return the right value from a generic pair")
+        |pair-right $ %{} 'CodeEntry (:doc "|Return the right value from a generic pair")
           :code $ quote
             defn pair-right (pair) (:right pair)
           :examples $ []
@@ -43,12 +43,12 @@
             {} (:return 'U)
               :args $ [] (:: 'test-generics.main/Pair 'T 'U)
               :generics $ [] 'T 'U
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-fn-generics $ %{} :CodeEntry (:doc |)
+        |test-fn-generics $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-fn-generics () $ let
                 id $ fn (x)
@@ -91,7 +91,7 @@
               &inspect-type show-id
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-recursive-struct $ %{} :CodeEntry (:doc |)
+        |test-recursive-struct $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-recursive-struct () (println "|Testing recursive struct support...")
               let
@@ -102,7 +102,7 @@
                 println "|Recursive struct support passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-generics $ %{} :CodeEntry (:doc |)
+        |test-struct-generics $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-struct-generics () $ do (println "|Testing generic struct support...")
               assert= 2 $ unbox (&%{} Box :value 2)
@@ -119,7 +119,7 @@
               println "|Generic struct support passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |unbox $ %{} :CodeEntry (:doc "|Return value from a generic box")
+        |unbox $ %{} 'CodeEntry (:doc "|Return value from a generic box")
           :code $ quote
             defn unbox (box) (:value box)
           :examples $ []
@@ -127,5 +127,5 @@
             {} (:return 'T)
               :args $ [] (:: 'test-generics.main/Box 'T)
               :generics $ [] 'T
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-generics.main)

--- a/calcit/test-hygienic.cirru
+++ b/calcit/test-hygienic.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-hygienic.lib $ %{} :FileEntry
+    |test-hygienic.lib $ %{} 'FileEntry
       :defs $ {}
-        |add-11 $ %{} :CodeEntry (:doc |)
+        |add-11 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro add-11 (a b)
               let
@@ -18,7 +18,7 @@
           :examples $ []
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic 'Dynamic)
-        |add-11-safe $ %{} :CodeEntry (:doc |)
+        |add-11-safe $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro add-11-safe (a b)
               with-gensyms (c)
@@ -28,25 +28,25 @@
           :examples $ []
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic 'Dynamic)
-        |add-2 $ %{} :CodeEntry (:doc |)
+        |add-2 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn add-2 (x) (&+ x 2)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (:ns test-hygienic.lib)
-    |test-hygienic.main $ %{} :FileEntry
+    |test-hygienic.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ try-hygienic
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ []
-        |try-hygienic $ %{} :CodeEntry (:doc |)
+        |try-hygienic $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn try-hygienic () (println "|Testing hygienic")
               let
@@ -58,7 +58,7 @@
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-hygienic.main $ :require
             test-hygienic.lib :refer $ add-11 add-11-safe

--- a/calcit/test-invalid-tag.cirru
+++ b/calcit/test-invalid-tag.cirru
@@ -5,20 +5,20 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-invalid-tag.main $ %{} :FileEntry
+    |test-invalid-tag.main $ %{} 'FileEntry
       :defs $ {}
-        |Result $ %{} :CodeEntry (:doc |)
+        |Result $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Result (:err 'String) (:ok)
           :examples $ []
           :schema $ :: 'Dynamic
-        |ResultImpl $ %{} :CodeEntry (:doc |)
+        |ResultImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl ResultImpl ResultTrait $ .dummy
               fn $ _x
           :examples $ []
           :schema $ :: 'Dynamic
-        |ResultTrait $ %{} :CodeEntry (:doc |)
+        |ResultTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait ResultTrait $ .dummy
               :: :fn $ {}
@@ -27,7 +27,7 @@
                 :return 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|Testing %:: call") (println |Result: Result)
               println |ResultImpl: ResultImpl (; Direct call to %:: to see if function is invoked) (println "|Calling %:: ...")
@@ -36,12 +36,12 @@
                 println "|Should not reach here:" result
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-invalid-tag.main)

--- a/calcit/test-ir-type-info.cirru
+++ b/calcit/test-ir-type-info.cirru
@@ -5,26 +5,26 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |get-number $ %{} :CodeEntry (:doc |)
+        |get-number $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn get-number () 'Number $ do 123
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ test-type-info
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-type-info $ %{} :CodeEntry (:doc |)
+        |test-type-info $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-type-info () $ let
                 x 123
@@ -51,5 +51,5 @@
                 println nested
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.main)

--- a/calcit/test-js.cirru
+++ b/calcit/test-js.cirru
@@ -5,15 +5,15 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-js.main $ %{} :FileEntry
+    |test-js.main $ %{} 'FileEntry
       :defs $ {}
-        |load-data-code $ %{} :CodeEntry (:doc |)
+        |load-data-code $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro load-data-code (s)
               &data-to-code $ parse-cirru-edn s
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing js") (test-js) (test-let-example) (test-collection) (test-async) (test-async-in-data) (test-data-gen) (test-regexp) (test-property) (test-tag-keys)
               when (> 1 2)
@@ -35,7 +35,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-async $ %{} :CodeEntry (:doc |)
+        |test-async $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () $ let
                 f1 $ fn ()
@@ -58,7 +58,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-async-in-data $ %{} :CodeEntry (:doc "|async fn inside data. if wrong, it will be a syntax error from await outside async")
+        |test-async-in-data $ %{} 'CodeEntry (:doc "|async fn inside data. if wrong, it will be a syntax error from await outside async")
           :code $ quote
             fn () $ let
                 timeout $ fn (ms)
@@ -78,7 +78,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-case-async $ %{} :CodeEntry (:doc "|case async")
+        |test-case-async $ %{} 'CodeEntry (:doc "|case async")
           :code $ quote
             fn ()
               hint-fn $ {} (:async true)
@@ -101,7 +101,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-collection $ %{} :CodeEntry (:doc |)
+        |test-collection $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing quick collection syntax")
               &let
@@ -140,7 +140,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-data-gen $ %{} :CodeEntry (:doc |)
+        |test-data-gen $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing code gen from Cirru Edn")
               assert=
@@ -148,7 +148,7 @@
                 load-data-code "|:: :code $ quote $ + 1 2"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-for-await $ %{} :CodeEntry (:doc "|for await")
+        |test-for-await $ %{} 'CodeEntry (:doc "|for await")
           :code $ quote
             fn ()
               hint-fn $ {} (:async true)
@@ -165,7 +165,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-js $ %{} :CodeEntry (:doc |)
+        |test-js $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               js/console.log $ js/Math.pow 4 4
@@ -230,7 +230,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-let-example $ %{} :CodeEntry (:doc |)
+        |test-let-example $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing code emitting of using let")
               let
@@ -251,7 +251,7 @@
                 assert= b -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-property $ %{} :CodeEntry (:doc "|try property ops")
+        |test-property $ %{} 'CodeEntry (:doc "|try property ops")
           :code $ quote
             fn () $ let
                 a $ js-object
@@ -264,7 +264,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-regexp $ %{} :CodeEntry (:doc "|try raw code and regexp")
+        |test-regexp $ %{} 'CodeEntry (:doc "|try raw code and regexp")
           :code $ quote
             fn () $ let
                 pattern $ &raw-code |/^\d+$/
@@ -278,7 +278,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-return-raw-code $ %{} :CodeEntry (:doc "|return with &raw-code")
+        |test-return-raw-code $ %{} 'CodeEntry (:doc "|return with &raw-code")
           :code $ quote
             fn () $ let
                 a $ js-array 1 2
@@ -291,7 +291,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-tag-keys $ %{} :CodeEntry (:doc "|tag keys for js")
+        |test-tag-keys $ %{} 'CodeEntry (:doc "|tag keys for js")
           :code $ quote
             fn ()
               assert= |a_b $ turn-string :a_b
@@ -300,7 +300,7 @@
               assert= |ab! $ turn-string :ab!
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-js.main $ :require (|os :as os) (|assert :as assert)
             util.core :refer $ log-title

--- a/calcit/test-lens.cirru
+++ b/calcit/test-lens.cirru
@@ -5,14 +5,14 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-lens.main $ %{} :FileEntry
+    |test-lens.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing lens") (test-lens) (do true)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-lens $ %{} :CodeEntry (:doc |)
+        |test-lens $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-lens ()
               assert=
@@ -36,7 +36,7 @@
                       {} $ :c 2
                   [] :a :b :c
                   fn (value)
-                    inc $ option:unwrap value
+                    inc $ value .unwrap
                 {} $ :a
                   {} $ :b
                     {} $ :c 3
@@ -45,19 +45,19 @@
                   {} $ :a ([] 1 2 3)
                   [] :a 1
                   fn (value)
-                    inc $ option:unwrap value
+                    inc $ value .unwrap
                 {} $ :a ([] 1 3 3)
               assert=
                 update-in
                   {} $ :a (:: 'quote 1)
                   [] :a 1
                   fn (value)
-                    inc $ option:unwrap value
+                    inc $ value .unwrap
                 {} $ :a (:: 'quote 2)
               assert=
                 update-in ({}) ([] :a :b)
                   fn (value)
-                    if (option:none? value) 1 $ raise |expected-missing-value
+                    if (value .none?) 1 $ raise |expected-missing-value
                 {} $ :a
                   {} $ :b 1
               assert=
@@ -116,7 +116,7 @@
                 [] 2 2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-lens.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-list.cirru
+++ b/calcit/test-list.cirru
@@ -5,20 +5,20 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-list.main $ %{} :FileEntry
+    |test-list.main $ %{} 'FileEntry
       :defs $ {}
-        |*counted $ %{} :CodeEntry (:doc |)
+        |*counted $ %{} 'CodeEntry (:doc |)
           :code $ quote (defatom *counted 0)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing list") (test-list) (log-title "|Testing foldl") (test-foldl) (log-title "|Testing every/any") (test-every) (log-title "|Testing groups") (test-groups) (log-title "|Testing apply") (test-apply) (log-title "|Testing join") (test-join) (log-title "|Testing repeat") (test-repeat) (log-title "|Testing sort") (test-sort) (test-alias) (test-doseq) (test-let[]) (test-methods) (test-methods-shorthand) (test-pair) (test-match) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-alias $ %{} :CodeEntry (:doc |)
+        |test-alias $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing alias")
               assert= (' 1 2 3) ([] 1 2 3)
@@ -26,7 +26,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-apply $ %{} :CodeEntry (:doc |)
+        |test-apply $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-apply ()
               assert= 10 $ apply + ([] 1 2 3 4)
@@ -35,14 +35,14 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-comma $ %{} :CodeEntry (:doc |)
+        |test-comma $ %{} 'CodeEntry (:doc |)
           :code $ quote
             assert= ([] 1 2 3 4) ([,] 1 2 3 4)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-doseq $ %{} :CodeEntry (:doc |)
+        |test-doseq $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing doseq")
               inside-eval: $ =
@@ -68,7 +68,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-every $ %{} :CodeEntry (:doc |)
+        |test-every $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-every ()
               let
@@ -87,7 +87,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-foldl $ %{} :CodeEntry (:doc |)
+        |test-foldl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-foldl ()
               assert= (%some 1)
@@ -113,7 +113,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-groups $ %{} :CodeEntry (:doc |)
+        |test-groups $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-groups ()
               assert=
@@ -139,7 +139,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-join $ %{} :CodeEntry (:doc |)
+        |test-join $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert= |1-2-3-4 $ join-str ([] 1 2 3 4) |-
@@ -153,7 +153,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-let[] $ %{} :CodeEntry (:doc |)
+        |test-let[] $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing let[]")
               inside-eval: $ println
@@ -165,7 +165,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-list $ %{} :CodeEntry (:doc |)
+        |test-list $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list () $ let
                 a $ [] 1 2 3
@@ -324,7 +324,7 @@
                   , 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match $ %{} :CodeEntry (:doc |)
+        |test-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing list match")
               assert= :empty $ list-match ([])
@@ -348,7 +348,7 @@
                   (l0 ls) (println "|...effect in match") ([] l0 ls)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-methods $ %{} :CodeEntry (:doc |)
+        |test-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing list methods")
               assert= true $ .any? ([] 1 2 3 4)
@@ -506,7 +506,7 @@
                 distinct $ [] 1 2 3 1 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-methods-shorthand $ %{} :CodeEntry (:doc "|test shorthand")
+        |test-methods-shorthand $ %{} 'CodeEntry (:doc "|test shorthand")
           :code $ quote
             fn () $ &let
               xs $ [] 1 2 3 4
@@ -515,7 +515,7 @@
                 fn (x) (&> x 3)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-pair $ %{} :CodeEntry (:doc |)
+        |test-pair $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert=
@@ -531,7 +531,7 @@
                   fn (k n) (> n 10)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-repeat $ %{} :CodeEntry (:doc |)
+        |test-repeat $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert= (repeat :a 5) ([] :a :a :a :a :a)
@@ -542,7 +542,7 @@
                 interleave ([] :a :b :c :d) ([] 1 2 3 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-sort $ %{} :CodeEntry (:doc |)
+        |test-sort $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert=
@@ -553,7 +553,7 @@
                 [] 1 2 3 4
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-list.main $ :require
             util.core :refer $ log-title inside-eval:

--- a/calcit/test-macro.cirru
+++ b/calcit/test-macro.cirru
@@ -5,21 +5,21 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-macro.main $ %{} :FileEntry
+    |test-macro.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (test-case) (log-title "|Testing expr in case") (test-expr-in-case) (test-thread-macros) (test-lambda) (test-gensym) (test-w-log) (test-with-cpu-time) (test-assert) (test-extract) (test-detector) (test-if-let) (test-flipped) (test-misc) (test-or-linear-expansion) (do true)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-assert $ %{} :CodeEntry (:doc |)
+        |test-assert $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Assert in different order")
               assert (= 1 1) |string
               assert |string $ = 1 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-case $ %{} :CodeEntry (:doc |)
+        |test-case $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-case () (log-title "|Testing case")
               let
@@ -54,7 +54,7 @@
                     &case v__2 nil (2 |two) (3 |three)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-detector $ %{} :CodeEntry (:doc |)
+        |test-detector $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Detector function")
               inside-eval: (&reset-gensym-index!)
@@ -75,7 +75,7 @@
                         raise "|Not satisfied in assertion!"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-expr-in-case $ %{} :CodeEntry (:doc |)
+        |test-expr-in-case $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-expr-in-case () $ assert= |5
               case (+ 1 4)
@@ -86,7 +86,7 @@
                 (+ 2 4) |6
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-extract $ %{} :CodeEntry (:doc |)
+        |test-extract $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Extract map via tags")
               inside-eval: (&reset-gensym-index!)
@@ -148,7 +148,7 @@
                   [] a b c d
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-flipped $ %{} :CodeEntry (:doc |)
+        |test-flipped $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title |flipped)
               assert=
@@ -156,14 +156,14 @@
                 [] 7 2 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-gensym $ %{} :CodeEntry (:doc |)
+        |test-gensym $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () $ inside-eval: (log-title "|Testing gensym") (&reset-gensym-index!)
               assert= (gensym) 'G__1
               assert= (gensym |a) 'a__2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-if-let $ %{} :CodeEntry (:doc |)
+        |test-if-let $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|if let")
               assert= 6 $ if-let
@@ -185,7 +185,7 @@
                   , 1 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-lambda $ %{} :CodeEntry (:doc |)
+        |test-lambda $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing lambda macro")
               inside-eval:
@@ -245,19 +245,19 @@
                 , 3
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-misc $ %{} :CodeEntry (:doc |)
+        |test-misc $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title |misc)
               assert= (noted nothing 1) 1
               inside-eval: $ println (&extract-code-into-edn 'code)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-or-linear-expansion $ %{} :CodeEntry (:doc |)
+        |test-or-linear-expansion $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-or-linear-expansion () $ assert= |done (or false false false false false false false false false false false false false false false false false false false false |done)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-thread-macros $ %{} :CodeEntry (:doc |)
+        |test-thread-macros $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-thread-macros () (log-title "|Testing thread macros")
               inside-eval:
@@ -337,7 +337,7 @@
               assert= 18 $ %<- (+ % %) (* % %) 3
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-w-log $ %{} :CodeEntry (:doc |)
+        |test-w-log $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing w-log") (&reset-gensym-index!)
               inside-eval: $ assert=
@@ -381,7 +381,7 @@
                 assert= 7 $ f3 3 4
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-with-cpu-time $ %{} :CodeEntry (:doc |)
+        |test-with-cpu-time $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing with-cpu-time")
               inside-eval: (&reset-gensym-index!)
@@ -407,7 +407,7 @@
                 , 3
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-macro.main $ :require
             [] util.core :refer $ [] log-title inside-eval:

--- a/calcit/test-map.cirru
+++ b/calcit/test-map.cirru
@@ -5,16 +5,16 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-map.main $ %{} :FileEntry
+    |test-map.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing maps") (test-maps) (log-title "|Testing map pairs") (test-pairs) (log-title "|Testing map syntax") (test-native-map-syntax) (test-map-comma) (test-keys) (test-get) (test-select) (test-methods) (test-diff) (test-shorthand) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-diff $ %{} :CodeEntry (:doc |)
+        |test-diff $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing diff")
               assert=
@@ -59,7 +59,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-get $ %{} :CodeEntry (:doc |)
+        |test-get $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing get")
               assert= (%none)
@@ -83,7 +83,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-keys $ %{} :CodeEntry (:doc |)
+        |test-keys $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing keys")
               assert=
@@ -96,7 +96,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-map-comma $ %{} :CodeEntry (:doc |)
+        |test-map-comma $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing {,}")
               inside-eval: $ assert=
@@ -109,7 +109,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-maps $ %{} :CodeEntry (:doc |)
+        |test-maps $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-maps ()
               assert= 2 $ count
@@ -182,7 +182,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-methods $ %{} :CodeEntry (:doc |)
+        |test-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing map methods")
               assert= (&{} :a 1 :b 2)
@@ -303,7 +303,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-native-map-syntax $ %{} :CodeEntry (:doc |)
+        |test-native-map-syntax $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-native-map-syntax () $ inside-eval:
               assert=
@@ -314,7 +314,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-pairs $ %{} :CodeEntry (:doc |)
+        |test-pairs $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert=
@@ -353,7 +353,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-select $ %{} :CodeEntry (:doc |)
+        |test-select $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing select")
               assert=
@@ -380,7 +380,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-shorthand $ %{} :CodeEntry (:doc |)
+        |test-shorthand $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing shorthand")
               let
@@ -390,7 +390,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-map.main $ :require
             [] util.core :refer $ [] log-title inside-eval: inside-js:

--- a/calcit/test-math.cirru
+++ b/calcit/test-math.cirru
@@ -5,14 +5,14 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-math.main $ %{} :FileEntry
+    |test-math.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing numbers") (test-numbers) (log-title "|Testing math") (test-math) (log-title "|Testing compare") (test-compare) (test-hex) (test-integer) (test-methods) (test-bit-math) (do true)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-math $ %{} :CodeEntry (:doc |)
+        |test-bit-math $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|testing bit math")
               assert= 0 $ bit-shr 1 1
@@ -23,7 +23,7 @@
               assert= 16 $ bit-shl 4 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-compare $ %{} :CodeEntry (:doc |)
+        |test-compare $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-compare ()
               assert= (%some 4)
@@ -51,19 +51,19 @@
                 , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-hex $ %{} :CodeEntry (:doc |)
+        |test-hex $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing hex") (assert= 16 0x10) (assert= 15 0xf)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-integer $ %{} :CodeEntry (:doc |)
+        |test-integer $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing integer")
               assert= true $ round? 1
               assert= false $ round? 1.1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-math $ %{} :CodeEntry (:doc |)
+        |test-math $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-math ()
               println "|sin 1" $ sin 1
@@ -86,7 +86,7 @@
               assert= (negate -4) (abs -4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-methods $ %{} :CodeEntry (:doc |)
+        |test-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing number methods")
               assert= 1 $ .floor 1.1
@@ -103,7 +103,7 @@
               ; "has problem in comparing float numbers" $ assert= 0.1 (.fract 1.1)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-numbers $ %{} :CodeEntry (:doc |)
+        |test-numbers $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-numbers ()
               assert= 3 $ + 1 2
@@ -119,7 +119,7 @@
               do true
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-math.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-method-errors.cirru
+++ b/calcit/test-method-errors.cirru
@@ -5,19 +5,19 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-method-errors.main $ %{} :FileEntry
+    |test-method-errors.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Entry for reproducing preprocess failures")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for reproducing preprocess failures")
           :code $ quote
             defn main! () (; "运行该入口会在" preprocess "阶段报错，验证类型推断是否生效") (trigger-type-error)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |trigger-type-error $ %{} :CodeEntry (:doc "|Pipeline sample that should fail preprocess type checks")
+        |trigger-type-error $ %{} 'CodeEntry (:doc "|Pipeline sample that should fail preprocess type checks")
           :code $ quote
             defn trigger-type-error () $ let
                 src $ {} (:a 1) (:b 2)
@@ -25,5 +25,5 @@
               .map by-set $ fn (x) false
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc "|Namespace for standalone repro")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for standalone repro")
         :code $ quote (ns test-method-errors.main)

--- a/calcit/test-method-validation.cirru
+++ b/calcit/test-method-validation.cirru
@@ -5,21 +5,21 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (test-valid-list-methods) (; test-invalid-list-method ; "会导致" preprocess "错误") (; test-invalid-string-method ; "会导致" preprocess "错误") (test-invalid-map-method ; "测试" map "方法验证") (println |All tests passed)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-invalid-list-method $ %{} :CodeEntry (:doc |)
+        |test-invalid-list-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-invalid-list-method () $ let
                 xs $ [] 1 2 3
@@ -28,7 +28,7 @@
               .invalid-method xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-invalid-map-method $ %{} :CodeEntry (:doc |)
+        |test-invalid-map-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-invalid-map-method () $ let
                 m $ {} (:a 1)
@@ -37,7 +37,7 @@
               .invalid-map-method m
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-invalid-string-method $ %{} :CodeEntry (:doc |)
+        |test-invalid-string-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-invalid-string-method () $ let
                 text |hello
@@ -46,7 +46,7 @@
               .invalid-string-method text
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-valid-list-methods $ %{} :CodeEntry (:doc |)
+        |test-valid-list-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-valid-list-methods () $ let
                 xs $ [] 1 2 3
@@ -55,5 +55,5 @@
               .first xs
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.main)

--- a/calcit/test-nested-types.cirru
+++ b/calcit/test-nested-types.cirru
@@ -5,26 +5,26 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |compute $ %{} :CodeEntry (:doc |)
+        |compute $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn compute (x) 'Number $ &+ x 10
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ println (test-nested-scope)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-nested-scope $ %{} :CodeEntry (:doc |)
+        |test-nested-scope $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-nested-scope () (; "测试：外层定义的变量可以被内层使用，并保留类型信息")
               let
@@ -41,5 +41,5 @@
                     d
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.main)

--- a/calcit/test-nil.cirru
+++ b/calcit/test-nil.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-nil.main $ %{} :FileEntry
+    |test-nil.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing nil")
               assert= ([]) (.to-list nil)
@@ -16,7 +16,7 @@
               assert= nil $ .filter nil inc
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-nil.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-optimize.cirru
+++ b/calcit/test-optimize.cirru
@@ -5,36 +5,36 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-optimize.main $ %{} :FileEntry
+    |test-optimize.main $ %{} 'FileEntry
       :defs $ {}
-        |LocalPerson0 $ %{} :CodeEntry (:doc |)
+        |LocalPerson0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct LocalPerson0 $ :name 'String
           :examples $ []
           :schema $ :: 'Dynamic
-        |Person $ %{} :CodeEntry (:doc |)
+        |Person $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def Person $ impl-traits Person0 ShowImpl
           :examples $ []
           :schema $ :: 'Dynamic
-        |Person0 $ %{} :CodeEntry (:doc |)
+        |Person0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Person0 $ :name 'String
           :examples $ []
           :schema $ :: 'Dynamic
-        |ShowImpl $ %{} :CodeEntry (:doc |)
+        |ShowImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl ShowImpl ShowTrait $ .show
               fn (self)
                 str "|Person: " $ &struct:get self :name
           :examples $ []
           :schema $ :: 'Dynamic
-        |ShowTrait $ %{} :CodeEntry (:doc |)
+        |ShowTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait ShowTrait $ .show :fn
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ let
                 p $ %{} Person (:name |Jim)
@@ -64,6 +64,6 @@
                 println $ lp .show
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-optimize.main $ :require

--- a/calcit/test-proc-type-warnings.cirru
+++ b/calcit/test-proc-type-warnings.cirru
@@ -5,21 +5,21 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|=== Proc Type Warning Demo ===") (println "|This file demonstrates type checking for Proc (builtin) functions") (println "|Expected warning: Proc &+ arg 1 expects type :number, but got :string") (println |) (test-type-mismatch) (println |Done!)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-type-mismatch $ %{} :CodeEntry (:doc "|Demonstrates Proc type checking - intentional type error")
+        |test-type-mismatch $ %{} 'CodeEntry (:doc "|Demonstrates Proc type checking - intentional type error")
           :code $ quote
             defn test-type-mismatch () (; This should generate a warning: passing string to numeric operation)
               let
@@ -32,5 +32,5 @@
                 &+ text 10
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.main)

--- a/calcit/test-recur-arity.cirru
+++ b/calcit/test-recur-arity.cirru
@@ -5,9 +5,9 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-recur-arity.main $ %{} :FileEntry
+    |test-recur-arity.main $ %{} 'FileEntry
       :defs $ {}
-        |add-until $ %{} :CodeEntry (:doc |)
+        |add-until $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn add-until (acc target step)
               if (>= acc target) acc $ recur (+ acc step) target step
@@ -15,7 +15,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic 'Dynamic 'Dynamic
-        |bad-recur-too-few $ %{} :CodeEntry (:doc |)
+        |bad-recur-too-few $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn bad-recur-too-few (x y z)
               if (< x 10)
@@ -25,7 +25,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic 'Dynamic 'Dynamic
-        |bad-recur-too-many $ %{} :CodeEntry (:doc |)
+        |bad-recur-too-many $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn bad-recur-too-many (x y)
               if (< x 10)
@@ -35,7 +35,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic 'Dynamic
-        |bad-recur-wrong-count $ %{} :CodeEntry (:doc |)
+        |bad-recur-wrong-count $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn bad-recur-wrong-count (a b c d)
               if (< a 10)
@@ -45,7 +45,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic 'Dynamic 'Dynamic 'Dynamic
-        |factorial $ %{} :CodeEntry (:doc |)
+        |factorial $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn factorial (n acc)
               if (<= n 1) acc $ recur (dec n) (* n acc)
@@ -53,7 +53,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing recur arity")
               assert= 10 $ sum-to-n 4
@@ -64,12 +64,12 @@
               assert= 24 $ factorial 4 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ println "|Code updated"
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-to-n $ %{} :CodeEntry (:doc |)
+        |sum-to-n $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sum-to-n (n)
               if (<= n 0) 0 $ + n
@@ -78,7 +78,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-recur-arity.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-recursion.cirru
+++ b/calcit/test-recursion.cirru
@@ -5,13 +5,13 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-recursion.main $ %{} :FileEntry
+    |test-recursion.main $ %{} 'FileEntry
       :defs $ {}
-        |*count-effects $ %{} :CodeEntry (:doc |)
+        |*count-effects $ %{} 'CodeEntry (:doc |)
           :code $ quote (defatom *count-effects 0)
           :examples $ []
           :schema $ :: 'Dynamic
-        |hole-series $ %{} :CodeEntry (:doc |)
+        |hole-series $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn hole-series (x) (assert-type x 'Number)
               if (&<= x 0) (raise "|unexpected small number")
@@ -37,7 +37,7 @@
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing hole series") (test-hole-series) (; set-trace-fn! |app.main |hole-series)
               ; println $ hole-series 100
@@ -46,7 +46,7 @@
               do true
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-hole-series $ %{} :CodeEntry (:doc |)
+        |test-hole-series $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-hole-series () $ assert "|hole series numbers"
               =
@@ -54,7 +54,7 @@
                 [] 0 1 0 1 2 3 2 1 0 1 2 3 4 5 6 7 8 9 8
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-loop $ %{} :CodeEntry (:doc |)
+        |test-loop $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert= 55 $ apply
@@ -75,7 +75,7 @@
               assert= 6 @*count-effects
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-recursion.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-set.cirru
+++ b/calcit/test-set.cirru
@@ -5,16 +5,16 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-set.main $ %{} :FileEntry
+    |test-set.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing set") (test-set) (test-methods) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-methods $ %{} :CodeEntry (:doc |)
+        |test-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert= (#{} 1 2 3)
@@ -75,7 +75,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-set $ %{} :CodeEntry (:doc |)
+        |test-set $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-set ()
               assert= 4 $ count (#{} 1 2 3 4)
@@ -134,7 +134,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-set.main $ :require
             util.core :refer $ log-title

--- a/calcit/test-string.cirru
+++ b/calcit/test-string.cirru
@@ -5,14 +5,14 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-string.main $ %{} :FileEntry
+    |test-string.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing str") (test-str) (test-includes) (log-title "|Testing parse") (test-parse) (log-title "|Testing trim") (test-trim) (test-format) (test-char) (test-whitespace) (test-lisp-style) (test-methods) (test-bitwise) (do true)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bitwise $ %{} :CodeEntry (:doc |)
+        |test-bitwise $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert= (bit-and 15 7) 7
@@ -28,7 +28,7 @@
               assert= |0x11 $ &number:display-by 17 16
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-char $ %{} :CodeEntry (:doc |)
+        |test-char $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Test char")
               assert= 97 $ .get-char-code |a
@@ -42,7 +42,7 @@
               assert= (%none) (last |)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-format $ %{} :CodeEntry (:doc |)
+        |test-format $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing format")
               assert= |1.2346 $ .format 1.23456789 4
@@ -67,7 +67,7 @@
               println |hashing: $ &hash 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-includes $ %{} :CodeEntry (:doc |)
+        |test-includes $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing includes")
               assert= true $ includes? |abc |abc
@@ -91,7 +91,7 @@
               assert= |abc0 $ strip-suffix |abc0 |bc
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-lisp-style $ %{} :CodeEntry (:doc |)
+        |test-lisp-style $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Test lisp style")
               assert=
@@ -127,7 +127,7 @@
                 , "|+ 1 2"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-methods $ %{} :CodeEntry (:doc |)
+        |test-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-methods () (log-title "|Testing string methods")
               assert= true $ .blank? |
@@ -175,7 +175,7 @@
               assert= |a12312 $ .pad-right |a 6 |123
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-parse $ %{} :CodeEntry (:doc |)
+        |test-parse $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert= (%ok 0) (parse-float |0)
@@ -183,7 +183,7 @@
               assert= (%err |1e) (parse-float |1e)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str $ %{} :CodeEntry (:doc |)
+        |test-str $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str ()
               assert= (&str:concat |a |b) |ab
@@ -215,7 +215,7 @@
               assert= 0 $ &compare |a |a
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-trim $ %{} :CodeEntry (:doc |)
+        |test-trim $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               assert= | $ trim "|    "
@@ -225,7 +225,7 @@
               assert= |1 $ trim |__1__ |_
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-whitespace $ %{} :CodeEntry (:doc |)
+        |test-whitespace $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Test blank?")
               assert-detect identity $ blank? |
@@ -239,7 +239,7 @@
               assert-detect not $ blank? "|1 "
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-string.main $ :require
             util.core :refer $ inside-eval: log-title

--- a/calcit/test-struct.cirru
+++ b/calcit/test-struct.cirru
@@ -5,24 +5,24 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-struct.main $ %{} :FileEntry
+    |test-struct.main $ %{} 'FileEntry
       :defs $ {}
-        |A $ %{} :CodeEntry (:doc |)
+        |A $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct A $ :a 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |A0 $ %{} :CodeEntry (:doc |)
+        |A0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct A0 $ :name 'String
           :examples $ []
           :schema $ :: 'Dynamic
-        |B $ %{} :CodeEntry (:doc |)
+        |B $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct B $ :b 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |BirdImpl $ %{} :CodeEntry (:doc |)
+        |BirdImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl BirdImpl BirdTrait
               .show $ fn (self)
@@ -30,47 +30,47 @@
               .rename $ fn (self name) (assoc self :name name)
           :examples $ []
           :schema $ :: 'Dynamic
-        |BirdShape $ %{} :CodeEntry (:doc |)
+        |BirdShape $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct BirdShape (:show 'Fn) (:rename 'Fn)
           :examples $ []
           :schema $ :: 'Dynamic
-        |BirdTrait $ %{} :CodeEntry (:doc |)
+        |BirdTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait BirdTrait (.show :fn) (.rename :fn)
           :examples $ []
           :schema $ :: 'Dynamic
-        |C $ %{} :CodeEntry (:doc |)
+        |C $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct C $ :c 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |Cat $ %{} :CodeEntry (:doc |)
+        |Cat $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Cat (:name 'String) (:color 'Tag)
           :examples $ []
           :schema $ :: 'Dynamic
-        |City $ %{} :CodeEntry (:doc |)
+        |City $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct City (:name 'String) (:province 'String)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Demo $ %{} :CodeEntry (:doc |)
+        |Demo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Demo (:a 'Dynamic) (:b 'Dynamic) (:c 'Dynamic) (:d 'Dynamic)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Lagopus $ %{} :CodeEntry (:doc |)
+        |Lagopus $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def Lagopus $ impl-traits Lagopus0 BirdImpl
           :examples $ []
           :schema $ :: 'Dynamic
-        |Lagopus0 $ %{} :CodeEntry (:doc |)
+        |Lagopus0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Lagopus0 $ :name (:: 'Optional 'String)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Person $ %{} :CodeEntry (:doc |)
+        |Person $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Person
               :name $ :: 'Optional 'String
@@ -78,31 +78,31 @@
               :position $ :: 'Optional 'Tag
           :examples $ []
           :schema $ :: 'Dynamic
-        |Point2D $ %{} :CodeEntry (:doc |)
+        |Point2D $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Point2D (:x 'Number) (:y 'Number)
           :examples $ []
           :schema $ :: 'Dynamic
-        |check-point-type $ %{} :CodeEntry (:doc |)
+        |check-point-type $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn check-point-type (p) (struct? p)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] 'test-struct.main/Point2D
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (test-struct) (test-methods) (test-match) (test-polymorphism) (test-edn) (test-struct-with) (test-partial-struct) (test-loose-struct-rewrite) (test-map-to-struct) (test-postfix) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ println |reloaded
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-point $ %{} :CodeEntry (:doc |)
+        |sum-point $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sum-point (p)
               &+ (:x p) (:y p)
@@ -110,7 +110,7 @@
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'test-struct.main/Point2D
-        |test-edn $ %{} :CodeEntry (:doc |)
+        |test-edn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               let
@@ -135,14 +135,14 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-loose-struct-rewrite $ %{} :CodeEntry (:doc |)
+        |test-loose-struct-rewrite $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing loose-to-struct rewrite")
               assert= 30 $ sum-point (?{} :x 10 :y 20)
               assert= true $ check-point-type (?{} :x 10 :y 20)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-to-struct $ %{} :CodeEntry (:doc |)
+        |test-map-to-struct $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing map-to-struct rewrite")
               assert= 30 $ sum-point
@@ -151,7 +151,7 @@
                 {} (:x 10) (:y 20)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match $ %{} :CodeEntry (:doc |)
+        |test-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing struct match")
               let
@@ -174,7 +174,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-methods $ %{} :CodeEntry (:doc |)
+        |test-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing struct methods")
               &let
@@ -211,7 +211,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-partial-struct $ %{} :CodeEntry (:doc |)
+        |test-partial-struct $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing partial struct")
               let
@@ -229,7 +229,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-polymorphism $ %{} :CodeEntry (:doc |)
+        |test-polymorphism $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Test struct polymorphism") (println Lagopus)
               let
@@ -251,7 +251,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-postfix $ %{} :CodeEntry (:doc "|test postfix syntax")
+        |test-postfix $ %{} 'CodeEntry (:doc "|test postfix syntax")
           :code $ quote
             fn () (log-title "|Testing postfix syntax")
               let
@@ -273,7 +273,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-struct $ %{} :CodeEntry (:doc |)
+        |test-struct $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing struct")
               let
@@ -328,7 +328,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-struct-with $ %{} :CodeEntry (:doc "|test struct-with")
+        |test-struct-with $ %{} 'CodeEntry (:doc "|test struct-with")
           :code $ quote
             fn () (log-title "|Testing struct-with")
               let
@@ -344,7 +344,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-struct.main $ :require
             util.core :refer $ log-title inside-js:

--- a/calcit/test-sum-types.cirru
+++ b/calcit/test-sum-types.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-sum-types.main $ %{} :FileEntry
+    |test-sum-types.main $ %{} 'FileEntry
       :defs $ {}
-        |ActionImpl $ %{} :CodeEntry (:doc |)
+        |ActionImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             let
                 ActionTrait $ deftrait ActionTrait (.describe :fn)
@@ -18,17 +18,17 @@
                     (:err message) (str "|Action err -> " message)
           :examples $ []
           :schema $ :: 'Dynamic
-        |ActionResult $ %{} :CodeEntry (:doc |)
+        |ActionResult $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def ActionResult $ impl-traits Result ActionImpl
           :examples $ []
           :schema $ :: 'Dynamic
-        |Result $ %{} :CodeEntry (:doc |)
+        |Result $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Result (:ok 'Number) (:err 'String)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|Testing sum types...")
               let
@@ -46,28 +46,28 @@
               println |Done!
           :examples $ []
           :schema $ :: 'Dynamic
-        |make-err $ %{} :CodeEntry (:doc |)
+        |make-err $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn make-err (message) (%:: ActionResult :err message)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |make-ok $ %{} :CodeEntry (:doc |)
+        |make-ok $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn make-ok (value) (%:: ActionResult :ok value)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |summarize $ %{} :CodeEntry (:doc |)
+        |summarize $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn summarize (action)
               tag-match action
@@ -77,5 +77,5 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-sum-types.main)

--- a/calcit/test-tag-match-validation.cirru
+++ b/calcit/test-tag-match-validation.cirru
@@ -5,20 +5,20 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-tag-match-validation.main $ %{} :FileEntry
+    |test-tag-match-validation.main $ %{} 'FileEntry
       :defs $ {}
-        |Result $ %{} :CodeEntry (:doc |)
+        |Result $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Result (:err 'String 'String) (:ok)
           :examples $ []
           :schema $ :: 'Dynamic
-        |ResultImpl $ %{} :CodeEntry (:doc |)
+        |ResultImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl ResultImpl ResultTrait $ .dummy
               fn $ _x
           :examples $ []
           :schema $ :: 'Dynamic
-        |ResultTrait $ %{} :CodeEntry (:doc |)
+        |ResultTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait ResultTrait $ .dummy
               :: :fn $ {}
@@ -27,19 +27,19 @@
                 :return 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|Testing tag-match enum validation...") (test-valid-matches) (test-invalid-tag) (test-wrong-arity) (println "|All tag-match validation tests passed!")
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |test-invalid-tag $ %{} :CodeEntry (:doc |)
+        |test-invalid-tag $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-invalid-tag () (println "|  Testing invalid tag detection...") (; Create a valid enum tuple then corrupt its tag)
               let
@@ -54,7 +54,7 @@
                       raise $ str "|Unexpected error:" e
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-valid-matches $ %{} :CodeEntry (:doc |)
+        |test-valid-matches $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-valid-matches () (println "|  Testing valid tag-match patterns...")
               let
@@ -72,7 +72,7 @@
               println "|  ✓ Valid matches work correctly"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-wrong-arity $ %{} :CodeEntry (:doc |)
+        |test-wrong-arity $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-wrong-arity () (println "|  Testing wrong arity detection...")
               let
@@ -93,5 +93,5 @@
                         raise $ str "|Unexpected error:" e
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-tag-match-validation.main)

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -5,89 +5,89 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-traits.main $ %{} :FileEntry
+    |test-traits.main $ %{} 'FileEntry
       :defs $ {}
-        |Demo0 $ %{} :CodeEntry (:doc "|Enum prototype for tuple trait tests")
+        |Demo0 $ %{} 'CodeEntry (:doc "|Enum prototype for tuple trait tests")
           :code $ quote
             defenum Demo $ :demo 'Dynamic
           :examples $ []
           :schema $ :: 'Enum
-        |DemoBar $ %{} :CodeEntry (:doc "|Enum with MyBar impls")
+        |DemoBar $ %{} 'CodeEntry (:doc "|Enum with MyBar impls")
           :code $ quote
             def DemoBar $ impl-traits Demo0 MyBarImpl MyBarImpl2
           :examples $ []
           :schema $ :: 'Impl
-        |DemoZap $ %{} :CodeEntry (:doc "|Enum with MyZapA/MyZapB")
+        |DemoZap $ %{} 'CodeEntry (:doc "|Enum with MyZapA/MyZapB")
           :code $ quote
             def DemoZap $ impl-traits Demo0 MyZapAImpl MyZapBImpl
           :examples $ []
           :schema $ :: 'Impl
-        |DemoZapA $ %{} :CodeEntry (:doc "|Enum with MyZapA then MyZapB")
+        |DemoZapA $ %{} 'CodeEntry (:doc "|Enum with MyZapA then MyZapB")
           :code $ quote
             def DemoZapA $ impl-traits Demo0 MyZapAImpl MyZapBImpl
           :examples $ []
           :schema $ :: 'Impl
-        |DemoZapB $ %{} :CodeEntry (:doc "|Enum with MyZapB then MyZapA")
+        |DemoZapB $ %{} 'CodeEntry (:doc "|Enum with MyZapB then MyZapA")
           :code $ quote
             def DemoZapB $ impl-traits Demo0 MyZapBImpl MyZapAImpl
           :examples $ []
           :schema $ :: 'Impl
-        |MyBar $ %{} :CodeEntry (:doc "|Trait for tuple override test")
+        |MyBar $ %{} 'CodeEntry (:doc "|Trait for tuple override test")
           :code $ quote
             deftrait MyBar $ .bar :fn
           :examples $ []
           :schema $ :: 'Trait
-        |MyBarImpl $ %{} :CodeEntry (:doc "|Trait impl for tuple override test")
+        |MyBarImpl $ %{} 'CodeEntry (:doc "|Trait impl for tuple override test")
           :code $ quote
             defimpl MyBarImpl MyBar $ .bar mybar:bar1
           :examples $ []
           :schema $ :: 'Impl
-        |MyBarImpl2 $ %{} :CodeEntry (:doc "|Trait impl for tuple override test")
+        |MyBarImpl2 $ %{} 'CodeEntry (:doc "|Trait impl for tuple override test")
           :code $ quote
             defimpl MyBarImpl2 MyBar $ .bar mybar:bar2
           :examples $ []
           :schema $ :: 'Impl
-        |MyFoo $ %{} :CodeEntry (:doc "|Trait for deftrait test")
+        |MyFoo $ %{} 'CodeEntry (:doc "|Trait for deftrait test")
           :code $ quote
             deftrait MyFoo $ .foo :fn
           :examples $ []
           :schema $ :: 'Trait
-        |MyFooImpl $ %{} :CodeEntry (:doc "|Trait impl for deftrait test")
+        |MyFooImpl $ %{} 'CodeEntry (:doc "|Trait impl for deftrait test")
           :code $ quote
             defimpl MyFooImpl MyFoo $ .foo myfoo:foo
           :examples $ []
           :schema $ :: 'Impl
-        |MyFooImpl2 $ %{} :CodeEntry (:doc "|Trait impl for override test")
+        |MyFooImpl2 $ %{} 'CodeEntry (:doc "|Trait impl for override test")
           :code $ quote
             defimpl MyFooImpl2 MyFoo $ .foo myfoo:foo2
           :examples $ []
           :schema $ :: 'Impl
-        |MyZapA $ %{} :CodeEntry (:doc "|Trait A for cross-trait method conflict test")
+        |MyZapA $ %{} 'CodeEntry (:doc "|Trait A for cross-trait method conflict test")
           :code $ quote
             deftrait MyZapA $ .zap :fn
           :examples $ []
           :schema $ :: 'Trait
-        |MyZapAImpl $ %{} :CodeEntry (:doc "|Trait A impl for cross-trait method conflict test")
+        |MyZapAImpl $ %{} 'CodeEntry (:doc "|Trait A impl for cross-trait method conflict test")
           :code $ quote
             defimpl MyZapAImpl MyZapA $ .zap myzap:a
           :examples $ []
           :schema $ :: 'Impl
-        |MyZapB $ %{} :CodeEntry (:doc "|Trait B for cross-trait method conflict test")
+        |MyZapB $ %{} 'CodeEntry (:doc "|Trait B for cross-trait method conflict test")
           :code $ quote
             deftrait MyZapB $ .zap :fn
           :examples $ []
           :schema $ :: 'Trait
-        |MyZapBImpl $ %{} :CodeEntry (:doc "|Trait B impl for cross-trait method conflict test")
+        |MyZapBImpl $ %{} 'CodeEntry (:doc "|Trait B impl for cross-trait method conflict test")
           :code $ quote
             defimpl MyZapBImpl MyZapB $ .zap myzap:b
           :examples $ []
           :schema $ :: 'Impl
-        |Person0 $ %{} :CodeEntry (:doc "|Struct used in trait tests")
+        |Person0 $ %{} 'CodeEntry (:doc "|Struct used in trait tests")
           :code $ quote
             defstruct Person0 $ :name 'String
           :examples $ []
           :schema $ :: 'Struct
-        |compare-with-trait $ %{} :CodeEntry (:doc |)
+        |compare-with-trait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn compare-with-trait (a b) (a .compare b)
           :examples $ []
@@ -96,7 +96,7 @@
               :args $ [] 'T 'T
               :generics $ [] 'T
               :where $ {} ('T 'Compare)
-        |contains-with-trait? $ %{} :CodeEntry (:doc |)
+        |contains-with-trait? $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn contains-with-trait? (x k) (x .contains? k)
           :examples $ []
@@ -105,7 +105,7 @@
               :args $ [] 'T 'K
               :generics $ [] 'T 'K
               :where $ {} ('T 'Contains)
-        |count-with-trait $ %{} :CodeEntry (:doc |)
+        |count-with-trait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn count-with-trait (x) (x .count)
           :examples $ []
@@ -114,28 +114,28 @@
               :args $ [] 'T
               :generics $ [] 'T
               :where $ {} ('T 'Countable)
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (&init-builtin-impls!) (println "|Testing built-in traits...") (; Test Show trait - all types should have it) (test-show-trait) (; Test deftrait macro) (test-deftrait) (; Test impl precedence order) (test-impl-precedence-order) (test-enum-impl-precedence-order) (test-cross-trait-method-conflict) (test-explicit-trait-call) (; Test Eq trait) (test-eq-trait) (; Test Compare trait) (test-compare-trait) (; Test Add trait) (test-add-trait) (; Test Len/Empty traits) (test-collection-traits) (; Test Option/Result Mappable) (test-option-result-map) (; Test assert-traits) (test-assert-trait) (; Debug helpers: methods introspection) (test-method-introspection) (println "|All trait tests passed!")
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |mybar:bar1 $ %{} :CodeEntry (:doc "|method implementation for MyBarImpl/:bar")
+        |mybar:bar1 $ %{} 'CodeEntry (:doc "|method implementation for MyBarImpl/:bar")
           :code $ quote
             defn mybar:bar1 (_x) |bar1
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |mybar:bar2 $ %{} :CodeEntry (:doc "|method implementation for MyBarImpl2/:bar")
+        |mybar:bar2 $ %{} 'CodeEntry (:doc "|method implementation for MyBarImpl2/:bar")
           :code $ quote
             defn mybar:bar2 (_x) |bar2
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |myfoo:foo $ %{} :CodeEntry (:doc "|method implementation for MyFoo/:foo")
+        |myfoo:foo $ %{} 'CodeEntry (:doc "|method implementation for MyFoo/:foo")
           :code $ quote
             defn myfoo:foo (p)
               str "|foo " $ &struct:get p :name
@@ -143,7 +143,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |myfoo:foo2 $ %{} :CodeEntry (:doc "|method implementation for MyFooImpl2/:foo")
+        |myfoo:foo2 $ %{} 'CodeEntry (:doc "|method implementation for MyFooImpl2/:foo")
           :code $ quote
             defn myfoo:foo2 (p)
               str "|foo2 " $ &struct:get p :name
@@ -151,21 +151,21 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |myzap:a $ %{} :CodeEntry (:doc "|method implementation for MyZapA/:zap")
+        |myzap:a $ %{} 'CodeEntry (:doc "|method implementation for MyZapA/:zap")
           :code $ quote
             defn myzap:a (_x) |zapA
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |myzap:b $ %{} :CodeEntry (:doc "|method implementation for MyZapB/:zap")
+        |myzap:b $ %{} 'CodeEntry (:doc "|method implementation for MyZapB/:zap")
           :code $ quote
             defn myzap:b (_x) |zapB
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |test-add-trait $ %{} :CodeEntry (:doc "|Test Add trait")
+        |test-add-trait $ %{} 'CodeEntry (:doc "|Test Add trait")
           :code $ quote
             defn test-add-trait () (println "|Testing Add trait...") (; Number addition)
               assert= 3 $ + 1 2
@@ -184,7 +184,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-assert-trait $ %{} :CodeEntry (:doc "|Test assert-traits")
+        |test-assert-trait $ %{} 'CodeEntry (:doc "|Test assert-traits")
           :code $ quote
             defn test-assert-trait () (println "|Testing assert-traits...")
               let
@@ -232,7 +232,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-collection-traits $ %{} :CodeEntry (:doc "|Test Len/Empty/Contains traits for collections")
+        |test-collection-traits $ %{} 'CodeEntry (:doc "|Test Len/Empty/Contains traits for collections")
           :code $ quote
             defn test-collection-traits () (println "|Testing Collection traits (Len, Empty)...") (; Len trait)
               assert= 0 $ count ([])
@@ -292,7 +292,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-compare-trait $ %{} :CodeEntry (:doc "|Test Compare trait")
+        |test-compare-trait $ %{} 'CodeEntry (:doc "|Test Compare trait")
           :code $ quote
             defn test-compare-trait () (println "|Testing Compare trait...") (; Number comparison)
               assert= true $ < 1 2
@@ -319,7 +319,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-cross-trait-method-conflict $ %{} :CodeEntry (:doc "|Test method conflict across traits")
+        |test-cross-trait-method-conflict $ %{} 'CodeEntry (:doc "|Test method conflict across traits")
           :code $ quote
             defn test-cross-trait-method-conflict () (println "|Testing cross-trait method conflict...")
               let
@@ -344,7 +344,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-deftrait $ %{} :CodeEntry (:doc "|Test deftrait macro")
+        |test-deftrait $ %{} 'CodeEntry (:doc "|Test deftrait macro")
           :code $ quote
             defn test-deftrait () (println "|Testing deftrait macro...")
               assert= :trait $ type-of MyFoo
@@ -357,7 +357,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-enum-impl-precedence-order $ %{} :CodeEntry (:doc "|Test enum impl precedence order")
+        |test-enum-impl-precedence-order $ %{} 'CodeEntry (:doc "|Test enum impl precedence order")
           :code $ quote
             defn test-enum-impl-precedence-order () (println "|Testing enum impl precedence order...")
               let
@@ -369,7 +369,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-eq-trait $ %{} :CodeEntry (:doc "|Test Eq trait")
+        |test-eq-trait $ %{} 'CodeEntry (:doc "|Test Eq trait")
           :code $ quote
             defn test-eq-trait () (println "|Testing Eq trait...") (; Value equality)
               assert= true $ = 1 1
@@ -388,7 +388,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-explicit-trait-call $ %{} :CodeEntry (:doc "|Test explicit trait-call for disambiguation")
+        |test-explicit-trait-call $ %{} 'CodeEntry (:doc "|Test explicit trait-call for disambiguation")
           :code $ quote
             defn test-explicit-trait-call () (println "|Testing explicit trait-call...")
               let
@@ -424,7 +424,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-impl-precedence-order $ %{} :CodeEntry (:doc "|Test impl precedence order")
+        |test-impl-precedence-order $ %{} 'CodeEntry (:doc "|Test impl precedence order")
           :code $ quote
             defn test-impl-precedence-order () (println "|Testing impl precedence order...")
               let
@@ -437,7 +437,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-method-introspection $ %{} :CodeEntry (:doc "|Test runtime method introspection helpers")
+        |test-method-introspection $ %{} 'CodeEntry (:doc "|Test runtime method introspection helpers")
           :code $ quote
             defn test-method-introspection () (println "|Testing method introspection...")
               let
@@ -467,7 +467,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-option-result-map $ %{} :CodeEntry (:doc "|Test Mappable trait for Option/Result")
+        |test-option-result-map $ %{} 'CodeEntry (:doc "|Test Mappable trait for Option/Result")
           :code $ quote
             defn test-option-result-map () (println "|Testing Option/Result Mappable...")
               let
@@ -524,7 +524,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-show-trait $ %{} :CodeEntry (:doc "|Test Show trait for built-in types")
+        |test-show-trait $ %{} 'CodeEntry (:doc "|Test Show trait for built-in types")
           :code $ quote
             defn test-show-trait () (println "|Testing Show trait...") (; All types should be showable)
               assert= |true $ str true
@@ -541,6 +541,6 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-traits.main $ :require

--- a/calcit/test-types-inference.cirru
+++ b/calcit/test-types-inference.cirru
@@ -5,52 +5,52 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-types-inference.main $ %{} :FileEntry
+    |test-types-inference.main $ %{} 'FileEntry
       :defs $ {}
-        |Address $ %{} :CodeEntry (:doc |)
+        |Address $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Address $ :city 'String
           :examples $ []
           :schema $ :: 'Dynamic
-        |Job $ %{} :CodeEntry (:doc |)
+        |Job $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Job (:title 'String) (:status Status)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Outcome $ %{} :CodeEntry (:doc |)
+        |Outcome $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Outcome (:status Status) (:none)
           :examples $ []
           :schema $ :: 'Dynamic
-        |Person $ %{} :CodeEntry (:doc |)
+        |Person $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Person (:name 'String) (:age 'Number)
               :address $ :: Address
           :examples $ []
           :schema $ :: 'Dynamic
-        |PersonWrap $ %{} :CodeEntry (:doc |)
+        |PersonWrap $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum PersonWrap
               :person $ :: Person
               :none
           :examples $ []
           :schema $ :: 'Dynamic
-        |Status $ %{} :CodeEntry (:doc |)
+        |Status $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Status (:ok 'Number) (:err 'String)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|Testing type inference...") (test-list-inference) (test-optional-inference) (test-count-inference) (test-fn-inference) (test-map-inference) (test-set-inference) (test-ref-inference) (test-struct-inference) (test-type-ref-combos) (test-generics-identity)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-count-inference $ %{} :CodeEntry (:doc |)
+        |test-count-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-count-inference ()
               assert-type
@@ -59,7 +59,7 @@
               assert-type (count |abc) 'Number
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-fn-inference $ %{} :CodeEntry (:doc |)
+        |test-fn-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-fn-inference () $ let
                 f $ fn (x) (+ x 1)
@@ -70,7 +70,7 @@
               &inspect-type f
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-generics-identity $ %{} :CodeEntry (:doc |)
+        |test-generics-identity $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-generics-identity () $ let
                 n $ identity 42
@@ -81,7 +81,7 @@
               &inspect-type s
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-inference $ %{} :CodeEntry (:doc |)
+        |test-list-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-inference () $ let
                 nested $ [] ([] 1 2) ([] 3)
@@ -102,7 +102,7 @@
                 &inspect-type rest-xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-inference $ %{} :CodeEntry (:doc |)
+        |test-map-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-map-inference () $ let
                 m $ {}
@@ -120,7 +120,7 @@
                 &inspect-type m5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-optional-inference $ %{} :CodeEntry (:doc |)
+        |test-optional-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-optional-inference ()
               let
@@ -277,7 +277,30 @@
                 &inspect-type nil-nested
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-inference $ %{} :CodeEntry (:doc |)
+        |test-ref-inference $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-ref-inference () $ let
+                r $ atom 1
+              assert-type r $ :: 'Ref 'Number
+              let
+                  x $ &atom:deref r
+                assert-type x 'Number
+                &inspect-type r
+                &inspect-type x
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-set-inference $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-set-inference () $ let
+                s $ #{}
+              assert-type s $ :: 'Set 'Number
+              let
+                  xs $ &set:to-list s
+                &inspect-type s
+                &inspect-type xs
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-struct-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-struct-inference () $ let
                 addr $ %{} Address (:city |sh)
@@ -297,30 +320,7 @@
                 &inspect-type city-v
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-ref-inference $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            defn test-ref-inference () $ let
-                r $ atom 1
-              assert-type r $ :: 'Ref 'Number
-              let
-                  x $ &atom:deref r
-                assert-type x 'Number
-                &inspect-type r
-                &inspect-type x
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-set-inference $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            defn test-set-inference () $ let
-                s $ #{}
-              assert-type s $ :: 'Set 'Number
-              let
-                  xs $ &set:to-list s
-                &inspect-type s
-                &inspect-type xs
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-type-ref-combos $ %{} :CodeEntry (:doc |)
+        |test-type-ref-combos $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-type-ref-combos () $ let
                 addr $ %{} Address (:city |sh)
@@ -340,5 +340,5 @@
                 &inspect-type outcome
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-types-inference.main)

--- a/calcit/test-types.cirru
+++ b/calcit/test-types.cirru
@@ -5,15 +5,15 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-types.main $ %{} :FileEntry
+    |test-types.main $ %{} 'FileEntry
       :defs $ {}
-        |EnumImpl $ %{} :CodeEntry (:doc "|Trait impl for enum metadata")
+        |EnumImpl $ %{} 'CodeEntry (:doc "|Trait impl for enum metadata")
           :code $ quote
             defimpl EnumImpl EnumMetadata $ .dummy
               fn $ self
           :examples $ []
           :schema $ :: 'Impl
-        |EnumMetadata $ %{} :CodeEntry (:doc |)
+        |EnumMetadata $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait EnumMetadata $ .dummy
               :: :fn $ {}
@@ -22,17 +22,17 @@
                 :return 'Unit
           :examples $ []
           :schema $ :: 'Trait
-        |Person $ %{} :CodeEntry (:doc "|Struct definition for type checks")
+        |Person $ %{} 'CodeEntry (:doc "|Struct definition for type checks")
           :code $ quote
             defstruct Person (:name 'String) (:age nil)
           :examples $ []
           :schema $ :: 'Struct
-        |Result $ %{} :CodeEntry (:doc "|Enum prototype for type checks")
+        |Result $ %{} 'CodeEntry (:doc "|Enum prototype for type checks")
           :code $ quote
             defenum Result (:ok 'Number) (:err 'String)
           :examples $ []
           :schema $ :: 'Enum
-        |ResultImpl $ %{} :CodeEntry (:doc "|Trait impl for enum tuple tests")
+        |ResultImpl $ %{} 'CodeEntry (:doc "|Trait impl for enum tuple tests")
           :code $ quote
             defimpl ResultImpl ResultTrait $ .describe
               fn (self)
@@ -41,18 +41,18 @@
                   (:err msg) (str "|err " msg)
           :examples $ []
           :schema $ :: 'Impl
-        |ResultTrait $ %{} :CodeEntry (:doc "|Trait definition for enum tuple tests")
+        |ResultTrait $ %{} 'CodeEntry (:doc "|Trait definition for enum tuple tests")
           :code $ quote
             deftrait ResultTrait $ .describe :fn
           :examples $ []
           :schema $ :: 'Trait
-        |StructImpl $ %{} :CodeEntry (:doc "|Trait impl for struct metadata")
+        |StructImpl $ %{} 'CodeEntry (:doc "|Trait impl for struct metadata")
           :code $ quote
             defimpl StructImpl StructMetadata $ .dummy
               fn $ self
           :examples $ []
           :schema $ :: 'Impl
-        |StructMetadata $ %{} :CodeEntry (:doc |)
+        |StructMetadata $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait StructMetadata $ .dummy
               :: :fn $ {}
@@ -61,14 +61,14 @@
                 :return 'Unit
           :examples $ []
           :schema $ :: 'Trait
-        |add-numbers $ %{} :CodeEntry (:doc |)
+        |add-numbers $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn add-numbers (a b) (&+ a b)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number 'Number
-        |chained-return-type $ %{} :CodeEntry (:doc "|Uses return-type hinting more than once")
+        |chained-return-type $ %{} 'CodeEntry (:doc "|Uses return-type hinting more than once")
           :code $ quote
             defn chained-return-type (base extra)
               let
@@ -80,14 +80,14 @@
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number 'Number
-        |describe-typed $ %{} :CodeEntry (:doc "|Combines typed label and number")
+        |describe-typed $ %{} 'CodeEntry (:doc "|Combines typed label and number")
           :code $ quote
             defn describe-typed (label value) (str label "|: " value)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String 'Number
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println "|Testing types...")
               println $ add-numbers 1 2
@@ -122,40 +122,40 @@
               ; Currently not supported for runtime Struct literals.
           :examples $ []
           :schema $ :: 'Dynamic
-        |process-string $ %{} :CodeEntry (:doc |)
+        |process-string $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn process-string (s) (str s |!!!)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |show-type-info $ %{} :CodeEntry (:doc |)
+        |show-type-info $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn show-type-info (x) (println "|Type info demo: value is" x) (; "后续引用" x "应该仍然保留类型信息") (&+ x 1)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-        |slice-as-string $ %{} :CodeEntry (:doc "|Guarded dynamic .slice call")
+        |slice-as-string $ %{} 'CodeEntry (:doc "|Guarded dynamic .slice call")
           :code $ quote
             defn slice-as-string (text) (.slice text 1 4)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String
-        |test-arg-type-hints $ %{} :CodeEntry (:doc "|Checks arg hint path without emitting warning")
+        |test-arg-type-hints $ %{} 'CodeEntry (:doc "|Checks arg hint path without emitting warning")
           :code $ quote
             defn test-arg-type-hints () (typed-only 1) (println "|arg type hints check executed")
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-builtin-proc-types $ %{} :CodeEntry (:doc "|Tests that Proc (builtin) functions check argument types during preprocess")
+        |test-builtin-proc-types $ %{} 'CodeEntry (:doc "|Tests that Proc (builtin) functions check argument types during preprocess")
           :code $ quote
             defn test-builtin-proc-types () (; Test math operations with typed arguments)
               let
@@ -172,7 +172,7 @@
                   println |negated: negated
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-complex-threading $ %{} :CodeEntry (:doc "|Tests type preservation with multiple typed functions in -> chain")
+        |test-complex-threading $ %{} 'CodeEntry (:doc "|Tests type preservation with multiple typed functions in -> chain")
           :code $ quote
             defn test-complex-threading (a b)
               let
@@ -186,7 +186,7 @@
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number 'Number
-        |test-defstruct-defenum $ %{} :CodeEntry (:doc "|Smoke test for defstruct/defenum and %:: tuples")
+        |test-defstruct-defenum $ %{} 'CodeEntry (:doc "|Smoke test for defstruct/defenum and %:: tuples")
           :code $ quote
             defn test-defstruct-defenum ()
               assert= :struct-def $ type-of Person
@@ -205,7 +205,7 @@
               , "|defstruct/defenum checks passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-dynamic-methods $ %{} :CodeEntry (:doc "|Ensures .slice target type is validated")
+        |test-dynamic-methods $ %{} 'CodeEntry (:doc "|Ensures .slice target type is validated")
           :code $ quote
             defn test-dynamic-methods ()
               let
@@ -220,7 +220,7 @@
               , "|slice checks passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-fn-type $ %{} :CodeEntry (:doc |)
+        |test-fn-type $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-fn-type (f x) (f x)
           :examples $ []
@@ -231,7 +231,7 @@
                   :args $ [] 'Number
                 , 'Number
               :generics $ [] 'T
-        |test-list-methods $ %{} :CodeEntry (:doc "|Tests method calls on typed list objects")
+        |test-list-methods $ %{} 'CodeEntry (:doc "|Tests method calls on typed list objects")
           :code $ quote
             defn test-list-methods () (; Create a list and annotate its type)
               let
@@ -253,7 +253,7 @@
               , "|List method checks passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-method-type-errors $ %{} :CodeEntry (:doc "|Tests that invalid method calls are caught in preprocess")
+        |test-method-type-errors $ %{} 'CodeEntry (:doc "|Tests that invalid method calls are caught in preprocess")
           :code $ quote
             defn test-method-type-errors () (; "⚠️" "这些代码故意包含错误，用于验证" preprocess "阶段的类型检查") (; "当启用时，会在编译阶段就报错，而不是运行时") (; "测试" 1: list "对象调用不存在的方法") (; let)
               ; xs $ [] 1 2 3
@@ -274,7 +274,7 @@
               , "|Tests disabled to allow compilation"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-preprocess-method-validation $ %{} :CodeEntry (:doc "|Demonstrates that valid method calls pass preprocess validation")
+        |test-preprocess-method-validation $ %{} 'CodeEntry (:doc "|Demonstrates that valid method calls pass preprocess validation")
           :code $ quote
             defn test-preprocess-method-validation () (; "所有这些方法调用都是合法的，应该通过" preprocess "检查")
               let
@@ -304,7 +304,7 @@
               , "|All valid method calls passed preprocess validation"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-proc-type $ %{} :CodeEntry (:doc "|Tests Proc (builtin function) type annotation")
+        |test-proc-type $ %{} 'CodeEntry (:doc "|Tests Proc (builtin function) type annotation")
           :code $ quote
             defn test-proc-type (p x y) (p x y)
           :examples $ []
@@ -314,29 +314,12 @@
                 :: 'Fn $ {} (:return 'Number)
                   :args $ [] 'Number 'Number
                 , 'Number 'Number
-        |test-proc-type-warnings $ %{} :CodeEntry (:doc "|Test that should generate type warnings - disabled by default")
+        |test-proc-type-warnings $ %{} 'CodeEntry (:doc "|Test that should generate type warnings - disabled by default")
           :code $ quote
             defn test-proc-type-warnings () (; This function intentionally contains type errors for testing) (; It is not called in normal tests to avoid blocking execution) (println "|Warning: This test contains intentional type errors")
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-methods $ %{} :CodeEntry (:doc "|Tests method calls on Struct instances with impls")
-          :code $ quote
-            defn test-struct-methods () (; "使用" impl-traits "挂载实现" Struct methods)
-              let
-                  PersonGreeting $ deftrait PersonGreeting (.greet :fn)
-                  PersonImpl $ defimpl PersonImpl PersonGreeting
-                    .greet $ fn (self)
-                      str "|Hello, I'm " $ :name self
-                  Person $ impl-traits Person PersonImpl
-                  alice $ %{} Person (:name |Alice) (:age 30)
-                let
-                    greeting $ alice .greet
-                  println |greeting: greeting
-                  assert= "|Hello, I'm Alice" greeting
-              , "|Struct method checks passed"
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-string-methods $ %{} :CodeEntry (:doc "|Tests method calls on typed string objects")
+        |test-string-methods $ %{} 'CodeEntry (:doc "|Tests method calls on typed string objects")
           :code $ quote
             defn test-string-methods ()
               let
@@ -361,7 +344,24 @@
               , "|String method checks passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-threading-types $ %{} :CodeEntry (:doc "|Tests type preservation through -> threading macro")
+        |test-struct-methods $ %{} 'CodeEntry (:doc "|Tests method calls on Struct instances with impls")
+          :code $ quote
+            defn test-struct-methods () (; "使用" impl-traits "挂载实现" Struct methods)
+              let
+                  PersonGreeting $ deftrait PersonGreeting (.greet :fn)
+                  PersonImpl $ defimpl PersonImpl PersonGreeting
+                    .greet $ fn (self)
+                      str "|Hello, I'm " $ :name self
+                  Person $ impl-traits Person PersonImpl
+                  alice $ %{} Person (:name |Alice) (:age 30)
+                let
+                    greeting $ alice .greet
+                  println |greeting: greeting
+                  assert= "|Hello, I'm Alice" greeting
+              , "|Struct method checks passed"
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-threading-types $ %{} 'CodeEntry (:doc "|Tests type preservation through -> threading macro")
           :code $ quote
             defn test-threading-types (text) (; "使用" -> "串联：text" "先经过" str "拼接，再经过" process-string) (; "最终结果应该保留" :string "类型（从" process-string "的" return-type "推断）")
               -> text (str |prefix:) (process-string)
@@ -369,7 +369,7 @@
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String
-        |test-typed-method-access $ %{} :CodeEntry (:doc "|Demonstrates type-safe method access patterns")
+        |test-typed-method-access $ %{} 'CodeEntry (:doc "|Demonstrates type-safe method access patterns")
           :code $ quote
             defn test-typed-method-access () (; "当对象有类型标注时，方法调用会检查该类型支持的方法")
               let
@@ -398,12 +398,12 @@
               , "|Typed method access checks passed"
           :examples $ []
           :schema $ :: 'Dynamic
-        |typed-only $ %{} :CodeEntry (:doc "|Used to verify arg type hints are collected")
+        |typed-only $ %{} 'CodeEntry (:doc "|Used to verify arg type hints are collected")
           :code $ quote
             defn typed-only (a) (&+ 1 0)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-types.main)

--- a/calcit/test-wasm-suite.cirru
+++ b/calcit/test-wasm-suite.cirru
@@ -5,18 +5,18 @@
       :modules $ [] |./util.cirru |./test-cond.cirru |./test-math.cirru |./test-set.cirru |./test-anonymous-enum.cirru |./test-fn.cirru |./test-lens.cirru |./test-edn.cirru |./test-string.cirru |./test-nil.cirru
       :type-slots $ {}
   :files $ {}
-    |test-wasm-suite.main $ %{} :FileEntry
+    |test-wasm-suite.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (test-cond/main!) (test-math/main!) (test-set/main!) (test-anonymous-enum/main!) (test-fn/main!) (test-lens/main!) (test-edn/main!) (test-string/main!) (test-nil/main!)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ main!
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-wasm-suite.main $ :require ([] test-cond.main :as test-cond) ([] test-math.main :as test-math) ([] test-set.main :as test-set) ([] test-anonymous-enum.main :as test-anonymous-enum) ([] test-fn.main :as test-fn) ([] test-lens.main :as test-lens) ([] test-edn.main :as test-edn) ([] test-string.main :as test-string) (test-nil.main :as test-nil)

--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -5,28 +5,28 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-wasm.helper $ %{} :FileEntry
+    |test-wasm.helper $ %{} 'FileEntry
       :defs $ {}
-        |add-and-double $ %{} :CodeEntry (:doc "|Helper: add two numbers and double")
+        |add-and-double $ %{} 'CodeEntry (:doc "|Helper: add two numbers and double")
           :code $ quote
             defn add-and-double (a b)
               &* (&+ a b) 2
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-wasm.helper)
-    |test-wasm.main $ %{} :FileEntry
+    |test-wasm.main $ %{} 'FileEntry
       :defs $ {}
-        |Point $ %{} :CodeEntry (:doc "|Record definition for WASM test")
+        |Point $ %{} 'CodeEntry (:doc "|Record definition for WASM test")
           :code $ quote (defrecord Point :x :y)
           :examples $ []
           :schema $ :: 'Dynamic
-        |add-two $ %{} :CodeEntry (:doc "|Simple addition")
+        |add-two $ %{} 'CodeEntry (:doc "|Simple addition")
           :code $ quote
             defn add-two (a b) (&+ a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |collatz-steps $ %{} :CodeEntry (:doc "|Collatz conjecture step counter")
+        |collatz-steps $ %{} 'CodeEntry (:doc "|Collatz conjecture step counter")
           :code $ quote
             defn collatz-steps (n)
               if (&< n 2) 0 $ if
@@ -36,19 +36,19 @@
                   &+ (&* 3 n) 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |collect-rest $ %{} :CodeEntry (:doc "|returns rest list unchanged")
+        |collect-rest $ %{} 'CodeEntry (:doc "|returns rest list unchanged")
           :code $ quote
             defn collect-rest (a & xs) xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |factorial $ %{} :CodeEntry (:doc "|Factorial — recursive")
+        |factorial $ %{} 'CodeEntry (:doc "|Factorial — recursive")
           :code $ quote
             defn factorial (n)
               if (&< n 2) 1 $ &* n
                 factorial $ &- n 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |fibo $ %{} :CodeEntry (:doc "|Fibonacci — recursive")
+        |fibo $ %{} 'CodeEntry (:doc "|Fibonacci — recursive")
           :code $ quote
             defn fibo (n)
               if (&< n 2) 1 $ &+
@@ -56,54 +56,54 @@
                 fibo $ &- n 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |gcd $ %{} :CodeEntry (:doc "|Greatest common divisor")
+        |gcd $ %{} 'CodeEntry (:doc "|Greatest common divisor")
           :code $ quote
             defn gcd (a b)
               if (&= b 0) a $ recur b (&number:rem a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |host-string-upcase $ %{} :CodeEntry (:doc |)
+        |host-string-upcase $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defwasm-import host-string-upcase (text) |host |string-upcase
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ println (fibo 10)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |sum-range $ %{} :CodeEntry (:doc "|Sum 1..n via helper")
+        |sum-range $ %{} 'CodeEntry (:doc "|Sum 1..n via helper")
           :code $ quote
             defn sum-range (n) (sum-range-step 0 1 n)
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-range-step $ %{} :CodeEntry (:doc "|Sum step helper: sum-range-step(acc, i, n)")
+        |sum-range-step $ %{} 'CodeEntry (:doc "|Sum step helper: sum-range-step(acc, i, n)")
           :code $ quote
             defn sum-range-step (acc i n)
               if (&> i n) acc $ recur (&+ acc i) (&+ i 1) n
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-rest $ %{} :CodeEntry (:doc "|variadic sum: a + b + rest...")
+        |sum-rest $ %{} 'CodeEntry (:doc "|variadic sum: a + b + rest...")
           :code $ quote
             defn sum-rest (a b & xs)
               sum-rest-list (&+ a b) xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-rest-forward $ %{} :CodeEntry (:doc "|forwards a rest list via &call-spread")
+        |sum-rest-forward $ %{} 'CodeEntry (:doc "|forwards a rest list via &call-spread")
           :code $ quote
             defn sum-rest-forward (a b & xs) (sum-rest a b & xs)
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-rest-list $ %{} :CodeEntry (:doc "|helper: sums a list via recur")
+        |sum-rest-list $ %{} 'CodeEntry (:doc "|helper: sums a list via recur")
           :code $ quote
             defn sum-rest-list (acc xs)
               if (&list:empty? xs) acc $ recur
@@ -111,42 +111,42 @@
                 &list:rest xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-abs $ %{} :CodeEntry (:doc "|abs from calcit.core")
+        |test-abs $ %{} 'CodeEntry (:doc "|abs from calcit.core")
           :code $ quote
             defn test-abs (x) (abs x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-and $ %{} :CodeEntry (:doc "|Bitwise AND")
+        |test-bit-and $ %{} 'CodeEntry (:doc "|Bitwise AND")
           :code $ quote
             defn test-bit-and (a b) (bit-and a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-not $ %{} :CodeEntry (:doc "|Bitwise NOT")
+        |test-bit-not $ %{} 'CodeEntry (:doc "|Bitwise NOT")
           :code $ quote
             defn test-bit-not (a) (bit-not a)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-or $ %{} :CodeEntry (:doc "|Bitwise OR")
+        |test-bit-or $ %{} 'CodeEntry (:doc "|Bitwise OR")
           :code $ quote
             defn test-bit-or (a b) (bit-or a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-shl $ %{} :CodeEntry (:doc "|Bitwise shift left")
+        |test-bit-shl $ %{} 'CodeEntry (:doc "|Bitwise shift left")
           :code $ quote
             defn test-bit-shl (a b) (bit-shl a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-shr $ %{} :CodeEntry (:doc "|Bitwise shift right")
+        |test-bit-shr $ %{} 'CodeEntry (:doc "|Bitwise shift right")
           :code $ quote
             defn test-bit-shr (a b) (bit-shr a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-xor $ %{} :CodeEntry (:doc "|Bitwise XOR")
+        |test-bit-xor $ %{} 'CodeEntry (:doc "|Bitwise XOR")
           :code $ quote
             defn test-bit-xor (a b) (bit-xor a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-doseq $ %{} :CodeEntry (:doc "||buf-list: use doseq to push 4 items, count=4")
+        |test-buf-list-doseq $ %{} 'CodeEntry (:doc "||buf-list: use doseq to push 4 items, count=4")
           :code $ quote
             defn test-buf-list-doseq () $ let
                 buf $ &buf-list:new
@@ -156,7 +156,7 @@
               &buf-list:count buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-each $ %{} :CodeEntry (:doc "||buf-list: use each to push 3 items, count=3")
+        |test-buf-list-each $ %{} 'CodeEntry (:doc "||buf-list: use each to push 3 items, count=3")
           :code $ quote
             defn test-buf-list-each () $ let
                 buf $ &buf-list:new
@@ -165,7 +165,7 @@
               &buf-list:count buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-filter $ %{} :CodeEntry (:doc "||buf-list: concat [1..5], filter even from to-list, count=2")
+        |test-buf-list-filter $ %{} 'CodeEntry (:doc "||buf-list: concat [1..5], filter even from to-list, count=2")
           :code $ quote
             defn test-buf-list-filter () $ let
                 buf $ &buf-list:new
@@ -175,7 +175,7 @@
                   &= (&number:rem x 2) 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-map $ %{} :CodeEntry (:doc "||buf-list: concat 3 items, map to-list, count=3")
+        |test-buf-list-map $ %{} 'CodeEntry (:doc "||buf-list: concat 3 items, map to-list, count=3")
           :code $ quote
             defn test-buf-list-map () $ let
                 buf $ &buf-list:new
@@ -184,7 +184,7 @@
                 fn (x) (&* x 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-push $ %{} :CodeEntry (:doc "||buf-list push 3 items, count=3")
+        |test-buf-list-push $ %{} 'CodeEntry (:doc "||buf-list push 3 items, count=3")
           :code $ quote
             defn test-buf-list-push () $ let
                 buf $ &buf-list:new
@@ -194,7 +194,7 @@
               &buf-list:count buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-to-list $ %{} :CodeEntry (:doc "||buf-list concat [1,2,3] then to-list, count=3")
+        |test-buf-list-to-list $ %{} 'CodeEntry (:doc "||buf-list concat [1,2,3] then to-list, count=3")
           :code $ quote
             defn test-buf-list-to-list () $ let
                 buf $ &buf-list:new
@@ -203,43 +203,43 @@
               &list:count $ &buf-list:to-list buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-call-spread-rest $ %{} :CodeEntry (:doc "|rest list forwarding via &call-spread")
+        |test-call-spread-rest $ %{} 'CodeEntry (:doc "|rest list forwarding via &call-spread")
           :code $ quote
             defn test-call-spread-rest () $ sum-rest-forward 1 2 3 4 5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-ceil $ %{} :CodeEntry (:doc "|ceil function")
+        |test-ceil $ %{} 'CodeEntry (:doc "|ceil function")
           :code $ quote
             defn test-ceil (x) (ceil x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-compare $ %{} :CodeEntry (:doc "|comparison chain")
+        |test-compare $ %{} 'CodeEntry (:doc "|comparison chain")
           :code $ quote
             defn test-compare (a b)
               if (&< a b) -1 $ if (&> a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-cos $ %{} :CodeEntry (:doc "|cos via host import")
+        |test-cos $ %{} 'CodeEntry (:doc "|cos via host import")
           :code $ quote
             defn test-cos (x) (cos x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-cross-ns $ %{} :CodeEntry (:doc "|Cross-namespace function call")
+        |test-cross-ns $ %{} 'CodeEntry (:doc "|Cross-namespace function call")
           :code $ quote
             defn test-cross-ns (a b) (helper/add-and-double a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-display-by-bin $ %{} :CodeEntry (:doc "|17 in binary = 0b10001, length 7")
+        |test-display-by-bin $ %{} 'CodeEntry (:doc "|17 in binary = 0b10001, length 7")
           :code $ quote
             defn test-display-by-bin () $ &str:count (&number:display-by 17 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-display-by-hex $ %{} :CodeEntry (:doc "|17 in hex = 0x11, length 4")
+        |test-display-by-hex $ %{} 'CodeEntry (:doc "|17 in hex = 0x11, length 4")
           :code $ quote
             defn test-display-by-hex () $ &str:count (&number:display-by 17 16)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-found $ %{} :CodeEntry (:doc |)
+        |test-find-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-found () $ option:unwrap-or
               find ([] 1 2 3)
@@ -247,7 +247,7 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-index-found $ %{} :CodeEntry (:doc |)
+        |test-find-index-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-index-found () $ option:unwrap-or
               find-index ([] 1 2 3)
@@ -255,7 +255,7 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-index-not-found $ %{} :CodeEntry (:doc |)
+        |test-find-index-not-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-index-not-found () $ option:unwrap-or
               find-index ([] 1 2 3)
@@ -263,7 +263,7 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-not-found $ %{} :CodeEntry (:doc |)
+        |test-find-not-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-not-found () $ option:unwrap-or
               find ([] 1 2 3)
@@ -271,25 +271,25 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-floor $ %{} :CodeEntry (:doc "|floor function")
+        |test-floor $ %{} 'CodeEntry (:doc "|floor function")
           :code $ quote
             defn test-floor (x) (floor x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-gte $ %{} :CodeEntry (:doc |greater-than-or-equal)
+        |test-gte $ %{} 'CodeEntry (:doc |greater-than-or-equal)
           :code $ quote
             defn test-gte (a b)
               if (&> a b) 1 $ if (&= a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-hash-number $ %{} :CodeEntry (:doc "|hash on number returns stable non-zero value")
+        |test-hash-number $ %{} 'CodeEntry (:doc "|hash on number returns stable non-zero value")
           :code $ quote
             defn test-hash-number () $ if
               &> (&hash 42) 0
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-let-chain $ %{} :CodeEntry (:doc "|chained let bindings")
+        |test-let-chain $ %{} 'CodeEntry (:doc "|chained let bindings")
           :code $ quote
             defn test-let-chain (x)
               &let
@@ -299,54 +299,54 @@
                   &* b 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-append $ %{} :CodeEntry (:doc "|append returns correct count and last elem")
+        |test-list-append $ %{} 'CodeEntry (:doc "|append returns correct count and last elem")
           :code $ quote
             defn test-list-append () $ &let
               xs $ append ([] 10 20) 30
               &+ (&list:count xs) (&list:nth xs 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-assoc $ %{} :CodeEntry (:doc "|assoc replaces element")
+        |test-list-assoc $ %{} 'CodeEntry (:doc "|assoc replaces element")
           :code $ quote
             defn test-list-assoc () $ &list:nth
               &list:assoc ([] 10 20 30) 1 99
               , 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-assoc-after $ %{} :CodeEntry (:doc "|assoc-after inserts element after index")
+        |test-list-assoc-after $ %{} 'CodeEntry (:doc "|assoc-after inserts element after index")
           :code $ quote
             defn test-list-assoc-after () $ &let
               xs $ &list:assoc-after ([] 10 20 30) 0 99
               &+ (&list:count xs) (&list:nth xs 1)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-assoc-before $ %{} :CodeEntry (:doc "|assoc-before inserts element before index")
+        |test-list-assoc-before $ %{} 'CodeEntry (:doc "|assoc-before inserts element before index")
           :code $ quote
             defn test-list-assoc-before () $ &let
               xs $ &list:assoc-before ([] 10 20 30) 1 99
               &+ (&list:count xs) (&list:nth xs 1)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-butlast $ %{} :CodeEntry (:doc "|butlast drops last element")
+        |test-list-butlast $ %{} 'CodeEntry (:doc "|butlast drops last element")
           :code $ quote
             defn test-list-butlast () $ &list:count
               butlast $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-butlast-empty $ %{} :CodeEntry (:doc |)
+        |test-list-butlast-empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-butlast-empty () $ &list:count
               butlast $ []
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-concat $ %{} :CodeEntry (:doc "|concat two lists")
+        |test-list-concat $ %{} 'CodeEntry (:doc "|concat two lists")
           :code $ quote
             defn test-list-concat () $ &let
               xs $ &list:concat ([] 10 20) ([] 30 40)
               &+ (&list:count xs) (&list:nth xs 3)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-contains $ %{} :CodeEntry (:doc "|contains checks index bounds")
+        |test-list-contains $ %{} 'CodeEntry (:doc "|contains checks index bounds")
           :code $ quote
             defn test-list-contains () $ &let
               xs $ [] 10 20 30
@@ -355,7 +355,7 @@
                 if (&list:contains? xs 5) 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-contains-method $ %{} :CodeEntry (:doc "|.contains? dispatches on list")
+        |test-list-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on list")
           :code $ quote
             defn test-list-contains-method () $ &+
               if
@@ -366,57 +366,57 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-count $ %{} :CodeEntry (:doc "|list count")
+        |test-list-count $ %{} 'CodeEntry (:doc "|list count")
           :code $ quote
             defn test-list-count () $ &list:count ([] 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-dissoc $ %{} :CodeEntry (:doc "|dissoc removes element")
+        |test-list-dissoc $ %{} 'CodeEntry (:doc "|dissoc removes element")
           :code $ quote
             defn test-list-dissoc () $ &let
               xs $ &list:dissoc ([] 10 20 30) 1
               &+ (&list:count xs) (&list:nth xs 1)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty-false $ %{} :CodeEntry (:doc "|non-empty list not empty")
+        |test-list-empty-false $ %{} 'CodeEntry (:doc "|non-empty list not empty")
           :code $ quote
             defn test-list-empty-false () $ if
               &list:empty? $ [] 1
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty-method $ %{} :CodeEntry (:doc "|.empty returns an empty list")
+        |test-list-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty list")
           :code $ quote
             defn test-list-empty-method () $ count
               .empty $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty-true $ %{} :CodeEntry (:doc "|empty list is empty")
+        |test-list-empty-true $ %{} 'CodeEntry (:doc "|empty list is empty")
           :code $ quote
             defn test-list-empty-true () $ if
               &list:empty? $ []
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty?-method $ %{} :CodeEntry (:doc "|.empty? uses generic method dispatch")
+        |test-list-empty?-method $ %{} 'CodeEntry (:doc "|.empty? uses generic method dispatch")
           :code $ quote
             defn test-list-empty?-method () $ if
               .empty? $ []
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-first $ %{} :CodeEntry (:doc "|list first element")
+        |test-list-first $ %{} 'CodeEntry (:doc "|list first element")
           :code $ quote
             defn test-list-first () $ &list:first ([] 42 99)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-first-generic $ %{} :CodeEntry (:doc "|generic first() on list via invoke")
+        |test-list-first-generic $ %{} 'CodeEntry (:doc "|generic first() on list via invoke")
           :code $ quote
             defn test-list-first-generic () $ option:unwrap
               first $ [] 42 99
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-includes $ %{} :CodeEntry (:doc "|includes checks value presence")
+        |test-list-includes $ %{} 'CodeEntry (:doc "|includes checks value presence")
           :code $ quote
             defn test-list-includes () $ &+
               if
@@ -427,7 +427,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-includes-method $ %{} :CodeEntry (:doc "|.includes? dispatches on list")
+        |test-list-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on list")
           :code $ quote
             defn test-list-includes-method () $ &+
               if
@@ -438,117 +438,117 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-max-empty $ %{} :CodeEntry (:doc |)
+        |test-list-max-empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-max-empty () $ option:unwrap-or
               .max $ []
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-max-method $ %{} :CodeEntry (:doc "|.max dispatches on list")
+        |test-list-max-method $ %{} 'CodeEntry (:doc "|.max dispatches on list")
           :code $ quote
             defn test-list-max-method () $ option:unwrap-or
               .max $ [] 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-min-method $ %{} :CodeEntry (:doc "|.min dispatches on list")
+        |test-list-min-method $ %{} 'CodeEntry (:doc "|.min dispatches on list")
           :code $ quote
             defn test-list-min-method () $ option:unwrap-or
               .min $ [] 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-nth $ %{} :CodeEntry (:doc "|list nth element")
+        |test-list-nth $ %{} 'CodeEntry (:doc "|list nth element")
           :code $ quote
             defn test-list-nth (i)
               &list:nth ([] 10 20 30 40) i
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-prepend $ %{} :CodeEntry (:doc "|prepend returns correct first elem")
+        |test-list-prepend $ %{} 'CodeEntry (:doc "|prepend returns correct first elem")
           :code $ quote
             defn test-list-prepend () $ &list:first
               prepend ([] 10 20) 5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-count $ %{} :CodeEntry (:doc "|count of rest")
+        |test-list-rest-count $ %{} 'CodeEntry (:doc "|count of rest")
           :code $ quote
             defn test-list-rest-count () $ &list:count
               &list:rest $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-empty $ %{} :CodeEntry (:doc |)
+        |test-list-rest-empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-rest-empty () $ &list:count
               &list:rest $ []
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-first $ %{} :CodeEntry (:doc "|first of rest")
+        |test-list-rest-first $ %{} 'CodeEntry (:doc "|first of rest")
           :code $ quote
             defn test-list-rest-first () $ &list:first
               &list:rest $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-generic-first $ %{} :CodeEntry (:doc "|generic rest() on list via invoke")
+        |test-list-rest-generic-first $ %{} 'CodeEntry (:doc "|generic rest() on list via invoke")
           :code $ quote
             defn test-list-rest-generic-first () $ option:unwrap
               first $ rest ([] 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-reverse $ %{} :CodeEntry (:doc "|reverse a list")
+        |test-list-reverse $ %{} 'CodeEntry (:doc "|reverse a list")
           :code $ quote
             defn test-list-reverse () $ &let
               xs $ &list:reverse ([] 10 20 30)
               &+ (&list:first xs) (&list:nth xs 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-slice $ %{} :CodeEntry (:doc "|slice with start and end")
+        |test-list-slice $ %{} 'CodeEntry (:doc "|slice with start and end")
           :code $ quote
             defn test-list-slice () $ &let
               xs $ &list:slice ([] 10 20 30 40 50) 1 4
               &+ (&list:count xs) (&list:first xs)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-to-set $ %{} :CodeEntry (:doc "|list to set deduplicates elements")
+        |test-list-to-set $ %{} 'CodeEntry (:doc "|list to set deduplicates elements")
           :code $ quote
             defn test-list-to-set () $ &let
               s $ &list:to-set ([] 10 20 30 20 10)
               &set:count s
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list?-false $ %{} :CodeEntry (:doc "|list? on number returns false (0)")
+        |test-list?-false $ %{} 'CodeEntry (:doc "|list? on number returns false (0)")
           :code $ quote
             defn test-list?-false () $ if (list? 42) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list?-true $ %{} :CodeEntry (:doc "|list? on a list returns true (1)")
+        |test-list?-true $ %{} 'CodeEntry (:doc "|list? on a list returns true (1)")
           :code $ quote
             defn test-list?-true () $ if
               list? $ [] 1 2
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-lte $ %{} :CodeEntry (:doc |less-than-or-equal)
+        |test-lte $ %{} 'CodeEntry (:doc |less-than-or-equal)
           :code $ quote
             defn test-lte (a b)
               if (&< a b) 1 $ if (&= a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-assoc-new $ %{} :CodeEntry (:doc "|assoc adds new key")
+        |test-map-assoc-new $ %{} 'CodeEntry (:doc "|assoc adds new key")
           :code $ quote
             defn test-map-assoc-new () $ &let
               m $ &map:assoc (&{} :a 1) :b 2
               &+ (&map:count m) (&map:get m :b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-assoc-update $ %{} :CodeEntry (:doc "|assoc updates existing key")
+        |test-map-assoc-update $ %{} 'CodeEntry (:doc "|assoc updates existing key")
           :code $ quote
             defn test-map-assoc-update () $ &map:get
               &map:assoc (&{} :a 1 :b 2) :b 99
               , :b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-bucket-update $ %{} :CodeEntry (:doc "|update on collided numeric keys keeps lookup correct")
+        |test-map-bucket-update $ %{} 'CodeEntry (:doc "|update on collided numeric keys keeps lookup correct")
           :code $ quote
             defn test-map-bucket-update (a b)
               &let
@@ -556,13 +556,13 @@
                 &+ (&map:get m a) (&map:get m b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-common-keys $ %{} :CodeEntry (:doc "|common-keys: keys in both a and b")
+        |test-map-common-keys $ %{} 'CodeEntry (:doc "|common-keys: keys in both a and b")
           :code $ quote
             defn test-map-common-keys () $ &set:count
               &map:common-keys (&{} :a 1 :b 2 :c 3) (&{} :b 10 :c 20 :d 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-contains $ %{} :CodeEntry (:doc "|contains checks key presence")
+        |test-map-contains $ %{} 'CodeEntry (:doc "|contains checks key presence")
           :code $ quote
             defn test-map-contains () $ &+
               if
@@ -573,7 +573,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-contains-method $ %{} :CodeEntry (:doc "|.contains? dispatches on map")
+        |test-map-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on map")
           :code $ quote
             defn test-map-contains-method () $ &+
               if
@@ -584,56 +584,56 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-count $ %{} :CodeEntry (:doc "|map count")
+        |test-map-count $ %{} 'CodeEntry (:doc "|map count")
           :code $ quote
             defn test-map-count () $ &map:count (&{} :a 1 :b 2 :c 3)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-diff-keys $ %{} :CodeEntry (:doc "|diff-keys: keys in a not in b")
+        |test-map-diff-keys $ %{} 'CodeEntry (:doc "|diff-keys: keys in a not in b")
           :code $ quote
             defn test-map-diff-keys () $ &set:count
               &map:diff-keys (&{} :a 1 :b 2 :c 3) (&{} :b 10)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-diff-new $ %{} :CodeEntry (:doc "|diff-new: entries in b not in a")
+        |test-map-diff-new $ %{} 'CodeEntry (:doc "|diff-new: entries in b not in a")
           :code $ quote
             defn test-map-diff-new () $ &map:count
               &map:diff-new (&{} :a 1 :b 2) (&{} :b 3 :c 4 :d 5)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-dissoc $ %{} :CodeEntry (:doc "|dissoc removes key")
+        |test-map-dissoc $ %{} 'CodeEntry (:doc "|dissoc removes key")
           :code $ quote
             defn test-map-dissoc () $ &let
               m $ &map:dissoc (&{} :a 1 :b 2 :c 3) :b
               &+ (&map:count m) (&map:get m :c)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-empty-false $ %{} :CodeEntry (:doc "|non-empty map not empty")
+        |test-map-empty-false $ %{} 'CodeEntry (:doc "|non-empty map not empty")
           :code $ quote
             defn test-map-empty-false () $ if
               &map:empty? $ &{} :a 1
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-empty-method $ %{} :CodeEntry (:doc "|.empty returns an empty map")
+        |test-map-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty map")
           :code $ quote
             defn test-map-empty-method () $ count
               .empty $ &{} :a 1 :b 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-empty-true $ %{} :CodeEntry (:doc "|empty map is empty")
+        |test-map-empty-true $ %{} 'CodeEntry (:doc "|empty map is empty")
           :code $ quote
             defn test-map-empty-true () $ if
               &map:empty? $ &{}
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-get $ %{} :CodeEntry (:doc "|map get by key")
+        |test-map-get $ %{} 'CodeEntry (:doc "|map get by key")
           :code $ quote
             defn test-map-get () $ &map:get (&{} :a 10 :b 20 :c 30) :b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-hash-index1 $ %{} :CodeEntry (:doc "|second 5 bits of number hash")
+        |test-map-hash-index1 $ %{} 'CodeEntry (:doc "|second 5 bits of number hash")
           :code $ quote
             defn test-map-hash-index1 (n)
               bit-and
@@ -641,12 +641,12 @@
                 , 31
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-hash-value $ %{} :CodeEntry (:doc "|raw hash for numeric key")
+        |test-map-hash-value $ %{} 'CodeEntry (:doc "|raw hash for numeric key")
           :code $ quote
             defn test-map-hash-value (n) (&hash n)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-includes $ %{} :CodeEntry (:doc "|map includes checks value")
+        |test-map-includes $ %{} 'CodeEntry (:doc "|map includes checks value")
           :code $ quote
             defn test-map-includes () $ &+
               if
@@ -657,7 +657,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-includes-method $ %{} :CodeEntry (:doc "|.includes? dispatches on map")
+        |test-map-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on map")
           :code $ quote
             defn test-map-includes-method () $ &+
               if
@@ -668,20 +668,20 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-merge $ %{} :CodeEntry (:doc "|merge two maps, b overrides a")
+        |test-map-merge $ %{} 'CodeEntry (:doc "|merge two maps, b overrides a")
           :code $ quote
             defn test-map-merge () $ &map:count
               &merge (&{} :a 1 :b 2) (&{} :b 3 :c 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-merge-value $ %{} :CodeEntry (:doc "|merge override check via get")
+        |test-map-merge-value $ %{} 'CodeEntry (:doc "|merge override check via get")
           :code $ quote
             defn test-map-merge-value () $ &map:get
               &merge (&{} :a 1 :b 2) (&{} :b 99)
               , :b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-two-keys-sum $ %{} :CodeEntry (:doc "|sum lookups for two numeric keys")
+        |test-map-two-keys-sum $ %{} 'CodeEntry (:doc "|sum lookups for two numeric keys")
           :code $ quote
             defn test-map-two-keys-sum (a b)
               &let
@@ -689,14 +689,14 @@
                 &+ (&map:get m a) (&map:get m b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map?-true $ %{} :CodeEntry (:doc "|map? on map returns true (1)")
+        |test-map?-true $ %{} 'CodeEntry (:doc "|map? on map returns true (1)")
           :code $ quote
             defn test-map?-true () $ if
               map? $ &{} :a 1
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match-sub $ %{} :CodeEntry (:doc "|Match on second variant")
+        |test-match-sub $ %{} 'CodeEntry (:doc "|Match on second variant")
           :code $ quote
             defn test-match-sub (x y)
               &let
@@ -707,7 +707,7 @@
                   _ 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match-tag $ %{} :CodeEntry (:doc "|Match on tuple tag")
+        |test-match-tag $ %{} 'CodeEntry (:doc "|Match on tuple tag")
           :code $ quote
             defn test-match-tag (x y)
               &let
@@ -718,7 +718,7 @@
                   _ 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match-wildcard $ %{} :CodeEntry (:doc "|Match falls to wildcard")
+        |test-match-wildcard $ %{} 'CodeEntry (:doc "|Match falls to wildcard")
           :code $ quote
             defn test-match-wildcard () $ &let
               t $ :: :unknown 99
@@ -727,71 +727,71 @@
                 _ -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-max $ %{} :CodeEntry (:doc "|max of two numbers")
+        |test-max $ %{} 'CodeEntry (:doc "|max of two numbers")
           :code $ quote
             defn test-max (a b)
               if (&> a b) a b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-min $ %{} :CodeEntry (:doc "|min of two numbers")
+        |test-min $ %{} 'CodeEntry (:doc "|min of two numbers")
           :code $ quote
             defn test-min (a b)
               if (&< a b) a b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-negate $ %{} :CodeEntry (:doc "|negate from calcit.core")
+        |test-negate $ %{} 'CodeEntry (:doc "|negate from calcit.core")
           :code $ quote
             defn test-negate (x) (negate x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-not $ %{} :CodeEntry (:doc "|not operation")
+        |test-not $ %{} 'CodeEntry (:doc "|not operation")
           :code $ quote
             defn test-not (x) (not x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-number-compare-method $ %{} :CodeEntry (:doc |)
+        |test-number-compare-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-number-compare-method () $ .compare 1 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-number?-true $ %{} :CodeEntry (:doc "|number? on number returns true (1)")
+        |test-number?-true $ %{} 'CodeEntry (:doc "|number? on number returns true (1)")
           :code $ quote
             defn test-number?-true () $ if (number? 42) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-option-unwrap-or $ %{} :CodeEntry (:doc |)
+        |test-option-unwrap-or $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-option-unwrap-or () $ option:unwrap-or (%none) 7
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-pow $ %{} :CodeEntry (:doc "|pow via host import")
+        |test-pow $ %{} 'CodeEntry (:doc "|pow via host import")
           :code $ quote
             defn test-pow (base exp) (pow base exp)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-println $ %{} :CodeEntry (:doc |)
+        |test-println $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-println () do (println 42) 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-range $ %{} :CodeEntry (:doc "|range creates list of numbers")
+        |test-range $ %{} 'CodeEntry (:doc "|range creates list of numbers")
           :code $ quote
             defn test-range () $ &list:count (range 5)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-range-sum $ %{} :CodeEntry (:doc "|range 5 first+last: 0+4=4")
+        |test-range-sum $ %{} 'CodeEntry (:doc "|range 5 first+last: 0+4=4")
           :code $ quote
             defn test-range-sum () $ &let
               xs $ range 5
               &+ (&list:nth xs 0) (&list:nth xs 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-range-two-args $ %{} :CodeEntry (:doc "|range 2 5 creates 3 elements")
+        |test-range-two-args $ %{} 'CodeEntry (:doc "|range 2 5 creates 3 elements")
           :code $ quote
             defn test-range-two-args () $ &list:count (range 2 5)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-record-field-tag $ %{} :CodeEntry (:doc "|record field-tag resolves by index")
+        |test-record-field-tag $ %{} 'CodeEntry (:doc "|record field-tag resolves by index")
           :code $ quote
             defn test-record-field-tag () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -800,7 +800,7 @@
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-record-get-name $ %{} :CodeEntry (:doc "|record get-name returns struct tag")
+        |test-record-get-name $ %{} 'CodeEntry (:doc "|record get-name returns struct tag")
           :code $ quote
             defn test-record-get-name () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -809,7 +809,7 @@
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-record-matches-true $ %{} :CodeEntry (:doc "|record:matches? returns true for same type")
+        |test-record-matches-true $ %{} 'CodeEntry (:doc "|record:matches? returns true for same type")
           :code $ quote
             defn test-record-matches-true () $ &let
               a $ %{} Point (:x 1) (:y 2)
@@ -818,7 +818,7 @@
                 if (&struct:matches? a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-record-struct-eq $ %{} :CodeEntry (:doc "|record struct equals source struct")
+        |test-record-struct-eq $ %{} 'CodeEntry (:doc "|record struct equals source struct")
           :code $ quote
             defn test-record-struct-eq () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -827,7 +827,7 @@
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-record-sum $ %{} :CodeEntry (:doc "|Record create + field access")
+        |test-record-sum $ %{} 'CodeEntry (:doc "|Record create + field access")
           :code $ quote
             defn test-record-sum (x y)
               &let
@@ -835,7 +835,7 @@
                 &+ (&struct:nth p 0 :x) (&struct:nth p 1 :y)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-record-to-map $ %{} :CodeEntry (:doc "|record to-map exposes field values by tag")
+        |test-record-to-map $ %{} 'CodeEntry (:doc "|record to-map exposes field values by tag")
           :code $ quote
             defn test-record-to-map () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -844,37 +844,37 @@
                 &+ (&map:get m :x) (&map:get m :y)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rem $ %{} :CodeEntry (:doc |remainder)
+        |test-rem $ %{} 'CodeEntry (:doc |remainder)
           :code $ quote
             defn test-rem (a b) (&number:rem a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rest-count $ %{} :CodeEntry (:doc "|rest args count: 3 extras")
+        |test-rest-count $ %{} 'CodeEntry (:doc "|rest args count: 3 extras")
           :code $ quote
             defn test-rest-count () $ &list:count (collect-rest 1 2 3 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rest-empty $ %{} :CodeEntry (:doc "|rest args with no extras: 10+20 = 30")
+        |test-rest-empty $ %{} 'CodeEntry (:doc "|rest args with no extras: 10+20 = 30")
           :code $ quote
             defn test-rest-empty () $ sum-rest 10 20
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rest-sum $ %{} :CodeEntry (:doc "|rest args: 1+2+3+4+5 = 15")
+        |test-rest-sum $ %{} 'CodeEntry (:doc "|rest args: 1+2+3+4+5 = 15")
           :code $ quote
             defn test-rest-sum () $ sum-rest 1 2 3 4 5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-result-unwrap-or $ %{} :CodeEntry (:doc |)
+        |test-result-unwrap-or $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-result-unwrap-or () $ result:unwrap-or (%err 3) 7
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-round $ %{} :CodeEntry (:doc "|round function")
+        |test-round $ %{} 'CodeEntry (:doc "|round function")
           :code $ quote
             defn test-round (x) (round x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-contains-method $ %{} :CodeEntry (:doc "|.contains? dispatches on set")
+        |test-set-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on set")
           :code $ quote
             defn test-set-contains-method () $ &+
               if
@@ -885,24 +885,24 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-count $ %{} :CodeEntry (:doc "|set count")
+        |test-set-count $ %{} 'CodeEntry (:doc "|set count")
           :code $ quote
             defn test-set-count () $ &set:count (#{} 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-difference $ %{} :CodeEntry (:doc "|difference removes elements in second set")
+        |test-set-difference $ %{} 'CodeEntry (:doc "|difference removes elements in second set")
           :code $ quote
             defn test-set-difference () $ &set:count
               &difference (#{} 10 20 30 40) (#{} 20 40)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-difference-empty $ %{} :CodeEntry (:doc "|difference with disjoint sets keeps all")
+        |test-set-difference-empty $ %{} 'CodeEntry (:doc "|difference with disjoint sets keeps all")
           :code $ quote
             defn test-set-difference-empty () $ &set:count
               &difference (#{} 10 20) (#{} 30 40)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-empty $ %{} :CodeEntry (:doc "|empty set")
+        |test-set-empty $ %{} 'CodeEntry (:doc "|empty set")
           :code $ quote
             defn test-set-empty () $ &+
               if
@@ -913,25 +913,25 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-empty-method $ %{} :CodeEntry (:doc "|.empty returns an empty set")
+        |test-set-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty set")
           :code $ quote
             defn test-set-empty-method () $ count
               .empty $ #{} 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-exclude $ %{} :CodeEntry (:doc "|exclude removes element")
+        |test-set-exclude $ %{} 'CodeEntry (:doc "|exclude removes element")
           :code $ quote
             defn test-set-exclude () $ &set:count
               &exclude (#{} 10 20 30) 20
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-include $ %{} :CodeEntry (:doc "|include adds element")
+        |test-set-include $ %{} 'CodeEntry (:doc "|include adds element")
           :code $ quote
             defn test-set-include () $ &set:count
               &include (#{} 10 20) 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-includes $ %{} :CodeEntry (:doc "|set includes value")
+        |test-set-includes $ %{} 'CodeEntry (:doc "|set includes value")
           :code $ quote
             defn test-set-includes () $ &+
               if
@@ -942,7 +942,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-includes-method $ %{} :CodeEntry (:doc "|.includes? dispatches on set")
+        |test-set-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on set")
           :code $ quote
             defn test-set-includes-method () $ &+
               if
@@ -953,162 +953,162 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-max-method $ %{} :CodeEntry (:doc "|.max dispatches on set")
+        |test-set-max-method $ %{} 'CodeEntry (:doc "|.max dispatches on set")
           :code $ quote
             defn test-set-max-method () $ option:unwrap-or
               .max $ #{} 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-min-method $ %{} :CodeEntry (:doc "|.min dispatches on set")
+        |test-set-min-method $ %{} 'CodeEntry (:doc "|.min dispatches on set")
           :code $ quote
             defn test-set-min-method () $ option:unwrap-or
               .min $ #{} 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-union $ %{} :CodeEntry (:doc "|union merges two sets")
+        |test-set-union $ %{} 'CodeEntry (:doc "|union merges two sets")
           :code $ quote
             defn test-set-union () $ &set:count
               &union (#{} 10 20) (#{} 20 30 40)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-union-same $ %{} :CodeEntry (:doc "|union of identical sets")
+        |test-set-union-same $ %{} 'CodeEntry (:doc "|union of identical sets")
           :code $ quote
             defn test-set-union-same () $ &set:count
               &union (#{} 10 20 30) (#{} 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-sin $ %{} :CodeEntry (:doc "|sin via host import")
+        |test-sin $ %{} 'CodeEntry (:doc "|sin via host import")
           :code $ quote
             defn test-sin (x) (sin x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-sqrt $ %{} :CodeEntry (:doc "|sqrt function")
+        |test-sqrt $ %{} 'CodeEntry (:doc "|sqrt function")
           :code $ quote
             defn test-sqrt (x) (sqrt x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-compare-eq $ %{} :CodeEntry (:doc "|compare equal strings = 0")
+        |test-str-compare-eq $ %{} 'CodeEntry (:doc "|compare equal strings = 0")
           :code $ quote
             defn test-str-compare-eq () $ &str:compare |abc |abc
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-compare-gt $ %{} :CodeEntry (:doc "|compare abd > abc = 1")
+        |test-str-compare-gt $ %{} 'CodeEntry (:doc "|compare abd > abc = 1")
           :code $ quote
             defn test-str-compare-gt () $ &str:compare |abd |abc
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-compare-lt $ %{} :CodeEntry (:doc "|compare abc < abd = -1")
+        |test-str-compare-lt $ %{} 'CodeEntry (:doc "|compare abc < abd = -1")
           :code $ quote
             defn test-str-compare-lt () $ &str:compare |abc |abd
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-concat $ %{} :CodeEntry (:doc "|concat two strings and return byte count")
+        |test-str-concat $ %{} 'CodeEntry (:doc "|concat two strings and return byte count")
           :code $ quote
             defn test-str-concat () $ &str:count (&str:concat |foo |bar)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-contains-false $ %{} :CodeEntry (:doc |)
+        |test-str-contains-false $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-contains-false () $ &str:contains? |hello 10
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-contains-true $ %{} :CodeEntry (:doc |)
+        |test-str-contains-true $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-contains-true () $ &str:contains? |hello 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-count $ %{} :CodeEntry (:doc "|string byte length")
+        |test-str-count $ %{} 'CodeEntry (:doc "|string byte length")
           :code $ quote
             defn test-str-count () $ &str:count |hello
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-empty-false $ %{} :CodeEntry (:doc "|non-empty string has non-zero count")
+        |test-str-empty-false $ %{} 'CodeEntry (:doc "|non-empty string has non-zero count")
           :code $ quote
             defn test-str-empty-false () $ &= (&str:count |hi) 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-empty-true $ %{} :CodeEntry (:doc "|rest of 1-char string has 0 bytes")
+        |test-str-empty-true $ %{} 'CodeEntry (:doc "|rest of 1-char string has 0 bytes")
           :code $ quote
             defn test-str-empty-true () $ &=
               &str:count $ &str:rest |a
               , 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-escape $ %{} :CodeEntry (:doc "|escape special chars")
+        |test-str-escape $ %{} 'CodeEntry (:doc "|escape special chars")
           :code $ quote
             defn test-str-escape () $ &str:count (&str:escape |hello)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-find-index-found $ %{} :CodeEntry (:doc |)
+        |test-str-find-index-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-find-index-found () $ option:unwrap-or (.find-index |hello |ell) -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-find-index-not-found $ %{} :CodeEntry (:doc |)
+        |test-str-find-index-not-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-find-index-not-found () $ option:unwrap-or (.find-index |hello |xyz) -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-first $ %{} :CodeEntry (:doc "|first byte of hello = 104 (h)")
+        |test-str-first $ %{} 'CodeEntry (:doc "|first byte of hello = 104 (h)")
           :code $ quote
             defn test-str-first () $ &str:first |hello
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-includes-false $ %{} :CodeEntry (:doc |)
+        |test-str-includes-false $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-includes-false () $ &str:includes? |hello |xyz
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-includes-true $ %{} :CodeEntry (:doc |)
+        |test-str-includes-true $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-includes-true () $ &str:includes? |hello |ell
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-nth $ %{} :CodeEntry (:doc "|nth character at index 1 of hello is e")
+        |test-str-nth $ %{} 'CodeEntry (:doc "|nth character at index 1 of hello is e")
           :code $ quote
             defn test-str-nth () $ if
               = (&str:nth |hello 1) |e
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-pad-left $ %{} :CodeEntry (:doc |)
+        |test-str-pad-left $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-pad-left () $ &str:count (&str:pad-left |hi 5 |-)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-pad-right $ %{} :CodeEntry (:doc |)
+        |test-str-pad-right $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-pad-right () $ &str:count (&str:pad-right |hi 5 |-)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-rest $ %{} :CodeEntry (:doc "|rest of hello has 4 bytes")
+        |test-str-rest $ %{} 'CodeEntry (:doc "|rest of hello has 4 bytes")
           :code $ quote
             defn test-str-rest () $ &str:count (&str:rest |hello)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-slice $ %{} :CodeEntry (:doc "|slice bytes 1..4 from abcde = 3 bytes (bcd)")
+        |test-str-slice $ %{} 'CodeEntry (:doc "|slice bytes 1..4 from abcde = 3 bytes (bcd)")
           :code $ quote
             defn test-str-slice () $ &str:count (&str:slice |abcde 1 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-string-compare-method $ %{} :CodeEntry (:doc |)
+        |test-string-compare-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-string-compare-method () $ .compare |abc |abd
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tag-eq $ %{} :CodeEntry (:doc "|Tag equality — same tags")
+        |test-tag-eq $ %{} 'CodeEntry (:doc "|Tag equality — same tags")
           :code $ quote
             defn test-tag-eq () $ if (&= :ok :ok) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tag-neq $ %{} :CodeEntry (:doc "|Tag inequality — different tags")
+        |test-tag-neq $ %{} 'CodeEntry (:doc "|Tag inequality — different tags")
           :code $ quote
             defn test-tag-neq () $ if (&= :ok :err) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-to-pairs $ %{} :CodeEntry (:doc "|to-pairs count")
+        |test-to-pairs $ %{} 'CodeEntry (:doc "|to-pairs count")
           :code $ quote
             defn test-to-pairs () $ &let
               ps $ to-pairs (&{} :a 1 :b 2)
@@ -1116,28 +1116,28 @@
                 &list:count $ &list:first ps
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tuple-assoc $ %{} :CodeEntry (:doc "|Tuple assoc updates payload by index")
+        |test-tuple-assoc $ %{} 'CodeEntry (:doc "|Tuple assoc updates payload by index")
           :code $ quote
             defn test-tuple-assoc () $ &let
               t $ &enum:assoc (:: :pair 10 20) 1 9
               &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tuple-count $ %{} :CodeEntry (:doc "|Tuple count returns payload count")
+        |test-tuple-count $ %{} 'CodeEntry (:doc "|Tuple count returns payload count")
           :code $ quote
             defn test-tuple-count () $ &let
               t $ :: :pair 10 20
               &enum:count t
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tuple-sum $ %{} :CodeEntry (:doc "|Tuple create + nth access: idx 1 and 2 are payloads")
+        |test-tuple-sum $ %{} 'CodeEntry (:doc "|Tuple create + nth access: idx 1 and 2 are payloads")
           :code $ quote
             defn test-tuple-sum () $ &let
               t $ :: :pair 10 20
               &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-list $ %{} :CodeEntry (:doc "|type-of list == :list tag")
+        |test-type-of-list $ %{} 'CodeEntry (:doc "|type-of list == :list tag")
           :code $ quote
             defn test-type-of-list () $ if
               &=
@@ -1146,7 +1146,7 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-map $ %{} :CodeEntry (:doc "|type-of map == :map tag")
+        |test-type-of-map $ %{} 'CodeEntry (:doc "|type-of map == :map tag")
           :code $ quote
             defn test-type-of-map () $ if
               &=
@@ -1155,14 +1155,14 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-number $ %{} :CodeEntry (:doc "|type-of number == :number tag")
+        |test-type-of-number $ %{} 'CodeEntry (:doc "|type-of number == :number tag")
           :code $ quote
             defn test-type-of-number () $ if
               &= (type-of 42) :number
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-set $ %{} :CodeEntry (:doc "|type-of set == :set tag")
+        |test-type-of-set $ %{} 'CodeEntry (:doc "|type-of set == :set tag")
           :code $ quote
             defn test-type-of-set () $ if
               &=
@@ -1171,7 +1171,7 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-tuple $ %{} :CodeEntry (:doc "|type-of tuple == :tuple tag")
+        |test-type-of-tuple $ %{} 'CodeEntry (:doc "|type-of tuple == :tuple tag")
           :code $ quote
             defn test-type-of-tuple () $ if
               &=
@@ -1180,20 +1180,20 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |wasm-ffi-add $ %{} :CodeEntry (:doc |)
+        |wasm-ffi-add $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defwasm-export wasm-ffi-add (a b) (&+ a b)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number 'Number
-        |wasm-ffi-upcase $ %{} :CodeEntry (:doc |)
+        |wasm-ffi-upcase $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defwasm-export wasm-ffi-upcase (text) (host-string-upcase text)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns test-wasm.main $ :require (test-wasm.helper :as helper)

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -5,9 +5,9 @@
       :modules $ [] |./test-cond.cirru |./test-hygienic.cirru |./test-lens.cirru |./test-list.cirru |./test-macro.cirru |./test-map.cirru |./test-math.cirru |./test-recursion.cirru |./test-set.cirru |./test-string.cirru |./test-edn.cirru |./test-js.cirru |./test-struct.cirru |./test-fn.cirru |./test-anonymous-enum.cirru |./test-algebra.cirru |./test-types.cirru |./test-types-inference.cirru |./test-generics.cirru |./test-enum.cirru |./test-traits.cirru |./test-doc-smoke.cirru |./test-def-meta.cirru |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |%A $ %{} :CodeEntry (:doc |)
+        |%A $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl %A AtomDerefTrait $ .deref
               fn (self)
@@ -16,58 +16,58 @@
                   , x
           :examples $ []
           :schema $ :: 'Dynamic
-        |%r $ %{} :CodeEntry (:doc |)
+        |%r $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl %r DemoGetTrait $ .get
               fn (self) 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |*ref-demo $ %{} :CodeEntry (:doc |)
+        |*ref-demo $ %{} 'CodeEntry (:doc |)
           :code $ quote (defatom *ref-demo 0)
           :examples $ []
           :schema $ :: 'Ref 'Number
-        |AtomBox $ %{} :CodeEntry (:doc |)
+        |AtomBox $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def AtomBox $ impl-traits AtomBox0 %A
           :examples $ []
           :schema $ :: 'Dynamic
-        |AtomBox0 $ %{} :CodeEntry (:doc |)
+        |AtomBox0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum AtomBox $ :atom 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |AtomDerefTrait $ %{} :CodeEntry (:doc |)
+        |AtomDerefTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait AtomDerefTrait $ .deref :fn
           :examples $ []
           :schema $ :: 'Trait
-        |Demo $ %{} :CodeEntry (:doc |)
+        |Demo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def Demo $ impl-traits Demo0 %r
           :examples $ []
           :schema $ :: 'Dynamic
-        |Demo0 $ %{} :CodeEntry (:doc |)
+        |Demo0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Demo $ :a 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |DemoGetTrait $ %{} :CodeEntry (:doc |)
+        |DemoGetTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait DemoGetTrait $ .get :fn
           :examples $ []
           :schema $ :: 'Trait
-        |Deref $ %{} :CodeEntry (:doc |)
+        |Deref $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl Deref DerefTrait $ .deref
               fn (self) 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |DerefTrait $ %{} :CodeEntry (:doc |)
+        |DerefTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait DerefTrait $ .deref :fn
           :examples $ []
           :schema $ :: 'Trait
-        |Num $ %{} :CodeEntry (:doc |)
+        |Num $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl Num NumTrait
               .inc $ fn (x) (update x 1 inc)
@@ -75,32 +75,32 @@
                 str $ &enum:nth x 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |NumBox $ %{} :CodeEntry (:doc |)
+        |NumBox $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def NumBox $ impl-traits NumBox0 Num
           :examples $ []
           :schema $ :: 'Dynamic
-        |NumBox0 $ %{} :CodeEntry (:doc |)
+        |NumBox0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum NumBox $ :number 'Number
           :examples $ []
           :schema $ :: 'Dynamic
-        |NumTrait $ %{} :CodeEntry (:doc |)
+        |NumTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait NumTrait (.inc :fn) (.show :fn)
           :examples $ []
           :schema $ :: 'Dynamic
-        |ValueBox $ %{} :CodeEntry (:doc |)
+        |ValueBox $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def ValueBox $ impl-traits ValueBox0 Deref
           :examples $ []
           :schema $ :: 'Dynamic
-        |ValueBox0 $ %{} :CodeEntry (:doc |)
+        |ValueBox0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum ValueBox $ :value 'Dynamic
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (&init-builtin-impls!)
               println $ &get-os
@@ -153,14 +153,63 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-arguments $ %{} :CodeEntry (:doc |)
+        |test-anonymous-enum $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            fn () (log-title "|Testing tuple")
+              assert= :enum $ type-of (:: :a :b)
+              assert= (%some :a)
+                nth (:: :a :b) 0
+              assert= (%some :b)
+                nth (:: :a :b) 1
+              assert= (%some :c)
+                nth (:: :a :b :c) 2
+              assert= 2 $ count (:: :a :b)
+              assert= 3 $ count (:: :a :b :c)
+              assert= 4 $ count (:: :a :b :c :d)
+              assert= (%some :a)
+                get (:: :a :b) 0
+              assert= (%some :b)
+                get (:: :a :b) 1
+              assert= (%some :c)
+                get (:: :a :b :c) 2
+              assert= true $ contains? (:: :a :b :c) 2
+              assert= (:: 1 0)
+                update (:: 0 0) 0 inc
+              assert= (:: 0 1)
+                update (:: 0 0) 1 inc
+              assert= (:: 1 0 0)
+                update (:: 0 0 0) 0 inc
+              assert= (:: 0 1 0)
+                update (:: 0 0 0) 1 inc
+              assert= (:: 0 0 1)
+                update (:: 0 0 0) 2 inc
+              assert= 1 $ count (:: :none)
+              assert-detect enum? $ parse-cirru-edn "|:: :none"
+              assert= false $ = (:: :t 1) (:: :t 2)
+              assert= false $ = (:: :t 1) (:: :t 1 2)
+              let
+                  a $ :: :a 1
+                  b $ %:: Demo :a 1
+                assert= true $ any? (&enum:impls b)
+                  fn (impl)
+                    includes? (str impl) |DemoGetTrait
+                assert=
+                  &enum:params $ :: :a 1 2 3
+                  [] 1 2 3
+                assert= "|(%:: 'Demo :a 1)" $ str b
+              assert= "|(%:: _ :a :b :c)" $ str (:: :a :b :c)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
+        |test-arguments $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing arguments")
               let
@@ -176,7 +225,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-atom $ %{} :CodeEntry (:doc |)
+        |test-atom $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               let
@@ -190,7 +239,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-buffer $ %{} :CodeEntry (:doc |)
+        |test-buffer $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title |Buffer)
               println "|buffer value:" $ &buffer 0x11 |11
@@ -198,7 +247,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-cirru-parser $ %{} :CodeEntry (:doc |)
+        |test-cirru-parser $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing Cirru parser")
               assert= (parse-cirru-list "|def f (a b) $ + a b")
@@ -228,7 +277,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-detects $ %{} :CodeEntry (:doc |)
+        |test-detects $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-detects ()
               assert-detect fn? $ fn () 1
@@ -281,14 +330,14 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-display-stack $ %{} :CodeEntry (:doc |)
+        |test-display-stack $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing display stack") (&display-stack "|show stack here")
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-effect $ %{} :CodeEntry (:doc |)
+        |test-effect $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing effect")
               println "|Env mode:" $ get-env |mode
@@ -298,7 +347,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-fn $ %{} :CodeEntry (:doc |)
+        |test-fn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing fn")
               &let
@@ -312,7 +361,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-fn-eq $ %{} :CodeEntry (:doc |)
+        |test-fn-eq $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing equality of functions")
               let
@@ -325,7 +374,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-if $ %{} :CodeEntry (:doc |)
+        |test-if $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing if with nil")
               assert= (if false 1) (if nil 1)
@@ -334,7 +383,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-json $ %{} :CodeEntry (:doc |)
+        |test-json $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing JSON")
               let
@@ -358,7 +407,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-method $ %{} :CodeEntry (:doc |)
+        |test-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing method")
               let
@@ -384,7 +433,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-refs $ %{} :CodeEntry (:doc |)
+        |test-refs $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing refs") (assert= 0 @*ref-demo)
               add-watch *ref-demo :change $ fn (current prev) (println "|change happened:" prev current)
@@ -412,7 +461,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-tag $ %{} :CodeEntry (:doc |)
+        |test-tag $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-tag ()
               ; assert "|tag function" $ =
@@ -429,7 +478,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-try $ %{} :CodeEntry (:doc |)
+        |test-try $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-try ()
               assert= false $ try
@@ -446,56 +495,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-anonymous-enum $ %{} :CodeEntry (:doc |)
-          :code $ quote
-            fn () (log-title "|Testing tuple")
-              assert= :enum $ type-of (:: :a :b)
-              assert= (%some :a)
-                nth (:: :a :b) 0
-              assert= (%some :b)
-                nth (:: :a :b) 1
-              assert= (%some :c)
-                nth (:: :a :b :c) 2
-              assert= 2 $ count (:: :a :b)
-              assert= 3 $ count (:: :a :b :c)
-              assert= 4 $ count (:: :a :b :c :d)
-              assert= (%some :a)
-                get (:: :a :b) 0
-              assert= (%some :b)
-                get (:: :a :b) 1
-              assert= (%some :c)
-                get (:: :a :b :c) 2
-              assert= true $ contains? (:: :a :b :c) 2
-              assert= (:: 1 0)
-                update (:: 0 0) 0 inc
-              assert= (:: 0 1)
-                update (:: 0 0) 1 inc
-              assert= (:: 1 0 0)
-                update (:: 0 0 0) 0 inc
-              assert= (:: 0 1 0)
-                update (:: 0 0 0) 1 inc
-              assert= (:: 0 0 1)
-                update (:: 0 0 0) 2 inc
-              assert= 1 $ count (:: :none)
-              assert-detect enum? $ parse-cirru-edn "|:: :none"
-              assert= false $ = (:: :t 1) (:: :t 2)
-              assert= false $ = (:: :t 1) (:: :t 1 2)
-              let
-                  a $ :: :a 1
-                  b $ %:: Demo :a 1
-                assert= true $ any? (&enum:impls b)
-                  fn (impl)
-                    includes? (str impl) |DemoGetTrait
-                assert=
-                  &enum:params $ :: :a 1 2 3
-                  [] 1 2 3
-                assert= "|(%:: 'Demo :a 1)" $ str b
-              assert= "|(%:: _ :a :b :c)" $ str (:: :a :b :c)
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Dynamic)
-              :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require (test-cond.main :as test-cond) (test-hygienic.main :as test-hygienic) (test-lens.main :as test-lens) (test-list.main :as test-list) (test-macro.main :as test-macro) (test-map.main :as test-map) (test-math.main :as test-math) (test-recursion.main :as test-recursion) (test-set.main :as test-set) (test-string.main :as test-string) (test-edn.main :as test-edn) (test-js.main :as test-js) (test-struct.main :as test-struct) (test-nil.main :as test-nil) (test-fn.main :as test-fn) (test-anonymous-enum.main :as test-anonymous-enum) (test-algebra.main :as test-algebra) (test-types.main :as test-types) (test-types-inference.main :as test-types-inference) (test-enum.main :as test-enum) (test-generics.main :as test-generics) (test-traits.main :as test-traits) (test-doc-smoke.main :as test-doc-smoke) (test-def-meta.main :as test-def-meta)
             util.core :refer $ log-title inside-eval: inside-js:

--- a/calcit/type-fail/core-map-where-bound-mismatch.cirru
+++ b/calcit/type-fail/core-map-where-bound-mismatch.cirru
@@ -5,21 +5,21 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-map-where-bound.main $ %{} :FileEntry
+    |type-fail-map-where-bound.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Entry for core map where-bound mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for core map where-bound mismatch")
           :code $ quote
             defn main! () $ map 1 inc
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for core map where-bound mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for core map where-bound mismatch")
         :code $ quote (ns type-fail-map-where-bound.main)

--- a/calcit/type-fail/generic-where-bound-mismatch.cirru
+++ b/calcit/type-fail/generic-where-bound-mismatch.cirru
@@ -5,23 +5,23 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-generic-where-bound.main $ %{} :FileEntry
+    |type-fail-generic-where-bound.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Entry for generic where-bound mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for generic where-bound mismatch")
           :code $ quote
             defn main! () (require-mappable 1) nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |require-mappable $ %{} :CodeEntry (:doc "|Requires the argument type to satisfy Mappable")
+        |require-mappable $ %{} 'CodeEntry (:doc "|Requires the argument type to satisfy Mappable")
           :code $ quote
             defn require-mappable (x) x
           :examples $ []
@@ -30,5 +30,5 @@
               :args $ [] 'T
               :generics $ [] 'T
               :where $ {} ('T 'Mappable)
-      :ns $ %{} :NsEntry (:doc "|Namespace for generic where-bound mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for generic where-bound mismatch")
         :code $ quote (ns type-fail-generic-where-bound.main)

--- a/calcit/type-fail/schema-call-arg-type-mismatch.cirru
+++ b/calcit/type-fail/schema-call-arg-type-mismatch.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-schema-call-arg-type.main $ %{} :FileEntry
+    |type-fail-schema-call-arg-type.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Entry for type-fail schema call-site arg type mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for type-fail schema call-site arg type mismatch")
           :code $ quote
             defn main! () $ let
                 text |hello
@@ -19,19 +19,19 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |plus1 $ %{} :CodeEntry (:doc "|Schema expects :number, call-site passes :string")
+        |plus1 $ %{} 'CodeEntry (:doc "|Schema expects :number, call-site passes :string")
           :code $ quote
             defn plus1 (x) (&+ x 1)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for schema call-site mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for schema call-site mismatch")
         :code $ quote (ns type-fail-schema-call-arg-type.main)

--- a/calcit/type-fail/schema-kind-mismatch.cirru
+++ b/calcit/type-fail/schema-kind-mismatch.cirru
@@ -5,27 +5,27 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-schema-kind-mismatch.main $ %{} :FileEntry
+    |type-fail-schema-kind-mismatch.main $ %{} 'FileEntry
       :defs $ {}
-        |bad-kind $ %{} :CodeEntry (:doc "|Expect preprocess error: schema :kind is :macro but code uses defn")
+        |bad-kind $ %{} 'CodeEntry (:doc "|Expect preprocess error: schema :kind is :macro but code uses defn")
           :code $ quote
             defn bad-kind () 1
           :examples $ []
           :schema $ :: 'Macro
             {} $ :args ([])
-        |main! $ %{} :CodeEntry (:doc "|Entry for type-fail schema kind mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for type-fail schema kind mismatch")
           :code $ quote
             defn main! () $ do (; call to force preprocessing of bad-kind) (bad-kind) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for schema kind mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for schema kind mismatch")
         :code $ quote (ns type-fail-schema-kind-mismatch.main)

--- a/calcit/type-fail/schema-required-arity.cirru
+++ b/calcit/type-fail/schema-required-arity.cirru
@@ -5,28 +5,28 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-schema-required-arity.main $ %{} :FileEntry
+    |type-fail-schema-required-arity.main $ %{} 'FileEntry
       :defs $ {}
-        |bad-arity $ %{} :CodeEntry (:doc "|Expect preprocess error: schema has 2 required args but code has 1")
+        |bad-arity $ %{} 'CodeEntry (:doc "|Expect preprocess error: schema has 2 required args but code has 1")
           :code $ quote
             defn bad-arity (x) (do x)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number 'Number
-        |main! $ %{} :CodeEntry (:doc "|Entry for type-fail schema arity mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for type-fail schema arity mismatch")
           :code $ quote
             defn main! () $ do (; calling to force preprocessing of bad-arity) (bad-arity 1) (println |unreachable)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for schema arity mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for schema arity mismatch")
         :code $ quote (ns type-fail-schema-required-arity.main)

--- a/calcit/type-fail/schema-rest-missing.cirru
+++ b/calcit/type-fail/schema-rest-missing.cirru
@@ -5,28 +5,28 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-schema-rest-missing.main $ %{} :FileEntry
+    |type-fail-schema-rest-missing.main $ %{} 'FileEntry
       :defs $ {}
-        |bad-rest $ %{} :CodeEntry (:doc "|Expect preprocess error: code has & rest but schema is missing :rest")
+        |bad-rest $ %{} 'CodeEntry (:doc "|Expect preprocess error: code has & rest but schema is missing :rest")
           :code $ quote
             defn bad-rest (& xs) (do xs)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'List)
               :args $ []
-        |main! $ %{} :CodeEntry (:doc "|Entry for type-fail schema rest mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for type-fail schema rest mismatch")
           :code $ quote
             defn main! () $ do (; calling to force preprocessing of bad-rest) (bad-rest 1 2 3) (println |unreachable)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for schema rest mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for schema rest mismatch")
         :code $ quote (ns type-fail-schema-rest-missing.main)

--- a/calcit/type-fail/schema-rest-unexpected.cirru
+++ b/calcit/type-fail/schema-rest-unexpected.cirru
@@ -5,28 +5,28 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-schema-rest-unexpected.main $ %{} :FileEntry
+    |type-fail-schema-rest-unexpected.main $ %{} 'FileEntry
       :defs $ {}
-        |bad-rest $ %{} :CodeEntry (:doc "|Expect preprocess error: schema has :rest but code has no & param")
+        |bad-rest $ %{} 'CodeEntry (:doc "|Expect preprocess error: schema has :rest but code has no & param")
           :code $ quote
             defn bad-rest (x) (do x)
           :examples $ []
           :schema $ :: 'Fn
             {} (:rest 'Number) (:return 'Number)
               :args $ [] 'Number
-        |main! $ %{} :CodeEntry (:doc "|Entry for type-fail schema unexpected rest")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for type-fail schema unexpected rest")
           :code $ quote
             defn main! () $ do (; calling to force preprocessing of bad-rest) (bad-rest 1) (println |unreachable)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for schema unexpected rest")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for schema unexpected rest")
         :code $ quote (ns type-fail-schema-rest-unexpected.main)

--- a/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
+++ b/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
@@ -5,28 +5,28 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-trait-method-generic-receiver.main $ %{} :FileEntry
+    |type-fail-trait-method-generic-receiver.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} :CodeEntry (:doc "|Entry for generic Option receiver method argument mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for generic Option receiver method argument mismatch")
           :code $ quote
             defn main! (option) (option .unwrap-or 0)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] (:: 'Option 'String)
-        |plus1 $ %{} :CodeEntry (:doc "|Schema expects :number, call-site passes :string")
+        |plus1 $ %{} 'CodeEntry (:doc "|Schema expects :number, call-site passes :string")
           :code $ quote
             defn plus1 (x) (&+ x 1)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Namespace for generic method receiver mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for generic method receiver mismatch")
         :code $ quote (ns type-fail-trait-method-generic-receiver.main)

--- a/calcit/type-fail/type-slot-entry-scope.cirru
+++ b/calcit/type-fail/type-slot-entry-scope.cirru
@@ -8,26 +8,26 @@
       :modules $ []
       :type-slots $ {} (:dispatch-op |type-fail-type-slot-entry-scope.main/ServerOp)
   :files $ {}
-    |type-fail-type-slot-entry-scope.main $ %{} :FileEntry
+    |type-fail-type-slot-entry-scope.main $ %{} 'FileEntry
       :defs $ {}
-        |ClientOp $ %{} :CodeEntry (:doc "|Client entry enum")
+        |ClientOp $ %{} 'CodeEntry (:doc "|Client entry enum")
           :code $ quote
             defenum ClientOp $ :client/ping
           :examples $ []
           :schema $ :: 'Dynamic
-        |ServerOp $ %{} :CodeEntry (:doc "|Server entry enum")
+        |ServerOp $ %{} 'CodeEntry (:doc "|Server entry enum")
           :code $ quote
             defenum ServerOp $ :server/ping
           :examples $ []
           :schema $ :: 'Dynamic
-        |accept-op $ %{} :CodeEntry (:doc "|Schema depends on the entry-bound type slot")
+        |accept-op $ %{} 'CodeEntry (:doc "|Schema depends on the entry-bound type slot")
           :code $ quote
             defn accept-op (op) op
           :examples $ []
           :schema $ :: 'Fn
             {} (:return '*dispatch-op)
               :args $ [] '*dispatch-op
-        |client-main! $ %{} :CodeEntry (:doc "|Client entry binds dispatch-op for client enums")
+        |client-main! $ %{} 'CodeEntry (:doc "|Client entry binds dispatch-op for client enums")
           :code $ quote
             defn client-main! ()
               accept-op $ :: :client/ping
@@ -36,14 +36,14 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |server-main! $ %{} :CodeEntry (:doc "|Server entry binds the same slot name independently")
+        |server-main! $ %{} 'CodeEntry (:doc "|Server entry binds the same slot name independently")
           :code $ quote
             defn server-main! ()
               accept-op $ :: :server/ping
@@ -52,5 +52,5 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc "|Fixture for entry-scoped with-type-slot preprocessing")
+      :ns $ %{} 'NsEntry (:doc "|Fixture for entry-scoped with-type-slot preprocessing")
         :code $ quote (ns type-fail-type-slot-entry-scope.main)

--- a/calcit/type-fail/type-slot-enum-invalid-variant.cirru
+++ b/calcit/type-fail/type-slot-enum-invalid-variant.cirru
@@ -5,19 +5,19 @@
       :modules $ []
       :type-slots $ {} (:dispatch-op |type-fail-type-slot-enum-invalid-variant.main/Action)
   :files $ {}
-    |type-fail-type-slot-enum-invalid-variant.main $ %{} :FileEntry
+    |type-fail-type-slot-enum-invalid-variant.main $ %{} 'FileEntry
       :defs $ {}
-        |Action $ %{} :CodeEntry (:doc "|Enum used for type-slot binding")
+        |Action $ %{} 'CodeEntry (:doc "|Enum used for type-slot binding")
           :code $ quote
             defenum Action (:add 'String) (:remove 'String) (:clear)
           :examples $ []
           :schema $ :: 'Dynamic
-        |legacy-main! $ %{} :CodeEntry (:doc |)
+        |legacy-main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn legacy-main! () $ with-type-slot (:dispatch-op Action) 1 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc "|Entry testing enum auto-rewrite via type-slot with invalid variant")
+        |main! $ %{} 'CodeEntry (:doc "|Entry testing enum auto-rewrite via type-slot with invalid variant")
           :code $ quote
             defn main! ()
               takes-action $ :: :nonexistent |hello
@@ -26,19 +26,19 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |takes-action $ %{} :CodeEntry (:doc "|Function expecting a type-slot-bound enum value")
+        |takes-action $ %{} 'CodeEntry (:doc "|Function expecting a type-slot-bound enum value")
           :code $ quote
             defn takes-action (x) x
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] '*dispatch-op
-      :ns $ %{} :NsEntry (:doc "|Namespace for type-slot enum invalid variant detection")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for type-slot enum invalid variant detection")
         :code $ quote (ns type-fail-type-slot-enum-invalid-variant.main)

--- a/calcit/type-fail/type-slot-record-call-arg-type-mismatch.cirru
+++ b/calcit/type-fail/type-slot-record-call-arg-type-mismatch.cirru
@@ -5,33 +5,33 @@
       :modules $ []
       :type-slots $ {} (:payload |type-fail-type-slot-record-call-arg.main/User)
   :files $ {}
-    |type-fail-type-slot-record-call-arg.main $ %{} :FileEntry
+    |type-fail-type-slot-record-call-arg.main $ %{} 'FileEntry
       :defs $ {}
-        |User $ %{} :CodeEntry (:doc "|Record type used for bind-type fixture")
+        |User $ %{} 'CodeEntry (:doc "|Record type used for bind-type fixture")
           :code $ quote
             defstruct User $ :name 'String
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc "|Entry for type-slot record bind call-site arg type mismatch")
+        |main! $ %{} 'CodeEntry (:doc "|Entry for type-slot record bind call-site arg type mismatch")
           :code $ quote
             defn main! () (takes-user 1) nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc "|Reload handler")
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |takes-user $ %{} :CodeEntry (:doc "|Schema expects a value matching the bound type slot")
+        |takes-user $ %{} 'CodeEntry (:doc "|Schema expects a value matching the bound type slot")
           :code $ quote
             defn takes-user (x) x
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] '*payload
-      :ns $ %{} :NsEntry (:doc "|Namespace for type-slot record call-site arg mismatch")
+      :ns $ %{} 'NsEntry (:doc "|Namespace for type-slot record call-site arg mismatch")
         :code $ quote (ns type-fail-type-slot-record-call-arg.main)

--- a/calcit/util.cirru
+++ b/calcit/util.cirru
@@ -5,9 +5,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |util.core $ %{} :FileEntry
+    |util.core $ %{} 'FileEntry
       :defs $ {}
-        |inside-eval: $ %{} :CodeEntry (:doc |)
+        |inside-eval: $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro inside-eval: (& body)
               if
@@ -18,7 +18,7 @@
           :schema $ :: 'Macro
             {} (:rest 'Dynamic)
               :args $ [] 'Dynamic
-        |inside-js: $ %{} :CodeEntry (:doc |)
+        |inside-js: $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro inside-js: (& body)
               if
@@ -29,27 +29,27 @@
           :schema $ :: 'Macro
             {} (:rest 'Dynamic)
               :args $ [] 'Dynamic
-        |log-title $ %{} :CodeEntry (:doc |)
+        |log-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn log-title (title) (println) (println title) (println)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns util.core $ :require

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -111,7 +111,7 @@ let
     result2 $ assoc-in data ([] :a :b :c) 100
     result3 $ update-in data ([] :a :b :c)
       fn (current)
-        inc $ option:unwrap current
+        inc $ current .unwrap
   println result1
   ; => (%some 1)
   println result2
@@ -121,9 +121,9 @@ let
 ```
 
 `update-in` passes `Option<T>` to its updater. Existing values arrive as
-`%some value`; a missing leaf arrives as `%none`. Use `option:unwrap` only when
-the path is known to exist, or use `option:fold`/`option:unwrap-or` to define
-the creation behavior explicitly. An empty path updates `%some data`.
+`%some value`; a missing leaf arrives as `%none`. Use `.unwrap` only when the
+path is known to exist, or use `.fold`/`.unwrap-or` to define the creation
+behavior explicitly. An empty path updates `%some data`.
 
 ### Merging Maps
 
@@ -396,10 +396,18 @@ let
 let
     items $ [] ({} (:value 1)) ({} (:value 2)) ({} (:value 3))
     result1 $ reduce items 0 $ fn (acc item)
-      + acc $ option:unwrap $ get item :value
+      let
+          value $ get item :value
+        tag-match value
+          (:some number) (+ acc number)
+          (:none) , acc
     result2 $ apply +
       map items $ fn (item)
-        option:unwrap $ get item :value
+        let
+            value $ get item :value
+          tag-match value
+            (:some number) , number
+            (:none) 0
   println result1
   ; => 6
   println result2

--- a/docs/features/hashmap.md
+++ b/docs/features/hashmap.md
@@ -80,7 +80,7 @@ let
 
 `get-in` returns `Option<Dynamic>` (`%some` for a resolved value and `%none`
 for a missing path or a `nil` encountered while traversing). Use
-`option:unwrap-or` or `tag-match` before consuming the payload.
+`.unwrap-or` or `tag-match` before consuming the payload.
 
 ## Modifying Maps
 
@@ -190,7 +190,7 @@ let
 let
     m $ {} (:a :one) (:b :two)
     val $ get m :missing
-  option:unwrap-or val :default
+  val .unwrap-or :default
   ; => :default
 ```
 
@@ -203,7 +203,9 @@ let
     freq $ foldl words init $ fn (acc w)
       let
           cur $ get acc w
-          n $ option:unwrap-or cur 0
+          n $ tag-match cur
+            (:some value) , value
+            (:none) 0
         assoc acc w (inc n)
   println freq
   ; ({} (:a 3) (:b 2) (:c 1))

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -53,10 +53,9 @@ legacy `nil?`/`some?` reports `W_JS_FFI_NULLABLE_PREDICATE`. Convert explicitly
 with `js-nullish->option` only after accepting the opaque payload contract;
 generic `optionally` does not accept `JsNullish<T>`.
 
-A nominal `Option<T>` uses `option:some?`/`option:none?` (or `.some?`/`.none?`);
-preprocessing reports `W_NOMINAL_ENUM_LEGACY_USE` when old nullable checks are
-applied to an Option, so an API migration cannot silently preserve the wrong
-branch behavior.
+A nominal `Option<T>` uses `.some?`/`.none?`. Preprocessing reports
+`W_NOMINAL_ENUM_LEGACY_USE` when old nullable checks are applied to an Option,
+so an API migration cannot silently preserve the wrong branch behavior.
 
 ```cirru.no-run
 let

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -230,10 +230,15 @@ do
 
 ## Option and Result helpers
 
-`Option T` and `Result T E` are generic core enums. Their constructors remain `%some`/`%none` and `%ok`/`%err`; the following helpers make normal pipelines explicit without losing type relationships:
+`Option T` and `Result T E` are generic core enums. Their constructors remain `%some`/`%none` and `%ok`/`%err`; use inferred methods for normal pipelines without losing type relationships:
 
-- Option: `option:some?`, `option:none?`, `option:map`, `option:unwrap-or`, `option:and-then`
-- Result: `result:ok?`, `result:err?`, `result:map`, `result:map-err`, `result:unwrap-or`, `result:and-then`
+- Option: `.some?`, `.none?`, `.map`, `.unwrap`, `.unwrap-or`, `.and-then`, `.fold`
+- Result: `.ok?`, `.err?`, `.map`, `.map-err`, `.unwrap-or`, `.and-then`
+
+For a statically known receiver, preprocessing resolves these methods and lowers
+them to their internal direct implementations. Direct names such as
+`option:unwrap-or` and `result:unwrap-or` are core implementation details, not
+the public call style.
 
 `optionally` exists only for legacy core/internal `Optional<T>` compatibility. Public function schemas reject `Optional<T>`; new APIs return `Option<T>`, `Result<T,E>`, or `Unit` directly.
 
@@ -243,7 +248,7 @@ Core lookup APIs that no longer need to preserve bootstrapping compatibility use
 - `get-in` returns `Option<Dynamic>` while preserving a more precise payload type for literal paths when inference can resolve it.
 - List/set `max` and `min` return `Option<Number>` so empty collections are explicit.
 - String `.find-index` and `str-find-index` return `Option<Number>`; the internal `&str:find-index` primitive retains its `-1` ABI sentinel.
-- `get-env` returns `Option<String>`; use `option:unwrap-or` for a default.
+- `get-env` returns `Option<String>`; use `.unwrap-or` for a default.
 - `parse-float` returns `Result<Number,String>`, with the invalid source in `:err`.
 - Reflection uses `enum-definition: Enum -> Option<EnumDef>`, `struct-definition: Struct -> Option<StructDef>`, and `impl-origin: Impl -> Option<Trait>`.
 - `destruct-list`, `destruct-map`, `destruct-set`, and `destruct-str` return named `*Destruct` enums, preserving the familiar `:some`/`:none` branches with checked payloads.
@@ -252,7 +257,7 @@ Core lookup APIs that no longer need to preserve bootstrapping compatibility use
 
 Raw JavaScript property reads and native calls are different: they return `JsNullish<JsObject>`. Narrow them with `js-present?`/`js-nullish?`; `nil?`, `some?`, and generic `optionally` do not erase this host boundary. Use `js-nullish->option` only as an explicit conversion after accepting or validating the opaque payload contract.
 
-When a generic payload cannot be inferred, Calcit keeps the nominal wrapper and uses `Dynamic` only for the unknown payload—for example, `find` over a dynamically typed list is still `Option<Dynamic>`, not plain `Dynamic`. This makes migration mistakes visible. Using nullable predicates (`some?`/`nil?`), positional enum access, or raw comparison on that Option reports `W_NOMINAL_ENUM_LEGACY_USE`; switch to Option methods, `option:unwrap-or`, or `tag-match`.
+When a generic payload cannot be inferred, Calcit keeps the nominal wrapper and uses `Dynamic` only for the unknown payload—for example, `find` over a dynamically typed list is still `Option<Dynamic>`, not plain `Dynamic`. This makes migration mistakes visible. Using nullable predicates (`some?`/`nil?`), positional enum access, or raw comparison on that Option reports `W_NOMINAL_ENUM_LEGACY_USE`; switch to Option methods or `tag-match`.
 
 The same operations are available as methods on enum values:
 
@@ -262,7 +267,7 @@ do
   assert= (%none) $ optionally nil
   assert= (%some 2) $ find ([] 1 2 3) (fn (x) (> x 1))
   assert= (%ok 1.5) $ parse-float |1.5
-  assert= |fallback $ option:unwrap-or (get-env |__MISSING_ENV__) |fallback
+  assert= |fallback $ (get-env |__MISSING_ENV__) .unwrap-or |fallback
   assert= 0 $
     %none
     , .unwrap-or 0

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -192,7 +192,7 @@ let
   ; get the definition used to construct the value
   println $ struct-definition p
   ; compare definitions directly for an origin check
-  println $ = (option:unwrap $ struct-definition p) Point
+  println $ = (struct-definition p) .unwrap Point
   ; => true
   ; struct-def? is the definition predicate
   println $ struct-def? Point
@@ -264,7 +264,7 @@ let
     Dog $ defstruct Dog (:name :string)
     v1 $ %{} Cat (:name |Mimi) (:color :white)
   if
-    = (option:unwrap $ struct-definition v1) Cat
+    = (struct-definition v1) .unwrap Cat
     println "|Handle Cat branch"
     println "|Not a Cat"
 ```

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -92,11 +92,11 @@ cr calcit.cirru --check-only
 Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field` 和
 `.field` 直接返回字段声明类型，不再自动包装 `Option<T>`。不存在的字段会在
 静态检查阶段报告，运行期也会抛出普通错误；升级业务代码时应删除这类访问后的
-`option:unwrap`。Map 等动态容器的访问仍返回 `Option<T>`，`get-in` 也继续保留
+`.unwrap`。Map 等动态容器的访问仍返回 `Option<T>`，`get-in` 也继续保留
 可失败路径语义，不能批量删除其 unwrap。
 
 推荐先执行 `cr calcit.cirru --check-only`，按诊断逐项替换，再运行完整 JS
-回归。不要先全局删除 `option:unwrap`；只处理接收者已被推断为 Struct 且字段在
+回归。不要先全局删除 `.unwrap`；只处理接收者已被推断为 Struct 且字段在
 `defstruct` 中声明的访问。
 
 下面流程按“先确认版本，再对齐工具链，再更新依赖，最后按 CI 链路验证”的顺序执行。

--- a/editing-history/20260808-1117-option-result-method-api.md
+++ b/editing-history/20260808-1117-option-result-method-api.md
@@ -1,0 +1,7 @@
+# Option and Result Method API
+
+- Classified direct `option:*` and `result:*` helpers as `:internal`; they remain compiler-lowering targets and core implementation details.
+- Added public `Option` method entries for `.unwrap` and `.fold`, alongside the existing predicates, mapping, fallback, and chaining methods.
+- Migrated public Option examples and lens tests to inferred postfix methods when static type evidence exists; dynamic map lookups continue to use explicit `tag-match`.
+- Documented inferred Option/Result methods as the public API, including the JavaScript interop guide.
+- Verified direct helpers still provide Result method dispatch; current WASM codegen cannot consume a surviving nominal Option method call, so backend-only helper coverage remains direct until preprocessing lowering is extended.

--- a/editing-history/20260808-1126-format-cirru-snapshots.md
+++ b/editing-history/20260808-1126-format-cirru-snapshots.md
@@ -1,0 +1,6 @@
+# Canonical Cirru Snapshot Formatting
+
+- Ran `cr edit format` across every repository Snapshot identified by top-level `:files` metadata.
+- Canonicalized 57 Snapshot files, including runnable tests, debug/script fixtures, and type-fail fixtures.
+- The serializer normalized legacy Snapshot record tags to quoted symbols while preserving program semantics.
+- Verified formatting idempotence with a second formatter pass and ran `yarn check-all` successfully.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2349,7 +2349,7 @@
           :tags $ #{} :trait-impl
         |OptionMethods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def OptionMethods $ &impl::new :OptionMethods (:: .some? option:some?) (:: .none? option:none?) (:: .unwrap-or option:unwrap-or) (:: .and-then option:and-then)
+            def OptionMethods $ &impl::new :OptionMethods (:: .some? option:some?) (:: .none? option:none?) (:: .unwrap option:unwrap) (:: .unwrap-or option:unwrap-or) (:: .and-then option:and-then) (:: .fold option:fold)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -5103,6 +5103,7 @@
                   :return $ :: 'Option 'U
               :generics $ [] 'T 'U
               :return $ :: 'Option 'U
+          :tags $ #{} :internal
         |option:fold $ %{} 'CodeEntry (:doc "|Eliminate an Option by evaluating on-none for none or on-some with the payload.")
           :code $ quote
             defn option:fold (opt on-none on-some)
@@ -5126,6 +5127,7 @@
                 :: 'Fn $ {} (:return 'U)
                   :args $ [] 'T
               :generics $ [] 'T 'U
+          :tags $ #{} :internal
         |option:map $ %{} 'CodeEntry (:doc "|Mappable map implementation for Option")
           :code $ quote
             defn option:map (opt f)
@@ -5142,6 +5144,7 @@
                   :args $ [] 'T
               :generics $ [] 'T 'U
               :return $ :: 'Option 'U
+          :tags $ #{} :internal
         |option:none? $ %{} 'CodeEntry (:doc "|Returns true when an Option is :none.")
           :code $ quote
             defn option:none? (opt)
@@ -5155,6 +5158,7 @@
             {} (:return 'Bool)
               :args $ [] (:: 'Option 'T)
               :generics $ [] 'T
+          :tags $ #{} :internal
         |option:some? $ %{} 'CodeEntry (:doc "|Returns true when an Option is :some.")
           :code $ quote
             defn option:some? (opt)
@@ -5168,6 +5172,7 @@
             {} (:return 'Bool)
               :args $ [] (:: 'Option 'T)
               :generics $ [] 'T
+          :tags $ #{} :internal
         |option:unwrap $ %{} 'CodeEntry (:doc "|Return the payload of some; raise when the Option is none.")
           :code $ quote
             defn option:unwrap (opt)
@@ -5181,6 +5186,7 @@
             {} (:return 'T)
               :args $ [] (:: 'Option 'T)
               :generics $ [] 'T
+          :tags $ #{} :internal
         |option:unwrap-or $ %{} 'CodeEntry (:doc "|Returns the :some payload, or the fallback for :none.")
           :code $ quote
             defn option:unwrap-or (opt fallback)
@@ -5194,6 +5200,7 @@
             {} (:return 'T)
               :args $ [] (:: 'Option 'T) 'T
               :generics $ [] 'T
+          :tags $ #{} :internal
         |optionally $ %{} 'CodeEntry (:doc "|Convert a nullable Optional<T> value into nominal Option<T>.")
           :code $ quote
             defn optionally (s)
@@ -5494,6 +5501,7 @@
                   :return $ :: 'Result 'U 'E
               :generics $ [] 'T 'U 'E
               :return $ :: 'Result 'U 'E
+          :tags $ #{} :internal
         |result:err? $ %{} 'CodeEntry (:doc "|Returns true when a Result is :err.")
           :code $ quote
             defn result:err? (res)
@@ -5507,6 +5515,7 @@
             {} (:return 'Bool)
               :args $ [] (:: 'Result 'T 'E)
               :generics $ [] 'T 'E
+          :tags $ #{} :internal
         |result:map $ %{} 'CodeEntry (:doc "|Mappable map implementation for Result")
           :code $ quote
             defn result:map (res f)
@@ -5523,6 +5532,7 @@
                   :args $ [] 'T
               :generics $ [] 'T 'U 'E
               :return $ :: 'Result 'U 'E
+          :tags $ #{} :internal
         |result:map-err $ %{} 'CodeEntry (:doc "|Maps the error payload of a Result while preserving :ok.")
           :code $ quote
             defn result:map-err (res f)
@@ -5542,6 +5552,7 @@
                   :args $ [] 'E
               :generics $ [] 'T 'E 'F
               :return $ :: 'Result 'T 'F
+          :tags $ #{} :internal
         |result:ok? $ %{} 'CodeEntry (:doc "|Returns true when a Result is :ok.")
           :code $ quote
             defn result:ok? (res)
@@ -5555,6 +5566,7 @@
             {} (:return 'Bool)
               :args $ [] (:: 'Result 'T 'E)
               :generics $ [] 'T 'E
+          :tags $ #{} :internal
         |result:unwrap-or $ %{} 'CodeEntry (:doc "|Returns the :ok payload, or the fallback for :err.")
           :code $ quote
             defn result:unwrap-or (res fallback)
@@ -5568,6 +5580,7 @@
             {} (:return 'T)
               :args $ [] (:: 'Result 'T 'E) 'T
               :generics $ [] 'T 'E
+          :tags $ #{} :internal
         |reverse $ %{} 'CodeEntry (:doc "|Reverse the order of elements in a list")
           :code $ quote
             defn reverse (x) (&list:reverse x)


### PR DESCRIPTION
## Summary
- expose Option `.unwrap` and `.fold`, and classify direct `option:*` helpers as internal lowering targets
- classify direct `result:*` helpers as internal lowering targets
- update public docs and the lens fixture to prefer inferred postfix methods; retain explicit `tag-match` for dynamic map lookups
- canonicalize 57 Cirru Snapshot files with `cr edit format`

## Validation
- `cargo test`
- `cargo clippy --lib -- -D warnings`
- `yarn compile`
- `yarn try-wasm`
- `yarn check-agent-interface`
- edited markdown snippets (`common-patterns`, `hashmap`, `structs`, `polymorphism`, `js-interop`)
- formatter idempotence across all changed Snapshots
- `yarn check-all`

## Note
`cargo clippy --all-targets -- -D warnings` remains blocked by the pre-existing `items_after_test_module` lint in `src/bin/calcit_deps.rs` (the `caps` binary), outside this change.