### PR TITLE
feat: allow omitted trailing Option parameters

### DIFF
--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -218,9 +218,19 @@
                       :args $ [] 'Tag (:: 'Optional 'Tag) (:: 'Optional 'Tag)
                       :return $ :: 'List (:: 'Optional 'Tag)
                     [] a b c
+                  f2 $ fn (a maybe-label maybe-count)
+                    hint-fn $ {}
+                      :args $ [] 'Number (:: 'Option 'String) (:: 'Option 'Number)
+                      :return $ :: 'List 'Dynamic
+                    [] a maybe-label maybe-count
                 assert= (f1 :a) ([] :a nil nil)
                 assert= (f1 :a :b) ([] :a :b nil)
                 assert= (f1 :a :b :c) ([] :a :b :c)
+                assert= (f2 1)
+                  [] 1 (%none) (%none)
+                assert=
+                  f2 2 $ %some |ready
+                  [] 2 (%some |ready) (%none)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -282,7 +282,24 @@ div
 - `map`、`filter`、`foldl` 等 Calcit 集合函数把集合放在前面；不确定参数顺序时运行 `cr query examples calcit.core/map` 或查询对应定义，不要套用 Clojure 记忆。
 - 改动缩进、`$`、`,` 或圆括号都会改变 AST 和 path；修改后重新 show/search，或继续使用 cursor。
 
-### 5.3 CLI 的 `quote` 是代码/数据边界
+### 5.3 可选参数优先使用 `Option`
+
+新代码优先用 `Option<T>` 表达“可能没有值”，减少通过参数列表里的 `?` 设置可选参数，也减少用 `nil` 表达缺失。函数末尾连续声明为 `Option<T>` 的参数可以在调用时省略；Calcit 会依次补成 `%none`：
+
+```cirru.no-check
+defn request (url trace-id timeout-ms)
+  hint-fn $ {}
+    :args $ [] 'String (:: 'Option 'String) (:: 'Option 'Number)
+    :return 'Unit
+  println url trace-id timeout-ms
+
+request |/health
+request |/health (%some |trace-1)
+```
+
+这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `%none` 或 `%some`，带 rest 参数的函数也不会自动补值。`?` 参数仍用于兼容已有的非类型化 API，其缺省值是 `nil`；修改旧接口时，优先逐步迁移到 `Option`。在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。
+
+### 5.4 CLI 的 `quote` 是代码/数据边界
 
 所有接收 AST 的 Cirru 文本输入都必须让 `quote` **恰好包住一个节点**；提交 mutation 时 CLI 会剥离这个 transport wrapper。JSON 数组 AST 是兼容输入，不需要 `quote`，但不要手写大型 JSON AST。
 
