### PR TITLE
feat: support typed struct constructor sugar

### DIFF
--- a/202608121618-type-guidance.md
+++ b/202608121618-type-guidance.md
@@ -1,0 +1,6 @@
+# 类型强化与 Dynamic 审计记录
+
+- 为 `cr` 增加运行/编译阶段的 Dynamic 用量统计，按占比输出 stderr notice/warning，不影响 stdout 的机器可解析性。
+- 新增 `option:or-else` 与 `result:or-else`，并注册到 Option/Result 方法表，支持惰性 fallback 级联。
+- 在 `CalcitAgent.md` 与 `docs/type-guidance.md` 中整理 Dynamic、Option/Result、get-in/update-in 和 Enum 头部构造的推荐实践。
+- 保留 `%::` 作为显式 prototype/动态边界；已知 Enum 优先使用 `Enum :tag ...`，交给类型分析降为命名构造。

--- a/202608121730-struct-option-constructor.md
+++ b/202608121730-struct-option-constructor.md
@@ -1,0 +1,6 @@
+# Struct 头部构造与 Option 缺省字段
+
+- Struct 定义现在统一支持 `Struct :field value` 的类型化头部调用语法。
+- 构造器继续要求所有非 Option 字段显式提供，并校验字段名称、重复字段和字段值类型。
+- 名义 `Option<T>` 字段可以省略，预处理会补成 `%none`；旧 `Optional<T>` 仍保持 `nil` 兼容语义。
+- 补充 Struct、CalcitAgent 和类型指导文档，并新增预处理回归测试。

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -299,6 +299,30 @@ request |/health (%some |trace-1)
 
 这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数仍用于兼容已有的非类型化 API，其缺省值是 `nil`；修改旧接口时，优先逐步迁移到 `Option`。在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。
 
+Option/Result 的级联优先使用组合函数，不要在每一层都 `unwrap`：
+
+```cirru.no-check
+option:and-then profile
+  fn (profile)
+    option:and-then (get-in profile $ [] :account)
+      fn (account) $ get account :name
+
+result:and-then parsed
+  fn (value) $ validate value
+```
+
+需要尝试备用来源时使用 `option:or-else` 或 `result:or-else`；它们只在 `none`/`err` 分支调用 fallback。`option:unwrap` 只适合已经由 `tag-match`、`option:some?` 或明确不变量证明为 `some` 的位置；默认值用 `option:unwrap-or`，继续转换用 `option:map` / `option:and-then`。
+
+`get-in` 返回 `Option<T>`，适合 Map/List/字符串等可能缺失的路径；路径进入 Struct 时应改用类型化的 `(:field value)` 访问，字段需要可缺失时在 Struct 中声明 `Option<T>`。`update-in` 的 updater 接收 `Option<T>`，缺失分支应显式处理，不要无条件 unwrap：
+
+```cirru.no-check
+update-in data ([] :profile :visits)
+  fn (current)
+    option:unwrap-or current 1
+```
+
+这样可以让缺失、默认值和失败在类型上分开，而不是继续依赖 `nil` 或组件临时的 `read-field` 函数。
+
 ### 5.4 CLI 的 `quote` 是代码/数据边界
 
 所有接收 AST 的 Cirru 文本输入都必须让 `quote` **恰好包住一个节点**；提交 mutation 时 CLI 会剥离这个 transport wrapper。JSON 数组 AST 是兼容输入，不需要 `quote`，但不要手写大型 JSON AST。
@@ -355,6 +379,10 @@ cr cirru show-guide
 `cr query tests <ns>/<def>` 查询 definition-attached tests；`cr edit add-test <ns>/<def> <name> --code 'quote $ ...'` 添加稳定命名的测试，`cr edit rm-test <ns>/<def> <name>` 按名称删除。`cr test --affected <ns>/<def>` 使用编译后的传递依赖图选择测试；静态分析失败的测试会保守地被选中并报告为失败，不会静默漏测。
 
 不要用多个 `'Dynamic` 假装多态：参数与返回共享类型时声明 `:generics`/TypeVar，只依赖能力时增加 trait `:where`，同质 collection/ref 保留 type arg，有限异构值使用 enum。类型写法统一用 quoted symbols，例如 `'String`、`'Number`、`'List` 和 `'Dynamic`；`:any`、`:dynamic` 等旧 tag 写法仅为兼容输入，运行 `cr edit format` 后会在类型位置规范化。只有明确的 FFI、global state 或 macro 边界保留 dynamic，并尽快在进入 typed code 时 validate/convert。
