### PR TITLE
chore: release 0.13.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.6"
+version = "0.13.7"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608091812-release-0.13.7.md
+++ b/editing-history/202608091812-release-0.13.7.md
@@ -1,0 +1,8 @@
+# Release 0.13.7
+
+Released the merged definition-attached core test and `cr` CLI accuracy work.
+
+- Bumped the Rust crate and npm package versions from `0.13.6` to `0.13.7`.
+- Updated `Cargo.lock` with the workspace version through `cargo update --workspace`.
+- Release validation covers the merged PR's core tests, native/JS/WASM targets,
+  Agent CLI interface, and the repository test workflow before tagging.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Release 0.13.7\n\n- Bump Cargo and npm package versions from 0.13.6 to 0.13.7.\n- Update Cargo.lock for the workspace release.\n- Local installation and full native/JS/WASM validation passed.