@@ -313,7 +330,7 @@ quote $ if ready?
 END
 ```
 
-### 5.4 写入前先解析，写入后再做语义检查
+### 5.5 写入前先解析，写入后再做语义检查
 
 ```bash
 cr cirru parse -e --validate 'a $ b c'

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -297,7 +297,7 @@ request |/health
 request |/health (%some |trace-1)
 ```
 
-这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `%none` 或 `%some`，带 rest 参数的函数也不会自动补值。`?` 参数仍用于兼容已有的非类型化 API，其缺省值是 `nil`；修改旧接口时，优先逐步迁移到 `Option`。在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。
+这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数仍用于兼容已有的非类型化 API，其缺省值是 `nil`；修改旧接口时，优先逐步迁移到 `Option`。在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。
 
 ### 5.4 CLI 的 `quote` 是代码/数据边界
 

--- a/history/202608111550-trailing-option-parameters.md
+++ b/history/202608111550-trailing-option-parameters.md
@@ -1,0 +1,6 @@
+## Trailing Option parameters
+
+- Treat only the continuous `Option<T>` suffix in a typed fixed-arity function schema as omittable; an earlier `Option<T>` does not make later required parameters optional, and rest parameters keep their existing behavior.
+- Fill omitted arguments with the nominal `calcit.core/Option` `%none` value in the native runtime and with the matching `%none` enum value in generated JavaScript.
+- Keep preprocessing arity checks and method-call validation aligned with runtime behavior so accepted calls do not produce false arity diagnostics.
+- Consolidate the end-to-end coverage beside the legacy `?` argument tests, documenting `Option` as the preferred replacement for `?` and `nil` in new typed APIs.

--- a/history/202608111610-review-core-option-identity.md
+++ b/history/202608111610-review-core-option-identity.md
@@ -1,0 +1,5 @@
+## Review follow-up: core Option identity
+
+- Omitted-argument sugar is reserved for source references to `calcit.core/Option`; resolved enum values do not retain a namespace and therefore cannot be safely treated as the core type.
+- A user-defined enum named `Option`, including one with `some` and `none` variants, keeps exact arity and never receives an implicit `%none` argument.
+- Documentation examples use callable enum constructors: `(%none)` and `(%some value)`.

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -38,6 +38,7 @@ pub use calcit_impl::CalcitImpl;
 pub use calcit_struct::CalcitStructDef;
 pub use calcit_trait::{CalcitTrait, CalcitTraitMemberKind};
 pub use enum_value::CalcitEnumValue;
+pub(crate) use fns::trailing_option_arg_count;
 pub use fns::{CalcitArgLabel, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitMacro, CalcitScope};
 pub use list::CalcitList;
 pub use local::CalcitLocal;

--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -4,6 +4,15 @@ use crate::Calcit;
 
 use super::{CalcitGenericBound, CalcitLocal, CalcitTypeAnnotation};
 
+/// Counts the continuous `Option<T>` suffix of a fixed-arity parameter list.
+/// Incomplete type metadata is not enough to make any parameter omittable.
+pub(crate) fn trailing_option_arg_count(arg_types: &[Arc<CalcitTypeAnnotation>], param_len: usize) -> usize {
+  if arg_types.len() != param_len {
+    return 0;
+  }
+  arg_types.iter().rev().take_while(|arg| arg.is_option_type()).count()
+}
+
 /// structure of a function arguments
 #[derive(Debug, Clone)]
 pub enum CalcitArgLabel {
@@ -129,6 +138,20 @@ mod tests {
         .iter()
         .all(|item| matches!(**item, CalcitTypeAnnotation::Dynamic))
     );
+  }
+
+  #[test]
+  fn counts_only_continuous_option_suffix() {
+    let option_number = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    let types = vec![option_number.clone(), Arc::new(CalcitTypeAnnotation::String), option_number.clone()];
+    assert_eq!(trailing_option_arg_count(&types, 3), 1);
+
+    let types = vec![Arc::new(CalcitTypeAnnotation::Number), option_number.clone(), option_number];
+    assert_eq!(trailing_option_arg_count(&types, 3), 2);
+    assert_eq!(trailing_option_arg_count(&types, 4), 0, "partial metadata must keep exact arity");
   }
 }
 

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -325,18 +325,18 @@ pub enum CalcitTypeAnnotation {
 }
 
 impl CalcitTypeAnnotation {
-  /// Whether this annotation is the nominal `calcit.core/Option` type.
+  /// Whether this annotation is a source reference to the nominal `calcit.core/Option` type.
   ///
   /// This intentionally does not treat legacy `Optional<T>` as `Option<T>`:
-  /// the former uses `nil`, while the latter uses the named `:none` variant.
+  /// the former uses `nil`, while the latter uses the named `:none` variant. A resolved enum
+  /// does not retain its namespace, so it is deliberately excluded: a user enum named `Option`
+  /// must not acquire core `Option`'s omitted-argument behavior.
   pub(crate) fn is_option_type(&self) -> bool {
     match self {
       Self::TypeRef(name, args) => {
         let name = name.trim_start_matches('\'').trim_start_matches(':');
         args.len() == 1 && matches!(name, "Option" | "calcit.core/Option")
       }
-      Self::Enum(enum_def, args) => enum_def.name().ref_str() == "Option" && args.len() == 1,
-      Self::EnumValue(enum_def) => enum_def.name().ref_str() == "Option",
       Self::TypeSlot(name) => resolve_type_slot(name).is_some_and(|bound| bound.is_option_type()),
       _ => false,
     }
@@ -3700,6 +3700,32 @@ mod tests {
       })
       .expect("valid generic enum"),
     )
+  }
+
+  #[test]
+  fn trailing_option_sugar_requires_a_core_option_reference() {
+    let number = Arc::new(CalcitTypeAnnotation::Number);
+    let core_short = CalcitTypeAnnotation::TypeRef(Arc::from("Option"), Arc::new(vec![number.clone()]));
+    let core_qualified = CalcitTypeAnnotation::TypeRef(Arc::from("calcit.core/Option"), Arc::new(vec![number.clone()]));
+    let user_qualified = CalcitTypeAnnotation::TypeRef(Arc::from("app.main/Option"), Arc::new(vec![number.clone()]));
+    assert!(core_short.is_option_type());
+    assert!(core_qualified.is_option_type());
+    assert!(!user_qualified.is_option_type());
+
+    let user_option = CalcitEnumDef::from_struct(CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef {
+        name: EdnTag::new("Option"),
+        fields: Arc::new(vec![EdnTag::new("some"), EdnTag::new("none")]),
+        field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
+        generics: Arc::new(vec![Arc::from("T")]),
+        where_bounds: Arc::new(vec![]),
+        impls: vec![],
+      }),
+      values: Arc::new(vec![Calcit::from(vec![symbol("T")]), Calcit::Nil]),
+    })
+    .expect("valid user Option enum");
+    let resolved_user_option = CalcitTypeAnnotation::Enum(Arc::new(user_option), Arc::new(vec![number]));
+    assert!(!resolved_user_option.is_option_type());
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -325,6 +325,23 @@ pub enum CalcitTypeAnnotation {
 }
 
 impl CalcitTypeAnnotation {
+  /// Whether this annotation is the nominal `calcit.core/Option` type.
+  ///
+  /// This intentionally does not treat legacy `Optional<T>` as `Option<T>`:
+  /// the former uses `nil`, while the latter uses the named `:none` variant.
+  pub(crate) fn is_option_type(&self) -> bool {
+    match self {
+      Self::TypeRef(name, args) => {
+        let name = name.trim_start_matches('\'').trim_start_matches(':');
+        args.len() == 1 && matches!(name, "Option" | "calcit.core/Option")
+      }
+      Self::Enum(enum_def, args) => enum_def.name().ref_str() == "Option" && args.len() == 1,
+      Self::EnumValue(enum_def) => enum_def.name().ref_str() == "Option",
+      Self::TypeSlot(name) => resolve_type_slot(name).is_some_and(|bound| bound.is_option_type()),
+      _ => false,
+    }
+  }
+
   fn bind_declared_generics_from_applied_args(
     declared_generics: &[Arc<str>],
     applied_args: &[Arc<CalcitTypeAnnotation>],

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -477,7 +477,20 @@ fn gen_call_code(
               local_defs,
               file_imports,
             };
-            let ret = gen_js_func(sym, &get_raw_args_fn(ys)?, &func_body.to_vec(), &passed_defs, false, tags, ns);
+            let arg_types = extract_fn_param_types(ys);
+            let raw_args = get_raw_args_fn(ys)?;
+            let ret = gen_js_func(
+              sym,
+              JsFnParams {
+                args: &raw_args,
+                arg_types: &arg_types,
+              },
+              &func_body.to_vec(),
+              &passed_defs,
+              false,
+              tags,
+              ns,
+            );
             gen_stack::pop_call_stack();
             match ret {
               Ok(code) => Ok(format!("{return_code}{code}")),
@@ -1449,15 +1462,22 @@ fn uses_recur(xs: &Calcit) -> bool {
   }
 }
 
+struct JsFnParams<'a> {
+  args: &'a CalcitFnArgs,
+  arg_types: &'a [Arc<calcit::CalcitTypeAnnotation>],
+}
+
 fn gen_js_func(
   name: &str,
-  args: &CalcitFnArgs,
+  params: JsFnParams<'_>,
   raw_body: &[Calcit],
   passed_defs: &PassedDefs,
   exported: bool,
   tags: &RefCell<HashSet<EdnTag>>,
   at_ns: &str,
 ) -> Result<String, String> {
+  let args = params.args;
+  let arg_types = params.arg_types;
   let var_prefix = if passed_defs.ns == "calcit.core" { "" } else { "$clt." };
   let mut local_defs = passed_defs.local_defs.to_owned();
   let mut spreading_code = String::from(""); // js list and calcit-js list are different, need to convert
@@ -1467,6 +1487,14 @@ fn gen_js_func(
   let mut args_count = 0;
   let mut optional_count = 0;
   let mut recur_arg_names: Vec<String> = vec![];
+  let mut fixed_arg_names: Vec<String> = vec![];
+  let has_rest_param =
+    matches!(args, CalcitFnArgs::MarkedArgs(labels) if labels.iter().any(|label| matches!(label, CalcitArgLabel::RestMark)));
+  let trailing_option_count = if has_rest_param {
+    0
+  } else {
+    calcit::trailing_option_arg_count(arg_types, args.param_len())
+  };
 
   match args {
     CalcitFnArgs::MarkedArgs(args) => {
@@ -1497,7 +1525,9 @@ fn gen_js_func(
               args_code.push_str(", ");
             }
             let sym = CalcitLocal::read_name(*idx);
-            args_code.push_str(&escape_var(&sym));
+            let arg_name = escape_var(&sym);
+            args_code.push_str(&arg_name);
+            fixed_arg_names.push(arg_name);
             local_defs.insert(sym.into());
             optional_count += 1;
           } else {
@@ -1518,6 +1548,7 @@ fn gen_js_func(
               let sym = CalcitLocal::read_name(*idx);
               let arg_name = escape_var(&sym);
               args_code.push_str(&arg_name);
+              fixed_arg_names.push(arg_name.clone());
               recur_arg_names.push(arg_name);
               local_defs.insert(sym.into());
               args_count += 1;
@@ -1534,6 +1565,7 @@ fn gen_js_func(
         let sym = CalcitLocal::read_name(*idx);
         let arg_name = escape_var(&sym);
         args_code.push_str(&arg_name);
+        fixed_arg_names.push(arg_name.clone());
         recur_arg_names.push(arg_name);
         local_defs.insert(sym.into());
         args_count += 1;
@@ -1545,11 +1577,38 @@ fn gen_js_func(
     "".into()
   } else if spreading {
     snippets::tmpl_args_fewer_than(name, args_count, at_ns)
+  } else if trailing_option_count > 0 {
+    let option_required = args.param_len() - trailing_option_count;
+    let required = if has_optional {
+      args_count.min(option_required)
+    } else {
+      option_required
+    };
+    snippets::tmpl_args_between(name, required, args.param_len(), at_ns)
   } else if has_optional {
     snippets::tmpl_args_between(name, args_count, args_count + optional_count, at_ns)
   } else {
     snippets::tmpl_args_exact(name, args_count, at_ns)
   };
+
+  let option_fill_code = if trailing_option_count == 0 {
+    String::new()
+  } else {
+    let option_start = args.param_len() - trailing_option_count;
+    let none_call = format!("{var_prefix}{}()", escape_var("%none"));
+    fixed_arg_names
+      .iter()
+      .enumerate()
+      .skip(option_start)
+      .map(|(idx, arg_name)| format!("if (arguments.length >= {option_start} && arguments.length <= {idx}) {arg_name} = {none_call};"))
+      .collect::<Vec<_>>()
+      .join("\n")
+  };
+  let entry_check_code = [check_args.trim(), option_fill_code.trim()]
+    .into_iter()
+    .filter(|part| !part.is_empty())
+    .collect::<Vec<_>>()
+    .join("\n");
 
   let recur_assign_code_template = if !spreading && !has_optional {
     let mut code = String::new();
@@ -1605,7 +1664,7 @@ fn gen_js_func(
     let fn_def = snippets::tmpl_tail_recursion(
       /* name = */ escape_var(name),
       /* args_code = */ args_code,
-      /* check_args = */ check_args,
+      /* check_args = */ entry_check_code,
       /* spreading_code = */ spreading_code,
       /* recur_assign_code_template = */ recur_assign_code_template,
       /* body = */
@@ -1628,8 +1687,8 @@ fn gen_js_func(
     // `check_args` and `spreading_code` both contribute to the prologue; keep
     // each on its own line without leaving a leading blank line.
     let mut header_parts: Vec<&str> = vec![];
-    if !check_args.trim().is_empty() {
-      header_parts.push(check_args.trim());
+    if !entry_check_code.trim().is_empty() {
+      header_parts.push(entry_check_code.trim());
     }
     if !spreading_code.trim().is_empty() {
       header_parts.push(spreading_code.trim());
@@ -1718,7 +1777,23 @@ fn is_schema_map_form(form: &Calcit) -> bool {
   }
 }
 
-fn extract_preprocessed_fn_parts(code: &Calcit) -> Result<(CalcitFnArgs, Vec<Calcit>), String> {
+fn extract_fn_param_types(args: &CalcitList) -> Vec<Arc<calcit::CalcitTypeAnnotation>> {
+  args
+    .iter()
+    .filter_map(|arg| match arg {
+      Calcit::Local(local) => Some(local.type_info.clone()),
+      _ => None,
+    })
+    .collect()
+}
+
+struct PreprocessedFnParts {
+  args: CalcitFnArgs,
+  arg_types: Vec<Arc<calcit::CalcitTypeAnnotation>>,
+  body: Vec<Calcit>,
+}
+
+fn extract_preprocessed_fn_parts(code: &Calcit) -> Result<PreprocessedFnParts, String> {
   let Calcit::List(items) = code else {
     return Err(format!("expected preprocessed defn list, got: {code}"));
   };
@@ -1730,7 +1805,11 @@ fn extract_preprocessed_fn_parts(code: &Calcit) -> Result<(CalcitFnArgs, Vec<Cal
       Some(Calcit::List(args)),
     ) => {
       let raw_args = get_raw_args_fn(args)?;
-      Ok((raw_args, items.drop_left().drop_left().drop_left().to_vec()))
+      Ok(PreprocessedFnParts {
+        args: raw_args,
+        arg_types: extract_fn_param_types(args),
+        body: items.drop_left().drop_left().drop_left().to_vec(),
+      })
     }
     _ => Err(format!("expected preprocessed defn form, got: {code}")),
   }
@@ -1822,7 +1901,7 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
           writeln!(defs_code, "\nvar {} = $procs.{};", escape_var(&def), escape_var(&def)).expect("write");
         }
         program::CompiledDefKind::Fn => {
-          let (raw_args, raw_body) = extract_preprocessed_fn_parts(&compiled_def.preprocessed_code)?;
+          let fn_parts = extract_preprocessed_fn_parts(&compiled_def.preprocessed_code)?;
           gen_stack::push_call_stack(ns, &def, StackKind::Codegen, compiled_def.preprocessed_code.to_owned(), &[]);
           let passed_defs = PassedDefs {
             ns,
@@ -1833,7 +1912,18 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
           if !defs_code.is_empty() {
             defs_code.push('\n');
           }
-          defs_code.push_str(&gen_js_func(&def, &raw_args, &raw_body, &passed_defs, true, &collected_tags, ns)?);
+          defs_code.push_str(&gen_js_func(
+            &def,
+            JsFnParams {
+              args: &fn_parts.args,
+              arg_types: &fn_parts.arg_types,
+            },
+            &fn_parts.body,
+            &passed_defs,
+            true,
+            &collected_tags,
+            ns,
+          )?);
           gen_stack::pop_call_stack();
         }
         program::CompiledDefKind::LazyValue => {
@@ -2102,7 +2192,19 @@ mod tests {
     let args = CalcitFnArgs::Args(vec![]);
     let raw_body = vec![Calcit::RawCode(calcit::RawCodeType::Js, Arc::from("let t = `line1\nline2`;"))];
 
-    let code = gen_js_func("demo", &args, &raw_body, &passed_defs, true, &tags, "tests.emit-js").expect("raw-code body should compile");
+    let code = gen_js_func(
+      "demo",
+      JsFnParams {
+        args: &args,
+        arg_types: &[],
+      },
+      &raw_body,
+      &passed_defs,
+      true,
+      &tags,
+      "tests.emit-js",
+    )
+    .expect("raw-code body should compile");
     // Multiline raw-code must stay byte-for-byte: the second line is not indented.
     assert!(code.contains("let t = `line1\nline2`;"), "raw-code changed:\n{code}");
     assert!(code.contains("\nline2`;"), "raw-code newline content indented:\n{code}");