+
+每次 `cr` 执行或编译都会在 stderr 审计项目自身的 Dynamic 类型位置：少量仅提示，达到较高占比会告警。该提示不写入 stdout，也不替代 `analyze check-types` / `analyze weak-types`；Agent 应先查看告警，再用 `cr analyze weak-types --intent unresolved --format json` 定位并逐步收窄类型。
+
+`:: :tag ...` 是匿名 Enum 字面量；当已有 Enum 定义在头部时，直接使用 `Enum :tag ...`，类型分析会检查变体和 payload，并在预处理阶段降为命名构造。只有需要显式携带运行时 enum prototype、跨模块动态构造或兼容旧代码时才使用 `%:: Enum :tag ...`。不要为了绕过类型检查而主动选择 `%::`。
 
 | 现象                   | 恢复动作                                                                 |
 | ---------------------- | ------------------------------------------------------------------------ |

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -284,7 +284,7 @@ div
 
 ### 5.3 可选参数优先使用 `Option`
 
-新代码优先用 `Option<T>` 表达“可能没有值”，减少通过参数列表里的 `?` 设置可选参数，也减少用 `nil` 表达缺失。函数末尾连续声明为 `Option<T>` 的参数可以在调用时省略；Calcit 会依次补成 `%none`：
+新代码优先用 `Option<T>` 表达“可能没有值”，减少通过参数列表里的 `?` 设置可选参数，也减少用 `nil` 表达缺失。函数末尾连续声明为 `Option<T>` 的参数可以在调用时省略；Calcit 会依次补成 `%none`。同样，已知 Struct 定义可以直接用 `Struct :field value` 构造，声明为 `Option<T>` 的字段可以省略并自动得到 `%none`：
 
 ```cirru.no-check
 defn request (url trace-id timeout-ms)
@@ -295,6 +295,9 @@ defn request (url trace-id timeout-ms)
 
 request |/health
 request |/health (%some |trace-1)
+
+defstruct Profile (:name 'String) (:bio (:: 'Option 'String))
+Profile :name |Ada
 ```
 
 这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数仍用于兼容已有的非类型化 API，其缺省值是 `nil`；修改旧接口时，优先逐步迁移到 `Option`。在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,6 +19,7 @@ leads_to:
   - core/features/structs
   - core/features/anonymous-enums
   - core/features/enums
+  - core/features/type-guidance
 ---
 
 # Features
@@ -58,6 +59,7 @@ For detailed information about specific features:
 - [Polymorphism](features/polymorphism.md) - Object-oriented programming patterns
 - [Traits](features/traits.md) - Capability-based method dispatch and explicit trait calls
 - [Static Analysis](features/static-analysis.md) - Type checking and compile-time validation
+- [Type Guidance](type-guidance.md) - Dynamic audits, Option/Result composition, nested lookup, and typed Enum construction
 
 ## Compilation Targets
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -240,6 +240,22 @@ let
 
 `:any` is a legacy alias for `:dynamic`; both are accepted as input and formatter output is `'Dynamic`.
 
+### Dynamic 用量审计
+
+每次 `cr` 执行或编译都会在 stderr 统计当前项目的 Dynamic 类型位置。少量使用只保留静默结果；达到一定数量且占比超过阈值时输出 notice 或 warning。该审计不会改变程序语义，也不会污染 stdout；需要定位时运行：
+
+```bash
+cr analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --format json
+```
+
+Dynamic 应限制在 JS FFI、宏和框架开放数据边界。普通多态使用 TypeVar/`:generics`，能力约束使用 trait/`:where`，缺失使用 `Option<T>`，失败使用 `Result<T,E>`。
+
+### Option / Result 级联
+
+使用 `option:map`、`option:and-then`、`option:or-else` 组合可选值；使用 `result:and-then`、`result:map-err`、`result:or-else` 组合失败路径。`unwrap` 只用于已经证明为 `some`/`ok` 的分支。
+
+`get-in` 返回 `Option<T>`，适合开放 Map/List 路径；不要用它绕过 Struct 字段检查，Struct 应使用 `(:field value)`。`update-in` 的 updater 接收 `Option<T>`，必须显式处理缺失值。
+
 ### Complex Types
 
 #### Legacy Optional Types
