### PR TITLE
test: guard malformed import edits

### DIFF
--- a/editing-history/202608091056-import-rule-cli-regression.md
+++ b/editing-history/202608091056-import-rule-cli-regression.md
@@ -1,0 +1,15 @@
+# Import rule CLI regression coverage
+
+- Added direct handler regressions for `cr edit imports` and
+  `cr edit add-import` when an import rule has the wrong arity.
+- Both tests assert the indexed validation diagnostic and verify that the
+  snapshot remains byte-for-byte unchanged after rejection.
+- This protects the persistence boundary in addition to the existing
+  `validate_import_rules` unit coverage.
+
+Validation:
+
+- `cargo fmt`
+- `cargo clippy --bin cr -- -D warnings`
+- `cargo test --bin cr` (194 passed)
+- `git diff --check`

--- a/editing-history/202608091119-import-rule-review-followup.md
+++ b/editing-history/202608091119-import-rule-review-followup.md
@@ -1,0 +1,12 @@
+# Import rule regression review follow-up
+
+- Changed the malformed-import persistence assertions to compare raw file
+  bytes instead of UTF-8 strings, matching the byte-for-byte guarantee and
+  keeping the tests independent of snapshot text encoding.
+
+Validation:
+
+- `cargo fmt`
+- `cargo clippy --bin cr -- -D warnings`
+- `cargo test --bin cr malformed_rule`
+- `git diff --check`

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -2720,10 +2720,11 @@ fn print_import_usage_tips(rule: &Cirru, source_ns: &str) {
 mod tests {
   use super::{
     TransactionOperationReport, bump_semver_value, collect_format_advisories, count_legacy_any_schema_fields,
-    count_legacy_inherent_impls, load_snapshot, parse_examples_input, parse_input_to_cirru, parse_schema_input,
-    parse_transaction_operations, rename_definition_declaration, run_staged_transaction_with, save_schema_preserving_snapshot,
-    save_snapshot,
+    count_legacy_inherent_impls, handle_add_import, handle_imports, load_snapshot, parse_examples_input, parse_input_to_cirru,
+    parse_schema_input, parse_transaction_operations, rename_definition_declaration, run_staged_transaction_with,
+    save_schema_preserving_snapshot, save_snapshot,
   };
+  use crate::cli_args::{EditAddImportCommand, EditImportsCommand};
   use crate::cli_handlers::test_support::TestProject;
   use cirru_parser::Cirru;
   use std::fs;
@@ -2803,6 +2804,41 @@ mod tests {
 
     assert_eq!(count_legacy_inherent_impls(&legacy), 1);
     assert_eq!(count_legacy_inherent_impls(&nominal), 0);
+  }
+
+  #[test]
+  fn imports_rejects_malformed_rule_without_writing_snapshot() {
+    let fixture = TestSnapshot::from_fixture();
+    let original = fs::read_to_string(&fixture.path).expect("fixture should read");
+    let opts = EditImportsCommand {
+      namespace: "app.main".to_string(),
+      file: None,
+      code: Some("quote (audit.invalid :as)".to_string()),
+    };
+
+    let error = handle_imports(&opts, &fixture.snapshot_string()).expect_err("malformed import rule should fail");
+
+    assert!(error.contains("import rule 1"), "error: {error}");
+    assert!(error.contains("exactly 3 items"), "error: {error}");
+    assert_eq!(fs::read_to_string(&fixture.path).expect("fixture should remain"), original);
+  }
+
+  #[test]
+  fn add_import_rejects_malformed_rule_without_writing_snapshot() {
+    let fixture = TestSnapshot::from_fixture();
+    let original = fs::read_to_string(&fixture.path).expect("fixture should read");
+    let opts = EditAddImportCommand {
+      namespace: "app.main".to_string(),
+      file: None,
+      code: Some("quote (audit.invalid :as)".to_string()),
+      overwrite: false,
+    };
+
+    let error = handle_add_import(&opts, &fixture.snapshot_string()).expect_err("malformed import rule should fail");
+
+    assert!(error.contains("import rule 1"), "error: {error}");
+    assert!(error.contains("exactly 3 items"), "error: {error}");
+    assert_eq!(fs::read_to_string(&fixture.path).expect("fixture should remain"), original);
   }
 
   #[test]

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -2809,7 +2809,7 @@ mod tests {
   #[test]
   fn imports_rejects_malformed_rule_without_writing_snapshot() {
     let fixture = TestSnapshot::from_fixture();
-    let original = fs::read_to_string(&fixture.path).expect("fixture should read");
+    let original = fs::read(&fixture.path).expect("fixture should read");
     let opts = EditImportsCommand {
       namespace: "app.main".to_string(),
       file: None,
@@ -2820,13 +2820,13 @@ mod tests {
 
     assert!(error.contains("import rule 1"), "error: {error}");
     assert!(error.contains("exactly 3 items"), "error: {error}");
-    assert_eq!(fs::read_to_string(&fixture.path).expect("fixture should remain"), original);
+    assert_eq!(fs::read(&fixture.path).expect("fixture should remain"), original);
   }
 
   #[test]
   fn add_import_rejects_malformed_rule_without_writing_snapshot() {
     let fixture = TestSnapshot::from_fixture();
-    let original = fs::read_to_string(&fixture.path).expect("fixture should read");
+    let original = fs::read(&fixture.path).expect("fixture should read");
     let opts = EditAddImportCommand {
       namespace: "app.main".to_string(),
       file: None,
@@ -2838,7 +2838,7 @@ mod tests {
 
     assert!(error.contains("import rule 1"), "error: {error}");
     assert!(error.contains("exactly 3 items"), "error: {error}");
-    assert_eq!(fs::read_to_string(&fixture.path).expect("fixture should remain"), original);
+    assert_eq!(fs::read(&fixture.path).expect("fixture should remain"), original);
   }
 
   #[test]


### PR DESCRIPTION
Adds direct CLI handler regressions for malformed import rules. Both edit imports and edit add-import must return the indexed validation error and leave the snapshot byte-for-byte unchanged.\n\nValidation:\n- cargo clippy --bin cr -- -D warnings\n- cargo test --bin cr (194 passed)\n- git diff --check