@@ -2132,14 +2234,73 @@ mod tests {
 
     let prev = crate::codegen::skip_arity_check();
     crate::codegen::set_code_gen_skip_arity_check(true);
-    let code =
-      gen_js_func("demo", &args, &raw_body, &passed_defs, true, &tags, "tests.emit-js").expect("spreading body should compile");
+    let code = gen_js_func(
+      "demo",
+      JsFnParams {
+        args: &args,
+        arg_types: &[],
+      },
+      &raw_body,
+      &passed_defs,
+      true,
+      &tags,
+      "tests.emit-js",
+    )
+    .expect("spreading body should compile");
     crate::codegen::set_code_gen_skip_arity_check(prev);
 
     assert!(!code.contains("{\n\n"), "no leading blank line expected:\n{code}");
     assert!(
       code.contains("{\n  xs = $clt.arrayToList(xs);"),
       "spreading should be the first indented line:\n{code}"
+    );
+  }
+
+  #[test]
+  fn trailing_option_params_are_filled_with_none() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let passed_defs = PassedDefs {
+      ns: "tests.emit-js",
+      local_defs: &local_defs,
+      file_imports: &file_imports,
+    };
+    let first = CalcitLocal::track_sym(&Arc::from("required"));
+    let second = CalcitLocal::track_sym(&Arc::from("optional"));
+    let args = CalcitFnArgs::Args(vec![first, second]);
+    let option_number = Arc::new(calcit::CalcitTypeAnnotation::TypeRef(
+      Arc::from("Option"),
+      Arc::new(vec![Arc::new(calcit::CalcitTypeAnnotation::Number)]),
+    ));
+    let arg_types = vec![Arc::new(calcit::CalcitTypeAnnotation::Number), option_number];
+    let raw_body = vec![Calcit::Local(CalcitLocal {
+      idx: second,
+      sym: Arc::from("optional"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.emit-js"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: arg_types[1].clone(),
+    })];
+
+    let code = gen_js_func(
+      "demo",
+      JsFnParams {
+        args: &args,
+        arg_types: &arg_types,
+      },
+      &raw_body,
+      &passed_defs,
+      true,
+      &tags,
+      "tests.emit-js",
+    )
+    .expect("Option defaults should compile");
+    assert!(
+      code.contains("optional = $clt._PCT_none();"),
+      "omitted Option should be initialized with %none:\n{code}"
     );
   }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -7,13 +7,14 @@ use std::vec;
 
 use crate::builtins;
 use crate::calcit::{
-  CORE_NS, Calcit, CalcitArgLabel, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitImport, CalcitList, CalcitLocal, CalcitProc,
-  CalcitScope, CalcitSyntax, MethodKind, NodeLocation,
+  CORE_NS, Calcit, CalcitArgLabel, CalcitEnumValue, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitImport, CalcitList,
+  CalcitLocal, CalcitProc, CalcitScope, CalcitSyntax, MethodKind, NodeLocation, trailing_option_arg_count,
 };
 use crate::call_stack::{CallStackList, StackKind, using_stack};
 use crate::data::cirru;
 use crate::program;
 use crate::util::string::has_ns_part;
