### PR TITLE
chore: release 0.13.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.3"
+version = "0.13.4"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/20260808-1817-release-0.13.4.md
+++ b/editing-history/20260808-1817-release-0.13.4.md
@@ -1,0 +1,4 @@
+# Release 0.13.4
+
+- Bumped the Calcit package versions in `Cargo.toml`, `package.json`, and `Cargo.lock` from 0.13.3 to 0.13.4 after merging the typed host FFI work.
+- Verified the release with formatting, tests, clippy, compilation, full checks, and the agent interface smoke checks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Summary
- bump Cargo, npm, and lockfile versions to 0.13.4
- record release verification history

## Verification
- cargo fmt --check
- cargo test -q
- cargo clippy -- -D warnings
- yarn check-all
- yarn check-agent-interface