### PR TITLE
chore: release 0.13.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.8"
+version = "0.13.9"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/history/202608110140-release-0.13.9.md
+++ b/history/202608110140-release-0.13.9.md
@@ -1,0 +1,4 @@
+## Release 0.13.9
+
+- Bump the Cargo and npm package versions together after merging PR #331.
+- Refresh the workspace lockfile before creating the release PR and tag.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
升级 Cargo 与 npm 包版本至 0.13.9，并同步更新 Cargo.lock。