### PR TITLE
feat: warn on untyped JS FFI access and improve codegen readability

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -54,6 +54,7 @@ cr docs agents --full
 - **`foldl` 初始空集合语法**：`foldl xs [] $ fn ...` 中，`[]` 会因 `$` 右结合被解析为 `([] (fn ...))` 而非空列表。正确写法是先绑定 `init $ []`，再传 `init`；或对空 map 同理使用 `init $ {}`。
 - **告警会使 eval 失败**：有类型告警时，`cr eval` 会以错误退出（这是预期行为，便于阻断不安全用法）。
   - 例：`cargo run --bin cr -- calcit/test.cirru eval '&list:nth 1 0'` 会提示 `:list` vs `:number` 的类型告警。
+- **JS FFI 动态访问告警（opt-in）**：传 `--warn-dyn-method` 时，裸 `JsObject` 上的 `.-`/`.!`/`aget`/`aset`/`js-get`/`js-set`（静态字面量 key）会额外报告 `W_JS_FFI_UNTYPED_ACCESS`，提示声明 external-object trait 提升类型覆盖度；不传 flag 时静默。
 - **assert-type 仅做检查**：`assert-type` 在预处理阶段生效，不会改变运行值。
   - 例：`cargo run --bin cr -- calcit/test.cirru eval 'let ((x 1)) (assert-type x :list) x'` 依然返回 `1`，并在检查阶段报告类型不匹配。
 - **常用排错方式**：遇到报错先看 `.calcit/error.cirru`，它会提供更完整的栈信息。
@@ -126,6 +127,10 @@ npm view @calcit/procs version
 
 - **高频分配规约**：在 Preprocessing 阶段，严禁在循环内调用 `Arc::new(CalcitTypeAnnotation::Dynamic)`。应始终 clone 单例 `crate::calcit::DYNAMIC_TYPE`。
 - **验证手段**：对于大规模 Cirru 项目的预处理，可通过 `repeat 10 { time ./target/release/cr ... }` 观察耗时抖动。若抖动剧烈，通常预示着堆内存申请频率过高或冷热数据加载策略存在问题。
+
+### JS 代码生成可读性
+
+- JS codegen 采用**行级缩进**（复用 `indent_block`，O(n) 单遍处理），不做 AST 级美化：函数体与嵌套语句块缩进一级，顶层函数间插入空行。改动 codegen 时保持这一低成本风格即可，不要引入完整格式化器。
 
 ## 项目结构概览
 

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -53,6 +53,16 @@ legacy `nil?`/`some?` reports `W_JS_FFI_NULLABLE_PREDICATE`. Convert explicitly
 with `js-nullish->option` only after accepting the opaque payload contract;
 generic `optionally` does not accept `JsNullish<T>`.
 
+### Opt-in: flagging untyped access points
+
+`.-name`, `.!name`, `aget`, `aset`, `js-get`, and `js-set` against a bare
+`JsObject` receiver (no external-object trait attached) still work, but nothing
+about the field is checked. Running with `--warn-dyn-method` additionally
+reports `W_JS_FFI_UNTYPED_ACCESS` for these calls whenever the field key is a
+literal tag/string, since that is the case where declaring a trait for the
+receiver is directly actionable. A dynamic (non-literal) key, or a receiver
+that already carries trait or nullable evidence, does not trigger it.
+
 ## ES modules with typed adapters
 
 Import npm packages with the ordinary namespace rules, then keep the unchecked

