### PR TITLE
fix: terminate JS string replacement

### DIFF
--- a/history/202608111624-js-string-replace-termination.md
+++ b/history/202608111624-js-string-replace-termination.md
@@ -1,0 +1,5 @@
+## JS string replacement termination
+
+- `&str:replace` must replace each original literal match exactly once; repeatedly replacing until the pattern disappears loops forever when the replacement contains the pattern.
+- Escape the literal pattern and use a global callback replacement so replacement text remains literal too, including `$` sequences.
+- Keep empty-pattern behavior aligned with Rust `str::replace`, and cover self-containing replacements, regex metacharacters, literal replacement text, and empty patterns in the JS runtime regression script.

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -17,6 +17,17 @@ try {
   const runtimeB = await import(pathToFileURL(join(runtimeBPath, "calcit.procs.mjs")).href);
   assert.equal(runtimeA.get_env, runtimeA._$n_get_env, "legacy get_env export should delegate to the raw proc");
   assert.equal(runtimeA.get_env("CALCIT_MISSING_ENV_FOR_RUNTIME_TEST", "fallback"), "fallback");
+  assert.equal(
+    runtimeA._$n_str_$o_replace("a&a&", "&", "&amp;"),
+    "a&amp;a&amp;",
+    "string replacement must finish when the replacement contains the pattern"
+  );
+  assert.equal(
+    runtimeA._$n_str_$o_replace("a.b", ".", "$&"),
+    "a$&b",
+    "string replacement must treat patterns and replacement text literally"
+  );
+  assert.equal(runtimeA._$n_str_$o_replace("ab", "", "-"), "-a-b-", "empty string patterns should replace each boundary");
 
   const todoName = runtimeA.newTag("TodoState");
   const todoField = runtimeA.newTag("draft");

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1329,11 +1329,11 @@ export let _$n_set_$o_intersection = (xs: CalcitSet, ys: CalcitSet): CalcitSet =
 };
 
 export let _$n_str_$o_replace = (x: string, y: string, z: string): string => {
-  var result = x;
-  while (result.indexOf(y) >= 0) {
-    result = result.replace(y, z);
-  }
-  return result;
+  // Use a callback replacement so `$` sequences in `z` remain literal, matching Rust's
+  // `str::replace`. Escaping `y` preserves the proc's literal-pattern contract, while the
+  // global regex completes each original match once even when `z` contains `y`.
+  const literalPattern = y.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return x.replace(new RegExp(literalPattern, "gu"), () => z);
 };
 
 export let split = (xs: string, x: string): CalcitSliceList => {


### PR DESCRIPTION
Fixes #335.

## Summary

- replace each original literal match once instead of repeatedly rewriting the result
- preserve literal replacement text, including dollar sequences
- cover replacements containing the pattern, regex metacharacters, and empty patterns

## Validation

- yarn check-js-runtime
- yarn check-all
- cargo fmt
- cargo clippy -- -D warnings
- cargo test