### PR TITLE
chore: release 0.13.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.10"
+version = "0.13.11"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/history/202608111650-release-0.13.11.md
+++ b/history/202608111650-release-0.13.11.md
@@ -1,0 +1,5 @@
+## Release 0.13.11
+
+- Bump the Cargo crate and `@calcit/procs` package together so published artifacts stay version-aligned.
+- This release includes trailing `Option` parameter sugar, stronger typed Option/struct handling, and the terminating JS string replacement fix from the preceding merged PRs.
+- Run the full repository validation before tagging and publishing the release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
Release 0.13.11

- Bump Cargo crate and @calcit/procs package versions together.
- Includes trailing Option parameter sugar, typed Option/struct handling, and the JS string replacement termination fix from merged PRs.
- Local validation: cargo fmt, cargo clippy -- -D warnings, cargo test, yarn compile, yarn check-all.

After required CI passes, merge this PR, then tag 0.13.11 and publish the GitHub release.