--- a/editing-history/202608090039-ffi-untyped-warning-and-codegen-format.md
+++ b/editing-history/202608090039-ffi-untyped-warning-and-codegen-format.md
@@ -1,0 +1,22 @@
+# Untyped FFI access warning and JS codegen readability
+
+- Added opt-in `W_JS_FFI_UNTYPED_ACCESS` diagnostic (enabled with
+  `--warn-dyn-method`): raw `.-`/`.!`/`aget`/`aset`/`js-get`/`js-set` on a bare
+  `JsObject` receiver with a literal key now suggests declaring an
+  external-object trait. Dynamic keys and typed/ nullable receivers are
+  skipped; silent by default.
+- Improved generated JavaScript readability without a real formatter: function
+  bodies and nested statement blocks are indented one level (reusing
+  `indent_block`, O(n)), top-level functions are separated by a blank line, and
+  a stray-space typo in raised-error codegen was fixed.
+- Documented both in `docs/features/js-interop.md` and the repo `Agents.md`.
+
+Validation:
+
+- `cargo test -q`（366 lib + 192 integration）
+- `cargo clippy --lib --bin cr -- -D warnings`
+- `cargo fmt --check`
+- `yarn compile` / `yarn check-all`
+- `yarn check-agent-interface`
+- `cr docs check-md docs/features/js-interop.md --entry calcit/test.cirru`
+- Respo: `cr js` + `yarn test`

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -269,6 +269,17 @@ fn indent_block(body: &str, indent: &str) -> String {
     .join("\n")
 }
 