+use cirru_edn::EdnTag;
 
 fn build_runtime_cell_error(ns: &str, def: &str, call_stack: &CallStackList, cell: program::RuntimeCell) -> CalcitErr {
   match cell {
@@ -532,7 +533,51 @@ pub fn eval_symbol_from_program(sym: &str, ns: &str, call_stack: &CallStackList)
   Ok(None)
 }
 
+fn option_none_value(expected_type: &crate::calcit::CalcitTypeAnnotation) -> Option<Calcit> {
+  if !expected_type.is_option_type() {
+    return None;
+  }
+  let enum_def = expected_type.resolve_to_enum()?;
+  let none_variant = enum_def.find_variant_by_name("none")?;
+  if enum_def.name().ref_str() != "Option" || none_variant.arity() != 0 {
+    return None;
+  }
+  Some(Calcit::Enum(CalcitEnumValue {
+    tag: Arc::new(Calcit::Tag(EdnTag::new("none"))),
+    extra: vec![],
+    sum_type: Some(Arc::new(enum_def)),
+  }))
+}
+
+/// Fill only a continuous trailing run of omitted `Option<T>` parameters.
+/// A rest parameter keeps the function variadic and therefore disables this sugar.
+fn complete_trailing_option_args(values: &[Calcit], info: &CalcitFn) -> Option<Vec<Calcit>> {
+  if info.rest_type.is_some()
+    || matches!(info.args.as_ref(), CalcitFnArgs::MarkedArgs(args) if args.iter().any(|arg| matches!(arg, CalcitArgLabel::RestMark)))
+  {
+    return None;
+  }
+
+  let param_len = info.args.param_len();
+  let optional_count = trailing_option_arg_count(&info.arg_types, param_len);
+  let required_len = param_len.saturating_sub(optional_count);
+  if optional_count == 0 || values.len() < required_len || values.len() >= param_len {
+    return None;
+  }
+
+  let missing = info.arg_types[values.len()..]
+    .iter()
+    .map(|expected| option_none_value(expected.as_ref()))
+    .collect::<Option<Vec<_>>>()?;
+  let mut completed = Vec::with_capacity(param_len);
+  completed.extend_from_slice(values);
+  completed.extend(missing);
+  Some(completed)
+}
+
 pub fn run_fn(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  let completed_values = complete_trailing_option_args(values, info);
+  let values = completed_values.as_deref().unwrap_or(values);
   let mut body_scope = (*info.scope).to_owned();
   match &*info.args {
     CalcitFnArgs::Args(args) => {
@@ -574,6 +619,7 @@ pub fn run_fn(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) ->
 
 /// quick path for `run_fn` which takes ownership of values
 pub fn run_fn_owned(values: Vec<Calcit>, info: &CalcitFn, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  let values = complete_trailing_option_args(&values, info).unwrap_or(values);
   let mut body_scope = (*info.scope).to_owned();
   match &*info.args {
     CalcitFnArgs::Args(args) => {
@@ -854,4 +900,65 @@ pub fn evaluate_spreaded_args_from(
   })?;
   // println!("Evaluated args: {}", ret);
   Ok(ret)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::calcit::{CalcitFnUsageMeta, CalcitStructDef, CalcitStructValue, CalcitTypeAnnotation};
+
+  fn option_type() -> Arc<CalcitTypeAnnotation> {
+    let option_def = crate::calcit::CalcitEnumDef::from_struct(CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(
+        EdnTag::new("Option"),
+        vec![EdnTag::new("some"), EdnTag::new("none")],
+      )),
+      values: Arc::new(vec![Calcit::from(vec![Calcit::tag("dynamic")]), Calcit::Nil]),
+    })
+    .expect("valid Option enum");
+    Arc::new(CalcitTypeAnnotation::Enum(
+      Arc::new(option_def),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ))
+  }
+
+  fn fn_info(arg_types: Vec<Arc<CalcitTypeAnnotation>>) -> CalcitFn {
+    let args = (0..arg_types.len()).map(|idx| idx as u16).collect();
+    CalcitFn {
+      name: Arc::from("with-options"),
+      def_ns: Arc::from("tests.runner"),
+      def_ref: None,
+      usage: CalcitFnUsageMeta::default(),
+      scope: Arc::new(CalcitScope::default()),
+      args: Arc::new(CalcitFnArgs::Args(args)),
+      body: vec![],
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      return_type: crate::calcit::DYNAMIC_TYPE.clone(),
+      arg_types,
+      rest_type: None,
+    }
+  }
+
+  #[test]
+  fn fills_omitted_trailing_options_with_none() {
+    let option = option_type();
+    let info = fn_info(vec![Arc::new(CalcitTypeAnnotation::Number), option.clone(), option]);
+    let completed = complete_trailing_option_args(&[Calcit::Number(1.0)], &info).expect("two omitted Option args");
+    assert_eq!(completed.len(), 3);
+    assert!(completed[1..].iter().all(
+      |value| matches!(value, Calcit::Enum(enum_value) if matches!(enum_value.tag.as_ref(), Calcit::Tag(tag) if tag.ref_str() == "none"))
+    ));
+  }
+
+  #[test]
+  fn does_not_skip_required_parameter_before_option_suffix() {
+    let option = option_type();
+    let info = fn_info(vec![option.clone(), Arc::new(CalcitTypeAnnotation::Number), option]);
+    assert!(complete_trailing_option_args(&[Calcit::Number(1.0)], &info).is_none());
+
+    let completed =
+      complete_trailing_option_args(&[Calcit::Number(1.0), Calcit::Number(2.0)], &info).expect("only the final Option is omittable");
+    assert_eq!(completed.len(), 3);
+  }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -907,7 +907,7 @@ mod tests {
   use super::*;
   use crate::calcit::{CalcitFnUsageMeta, CalcitStructDef, CalcitStructValue, CalcitTypeAnnotation};
 
-  fn option_type() -> Arc<CalcitTypeAnnotation> {
+  fn user_option_type() -> Arc<CalcitTypeAnnotation> {
     let option_def = crate::calcit::CalcitEnumDef::from_struct(CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef::from_fields(
         EdnTag::new("Option"),
@@ -941,24 +941,9 @@ mod tests {
   }
 
   #[test]
-  fn fills_omitted_trailing_options_with_none() {
-    let option = option_type();
+  fn does_not_fill_user_defined_option_enums() {
+    let option = user_option_type();
     let info = fn_info(vec![Arc::new(CalcitTypeAnnotation::Number), option.clone(), option]);
-    let completed = complete_trailing_option_args(&[Calcit::Number(1.0)], &info).expect("two omitted Option args");
-    assert_eq!(completed.len(), 3);
-    assert!(completed[1..].iter().all(
-      |value| matches!(value, Calcit::Enum(enum_value) if matches!(enum_value.tag.as_ref(), Calcit::Tag(tag) if tag.ref_str() == "none"))
-    ));
-  }
-
-  #[test]
-  fn does_not_skip_required_parameter_before_option_suffix() {
-    let option = option_type();
-    let info = fn_info(vec![option.clone(), Arc::new(CalcitTypeAnnotation::Number), option]);
     assert!(complete_trailing_option_args(&[Calcit::Number(1.0)], &info).is_none());
-
-    let completed =
-      complete_trailing_option_args(&[Calcit::Number(1.0), Calcit::Number(2.0)], &info).expect("only the final Option is omittable");
-    assert_eq!(completed.len(), 3);
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1357,10 +1357,10 @@ fn preprocess_list_call(
     Some(Calcit::Fn { info, .. }) => {
       match &*info.args {
         CalcitFnArgs::MarkedArgs(xs) => {
-          check_fn_marked_args(xs, &args, file_ns, &info.name, &def_name, check_warnings);
+          check_fn_marked_args(xs, &info.arg_types, &args, file_ns, &info.name, &def_name, check_warnings);
         }
         CalcitFnArgs::Args(xs) => {
-          check_fn_args(xs, &args, file_ns, &info.name, &def_name, check_warnings);
+          check_fn_args(xs, &info.arg_types, &args, file_ns, &info.name, &def_name, check_warnings);
         }
       }
       let mut ys = CalcitList::new_inner_from(std::slice::from_ref(&head_form));
@@ -2219,12 +2219,24 @@ fn data_definition_kind(ns: &str, def: &str) -> Option<&'static str> {
 /// detects arguments of top-level functions when possible
 fn check_fn_marked_args(
   defined_args: &[CalcitArgLabel],
+  arg_types: &[Arc<CalcitTypeAnnotation>],
   params: &CalcitList,
   file_ns: &str,
   f_name: &str,
   def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
+  let param_len = defined_args.iter().filter(|arg| matches!(arg, CalcitArgLabel::Idx(_))).count();
+  let has_rest = defined_args.iter().any(|arg| matches!(arg, CalcitArgLabel::RestMark));
+  let trailing_options = if has_rest {
+    0
+  } else {
+    calcit::trailing_option_arg_count(arg_types, param_len)
+  };
+  if trailing_options > 0 && (param_len - trailing_options..=param_len).contains(&params.len()) {
+    return;
+  }
+
   let mut i = 0;
   let mut j = 0;
   let mut optional = false;
@@ -2283,6 +2295,7 @@ fn check_fn_marked_args(
 /// quick path check function without marks
 fn check_fn_args(
   defined_args: &[u16],
+  arg_types: &[Arc<CalcitTypeAnnotation>],
   params: &CalcitList,
   file_ns: &str,
   f_name: &str,
@@ -2291,6 +2304,7 @@ fn check_fn_args(
 ) {
   let expected_size = defined_args.len();
   let actual_size = params.len();
+  let trailing_options = calcit::trailing_option_arg_count(arg_types, expected_size);
 
   for (idx, item) in params.iter().enumerate() {
     if let Calcit::Syntax(CalcitSyntax::ArgSpread, _) = item {
@@ -2306,7 +2320,8 @@ fn check_fn_args(
     }
   }
 
-  if expected_size != actual_size {
+  let accepts_omission = trailing_options > 0 && (expected_size - trailing_options..=expected_size).contains(&actual_size);
+  if expected_size != actual_size && !accepts_omission {
     gen_check_warning(
       format!("[Warn] expected {expected_size} args in {f_name} `{defined_args:?}` with `{params}`, at {file_ns}/{def_name}"),
       file_ns,
@@ -2873,7 +2888,13 @@ fn check_struct_method_args(
 
     let expected_count = signature.arg_types.len();
     let actual_with_receiver = method_args.len() + 1;
-    if expected_count != 0 && expected_count != actual_with_receiver {
+    let trailing_options = if signature.rest_type.is_none() {
+      calcit::trailing_option_arg_count(&signature.arg_types, expected_count)
+    } else {
+      0
+    };
+    let accepts_omission = trailing_options > 0 && (expected_count - trailing_options..=expected_count).contains(&actual_with_receiver);
+    if expected_count != 0 && expected_count != actual_with_receiver && !accepts_omission {
       gen_check_warning(
         format!(
           "[Warn] Method `.{method_name}` expects {expected_count} args (including receiver), got {actual_with_receiver} in call at {file_ns}/{def_name}"
@@ -2952,7 +2973,13 @@ fn check_struct_method_args(
     };
     let expected_count = signature.arg_types.len();
     let actual_with_receiver = method_args.len() + 1;
-    if expected_count != 0 && expected_count != actual_with_receiver {
+    let trailing_options = if signature.rest_type.is_none() {
+      calcit::trailing_option_arg_count(&signature.arg_types, expected_count)
+    } else {
+      0
+    };
+    let accepts_omission = trailing_options > 0 && (expected_count - trailing_options..=expected_count).contains(&actual_with_receiver);
+    if expected_count != 0 && expected_count != actual_with_receiver && !accepts_omission {
       gen_check_warning(
         format!(
           "[Warn] Method `.{method_name}` expects {expected_count} args (including receiver), got {actual_with_receiver} in call at {file_ns}/{def_name}"
@@ -3022,7 +3049,13 @@ fn check_struct_method_args(
     CalcitFnArgs::Args(_) => false,
   };
 
-  if !has_variadic && expected_count != actual_with_receiver {
+  let trailing_options = if has_variadic {
+    0
+  } else {
+    calcit::trailing_option_arg_count(&fn_info.arg_types, expected_count)
+  };
+  let accepts_omission = trailing_options > 0 && (expected_count - trailing_options..=expected_count).contains(&actual_with_receiver);
+  if !has_variadic && expected_count != actual_with_receiver && !accepts_omission {
     gen_check_warning(
       format!(
         "[Warn] Method `.{method_name}` expects {expected_count} args (including receiver), got {actual_with_receiver} in call at {file_ns}/{def_name}"


### PR DESCRIPTION
## Summary

- allow calls to omit a continuous suffix of typed Option parameters and fill each omitted value with Option none
- align native runtime, JS codegen, preprocessing arity checks, and method calls
- consolidate coverage with the existing optional-argument tests and document Option as the preferred typed API style

## Boundaries

- only a continuous trailing Option suffix is omittable
- an Option before a required parameter remains explicit
- rest-parameter functions retain their current behavior

## Validation

- cargo fmt
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-agent-interface
- yarn check-all
- target/debug/cr docs check-md docs/CalcitAgent.md --entry calcit/test.cirru