@@ -741,6 +757,15 @@ d! $ %:: Op :delete (:id task)
 ;; Warning: "expects 0 payload(s), got 1"
 
 d! $ %:: Op :clear 42
+```
+
+### Typed Enum Constructor Sugar
+
+When an existing Enum definition is the head of a call, prefer `Enum :tag ...`. The preprocessor resolves the definition, checks the variant and payload types, and lowers it to the named constructor. `%:: Enum :tag ...` remains for explicit runtime prototypes, dynamic cross-module construction, and compatibility boundaries.
+
+```cirru.no-check
+Option :some value
+Result :err message
 ```
 
 ### Cirru EDN Representation

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -13,12 +13,13 @@ parent: core/features
 
 # Structs
 
-Calcit structs are declared data types with a fixed set of named fields. Struct definitions are created with `defstruct`; struct values are constructed with `%{}`.
+Calcit structs are declared data types with a fixed set of named fields. Struct definitions are created with `defstruct`; struct values are constructed with `%{}` or by calling the definition directly with tag/value pairs.
 
 ## Quick Recipes
 
 - **Define**: `defstruct Point (:x 'Number) (:y 'Number)`
 - **Create**: `%{} Point (:x 1) (:y 2)`
+- **Constructor sugar**: `Point :x 1 :y 2`
 - **Access**: `(:x p)`
 - **Update**: `assoc p :x 10` or `update p :x inc`
 - **Type Check**: `assert-type p 'Point`
@@ -75,6 +76,20 @@ let
 Here `({} ('T Show))` means `T` must satisfy the `Show` trait. `%{}` enforces that bound when constructing a struct value, so the constraint lives on the data definition rather than on each individual function schema.
 
 ## Creating Struct Values
+
+When the definition is in scope, the concise constructor form keeps field names at
+the call site:
+
+```cirru.no-check
+let
+    Point $ defstruct Point (:x 'Number) (:y 'Number)
+    p $ Point :x 1 :y 2
+  , p
+```
+
+Arguments must be tag/value pairs. Required fields must be present, while a field
+declared as `Option<T>` may be omitted; the constructor inserts the nominal
+`%none` variant. Non-`Option` fields are never silently filled with `nil`.
 
 Use the `%{}` macro to instantiate a struct:
 

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -55,6 +55,17 @@ update-in data ([] :settings :retries)
 
 ## Enum 构造
 
