### PR TITLE
refactor: migrate remaining record/tuple naming to struct/enum

### DIFF
--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -17,7 +17,7 @@
         :code $ quote (ns test-wasm.helper)
     |test-wasm.main $ %{} 'FileEntry
       :defs $ {}
-        |Point $ %{} 'CodeEntry (:doc "|Record definition for WASM test")
+        |Point $ %{} 'CodeEntry (:doc "|Struct definition for WASM test")
           :code $ quote (defrecord Point :x :y)
           :examples $ []
           :schema $ :: 'Dynamic
@@ -237,6 +237,27 @@
         |test-display-by-hex $ %{} 'CodeEntry (:doc "|17 in hex = 0x11, length 4")
           :code $ quote
             defn test-display-by-hex () $ &str:count (&number:display-by 17 16)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-enum-assoc $ %{} 'CodeEntry (:doc "|Enum assoc updates payload by index")
+          :code $ quote
+            defn test-enum-assoc () $ &let
+              t $ &enum:assoc (:: :pair 10 20) 1 9
+              &+ (&enum:nth t 1) (&enum:nth t 2)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-enum-count $ %{} 'CodeEntry (:doc "|Enum count returns payload count")
+          :code $ quote
+            defn test-enum-count () $ &let
+              t $ :: :pair 10 20
+              &enum:count t
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-enum-sum $ %{} 'CodeEntry (:doc "|Enum create + nth access: idx 1 and 2 are payloads")
+          :code $ quote
+            defn test-enum-sum () $ &let
+              t $ :: :pair 10 20
+              &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
         |test-find-found $ %{} 'CodeEntry (:doc |)
@@ -707,7 +728,7 @@
                   _ 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match-tag $ %{} 'CodeEntry (:doc "|Match on tuple tag")
+        |test-match-tag $ %{} 'CodeEntry (:doc "|Match on enum tag")
           :code $ quote
             defn test-match-tag (x y)
               &let
@@ -789,59 +810,6 @@
         |test-range-two-args $ %{} 'CodeEntry (:doc "|range 2 5 creates 3 elements")
           :code $ quote
             defn test-range-two-args () $ &list:count (range 2 5)
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-record-field-tag $ %{} 'CodeEntry (:doc "|record field-tag resolves by index")
-          :code $ quote
-            defn test-record-field-tag () $ &let
-              point $ %{} Point (:x 1) (:y 2)
-              if
-                &= (&struct:field-tag point 0) :x
-                , 1 0
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-record-get-name $ %{} 'CodeEntry (:doc "|record get-name returns struct tag")
-          :code $ quote
-            defn test-record-get-name () $ &let
-              point $ %{} Point (:x 1) (:y 2)
-              if
-                &= (&struct:get-name point) :Point
-                , 1 0
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-record-matches-true $ %{} 'CodeEntry (:doc "|record:matches? returns true for same type")
-          :code $ quote
-            defn test-record-matches-true () $ &let
-              a $ %{} Point (:x 1) (:y 2)
-              &let
-                b $ %{} Point (:x 3) (:y 4)
-                if (&struct:matches? a b) 1 0
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-record-struct-eq $ %{} 'CodeEntry (:doc "|record struct equals source struct")
-          :code $ quote
-            defn test-record-struct-eq () $ &let
-              point $ %{} Point (:x 1) (:y 2)
-              if
-                &= (&struct:definition point) Point
-                , 1 0
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-record-sum $ %{} 'CodeEntry (:doc "|Record create + field access")
-          :code $ quote
-            defn test-record-sum (x y)
-              &let
-                p $ %{} Point (:x x) (:y y)
-                &+ (&struct:nth p 0 :x) (&struct:nth p 1 :y)
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-record-to-map $ %{} 'CodeEntry (:doc "|record to-map exposes field values by tag")
-          :code $ quote
-            defn test-record-to-map () $ &let
-              point $ %{} Point (:x 1) (:y 2)
-              &let
-                m $ &struct:to-map point
-                &+ (&map:get m :x) (&map:get m :y)
           :examples $ []
           :schema $ :: 'Dynamic
         |test-rem $ %{} 'CodeEntry (:doc |remainder)
