### PR TITLE
feat: type static JavaScript field access

### DIFF
--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -28,8 +28,8 @@ Calcit keeps JS interop syntax intentionally small. This page covers the existin
 ## Typed FFI boundary
 
 Raw JavaScript values are not ordinary `Dynamic` Calcit values. Property reads,
-native method calls, `aget`/`js-get`, and `js/...` calls are conservatively
-inferred as `JsNullish<JsObject>`:
+native method calls, `aget`, untyped `js-get`, and `js/...` calls are
+conservatively inferred as `JsNullish<JsObject>`:
 
 - `JsNullish` is reserved for the actual JavaScript `null`/`undefined` boundary;
   it is deliberately distinct from legacy `Optional` and nominal `Option`.
@@ -84,6 +84,23 @@ External trait members translate common Calcit names by default:
 For any exception, declare the exact JavaScript key in the trait's `:ffi
 :names` map. The override is emitted with bracket access, so keys containing
 punctuation are supported.
+
+`js-get` and `js-set` also use external trait field declarations when both the
+receiver type and key are static. A tag or string literal key is checked against
+the trait: `js-get` returns `JsNullish<FieldType>`, while `js-set` checks the
+assigned value and emits the mapped JavaScript property name. Unknown fields
+report `W_JS_FFI_UNKNOWN_FIELD`; incompatible writes report
+`W_JS_FFI_FIELD_TYPE_MISMATCH`.
+
+```cirru.no-check
+defn clear-input (element)
+  js-set element :value |
+```
+
+Dynamic keys retain raw JavaScript semantics. Use `aget`/`aset` when bypassing
+the external trait contract is intentional. When a trusted raw receiver needs
+typed field access, establish that evidence once with `unsafe-coerce` at the
+adapter boundary rather than coercing each field value.
 
 A nominal `Option<T>` uses `.some?`/`.none?`. Preprocessing reports
 `W_NOMINAL_ENUM_LEGACY_USE` when old nullable checks are applied to an Option,

--- a/editing-history/202608082207-typed-js-field-access.md
+++ b/editing-history/202608082207-typed-js-field-access.md
@@ -1,0 +1,15 @@
+# Typed `js-get` and `js-set` fields
+
+- Added external-object-aware inference for static `js-get` field reads.
+- Added declared field validation for static `js-set` writes, including unknown-field and value-type diagnostics.
+- Lowered typed static reads and writes through dedicated AST method kinds so JavaScript codegen applies external trait `:names` overrides and default kebab-to-camel mapping.
+- Kept dynamic keys and `aget`/`aset` as explicit raw JavaScript escape hatches.
+- Migrated representative Respo DOM field writes and methods to the typed external-object path and verified add/remove behavior in a controlled browser.
+
+Validation:
+
+- `cargo test -q`
+- `cargo clippy --lib --bin cr -- -D warnings`
+- `yarn compile`
+- `cr docs check-md docs/features/js-interop.md --entry calcit/test.cirru`
+- Respo: `cr js`, `yarn test`, controlled Chrome add/remove regression

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -358,6 +358,8 @@ impl fmt::Display for Calcit {
         MethodKind::InvokeNative => f.write_str(&format!(".!{name}")),
         MethodKind::TagAccess => f.write_str(&format!(".:{name}")),
         MethodKind::ExternalAccess(_) => f.write_str(&format!(".:{name}")),
+        MethodKind::ExternalGet(_) => f.write_str(&format!("(js-get :{name})")),
+        MethodKind::ExternalSet(_) => f.write_str(&format!("(js-set :{name})")),
         MethodKind::ExternalInvoke(_) => f.write_str(&format!(".{name}")),
         MethodKind::AccessOptional => f.write_str(&format!(".?-{name}")),
         MethodKind::InvokeNativeOptional => f.write_str(&format!(".?!{name}")),
@@ -833,6 +835,8 @@ impl Calcit {
         MethodKind::InvokeNative => format!(".!{name}"),
         MethodKind::TagAccess => format!(".:{name}"),
         MethodKind::ExternalAccess(_) => format!(".:{name}"),
+        MethodKind::ExternalGet(_) => format!("js-get:{name}"),
+        MethodKind::ExternalSet(_) => format!("js-set:{name}"),
         MethodKind::ExternalInvoke(_) => format!(".{name}"),
         MethodKind::AccessOptional => format!(".?-{name}"),
         MethodKind::InvokeNativeOptional => format!(".?!{name}"),
@@ -937,6 +941,8 @@ impl Calcit {
           crate::calcit::MethodKind::Invoke(_) => "method call",
           crate::calcit::MethodKind::TagAccess => "tag attribute access",
           crate::calcit::MethodKind::ExternalAccess(_) => "external object field access",
+          crate::calcit::MethodKind::ExternalGet(_) => "nullable external object field access",
+          crate::calcit::MethodKind::ExternalSet(_) => "external object field assignment",
           crate::calcit::MethodKind::ExternalInvoke(_) => "external object method call",
           crate::calcit::MethodKind::AccessOptional => "optional attribute access",
           crate::calcit::MethodKind::InvokeNativeOptional => "optional native method call",
@@ -1331,6 +1337,10 @@ pub enum MethodKind {
   TagAccess,
   /// Typed access to a field on an external host object.
   ExternalAccess(Arc<CalcitTypeAnnotation>),
+  /// Nullable field read produced by a typed `js-get` call.
+  ExternalGet(Arc<CalcitTypeAnnotation>),
+  /// Field assignment produced by a typed `js-set` call.
+  ExternalSet(Arc<CalcitTypeAnnotation>),
   /// Typed method invocation on an external host object.
   ExternalInvoke(Arc<CalcitTypeAnnotation>),
   /// (.-p a)
@@ -1347,6 +1357,8 @@ impl fmt::Display for MethodKind {
       MethodKind::InvokeNativeOptional => write!(f, "invoke-native-optional"),
       MethodKind::TagAccess => write!(f, "tag-access"),
       MethodKind::ExternalAccess(_) => write!(f, "external-access"),
+      MethodKind::ExternalGet(_) => write!(f, "external-get"),
+      MethodKind::ExternalSet(_) => write!(f, "external-set"),
       MethodKind::ExternalInvoke(_) => write!(f, "external-invoke"),
       MethodKind::Access => write!(f, "access"),
       MethodKind::AccessOptional => write!(f, "access-optional"),

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -221,6 +221,8 @@ fn quote_to_js(xs: &Calcit, var_prefix: &str, tags: &RefCell<HashSet<EdnTag>>) -
         MethodKind::Invoke(_) => ".",
         MethodKind::TagAccess => ".:",
         MethodKind::ExternalAccess(_) => ".:",
+        MethodKind::ExternalGet(_) => "js-get:",
+        MethodKind::ExternalSet(_) => "js-set:",
         MethodKind::ExternalInvoke(_) => ".",
         MethodKind::AccessOptional => ".?-",
         MethodKind::InvokeNativeOptional => ".?!",
@@ -810,6 +812,25 @@ fn gen_call_code(
           Ok(format!("{obj}[{}]", escape_cirru_str(&property)))
         } else {
           Err(format!("external-access takes only 1 argument, {xs}"))
+        }
+      }
+      MethodKind::ExternalGet(type_hint) => {
+        if body.len() == 1 {
+          let obj = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
+          let property = external_js_property_name(type_hint, name.as_ref());
+          Ok(format!("{return_code}{obj}[{}]", escape_cirru_str(&property)))
+        } else {
+          Err(format!("external-get takes only 1 argument, {xs}"))
+        }
+      }
+      MethodKind::ExternalSet(type_hint) => {
+        if body.len() == 2 {
+          let obj = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
+          let value = to_js_code(&body[1], ns, local_defs, file_imports, tags, None)?;
+          let property = external_js_property_name(type_hint, name.as_ref());
+          Ok(format!("{return_code}({obj}[{}] = {value})", escape_cirru_str(&property)))
+        } else {
+          Err(format!("external-set takes 2 arguments, {xs}"))
         }
       }
       MethodKind::ExternalInvoke(type_hint) => {
@@ -1898,6 +1919,45 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
 mod tests {
   use super::*;
   use crate::calcit::CalcitSymbolInfo;
+  use std::collections::HashMap;
+
+  fn external_trait_with_names() -> Arc<calcit::CalcitTrait> {
+    let ns = "tests.emit-js-external";
+    let def = "HostElement";
+    program::PROGRAM_CODE_DATA.write().expect("open program code").insert(
+      Arc::from(ns),
+      program::ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([(
+          Arc::from(def),
+          program::ProgramDefEntry {
+            code: Calcit::Nil,
+            schema: calcit::DYNAMIC_TYPE.clone(),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: Some(cirru_edn::Edn::map_from_iter([
+              (cirru_edn::Edn::tag("backend"), cirru_edn::Edn::tag("js")),
+              (cirru_edn::Edn::tag("kind"), cirru_edn::Edn::tag("external-object")),
+              (
+                cirru_edn::Edn::tag("names"),
+                cirru_edn::Edn::map_from_iter([(cirru_edn::Edn::tag("inner-text"), cirru_edn::Edn::str("textContent"))]),
+              ),
+            ])),
+          },
+        )]),
+      },
+    );
+    Arc::new(calcit::CalcitTrait {
+      runtime_id: None,
+      definition_ref: Some(Arc::from(format!("{ns}/{def}"))),
+      name: EdnTag::new(def),
+      methods: Arc::new(vec![]),
+      defaults: Arc::new(vec![]),
+      method_types: Arc::new(vec![]),
+      member_kinds: Arc::new(vec![]),
+      requires: Arc::new(vec![]),
+    })
+  }
 
   fn runtime_placeholder_quote() -> Calcit {
     Calcit::List(Arc::new(CalcitList::from(&[
@@ -1965,6 +2025,32 @@ mod tests {
     assert_eq!(default_external_js_member_name("matches?"), "matches");
     assert_eq!(default_external_js_member_name("set-item!"), "setItem");
     assert_eq!(default_external_js_member_name("!"), "!");
+  }
+
+  #[test]
+  fn typed_external_field_codegen_uses_ffi_name_overrides() {
+    let type_hint = Arc::new(calcit::CalcitTypeAnnotation::Trait(external_trait_with_names()));
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let get_form = Calcit::List(Arc::new(CalcitList::from(&[
+      Calcit::Method(Arc::from("inner-text"), MethodKind::ExternalGet(type_hint.clone())),
+      symbol("element"),
+    ])));
+    let set_form = Calcit::List(Arc::new(CalcitList::from(&[
+      Calcit::Method(Arc::from("inner-text"), MethodKind::ExternalSet(type_hint)),
+      symbol("element"),
+      Calcit::Str(Arc::from("ready")),
+    ])));
+
+    assert_eq!(
+      to_js_code(&get_form, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("external get should compile"),
+      "element[\"textContent\"]"
+    );
+    assert_eq!(
+      to_js_code(&set_form, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("external set should compile"),
+      "(element[\"textContent\"] = \"ready\")"
+    );
   }
 
   #[test]

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -287,6 +287,8 @@ pub fn calcit_to_cirru(x: &Calcit) -> Result<Cirru, String> {
         Invoke(_) => Ok(Cirru::leaf(format!(".{name}"))),
         TagAccess => Ok(Cirru::leaf(format!(".:{name}"))),
         ExternalAccess(_) => Ok(Cirru::leaf(format!(".:{name}"))),
+        ExternalGet(_) => Ok(Cirru::leaf(format!("js-get:{name}"))),
+        ExternalSet(_) => Ok(Cirru::leaf(format!("js-set:{name}"))),
         ExternalInvoke(_) => Ok(Cirru::leaf(format!(".{name}"))),
         AccessOptional => Ok(Cirru::leaf(format!(".?-{name}"))),
         InvokeNativeOptional => Ok(Cirru::leaf(format!(".?!{name}"))),

--- a/src/data/edn.rs
+++ b/src/data/edn.rs
@@ -123,6 +123,8 @@ pub fn calcit_to_edn(x: &Calcit) -> Result<Edn, String> {
       MethodKind::Invoke(_) => Ok(Edn::Symbol(format!(".{name}").into())),
       MethodKind::TagAccess => Ok(Edn::Symbol(format!(".:{name}").into())),
       MethodKind::ExternalAccess(_) => Ok(Edn::Symbol(format!(".:{name}").into())),
+      MethodKind::ExternalGet(_) => Ok(Edn::Symbol(format!("js-get:{name}").into())),
+      MethodKind::ExternalSet(_) => Ok(Edn::Symbol(format!("js-set:{name}").into())),
       MethodKind::ExternalInvoke(_) => Ok(Edn::Symbol(format!(".{name}").into())),
       MethodKind::AccessOptional => Ok(Edn::Symbol(format!(".?-{name}").into())),
       MethodKind::InvokeNativeOptional => Ok(Edn::Symbol(format!(".?!{name}").into())),

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1640,6 +1640,10 @@ fn preprocess_list_call(
         check_struct_field_access(&head_form, &processed_args, scope_types, file_ns, check_warnings);
         check_struct_update_fields(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
         check_struct_method_args(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
+        check_typed_js_field_operation(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
+        if let Some(rewritten) = rewrite_typed_js_field_operation(&head_form, &processed_args, scope_types) {
+          return Ok(rewritten);
+        }
 
         // Optimize &struct:get to &struct:nth when field index can be resolved at compile time
         if matches!(&head_form, Calcit::Proc(CalcitProc::NativeStructGet))
@@ -3023,6 +3027,106 @@ fn warn_on_nullable_js_ffi_dereference(
     gen_check_warning_with_location_code(message, "W_JS_FFI_NULLABLE_DEREF", location, check_warnings);
   } else {
     gen_check_warning_code(message, "W_JS_FFI_NULLABLE_DEREF", file_ns, check_warnings);
+  }
+}
+
+fn static_js_field_name(form: &Calcit) -> Option<&str> {
+  match form {
+    Calcit::Tag(tag) => Some(tag.ref_str()),
+    Calcit::Str(name) => Some(name.as_ref()),
+    _ => None,
+  }
+}
+
+fn rewrite_typed_js_field_operation(head: &Calcit, args: &CalcitList, scope_types: &ScopeTypes) -> Option<Calcit> {
+  let operation = match head {
+    Calcit::Symbol { sym, .. } if sym.as_ref() == "js-get" => "get",
+    Calcit::Symbol { sym, .. } if sym.as_ref() == "js-set" => "set",
+    _ => return None,
+  };
+  let receiver = args.first()?;
+  let field_name = static_js_field_name(args.get(1)?)?;
+  let receiver_type = resolve_type_value(receiver, scope_types)?;
+  let traits = trait_list_from_type(receiver_type.as_ref())?;
+  let (trait_def, _) = find_trait_field_type(&traits, field_name)?;
+  if !trait_is_external_object(trait_def) {
+    return None;
+  }
+  let kind = if operation == "get" {
+    calcit::MethodKind::ExternalGet(receiver_type)
+  } else {
+    calcit::MethodKind::ExternalSet(receiver_type)
+  };
+  let mut rewritten = vec![Calcit::Method(Arc::from(field_name), kind), receiver.clone()];
+  if operation == "set" {
+    rewritten.push(args.get(2)?.clone());
+  }
+  Some(Calcit::from(rewritten))
+}
+
+fn check_typed_js_field_operation(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  def_name: &str,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  let operation = match head {
+    Calcit::Symbol { sym, .. } if sym.as_ref() == "js-get" => "js-get",
+    Calcit::Symbol { sym, .. } if sym.as_ref() == "js-set" => "js-set",
+    _ => return,
+  };
+  let (Some(receiver), Some(key)) = (args.first(), args.get(1)) else {
+    return;
+  };
+  let Some(field_name) = static_js_field_name(key) else {
+    return;
+  };
+  let Some(receiver_type) = resolve_type_value(receiver, scope_types) else {
+    return;
+  };
+  let Some(traits) = trait_list_from_type(receiver_type.as_ref()) else {
+    return;
+  };
+  let external_traits = traits
+    .iter()
+    .filter(|trait_def| trait_is_external_object(trait_def.as_ref()))
+    .cloned()
+    .collect::<Vec<_>>();
+  if external_traits.is_empty() {
+    return;
+  }
+  let Some((_, field_type)) = find_trait_field_type(&external_traits, field_name) else {
+    let message = format!(
+      "[Warn] `{operation}` cannot access undeclared external-object field `:{field_name}` in {file_ns}/{def_name}; declare the field on the external trait, use a dynamic key, or use raw `aget`/`aset`"
+    );
+    gen_check_warning_code_at(
+      message,
+      "W_JS_FFI_UNKNOWN_FIELD",
+      file_ns,
+      key.get_location().or_else(|| head.get_location()),
+      check_warnings,
+    );
+    return;
+  };
+  if operation == "js-set"
+    && let Some(value) = args.get(2)
+    && let Some(value_type) = resolve_type_value(value, scope_types)
+    && !value_type.as_ref().matches_annotation(field_type.as_ref())
+  {
+    let message = format!(
+      "[Warn] `js-set` field `:{field_name}` expects {}, got {} in {file_ns}/{def_name}",
+      field_type.to_brief_string(),
+      value_type.to_brief_string()
+    );
+    gen_check_warning_code_at(
+      message,
+      "W_JS_FFI_FIELD_TYPE_MISMATCH",
+      file_ns,
+      value.get_location().or_else(|| head.get_location()),
+      check_warnings,
+    );
   }
 }
 
@@ -6213,6 +6317,150 @@ mod tests {
     assert_eq!(trait_def.name.ref_str(), "MySourceTrait");
     assert_eq!(trait_def.definition_ref.as_deref(), Some("tests.source-trait/MySourceTrait"));
     assert!(trait_def.has_method("show"));
+  }
+
+  fn seed_external_field_trait() -> Arc<CalcitTrait> {
+    let ns = "tests.external-field";
+    let def = "HostElement";
+    let trait_code = code_to_calcit(
+      &Cirru::List(vec![
+        Cirru::leaf("deftrait"),
+        Cirru::leaf(def),
+        Cirru::List(vec![Cirru::leaf(":value"), Cirru::leaf("'String")]),
+      ]),
+      ns,
+      def,
+      vec![],
+    )
+    .expect("parse external trait");
+    let trait_def = resolve_trait_def_from_source_code(&trait_code)
+      .expect("resolve external trait")
+      .with_definition_ref(ns, def);
+    program::PROGRAM_CODE_DATA.write().expect("open program code").insert(
+      Arc::from(ns),
+      program::ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([(
+          Arc::from(def),
+          program::ProgramDefEntry {
+            code: trait_code,
+            schema: calcit::DYNAMIC_TYPE.clone(),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: Some(cirru_edn::Edn::map_from_iter([
+              (cirru_edn::Edn::tag("backend"), cirru_edn::Edn::tag("js")),
+              (cirru_edn::Edn::tag("kind"), cirru_edn::Edn::tag("external-object")),
+            ])),
+          },
+        )]),
+      },
+    );
+    Arc::new(trait_def)
+  }
+
+  fn external_field_test_symbol(name: &str) -> Calcit {
+    Calcit::Symbol {
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.external-field"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+    }
+  }
+
+  fn external_field_test_receiver(trait_def: Arc<CalcitTrait>) -> Calcit {
+    let sym: Arc<str> = Arc::from("element");
+    Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&sym),
+      sym,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.external-field"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::Trait(trait_def)),
+    })
+  }
+
+  #[test]
+  fn js_get_infers_external_trait_field_payload() {
+    let _guard = lock_preprocess_test_state();
+    let receiver = external_field_test_receiver(seed_external_field_trait());
+    let expression = Calcit::from(vec![
+      external_field_test_symbol("js-get"),
+      receiver,
+      Calcit::Tag(EdnTag::new("value")),
+    ]);
+
+    assert!(matches!(
+      infer_static_type_from_expr(&expression).as_deref(),
+      Some(CalcitTypeAnnotation::JsNullish(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::String)
+    ));
+
+    let receiver = external_field_test_receiver(seed_external_field_trait());
+    let rewritten = rewrite_typed_js_field_operation(
+      &external_field_test_symbol("js-get"),
+      &CalcitList::from(&[receiver, Calcit::Tag(EdnTag::new("value"))]),
+      &ScopeTypes::new(),
+    )
+    .expect("typed js-get should rewrite");
+    assert!(matches!(
+      rewritten,
+      Calcit::List(items)
+        if matches!(items.first(), Some(Calcit::Method(name, calcit::MethodKind::ExternalGet(_))) if name.as_ref() == "value")
+    ));
+  }
+
+  #[test]
+  fn js_set_checks_external_trait_static_fields() {
+    let _guard = lock_preprocess_test_state();
+    let receiver = external_field_test_receiver(seed_external_field_trait());
+    let head = external_field_test_symbol("js-set");
+
+    let valid_warnings = RefCell::new(vec![]);
+    check_typed_js_field_operation(
+      &head,
+      &CalcitList::from(&[receiver.clone(), Calcit::Tag(EdnTag::new("value")), Calcit::Str(Arc::from("ok"))]),
+      &ScopeTypes::new(),
+      "tests.external-field",
+      "valid",
+      &valid_warnings,
+    );
+    assert!(valid_warnings.borrow().is_empty());
+    let rewritten = rewrite_typed_js_field_operation(
+      &head,
+      &CalcitList::from(&[receiver.clone(), Calcit::Tag(EdnTag::new("value")), Calcit::Str(Arc::from("ok"))]),
+      &ScopeTypes::new(),
+    )
+    .expect("typed js-set should rewrite");
+    assert!(matches!(
+      rewritten,
+      Calcit::List(items)
+        if matches!(items.first(), Some(Calcit::Method(name, calcit::MethodKind::ExternalSet(_))) if name.as_ref() == "value")
+    ));
+
+    let unknown_warnings = RefCell::new(vec![]);
+    check_typed_js_field_operation(
+      &head,
+      &CalcitList::from(&[receiver.clone(), Calcit::Tag(EdnTag::new("missing")), Calcit::Str(Arc::from("x"))]),
+      &ScopeTypes::new(),
+      "tests.external-field",
+      "unknown",
+      &unknown_warnings,
+    );
+    assert_eq!(unknown_warnings.borrow()[0].code(), Some("W_JS_FFI_UNKNOWN_FIELD"));
+
+    let mismatch_warnings = RefCell::new(vec![]);
+    check_typed_js_field_operation(
+      &head,
+      &CalcitList::from(&[receiver, Calcit::Tag(EdnTag::new("value")), Calcit::Number(1.0)]),
+      &ScopeTypes::new(),
+      "tests.external-field",
+      "mismatch",
+      &mismatch_warnings,
+    );
+    assert_eq!(mismatch_warnings.borrow()[0].code(), Some("W_JS_FFI_FIELD_TYPE_MISMATCH"));
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -388,12 +388,30 @@ fn js_nullish_host_value_type() -> Arc<CalcitTypeAnnotation> {
   Arc::new(CalcitTypeAnnotation::JsNullish(js_host_value_type()))
 }
 
+fn infer_external_field_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&Calcit>) -> Option<Arc<CalcitTypeAnnotation>> {
+  let field_name = key_arg.and_then(extract_field_name)?;
+  let traits = trait_list_from_type(base_type)?;
+  let (trait_def, field_type) = find_trait_field_type(&traits, field_name)?;
+  trait_is_external_object(trait_def).then(|| field_type.clone())
+}
+
 fn infer_js_ffi_call_return_type(name: &str, call_expr: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
   match name {
     // JavaScript indexed/property reads may yield `undefined` or `null`. Keep
     // the raw host value opaque as well as nullable so a nil check alone does
     // not silently prove that it is a Calcit Number/String/etc.
-    "aget" | "js-get" => Some(js_nullish_host_value_type()),
+    "js-get" => {
+      let field_type = call_expr
+        .get(1)
+        .and_then(|base| resolve_type_value(base, scope_types))
+        .and_then(|base_type| infer_external_field_type(base_type.as_ref(), call_expr.get(2)));
+      Some(
+        field_type
+          .map(|field_type| Arc::new(CalcitTypeAnnotation::JsNullish(field_type)))
+          .unwrap_or_else(js_nullish_host_value_type),
+      )
+    }
+    "aget" => Some(js_nullish_host_value_type()),
     // Assignment expressions evaluate to the assigned value in JavaScript.
     "aset" | "js-set" => call_expr
       .get(3)
@@ -624,7 +642,10 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
         // Method access: infer struct field type when available
         Calcit::Method(
           field_name,
-          calcit::MethodKind::Access | calcit::MethodKind::TagAccess | calcit::MethodKind::ExternalAccess(_),
+          calcit::MethodKind::Access
+          | calcit::MethodKind::TagAccess
+          | calcit::MethodKind::ExternalAccess(_)
+          | calcit::MethodKind::ExternalGet(_),
         ) => {
           if let Some(receiver) = xs.get(1)
             && let Some(field_type) = infer_struct_field_type(receiver, field_name.as_ref(), scope_types)
@@ -637,13 +658,18 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
             && let Some((trait_def, field_type)) = find_trait_field_type(&traits, field_name.as_ref())
             && trait_is_external_object(trait_def)
           {
-            return Some(field_type.clone());
+            return Some(if matches!(head, Calcit::Method(_, calcit::MethodKind::ExternalGet(_))) {
+              Arc::new(CalcitTypeAnnotation::JsNullish(field_type.clone()))
+            } else {
+              field_type.clone()
+            });
           }
           match head {
             Calcit::Method(_, calcit::MethodKind::Access) => Some(js_nullish_host_value_type()),
             _ => None,
           }
         }
+        Calcit::Method(_, calcit::MethodKind::ExternalSet(_)) => xs.get(2).and_then(|value| resolve_type_value(value, scope_types)),
 
         // Native JavaScript access/calls remain explicit JsNullish boundary values,
         // not legacy Optional or nominal Option values. The opaque JsObject payload

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -521,7 +521,10 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           Some(infer_preprocessed_function_type(xs))
         }
 
-        Calcit::Syntax(CalcitSyntax::UnsafeCoerce, _) => xs.get(2).map(CalcitTypeAnnotation::parse_type_annotation_form),
+        // Coercion type expressions have no local generics, so names are concrete refs.
+        Calcit::Syntax(CalcitSyntax::UnsafeCoerce, _) => xs
+          .get(2)
+          .map(|form| CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[])),
 
         Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _) => xs
           .get(2)


### PR DESCRIPTION
## 概要

增强 `js-get` / `js-set`，当 receiver 为 external-object trait 且 key 为静态 tag/string 时启用字段类型检查与 JavaScript 属性名映射：

- `js-get` 对声明字段推断为 `JsNullish<FieldType>`。
- `js-set` 校验字段存在性与值类型，新增 `W_JS_FFI_UNKNOWN_FIELD`、`W_JS_FFI_FIELD_TYPE_MISMATCH`。
- 新增 `ExternalGet` / `ExternalSet` AST lowering，支持 `:names` 覆盖与 kebab→camel 默认映射。
- 动态 key 与 `aget` / `aset` 保持原始逃生口。
- 补充 `unsafe-coerce` 命名类型保留修复。

## 验证

- `cargo test -q`（364 lib + 192 integration）
- `cargo clippy --lib --bin cr -- -D warnings`
- `yarn compile` / `yarn check-all`
- `yarn check-agent-interface`（12/12）
- `cr docs check-md docs/features/js-interop.md --entry calcit/test.cirru`（16/16）
- Respo：`cr js`、`yarn test`、受控 Chrome 增删回归