+Struct 也支持同样的类型化头部调用：
+
+```cirru.no-check
+defstruct Profile (:name 'String) (:bio (:: 'Option 'String))
+Profile :name |Ada
+```
+
+参数必须是 `:field value` 对，必填字段不能省略；末尾声明为 `Option<T>`
+的字段可以省略，Calcit 会补成 `%none`。需要显式控制所有字段或构造部分值时，
+继续使用 `%{} Profile ...` / `%{}? Profile ...`。
+
 已知 Enum 定义时使用头部调用：
 
 ```cirru.no-check

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -1,0 +1,65 @@
+---
+title: "Type Guidance"
+summary: "Dynamic 审计、Option/Result 组合、嵌套数据访问和类型化 Enum 构造"
+scope: "core"
+kind: "guide"
+category: "features"
+aliases:
+  - "dynamic audit"
+  - "option result"
+  - "typed enum"
+id: core/features/type-guidance
+parent: core/features
+---
+
+# Calcit 类型使用指南
+
+## Dynamic 是边界，不是默认多态
+
+`Dynamic` 适合 JS FFI、框架开放数据、宏和确实无法提前知道的外部输入。普通函数不要用多个 `Dynamic` 表示“它们应该是同一个类型”：输入和返回关联时用 `:generics` 与 TypeVar；只需要能力时用 trait 与 `:where`；同质集合写出元素类型；有限异构数据定义为 Enum；可缺失值使用 `Option<T>`，带失败信息使用 `Result<T, E>`。
+
+每次执行和编译会在 stderr 输出 Dynamic 用量提示。它是趋势信号，不会替代具体路径检查：
+
+```bash
+cr analyze check-types --summary-only
+cr analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --format json
+```
+
+## Option / Result 组合
+
+优先组合而不是逐层 `unwrap`：
+
+```cirru.no-check
+option:and-then user
+  fn (user)
+    option:and-then (get user :profile)
+      fn (profile) $ get profile :name
+
+result:and-then loaded
+  fn (value) $ validate value
+```
+
+备用来源使用 `option:or-else` / `result:or-else`。`unwrap-or` 只用于默认值，`map` 用于同步转换，`and-then` 用于下一个仍可能失败的操作。
+
+## get-in / update-in
+
+`get-in` 是可能失败的开放数据访问，返回 `Option<T>`。不要用它绕过 Struct 字段检查；Struct 路径应使用 `(:field value)`，字段可缺失就把字段声明为 `Option<T>`。
+
+`update-in` 的 updater 接收 `Option<T>`。对缺失值给默认值或明确返回 `%none`，不要无条件 unwrap：
+
+```cirru.no-check
+update-in data ([] :settings :retries)
+  fn (current)
+    option:unwrap-or current 0
+```
+
+## Enum 构造
+
+已知 Enum 定义时使用头部调用：
+
+```cirru.no-check
+Option :some value
+Result :err message
+```
+
+Calcit 会根据 Enum 定义检查 variant 和 payload，并在预处理阶段生成命名构造。`%::` 保留给显式 prototype、动态跨模块构造和兼容旧代码的边界。

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -298,6 +298,15 @@ fn main() -> Result<(), String> {
   // with an older globally installed `cr` binary.
   attach_missing_core_namespaces(&mut snapshot, core_snapshot);
 
+  // Dynamic usage is a project-health signal, not a type-check failure. Keep
+  // it on stderr so command stdout remains machine-readable for Agent/CI use.
+  if !calcit::quiet_tool_output()
+    && let Ok(summary) = type_coverage::collect_dynamic_usage_summary(&snapshot)
+    && let Some(notice) = type_coverage::format_dynamic_usage_notice(summary)
+  {
+    eprintln!("{notice}");
+  }
+
   // now global states
   {
     let mut prgm = { program::PROGRAM_CODE_DATA.write().expect("open program data") };
@@ -1774,6 +1783,32 @@ mod tests {
     assert_eq!(row.level, type_coverage::CoverageLevel::Full);
     assert_eq!(row.params, vec!["arg0"]);
     assert_eq!(row.return_type_hints, vec!["'String"]);
+  }
+
+  #[test]
+  fn dynamic_usage_summary_escalates_by_ratio() {
+    let summary = type_coverage::DynamicUsageSummary {
+      total_positions: 20,
+      dynamic_positions: 1,
+    };
+    assert_eq!(summary.severity(), None);
+
+    let summary = type_coverage::DynamicUsageSummary {
+      total_positions: 10,
+      dynamic_positions: 2,
+    };
+    assert_eq!(summary.severity(), Some("notice"));
+
+    let summary = type_coverage::DynamicUsageSummary {
+      total_positions: 10,
+      dynamic_positions: 3,
+    };
+    assert_eq!(summary.severity(), Some("warning"));
+    assert!(
+      type_coverage::format_dynamic_usage_notice(summary)
+        .expect("dynamic notice")
+        .contains("30.0%")
+    );
   }
 
   #[test]

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2843,7 +2843,7 @@
           :tags $ #{} :trait-impl
         |OptionMethods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def OptionMethods $ &impl::new :OptionMethods (:: .some? option:some?) (:: .none? option:none?) (:: .unwrap option:unwrap) (:: .unwrap-or option:unwrap-or) (:: .and-then option:and-then) (:: .fold option:fold)
+            def OptionMethods $ &impl::new :OptionMethods (:: .some? option:some?) (:: .none? option:none?) (:: .unwrap option:unwrap) (:: .unwrap-or option:unwrap-or) (:: .and-then option:and-then) (:: .or-else option:or-else) (:: .fold option:fold)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -2863,7 +2863,7 @@
           :tags $ #{} :trait-impl
         |ResultMethods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def ResultMethods $ &impl::new :ResultMethods (:: .ok? result:ok?) (:: .err? result:err?) (:: .unwrap-or result:unwrap-or) (:: .and-then result:and-then) (:: .map-err result:map-err)
+            def ResultMethods $ &impl::new :ResultMethods (:: .ok? result:ok?) (:: .err? result:err?) (:: .unwrap-or result:unwrap-or) (:: .and-then result:and-then) (:: .map-err result:map-err) (:: .or-else result:or-else)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -6186,6 +6186,23 @@
               :generics $ [] 'T 'U
               :return $ :: 'Option 'U
           :tags $ #{} :internal
+        |option:or-else $ %{} 'CodeEntry (:doc "|Return the current Option when it is :some, otherwise evaluate a fallback Option-producing function.")
+          :code $ quote
+            defn option:or-else (opt fallback)
+              tag-match opt
+                (:some _) opt
+                (:none) (fallback)
+          :examples $ []
+            quote $ assert= (%some 2)
+              option:or-else (%none)
+                fn () (%some 2)
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Option 'T)
+                :: 'Fn $ {} (:return $ :: 'Option 'T) (:args $ [])
+              :generics $ [] 'T
+              :return $ :: 'Option 'T
+          :tags $ #{} :internal
         |option:fold $ %{} 'CodeEntry (:doc "|Eliminate an Option by evaluating on-none for none or on-some with the payload.")
           :code $ quote
             defn option:fold (opt on-none on-some)
@@ -6671,6 +6688,23 @@
                   :return $ :: 'Result 'U 'E
               :generics $ [] 'T 'U 'E
               :return $ :: 'Result 'U 'E
+          :tags $ #{} :internal
+        |result:or-else $ %{} 'CodeEntry (:doc "|Return the current Result when it is :ok, otherwise evaluate a fallback Result-producing function.")
+          :code $ quote
+            defn result:or-else (res fallback)
+              tag-match res
+                (:ok _) res
+                (:err _) (fallback)
+          :examples $ []
+            quote $ assert= (%ok 2)
+              result:or-else (%err |missing)
+                fn () (%ok 2)
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Result 'T 'E)
+                :: 'Fn $ {} (:return $ :: 'Result 'T 'E) (:args $ [])
+              :generics $ [] 'T 'E
+              :return $ :: 'Result 'T 'E
           :tags $ #{} :internal
         |result:err? $ %{} 'CodeEntry (:doc "|Returns true when a Result is :err.")
           :code $ quote

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2079,10 +2079,10 @@ fn try_rewrite_struct_enum_constructor_head_call(
 
     for (idx, field) in struct_def.fields.iter().enumerate() {
       if !provided_fields.contains_key(field)
-        && !matches!(
-          struct_def.field_types.get(idx).map(AsRef::as_ref),
-          Some(CalcitTypeAnnotation::Optional(_))
-        )
+        && !struct_def
+          .field_types
+          .get(idx)
+          .is_some_and(|field_type| matches!(field_type.as_ref(), CalcitTypeAnnotation::Optional(_)) || field_type.is_option_type())
       {
         gen_check_warning(
           format!(
@@ -2129,10 +2129,23 @@ fn try_rewrite_struct_enum_constructor_head_call(
     let mut struct_items: Vec<Calcit> = Vec::with_capacity(struct_def.fields.len() * 2 + 2);
     struct_items.push(Calcit::Proc(CalcitProc::NativeStruct));
     struct_items.push(struct_ref_node);
-    for field in struct_def.fields.iter() {
+    for (field_idx, field) in struct_def.fields.iter().enumerate() {
       struct_items.push(Calcit::Tag(field.to_owned()));
       if let Some(value) = provided_fields.get(field) {
         struct_items.push((*value).to_owned());
+      } else if struct_def
+        .field_types
+        .get(field_idx)
+        .is_some_and(|field_type| field_type.is_option_type())
+      {
+        // Nominal Option fields use the typed `%none` variant when omitted.
+        // Keep legacy Optional<T> fields on their historical nil representation.
+        struct_items.push(Calcit::from(vec![Calcit::Import(CalcitImport {
+          ns: calcit::CORE_NS.into(),
+          def: "%none".into(),
+          info: Arc::new(ImportInfo::Core { at_ns: Arc::from(file_ns) }),
+          def_id: None,
+        })]));
       } else {
         struct_items.push(Calcit::Nil);
       }
@@ -7314,6 +7327,60 @@ mod tests {
     assert_eq!(*items.get(4).expect("age field key"), Calcit::Tag(EdnTag::from("age")));
     assert_eq!(*items.get(3).expect("name value"), Calcit::Str(Arc::from("Alice")));
     assert_eq!(*items.get(5).expect("age value"), Calcit::Number(20.0));
+  }
+
+  #[test]
+  fn rewrites_omitted_option_struct_field_to_none() {
+    use crate::data::cirru::code_to_calcit;
+    use cirru_edn::EdnTag;
+    use cirru_parser::Cirru;
+
+    let mut person_struct = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name"), EdnTag::from("trace")]);
+    person_struct.field_types = Arc::new(vec![
+      Arc::new(CalcitTypeAnnotation::String),
+      Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from("calcit.core/Option"),
+        Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),
+      )),
+    ]);
+
+    let expr = Cirru::List(vec![Cirru::leaf("Person"), Cirru::leaf(":name"), Cirru::leaf("|Alice")]);
+    let parsed = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse struct ctor");
+    let Calcit::List(parsed_items) = parsed else {
+      panic!("expected parsed call");
+    };
+    let mut code_items = parsed_items.to_vec();
+    code_items[0] = Calcit::StructDef(person_struct.clone());
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(
+      Arc::from("Person"),
+      Arc::new(CalcitTypeAnnotation::Struct(Arc::new(person_struct.clone()), Arc::new(vec![]))),
+    );
+
+    let warnings = RefCell::new(vec![]);
+    let result = try_rewrite_struct_enum_constructor_head_call(
+      code_items.first().expect("struct head"),
+      &CalcitList::from(&code_items[1..]),
+      &scope_types,
+      "tests.struct",
+      "demo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("rewrite struct ctor")
+    .expect("struct ctor should rewrite");
+    let Calcit::List(items) = result else {
+      panic!("expected rewritten struct list");
+    };
+    assert!(matches!(items.first(), Some(Calcit::Proc(CalcitProc::NativeStruct))));
+    assert!(matches!(items.get(3), Some(Calcit::Str(value)) if value.as_ref() == "Alice"));
+    let Some(Calcit::List(none_call)) = items.get(5) else {
+      panic!("expected omitted Option field to become a %none call");
+    };
+    assert!(
+      matches!(none_call.first(), Some(Calcit::Import(CalcitImport { ns, def, .. })) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "%none")
+    );
+    assert!(warnings.borrow().is_empty());
   }
 
   #[test]

--- a/src/type_coverage.rs
+++ b/src/type_coverage.rs
@@ -175,6 +175,115 @@ pub struct WeakTypeRow {
   pub occurrences: Vec<WeakTypeOccurrence>,
 }
 
+/// Aggregate the amount of explicit dynamic type evidence in the current
+/// project scope. This is intentionally a heuristic: every annotation node is
+/// counted as one type position, and explicit `:dynamic` / `:any` code markers
+/// are counted as additional positions. It is meant as an execution-time
+/// hygiene signal, not as a replacement for `check-types`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DynamicUsageSummary {
+  pub total_positions: usize,
+  pub dynamic_positions: usize,
+}
+
+impl DynamicUsageSummary {
+  pub fn ratio(self) -> f64 {
+    if self.total_positions == 0 {
+      0.0
+    } else {
+      self.dynamic_positions as f64 / self.total_positions as f64
+    }
+  }
+
+  pub fn severity(self) -> Option<&'static str> {
+    if self.dynamic_positions == 0 {
+      return None;
+    }
+    match self.ratio() {
+      ratio if ratio >= 0.25 => Some("warning"),
+      ratio if ratio >= 0.10 => Some("notice"),
+      _ => None,
+    }
+  }
+}
+
+fn count_annotation_positions(annotation: &CalcitTypeAnnotation) -> (usize, usize) {
+  let (mut total, mut dynamic) = (1, usize::from(matches!(annotation, CalcitTypeAnnotation::Dynamic)));
+  let mut add = |child: &CalcitTypeAnnotation| {
+    let (child_total, child_dynamic) = count_annotation_positions(child);
+    total += child_total;
+    dynamic += child_dynamic;
+  };
+  match annotation {
+    CalcitTypeAnnotation::List(inner)
+    | CalcitTypeAnnotation::Set(inner)
+    | CalcitTypeAnnotation::Ref(inner)
+    | CalcitTypeAnnotation::Variadic(inner)
+    | CalcitTypeAnnotation::Optional(inner)
+    | CalcitTypeAnnotation::JsNullish(inner) => add(inner),
+    CalcitTypeAnnotation::Map(key, value) => {
+      add(key);
+      add(value);
+    }
+    CalcitTypeAnnotation::Fn(fn_annot) => {
+      for arg in &fn_annot.arg_types {
+        add(arg);
+      }
+      add(&fn_annot.return_type);
+      if let Some(rest) = &fn_annot.rest_type {
+        add(rest);
+      }
+    }
+    CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => {
+      for arg in args.iter() {
+        add(arg);
+      }
+    }
+    _ => {}
+  }
+  (total, dynamic)
+}
+
+fn count_code_dynamic_markers(code: &Cirru) -> usize {
+  match code {
+    Cirru::Leaf(text) => usize::from(matches!(text.as_ref(), ":dynamic" | ":any")),
+    Cirru::List(items) => items.iter().map(count_code_dynamic_markers).sum(),
+  }
+}
+
+pub fn collect_dynamic_usage_summary(snapshot: &snapshot::Snapshot) -> Result<DynamicUsageSummary, String> {
+  let mut summary = DynamicUsageSummary {
+    total_positions: 0,
+    dynamic_positions: 0,
+  };
+  visit_scoped_definitions(
+    snapshot,
+    AnalysisScope {
+      namespace: None,
+      namespace_prefix: None,
+      include_dependencies: false,
+    },
+    |_namespace, _definition, entry| {
+      let (schema_total, schema_dynamic) = count_annotation_positions(entry.schema.as_ref());
+      let code_dynamic = count_code_dynamic_markers(&entry.code);
+      summary.total_positions += schema_total + code_dynamic;
+      summary.dynamic_positions += schema_dynamic + code_dynamic;
+    },
+  )?;
+  Ok(summary)
+}
+
+pub fn format_dynamic_usage_notice(summary: DynamicUsageSummary) -> Option<String> {
+  let severity = summary.severity()?;
+  Some(format!(
+    "[{}] Dynamic type usage is {}/{} ({:.1}%) of analyzed type positions. Prefer concrete schemas, generics, traits, Option/Result, or named enums; keep Dynamic at documented FFI and framework boundaries. Run `cr analyze weak-types --intent unresolved` for paths.",
+    severity,
+    summary.dynamic_positions,
+    summary.total_positions,
+    summary.ratio() * 100.0,
+  ))
+}
+
 pub fn parse_weak_type_kinds(raw: &str) -> Result<BTreeSet<WeakTypeKind>, String> {
   let mut selected = BTreeSet::new();
 


### PR DESCRIPTION
## Summary
- support `Struct :field value` constructor syntax
- fill omitted nominal `Option<T>` fields with `%none`
- document Struct and Option guidance

## Verification
- `cargo test`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `yarn try-js`
- `yarn try-wasm`
- docs checks for `docs/features/structs.md` and `docs/type-guidance.md