@@ -1098,6 +1066,59 @@
             defn test-string-compare-method () $ .compare |abc |abd
           :examples $ []
           :schema $ :: 'Dynamic
+        |test-struct-eq $ %{} 'CodeEntry (:doc "|struct definition equals source struct")
+          :code $ quote
+            defn test-struct-eq () $ &let
+              point $ %{} Point (:x 1) (:y 2)
+              if
+                &= (&struct:definition point) Point
+                , 1 0
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-struct-field-tag $ %{} 'CodeEntry (:doc "|struct field-tag resolves by index")
+          :code $ quote
+            defn test-struct-field-tag () $ &let
+              point $ %{} Point (:x 1) (:y 2)
+              if
+                &= (&struct:field-tag point 0) :x
+                , 1 0
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-struct-get-name $ %{} 'CodeEntry (:doc "|struct get-name returns struct tag")
+          :code $ quote
+            defn test-struct-get-name () $ &let
+              point $ %{} Point (:x 1) (:y 2)
+              if
+                &= (&struct:get-name point) :Point
+                , 1 0
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-struct-matches-true $ %{} 'CodeEntry (:doc "|struct:matches? returns true for same type")
+          :code $ quote
+            defn test-struct-matches-true () $ &let
+              a $ %{} Point (:x 1) (:y 2)
+              &let
+                b $ %{} Point (:x 3) (:y 4)
+                if (&struct:matches? a b) 1 0
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-struct-sum $ %{} 'CodeEntry (:doc "|Struct create + field access")
+          :code $ quote
+            defn test-struct-sum (x y)
+              &let
+                p $ %{} Point (:x x) (:y y)
+                &+ (&struct:nth p 0 :x) (&struct:nth p 1 :y)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-struct-to-map $ %{} 'CodeEntry (:doc "|struct to-map exposes field values by tag")
+          :code $ quote
+            defn test-struct-to-map () $ &let
+              point $ %{} Point (:x 1) (:y 2)
+              &let
+                m $ &struct:to-map point
+                &+ (&map:get m :x) (&map:get m :y)
+          :examples $ []
+          :schema $ :: 'Dynamic
         |test-tag-eq $ %{} 'CodeEntry (:doc "|Tag equality — same tags")
           :code $ quote
             defn test-tag-eq () $ if (&= :ok :ok) 1 0
@@ -1116,25 +1137,13 @@
                 &list:count $ &list:first ps
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tuple-assoc $ %{} 'CodeEntry (:doc "|Tuple assoc updates payload by index")
+        |test-type-of-enum $ %{} 'CodeEntry (:doc "|type-of enum == :enum tag")
           :code $ quote
-            defn test-tuple-assoc () $ &let
-              t $ &enum:assoc (:: :pair 10 20) 1 9
-              &+ (&enum:nth t 1) (&enum:nth t 2)
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-tuple-count $ %{} 'CodeEntry (:doc "|Tuple count returns payload count")
-          :code $ quote
-            defn test-tuple-count () $ &let
-              t $ :: :pair 10 20
-              &enum:count t
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-tuple-sum $ %{} 'CodeEntry (:doc "|Tuple create + nth access: idx 1 and 2 are payloads")
-          :code $ quote
-            defn test-tuple-sum () $ &let
-              t $ :: :pair 10 20
-              &+ (&enum:nth t 1) (&enum:nth t 2)
+            defn test-type-of-enum () $ if
+              &=
+                type-of $ :: :Pair 1 2
+                , :enum
+              , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
         |test-type-of-list $ %{} 'CodeEntry (:doc "|type-of list == :list tag")
@@ -1168,15 +1177,6 @@
               &=
                 type-of $ #{} 1 2
                 , :set
-              , 1 0
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |test-type-of-tuple $ %{} 'CodeEntry (:doc "|type-of tuple == :tuple tag")
-          :code $ quote
-            defn test-type-of-tuple () $ if
-              &=
-                type-of $ :: :Pair 1 2
-                , :enum
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic

