### PR TITLE
fix: enforce typed Struct field access

### DIFF
--- a/calcit/test-algebra.cirru
+++ b/calcit/test-algebra.cirru
@@ -91,7 +91,7 @@
               assert-traits bf AlgebraApply
               let
                   b2 $ .apply b1 bf
-                assert= 12 $ get b2 :value
+                assert= 12 $ &struct:get b2 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -105,7 +105,7 @@
                   b2 $ .bind b1
                     fn (x)
                       %{} AlgebraBox $ :value (+ x 20)
-                assert= 25 $ get b2 :value
+                assert= 25 $ &struct:get b2 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -118,7 +118,7 @@
               let
                   b2 $ .map b1
                     fn (x) (+ x 10)
-                assert= 12 $ get b2 :value
+                assert= 12 $ &struct:get b2 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -132,7 +132,7 @@
               assert-traits b2 AlgebraMappend
               let
                   b3 $ .mappend b1 b2
-                assert= 7 $ get b3 :value
+                assert= 7 $ &struct:get b3 :value
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/test-js.cirru
+++ b/calcit/test-js.cirru
@@ -84,7 +84,7 @@
               hint-fn $ {} (:async true)
               let
                   a $ {} (:a 1)
-                  b $ option:unwrap (:a a)
+                  b $ option:unwrap (get a :a)
                   ret $ js-await
                     case-default b
                       new js/Promise $ fn (resolve _reject)

--- a/calcit/test-string.cirru
+++ b/calcit/test-string.cirru
@@ -81,8 +81,8 @@
               assert= true $ starts-with? |01234 |0
               assert= true $ starts-with? |01234 |01
               assert= false $ starts-with? |01234 |12
-              assert= true $ starts-with? :a/b :a/
-              assert= true $ starts-with? :a/b |a/
+              assert= true $ starts-with? (unsafe-coerce :a/b String) (unsafe-coerce :a/ String)
+              assert= true $ starts-with? (unsafe-coerce :a/b String) |a/
               assert= true $ ends-with? |01234 |34
               assert= true $ ends-with? |01234 |4
               assert= false $ ends-with? |01234 |23

--- a/calcit/test-struct.cirru
+++ b/calcit/test-struct.cirru
@@ -26,7 +26,7 @@
           :code $ quote
             defimpl BirdImpl BirdTrait
               .show $ fn (self)
-                println $ :name self
+                println $ &struct:get self :name
               .rename $ fn (self name) (assoc self :name name)
           :examples $ []
           :schema $ :: 'Dynamic
@@ -218,13 +218,13 @@
                   p1 $ %{}? Person (:name |Chen)
                   p2 $ %{}? Person (:name |Chen) (:age 20) (:position :mainland)
                   p3 $ %{}? Person (:age 31)
-                assert= |Chen $ get p1 :name
-                assert= nil $ get p1 :age
-                assert= nil $ get p1 :position
-                assert= 20 $ get p2 :age
-                assert= nil $ get p3 :name
-                assert= 31 $ get p3 :age
-                assert= nil $ get p3 :position
+                assert= |Chen $ :name p1
+                assert= nil $ :age p1
+                assert= nil $ :position p1
+                assert= 20 $ :age p2
+                assert= nil $ :name p3
+                assert= 31 $ :age p3
+                assert= nil $ :position p3
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -283,27 +283,26 @@
                   p3 $ &%{} Person :name |Chen :age 23 :position :mainland
                   c1 $ %{} City (:name |Shanghai) (:province |Shanghai)
                 assert= true $ = (&struct:definition p0) Person
-                assert= nil $ get p0 :age
-                assert= nil $ get p0 :name
-                assert= nil $ get p0 :position
-                assert= 20 $ get p1 :age
-                assert= 20 $ get p2 :age
-                assert= 23 $ get p3 :age
+                assert= nil $ :age p0
+                assert= nil $ :name p0
+                assert= nil $ :position p0
+                assert= 20 $ :age p1
+                assert= 20 $ :age p2
+                assert= 23 $ :age p3
                 assert= 23 $ &struct:get p3 :age
                 assert= :struct $ type-of p1
                 assert= (&struct:to-map p1)
                   {} (:name |Chen) (:age 20) (:position :mainland)
-                assert= 21 $ get
+                assert= 21 $ :age
                   &struct:from-map Person $ {} (:name |Chen) (:age 21) (:position :mainland)