+/// Detects verbatim `&raw-code` segments anywhere in an expression tree. These
+/// are emitted byte-for-byte, so line-based indentation must not touch them
+/// (a multiline template literal would otherwise change value).
+fn contains_raw_code(x: &Calcit) -> bool {
+  match x {
+    Calcit::RawCode(..) => true,
+    Calcit::List(xs) => xs.iter().any(contains_raw_code),
+    _ => false,
+  }
+}
+
 fn raw_syntax_codegen_error(syntax: &CalcitSyntax) -> String {
   format!(
     "invalid JS codegen: raw syntax node `{syntax}` cannot be emitted as a standalone JS value. LLM hint: special forms must start an expression, for example `(if cond a b)`, or appear at the beginning of a line / after `$`, instead of being left as a separate argument node."
@@ -1407,7 +1418,11 @@ fn list_to_js_code(
     } else {
       let line = to_js_code(x, ns, &local_defs, file_imports, tags, Some(""))?;
       result.push_str("{\n");
-      result.push_str(&indent_block(&line, "  "));
+      if contains_raw_code(x) {
+        result.push_str(&line);
+      } else {
+        result.push_str(&indent_block(&line, "  "));
+      }
       result.push_str(";\n}\n");
     }
   }
@@ -1610,21 +1625,31 @@ fn gen_js_func(
     Ok(format!("{export_mark}{fn_def}\n"))
   } else {
     let body_code = list_to_js_code(&body, passed_defs.ns, local_defs, "return ", passed_defs.file_imports, tags)?;
-    let header = format!("{check_args}{spreading_code}");
-    let full_body = if header.trim().is_empty() {
+    // `check_args` and `spreading_code` both contribute to the prologue; keep
+    // each on its own line without leaving a leading blank line.
+    let mut header_parts: Vec<&str> = vec![];
+    if !check_args.trim().is_empty() {
+      header_parts.push(check_args.trim());
+    }
+    if !spreading_code.trim().is_empty() {
+      header_parts.push(spreading_code.trim());
+    }
+    let header = header_parts.join("\n");
+    let full_body = if header.is_empty() {
       body_code
     } else {
       format!("{header}\n{body_code}")
     };
-    // Cheap, line-based indentation only (no AST-aware pretty-printing) so
-    // generated code stays readable without adding real compile cost.
-    let fn_definition = format!(
-      "{}function {}({}) {{\n{}\n}}",
-      async_prefix,
-      escape_var(name),
-      args_code,
+    let body_code = if raw_body.iter().any(contains_raw_code) {
+      // Raw-code segments are emitted verbatim; indenting them could change
+      // multiline template literals, so keep the body unindented.
+      full_body
+    } else {
+      // Cheap, line-based indentation only (no AST-aware pretty-printing) so
+      // generated code stays readable without adding real compile cost.
       indent_block(&full_body, "  ")
-    );
+    };
+    let fn_definition = format!("{}function {}({}) {{\n{}\n}}", async_prefix, escape_var(name), args_code, body_code);
     let export_mark = if exported { "export " } else { "" };
     Ok(format!("{export_mark}{fn_definition}\n"))
   }
@@ -2061,6 +2086,60 @@ mod tests {
     assert_eq!(
       to_js_code(&set_form, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("external set should compile"),
       "(element[\"textContent\"] = \"ready\")"
+    );
+  }
+
+  #[test]
+  fn raw_code_body_is_kept_verbatim() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let passed_defs = PassedDefs {
+      ns: "tests.emit-js",
+      local_defs: &local_defs,
+      file_imports: &file_imports,
+    };
+    let args = CalcitFnArgs::Args(vec![]);
+    let raw_body = vec![Calcit::RawCode(calcit::RawCodeType::Js, Arc::from("let t = `line1\nline2`;"))];
+
+    let code = gen_js_func("demo", &args, &raw_body, &passed_defs, true, &tags, "tests.emit-js").expect("raw-code body should compile");
+    // Multiline raw-code must stay byte-for-byte: the second line is not indented.
+    assert!(code.contains("let t = `line1\nline2`;"), "raw-code changed:\n{code}");
+    assert!(code.contains("\nline2`;"), "raw-code newline content indented:\n{code}");
+  }
+
+  #[test]
+  fn spreading_prologue_has_no_leading_blank_line() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let passed_defs = PassedDefs {
+      ns: "tests.emit-js",
+      local_defs: &local_defs,
+      file_imports: &file_imports,
+    };
+    let sym: Arc<str> = Arc::from("xs");
+    let idx = CalcitLocal::track_sym(&sym);
+    let args = CalcitFnArgs::MarkedArgs(vec![CalcitArgLabel::RestMark, CalcitArgLabel::Idx(idx)]);
+    let raw_body = vec![Calcit::Symbol {
+      sym: sym.clone(),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.emit-js"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+    }];
+
+    let prev = crate::codegen::skip_arity_check();
+    crate::codegen::set_code_gen_skip_arity_check(true);
+    let code =
+      gen_js_func("demo", &args, &raw_body, &passed_defs, true, &tags, "tests.emit-js").expect("spreading body should compile");
+    crate::codegen::set_code_gen_skip_arity_check(prev);
+
+    assert!(!code.contains("{\n\n"), "no leading blank line expected:\n{code}");
+    assert!(
+      code.contains("{\n  xs = $clt.arrayToList(xs);"),
+      "spreading should be the first indented line:\n{code}"
     );
   }
 

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -552,7 +552,7 @@ fn gen_call_code(
             None => String::from("null"),
           };
           let err_var = js_gensym("err");
-          let ret = format!("let {err_var} = new Error({message});\n {err_var}.data = {data_code};\n throw {err_var};");
+          let ret = format!("let {err_var} = new Error({message});\n{err_var}.data = {data_code};\nthrow {err_var};");
           // println!("inside raise: {:?} {}", return_label, xs);
           match return_label {
             Some(_) => Ok(ret),
@@ -1407,7 +1407,7 @@ fn list_to_js_code(
     } else {
       let line = to_js_code(x, ns, &local_defs, file_imports, tags, Some(""))?;
       result.push_str("{\n");
-      result.push_str(&line);
+      result.push_str(&indent_block(&line, "  "));
       result.push_str(";\n}\n");
     }
   }
@@ -1609,14 +1609,21 @@ fn gen_js_func(
     };
     Ok(format!("{export_mark}{fn_def}\n"))
   } else {
+    let body_code = list_to_js_code(&body, passed_defs.ns, local_defs, "return ", passed_defs.file_imports, tags)?;
+    let header = format!("{check_args}{spreading_code}");
+    let full_body = if header.trim().is_empty() {
+      body_code
+    } else {
+      format!("{header}\n{body_code}")
+    };
+    // Cheap, line-based indentation only (no AST-aware pretty-printing) so
+    // generated code stays readable without adding real compile cost.
     let fn_definition = format!(
-      "{}function {}({}) {{ {}{}\n{}}}",
+      "{}function {}({}) {{\n{}\n}}",
       async_prefix,
       escape_var(name),
       args_code,
-      check_args,
-      spreading_code,
-      list_to_js_code(&body, passed_defs.ns, local_defs, "return ", passed_defs.file_imports, tags)?
+      indent_block(&full_body, "  ")
     );
     let export_mark = if exported { "export " } else { "" };
     Ok(format!("{export_mark}{fn_definition}\n"))
@@ -1797,6 +1804,10 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
             local_defs: &def_names,
             file_imports: &file_imports,
           };
+          // Blank line between generated functions is a cheap, no-cost readability win.
+          if !defs_code.is_empty() {
+            defs_code.push('\n');
+          }
           defs_code.push_str(&gen_js_func(&def, &raw_args, &raw_body, &passed_defs, true, &collected_tags, ns)?);
           gen_stack::pop_call_stack();
         }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1747,6 +1747,7 @@ fn preprocess_list_call(
           // Recompute processed_args from ys after optimization rewrites (e.g. struct:get→nth, assoc→assoc-at)
           let processed_args = CalcitList::from(ys.drop_left());
           warn_on_nullable_js_ffi_dereference(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          warn_on_untyped_js_ffi_field_access(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_nominal_enum_legacy_absence_use(head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_legacy_js_nullish_predicate(head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_dynamic_trait_call(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
@@ -3128,6 +3129,67 @@ fn check_typed_js_field_operation(
       check_warnings,
     );
   }
+}
+
+/// Raw `.-`/`.!`/`aget`/`aset`/`js-get`/`js-set` on a bare `JsObject` receiver
+/// (no external-object trait attached) has nothing left to check statically.
+/// This is opt-in (behind `--warn-dyn-method`) since it fires on any untyped
+/// FFI touch point, including code that intentionally stays dynamic.
+fn warn_on_untyped_js_ffi_field_access(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  def_name: &str,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  if file_ns == calcit::CORE_NS {
+    return;
+  }
+
+  if !warn_dyn_method_enabled() {
+    return;
+  }
+
+  let (operation, field_name) = match head {
+    Calcit::Method(name, calcit::MethodKind::Access) => (format!(".-{name}"), name.to_string()),
+    Calcit::Method(name, calcit::MethodKind::InvokeNative) => (format!(".!{name}"), name.to_string()),
+    Calcit::Symbol { sym, .. } if matches!(sym.as_ref(), "aget" | "js-get" | "aset" | "js-set") => {
+      let Some(field_name) = args.get(1).and_then(static_js_field_name) else {
+        // A dynamic (non-literal) key cannot be described by a trait field
+        // either, so there is no actionable next step to suggest here.
+        return;
+      };
+      (sym.to_string(), field_name.to_owned())
+    }
+    _ => return,
+  };
+
+  let Some(receiver) = args.first() else {
+    return;
+  };
+  let Some(receiver_type) = resolve_type_value(receiver, scope_types) else {
+    return;
+  };
+  // Only the bare, non-nullable `JsObject` case is targeted here: it already
+  // proves the value is a raw host object, and the key is a literal the
+  // developer already knows, so declaring a trait is directly actionable.
+  // Nullable receivers and declared traits are covered by other diagnostics.
+  if !matches!(receiver_type.as_ref(), CalcitTypeAnnotation::JsObject) {
+    return;
+  }
+
+  let message = format!(
+    "[Warn] `{operation}` accesses untyped JS field `:{field_name}` in {file_ns}/{def_name}; still permitted, but declaring an external-object trait (`deftrait ... :ffi {{:kind :external-object ...}}`) for the receiver unlocks static field/method checking and `:names` mapping"
+  );
+
+  gen_check_warning_code_at(
+    message,
+    "W_JS_FFI_UNTYPED_ACCESS",
+    file_ns,
+    head.get_location().or_else(|| receiver.get_location()),
+    check_warnings,
+  );
 }
 
 fn warn_on_legacy_js_nullish_predicate(
@@ -6461,6 +6523,84 @@ mod tests {
       &mismatch_warnings,
     );
     assert_eq!(mismatch_warnings.borrow()[0].code(), Some("W_JS_FFI_FIELD_TYPE_MISMATCH"));
+  }
+
+  fn untyped_js_ffi_test_receiver() -> Calcit {
+    let sym: Arc<str> = Arc::from("host");
+    Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&sym),
+      sym,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.untyped-ffi"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::JsObject),
+    })
+  }
+
+  #[test]
+  fn warns_on_untyped_js_ffi_field_access_when_enabled() {
+    let _warn_guard = WarnDynMethodGuard::new(true);
+    let receiver = untyped_js_ffi_test_receiver();
+    let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
+    let warnings = RefCell::new(vec![]);
+
+    warn_on_untyped_js_ffi_field_access(
+      &head,
+      &CalcitList::from(std::slice::from_ref(&receiver)),
+      &ScopeTypes::new(),
+      "tests.untyped-ffi",
+      "demo",
+      &warnings,
+    );
+
+    assert_eq!(warnings.borrow()[0].code(), Some("W_JS_FFI_UNTYPED_ACCESS"));
+  }
+
+  #[test]
+  fn untyped_js_ffi_field_access_warning_is_opt_in_and_scoped() {
+    let receiver = untyped_js_ffi_test_receiver();
+    let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
+
+    // Disabled by default: the flag must be explicitly turned on.
+    let disabled_warnings = RefCell::new(vec![]);
+    warn_on_untyped_js_ffi_field_access(
+      &head,
+      &CalcitList::from(std::slice::from_ref(&receiver)),
+      &ScopeTypes::new(),
+      "tests.untyped-ffi",
+      "demo",
+      &disabled_warnings,
+    );
+    assert!(disabled_warnings.borrow().is_empty());
+
+    let _warn_guard = WarnDynMethodGuard::new(true);
+
+    // A dynamic (non-literal) key gives no actionable static field to suggest.
+    let dynamic_key_warnings = RefCell::new(vec![]);
+    warn_on_untyped_js_ffi_field_access(
+      &external_field_test_symbol("aget"),
+      &CalcitList::from(&[receiver.clone(), external_field_test_symbol("k")]),
+      &ScopeTypes::new(),
+      "tests.untyped-ffi",
+      "demo",
+      &dynamic_key_warnings,
+    );
+    assert!(dynamic_key_warnings.borrow().is_empty());
+
+    // Already-typed external-object receivers are covered by other diagnostics.
+    let typed_receiver = external_field_test_receiver(seed_external_field_trait());
+    let typed_warnings = RefCell::new(vec![]);
+    warn_on_untyped_js_ffi_field_access(
+      &external_field_test_symbol("aget"),
+      &CalcitList::from(&[typed_receiver, Calcit::Tag(EdnTag::new("value"))]),
+      &ScopeTypes::new(),
+      "tests.untyped-ffi",
+      "demo",
+      &typed_warnings,
+    );
+    assert!(typed_warnings.borrow().is_empty());
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6541,6 +6541,7 @@ mod tests {
 
   #[test]
   fn warns_on_untyped_js_ffi_field_access_when_enabled() {
+    let _lock = lock_preprocess_test_state();
     let _warn_guard = WarnDynMethodGuard::new(true);
     let receiver = untyped_js_ffi_test_receiver();
     let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
@@ -6560,6 +6561,7 @@ mod tests {
 
   #[test]
   fn untyped_js_ffi_field_access_warning_is_opt_in_and_scoped() {
+    let _lock = lock_preprocess_test_state();
     let receiver = untyped_js_ffi_test_receiver();
     let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
 


### PR DESCRIPTION
## 概要

- **新增 opt-in 诊断 `W_JS_FFI_UNTYPED_ACCESS`**：`--warn-dyn-method` 开启后，裸 `JsObject` 上的 `.-`/`.!`/`aget`/`aset`/`js-get`/`js-set`（静态字面量 key）会提示声明 external-object trait 提升类型覆盖度；动态 key 与已类型化/可空 receiver 跳过，默认静默。
- **JS codegen 可读性**：函数体与嵌套语句块行级缩进（复用 `indent_block`，O(n)），顶层函数间插入空行，修复 raise codegen 一处杂散空格。不引入完整格式化器。
- 文档更新：`docs/features/js-interop.md` 与仓库 `Agents.md`。

## 验证

- `cargo test -q`（366 lib + 192 integration）
- `cargo clippy --lib --bin cr -- -D warnings`
- `cargo fmt --check`
- `yarn compile` / `yarn check-all`（含 WASM）
- `yarn check-agent-interface`（12/12）
- `cr docs check-md docs/features/js-interop.md --entry calcit/test.cirru`（16/16）
- Respo：`cr js` 重新编译 + `yarn test` 全过