### PR TITLE
chore: release 0.13.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.9"
+version = "0.13.10"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.9"
+version = "0.13.10"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608111349-release-0.13.10.md
+++ b/editing-history/202608111349-release-0.13.10.md
@@ -1,0 +1,13 @@
+# Release 0.13.10
+
+Release the agent migration convergence improvements merged in PR #333:
+
+- quoted Cirru import-list input for `cr edit imports`;
+- safe transaction round-tripping for quoted empty lists;
+- revision support for leaf examples and definition-attached tests;
+- a larger codegen worker stack for finite real-world module graphs;
+- corrected tree path help and serialized snapshot mutation guidance.
+
+The changes were validated against the Respo dependency chain without Lilac or
+the external `calcit-test` module, in addition to the full Calcit Rust, native,
+JavaScript, agent-interface, and WASM gates.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
Release 0.13.10 after PR #333.

Validation:
- cargo fmt
- cargo clippy -- -D warnings
- yarn compile
- cargo test
- yarn check-agent-interface (12/12)
- yarn check-all (211 built-in Calcit tests plus JS/WASM)