### PR TITLE
chore: release 0.13.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.5"
+version = "0.13.6"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608090107-release-0.13.6.md
+++ b/editing-history/202608090107-release-0.13.6.md
@@ -1,0 +1,10 @@
+# Release 0.13.6
+
+- Bumped the Calcit package versions in `Cargo.toml`, `package.json`, and
+  `Cargo.lock` from 0.13.5 to 0.13.6.
+- Releases the opt-in `W_JS_FFI_UNTYPED_ACCESS` warning (behind
+  `--warn-dyn-method`) for untyped raw JS FFI access on bare `JsObject`, plus
+  the cheap JS codegen readability improvements (line-based indentation, blank
+  lines between top-level functions, verbatim `&raw-code` preservation).
+- Verified with formatting, tests, clippy, compilation, full checks, agent
+  interface smoke checks, and Markdown example checks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## 概要

- 将 `Cargo.toml` / `package.json` / `Cargo.lock` 版本从 `0.13.5` 升级到 `0.13.6`。
- 发布已合并的 opt-in `W_JS_FFI_UNTYPED_ACCESS` 警告（`--warn-dyn-method`）与 JS codegen 可读性改进。

## 验证

- `cargo test -q --lib`（368 passed）
- `cargo clippy --lib --bin cr -- -D warnings`
- `yarn compile`