--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -17,7 +17,7 @@
         :code $ quote (ns test-wasm.helper)
     |test-wasm.main $ %{} 'FileEntry
       :defs $ {}
-        |Point $ %{} 'CodeEntry (:doc "|Struct definition for WASM test")
+        |Point $ %{} 'CodeEntry (:doc "|Struct definition (via legacy defrecord) for WASM test")
           :code $ quote (defrecord Point :x :y)
           :examples $ []
           :schema $ :: 'Dynamic

--- a/editing-history/202608090140-record-tuple-to-struct-enum.md
+++ b/editing-history/202608090140-record-tuple-to-struct-enum.md
@@ -1,0 +1,38 @@
+# Migrate remaining record/tuple naming to struct/enum
+
+Follow-up to the earlier terminology migration: located and updated the
+remaining stale `record`/`tuple` naming that refers to the current
+struct/enum data model, keeping genuine legacy-compat and EDN semantics.
+
+## Updated
+
+- `calcit/test-wasm.cirru`: renamed `test-record-*` → `test-struct-*` and
+  `test-tuple-*` → `test-enum-*` (incl. `test-type-of-tuple` →
+  `test-type-of-enum`) via `cr edit rename`; updated 12 doc strings. Kept
+  `defrecord Point :x :y` as the WASM legacy-compat coverage.
+- `scripts/test-wasm.mjs`: synced the renamed def references and section
+  labels.
+- `src/runner/preprocess/mod.rs`: test-namespace labels `tests.record` →
+  `tests.struct` (kept the legacy `record` tag coverage in the loose-struct
+  test).
+- `src/builtins/meta.rs`: `Calcit::Enum(tuple)` local bindings →
+  `enum_value`.
+- `src/codegen/emit_wasm.rs`: comments `tuple fields`/`tuple pointer` →
+  `enum fields`/`enum pointer`.
+- `src/bin/cli_handlers/query.rs`: test message `tuple operations` →
+  `enum operations`.
+
+## Deliberately kept
+
+- Legacy migration tables in `docs/`, `deprecated_api.rs`, and
+  `removed_data_api_replacement`.
+- Type-name aliases (`record`/`tuple` → Struct/Enum parsing), `SIMPLE_TYPES`
+  `tuple` query name, and IR/format-stable kind tags.
+- `cirru_edn` `Edn::Record`/`Edn::Enum` contexts and hash prefixes.
+
+Validation:
+
+- `cargo test -q`（368 lib + 192 integration）
+- `cargo clippy --lib --bin cr -- -D warnings`
+- `cargo fmt --check`
+- `yarn try-wasm`（含重命名后的 `test-struct-*` / `test-enum-*`）

--- a/scripts/test-wasm.mjs
+++ b/scripts/test-wasm.mjs
@@ -304,18 +304,18 @@ check("test-tag-eq()", 1, e["test-tag-eq"]);
 check("test-tag-neq()", 0, e["test-tag-neq"]);
 
 // --- Struct tests ---
-check("test-record-sum(3,4)", 7, e["test-record-sum"], 3, 4);
-check("test-record-sum(10,20)", 30, e["test-record-sum"], 10, 20);
-check("test-record-matches-true()", 1, e["test-record-matches-true"]);
-check("test-record-field-tag()", 1, e["test-record-field-tag"]);
-check("test-record-get-name()", 1, e["test-record-get-name"]);
-check("test-record-struct-eq()", 1, e["test-record-struct-eq"]);
-check("test-record-to-map()", 3, e["test-record-to-map"]);
+check("test-struct-sum(3,4)", 7, e["test-struct-sum"], 3, 4);
+check("test-struct-sum(10,20)", 30, e["test-struct-sum"], 10, 20);
+check("test-struct-matches-true()", 1, e["test-struct-matches-true"]);
+check("test-struct-field-tag()", 1, e["test-struct-field-tag"]);
+check("test-struct-get-name()", 1, e["test-struct-get-name"]);
+check("test-struct-eq()", 1, e["test-struct-eq"]);
+check("test-struct-to-map()", 3, e["test-struct-to-map"]);
 check("test-call-spread-rest()", 15, e["test-call-spread-rest"]);
 
