### PR TITLE
fix: make list first optional and quiet small edit advice

### DIFF
--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -429,7 +429,7 @@ let
 let
     ; inferred as :list
     numbers $ range 10
-    ; inferred as :number
+    ; inferred as :optional<number>; handle nil before using it as a number
     n $ &list:first numbers
   [] n numbers
 ```

--- a/history/202608110054-small-edit-advice.md
+++ b/history/202608110054-small-edit-advice.md
@@ -1,0 +1,13 @@
+## Suppress structural-edit advice for small definitions
+
+- Structural-edit guidance now requires either the existing or incoming Cirru
+  tree to contain at least 32 AST nodes.
+- Tiny definitions do not benefit from a path-finding workflow, so full
+  definition updates no longer emit a misleadingly heavyweight warning.
+- Keep the threshold in `analyze_cirru_edit_advice` so every caller shares the
+  same behavior, including identical-definition advice.
+- `&list:first` now consistently reports its nullable `Optional<T>` result to
+  static analysis, matching the Core schema and its `nil` result for empty
+  lists.
+- Core macros and comparison helpers that first establish non-emptiness now
+  use the explicitly indexed low-level read `&list:nth xs 0`.

--- a/history/202608110125-review-optional-list-first.md
+++ b/history/202608110125-review-optional-list-first.md
@@ -1,0 +1,4 @@
+## Review follow-ups for nullable list-first inference
+
+- Normalize `optional_of` so already-optional types are not wrapped into nested optionals.
+- Rename the list-first inference regression test and cover both non-empty and empty lists.

--- a/history/202608110133-review-core-call-sites-and-thresholds.md
+++ b/history/202608110133-review-core-call-sites-and-thresholds.md
@@ -1,0 +1,5 @@
+## Follow-up review fixes for nullable list-first
+
+- Migrate remaining guarded Core reads in max/min, comparison folding, and list destructuring to `&list:nth ... 0`.
+- Tag the empty-list regression as both `:core` and `:unit`.
+- Make edit-advice fixtures assert exact 31/32-node boundary behavior, including one-sided threshold crossings.

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -554,6 +554,10 @@ fn optional_tag(name: &str) -> Arc<CalcitTypeAnnotation> {
   Arc::new(CalcitTypeAnnotation::Optional(tag_type(name)))
 }
 
+fn optional_of(inner: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
+  Arc::new(CalcitTypeAnnotation::Optional(inner))
+}
+
 fn optional_dynamic() -> Arc<CalcitTypeAnnotation> {
   Arc::new(CalcitTypeAnnotation::Optional(dynamic_tag()))
 }
@@ -946,7 +950,7 @@ impl CalcitProc {
         arg_types: vec![list_of(type_var("T")), some_tag("number")],
       }),
       NativeListFirst => Some(ProcTypeSignature {
-        return_type: dynamic_tag(),
+        return_type: optional_of(type_var("T")),
         arg_types: vec![list_of(type_var("T"))],
       }),
       NativeListRest => Some(ProcTypeSignature {
@@ -1533,6 +1537,12 @@ mod tests {
       .get_type_signature()
       .expect("record-struct signature");
     assert_eq!(record_struct.return_type, optional_tag("struct-def"));
+
+    let list_first = CalcitProc::NativeListFirst.get_type_signature().expect("&list:first signature");
+    assert!(matches!(
+      list_first.return_type.as_ref(),
+      CalcitTypeAnnotation::Optional(inner) if matches!(inner.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "T")
+    ));
   }
 
   #[test]

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -555,7 +555,10 @@ fn optional_tag(name: &str) -> Arc<CalcitTypeAnnotation> {
 }
 
 fn optional_of(inner: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
-  Arc::new(CalcitTypeAnnotation::Optional(inner))
+  match inner.as_ref() {
+    CalcitTypeAnnotation::Optional(_) => inner,
+    _ => Arc::new(CalcitTypeAnnotation::Optional(inner)),
+  }
 }
 
 fn optional_dynamic() -> Arc<CalcitTypeAnnotation> {

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1128,6 +1128,7 @@
             %{} 'TestEntry (:name |returns-nil-for-empty-list)
               :code $ quote
                 assert= nil $ &list:first ([])
+              :tags $ #{} :core :unit
         |&list:flatten $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn &list:flatten (xs)
@@ -1258,7 +1259,7 @@
           :code $ quote
             defn &list:max (xs)
               if (&list:empty? xs) (%none)
-                %some $ &list:max-loop (&list:rest xs) (&list:first xs)
+                %some $ &list:max-loop (&list:rest xs) (&list:nth xs 0)
           :examples $ []
           :schema $ :: 'Fn
             {}
@@ -1269,7 +1270,7 @@
           :code $ quote
             defn &list:max-loop (xs acc)
               if (&list:empty? xs) acc $ &let
-                x $ &list:first xs
+                x $ &list:nth xs 0
                 recur (&list:rest xs)
                   if (&> x acc) x acc
           :examples $ []
@@ -1281,7 +1282,7 @@
           :code $ quote
             defn &list:min (xs)
               if (&list:empty? xs) (%none)
-                %some $ &list:min-loop (&list:rest xs) (&list:first xs)
+                %some $ &list:min-loop (&list:rest xs) (&list:nth xs 0)
           :examples $ []
           :schema $ :: 'Fn
             {}
@@ -1292,7 +1293,7 @@
           :code $ quote
             defn &list:min-loop (xs acc)
               if (&list:empty? xs) acc $ &let
-                x $ &list:first xs
+                x $ &list:nth xs 0
                 recur (&list:rest xs)
                   if (&< x acc) x acc
           :examples $ []
@@ -4148,7 +4149,7 @@
           :code $ quote
             defn destruct-list (xs)
               if (empty? xs) (%:: ListDestruct :none)
-                %:: ListDestruct :some (&list:first xs) (&list:rest xs)
+                %:: ListDestruct :some (&list:nth xs 0) (&list:rest xs)
           :examples $ []
             quote $ assert=
               %:: ListDestruct :some 1 $ [] 2
@@ -4827,8 +4828,8 @@
           :code $ quote
             defn foldl-compare (xs acc f)
               if (&list:empty? xs) true $ if
-                f acc $ &list:first xs
-                recur (&list:rest xs) (&list:first xs) f
+                f acc $ &list:nth xs 0
+                recur (&list:rest xs) (&list:nth xs 0) f
                 , false
           :examples $ []
             quote $ assert= true

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1125,6 +1125,9 @@
               :code $ quote
                 assert= 1 $ &list:first ([] 1 2)
               :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |returns-nil-for-empty-list)
+              :code $ quote
+                assert= nil $ &list:first ([])
         |&list:flatten $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn &list:flatten (xs)
@@ -2634,7 +2637,7 @@
             defn < (x & ys)
               if
                 &= 1 $ &list:count ys
-                &< x $ &list:first ys
+                &< x $ &list:nth ys 0
                 foldl-compare ys x &<
           :examples $ []
           :schema $ :: 'Fn
@@ -2661,7 +2664,7 @@
             defn <= (x & ys)
               if
                 &= 1 $ &list:count ys
-                &<= x $ &list:first ys
+                &<= x $ &list:nth ys 0
                 foldl-compare ys x &<=
           :examples $ []
             quote $ assert= true (<= 3 5)
@@ -2690,7 +2693,7 @@
             defn > (x & ys)
               if
                 &= 1 $ &list:count ys
-                &> x $ &list:first ys
+                &> x $ &list:nth ys 0
                 foldl-compare ys x &>
           :examples $ []
             quote $ assert= true (> 5 3)
@@ -2710,7 +2713,7 @@
             defn >= (x & ys)
               if
                 &= 1 $ &list:count ys
-                &>= x $ &list:first ys
+                &>= x $ &list:nth ys 0
                 foldl-compare ys x &>=
           :examples $ []
             quote $ assert= true (>= 5 3)
@@ -5526,7 +5529,7 @@
                         nil? $ &list:last pair
                         recur acc remaining
                         recur
-                          include acc $ &list:first pair
+                          include acc $ &list:nth pair 0
                           , remaining
           :examples $ []
             quote $ assert= (#{} :a :b)
@@ -5645,7 +5648,7 @@
               if (&list:empty? pairs)
                 quasiquote $ &let () ~@body
                 &let
-                  pair $ &list:first pairs
+                  pair $ &list:nth pairs 0
                   if
                     not $ &= 2 (&list:count pair)
                     raise $ str-spaced "|expected pair length of 2, got:" pair
@@ -7994,7 +7997,7 @@
               if (&list:empty? body)
                 quasiquote $ eprintln "|[Warn] field-match found no matched case, missing `_` case?" ~value
                 &let
-                  pair $ &list:first body
+                  pair $ &list:nth body 0
                   if
                     not $ list? pair
                     raise $ str-spaced "|field-match expected arm in list, got:" pair

--- a/src/program_diff.rs
+++ b/src/program_diff.rs
@@ -114,6 +114,10 @@ pub struct CirruEditAdvice {
   pub strategy: CirruEditStrategy,
 }
 
+// A structural-edit suggestion is only useful when a definition is substantial
+// enough that locating a smaller subtree saves meaningful work.
+const MIN_EDIT_ADVICE_NODES: usize = 32;
+
 pub fn analyze_program_diff(git_ref: &str, base_ref: Option<&str>, input_path: &str) -> Result<ProgramDiffResult, String> {
   let cwd = env::current_dir().map_err(|e| format!("Failed to read current directory: {e}"))?;
   let input_abs = resolve_input_path(&cwd, input_path)?;
@@ -181,6 +185,10 @@ pub fn format_program_diff(result: &ProgramDiffResult) -> String {
 }
 
 pub fn analyze_cirru_edit_advice(old: &Cirru, new: &Cirru) -> Option<CirruEditAdvice> {
+  if count_cirru_nodes(old).max(count_cirru_nodes(new)) < MIN_EDIT_ADVICE_NODES {
+    return None;
+  }
+
   if old == new {
     return Some(CirruEditAdvice {
       similarity: 1.0,
@@ -1310,6 +1318,13 @@ mod tests {
     Cirru::List(items)
   }
 
+  fn large_list(last: &str) -> Cirru {
+    let mut items = vec![leaf("defn"), leaf("demo")];
+    items.extend((0..29).map(|index| leaf(&format!("arg-{index}"))));
+    items.push(leaf(last));
+    list(items)
+  }
+
   fn entry_with_type_slots(slots: &[(&str, &str)]) -> SnapshotEntry {
     SnapshotEntry {
       mode: SnapshotRunMode::Native,
@@ -1465,25 +1480,39 @@ mod tests {
 
   #[test]
   fn classifies_additive_similar_edits_as_insert_strategy() {
-    let old = list(vec![leaf("defn"), leaf("demo"), leaf("x")]);
-    let new = list(vec![leaf("defn"), leaf("demo"), leaf("x"), leaf("y")]);
+    let old = large_list("x");
+    let mut new_items = match old.clone() {
+      Cirru::List(items) => items,
+      Cirru::Leaf(_) => unreachable!("large_list always returns a list"),
+    };
+    new_items.push(leaf("y"));
+    let new = list(new_items);
     let advice = analyze_cirru_edit_advice(&old, &new).expect("expected advice for similar edit");
     assert_eq!(advice.strategy, CirruEditStrategy::Insert);
   }
 
   #[test]
   fn classifies_leaf_updates_as_replace_strategy() {
-    let old = list(vec![leaf("defn"), leaf("demo"), leaf("x")]);
-    let new = list(vec![leaf("defn"), leaf("demo"), leaf("y")]);
+    let old = large_list("x");
+    let new = large_list("y");
     let advice = analyze_cirru_edit_advice(&old, &new).expect("expected advice for similar edit");
     assert_eq!(advice.strategy, CirruEditStrategy::Replace);
   }
 
   #[test]
   fn reports_identical_trees() {
-    let old = list(vec![leaf("defn"), leaf("demo"), leaf("x")]);
+    let old = large_list("x");
     let advice = analyze_cirru_edit_advice(&old, &old).expect("expected advice for identical trees");
     assert_eq!(advice.strategy, CirruEditStrategy::Identical);
+  }
+
+  #[test]
+  fn omits_advice_for_small_trees() {
+    let old = list(vec![leaf("defn"), leaf("demo"), leaf("x")]);
+    let new = list(vec![leaf("defn"), leaf("demo"), leaf("y")]);
+
+    assert!(analyze_cirru_edit_advice(&old, &new).is_none());
+    assert!(analyze_cirru_edit_advice(&old, &old).is_none());
   }
 
   #[test]
@@ -1498,6 +1527,9 @@ mod tests {
       list(vec![leaf("println"), leaf("|d")]),
       list(vec![leaf("println"), leaf("|e")]),
       list(vec![leaf("println"), leaf("|f")]),
+      list(vec![leaf("println"), leaf("|g")]),
+      list(vec![leaf("println"), leaf("|h")]),
+      list(vec![leaf("println"), leaf("|i")]),
       list(vec![leaf("do"), leaf("true")]),
     ]);
     let new = list(vec![
@@ -1511,6 +1543,9 @@ mod tests {
       list(vec![leaf("println"), leaf("|extra-4")]),
       list(vec![leaf("println"), leaf("|extra-5")]),
       list(vec![leaf("println"), leaf("|extra-6")]),
+      list(vec![leaf("println"), leaf("|g")]),
+      list(vec![leaf("println"), leaf("|h")]),
+      list(vec![leaf("println"), leaf("|i")]),
       list(vec![leaf("do"), leaf("true")]),
     ]);
     let advice = analyze_cirru_edit_advice(&old, &new).expect("expected advice for mixed structural edit");

--- a/src/program_diff.rs
+++ b/src/program_diff.rs
@@ -1302,7 +1302,7 @@ fn align_sequence<T: Eq>(old: &[T], new: &[T]) -> Vec<SeqEdit> {
 mod tests {
   use super::{
     CirruEditStrategy, DiffNode, DiffStatus, SeqEdit, align_sequence, analyze_cirru_edit_advice, build_entry_tree, cirru_similarity,
-    diff_cirru, diff_code_entry, diff_entries, diff_entry, render_cirru_diff, render_text,
+    count_cirru_nodes, diff_cirru, diff_code_entry, diff_entries, diff_entry, render_cirru_diff, render_text,
   };
   use crate::calcit::DYNAMIC_TYPE;
   use crate::snapshot::{CodeEntry, SnapshotEntry, SnapshotRunMode, TestEntry};
@@ -1318,11 +1318,20 @@ mod tests {
     Cirru::List(items)
   }
 
-  fn large_list(last: &str) -> Cirru {
+  fn flat_list_with_node_count(node_count: usize, last: &str) -> Cirru {
+    assert!(node_count >= 4, "fixture needs room for a head, name, and tail");
     let mut items = vec![leaf("defn"), leaf("demo")];
-    items.extend((0..29).map(|index| leaf(&format!("arg-{index}"))));
+    while items.len() + 2 < node_count {
+      items.push(leaf(&format!("arg-{}", items.len())));
+    }
     items.push(leaf(last));
-    list(items)
+    let tree = list(items);
+    assert_eq!(count_cirru_nodes(&tree), node_count);
+    tree
+  }
+
+  fn large_list(last: &str) -> Cirru {
+    flat_list_with_node_count(32, last)
   }
 
   fn entry_with_type_slots(slots: &[(&str, &str)]) -> SnapshotEntry {
@@ -1513,6 +1522,24 @@ mod tests {
 
     assert!(analyze_cirru_edit_advice(&old, &new).is_none());
     assert!(analyze_cirru_edit_advice(&old, &old).is_none());
+  }
+
+  #[test]
+  fn respects_edit_advice_node_threshold_boundaries() {
+    let below_old = flat_list_with_node_count(31, "x");
+    let below_new = flat_list_with_node_count(31, "y");
+    assert!(analyze_cirru_edit_advice(&below_old, &below_new).is_none());
+
+    let at_old = flat_list_with_node_count(32, "x");
+    let at_new = flat_list_with_node_count(32, "y");
+    let replacement = analyze_cirru_edit_advice(&at_old, &at_new).expect("32-node trees should receive advice");
+    assert_eq!(replacement.strategy, CirruEditStrategy::Replace);
+
+    let insertion = analyze_cirru_edit_advice(&below_old, &at_old).expect("new tree at threshold should receive advice");
+    assert_eq!(insertion.strategy, CirruEditStrategy::Insert);
+
+    let deletion = analyze_cirru_edit_advice(&at_old, &below_old).expect("old tree at threshold should receive advice");
+    assert_eq!(deletion.strategy, CirruEditStrategy::Delete);
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -1069,15 +1069,19 @@ fn infer_proc_call_return_type(proc: &CalcitProc, xs: &CalcitList, scope_types: 
   {
     return Some(Arc::new(CalcitTypeAnnotation::Ref(initial_type)));
   }
-  // These low-level collection intrinsics retain their unchecked payload
-  // inference strictly for guarded core macro expansion. Public lookup APIs
-  // return nominal Option<T> and never expose this nullable representation.
+  // `&list:nth` retains its unchecked payload type for guarded core macro
+  // expansion. Unlike it, `&list:first` has a nullable Core schema and must
+  // expose that absence to callers.
   if matches!(proc, CalcitProc::NativeListNth | CalcitProc::NativeListFirst)
     && let Some(first_arg) = xs.get(1)
     && let Some(type_value) = resolve_type_value(first_arg, scope_types)
     && let CalcitTypeAnnotation::List(element_type) = type_value.as_ref()
   {
-    return Some(element_type.clone());
+    return Some(if matches!(proc, CalcitProc::NativeListFirst) {
+      wrap_optional_type(element_type.clone())
+    } else {
+      element_type.clone()
+    });
   }
   if matches!(
     proc,
@@ -1728,6 +1732,17 @@ mod tests {
       infer_static_type_from_expr(&map).as_deref(),
       Some(CalcitTypeAnnotation::Map(key, value))
         if matches!(key.as_ref(), CalcitTypeAnnotation::Tag) && matches!(value.as_ref(), CalcitTypeAnnotation::Number)
+    ));
+  }
+
+  #[test]
+  fn list_first_inference_preserves_empty_list_absence() {
+    let list = proc_call(CalcitProc::List, vec![Calcit::Number(1.0), Calcit::Number(2.0)]);
+    let first = proc_call(CalcitProc::NativeListFirst, vec![list]);
+
+    assert!(matches!(
+      infer_static_type_from_expr(&first).as_deref(),
+      Some(CalcitTypeAnnotation::Optional(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
     ));
   }
 

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -1736,13 +1736,20 @@ mod tests {
   }
 
   #[test]
-  fn list_first_inference_preserves_empty_list_absence() {
+  fn list_first_inference_preserves_nullable_result() {
     let list = proc_call(CalcitProc::List, vec![Calcit::Number(1.0), Calcit::Number(2.0)]);
     let first = proc_call(CalcitProc::NativeListFirst, vec![list]);
 
     assert!(matches!(
       infer_static_type_from_expr(&first).as_deref(),
       Some(CalcitTypeAnnotation::Optional(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
+    ));
+
+    let empty_list = proc_call(CalcitProc::List, vec![]);
+    let first_empty = proc_call(CalcitProc::NativeListFirst, vec![empty_list]);
+    assert!(matches!(
+      infer_static_type_from_expr(&first_empty).as_deref(),
+      Some(CalcitTypeAnnotation::Optional(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
     ));
   }
 


### PR DESCRIPTION
## Summary

- suppress structural edit advice for definitions smaller than 32 AST nodes
- make `&list:first` consistently infer as `Optional<T>`, matching its nil-on-empty behavior and Core schema
- migrate Core paths that already establish non-emptiness to `&list:nth ... 0`
- add regression coverage and update static-analysis documentation

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`