### PR TITLE
chore: release 0.13.12

### DIFF
--- a/202608121900-release-0.13.12.md
+++ b/202608121900-release-0.13.12.md
@@ -1,0 +1,5 @@
+# Release 0.13.12
+
+- 合并类型指导与 Dynamic 审计能力，强化 Option/Result 的组合式使用建议。
+- 支持 `Struct :field value` 类型化构造语法，省略的 `Option<T>` 字段自动补为 `%none`。
+- 更新 Struct、Agent 和类型系统相关文档及回归测试。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "calcit"
-version = "0.13.11"
+version = "0.13.12"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Release 0.13.12

- publish the merged Dynamic/Option guidance and typed Struct constructor support
- synchronize Cargo and npm package versions
- refresh Cargo.lock

The feature PR was merged as #340 and its checks passed.