-                  , :age
                 assert= (keys p2) (#{} :age :name :position)
                 assert-detect identity $ &struct:matches? p1 p1
                 assert-detect identity $ &struct:matches? p1 p2
                 assert-detect not $ &struct:matches? p1 c1
                 &let
                   p4 $ assoc p1 :age 30
-                  assert= 20 $ get p1 :age
-                  assert= 30 $ get p4 :age
+                  assert= 20 $ :age p1
+                  assert= 30 $ :age p4
                 inside-js: $ js/console.log (to-js-data p1)
                 assert-detect identity $ = p1 p1
                 assert-detect identity $ = p1 p2
@@ -318,10 +317,9 @@
                 assert-detect identity $ contains? p1 :name
                 assert-detect not $ contains? p1 :surname
                 assert= 3 $ count p1
-                assert= 21 $ get
+                assert= 21 $ :age
                   update p1 :age $ fn (age)
                     if (nil? age) 1 $ inc age
-                  , :age
                 assert= 20 $ :age p1
           :examples $ []
           :schema $ :: 'Fn
@@ -335,11 +333,11 @@
                   p1 $ %{} Person (:name |Chen) (:age 20) (:position :hangzhou)
                   p2 $ struct-with p1 (:age 21) (:position :shanghai)
                 ; println |P2 p2
-                assert= 20 $ get p1 :age
-                assert= 21 $ get p2 :age
-                assert= :hangzhou $ get p1 :position
-                assert= :shanghai $ get p2 :position
-                assert= |Chen $ get p2 :name
+                assert= 20 $ :age p1
+                assert= 21 $ :age p2
+                assert= :hangzhou $ :position p1
+                assert= :shanghai $ :position p2
+                assert= |Chen $ :name p2
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/test-types-inference.cirru
+++ b/calcit/test-types-inference.cirru
@@ -313,9 +313,9 @@
                 &inspect-type name-v
               let
                   top-name-v $ :name p
-                  city-v $ get-in p ([] :address :city)
+                  city-v $ :city (:address p)
                 assert-type top-name-v String
-                assert-type city-v $ :: 'Option 'String
+                assert-type city-v String
                 &inspect-type top-name-v
                 &inspect-type city-v
           :examples $ []

--- a/calcit/test-types-inference.cirru
+++ b/calcit/test-types-inference.cirru
@@ -312,7 +312,7 @@
                 assert-type name-v String
                 &inspect-type name-v
               let
-                  top-name-v $ get p :name
+                  top-name-v $ :name p
                   city-v $ get-in p ([] :address :city)
                 assert-type top-name-v String
                 assert-type city-v $ :: 'Option 'String

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -94,7 +94,7 @@ let
 let
     find-user $ fn (users id)
       find users $ fn (u)
-        = (get u :id) id
+        = (option:unwrap $ get u :id) id
   println $ find-user
     [] ({} (:id |001) (:name |Alice))
     , |001
@@ -236,8 +236,8 @@ let
     toggle-todo! $ fn (id)
       swap! todos $ fn (items)
         map items $ fn (todo)
-          if (= (get todo :id) id)
-            assoc todo :done $ not (get todo :done)
+          if (= (option:unwrap $ get todo :id) id)
+            assoc todo :done $ not (option:unwrap $ get todo :done)
             , todo
   add-todo! |buy-milk
   add-todo! |write-docs
@@ -397,14 +397,14 @@ let
     items $ [] ({} (:value 1)) ({} (:value 2)) ({} (:value 3))
     result1 $ reduce items 0 $ fn (acc item)
       let
-          value $ get item :value
+          value $ option:unwrap $ get item :value
         tag-match value
           (:some number) (+ acc number)
           (:none) , acc
     result2 $ apply +
       map items $ fn (item)
         let
-            value $ get item :value
+            value $ option:unwrap $ get item :value
           tag-match value
             (:some number) , number
             (:none) 0

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -397,14 +397,14 @@ let
     items $ [] ({} (:value 1)) ({} (:value 2)) ({} (:value 3))
     result1 $ reduce items 0 $ fn (acc item)
       let
-          value $ option:unwrap $ get item :value
+          value $ get item :value
         tag-match value
           (:some number) (+ acc number)
           (:none) , acc
     result2 $ apply +
       map items $ fn (item)
         let
-            value $ option:unwrap $ get item :value
+            value $ get item :value
           tag-match value
             (:some number) , number
             (:none) 0

--- a/docs/features/enums.md
+++ b/docs/features/enums.md
@@ -97,7 +97,7 @@ let
     p $ %{} Point (:x 1) (:y 2)
     shape $ %:: Shape :point p
   assert-type shape Shape
-  assert= 1 $ get (&enum:nth shape 1) :x
+  assert= 1 $ &struct:get (&enum:nth shape 1) :x
 ```
 
 Applied generic structs also work in enum payloads:
@@ -112,7 +112,7 @@ let
       %{} Box $ :value 1
     boxed $ &enum:nth value 1
   assert-type value $ :: 'Wrapped :number
-  assert= 1 $ :value boxed
+  assert= 1 $ &struct:get boxed :value
 ```
 
 When you annotate an enum payload with a struct type, `%::` validates both the variant tag and the payload value at runtime. Applied struct payload types must use the correct generic arity.

--- a/docs/features/hashmap.md
+++ b/docs/features/hashmap.md
@@ -58,9 +58,9 @@ The low-level primitive `&{}` takes flat key-value pairs:
 let
     m $ {} (:a 1) (:b 2) (:c 3)
   println $ get m :a
-  ; => 1
+  ; => (%some 1)
   println $ get m :missing
-  ; => nil
+  ; => (%none)
   println $ contains? m :b
   ; => true
   println $ count m

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -146,14 +146,14 @@ This mirrors the main reason Rust has `where` clauses: parameter declaration and
 
 Top-level definitions use `:schema`:
 
-```cirru-edn
+```cirru.edn
 %{} :CodeEntry
   :code $ quote
     defn show-it (x) (x .show)
   :schema $ :: 'Fn
     {}
       :generics $ [] 'T
-      :where $ {} ('T Show)
+      :where $ {} ('T 'Show)
       :args $ [] 'T
       :return 'String
 ```
@@ -174,9 +174,10 @@ let
 
 For multiple constraints on the same variable, use a list value:
 
-```cirru-edn
-:where $ {}
-  'T $ [] Show Eq
+```cirru.edn
+{}
+  :where $ {}
+    'T $ [] 'Show 'Eq
 ```
 
 Do not use the old tuple form like `:where $ [] (:: 'Show 'T)`.

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -68,7 +68,7 @@ let
           :return :string
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
-        str "|foo " $ :name p
+        str "|foo " $ &struct:get p :name
     Person0 $ defstruct Person (:name :string)
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
@@ -100,13 +100,13 @@ let
     Person0 $ defstruct Person (:name :string)
     ShowImpl $ defimpl ShowImpl ShowTrait
       .show $ fn (p)
-        str |Person: $ :name p
+        str |Person: $ &struct:get p :name
     EqImpl $ defimpl EqImpl EqTrait
       .eq $ fn (p)
-        str |eq: $ :name p
+        str |eq: $ &struct:get p :name
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
-        str |foo: $ :name p
+        str |foo: $ &struct:get p :name
     Person $ impl-traits Person0 ShowImpl EqImpl MyFooImpl
     p $ %{} Person (:name |Alice)
   [] (p .show) (p .foo)
@@ -127,7 +127,7 @@ let
     Person0 $ defstruct Person (:name :string)
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
-        str-spaced |foo $ :name p
+        str-spaced |foo $ &struct:get p :name
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo
@@ -146,7 +146,7 @@ This mirrors the main reason Rust has `where` clauses: parameter declaration and
 
 Top-level definitions use `:schema`:
 
-```cirru.no-run
+```cirru-edn
 %{} :CodeEntry
   :code $ quote
     defn show-it (x) (x .show)
@@ -174,7 +174,7 @@ let
 
 For multiple constraints on the same variable, use a list value:
 
-```cirru
+```cirru-edn
 :where $ {}
   'T $ [] Show Eq
 ```

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -19,7 +19,7 @@ Calcit structs are declared data types with a fixed set of named fields. Struct 
 
 - **Define**: `defstruct Point (:x 'Number) (:y 'Number)`
 - **Create**: `%{} Point (:x 1) (:y 2)`
-- **Access**: `get p :x` or `(:x p)`
+- **Access**: `(:x p)`
 - **Update**: `assoc p :x 10` or `update p :x inc`
 - **Type Check**: `assert-type p 'Point`
 
@@ -96,17 +96,29 @@ let
 
 ## Accessing Fields
 
-Use `get` (or `&struct:get`) to read a field:
+Use the required field accessor `(:field value)` to read a field:
 
 ```cirru
 let
     Point $ defstruct Point (:x :number) (:y :number)
     p $ %{} Point (:x 1) (:y 2)
-  println $ get p :x
+  println $ :x p
   ; => 1
 ```
 
-For a statically known struct, field access returns the field's declared type directly. A missing field is a type/checking error; struct access never produces `Option` merely because the field name might be absent.
+Required field access only accepts a statically known, typed Struct and returns
+the field's declared type directly. A missing field or an untyped receiver is a
+checking error. It never changes into an `Option` lookup merely because type
+information is missing.
+
+Use `get` for maps and indexed collections when absence is intentional; it
+always returns `Option<T>`. Struct fields do not use `get`, which keeps the two
+contracts visibly distinct in source code.
+
+Loose/anonymous structs (`?{}` or `%{} _ ...`) also cannot be read through the
+required field accessor until an expected named Struct type rewrites them. This
+prevents an undeclared field from silently becoming `Dynamic` and forces the
+schema to be established before application code depends on it.
 
 Standard collection functions like `keys`, `count`, and `contains?` also work on structs:
 
@@ -163,9 +175,9 @@ Use `%{}?` to create a partial struct with only some fields set (others default 
 let
     Person $ defstruct Person (:name :string) (:age :number) (:position :tag)
     p1 $ %{}? Person (:name |Chen)
-  println $ get p1 :name
+  println $ :name p1
   ; => |Chen
-  println $ get p1 :age
+  println $ :age p1
   ; => nil
 ```
 
@@ -212,8 +224,8 @@ let
     shape $ %{} Circle (:radius 5)
   struct-match shape
     Circle c $ * 3.14
-      * (get c :radius) (get c :radius)
-    Square s $ * (get s :radius) (get s :radius)
+      * (:radius c) (:radius c)
+    Square s $ * (:radius s) (:radius s)
     _ _ 0
 
 ; => 78.5
@@ -288,7 +300,9 @@ let
     BirdShape $ defstruct BirdShape (:name :string)
     BirdImpl $ defimpl BirdImpl BirdTrait
       .show $ fn (self)
-        println $ get self :name
+        ; defimpl bodies are reusable before a concrete Struct is attached,
+        ; so low-level access is explicit at this dynamic implementation boundary.
+        println $ &struct:get self :name
       .rename $ fn (self name) (assoc self :name name)
     Bird $ impl-traits BirdShape BirdImpl
     b $ %{} Bird (:name |Sparrow)
@@ -307,7 +321,7 @@ let
 let
     Config $ defstruct Config (:host :string) (:port :number) (:debug :bool)
     config $ %{} Config (:host |localhost) (:port 3000) (:debug false)
-  println $ get config :port
+  println $ :port config
   ; => 3000
 ```
 
@@ -317,7 +331,7 @@ let
 let
     Product $ defstruct Product (:id :string) (:name :string) (:price :number) (:discount :number)
     product $ %{} Product (:id |P001) (:name |Widget) (:price 100) (:discount 0.9)
-  println $ * (get product :price) (get product :discount)
+  println $ * (:price product) (:discount product)
   ; => 90
 ```
 

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -49,7 +49,7 @@ let
         :generics $ [] 'T
         :args $ [] (:: 'Box 'T)
         :return 'T
-      :value box
+      &struct:get box :value
     b $ %{} Box (:value 1)
   assert-type b $ :: 'Box :number
   assert= 1 $ keep b
@@ -67,7 +67,7 @@ let
       {} $ 'T Show
       :value 'T
     box $ %{} ShownBox (:value 1)
-    item $ :value box
+    item $ &struct:get box :value
   assert-type box $ :: 'ShownBox 'Number
   assert= |1 $ item .show
 ```
@@ -310,7 +310,7 @@ let
   b .show
   let
       b2 $ b .rename |Eagle
-    println $ :name b2
+    println $ &struct:get b2 :name
 ```
 
 ## Common Use Cases
@@ -396,12 +396,14 @@ Fields are automatically sorted alphabetically, matching the field ordering of n
 
 ### Accessing Fields
 
-Anonymous structs still have a fixed field set, so access is direct and missing fields are errors:
+Anonymous structs still have a fixed field set, but they do not carry a named
+type declaration. Use the explicit low-level accessor until the value has been
+rewritten to an expected named Struct:
 
 ```cirru
 let
     r $ %{} _ (:x 10) (:y 20)
-  println $ :x r
+  println $ &struct:get r :x
   ; => 10
   println $ type-of r
   ; => :struct

--- a/docs/features/traits.md
+++ b/docs/features/traits.md
@@ -53,7 +53,7 @@ let
     Person0 $ defstruct Person (:name 'String)
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
-        str-spaced |foo $ :name p
+        str-spaced |foo $ &struct:get p :name
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   p .foo
@@ -83,7 +83,7 @@ let
           :return 'String
     MyFooImplA $ defimpl MyFooImplA MyFooA
       .foo $ fn (p)
-        str-spaced |foo $ :name p
+        str-spaced |foo $ &struct:get p :name
     PersonA $ impl-traits PersonA0 MyFooImplA
     p $ %{} PersonA (:name |Alice)
   p .foo
@@ -104,7 +104,7 @@ let
     Person0 $ defstruct Person (:name 'String)
     ImplB $ defimpl ImplB MyFoo
       :: :foo $ fn (p)
-        str |B: $ :name p
+        str |B: $ &struct:get p :name
     PersonB $ impl-traits Person0 ImplB
     pb $ %{} PersonB (:name |Bob)
   pb .foo
@@ -159,11 +159,11 @@ let
           :return 'String
     ImplA $ defimpl ImplA MyFoo
       .foo $ fn (p)
-        str |A: $ :name p
+        str |A: $ &struct:get p :name
     MyBar $ deftrait MyBar (.bar 'Fn)
     ImplB $ defimpl ImplB MyBar
       .bar $ fn (p)
-        str |B: $ :name p
+        str |B: $ &struct:get p :name
     StructDef0 $ defstruct StructDef (:name 'String)
     StructDef $ impl-traits StructDef0 ImplA ImplB
     x $ %{} StructDef (:name |test)
@@ -186,7 +186,7 @@ do (; struct example)
             :return 'String
       MyFooImpl $ defimpl MyFooImpl MyFoo
         .foo $ fn (p)
-          str-spaced |foo $ :name p
+          str-spaced |foo $ &struct:get p :name
       Person0 $ defstruct Person (:name 'String)
       Person $ impl-traits Person0 MyFooImpl
       p $ %{} Person (:name |Alice)
@@ -326,7 +326,7 @@ let
     Person0 $ defstruct Person (:name 'String)
     MyFooImpl $ defimpl MyFooImpl MyFoo
       .foo $ fn (p)
-        str-spaced |foo $ :name p
+        str-spaced |foo $ &struct:get p :name
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo

--- a/docs/installation/modules.md
+++ b/docs/installation/modules.md
@@ -19,10 +19,11 @@ Packages are managed with `caps` command, which wraps `git clone` and `git pull`
 
 Configurations inside runtime snapshot files (`calcit.cirru`, legacy `compact.cirru`):
 
-```cirru-edn
-:entries $ {}
-  :default $ {}
-    :modules $ [] |memof/calcit.cirru |lilac/
+```cirru.edn
+{}
+  :entries $ {}
+    :default $ {}
+      :modules $ [] |memof/calcit.cirru |lilac/
 ```
 
 Paths defined in `:modules` field are just loaded as files from `~/.config/calcit/modules/`, i.e. `~/.config/calcit/modules/memof/calcit.cirru`.

--- a/docs/installation/modules.md
+++ b/docs/installation/modules.md
@@ -19,7 +19,7 @@ Packages are managed with `caps` command, which wraps `git clone` and `git pull`
 
 Configurations inside runtime snapshot files (`calcit.cirru`, legacy `compact.cirru`):
 
-```cirru
+```cirru-edn
 :entries $ {}
   :default $ {}
     :modules $ [] |memof/calcit.cirru |lilac/

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -26,10 +26,11 @@ Run `caps` to download. Sources are downloaded into `~/.config/calcit/modules/`.
 
 To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename: `compact.cirru`):
 
-```cirru-edn
-:entries $ {}
-  :default $ {}
-    :modules $ [] |memof/calcit.cirru |lilac/
+```cirru.edn
+{}
+  :entries $ {}
+    :default $ {}
+      :modules $ [] |memof/calcit.cirru |lilac/
 ```
 
 Paths defined in `:modules` field are just loaded as files from `~/.config/calcit/modules/`, i.e. `~/.config/calcit/modules/memof/calcit.cirru`.

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -26,7 +26,7 @@ Run `caps` to download. Sources are downloaded into `~/.config/calcit/modules/`.
 
 To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename: `compact.cirru`):
 
-```cirru
+```cirru-edn
 :entries $ {}
   :default $ {}
     :modules $ [] |memof/calcit.cirru |lilac/

--- a/history/202608092318-enum-edn-option-diagnostics.md
+++ b/history/202608092318-enum-edn-option-diagnostics.md
@@ -1,0 +1,21 @@
+# Cirru EDN enum identity and Option migration diagnostics
+
+## 背景
+
+- GitHub #326 暴露 JS `format-cirru-edn` / `parse-cirru-edn` 往返后 enum variant 从 interned `CalcitTag` 变成 `CalcitSymbol`，导致生成的 `match` 按身份比较时无法命中。
+- GitHub #325 暴露 Option migration 诊断仍使用预处理前的 source symbol，普通 `=`, `some?`, `assoc` 等调用不会触发告警，并且 `starts-with?` / `ends-with?` 的 proc metadata 比公开 schema 更宽。
+
+## 修改与边界
+
+- JS Cirru EDN parser 在匿名和具名 enum 分支统一把解析出的 symbol variant 通过 `newTag` intern；quoted nominal name 也按 tag key 恢复 options map 中的 `CalcitEnumDef`。
+- Option migration diagnostics 改用预处理后的 `head_form` / `call_head`，避免漏掉普通 source syntax，同时继续区分应用自行定义的同名函数。
+- 结构操作诊断覆盖 `assoc`, `dissoc`, `merge`, `update` 及其 nested/non-nil variants。
+- `starts-with?` / `ends-with?` proc 参数 metadata 收紧为 `String × String`，与文档和 core schema 一致；旧 Tag runtime 兼容测试用显式 `unsafe-coerce` 标明边界。
+- 合法的 nominal enum equality 继续允许，包括类型推断尚未完成时，Option/Result constructor 和已声明返回 nominal enum 的调用之间的比较。
+
+## 验证
+
+- JS runtime identity check 覆盖匿名 enum、具名 enum prototype 恢复和 identity-based match 条件。
+- Rust end-to-end snippet test 覆盖 issue 中的 `get-env`, `some?`, `update-in/assoc`, `nth/starts-with?` 普通源码写法。
+- `cargo fmt --all`, `cargo clippy -- -D warnings`, `yarn compile`, `cargo test`, `yarn check-all` 全部通过。
+- 安装当前全局 `cr` 后在 Respo 执行 `cr --check-only`，成功在真实项目中报告 3 个 Option migration warning（另有 1 个既有 JS nullable warning），未进入相关运行时失败路径。

--- a/history/202608100022-required-struct-field-access.md
+++ b/history/202608100022-required-struct-field-access.md
@@ -1,0 +1,46 @@
+# Required Struct field access
+
+## Background
+
+Field syntax previously changed its contract according to inferred receiver
+type: `(:field value)` returned the declared payload for a known Struct, but
+silently lowered to Option-producing `get` when the receiver looked like a Map
+or lost type information. This made local edits unstable: adding or losing a
+type annotation changed downstream control flow without changing source syntax.
+
+Issue #325 clarified that dynamic container absence and required model fields
+are different boundaries. AI-assisted edits need those boundaries to remain
+visible so diagnostics guide code toward a declared model instead of allowing
+`Dynamic`/`Option` patches to spread.
+
+## Contract
+
+- `(:field value)` is required access. The receiver must be a statically known
+  named Struct and the field must be declared. Its result is the declared field
+  type.
+- `get` and `get-in` are explicit partial lookup APIs for Map and indexed/path
+  access. They return nominal `Option<T>`.
+- `get` on a Struct is rejected with a diagnostic pointing to required field
+  syntax; the runtime also rejects dynamically hidden Struct receivers.
+- Loose/anonymous Struct field access is rejected until an expected named
+  Struct type rewrites or narrows it.
+- Low-level `&struct:get` remains available for internal dynamic boundaries
+  such as reusable trait implementation bodies.
+
+## Type inference details
+
+- `update` preserves the receiver's collection/Struct type.
+- `&struct:from-map` preserves the Struct definition supplied as its first
+  argument.
+- Struct pattern-match expansion is exempt from source field validation because
+  all nominal branches are preprocessed before runtime guards select a variant.
+
+## Diagnostics
+
+- `W_REQUIRED_STRUCT_FIELD_TYPE`: required field syntax lacks a named Struct
+  contract.
+- `W_UNKNOWN_STRUCT_FIELD`: a named Struct does not declare the requested field.
+- `W_STRUCT_FIELD_OPTIONAL_LOOKUP`: `get` is used on a Struct.
+
+Tests cover typed access, Map fallback rejection, unknown fields, `get` misuse,
+nominal type preservation, loose Struct access, and the existing Struct suite.

--- a/history/202608100102-docs-field-access-ci.md
+++ b/history/202608100102-docs-field-access-ci.md
@@ -1,0 +1,22 @@
+# Documentation validation for required Struct fields
+
+## Background
+
+The PR's local `yarn check-all` suite passed, but GitHub's Test workflow also
+runs `scripts/check-docs-md.sh`. Several executable documentation snippets
+still relied on the former context-sensitive field syntax.
+
+## Documentation migration
+
+- Map reads that branch on absence retain their `Option` value for `tag-match`
+  instead of unwrapping it first.
+- Generic enum payloads, local trait implementations, generic Struct bodies,
+  and anonymous Struct examples use explicit `&struct:get` when their receiver
+  has no statically resolvable named Struct declaration.
+- Snapshot/schema fragments now use `cirru-edn` fences so `check-md` validates
+  them as data instead of evaluating tags such as `:entries` or `:where` as
+  required field access.
+
+## Verification
+
+- `bash scripts/check-docs-md.sh`: 54 files, 286 blocks, all passed.

--- a/history/202608100102-docs-field-access-ci.md
+++ b/history/202608100102-docs-field-access-ci.md
@@ -13,9 +13,9 @@ still relied on the former context-sensitive field syntax.
 - Generic enum payloads, local trait implementations, generic Struct bodies,
   and anonymous Struct examples use explicit `&struct:get` when their receiver
   has no statically resolvable named Struct declaration.
-- Snapshot/schema fragments now use `cirru-edn` fences so `check-md` validates
-  them as data instead of evaluating tags such as `:entries` or `:where` as
-  required field access.
+- Snapshot/schema fragments now use standard `cirru.edn` fences with valid
+  EDN roots and quoted symbols, so `check-md` validates them as data instead
+  of evaluating tags such as `:entries` or `:where` as required field access.
 
 ## Verification
 

--- a/history/202608100145-cirru-edn-doc-fences.md
+++ b/history/202608100145-cirru-edn-doc-fences.md
@@ -1,0 +1,17 @@
+# Standard Cirru EDN documentation fences
+
+## Background
+
+Executable documentation fences use the standard `cirru.edn` marker. The
+non-standard `cirru-edn` spelling bypassed EDN validation and hid malformed
+configuration and schema fragments.
+
+## Change
+
+- Replaced all newly introduced `cirru-edn` fences with `cirru.edn`.
+- Wrapped standalone configuration/schema fields in top-level EDN maps.
+- Quoted symbolic trait references inside EDN schema values.
+
+## Verification
+
+- `bash scripts/check-docs-md.sh`: 54 files and 290 blocks passed.

--- a/history/202608100339-struct-path-boundaries.md
+++ b/history/202608100339-struct-path-boundaries.md
@@ -1,0 +1,11 @@
+## Struct path API boundaries
+
+- Public collection path APIs (`get-in`, `assoc-in`, `update-in`, `dissoc-in`)
+  now stop at nominal Struct boundaries. Required fields remain visible as direct
+  `(:field value)` accesses, preserving their declared types for the checker.
+- The preprocessor diagnoses literal and dynamic paths that would enter a Struct;
+  `get-in` no longer infers a field type through such a path.
+- Runtime core implementations reject the same traversal after a Dynamic boundary,
+  so unsafe coercion cannot silently bypass the typed field-access contract.
+- Updated the type-inference fixture to use nested direct field access instead of
+  `get-in` across a Struct.

--- a/history/202608100348-caps-branch-checkout.md
+++ b/history/202608100348-caps-branch-checkout.md
@@ -1,0 +1,8 @@
+## caps remote branch checkout
+
+- `caps` now fetches remote branch refs as well as tags when resolving an
+  existing module clone.
+- If a requested branch exists only as `origin/<branch>`, checkout now creates
+  a local tracking branch instead of failing after the fetch succeeds.
+- This keeps branch-based module integration reproducible through `caps
+  download`, without manually editing the module cache.

--- a/history/202608100349-caps-remote-branch-reset.md
+++ b/history/202608100349-caps-remote-branch-reset.md
@@ -1,0 +1,8 @@
+## caps remote branch checkout hardening
+
+- Existing module clones can use narrow or non-standard remote refspecs, for
+  which `git checkout --track origin/<branch>` may reject an otherwise fetched
+  remote ref.
+- `caps` now creates/resets the requested local branch with `git checkout -B
+  <branch> origin/<branch>`, keeping branch-based module downloads reliable and
+  compatible with later `--pull-branch` updates.

--- a/history/202608100959-struct-path-review-followups.md
+++ b/history/202608100959-struct-path-review-followups.md
@@ -1,0 +1,11 @@
+## Struct path-operation review follow-ups
+
+- `contains-in?` now follows the same Struct boundary as the other collection
+  path APIs: a path may not enter a declared Struct field. Direct typed field
+  access keeps required-field diagnostics and return types precise.
+- The preprocessor reports `W_STRUCT_PATH_OPERATION` for `contains-in?`, with
+  a regression test covering all five path APIs.
+- Runtime guidance for `dissoc-in` now explains that declared Struct fields
+  cannot be removed; model optionality explicitly or convert to a map first.
+- Module ref fetching now uses `--prune`, so stale remote-tracking branches do
+  not remain selectable after an upstream branch deletion.

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -31,6 +31,21 @@ try {
   assert.equal(todoEnum.toString(), "(%enum-def 'TodoState)");
   assert.equal(todoEnumValue.toString(), "(%:: 'TodoState :draft |)");
   assert.equal(anonymousEnumValue.toString(), "(%:: _ :draft |)");
+
+  const anonymousEnumCode = runtimeA.format_cirru_edn(anonymousEnumValue);
+  const parsedAnonymousEnum = runtimeA.parse_cirru_edn(anonymousEnumCode, null);
+  assert.equal(parsedAnonymousEnum.tag, todoField, "anonymous enum tags should stay interned after a Cirru EDN round-trip");
+  assert.equal(
+    parsedAnonymousEnum.tag === todoField ? "matched-draft" : "unmatched",
+    "matched-draft",
+    "a parsed enum should enter the same identity-based branch as a compiled match"
+  );
+
+  const enumOptions = new runtimeA.CalcitSliceMap([todoName, todoEnum]);
+  const namedEnumCode = runtimeA.format_cirru_edn(todoEnumValue);
+  const parsedNamedEnum = runtimeA.parse_cirru_edn(namedEnumCode, enumOptions);
+  assert.equal(parsedNamedEnum.tag, todoField, "named enum tags should stay interned after a Cirru EDN round-trip");
+  assert.equal(parsedNamedEnum.enumPrototype, todoEnum, "named enum round-trips should restore the provided prototype");
   assert.throws(
     () => runtimeA._$n_struct_$o_get(todoRecord, runtimeA.newTag("missing")),
     /does not define field :missing/,

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -259,7 +259,7 @@ fn required_struct_field_access_does_not_fall_back_to_option_lookup() {
 fn collection_path_operations_do_not_traverse_struct_fields() {
   run_with_large_stack(|| {
     let entries = load_snippet_entries(
-      "do\n  let\n      Person $ defstruct Person (:name 'String)\n      person $ %{} Person (:name |Ada)\n      people $ {} (:current person)\n    do\n      get-in person ([] :name)\n      get-in people ([] :current :name)\n      assoc-in person ([] :name) |Grace\n      update-in person ([] :name) $ fn (current) (, current)\n      dissoc-in person ([] :name)",
+      "do\n  let\n      Person $ defstruct Person (:name 'String)\n      person $ %{} Person (:name |Ada)\n      people $ {} (:current person)\n    do\n      get-in person ([] :name)\n      get-in people ([] :current :name)\n      contains-in? person ([] :name)\n      assoc-in person ([] :name) |Grace\n      update-in person ([] :name) $ fn (current) (, current)\n      dissoc-in person ([] :name)",
     );
     let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
 
@@ -273,10 +273,10 @@ fn collection_path_operations_do_not_traverse_struct_fields() {
       .collect::<Vec<_>>();
     assert_eq!(
       path_warnings.len(),
-      5,
+      6,
       "every collection path operation that reaches a Struct should be rejected, got: {warnings:?}"
     );
-    for operation in ["get-in", "assoc-in", "update-in", "dissoc-in"] {
+    for operation in ["get-in", "contains-in?", "assoc-in", "update-in", "dissoc-in"] {
       assert!(
         path_warnings
           .iter()

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -256,6 +256,44 @@ fn required_struct_field_access_does_not_fall_back_to_option_lookup() {
 }
 
 #[test]
+fn collection_path_operations_do_not_traverse_struct_fields() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries(
+      "do\n  let\n      Person $ defstruct Person (:name 'String)\n      person $ %{} Person (:name |Ada)\n      people $ {} (:current person)\n    do\n      get-in person ([] :name)\n      get-in people ([] :current :name)\n      assoc-in person ([] :name) |Grace\n      update-in person ([] :name) $ fn (current) (, current)\n      dissoc-in person ([] :name)",
+    );
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("Struct path misuse should preprocess far enough to report every operation");
+
+    let warnings = warnings.borrow();
+    let path_warnings = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_STRUCT_PATH_OPERATION"))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      path_warnings.len(),
+      5,
+      "every collection path operation that reaches a Struct should be rejected, got: {warnings:?}"
+    );
+    for operation in ["get-in", "assoc-in", "update-in", "dissoc-in"] {
+      assert!(
+        path_warnings
+          .iter()
+          .any(|warning| warning.message().contains(&format!("`{operation}`"))),
+        "missing Struct path diagnostic for `{operation}`, got: {warnings:?}"
+      );
+    }
+    assert!(
+      path_warnings
+        .iter()
+        .all(|warning| warning.message().contains("use `(:field value)` for reads or `assoc`/`update`")),
+      "Struct path diagnostics should point AI edits back to typed field operations, got: {warnings:?}"
+    );
+  });
+}
+
+#[test]
 fn type_fail_trait_method_generic_receiver_fixture_reports_warning_code() {
   run_with_large_stack(|| {
     let entries = load_fixture_entries("calcit/type-fail/trait-method-generic-receiver-mismatch.cirru");

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -32,6 +32,23 @@ fn load_fixture_entries_with_entry(path: &str, selected_entry: Option<&str>) -> 
   snapshot
     .select_entry(selected_entry)
     .unwrap_or_else(|e| panic!("Failed to select fixture entry for {path}: {e}"));
+
+  prepare_snapshot_entries(snapshot)
+}
+
+fn load_snippet_entries(snippet: &str) -> ProgramEntries {
+  builtins::effects::init_effects_states();
+
+  let mut snapshot = snapshot::Snapshot::default();
+  snapshot.files.insert(
+    "app.main".to_owned(),
+    snapshot::create_file_from_snippet(snippet).expect("test snippet should parse"),
+  );
+
+  prepare_snapshot_entries(snapshot)
+}
+
+fn prepare_snapshot_entries(mut snapshot: snapshot::Snapshot) -> ProgramEntries {
   let core_snapshot = calcit::load_core_snapshot().expect("load core snapshot");
 
   for (k, v) in core_snapshot.files {
@@ -148,6 +165,93 @@ fn type_fail_call_arg_fixture_reports_warning_code() {
         warning.message()
       );
     }
+  });
+}
+
+#[test]
+fn option_migration_source_calls_fail_during_preprocessing() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries(
+      "do\n  = |dev $ get-env |mode\n  let\n      x $ get-env |mode\n    some? x\n  update-in ({} (:a ({}))) ([] :a) $ fn (x) do (assoc x :b 1)\n  let\n      op $ :: :session/connect\n      tag-name $ nth op 0\n    starts-with? tag-name :session/",
+    );
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("Option migration examples should preprocess with warnings, not reach runtime");
+
+    let warnings = warnings.borrow();
+    for operation in ["=", "some?", "assoc"] {
+      assert!(
+        warnings.iter().any(|warning| {
+          warning.code() == Some("W_NOMINAL_ENUM_LEGACY_USE")
+            && warning.message().contains(&format!("`{operation}` consumes nominal enum `Option`"))
+        }),
+        "ordinary source call `{operation}` should report an Option migration warning, got: {warnings:?}"
+      );
+    }
+    assert!(
+      warnings.iter().any(|warning| {
+        warning.code() == Some("W_PROC_ARG_TYPE_MISMATCH")
+          && warning.message().contains("Proc `starts-with?` arg 1 expects type `:string`")
+          && warning.message().contains("Option")
+      }),
+      "starts-with? should reject an Option argument during preprocessing, got: {warnings:?}"
+    );
+  });
+}
+
+#[test]
+fn required_struct_field_access_does_not_fall_back_to_option_lookup() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries(
+      "do\n  let\n      record $ {} (:name |Ada)\n      name $ :name record\n    , name\n  let\n      Person $ defstruct Person (:name 'String)\n      person $ %{} Person (:name |Ada)\n      name $ :name person\n    assert-type name 'String\n  let\n      Person $ defstruct Person (:name 'String)\n      person $ %{} Person (:name |Ada)\n    :missing person\n  let\n      Person $ defstruct Person (:name 'String)\n      person $ %{} Person (:name |Ada)\n    get person :name",
+    );
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("required-field examples should preprocess with actionable diagnostics");
+
+    let warnings = warnings.borrow();
+    let required_warnings = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_REQUIRED_STRUCT_FIELD_TYPE"))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      required_warnings.len(),
+      1,
+      "only the Map-backed field syntax should require a Struct declaration, got: {warnings:?}"
+    );
+    assert!(
+      required_warnings[0]
+        .message()
+        .contains("use `(get value :name)` only when absence is intentional")
+    );
+
+    let struct_get_warnings = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_STRUCT_FIELD_OPTIONAL_LOOKUP"))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      struct_get_warnings.len(),
+      1,
+      "`get` on a typed Struct should point back to required field syntax, got: {warnings:?}"
+    );
+    assert!(struct_get_warnings[0].message().contains("Use `(:name value)`"));
+
+    let unknown_field_warnings = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_UNKNOWN_STRUCT_FIELD"))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      unknown_field_warnings.len(),
+      1,
+      "a missing declared Struct field should fail before runtime, got: {warnings:?}"
+    );
+    assert!(
+      unknown_field_warnings[0]
+        .message()
+        .contains("Field `:missing` does not exist in struct `Person`")
+    );
   });
 }
 

--- a/src/bin/git/mod.rs
+++ b/src/bin/git/mod.rs
@@ -111,7 +111,7 @@ impl GitRepo {
     // Fetch remote branch refs explicitly: existing module clones can have a
     // narrow fetch refspec, in which case `git fetch --tags` leaves a newly
     // pushed branch invisible to `show-ref` and checkout.
-    self.run_command(&["fetch", "origin", "--tags", "+refs/heads/*:refs/remotes/origin/*"])?;
+    self.run_command(&["fetch", "--prune", "origin", "--tags", "+refs/heads/*:refs/remotes/origin/*"])?;
     Ok(())
   }
 

--- a/src/bin/git/mod.rs
+++ b/src/bin/git/mod.rs
@@ -24,7 +24,17 @@ impl GitRepo {
   }
 
   pub fn checkout(&self, version: &str) -> Result<(), String> {
-    self.run_command(&["checkout", version]).map(|_a| ())
+    if self.run_command(&["checkout", version]).is_ok() {
+      return Ok(());
+    }
+
+    // A branch fetched into an existing module clone may only exist as a
+    // remote-tracking ref. `git checkout <branch>` cannot resolve that name
+    // until a local branch is created. `-B` works even for clones with a
+    // narrow/non-standard remote refspec, while still pointing the local
+    // branch at the explicitly fetched origin ref.
+    let remote_branch = format!("origin/{version}");
+    self.run_command(&["checkout", "-B", version, &remote_branch]).map(|_| ())
   }
 
   /// clone to directory
@@ -97,7 +107,11 @@ impl GitRepo {
   }
 
   pub fn fetch(&self) -> Result<(), String> {
-    self.run_command(&["fetch", "origin", "--tags"])?;
+    // Module versions may be development branches, not only release tags.
+    // Fetch remote branch refs explicitly: existing module clones can have a
+    // narrow fetch refspec, in which case `git fetch --tags` leaves a newly
+    // pushed branch invisible to `show-ref` and checkout.
+    self.run_command(&["fetch", "origin", "--tags", "+refs/heads/*:refs/remotes/origin/*"])?;
     Ok(())
   }
 

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -817,7 +817,7 @@ impl CalcitProc {
       }),
       StartsWith | EndsWith => Some(ProcTypeSignature {
         return_type: some_tag("bool"),
-        arg_types: vec![dynamic_tag(), dynamic_tag()],
+        arg_types: vec![some_tag("string"), some_tag("string")],
       }),
       GetCharCode => Some(ProcTypeSignature {
         return_type: some_tag("number"),

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -3204,11 +3204,12 @@
               list-match path
                 () v
                 (p0 ps)
-                  &let
-                    d $ either data (&{})
-                    assoc d p0 $ assoc-in
-                      if (contains? d p0) (&get-raw d p0) (&{})
-                      , ps v
+                  if (struct? data) (raise "|assoc-in does not traverse Struct fields; use assoc with a direct field key")
+                    &let
+                      d $ either data (&{})
+                      assoc d p0 $ assoc-in
+                        if (contains? d p0) (&get-raw d p0) (&{})
+                        , ps v
           :examples $ []
             quote $ assert=
               &{} :a $ &{} :b 1
@@ -4320,10 +4321,11 @@
               list-match path
                 () data
                 (p0 ps)
-                  if
-                    &= 1 $ &list:count path
-                    dissoc data p0
-                    assoc data p0 $ dissoc-in (&get-raw data p0) ps
+                  if (struct? data) (raise "|dissoc-in does not traverse Struct fields; use dissoc with a direct field key")
+                    if
+                      &= 1 $ &list:count path
+                      dissoc data p0
+                      assoc data p0 $ dissoc-in (&get-raw data p0) ps
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'D)
@@ -5036,8 +5038,7 @@
                 list-match path
                   () $ %some base
                   (y0 ys)
-                    if (struct? base)
-                      recur (&struct:get base y0) ys
+                    if (struct? base) (raise "|get-in does not traverse Struct fields; use (:field value) so the checker can enforce the declared type")
                       tag-match (get base y0)
                         (:some value) (recur value ys)
                         (:none) (%none)
@@ -7545,14 +7546,15 @@
               list-match path
                 () $ f (%some data)
                 (p0 ps)
-                  let
-                      current $ if (nil? data) (%none) (get data p0)
-                    assoc
-                      either data $ {}
-                      , p0 $ if (empty? ps) (f current)
-                        update-in
-                          option:unwrap-or current $ {}
-                          , ps f
+                  if (struct? data) (raise "|update-in does not traverse Struct fields; use update with a direct field key")
+                    let
+                        current $ if (nil? data) (%none) (get data p0)
+                      assoc
+                        either data $ {}
+                        , p0 $ if (empty? ps) (f current)
+                          update-in
+                            option:unwrap-or current $ {}
+                            , ps f
           :examples $ []
             quote $ assert=
               {} $ :a

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -3577,7 +3577,7 @@
                 assert= ([] 1 2 3 4 5)
                   conj ([] 1 2 3) 4 5
               :tags $ #{} :core :unit
-        |contains-in? $ %{} 'CodeEntry (:doc "|Check whether every hop in a nested path exists across maps, structs, enums, or lists.")
+        |contains-in? $ %{} 'CodeEntry (:doc "||Check whether every hop in a nested path exists across maps, enums, or lists. Struct fields are intentionally excluded; use direct field access instead.")
           :code $ quote
             defn contains-in? (xs path)
               list-match path
@@ -3593,10 +3593,7 @@
                       if (&map:contains? xs p0)
                         recur (&map:get xs p0) ps
                         , false
-                    (struct? xs)
-                      if (&struct:contains? xs p0)
-                        recur (&struct:get xs p0) ps
-                        , false
+                    (struct? xs) (raise "|contains-in? does not traverse Struct fields; end the path before the Struct and use (:field value)")
                     (enum? xs)
                       if
                         and (&>= p0 0)
@@ -4321,7 +4318,7 @@
               list-match path
                 () data
                 (p0 ps)
-                  if (struct? data) (raise "|dissoc-in does not traverse Struct fields; use dissoc with a direct field key")
+                  if (struct? data) (raise "|dissoc-in cannot remove declared Struct fields; use an optional field or convert the Struct to a map before removing keys")
                     if
                       &= 1 $ &list:count path
                       dissoc data p0

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -449,7 +449,7 @@
           :tags $ #{} :internal
         |&core-struct-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def &core-struct-methods $ &impl::new :&core-struct-methods (:: :count &struct:count) (:: :contains? &struct:contains?) (:: :get get) (:: :assoc &struct:assoc) (:: :to-map &struct:to-map)
+            def &core-struct-methods $ &impl::new :&core-struct-methods (:: :count &struct:count) (:: :contains? &struct:contains?) (:: :assoc &struct:assoc) (:: :to-map &struct:to-map)
               :: :empty? $ defn &struct:empty?-impl (x)
                 &= 0 $ &struct:count x
           :examples $ []
@@ -738,7 +738,7 @@
             {} (:return 'Tag)
               :args $ []
           :tags $ #{} :builtin :internal :io
-        |&get-raw $ %{} 'CodeEntry (:doc "|Internal raw lookup dispatcher. Public callers must use get, which returns Option.")
+        |&get-raw $ %{} 'CodeEntry (:doc "|Internal raw lookup dispatcher for collection algorithms and typed Struct traversal. Public optional lookups use get/get-in; required Struct fields use (:field value).")
           :code $ quote
             defn &get-raw (base k)
               cond
@@ -4963,7 +4963,7 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal :syntax
-        |get $ %{} 'CodeEntry (:doc "|Lookup by key or index. Struct fields return their declared value directly and unknown fields raise; maps and indexed collections return Option<T>.")
+        |get $ %{} 'CodeEntry (:doc "|Optional lookup by key or index for maps and indexed collections. Returns Option<T>. Required Struct fields use (:field value) and return their declared type directly.")
           :code $ quote
             defn get (base k)
               cond
@@ -4971,10 +4971,10 @@
                   if (&map:contains? base k)
                     %some $ &map:get base k
                     %none
-                (struct? base) (&struct:get base k)
+                (struct? base) (raise "|get does not read Struct fields; use (:field value) so the checker can enforce the declared type")
                 (or (list? base) (string? base) (enum? base))
                   if (number? k) (nth base k) (%none)
-                true $ raise (str-spaced |get |expected |a |collection |or |struct, |got: base)
+                true $ raise (str-spaced |get |expected |a |map |or |indexed |collection, |got: base)
           :examples $ []
             quote $ assert= (%some 2)
               get ([] 0 2 4) 1
@@ -6992,7 +6992,7 @@
               :code $ quote
                 do
                   assert= true $ starts-with? |01234 |01
-                  assert= true $ starts-with? :a/b :a/
+                  assert= true $ starts-with? (unsafe-coerce :a/b String) (unsafe-coerce :a/ String)
                   assert= false $ starts-with? |01234 |12
               :tags $ #{} :core :unit
         |str $ %{} 'CodeEntry (:doc "|converts values to string and concatenates them")

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2563,7 +2563,7 @@ fn check_struct_field_access(
       );
     }
     if &**ns == calcit::CORE_NS
-      && matches!(&**def, "get-in" | "assoc-in" | "update-in" | "dissoc-in")
+      && matches!(&**def, "get-in" | "contains-in?" | "assoc-in" | "update-in" | "dissoc-in")
       && args.len() >= 2
       && let (Some(base_arg), Some(path_arg)) = (args.first(), args.get(1))
       && let Some(base_type) = resolve_type_value(base_arg, scope_types)

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -20,7 +20,8 @@ use type_checking::{
 };
 pub use type_inference::infer_static_type_from_expr;
 use type_inference::{
-  infer_struct_field_type, infer_type_from_expr, resolve_enum_value, resolve_program_value_for_preprocess, resolve_type_value,
+  extract_literal_list_items, find_struct_lookup_in_literal_path, infer_struct_field_type, infer_type_from_expr, resolve_enum_value,
+  resolve_program_value_for_preprocess, resolve_type_value,
 };
 use type_rewriting::{
   build_enum_ref_node, build_struct_ref_node, try_rewrite_enum_args_to_named_enums, try_rewrite_local_fn_enum_args_to_named_enums,
@@ -2560,6 +2561,36 @@ fn check_struct_field_access(
         struct_arg.get_location(),
         check_warnings,
       );
+    }
+    if &**ns == calcit::CORE_NS
+      && matches!(&**def, "get-in" | "assoc-in" | "update-in" | "dissoc-in")
+      && args.len() >= 2
+      && let (Some(base_arg), Some(path_arg)) = (args.first(), args.get(1))
+      && let Some(base_type) = resolve_type_value(base_arg, scope_types)
+    {
+      let literal_path = extract_literal_list_items(path_arg);
+      let known_struct_with_dynamic_path =
+        literal_path.is_none() && (base_type.as_ref().resolve_to_struct().is_some() || is_anonymous_struct_type(base_type.as_ref()));
+      let struct_step = find_struct_lookup_in_literal_path(base_type.as_ref(), path_arg);
+
+      if known_struct_with_dynamic_path || struct_step.is_some() {
+        let (segment_text, location_text, location) = match struct_step {
+          Some((index, segment)) => (
+            format!("segment {} `{}`", index + 1, segment.lisp_str()),
+            "enters a Struct".to_owned(),
+            segment.get_location().or_else(|| path_arg.get_location()),
+          ),
+          None => (
+            "a dynamic path".to_owned(),
+            "starts from a Struct and cannot prove that the path is empty".to_owned(),
+            path_arg.get_location().or_else(|| base_arg.get_location()),
+          ),
+        };
+        let message = format!(
+          "[Warn] `{def}` {location_text} at {segment_text} in {file_ns}. Collection path APIs do not traverse Struct fields. End the path before the Struct, unwrap/narrow the value, then use `(:field value)` for reads or `assoc`/`update` for declared field writes"
+        );
+        gen_check_warning_code_at(message, "W_STRUCT_PATH_OPERATION", file_ns, location, check_warnings);
+      }
     }
   }
   // Check for Method(Access) which handles .-field syntax: (.-field struct_value)

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -167,15 +167,37 @@ fn warn_on_removed_data_api_call(
 }
 
 /// An anonymous struct has a runtime field set but no nominal declaration from
-/// which the preprocessor can derive an index. Postfix access must use the
-/// required struct lookup rather than the Option-producing
-/// collection `get` API.
+/// which the preprocessor can derive a required field type.
 fn is_anonymous_struct_type(type_info: &CalcitTypeAnnotation) -> bool {
   matches!(
     type_info,
     CalcitTypeAnnotation::Custom(value)
       if matches!(value.as_ref(), Calcit::Tag(tag) if matches!(tag.ref_str().trim_start_matches(':'), "record" | "struct"))
   )
+}
+
+fn warn_required_struct_field_type(
+  field_name: &str,
+  receiver: &Calcit,
+  receiver_type: Option<&CalcitTypeAnnotation>,
+  file_ns: &str,
+  def_name: &str,
+  location: Option<NodeLocation>,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  let receiver_type_text = receiver_type
+    .map(CalcitTypeAnnotation::to_brief_string)
+    .unwrap_or_else(|| ":unknown".to_owned());
+  let message = format!(
+    "[Warn] required field access `(:{field_name} value)` needs a statically typed Struct with a declared `:{field_name}` field, but the receiver is `{receiver_type_text}` at {file_ns}/{def_name}. Define the Struct and narrow/unwrap the receiver first; use `(get value :{field_name})` only when absence is intentional and handle the returned Option"
+  );
+  gen_check_warning_code_at(
+    message,
+    "W_REQUIRED_STRUCT_FIELD_TYPE",
+    file_ns,
+    location.or_else(|| receiver.get_location()),
+    check_warnings,
+  );
 }
 
 /// Extract type information from a Calcit definition
@@ -1069,6 +1091,14 @@ fn preprocess_list_call(
   {
     def_name = grab_def_name(receiver);
   }
+  // `struct-match` expands all nominal branches before runtime guards select
+  // one. Branch locals can temporarily carry the scrutinee's type while the
+  // generated code is preprocessed, so validating those generated probes here
+  // would report fields from the non-selected Struct variants as source errors.
+  let inside_struct_match_expansion = call_stack
+    .0
+    .iter()
+    .any(|frame| matches!(frame.kind, StackKind::Macro) && frame.def.as_ref() == "struct-match");
   let call_info = CallTypeCheckInfo {
     file_ns,
     def_name: &def_name,
@@ -1184,11 +1214,26 @@ fn preprocess_list_call(
             return Ok(Calcit::from(CalcitList::from(items.as_slice())));
           }
 
-          // A struct field is never an optional collection lookup. For a
-          // nominal struct this path means the tag was not declared; for a
-          // loose struct the field set is known only at runtime. Both use the
-          // required struct lookup and report a normal error when absent.
-          if type_info.as_ref().resolve_to_struct().is_some() || is_anonymous_struct_type(type_info.as_ref()) {
+          if type_info.as_ref().resolve_to_struct().is_some() {
+            if def_name.as_ref() != GENERATED_DEF && !inside_struct_match_expansion {
+              check_field_in_struct(&head_form, first_arg, scope_types, file_ns, check_warnings);
+            }
+            return Ok(Calcit::from(CalcitList::from(&[
+              Calcit::Proc(CalcitProc::NativeStructGet),
+              head_form,
+              first_arg.to_owned(),
+            ])));
+          }
+          if is_anonymous_struct_type(type_info.as_ref()) {
+            warn_required_struct_field_type(
+              field_tag.ref_str(),
+              &head_form,
+              Some(type_info.as_ref()),
+              file_ns,
+              def_name.as_ref(),
+              first_arg.get_location(),
+              check_warnings,
+            );
             return Ok(Calcit::from(CalcitList::from(&[
               Calcit::Proc(CalcitProc::NativeStructGet),
               head_form,
@@ -1371,8 +1416,8 @@ fn preprocess_list_call(
         // Core helpers such as `get` resolve to ordinary functions, so validate
         // their statically known struct fields in this branch as well.
         check_struct_field_access(&head_form, &current_args, scope_types, file_ns, check_warnings);
-        warn_on_nominal_enum_legacy_absence_use(head, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-        warn_on_legacy_js_nullish_predicate(head, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+        warn_on_nominal_enum_legacy_absence_use(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+        warn_on_legacy_js_nullish_predicate(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         let mut any_rewritten = false;
         // Rewrite hashmap literal args to struct literals when the expected type is a struct
         if let Some(rewritten) = try_rewrite_map_args_to_structs(info.as_ref(), &current_args, file_ns, &def_name, check_warnings) {
@@ -1447,16 +1492,53 @@ fn preprocess_list_call(
             let nth_call = Calcit::from(CalcitList::from(items.as_slice()));
             return Ok(nth_call);
           }
-          if let Some(type_info) = resolve_type_value(&processed_arg, scope_types)
-            && (type_info.as_ref().resolve_to_struct().is_some() || is_anonymous_struct_type(type_info.as_ref()))
-          {
-            return Ok(Calcit::from(CalcitList::from(&[
-              Calcit::Proc(CalcitProc::NativeStructGet),
-              processed_arg,
-              head.to_owned(),
-            ])));
+          if let Some(type_info) = resolve_type_value(&processed_arg, scope_types) {
+            if type_info.as_ref().resolve_to_struct().is_some() {
+              if def_name.as_ref() != GENERATED_DEF && !inside_struct_match_expansion {
+                check_field_in_struct(&processed_arg, head, scope_types, file_ns, check_warnings);
+              }
+              return Ok(Calcit::from(CalcitList::from(&[
+                Calcit::Proc(CalcitProc::NativeStructGet),
+                processed_arg,
+                head.to_owned(),
+              ])));
+            }
+            if is_anonymous_struct_type(type_info.as_ref()) {
+              warn_required_struct_field_type(
+                tag.ref_str(),
+                &processed_arg,
+                Some(type_info.as_ref()),
+                file_ns,
+                def_name.as_ref(),
+                head.get_location(),
+                check_warnings,
+              );
+              return Ok(Calcit::from(CalcitList::from(&[
+                Calcit::Proc(CalcitProc::NativeStructGet),
+                processed_arg,
+                head.to_owned(),
+              ])));
+            }
           }
-          // Fallback: rewrite to (get arg :tag) and re-preprocess
+          // A tag in function position is the required Struct-field accessor.
+          // Do not silently turn it into an Option-producing collection lookup:
+          // that makes the expression's contract depend on whether inference
+          // happened to recover a Struct type. Keep the fallback only to let
+          // preprocessing continue and collect more diagnostics; check-only and
+          // normal execution reject the warning below.
+          let receiver_type = resolve_type_value(&processed_arg, scope_types);
+          warn_required_struct_field_type(
+            tag.ref_str(),
+            &processed_arg,
+            receiver_type.as_deref(),
+            file_ns,
+            def_name.as_ref(),
+            head.get_location(),
+            check_warnings,
+          );
+
+          // Preserve the old lowering after recording the hard diagnostic so
+          // later expressions can still be checked in the same pass.
           let get_method = Calcit::Import(CalcitImport {
             ns: calcit::CORE_NS.into(),
             def: "get".into(),
@@ -1752,8 +1834,8 @@ fn preprocess_list_call(
           let processed_args = CalcitList::from(ys.drop_left());
           warn_on_nullable_js_ffi_dereference(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_untyped_js_ffi_field_access(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-          warn_on_nominal_enum_legacy_absence_use(head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-          warn_on_legacy_js_nullish_predicate(head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          warn_on_nominal_enum_legacy_absence_use(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          warn_on_legacy_js_nullish_predicate(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_dynamic_trait_call(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_method_name_conflict(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         }
@@ -2454,11 +2536,30 @@ fn check_struct_field_access(
   // Also check calcit.core imports that perform required struct field access.
   else if let Calcit::Import(CalcitImport { ns, def, .. }) = head {
     if &**ns == calcit::CORE_NS
-      && (&**def == "get" || &**def == "record-get" || &**def == "&struct:get")
+      && (&**def == "record-get" || &**def == "&struct:get")
       && args.len() >= 2
       && let (Some(struct_arg), Some(field_arg)) = (args.first(), args.get(1))
     {
       check_field_in_struct(struct_arg, field_arg, scope_types, file_ns, check_warnings);
+    }
+    if &**ns == calcit::CORE_NS
+      && &**def == "get"
+      && args.len() >= 2
+      && let Some(struct_arg) = args.first()
+      && let Some(type_info) = resolve_type_value(struct_arg, scope_types)
+      && (type_info.as_ref().resolve_to_struct().is_some() || is_anonymous_struct_type(type_info.as_ref()))
+    {
+      let field_text = args.get(1).map(Calcit::lisp_str).unwrap_or_else(|| "<field>".to_owned());
+      let message = format!(
+        "[Warn] `get` is the Option-returning lookup API for maps and indexed collections, not Struct fields, at {file_ns}. Use `({field_text} value)` so the checker can return the field's declared type and reject unknown fields"
+      );
+      gen_check_warning_code_at(
+        message,
+        "W_STRUCT_FIELD_OPTIONAL_LOOKUP",
+        file_ns,
+        struct_arg.get_location(),
+        check_warnings,
+      );
     }
   }
   // Check for Method(Access) which handles .-field syntax: (.-field struct_value)
@@ -2542,6 +2643,18 @@ fn check_field_in_struct(
   file_ns: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
+  // Macro-generated struct dispatch (for example struct pattern matching)
+  // may deliberately probe variant-specific fields after its own nominal
+  // guard. Source-level field diagnostics are emitted before expansion, so do
+  // not report those internal probes as user mistakes.
+  if [struct_arg.get_location(), field_arg.get_location()]
+    .into_iter()
+    .flatten()
+    .any(|location| location.def.as_ref() == GENERATED_DEF)
+  {
+    return;
+  }
+
   // Get the type of the struct argument - reuse resolve_type_value
   let Some(type_info) = resolve_type_value(struct_arg, scope_types) else {
     return; // No type info available
@@ -2567,7 +2680,7 @@ fn check_field_in_struct(
 
   // Field not found, generate warning
   let available_fields: Vec<&str> = struct_def.fields.iter().map(|f| f.ref_str()).collect();
-  gen_check_warning(
+  gen_check_warning_code_at(
     format!(
       "[Warn] Field `:{field_name}` does not exist in struct `{}`. Available fields: [{}]. Struct field access is required and never returns nil/Option for a missing field; use a declared field instead",
       struct_def.name,
@@ -2577,7 +2690,9 @@ fn check_field_in_struct(
         .collect::<Vec<_>>()
         .join(", ")
     ),
+    "W_UNKNOWN_STRUCT_FIELD",
     file_ns,
+    field_arg.get_location().or_else(|| struct_arg.get_location()),
     check_warnings,
   );
 }
@@ -3252,6 +3367,37 @@ fn nominal_enum_type_name(annotation: &CalcitTypeAnnotation) -> Option<String> {
   None
 }
 
+fn nominal_enum_expression_name(value: &Calcit, scope_types: &ScopeTypes) -> Option<String> {
+  if let Some(value_type) = resolve_type_value(value, scope_types)
+    && let Some(enum_name) = nominal_enum_type_name(value_type.as_ref())
+  {
+    return Some(enum_name);
+  }
+
+  let Calcit::List(items) = value else {
+    return None;
+  };
+  let declared_enum_name = match items.first() {
+    Some(Calcit::Import(CalcitImport { ns, def, .. })) => match program::lookup_def_schema(ns, def).as_ref() {
+      CalcitTypeAnnotation::Fn(info) => nominal_enum_type_name(info.return_type.as_ref()),
+      _ => None,
+    },
+    Some(Calcit::Fn { info, .. }) => nominal_enum_type_name(info.return_type.as_ref()),
+    _ => None,
+  };
+  if let Some(enum_name) = declared_enum_name {
+    return Some(enum_name);
+  }
+  match items.first().and_then(canonical_absence_operation_name) {
+    Some(
+      "%some" | "%none" | "find" | "find-index" | "index-of" | "first" | "last" | "nth" | "get" | "get-in" | "get-env" | "impl-origin"
+      | "enum-definition",
+    ) => Some("Option".to_owned()),
+    Some("%ok" | "%err" | "parse-float") => Some("Result".to_owned()),
+    _ => None,
+  }
+}
+
 fn warn_on_nominal_enum_legacy_absence_use(
   head: &Calcit,
   args: &CalcitList,
@@ -3296,6 +3442,14 @@ fn warn_on_nominal_enum_legacy_absence_use(
       | "empty?"
       | "contains?"
       | "includes?"
+      | "assoc"
+      | "assoc-in"
+      | "dissoc"
+      | "dissoc-in"
+      | "merge"
+      | "merge-non-nil"
+      | "update"
+      | "update-in"
       | "="
       | "&="
       | "&compare"
@@ -3306,8 +3460,7 @@ fn warn_on_nominal_enum_legacy_absence_use(
   let nominal_args = args
     .iter()
     .filter_map(|value| {
-      let value_type = resolve_type_value(value, scope_types)?;
-      let enum_name = nominal_enum_type_name(value_type.as_ref())?;
+      let enum_name = nominal_enum_expression_name(value, scope_types)?;
       Some((value, enum_name))
     })
     .collect::<Vec<_>>();
@@ -5804,7 +5957,7 @@ mod tests {
     });
     let args = CalcitList::from(std::slice::from_ref(&option_value));
 
-    for operation in ["some?", "get", "&compare", "struct?"] {
+    for operation in ["some?", "get", "assoc", "dissoc", "merge", "&compare", "struct?"] {
       let head = core_head(operation);
       let warnings = RefCell::new(vec![]);
       warn_on_nominal_enum_legacy_absence_use(&head, &args, &ScopeTypes::new(), "tests.option-migration", "demo", &warnings);
@@ -5849,6 +6002,22 @@ mod tests {
     assert!(
       nominal_equality_warnings.borrow().is_empty(),
       "Option-to-Option equality should stay valid"
+    );
+
+    let option_constructor = Calcit::from(vec![core_head("%some"), Calcit::Number(1.0)]);
+    let constructor_equality_args = CalcitList::from(&[option_value.to_owned(), option_constructor] as &[Calcit]);
+    let constructor_equality_warnings = RefCell::new(vec![]);
+    warn_on_nominal_enum_legacy_absence_use(
+      &equality_head,
+      &constructor_equality_args,
+      &ScopeTypes::new(),
+      "tests.option-migration",
+      "demo",
+      &constructor_equality_warnings,
+    );
+    assert!(
+      constructor_equality_warnings.borrow().is_empty(),
+      "Option equality with a core Option constructor should stay valid"
     );
 
     let application_get = Calcit::Symbol {
@@ -6883,7 +7052,7 @@ mod tests {
   }
 
   #[test]
-  fn common_get_reports_missing_known_struct_field_during_preprocess() {
+  fn common_get_rejects_known_struct_receivers() {
     let struct_type = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
       EdnTag::from("Person"),
       vec![EdnTag::from("name")],
@@ -6919,8 +7088,45 @@ mod tests {
     let warnings = warnings.borrow();
     assert_eq!(warnings.len(), 1);
     let message = warnings[0].message();
-    assert!(message.contains("Field `:missing` does not exist in struct `Person`"));
-    assert!(message.contains("never returns nil/Option"));
+    assert_eq!(warnings[0].code(), Some("W_STRUCT_FIELD_OPTIONAL_LOOKUP"));
+    assert!(message.contains("`get` is the Option-returning lookup API"));
+    assert!(message.contains("Use `(:missing value)`"));
+  }
+
+  #[test]
+  fn prefix_map_field_access_requires_a_typed_struct() {
+    let expr = Cirru::List(vec![Cirru::leaf(":name"), Cirru::leaf("record")]);
+    let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse required field access");
+    let mut scope_defs = HashSet::new();
+    scope_defs.insert(Arc::from("record"));
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(
+      Arc::from("record"),
+      Arc::new(CalcitTypeAnnotation::Map(
+        Arc::new(CalcitTypeAnnotation::Tag),
+        Arc::new(CalcitTypeAnnotation::String),
+      )),
+    );
+
+    let warnings = RefCell::new(vec![]);
+    let _ = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut scope_types,
+      "tests.struct",
+      &warnings,
+      &CallStackList::default(),
+    );
+
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].code(), Some("W_REQUIRED_STRUCT_FIELD_TYPE"));
+    assert!(warnings[0].message().contains("needs a statically typed Struct"));
+    assert!(
+      warnings[0]
+        .message()
+        .contains("use `(get value :name)` only when absence is intentional")
+    );
   }
 
   #[test]
@@ -6959,7 +7165,7 @@ mod tests {
   }
 
   #[test]
-  fn postfix_loose_struct_access_uses_required_struct_get() {
+  fn postfix_loose_struct_access_requires_a_nominal_declaration() {
     let expr = Cirru::List(vec![Cirru::leaf("record"), Cirru::leaf(":name")]);
     let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse postfix field access");
     let mut scope_defs = HashSet::new();
@@ -6983,8 +7189,12 @@ mod tests {
     };
     assert!(
       matches!(items.first(), Some(Calcit::Proc(CalcitProc::NativeStructGet))),
-      "loose record access should never use Option-producing get: {items}"
+      "loose record access keeps the raw lookup only after recording a hard diagnostic: {items}"
     );
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].code(), Some("W_REQUIRED_STRUCT_FIELD_TYPE"));
+    assert!(warnings[0].message().contains("with a declared `:name` field"));
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -191,6 +191,16 @@ pub(crate) fn infer_return_type_from_compiled_callable(
     return Some(inferred);
   }
   if ns == calcit::CORE_NS
+    && def == "update"
+    && let Some(receiver_type) = call_expr.get(1).and_then(|receiver| resolve_type_value(receiver, scope_types))
+  {
+    // `update` preserves its collection/Struct receiver. This is especially
+    // important when a required field access follows the update: losing the
+    // nominal Struct here would incorrectly turn a checked field into an
+    // untyped access.
+    return Some(receiver_type);
+  }
+  if ns == calcit::CORE_NS
     && def == "%::"
     && let Some(inferred) = infer_enum_annotation(call_expr, scope_types)
   {
@@ -330,15 +340,14 @@ fn infer_core_get_in_return_type(call_expr: &CalcitList, scope_types: &ScopeType
 }
 
 fn infer_get_return_type_from_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&Calcit>) -> Option<Arc<CalcitTypeAnnotation>> {
-  let payload = infer_lookup_payload_type_from_type(base_type, key_arg)?;
+  // Required Struct fields use `(:field value)` and are lowered to
+  // `&struct:nth`/`&struct:get`. Keeping Struct out of `get` gives this public
+  // API one stable contract: a partial collection lookup returns Option<T>.
   if base_type.resolve_to_struct().is_some() {
-    // Struct fields are declared and always present. Runtime `get` delegates
-    // to the required lookup and reports an unknown field instead of returning
-    // Option/nil, so the static type must expose the declared field directly.
-    Some(payload)
-  } else {
-    Some(core_type_ref("Option", vec![payload]))
+    return None;
   }
+  let payload = infer_lookup_payload_type_from_type(base_type, key_arg)?;
+  Some(core_type_ref("Option", vec![payload]))
 }
 
 fn infer_sequence_payload_type(base_type: &CalcitTypeAnnotation) -> Option<Arc<CalcitTypeAnnotation>> {
@@ -1145,6 +1154,11 @@ fn infer_proc_call_return_type(proc: &CalcitProc, xs: &CalcitList, scope_types: 
   {
     return Some(struct_type);
   }
+  if matches!(proc, CalcitProc::NativeStructFromMap)
+    && let Some(struct_value) = xs.get(1).and_then(|definition| resolve_struct_value(definition, scope_types))
+  {
+    return Some(Arc::new(CalcitTypeAnnotation::StructValue(struct_value.struct_ref)));
+  }
   if matches!(proc, CalcitProc::NativeLooseStruct) {
     return Some(tag_annotation("struct"));
   }
@@ -1758,20 +1772,51 @@ mod tests {
   }
 
   #[test]
-  fn known_struct_get_returns_the_required_field_type_directly() {
+  fn common_get_does_not_specialize_struct_fields() {
     let mut struct_def = CalcitStructDef::from_fields(EdnTag::from("User"), vec![EdnTag::from("name")]);
     struct_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]);
     let user_type = CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(vec![]));
     let key = Calcit::Tag(EdnTag::from("name"));
 
-    assert!(matches!(
-      infer_get_return_type_from_type(&user_type, Some(&key)).as_deref(),
-      Some(CalcitTypeAnnotation::String)
-    ));
+    assert!(infer_get_return_type_from_type(&user_type, Some(&key)).is_none());
     assert!(
       infer_get_return_type_from_type(&CalcitTypeAnnotation::Optional(Arc::new(user_type)), Some(&key)).is_none(),
       "legacy Optional receivers must be narrowed or converted before nominal lookup"
     );
+  }
+
+  #[test]
+  fn struct_preserving_operations_keep_nominal_type_for_required_field_access() {
+    let mut struct_def = CalcitStructDef::from_fields(EdnTag::from("User"), vec![EdnTag::from("name")]);
+    struct_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]);
+    let struct_def = Arc::new(struct_def);
+    let user_type = Arc::new(CalcitTypeAnnotation::StructValue(struct_def.clone()));
+    let user = local("user", user_type.clone());
+    let updater = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("updater")),
+      sym: Arc::from("updater"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.struct"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::from_function_parts(
+        vec![Arc::new(CalcitTypeAnnotation::String)],
+        Arc::new(CalcitTypeAnnotation::String),
+      )),
+    });
+    let update_call = CalcitList::from(&[symbol("update"), user, Calcit::Tag(EdnTag::from("name")), updater] as &[Calcit]);
+
+    assert_eq!(
+      infer_return_type_from_compiled_callable(calcit::CORE_NS, "update", &update_call, &ScopeTypes::new()),
+      Some(user_type.clone())
+    );
+
+    let from_map_call = proc_call(
+      CalcitProc::NativeStructFromMap,
+      vec![Calcit::StructDef(struct_def.as_ref().clone()), Calcit::Map(Default::default())],
+    );
+    assert_eq!(infer_type_from_expr(&from_map_call, &ScopeTypes::new()), Some(user_type));
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -333,10 +333,42 @@ fn infer_core_get_in_return_type(call_expr: &CalcitList, scope_types: &ScopeType
   }
 
   for key in path_items {
+    // A path API must not become an alternate, Option-producing Struct field
+    // accessor. Stop inference at the same boundary that preprocessing and the
+    // runtime reject, so adding/removing type evidence never changes get-in's
+    // contract.
+    if is_struct_lookup_boundary(current_type.as_ref()) {
+      return None;
+    }
     current_type = infer_lookup_payload_type_from_type(current_type.as_ref(), Some(key))?;
   }
 
   Some(core_type_ref("Option", vec![current_type]))
+}
+
+fn is_struct_lookup_boundary(type_info: &CalcitTypeAnnotation) -> bool {
+  type_info.resolve_to_struct().is_some()
+    || matches!(
+      type_info,
+      CalcitTypeAnnotation::Custom(value)
+        if matches!(value.as_ref(), Calcit::Tag(tag) if matches!(tag.ref_str().trim_start_matches(':'), "record" | "struct"))
+    )
+}
+
+/// Return the first literal path segment that would enter a Struct. Public
+/// path APIs use this to stop before nominal fields and keep required field
+/// access visible in source.
+pub(super) fn find_struct_lookup_in_literal_path(base_type: &CalcitTypeAnnotation, path_arg: &Calcit) -> Option<(usize, Calcit)> {
+  let path_items = extract_literal_list_items(path_arg)?;
+  let mut current_type = Arc::new(base_type.to_owned());
+
+  for (index, key) in path_items.into_iter().enumerate() {
+    if is_struct_lookup_boundary(current_type.as_ref()) {
+      return Some((index, key.to_owned()));
+    }
+    current_type = infer_lookup_payload_type_from_type(current_type.as_ref(), Some(key))?;
+  }
+  None
 }
 
 fn infer_get_return_type_from_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&Calcit>) -> Option<Arc<CalcitTypeAnnotation>> {
@@ -433,7 +465,7 @@ fn infer_js_ffi_call_return_type(name: &str, call_expr: &CalcitList, scope_types
   }
 }
 
-fn extract_literal_list_items(form: &Calcit) -> Option<Vec<&Calcit>> {
+pub(super) fn extract_literal_list_items(form: &Calcit) -> Option<Vec<&Calcit>> {
   let Calcit::List(items) = form else {
     return None;
   };
@@ -1782,6 +1814,36 @@ mod tests {
     assert!(
       infer_get_return_type_from_type(&CalcitTypeAnnotation::Optional(Arc::new(user_type)), Some(&key)).is_none(),
       "legacy Optional receivers must be narrowed or converted before nominal lookup"
+    );
+  }
+
+  #[test]
+  fn get_in_stops_before_struct_boundaries() {
+    let mut struct_def = CalcitStructDef::from_fields(EdnTag::from("User"), vec![EdnTag::from("name")]);
+    struct_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]);
+    let user_type = Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def), Arc::new(vec![])));
+    let users_type = Arc::new(CalcitTypeAnnotation::Map(tag_annotation("tag"), user_type.clone()));
+    let path = proc_call(
+      CalcitProc::List,
+      vec![Calcit::Tag(EdnTag::from("user")), Calcit::Tag(EdnTag::from("name"))],
+    );
+    let call = CalcitList::from(&[symbol("get-in"), local("users", users_type.clone()), path.clone()] as &[Calcit]);
+
+    assert!(
+      infer_core_get_in_return_type(&call, &ScopeTypes::new()).is_none(),
+      "get-in must not infer through a Struct field"
+    );
+    assert!(matches!(
+      find_struct_lookup_in_literal_path(users_type.as_ref(), &path),
+      Some((1, Calcit::Tag(field))) if field.ref_str() == "name"
+    ));
+
+    let empty_path = proc_call(CalcitProc::List, vec![]);
+    let empty_call = CalcitList::from(&[symbol("get-in"), local("user", user_type.clone()), empty_path] as &[Calcit]);
+    assert_eq!(
+      infer_core_get_in_return_type(&empty_call, &ScopeTypes::new()),
+      Some(core_type_ref("Option", vec![user_type])),
+      "an empty path does not access a Struct field"
     );
   }
 

--- a/ts-src/js-cirru.mts
+++ b/ts-src/js-cirru.mts
@@ -220,11 +220,16 @@ let recordFieldOrder = (a: [string, CirruEdnFormat], b: [string, CirruEdnFormat]
 
 /** makes sure we got string */
 let extractFieldTag = (x: string) => {
-  if (x[0] === ":") {
+  if (x[0] === ":" || x[0] === "'") {
     return newTag(x.slice(1));
   } else {
     return newTag(x);
   }
+};
+
+let extractEnumTag = (x: CirruEdnFormat, options: CalcitValue, preserveSourceEntries: boolean): CalcitValue => {
+  const parsedTag = extract_cirru_edn_inner(x, options, preserveSourceEntries);
+  return parsedTag instanceof CalcitSymbol ? newTag(parsedTag.value) : parsedTag;
 };
 
 let resolveEnumPrototype = (enumName: string, options: CalcitValue) => {
@@ -405,7 +410,7 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
         throw new Error(`anonymous enum expects at least 1 value, got: ${x}`);
       }
       return new CalcitEnumValue(
-        extract_cirru_edn_inner(x[1], options, preserveSourceEntries),
+        extractEnumTag(x[1], options, preserveSourceEntries),
         x
           .slice(2)
           .filter(notComment)
@@ -421,11 +426,8 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
         throw new Error(`Expected string for enum name, got: ${enumName}`);
       }
       let enumPrototype = resolveEnumPrototype(enumName, options);
-      // unwrap prototype to record then extract name
-      const proto = enumPrototype != null ? unwrap_enum_prototype_local(enumPrototype) : null;
-      const enumTag = proto != null ? proto.name.toString() : enumName;
       return new CalcitEnumValue(
-        extract_cirru_edn_inner(x[2], options, preserveSourceEntries),
+        extractEnumTag(x[2], options, preserveSourceEntries),
         x
           .slice(3)
           .filter(notComment)


### PR DESCRIPTION
## Summary
- make (:field value) require a declared named Struct and return its declared field type
- reserve get/get-in for Option-returning collection lookups; reject get on Structs
- improve Option migration diagnostics and restore JS Cirru EDN enum identity round-trips (#325, #326)

## Validation
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test
- yarn check-all