-// --- Tuple tests ---
-check("test-tuple-sum()", 30, e["test-tuple-sum"]);
-check("test-tuple-count()", 3, e["test-tuple-count"]);
+// --- Enum tests ---
+check("test-enum-sum()", 30, e["test-enum-sum"]);
+check("test-enum-count()", 3, e["test-enum-count"]);
 
 // --- Bitwise tests ---
 check("test-bit-and(0xFF,0x0F)", 0x0f, e["test-bit-and"], 0xff, 0x0f);
@@ -378,7 +378,7 @@ check("test-list-empty-method()", 0, e["test-list-empty-method"]);
 check("test-list-empty?-method()", 1, e["test-list-empty?-method"]);
 check("test-list-append()", 33, e["test-list-append"]); // count=3 + nth(2)=30
 check("test-list-prepend()", 5, e["test-list-prepend"]);
-check("test-tuple-assoc()", 29, e["test-tuple-assoc"]);
+check("test-enum-assoc()", 29, e["test-enum-assoc"]);
 check("test-list-butlast()", 2, e["test-list-butlast"]);
 check("test-list-butlast-empty()", 0, e["test-list-butlast-empty"]);
 check("test-list-slice()", 23, e["test-list-slice"]); // count=3 + first=20
@@ -479,7 +479,7 @@ check("test-type-of-list", 1, e["test-type-of-list"]);
 check("test-type-of-map", 1, e["test-type-of-map"]);
 check("test-type-of-set", 1, e["test-type-of-set"]);
 check("test-type-of-number", 1, e["test-type-of-number"]);
-check("test-type-of-tuple", 1, e["test-type-of-tuple"]);
+check("test-type-of-enum", 1, e["test-type-of-enum"]);
 
 // --- derived predicates (list?, number?, map?) ---
 check("test-list?-true", 1, e["test-list?-true"]);

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -1102,7 +1102,7 @@ mod type_query_tests {
     assert!(result_type.resolve_to_enum().is_some(), "source-backed Result0 should resolve");
     assert!(
       result_type.matches_annotation(&CalcitTypeAnnotation::AnonymousEnum),
-      "a source-backed enum reference should satisfy tuple operations"
+      "a source-backed enum reference should satisfy enum operations"
     );
     let person_symbol =
       code_to_calcit(&Cirru::Leaf(Arc::from("Person")), "test-struct.main", "test-struct", vec![]).expect("Person symbol should parse");

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -635,10 +635,10 @@ pub fn trait_new(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         }
         Calcit::List(Arc::new(CalcitList::from(items.as_slice())))
       }
