### PR TITLE
chore: release 0.13.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.7"
+version = "0.13.8"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/history/202608101042-release-0.13.8.md
+++ b/history/202608101042-release-0.13.8.md
@@ -1,0 +1,6 @@
+## Release 0.13.8
+
+- Publishes the typed Struct field-access and collection path-boundary work
+  merged through PR #327.
+- Keeps module branch resolution robust by fetching and pruning remote branch
+  refs before checkout.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
Release 0.13.8: typed Struct field access and collection path-boundary enforcement from PR #327.