### PR TITLE
feat: improve agent migration workflows

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -115,6 +115,8 @@ path 使用从零开始的 child index：`@3.2` 表示先取 definition 根 list
 - 在一个复杂表达式中连续移动和修改：`cr cursor` 与 `@cursor`。
 - 多个 mutation 必须一起成功：`cr edit transaction`，先 `--dry-run`；主格式是 Cirru EDN，先运行 `cr docs read edit-tree.md 'Atomic Transactions'` 查看最小 operation 文件和 revision 提交流程。
 
+同一个 Snapshot 的写命令必须串行执行，包括 `config`、`edit`、`tree` 和 cursor mutation；两个进程同时读取再保存会发生最后写入覆盖。需要并行时使用独立 Snapshot/worktree，需要同一文件内的原子多步修改时使用 transaction 和 `--expect-revision`。
+
 ## 3. 高频黄金路径：查询 → 编辑 → 验证
 
 下面是需要替换 `<...>` 占位符的任务模板，不能原样执行。target、needle 和 replacement 必须来自当前项目及用户目标。先看搜索结果中的 `[#N]`，确认后再用同一序号设置 cursor：
@@ -172,6 +174,16 @@ cr --check-only
 ```
 
 `edit add-import` 接收一条 import rule body，不包含 `:require`；优先使用它。只有明确要整体替换全部 imports 时才使用 `edit imports`。已有 definition 或同来源 import 需要覆盖时必须显式加 `--overwrite`。优先局部 tree mutation，不要为了改几个节点整段覆盖。最后仍需运行项目规定的测试与 codegen。
+
+整体替换多条 import 时，`edit imports --file imports.cirru` 的主格式是 quoted Cirru AST，而不是 JSON：
+
+```cirru
+quote $ []
+  respo.core :refer $ div span
+  respo-ui.core :as ui
+```
+
+CLI 去掉外层 `quote`，确认 `[]` marker 后，把数组内部每个表达式作为一条 import rule；不要包含外层 `:require`。JSON 数组仅作为互操作兼容格式保留。
 
 ## 4. Cursor 连续编辑
 

--- a/docs/run/edit-tree.md
+++ b/docs/run/edit-tree.md
@@ -239,6 +239,16 @@ cr edit add-import app.main --code 'quote (respo.core :refer $ deftime)'
 cr edit imports app.main --file imports.cirru
 ```
 