-      Calcit::Enum(tuple) => {
-        let tag = tuple.tag.to_owned();
-        let extra = tuple.extra.to_owned();
-        let sum_type = tuple.sum_type.to_owned();
+      Calcit::Enum(enum_value) => {
+        let tag = enum_value.tag.to_owned();
+        let extra = enum_value.extra.to_owned();
+        let sum_type = enum_value.sum_type.to_owned();
         Calcit::Enum(CalcitEnumValue { tag, extra, sum_type })
       }
       _ => form.to_owned(),
@@ -1092,8 +1092,8 @@ pub fn invoke_method(name: &str, method_args: &[Calcit], call_stack: &CallStackL
   use Calcit::*;
   match v0 {
     // user-defined values: impl-traits appends, so later impls override earlier ones
-    Enum(tuple) => {
-      let user_impls = tuple.impls();
+    Enum(enum_value) => {
+      let user_impls = enum_value.impls();
       let has_user_method = user_impls.iter().any(|imp| imp.get(name).is_some());
       if has_user_method {
         method_call_impls(user_impls, v0, name, method_args, call_stack, true)

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -2980,7 +2980,7 @@ fn emit_match(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
     ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
     ctx.block_depth += 1;
 
-    // Bind payload variables from tuple fields
+    // Bind payload variables from enum fields
     let binding_count = pat_xs.len() - 1;
     for bind_idx in 0..binding_count {
       let binding = &pat_xs[1 + bind_idx];
@@ -2989,7 +2989,7 @@ fn emit_match(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
         Calcit::Symbol { sym, .. } => sym.to_string(),
         other => return Err(format!("match binding expected symbol, got: {other}")),
       };
-      // Payload at offset (2 + bind_idx) * 8 from tuple pointer (skip count + tag)
+      // Payload at offset (2 + bind_idx) * 8 from enum pointer (skip count + tag)
       let offset = ((2 + bind_idx) * 8) as u64;
       ctx.emit(Instruction::LocalGet(ptr_f64));
       ctx.emit(Instruction::I32TruncF64U);

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6856,7 +6856,7 @@ mod tests {
       Cirru::List(vec![Cirru::leaf("&struct:get"), Cirru::leaf("user"), Cirru::leaf(":name")]),
     ]);
 
-    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse cirru");
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse cirru");
     let scope_defs: HashSet<Arc<str>> = HashSet::new();
     let mut scope_types: ScopeTypes = ScopeTypes::new();
 
@@ -6868,7 +6868,7 @@ mod tests {
 
     // This should not produce warnings since :name exists
     let _resolved =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess should succeed");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess should succeed");
 
     // Currently no warnings expected for valid field access
     // In future, we'll check warnings.borrow().is_empty()
@@ -6918,7 +6918,7 @@ mod tests {
   #[test]
   fn postfix_nominal_struct_access_uses_direct_field_lookup() {
     let expr = Cirru::List(vec![Cirru::leaf("person"), Cirru::leaf(":name")]);
-    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse postfix field access");
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse postfix field access");
     let mut scope_defs = HashSet::new();
     scope_defs.insert(Arc::from("person"));
     let mut scope_types = ScopeTypes::new();
@@ -6935,7 +6935,7 @@ mod tests {
       &code,
       &scope_defs,
       &mut scope_types,
-      "tests.record",
+      "tests.struct",
       &warnings,
       &CallStackList::default(),
     )
@@ -6953,7 +6953,7 @@ mod tests {
   #[test]
   fn postfix_loose_struct_access_uses_required_struct_get() {
     let expr = Cirru::List(vec![Cirru::leaf("record"), Cirru::leaf(":name")]);
-    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse postfix field access");
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse postfix field access");
     let mut scope_defs = HashSet::new();
     scope_defs.insert(Arc::from("record"));
     let mut scope_types = ScopeTypes::new();
@@ -6964,7 +6964,7 @@ mod tests {
       &code,
       &scope_defs,
       &mut scope_types,
-      "tests.record",
+      "tests.struct",
       &warnings,
       &CallStackList::default(),
     )
@@ -6995,7 +6995,7 @@ mod tests {
       Cirru::leaf("20"),
     ]);
 
-    let parsed = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse struct ctor");
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse struct ctor");
     let Calcit::List(parsed_items) = parsed else {
       panic!("expected parsed call");
     };
@@ -7016,7 +7016,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess struct head call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess struct head call");
 
     let items = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7055,7 +7055,7 @@ mod tests {
 
     let expr = Cirru::List(vec![Cirru::leaf("Result"), Cirru::leaf(":ok")]);
 
-    let parsed = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse enum ctor");
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse enum ctor");
     let Calcit::List(parsed_items) = parsed else {
       panic!("expected parsed call");
     };
@@ -7076,7 +7076,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess enum head call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess enum head call");
 
     let items = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7102,7 +7102,7 @@ mod tests {
 
     let expr = Cirru::List(vec![Cirru::leaf("Person"), Cirru::leaf(":name")]);
 
-    let parsed = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse struct ctor");
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse struct ctor");
     let Calcit::List(parsed_items) = parsed else {
       panic!("expected parsed call");
     };
@@ -7123,7 +7123,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess struct head call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess struct head call");
 
     let items = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7159,7 +7159,7 @@ mod tests {
       Cirru::leaf("20"),
     ]);
 
-    let parsed = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse struct ctor");
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse struct ctor");
     let Calcit::List(parsed_items) = parsed else {
       panic!("expected parsed call");
     };
@@ -7180,7 +7180,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess struct head call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess struct head call");
 
     let items = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7222,7 +7222,7 @@ mod tests {
       &Calcit::StructDef(person_struct.clone()),
       &duplicate_args,
       &scope_types,
-      "tests.record",
+      "tests.struct",
       "demo",
       &warnings,
       &stack,
@@ -7242,7 +7242,7 @@ mod tests {
       &Calcit::StructDef(person_struct),
       &missing_args,
       &scope_types,
-      "tests.record",
+      "tests.struct",
       "demo",
       &warnings,
       &stack,
@@ -7283,12 +7283,12 @@ mod tests {
     let stack = CallStackList::default();
 
     assert!(
-      try_rewrite_struct_enum_constructor_head_call(&person, &args, &scope_types, "tests.record", "demo", &warnings, &stack,)
+      try_rewrite_struct_enum_constructor_head_call(&person, &args, &scope_types, "tests.struct", "demo", &warnings, &stack,)
         .expect("record instance boundary")
         .is_none()
     );
     assert!(
-      try_rewrite_struct_enum_constructor_head_call(&enum_value, &args, &scope_types, "tests.record", "demo", &warnings, &stack,)
+      try_rewrite_struct_enum_constructor_head_call(&enum_value, &args, &scope_types, "tests.struct", "demo", &warnings, &stack,)
         .expect("enum instance boundary")
         .is_none()
     );
@@ -7307,7 +7307,7 @@ mod tests {
       &Calcit::StructDef(point_struct),
       &args,
       &ScopeTypes::new(),
-      "tests.record",
+      "tests.struct",
       "demo",
       &warnings,
       &CallStackList::default(),
@@ -7333,7 +7333,7 @@ mod tests {
       idx: CalcitLocal::track_sym(&Arc::from("box")),
       sym: Arc::from("box"),
       info: Arc::new(CalcitSymbolInfo {
-        at_ns: Arc::from("tests.record"),
+        at_ns: Arc::from("tests.struct"),
         at_def: Arc::from("demo"),
       }),
       location: None,
@@ -7349,7 +7349,7 @@ mod tests {
       &Calcit::Proc(CalcitProc::NativeStructAssoc),
       &args,
       &ScopeTypes::new(),
-      "tests.record",
+      "tests.struct",
       "demo",
       &warnings,
     );
@@ -7370,7 +7370,7 @@ mod tests {
     let cat_struct = CalcitStructDef::from_fields(EdnTag::from("Cat"), vec![EdnTag::from("name"), EdnTag::from("color")]);
 
     let expr = Cirru::List(vec![Cirru::leaf("kitty"), Cirru::leaf(".rename"), Cirru::leaf("|LagopusB")]);
-    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse struct method call");
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse struct method call");
 
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
     scope_defs.insert(Arc::from("kitty"));
@@ -7385,7 +7385,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess struct method call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess struct method call");
 
     let nodes = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7424,7 +7424,7 @@ mod tests {
 
     let expr = Cirru::List(vec![Cirru::leaf("Result")]);
 
-    let parsed = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse enum ctor");
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse enum ctor");
     let Calcit::List(parsed_items) = parsed else {
       panic!("expected parsed call");
     };
@@ -7445,7 +7445,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess enum head call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess enum head call");
 
     let items = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7486,7 +7486,7 @@ mod tests {
 
     let expr = Cirru::List(vec![Cirru::leaf("Result"), Cirru::leaf(":bad")]);
 
-    let parsed = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse enum ctor");
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse enum ctor");
     let Calcit::List(parsed_items) = parsed else {
       panic!("expected parsed call");
     };
@@ -7507,7 +7507,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess enum head call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess enum head call");
 
     let items = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7548,7 +7548,7 @@ mod tests {
 
     let expr = Cirru::List(vec![Cirru::leaf("Mode"), Cirru::leaf("dark")]);
 
-    let parsed = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse enum ctor");
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse enum ctor");
     let Calcit::List(parsed_items) = parsed else {
       panic!("expected parsed call");
     };
@@ -7569,7 +7569,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let result =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess enum head call");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess enum head call");
 
     let items = match result {
       Calcit::List(xs) => xs.to_vec(),
@@ -7608,7 +7608,7 @@ mod tests {
       Cirru::leaf(":email"), // invalid field
     ]);
 
-    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse cirru");
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse cirru");
 
     // Set up scope with user variable
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -7622,7 +7622,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let _resolved =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess should succeed");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess should succeed");
 
     // Should have a warning about invalid field
     let warnings_vec = warnings.borrow();
@@ -7710,7 +7710,7 @@ mod tests {
     // Test expression: (user.-name) - wrapped in a list to trigger method parsing
     let expr = Cirru::List(vec![Cirru::leaf("user.-name")]);
 
-    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse cirru");
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse cirru");
 
     // Set up scope with user variable
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -7724,7 +7724,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let _resolved =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess should succeed");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess should succeed");
 
     // Should not have warnings for valid field
     let warnings_vec = warnings.borrow();
@@ -7934,7 +7934,7 @@ mod tests {
     // Test expression: (user.-email) - invalid field, wrapped in list
     let expr = Cirru::List(vec![Cirru::leaf("user.-email")]);
 
-    let code = code_to_calcit(&expr, "tests.record", "demo", vec![]).expect("parse cirru");
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse cirru");
 
     // Set up scope with user variable
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
@@ -7948,7 +7948,7 @@ mod tests {
     let stack = CallStackList::default();
 
     let _resolved =
-      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.record", &warnings, &stack).expect("preprocess should succeed");
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess should succeed");
 
     // Should have a warning about invalid field
     let warnings_vec = warnings.borrow();


### PR DESCRIPTION
## 概要

延续此前的 struct/enum 术语迁移，定位并更新了剩余指向**当前 struct/enum 数据模型**的过期 `record`/`tuple` 命名。

- **`calcit/test-wasm.cirru`**：`test-record-*` → `test-struct-*`、`test-tuple-*` → `test-enum-*`（含 `test-type-of-tuple` → `test-type-of-enum`），同步 12 处 doc；**保留** `defrecord Point :x :y` 作为 WASM legacy 兼容覆盖。
- **`scripts/test-wasm.mjs`**：同步改名后的 def 引用与章节标签。
- **`src/runner/preprocess/mod.rs`**：测试命名空间标签 `tests.record` → `tests.struct`（保留 loose-struct 测试里的 legacy `record` tag 覆盖）。
- **`src/builtins/meta.rs`**：`Calcit::Enum(tuple)` 局部绑定 → `enum_value`。
- **`src/codegen/emit_wasm.rs`**：注释 `tuple fields`/`tuple pointer` → `enum fields`/`enum pointer`。
- **`src/bin/cli_handlers/query.rs`**：测试文案 `tuple operations` → `enum operations`。

## 有意保留（不替换）

- `docs/`、`deprecated_api.rs`、`removed_data_api_replacement` 的迁移对照表/诊断。
- 类型名别名解析（`record`/`tuple` → Struct/Enum）、`SIMPLE_TYPES` 的 `tuple` 查询名、IR/格式稳定 kind tag。
- `cirru_edn` 的 `Edn::Record`/`Edn::Enum` 上下文与哈希前缀。

## 验证

- `cargo test -q`（368 lib + 192 integration）
- `cargo clippy --lib --bin cr -- -D warnings`
- `cargo fmt --check`
- `yarn try-wasm`（含重命名后的 `test-struct-*` / `test-enum-*`）