+`imports.cirru` quotes one Cirru list node. The command removes the outer `quote`, checks the `[]` marker, and uses each child expression as one import rule:
+
+```cirru
+quote $ []
+  respo.core :refer $ div span
+  respo-ui.core :as ui
+```
+
+The older JSON array form remains accepted for interoperability. Do not include the outer `:require`; the command rebuilds it.
+
 ### Managing Schemas and Examples
 
 ```bash

--- a/editing-history/202608111322-agent-migration-convergence.md
+++ b/editing-history/202608111322-agent-migration-convergence.md
@@ -1,0 +1,40 @@
+# Improve agent migration convergence
+
+Migrating Respo and its dependent modules to stricter Calcit types exposed a
+few CLI and compiler failures that made automated repairs unnecessarily slow or
+unsafe:
+
+- `cr edit imports` documented Cirru input but only accepted a single flat rule;
+  multi-rule input effectively required JSON.
+- Cirru transaction output expanded quoted empty lists into a shape that did not
+  round-trip, blocking safe insertion of zero-argument function definitions.
+- definition revision hashes rejected leaf-shaped examples/tests, so semantic
+  queries failed on otherwise valid definition-attached tests.
+- large but finite UI/Markdown dependency graphs overflowed the 16 MiB codegen
+  worker stack before diagnostics could identify the actual type errors.
+- several tree command help strings still advertised removed comma-separated
+  paths even though the parser requires `@2.1.0` coordinates.
+- concurrent mutation processes can overwrite each other's snapshot changes,
+  which was easy to trigger when an agent updated multiple entries in parallel.
+
+Changes:
+
+- Accept a quoted Cirru `[]` whose child expressions are import rules in
+  `cr edit imports`, while preserving JSON compatibility and rejecting
+  malformed flat children.
+- Emit inline Cirru for transaction quoted code so empty lists round-trip.
+- Give leaf examples/tests stable revision encodings without changing existing
+  list revision hashes.
+- Raise the dedicated codegen worker stack to 64 MiB, which is sufficient for
+  the current Respo UI/Markdown graph and still keeps recursion isolated from
+  the process main thread.
+- Align all path option help with the dot-separated coordinate parser.
+- Document that writes to one snapshot must be serialized, or grouped in a
+  revision-guarded transaction; independent snapshots/worktrees may still run
+  in parallel.
+
+Real-project validation used local Respo, Router, Markdown, UI, Reel, and Alerts
+snapshots after removing the obsolete Lilac module dependency. UI, Router, Reel,
+Alerts, and all three Markdown entries completed JS codegen. Calcit built-in
+tests passed 35/35 in Respo and 6/6 in Router; no external `calcit-test` runner
+was used.

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -455,7 +455,10 @@ fn transaction_edn_arg(value: &cirru_edn::Edn) -> Result<String, String> {
       let quoted = Cirru::List(vec![Cirru::leaf("quote"), code.clone()]);
       cirru_parser::format(
         std::slice::from_ref(&quoted),
-        cirru_parser::CirruWriterOptions { use_inline: false },
+        // Transaction arguments are fed back through `--code`. Inline mode is
+        // required for leaf and empty-list payloads: the multiline writer can
+        // render `quote ()` as `quote $\n()`, which changes the quoted AST.
+        cirru_parser::CirruWriterOptions { use_inline: true },
       )
       .map_err(|error| format!("Failed to format quoted transaction code argument: {error}"))
     }
@@ -2174,49 +2177,11 @@ fn handle_imports(opts: &EditImportsCommand, snapshot_file: &str) -> Result<(), 
     .get_mut(&opts.namespace)
     .ok_or_else(|| format!("Namespace '{}' not found", opts.namespace))?;
 
-  // Determine input format: auto-detect JSON array vs Cirru EDN
-  let imports_json: serde_json::Value = if raw.trim().starts_with('[') {
-    serde_json::from_str(&raw).map_err(|e| format!("Failed to parse imports JSON: {e}"))?
-  } else {
-    // Parse as cirru and convert to JSON value
-    let cirru_node = parse_input_to_cirru(&raw)?;
-    use super::common::cirru_to_json_value;
-    cirru_to_json_value(&cirru_node)
-  };
-
   // Build new ns code with imports.
   // Always use build_ns_code to produce the correct nested structure:
   //   ["ns", "namespace", [":require", rule1, rule2, ...]]
   let ns_name = &opts.namespace;
-
-  let rules: Vec<Cirru> = if let serde_json::Value::Array(ref elems) = imports_json {
-    use super::common::json_value_to_cirru;
-    if elems.is_empty() {
-      vec![]
-    } else {
-      // Detect: array-of-arrays => multiple rules; array-of-strings => single flat rule
-      let first_is_array = elems.first().map(|e| e.is_array()).unwrap_or(false);
-      if first_is_array {
-        // Each element is one import rule
-        elems.iter().map(json_value_to_cirru).collect::<Result<Vec<_>, _>>()?
-      } else {
-        // The whole array is a single import rule (e.g. from `-e 'src-ns :refer $ sym'`)
-        // Guard: user may have accidentally included ':require' prefix
-        if let Some(serde_json::Value::String(first_str)) = elems.first()
-          && first_str == ":require"
-        {
-          return Err(
-            "Do not include ':require' as a prefix in the imports input. \
-               Pass rules directly, e.g. --code 'src-ns :refer $ sym' or use --file for multiple rules."
-              .to_string(),
-          );
-        }
-        vec![json_value_to_cirru(&imports_json)?]
-      }
-    }
-  } else {
-    return Err("Imports must be a Cirru list or JSON array of import rules.".to_string());
-  };
+  let rules = parse_import_rules_input(&raw)?;
 
   for warning in validate_import_rules(&rules)? {
     eprintln!("{} in namespace '{}': {warning}", "Warning:".yellow(), opts.namespace);
@@ -2288,6 +2253,66 @@ fn handle_imports(opts: &EditImportsCommand, snapshot_file: &str) -> Result<(), 
   }
 
   Ok(())
+}
+
+fn import_rules_from_json(value: &serde_json::Value) -> Result<Vec<Cirru>, String> {
+  use super::common::json_value_to_cirru;
+
+  let serde_json::Value::Array(elems) = value else {
+    return Err("Imports must be a Cirru EDN list or JSON array of import rules.".to_string());
+  };
+  if elems.is_empty() {
+    return Ok(vec![]);
+  }
+
+  // Detect: array-of-arrays => multiple rules; array-of-strings => single flat rule.
+  if elems.first().is_some_and(serde_json::Value::is_array) {
+    return elems.iter().map(json_value_to_cirru).collect::<Result<Vec<_>, _>>();
+  }
+
+  // Guard: user may have accidentally included ':require' prefix.
+  if let Some(serde_json::Value::String(first_str)) = elems.first()
+    && first_str == ":require"
+  {
+    return Err(
+      "Do not include ':require' as a prefix in the imports input. \
+       Pass rules directly, e.g. --code 'src-ns :refer $ sym' or use --file for multiple rules."
+        .to_string(),
+    );
+  }
+  Ok(vec![json_value_to_cirru(value)?])
+}
+
+fn parse_import_rules_input(raw: &str) -> Result<Vec<Cirru>, String> {
+  let trimmed = raw.trim();
+  if trimmed.is_empty() {
+    return Err("Imports input is empty. Provide a quoted Cirru `[]` containing import rules (JSON is also accepted).".to_string());
+  }
+
+  if trimmed.starts_with('[') {
+    let value = serde_json::from_str(trimmed).map_err(|error| format!("Failed to parse imports JSON: {error}"))?;
+    return import_rules_from_json(&value);
+  }
+
+  let cirru_node = parse_input_to_cirru(trimmed)?;
+  let Cirru::List(items) = cirru_node else {
+    return Err("Imports Cirru input must be `quote $ []` followed by zero or more import rules.".to_string());
+  };
+  if !matches!(items.first(), Some(Cirru::Leaf(head)) if &**head == "[]") {
+    return Err("Imports Cirru input must be `quote $ []` followed by zero or more import rules.".to_string());
+  }
+
+  items
+    .iter()
+    .skip(1)
+    .enumerate()
+    .map(|(index, rule)| {
+      if !matches!(rule, Cirru::List(_)) {
+        return Err(format!("Import rule {} inside the quoted `[]` must be an expression.", index + 1));
+      }
+      Ok(rule.clone())
+    })
+    .collect()
 }
 
 /// Extract formatted import list from ns code for comparison
@@ -2798,8 +2823,8 @@ mod tests {
   use super::{
     TransactionOperationReport, bump_semver_value, collect_format_advisories, count_legacy_any_schema_fields,
     count_legacy_inherent_impls, handle_add_import, handle_add_test, handle_imports, handle_rm_test, load_snapshot,
-    parse_examples_input, parse_input_to_cirru, parse_schema_input, parse_transaction_operations, rename_definition_declaration,
-    run_staged_transaction_with, save_schema_preserving_snapshot, save_snapshot,
+    parse_examples_input, parse_import_rules_input, parse_input_to_cirru, parse_schema_input, parse_transaction_operations,
+    rename_definition_declaration, run_staged_transaction_with, save_schema_preserving_snapshot, save_snapshot,
   };
   use crate::cli_args::{EditAddImportCommand, EditAddTestCommand, EditImportsCommand, EditRmTestCommand};
   use crate::cli_handlers::test_support::TestProject;
@@ -2890,7 +2915,7 @@ mod tests {
     let opts = EditImportsCommand {
       namespace: "app.main".to_string(),
       file: None,
-      code: Some("quote (audit.invalid :as)".to_string()),
+      code: Some("quote $ []\n  audit.invalid :as".to_string()),
     };
 
     let error = handle_imports(&opts, &fixture.snapshot_string()).expect_err("malformed import rule should fail");
@@ -2898,6 +2923,33 @@ mod tests {
     assert!(error.contains("import rule 1"), "error: {error}");
     assert!(error.contains("exactly 3 items"), "error: {error}");
     assert_eq!(fs::read(&fixture.path).expect("fixture should remain"), original);
+  }
+
+  #[test]
+  fn imports_parse_quoted_rule_list_and_keep_json_compatibility() {
+    let cirru = "quote $ []\n  respo.core :refer $ div span\n  respo-ui.core :as ui";
+    let json = r#"[["respo.core",":refer",["div","span"]],["respo-ui.core",":as","ui"]]"#;
+    let expected = vec![
+      list(vec![leaf("respo.core"), leaf(":refer"), list(vec![leaf("div"), leaf("span")])]),
+      list(vec![leaf("respo-ui.core"), leaf(":as"), leaf("ui")]),
+    ];
+
+    assert_eq!(
+      parse_import_rules_input(cirru).expect("quoted Cirru imports should parse"),
+      expected
+    );
+    assert_eq!(
+      parse_import_rules_input(json).expect("JSON imports should remain supported"),
+      expected
+    );
+  }
+
+  #[test]
+  fn imports_quoted_list_requires_each_rule_to_be_an_expression() {
+    let error = parse_import_rules_input("quote $ [] respo.core").expect_err("flat quoted imports should fail");
+
+    assert!(error.contains("rule 1"), "error: {error}");
+    assert!(error.contains("must be an expression"), "error: {error}");
   }
 
   #[test]
@@ -2963,6 +3015,19 @@ mod tests {
     assert_eq!(
       parse_input_to_cirru(code).expect("embedded quoted code should remain valid edit input"),
       list(vec![leaf("println"), leaf("|done")])
+    );
+  }
+
+  #[test]
+  fn transaction_cirru_round_trips_quoted_empty_list() {
+    let cirru =
+      "[]\n  []\n    , |tree\n    , |insert-after\n    , |app.main/main!\n    , |--path\n    , |@1\n    , |--code\n    quote ()";
+    let operations = parse_transaction_operations(cirru).expect("Cirru transaction with an empty quoted list should parse");
+    let code = operations[0].get(6).expect("formatted --code argument should exist");
+
+    assert_eq!(
+      parse_input_to_cirru(code).expect("quoted empty list should remain valid edit input"),
+      list(vec![])
     );
   }
 

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -1132,8 +1132,11 @@ fn run_codegen_with_timeout(
   let (tx, rx) = channel();
   std::thread::Builder::new()
     .name("calcit-codegen".into())
-    // Macro/type preprocessing can be deeply recursive for large schemas.
-    .stack_size(16 * 1024 * 1024)
+    // Macro/type preprocessing follows transitive definition dependencies and
+    // can be deeply recursive in real module graphs (for example UI ->
+    // Markdown -> math parser helpers). Keep this above the ordinary Rust
+    // thread default so the CLI returns diagnostics instead of aborting.
+    .stack_size(64 * 1024 * 1024)
     .spawn(move || {
       let result = run_codegen(&entries, &emit_path, ir_mode, verbose);
       let _ = tx.send(result);

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -1691,10 +1691,10 @@ pub struct EditCpCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the source node (comma-separated indices)
+  /// path to the source node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option, long = "from")]
   pub from: String,
-  /// path to the destination node (comma-separated indices)
+  /// path to the destination node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option, long = "path")]
   pub path: String,
   /// position relative to the destination node (before, after, append-child, prepend-child, replace)
@@ -1709,10 +1709,10 @@ pub struct EditMvNodeCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the source node (comma-separated indices)
+  /// path to the source node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option, long = "from")]
   pub from: String,
-  /// path to the destination node (comma-separated indices)
+  /// path to the destination node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option, long = "path")]
   pub path: String,
   /// position relative to the destination node (before, after, append-child, prepend-child, replace)
@@ -1739,7 +1739,7 @@ pub struct EditSplitDefCommand {
   /// source definition in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node to extract (comma-separated indices, e.g. "3,2,1")
+  /// path to the node to extract (dot-separated coordinates, e.g. "@3.2.1")
   #[argh(option, long = "path")]
   pub path: String,
   /// name for the new extracted definition (within the same namespace)
@@ -1754,7 +1754,7 @@ pub struct TreeStructuralCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// read syntax_tree from file (auto-detects JSON vs Cirru)
@@ -1824,7 +1824,7 @@ pub struct TreeReplaceCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// read syntax_tree from file (auto-detects JSON vs Cirru)
@@ -1872,7 +1872,7 @@ pub struct TreeDeleteCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// require the node at path to equal this quoted Cirru node before deleting
@@ -1890,7 +1890,7 @@ pub struct TreeInsertBeforeCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// read syntax_tree from file (auto-detects JSON vs Cirru)
@@ -1914,7 +1914,7 @@ pub struct TreeInsertAfterCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// read syntax_tree from file (auto-detects JSON vs Cirru)
@@ -1938,7 +1938,7 @@ pub struct TreeInsertChildCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// read syntax_tree from file (auto-detects JSON vs Cirru)
@@ -1962,7 +1962,7 @@ pub struct TreeAppendChildCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// read syntax_tree from file (auto-detects JSON vs Cirru)
@@ -1986,7 +1986,7 @@ pub struct TreeSwapNextCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// max depth for result preview (0 = unlimited, default 2)
@@ -2001,7 +2001,7 @@ pub struct TreeSwapPrevCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node (comma-separated indices, e.g. "2,1,0")
+  /// path to the node (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// max depth for result preview (0 = unlimited, default 2)
@@ -2016,7 +2016,7 @@ pub struct TreeUnwrapCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node to unwrap (comma-separated indices, e.g. "2,1,0")
+  /// path to the node to unwrap (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// max depth for result preview (0 = unlimited, default 2)
@@ -2046,7 +2046,7 @@ pub struct TreeWrapCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// path to the node to wrap (comma-separated indices, e.g. "2,1,0")
+  /// path to the node to wrap (dot-separated coordinates, e.g. "@2.1.0")
   #[argh(option)]
   pub path: String,
   /// wrapping expression with `self` as placeholder for the original node (e.g. 'println self')

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -694,6 +694,21 @@ pub fn definition_revision(entry: &CodeEntry) -> Result<String, String> {
     hasher.update(content);
   }
 
+  fn render_cirru_node_for_revision(node: &Cirru, label: &str) -> Result<Vec<u8>, String> {
+    match node {
+      // `cirru_parser::format` accepts top-level expressions, not a standalone
+      // leaf. Examples and definition-attached tests intentionally allow both.
+      Cirru::Leaf(value) => {
+        let mut rendered = b"leaf\0".to_vec();
+        rendered.extend_from_slice(value.as_bytes());
+        Ok(rendered)
+      }
+      Cirru::List(_) => cirru_parser::format(std::slice::from_ref(node), true.into())
+        .map(String::into_bytes)
+        .map_err(|error| format!("Failed to format definition {label} for revision: {error}")),
+    }
+  }
+
   let mut hasher = Md5::new();
   update_part(&mut hasher, "doc", entry.doc.as_bytes());
 
@@ -707,14 +722,12 @@ pub fn definition_revision(entry: &CodeEntry) -> Result<String, String> {
     .map_err(|error| format!("Failed to format definition schema for revision: {error}"))?;
   update_part(&mut hasher, "schema", schema.as_bytes());
 
-  let code = cirru_parser::format(std::slice::from_ref(&entry.code), true.into())
-    .map_err(|error| format!("Failed to format definition code for revision: {error}"))?;
-  update_part(&mut hasher, "code", code.as_bytes());
+  let code = render_cirru_node_for_revision(&entry.code, "code")?;
+  update_part(&mut hasher, "code", &code);
 
   for example in &entry.examples {
-    let rendered = cirru_parser::format(std::slice::from_ref(example), true.into())
-      .map_err(|error| format!("Failed to format definition example for revision: {error}"))?;
-    update_part(&mut hasher, "example", rendered.as_bytes());
+    let rendered = render_cirru_node_for_revision(example, "example")?;
+    update_part(&mut hasher, "example", &rendered);
   }
 
   for test in &entry.tests {
@@ -724,9 +737,8 @@ pub fn definition_revision(entry: &CodeEntry) -> Result<String, String> {
     for tag in tags {
       update_part(&mut hasher, "test-tag", tag.as_bytes());
     }
-    let rendered = cirru_parser::format(std::slice::from_ref(&test.code), true.into())
-      .map_err(|error| format!("Failed to format definition test for revision: {error}"))?;
-    update_part(&mut hasher, "test-code", rendered.as_bytes());
+    let rendered = render_cirru_node_for_revision(&test.code, "test")?;
+    update_part(&mut hasher, "test-code", &rendered);
   }
 
   if let Some(ffi) = &entry.ffi {
@@ -2558,6 +2570,22 @@ mod tests {
     assert_ne!(
       revision,
       definition_revision(&changed).expect("changed test revision should render")
+    );
+  }
+
+  #[test]
+  fn definition_revision_supports_leaf_examples_and_tests() {
+    let mut entry = revision_test_entry(&["public"]);
+    entry.examples = vec![Cirru::leaf("literal-example")];
+    entry.tests[0].code = Cirru::leaf("run-test");
+
+    let revision = definition_revision(&entry).expect("leaf code entries should have a revision");
+
+    assert!(revision.starts_with("md5:"));
+    entry.tests[0].code = Cirru::leaf("run-other-test");
+    assert_ne!(
+      revision,
+      definition_revision(&entry).expect("changed leaf test should have a revision")
     );
   }
 


### PR DESCRIPTION
## Summary
- accept quoted Cirru rule lists in `cr edit imports`, with JSON compatibility
- preserve quoted empty lists in transaction output and support leaf definition revisions
- raise the codegen worker stack for finite large module graphs
- correct tree path help and document serialized snapshot mutations

## Real-project validation
- Respo built-in tests: 35/35
- Router built-in tests: 6/6
- JS codegen: UI, Router, Reel, Alerts, and Markdown default/smoke/perf
- removed obsolete Lilac and external calcit-test dependencies from the validated module chain

## Core validation
- cargo fmt
- cargo clippy -- -D warnings
- yarn compile
- cargo test
- yarn check-agent-interface (12/12)
- yarn check-all (211 built-in Calcit tests plus JS/WASM checks)