### PR TITLE
feat: add project-scoped versioned module store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.12"
+version = "0.13.13"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "calcit"
 autobins = false
-version = "0.13.12"
+version = "0.13.13"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 
 [package]
 name = "calcit"
+autobins = false
 version = "0.13.12"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -132,7 +132,14 @@ Related examples and workflows:
     |calcit-lang/lilac |main
 ```
 
-Run `caps` to download. Sources are downloaded into `~/.config/calcit/modules/`. If a module contains `build.sh`, it will be executed mostly for compiling Rust dylibs.
+Run `caps` to resolve the recursive dependency graph and install it. Immutable revisions are stored under
+`~/.config/calcit/modules/.store/`, while the current project receives links under `.calcit/modules/`.
+Different projects can therefore use different revisions without switching a shared checkout. Existing
+`~/.config/calcit/modules/<repo>/` checkouts remain a runtime fallback during migration.
+
+Published SemVer tags are preferred. Branch refs remain supported for development, but `caps` warns with
+the resolved commit. When a graph requests several SemVer tags for one repository, the highest requested
+version is selected and reported.
 
 `:calcit-version` helps with version checks and provides hints in [CI](https://github.com/calcit-lang/setup-cr).
 
@@ -144,10 +151,19 @@ To load modules, use `:modules` configuration and the runtime snapshot file `cal
     :modules $ [] |memof/calcit.cirru |lilac/
 ```
 
-Paths defined in `:modules` field are just loaded as files from `~/.config/calcit/modules/`,
-i.e. `~/.config/calcit/modules/memof/calcit.cirru`.
+Paths defined in `:modules` first load from the snapshot directory's `.calcit/modules/`, then fall back to
+`~/.config/calcit/modules/`, i.e. `.calcit/modules/memof/calcit.cirru` or the legacy global path.
 
 Modules ending with `/` are automatically suffixed with `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
+
+Inspect and verify the resolved graph with:
+
+```bash
+caps tree
+caps why calcit-lang/memof
+caps status
+caps verify
+```
 
 ### Development
 

--- a/RFCs/07-28-git-module-store-rfc.md
+++ b/RFCs/07-28-git-module-store-rfc.md
@@ -99,7 +99,7 @@ basename 建立项目链接。如果依赖图里出现 `owner-a/utils` 与 `owne
 
 `caps` 按以下顺序修改本机状态：
 
-1. 在 `.calcit/tmp/` 下创建本次操作的临时目录，解析 ref、下载 source；
+1. 在 store 的 `.store/tmp/` 下创建临时目录，解析 ref、下载 source（与 store 同文件系统，保证 rename 原子）；项目侧临时 project view 写入 `.calcit/tmp/`；
 2. 完成递归依赖图和版本选择；
 3. 完成需要的 native realization 与验证；
 4. 写入临时 project view；

--- a/RFCs/07-28-git-module-store-rfc.md
+++ b/RFCs/07-28-git-module-store-rfc.md
@@ -1,59 +1,474 @@
-# RFC: Git 模块解析与本地内容寻址存储
+# RFC: Git 模块依赖图与项目级模块视图
 
 状态：Draft
 日期：2026-07-28
+更新：2026-08-12
 关联：`docs/run/load-deps.md`
 
-## 1. 决策
+## 1. 决策摘要
 
-Calcit 暂不提供 registry，也不引入 workspace。模块的发布、获取与版本身份继续以 Git repository + ref/commit 为基础；模块仍以目录形态提供 `calcit.cirru`、文档与可选 Rust 动态库构建输入。
+Calcit 继续使用 GitHub repository + Git ref 管理模块，不建设 registry，
+也暂不引入 workspace、依赖别名和同一项目内的多版本 namespace 隔离。
 
-依赖声明应优先使用发布 tag；tag 是可复现安装、兼容性沟通与 CI 的最佳实践。允许使用分支名以支持开发中的模块，但分支是可变引用：每次安装或更新都应显示其解析到的具体 commit，不能把“当前分支头”当作稳定版本身份。
+这次演进增加四层能力：
 
-依赖图中同一模块只能选择一个版本：解析多个约束时统一选择最高版本，并对不同声明或无法严格满足的约束输出 warning，说明最终选中的 ref/commit 与受影响依赖。由于 namespace 是全局语义空间，不支持同项目多版本并存或 Cargo 式依赖重命名隔离。
+1. 全局目录可以同时保存同一模块的多个 revision；
+2. 每个项目通过 `.calcit/modules/` 中的链接获得自己的模块视图；
+3. `caps` 递归读取各模块的 `deps.cirru`，解析单版本依赖图并提供
+   `tree`、`why`、`status` 和 `verify`；
+4. native 模块的构建产物按平台和 ABI 隔离，并生成可检查的构建回执。
 
-## 2. 问题
+依赖应优先声明为发布 tag。允许分支用于开发，但每次解析都必须 warning，
+并显示最终 commit。多个可比较的版本 tag 冲突时统一选择最高版本，并显示
+声明来源；不可比较的 branch、commit 或非版本 tag 不猜测“更高版本”。
 
-直接把每个项目依赖完整 clone 到全局 modules 目录会造成重复体积；但单纯的 archive cache 不适合需要文档浏览、Git 状态检查、`build.sh` 和 Rust dylib 的模块。目标是在保留目录体验和 Git 路径的前提下，获得类似 pnpm 的去重。
+整个迁移保持现有 `calcit.cirru` 的 `:modules` 内容可用。旧项目仍可从
+`~/.config/calcit/modules/<repo>/` 加载，新项目则优先从自身
+`.calcit/modules/<repo>/` 加载。
 
-## 3. 两层本地布局
+## 2. 目标与非目标
 
-建议将实现分为不可变 store 与项目可见链接：
+### 2.1 目标
+
+- 两个项目可以使用同一模块的不同版本，互不切换对方的 checkout；
+- 相同 repository + commit + native build key 在本机只安装一份；
+- `caps deps.cirru` 在没有 `calcit.cirru` 的目录中也能完成递归下载；
+- 依赖选择结果确定、可解释，冲突能追溯到每条父依赖；
+- 项目链接只在完整解析、下载和构建成功后切换；
+- native 产物不会在不同 target、Calcit ABI 或 `cirru_edn` ABI 间误用；
+- 当前 `caps`、`caps outdated`、`caps upgrade`、`caps status` 和
+  `caps reset` 在迁移期继续可用。
+
+### 2.2 非目标
+
+- 不建设中心 registry、账号或发布服务；
+- 第一阶段不支持 `^1.2`、`~1.2` 等版本范围，依赖值仍是准确 Git ref；
+- 不允许同一项目同时加载同一模块的两个版本；
+- 不用模块别名解决 namespace 冲突；
+- 不要求所有历史模块立刻增加 native manifest；
+- 不在第一阶段自动删除 legacy clone 或未引用的 store 内容。
+
+## 3. 目录模型
+
+当前正式路径是 `~/.config/calcit/modules/`。新 store 放在它下面，避免再引入
+一套顶级目录；路径解析应集中到一个 helper，后续再考虑 XDG 或其他平台差异。
 
 ```text
-~/.config/calcit/store/git/<content-id>/     # 完整模块目录，按 resolved commit 内容去重
-<project>/.calcit/modules/<module-name>/     # 指向 store 的符号链接或平台等价链接
+~/.config/calcit/modules/
+  .store/git/<owner>/<repo>/<commit>/source/
+  .store/git/<owner>/<repo>/<commit>/realizations/<build-key>/
+  <repo>/                                  # legacy clone，迁移期保留
+
+<project>/
+  deps.cirru
+  .calcit/
+    caps-state.cirru
+    modules/
+      <repo> -> ~/.config/calcit/modules/.store/.../source/
+      <native-repo> -> .../realizations/<build-key>/
+    tmp/
 ```
 
-`content-id` 至少由 canonical repository URL、resolved commit、submodule 状态与必要构建输入版本组成。tag 或分支名只用于解析；store 身份始终以其解析后的 commit 为准。链接目标是完整目录，因此 snapshot、docs、native source、已构建产物与诊断文件仍能按现有路径读取。
+Git tag 或 branch 只负责解析 commit；store 的 source 身份始终是 canonical Git
+URL + resolved commit。这样同一 commit 被两个 tag 指向时不会重复保存。
 
-项目 snapshot 的 `:modules` 可继续使用模块目录路径。链接层只解决本地寻址和项目隔离，不改变模块的目录接口。
+`.calcit/caps-state.cirru` 是本次安装的诊断记录，不是 lockfile，也不参与下一次版本
+选择。它至少记录：
 
-## 4. 解析与 native 模块
+- canonical repository URL；
+- 所有请求来源及声明的 ref；
+- 选中的 ref、ref 类型和 resolved commit；
+- 项目链接目标；
+- branch warning 和版本冲突 warning；
+- native build key、回执路径与验证状态。
 
-当前不引入 `calcit.lock`。`deps.cirru` 是唯一的依赖声明与解析来源；`caps` 每次按其 tag/branch 解析依赖图并选择统一最高版本。命令结果应记录 canonical Git URL、声明的 tag/branch、实际 resolved commit、版本选择 warning 和完整性信息，方便 CI 日志与问题排查。对于 branch 依赖，更新应明确提示其从哪个 commit 前进到哪个 commit。
+项目侧由 `caps` 生成或维护的内容统一放在 `.calcit/` 内，包括模块链接、状态、
+临时文件、构建日志以及未来的本机 override sidecar，避免在项目根目录或模块链接
+目录散落工具文件。项目根目录只保留用户维护、需要纳入版本控制的 `deps.cirru`。
+`.calcit/` 整体默认应加入 `.gitignore`；其中内容是本机安装状态，不能作为跨机器
+依赖身份。
 
-Rust dylib 不是 store 的例外：其 source 与 `build.sh` 仍在模块目录中。产物必须按 target triple、Calcit ABI/version、Rust toolchain 或 build-input hash 分桶，不能跨不兼容环境复用。构建前展示将执行的脚本、来源与 hash；失败信息关联到具体 module revision。
+### 3.1 模块目录名冲突
 
-## 5. caps 命令演进
+现有 `:modules` 使用 repository basename，例如 `memof/`。因此第一阶段继续用
+basename 建立项目链接。如果依赖图里出现 `owner-a/utils` 与 `owner-b/utils`，
+`caps` 必须报错并列出两者，不能静默覆盖。依赖别名需要同时解决 namespace
+身份，不在本 RFC 范围内。
 
-在保留 `caps`、`outdated`、`status`、`reset` 的基础上，逐步增加：
+### 3.2 原子切换
+
+`caps` 按以下顺序修改本机状态：
+
+1. 在 `.calcit/tmp/` 下创建本次操作的临时目录，解析 ref、下载 source；
+2. 完成递归依赖图和版本选择；
+3. 完成需要的 native realization 与验证；
+4. 写入临时 project view；
+5. 原子替换 `.calcit/modules/` 中的项目链接和 `.calcit/caps-state.cirru`。
+
+任何一步失败都保留项目原来的链接。下载完成但未被链接的 store 内容可以留给
+后续安装复用，由未来的 `caps clean` 回收。
+
+Windows 上优先使用 directory junction；不支持链接时允许显式 copy fallback，
+并在 `caps status` 中标记为非共享副本，不能假装已经去重。
+
+## 4. `deps.cirru` 协议
+
+保持当前字符串 map 兼容，先不引入复杂 constraint 对象：
+
+```cirru
+{}
+  :version |0.16.67
+  :calcit-version |0.13.10
+  :dependencies $ {}
+    |Respo/respo-ui.calcit |0.7.2
+    |calcit-lang/calcit.std |0.2.15
+```
+
+字段职责：
+
+- `:version`：当前项目或模块自身的发布版本，由 `caps version` 管理；
+- `:calcit-version`：期望使用的 Calcit 工具链版本；
+- `:dependencies`：repository 到准确 Git tag、branch 或 commit 的映射。
+
+依赖 key 继续要求 canonical `owner/repo`。GitHub URL 仅作为 `caps add` 输入，
+写回文件前必须规范化。
+
+### 4.1 项目版本迁移
+
+当前项目版本在 `calcit.cirru :version`。迁移时不能立即删除该字段：
+
+1. `deps.cirru :version` 存在时，它是发布工具的权威值；
+2. 只有 `calcit.cirru :version` 时，`caps version get` 读取旧值并提示迁移；
+3. `caps version set/bump` 只写入 `deps.cirru`，不隐式改写机器生成的 snapshot；
+   迁移期 snapshot `:version` 继续作为旧版 `cr` 的兼容字段，允许暂时不同；
+4. `cr config set version` 先保留，但提示改用 `caps version set`；
+5. 等生态完成迁移后，再让 snapshot 的 `:version` 变为可选并停止写入镜像。
+
+建议命令：
 
 ```bash
-caps add <git-url-or-org/repo>@<constraint>
-caps remove <module>
-caps tree
-caps why <module>
-caps update [module]
-caps verify
+caps version get
+caps version set 0.16.68
+caps version bump patch
 ```
 
-`caps status` 区分 store 完整性、项目链接、当前 `deps.cirru` 解析结果、版本选择 warning、native 产物兼容性和用户手工修改。不可变 store 不接受直接编辑；开发依赖使用明确的 path/checkout override，而不是污染共享内容。
+`caps version` 必须验证 SemVer。安装 tag 时，如果模块的 `deps.cirru :version`
+与 tag（允许 tag 带一个 `v` 前缀）不一致，`caps verify` 报错。branch 模块只做
+warning，因为 branch 没有稳定发布版本身份。
 
-## 6. 非目标与验收
+### 4.2 standalone `deps.cirru`
 
-- 不建设中心 registry、账号、发布服务、lockfile 或语义版本多版本安装；
-- 不支持 workspace，也不让多个版本进入同一 namespace 空间；
-- 不把模块压缩成失去 docs/native source 的 blob。
+位置参数继续是依赖文件：
 
-验收：两项目共享同一 resolved revision 只保存一份内容；项目链接可独立重建；版本不一致时选择最高版本并输出可读 warning；不同 native ABI/target 不会错误复用产物；原有目录模块加载与文档命令保持兼容。
+```bash
+caps ./fixtures/demo/deps.cirru
+caps /tmp/download-only/deps.cirru tree
+```
+
+项目根目录始终取该文件的父目录，项目视图写到同目录的 `.calcit/modules/`。
+这个流程不得要求同目录存在 `calcit.cirru`、`package.json` 或 Git repository。
+如果只想预览，`caps <file> tree --resolve` 可以解析远端但不创建项目链接。
+
+## 5. ref 分类和 warning
+
+不能只根据字符串长相判断 branch 或 tag。`caps` 获取远端 refs 后按以下顺序
+分类：
+
+1. 精确匹配 `refs/tags/<ref>`：tag；
+2. 精确匹配 `refs/heads/<ref>`：branch；
+3. 完整 commit hash：commit；
+4. 都不匹配：错误。
+
+如果远端同时存在同名 tag 和 branch，拒绝并要求用户明确修改命名；Git 自己的
+模糊 ref 选择不能成为包管理语义。
+
+warning 分级：
+
+- SemVer tag：正常推荐路径；
+- 非 SemVer tag：可复现，但无法参与“选择最高版本”，给提示；
+- branch：每次安装 warning，并显示 branch -> commit；
+- commit：可复现，但缺少发布版本语义，给提示。
+
+`--ci` 不隐藏 warning。未来可增加 `--deny-branch`，让发布 CI 把 branch 依赖
+升级为错误。
+
+## 6. 递归解析与单版本选择
+
+### 6.1 解析过程
+
+`caps` 维护带 provenance 的请求集合：
+
+```text
+Request {
+  repository,
+  requested_ref,
+  requested_by,   # root 或 owner/repo@resolved-ref
+}
+```
+
+解析采用 fixpoint，而不是“下载时顺手递归”：
+
+1. 读取 root `deps.cirru`，产生第一批 requests；
+2. 为每个 repository 解析 refs 并选择当前 revision；
+3. 读取选中 revision 的 `deps.cirru`，加入它的 requests；
+4. 如果新请求改变了某模块的选择，撤销旧 revision 贡献的传递请求，再展开新
+   revision；
+5. 重复直到选择和边集合都不再变化；
+6. 检测 dependency cycle，`tree` 展示 cycle 标记但安装不重复展开；
+7. graph 完整后才进入 native build 和项目链接阶段。
+
+模块没有 `deps.cirru` 时按空依赖处理并给兼容性提示。文件存在但无法解析，或
+`:dependencies` 类型错误时必须失败，不能静默当作空依赖。
+
+### 6.2 冲突规则
+
+同一 repository 在项目内只能有一个选择：
+
+- 所有请求都是可解析 SemVer 的 tag：选择最高 SemVer；
+- 多个请求指向同一 commit：合并为一个选择；
+- 相同 branch 名：选择该 branch 当前远端 commit，并 warning；
+- tag 与 branch 混合时，仍在所有请求中选择最高 SemVer tag 并给强 warning；
+  发布 tag 比可变 branch 更适合作为现有项目的兼容裁决，根项目的较低 tag 也
+  不压过传递依赖明确请求的较高 tag；
+- 不同 branch、commit 与其他 ref、或多个不可比较 tag：不能定义“更高”。如果
+  root 有直接声明，使用 root 声明并给强 warning；没有 root 直接声明则报错，
+  要求 root 在 `deps.cirru` 中显式裁决。
+
+选择较高 SemVer tag 时，即使能自动继续，也必须打印类似：
+
+```text
+warning: selected Respo/respo.calcit@0.16.67
+  requested 0.16.65 by Cumulo/cumulo-reel.calcit@0.6.7
+  requested 0.16.67 by root
+```
+
+`caps --strict` 可把所有版本提升和不可复现 ref warning 变为错误，适合对依赖
+漂移敏感的 CI。第一阶段不自动寻找远端“最新版本”；最高版本只在依赖图实际
+请求的版本集合中选择。
+
+### 6.3 确定性
+
+- repository、边、warning 和 tree 子节点统一排序后输出；
+- SemVer 比较使用标准 precedence，不用发布时间；
+- build metadata 不参与 SemVer precedence，相同 precedence 但不同 tag 指向不同
+  commit 时视为不可裁决冲突；
+- 解析结果中的每个 ref 都保存 resolved commit；
+- 网络并发只能改变耗时，不能改变选择或输出顺序。
+
+## 7. `caps tree` 与命令演进
+
+在保留已有命令的基础上增加：
+
+```bash
+caps [deps.cirru]                         # resolve + install + link
+caps [deps.cirru] add owner/repo@0.1.2
+caps [deps.cirru] remove owner/repo
+caps [deps.cirru] tree
+caps [deps.cirru] why owner/repo
+caps [deps.cirru] update [owner/repo]
+caps [deps.cirru] verify
+caps [deps.cirru] status
+```
+
+兼容规则：
+
+- 现有 `caps add owner/repo --version 0.1.2` 继续工作；
+- 现有 `upgrade` 先作为 `update` 的别名，不立即删除；
+- 现有 `download owner/repo@ref` 可以内部构造临时 root graph，默认也递归；
+- `reset` 只处理 legacy clone 或显式 path/checkout override。不可变 store 不做
+  `git reset --hard`，项目链接损坏时由 `caps` 重建。
+
+`caps tree` 默认展示实际选择和来源，而不只是 root 声明：
+
+```text
+root
+├─ Respo/reel.calcit@0.6.7
+│  └─ Respo/respo.calcit@0.16.67  ↑ requested 0.16.65
+└─ Respo/respo.calcit@0.16.67
+```
+
+建议同时支持：
+
+- `--depth <n>`：限制展示深度；
+- `--all`：重复展示共享子图，否则使用 `(*)` 引用；
+- `--format json`：供 Agent 和 CI 读取，stdout 必须是单个 JSON；
+- `--offline`：只使用已经解析进 store 的 refs；
+- `--resolve`：没有安装时允许访问远端完成预览。
+
+`caps why <module>` 为每个 root dependency 输出到该模块的一条最短路径，并
+列出全部直接版本请求和最终选择理由。稠密依赖图不枚举所有简单路径，避免输出
+组合爆炸。
+
+## 8. `cr` 的模块查找兼容层
+
+目前多个命令各自拼接 `~/.config/calcit/modules/`。实现项目视图前先把它们
+收敛到共享 resolver，至少覆盖运行、query、config、call-graph、docs 和 wasm
+内部验证路径。
+
+对于 snapshot 中的非相对模块路径，例如 `memof/`，查找顺序是：
+
+1. `<snapshot-dir>/.calcit/modules/memof/`；
+2. `~/.config/calcit/modules/memof/`（legacy fallback）。
+
+`./util.cirru` 这类明确相对路径仍只相对 snapshot，不进入模块 store。项目视图
+存在但单个模块链接缺失时仍允许逐项 fallback，并在 verbose/status 中提示，
+这样迁移不要求一次切换所有模块。
+
+模块源码中的 `calcit-dirname` 应解析到项目链接最终指向的完整 module view。
+这保证现有 `get-dylib-path` 拼接 `dylibs/lib...` 的代码无需修改。
+
+## 9. native 模块
+
+### 9.1 为什么不能直接在 source store 运行 `build.sh`
+
+现有脚本会删除并重建 `dylibs/`。如果直接在按 commit 共享的 source 中执行，
+不同平台、Rust toolchain 或 Calcit ABI 的项目会相互覆盖，source 也不再不可变。
+
+因此 native 模块分为：
+
+- `source/`：按 commit 保存，不运行构建脚本；
+- `realizations/<build-key>/`：从 source 创建的独立构建视图，项目链接指向这里。
+
+realization 可以先使用完整工作树保证简单可靠；以后再用 reflink、hardlink 或
+只读 source + artifact view 优化体积，不应在第一版提前增加复杂度。
+
+### 9.2 build key
+
+build key 至少包含：
+
+- canonical repository URL 和 resolved commit；
+- target triple 与 OS/architecture；
+- Calcit FFI ABI version；
+- `cirru_edn` version；
+- Calcit version（第一阶段保守隔离）；
+- `rustc -vV` 的 toolchain identity；
+- build command 和显式 build environment 的 hash。
+
+同一 build key 的 realization 构建成功后可跨项目复用。失败或未完成的临时目录
+不能被项目链接引用。
+
+### 9.3 可选 native manifest
+
+已有 `build.sh` 继续识别。新模块建议在自己的 `deps.cirru` 增加：
+
+```cirru
+:native $ {}
+  :build $ [] |sh |build.sh
+  :libraries $ [] |dylibs/libcalcit_std
+  :timeout-seconds 600
+```
+
+`:libraries` 使用不带平台扩展名的路径，`caps` 根据 target 补 `.so`、`.dylib`
+或 `.dll`。manifest 存在时，未产生声明产物是构建失败。只有 `build.sh` 而没有
+manifest 的旧模块仍构建，但给迁移提示，并至少验证 `dylibs/` 下存在当前平台
+动态库。
+
+构建脚本是来自依赖的代码执行。`caps` 执行前必须显示 module、ref、commit、
+脚本路径和 hash；CI 日志也不能隐藏。后续可增加 allow-list，但第一阶段不突然
+改变现有默认构建行为。
+
+### 9.4 构建回执与验证
+
+成功后在 realization 中写 `.calcit-native.cirru`，记录：
+
+- build key 的全部输入；
+- 开始/结束时间和 command；
+- 每个产物的相对路径、大小和内容 hash；
+- ABI version、`cirru_edn` version 和验证结果。
+
+`caps verify` 检查：
+
+1. project link 指向 state 声明的 source/realization；
+2. source commit 与 store identity 一致，且没有用户修改；
+3. native receipt 的 build key 与当前环境一致；
+4. 声明产物存在、未通过 symlink 逃出 realization、hash 匹配；
+5. 能加载动态库，存在 ABI 查询符号，且 ABI/EDN version 匹配；
+6. manifest 声明的业务符号（若未来增加）存在。
+
+动态库加载验证应放在短生命周期子进程中。错误库崩溃时只让 verifier 子进程
+失败，`caps` 仍能报告 module、commit、产物路径和退出状态。
+
+运行时继续执行 ABI 检查，不能因为 `caps verify` 已通过就跳过。加载错误应尝试
+附带相邻 build receipt 的 module revision、target 和 rebuild 提示。dylib cache
+应使用 canonical path 作为 key；项目链接在 watcher 运行期间切换后，提示重启
+进程，不尝试卸载已加载 library。
+
+## 10. 状态、override 与人工修改
+
+共享 store 视为不可变。开发某个依赖时不要在 store 中直接编辑，后续使用显式
+override，例如 `.calcit/overrides.cirru` 本机 sidecar 或 CLI 参数指向 path checkout。
+override 的正式语法另开小 RFC，不阻塞 store 和递归解析。
+
+在 override 落地前，`caps status` 至少区分：
+
+- dependency graph 是否仍能解析；
+- store source 是否完整、commit 是否匹配；
+- project link 是否缺失或指错；
+- 是否使用 legacy global clone；
+- branch 与版本选择 warning；
+- native realization 是否适配当前环境；
+- source 或 realization 是否被手工修改。
+
+发现 store 被修改时不自动 reset。重新安装到新的临时目录并原子替换，旧的损坏
+目录留待显式 clean，可以减少误删用户内容的风险。
+
+## 11. 渐进实现顺序
+
+### Phase A：共享路径解析和元数据
+
+- 集中 `cr`/docs/query 的 module resolver；
+- 项目 `.calcit/modules` 优先、legacy global fallback；
+- `PackageDeps` 支持 `:version` 与可选 `:native`；
+- 增加 `caps version`，只管理 `deps.cirru`；
+- 远端 ref 分类，branch/non-SemVer warning；
+- 保持当前单层下载行为作为兼容基线。
+
+### Phase B：多版本 store 与项目链接
+
+- source 以 canonical repo + commit 入 store；
+- 安装完成后原子创建项目链接和 state；
+- 从干净 legacy clone 导入/复用 commit，不删除旧目录；
+- `caps status` 同时理解 legacy 与 project view。
+
+### Phase C：递归依赖图
+
+- 带 provenance 的 fixpoint resolver；
+- SemVer tag 最高版本选择和不可比较冲突规则；
+- `caps tree`、`caps why`、JSON 输出；
+- cycle、缺失 `deps.cirru`、损坏子依赖文件的测试。
+
+### Phase D：native realization
+
+- build key、隔离构建目录和 receipt；
+- legacy `build.sh` 兼容与可选 native manifest；
+- `caps verify` 子进程加载检查；
+- runtime 错误关联 receipt。
+
+每个 phase 都可以单独发布，不能要求一次性修改所有模块。Phase A/B 稳定后再让
+默认 `caps` 开启递归解析；此前可用实验 flag 在真实 Respo 依赖链验证。
+
+## 12. 测试与验收
+
+除仓库常规 `cargo fmt`、`cargo clippy -- -D warnings`、`cargo test`、
+`yarn compile`、`yarn check-all` 和 `yarn check-agent-interface` 外，依赖管理需覆盖：
+
+- 两项目请求同模块不同 tag，链接到不同 commit；
+- 两项目请求相同 commit，store 只保存一份 source；
+- 菱形依赖选择最高 SemVer，并输出全部 provenance warning；
+- branch 依赖显示 resolved commit，`--strict` 失败；
+- branch/tag 混合时优先 SemVer tag 并强 warning；全是不可比较 ref 且没有 root
+  裁决时失败；
+- 依赖环不会无限递归，`tree` 输出稳定；
+- 子模块 `deps.cirru` 损坏时安装失败且旧项目链接不变；
+- standalone `deps.cirru` 在空目录完成安装；
+- basename 冲突不会覆盖链接；
+- native build key 在 target/ABI/toolchain 改变后失效；
+- native 构建中断不会留下可复用的“成功”目录；
+- 产物缺失、hash 改变、错误架构、ABI 不匹配和系统依赖缺失均能定位到具体
+  module revision；
+- legacy `~/.config/calcit/modules/<repo>` 项目仍可运行；
+- Respo 等真实项目的 compile、类型查询与 examples 回归通过。
+
+最终验收标准：项目之间不再通过切换全局 checkout 相互影响；依赖图的每个选择
+都可用 `tree/why` 解释；失败安装不破坏现有项目；native 产物不会跨不兼容环境
+复用，并能在运行前通过 `caps verify` 发现主要错误。

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -42,7 +42,7 @@ To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename
 Paths defined in `:modules` first use `<project>/.calcit/modules/` and then the legacy
 `~/.config/calcit/modules/` fallback. Existing snapshot `:modules` values do not need to change.
 
-Modules that ends with `/`s are automatically suffixed `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
+Modules that end with `/` are automatically suffixed with `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
 
 ### Dependency graph
 
@@ -114,7 +114,7 @@ reported as an error and should be moved aside before reinstalling.
 
 ```
 caps --help
-Usage: caps [<input>] [-v] [--pull-branch] [--ci] [--local-debug] [<command>] [<args>]
+Usage: caps [<input>] [-v] [--pull-branch] [--ci] [--local-debug] [--strict] [<command>] [<args>]
 
 Top-level command.
 
@@ -126,6 +126,7 @@ Options:
   --pull-branch     deprecated compatibility flag; branch refs resolve remotely
   --ci              CI mode loads shallow repo via HTTPS
   --local-debug     debug mode, clone to test-modules/
+  --strict          reject branch and version-conflict warnings
   --help, help      display usage information
 
 Commands:

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -22,7 +22,13 @@ aliases:
     |calcit-lang/lilac |main
 ```
 
-Run `caps` to download. Sources are downloaded into `~/.config/calcit/modules/`. If a module contains `build.sh`, it will be executed mostly for compiling Rust dylibs.
+Run `caps` to recursively resolve and install the graph. Sources are stored by resolved commit under
+`~/.config/calcit/modules/.store/`. The project gets a local module view in `.calcit/modules/`, with
+`caps-state.cirru`, temporary files, and other generated state kept under `.calcit/`.
+
+SemVer tags are the recommended dependency refs. Branches are supported for development, but every
+resolution warns and prints the current commit. Conflicting SemVer tags select the highest version actually
+requested by the graph and emit a warning that lists the request sources.
 
 To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename: `compact.cirru`):
 
@@ -33,9 +39,41 @@ To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename
       :modules $ [] |memof/calcit.cirru |lilac/
 ```
 
-Paths defined in `:modules` field are just loaded as files from `~/.config/calcit/modules/`, i.e. `~/.config/calcit/modules/memof/calcit.cirru`.
+Paths defined in `:modules` first use `<project>/.calcit/modules/` and then the legacy
+`~/.config/calcit/modules/` fallback. Existing snapshot `:modules` values do not need to change.
 
 Modules that ends with `/`s are automatically suffixed `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
+
+### Dependency graph
+
+```bash
+caps tree
+caps why calcit-lang/memof
+caps status
+caps verify
+```
+
+`tree` displays selected recursive revisions, while `why` prints one shortest path from every root
+dependency and all direct version requests. `status` checks project links; `verify` also checks immutable
+store commits, local source modifications, and native realization receipts.
+
+The positional input may point to a standalone dependency file. Its parent directory becomes the project
+root even when no `calcit.cirru` exists:
+
+```bash
+caps /tmp/demo/deps.cirru
+```
+
+New projects may keep their package version in `deps.cirru` and manage it with:
+
+```bash
+caps version get
+caps version set 1.2.3
+caps version bump patch
+```
+
+During migration, the snapshot `:version` field remains supported by `cr`; `caps version` only manages the
+dependency metadata file and does not rewrite the snapshot automatically.
 
 ### Outdated
 
@@ -53,26 +91,24 @@ caps upgrade --all
 
 ### Module status and local changes
 
-Installed modules are Git working trees. Check that every installed module is at the
-version declared by `deps.cirru`, and report local working-tree changes, with:
+Check that every project link points to the revision selected from `deps.cirru` with:
 
 ```bash
 caps status
 ```
 
-The regular `caps` command performs the same local-change check before syncing
-dependencies. If a module has local modifications, it prints a warning so that the
-changes are not mistaken for the version from the remote repository.
+Use `caps verify` for the stronger immutable-store and native-receipt checks. Shared
+store revisions should not be edited directly; reinstall a damaged revision instead.
 
-To discard tracked local changes and return each installed dependency to its current
-commit, run:
+`caps reset` rebuilds the current project's `.calcit/modules/` links from the resolved immutable
+store entries:
 
 ```bash
 caps reset
 ```
 
-This uses `git reset --hard HEAD`; review and back up any work you need before running
-it. Untracked files are reported by `caps status` but are not deleted by `caps reset`.
+It never runs `git reset` inside shared store revisions. A damaged or edited store entry is
+reported as an error and should be moved aside before reinstalling.
 
 ### CLI Options
 
@@ -87,17 +123,25 @@ Positional Arguments:
 
 Options:
   -v, --verbose     verbose mode
-  --pull-branch     pull branch in the repo
+  --pull-branch     deprecated compatibility flag; branch refs resolve remotely
   --ci              CI mode loads shallow repo via HTTPS
   --local-debug     debug mode, clone to test-modules/
   --help, help      display usage information
 
 Commands:
   outdated          show outdated versions
+  upgrade           upgrade dependencies
   download          download named packages with org/repo@branch
+  add               add dependencies to deps.cirru then install
+  remove            remove dependencies from deps.cirru then install
+  tree              show the resolved recursive dependency graph
+  why               explain why a module is present in the resolved graph
   status            check installed module versions and local modifications
-  reset             discard tracked local modifications in installed modules
+  verify            verify store contents, project links, and native receipts
+  reset             rebuild project links from immutable store entries
+  version           read or update the package version in deps.cirru
 ```
 
-- "pull branch" to fetch update if only branch name is specified like `main`.
+- `--pull-branch` is retained for CLI compatibility. Recursive resolution always checks
+  the current remote commit for branch refs.
 - "ci" does not support `git@` protocol, only `https://` protocol.

--- a/editing-history/202608122230-caps-project-module-store.md
+++ b/editing-history/202608122230-caps-project-module-store.md
@@ -41,6 +41,17 @@
 - Follow-up review fixes use `Path::is_absolute` for module paths, disable
   Git credential prompts in `caps outdated`, and create Windows directory
   junctions before falling back to directory symlinks.
+- The follow-up pass gives isolated commit hashes their own fetch-and-detached
+  checkout path, namespaces staging directories with an identity hash, and
+  keeps all network Git operations non-interactive with HTTPS-to-SSH fallback
+  where supported.
+- Native receipts now record every `dylibs/` artifact's relative path, size,
+  and MD5. Reuse and `caps verify` reject malformed receipts, path escapes,
+  symlinks, unlisted files, and changed contents. Native staging lives beside
+  the destination realization so its final rename stays on one filesystem.
+- On Windows a failed junction and symlink attempt uses a copy fallback. The
+  generated state records `:view-mode`, while `caps status` reports a
+  non-shared copy rather than treating it as a deduplicated store link.
 
 ## Real-project verification
 

--- a/editing-history/202608122230-caps-project-module-store.md
+++ b/editing-history/202608122230-caps-project-module-store.md
@@ -1,0 +1,67 @@
+# caps project module store and recursive dependency graph
+
+## Summary
+
+- Added a commit-addressed global module store under
+  `~/.config/calcit/modules/.store/` and a per-project module view under
+  `.calcit/modules/`.
+- Made runtime module loading prefer the project view while retaining the
+  legacy global module directory as a fallback.
+- Added recursive `deps.cirru` resolution with deterministic highest-SemVer
+  selection, branch warnings, request provenance, and basename collision
+  rejection.
+- Added `caps tree`, `caps why`, `caps verify`, strict warning handling, and
+  `caps version get/set/bump`.
+- Isolated native `build.sh` execution in keyed realizations so shared source
+  revisions stay clean and incompatible build outputs are not reused.
+- Kept generated project state, links, temporary files, and local ignore rules
+  inside `.calcit/`.
+
+## Compatibility findings
+
+- Older module metadata may omit `:dependencies`; it is treated as an empty
+  graph. A present but malformed `:dependencies` still fails the install.
+- Existing projects frequently mix published tags with transitive `main`
+  dependencies. Published SemVer tags take precedence over mutable refs and
+  produce an explicit warning. Completely incomparable mutable refs still
+  require a direct root decision.
+- Dense graphs make exhaustive `why` path enumeration impractical. The command
+  reports one shortest path per root dependency and all direct version
+  requests instead.
+- Review changed `caps reset` to rebuild project links instead of applying
+  `git reset --hard` to shared state. Existing store hits now reject the wrong
+  commit or local changes before they are linked.
+- Remote discovery prefers non-interactive HTTPS, falls back to SSH outside CI,
+  prints per-module progress, and resolves up to six repositories concurrently.
+  Temporary clone names include the repository so equal refs such as `main`
+  cannot collide.
+- `cr config modules` now uses the same project-first candidate search as the
+  runtime and continues from an invalid `calcit.cirru` to a valid legacy
+  `compact.cirru` candidate.
+
+## Real-project verification
+
+- Fast-forwarded clean local checkouts of `lilac`, `calcit.std`, `calcit-http`,
+  and `guidebook` before validation. `calcit.std` advanced to remote main;
+  the other three were already current.
+- Installed and checked standalone dependency files for `lilac`, `calcit.std`,
+  `calcit-http`, and the ten-module transitive `guidebook` graph in temporary
+  project roots sharing a temporary store.
+- Confirmed project-view loading with a copied `memof` snapshot and
+  `cr query ns lilac.core`.
+- Built `calcit.std@0.2.15` as a native realization, reused the cached build on
+  the second install, passed `caps verify`, then confirmed a changed ABI build
+  key is rejected until a normal `caps` install switches the project link.
+- Installed the release `cr` and `caps` binaries into `~/.cargo/bin`, then
+  installed modules directly inside updated `lilac` and `guidebook` checkouts.
+  `guidebook` resolved ten modules, reported all conflicts/branch refs, and
+  passed `status`, `verify`, and `cr query ns respo.core` using project links.
+
+## Repository verification
+
+- `cargo fmt -- --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-all`
+- `yarn check-agent-interface`

--- a/editing-history/202608122230-caps-project-module-store.md
+++ b/editing-history/202608122230-caps-project-module-store.md
@@ -38,6 +38,9 @@
 - `cr config modules` now uses the same project-first candidate search as the
   runtime and continues from an invalid `calcit.cirru` to a valid legacy
   `compact.cirru` candidate.
+- Follow-up review fixes use `Path::is_absolute` for module paths, disable
+  Git credential prompts in `caps outdated`, and create Windows directory
+  junctions before falling back to directory symlinks.
 
 ## Real-project verification
 

--- a/editing-history/202608130003-release-0.13.13.md
+++ b/editing-history/202608130003-release-0.13.13.md
@@ -1,0 +1,9 @@
+# release 0.13.13 from caps module-store branch
+
+## Summary
+
+- Released version `0.13.13` directly from `codex/caps-project-module-store`
+  while keeping the feature branch unmerged, as requested.
+- Kept the Rust crate, npm package, and workspace lockfile versions aligned.
+- The branch had already passed PR CI; the release update was additionally
+  checked with formatting and the `caps` test suite.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -3,13 +3,14 @@
 //!
 //! files are stored in `~/.config/calcit/modules/`.
 
+mod caps_graph;
 mod git;
 
 use argh::{self, FromArgs};
 
+use caps_graph::*;
 use cirru_edn::Edn;
 use colored::*;
-use git::*;
 use semver::Version;
 use std::{
   collections::HashMap,
@@ -23,6 +24,7 @@ use std::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PackageDeps {
+  version: Option<String>,
   calcit_version: Option<String>,
   dependencies: HashMap<Arc<str>, Arc<str>>,
 }
@@ -33,7 +35,10 @@ impl TryFrom<Edn> for PackageDeps {
   fn try_from(value: Edn) -> Result<Self, Self::Error> {
     let deps_info = value.view_map()?;
     #[allow(clippy::mutable_key_type)]
-    let dict = deps_info.get_or_nil("dependencies").view_map()?.0;
+    let dict = match deps_info.get_or_nil("dependencies") {
+      Edn::Nil => cirru_edn::EdnMapView::default().0,
+      value => value.view_map()?.0,
+    };
 
     let mut deps: HashMap<Arc<str>, Arc<str>> = HashMap::new();
     for (k, v) in &dict {
@@ -51,7 +56,13 @@ impl TryFrom<Edn> for PackageDeps {
       Edn::Nil => None,
       v => return Err(format!("invalid calcit-version: {v}")),
     };
+    let package_version: Option<String> = match deps_info.get_or_nil("version") {
+      Edn::Str(s) => Some((*s).to_owned()),
+      Edn::Nil => None,
+      v => return Err(format!("invalid version: {v}")),
+    };
     Ok(PackageDeps {
+      version: package_version,
       calcit_version: expected_version,
       dependencies: deps,
     })
@@ -61,7 +72,17 @@ impl TryFrom<Edn> for PackageDeps {
 pub fn main() -> Result<(), String> {
   // parse deps.cirru
 
+  let raw_args = std::env::args().collect::<Vec<_>>();
+  if raw_args.get(1).is_some_and(|arg| arg == "__verify-native") {
+    let path = raw_args.get(2).ok_or_else(|| "missing native library path".to_string())?;
+    verify_native_library(Path::new(path))?;
+    return Ok(());
+  }
+
   let cli_args: TopLevelCaps = argh::from_env();
+  if cli_args.pull_branch {
+    eprintln!("[Warn] --pull-branch is deprecated; branch refs are always resolved from the remote");
+  }
   if let Some(SubCommand::Download(dep_names)) = &cli_args.subcommand {
     if dep_names.packages.is_empty() {
       eprintln!("Error: no packages to download!");
@@ -134,10 +155,18 @@ pub fn main() -> Result<(), String> {
 
         let mut updated_deps = deps;
         for raw in &opts.packages {
-          let org_and_folder = normalize_package_name(raw)?;
+          let split_at = raw.rfind('@').filter(|index| {
+            let path_boundary = raw.rfind(['/', ':']).unwrap_or(0);
+            *index > path_boundary
+          });
+          let (package, inline_version) = split_at.map_or((raw.as_str(), None), |index| {
+            let (package, version) = raw.split_at(index);
+            (package, version.strip_prefix('@').filter(|version| !version.is_empty()))
+          });
+          let org_and_folder = normalize_package_name(package)?;
           updated_deps
             .dependencies
-            .insert(org_and_folder.into(), opts.version.to_owned().into());
+            .insert(org_and_folder.into(), inline_version.unwrap_or(&opts.version).to_owned().into());
         }
 
         write_deps_file(&cli_args.input, &updated_deps)?;
@@ -160,19 +189,49 @@ pub fn main() -> Result<(), String> {
         download_deps(updated_deps.dependencies, cli_args)?;
       }
       Some(SubCommand::Status(_)) => {
-        let issues = check_dependency_status(&deps, &cli_args, false)?;
+        let graph = resolve_for_cli(&deps, &cli_args, false)?;
+        print_warnings(&graph);
+        let issues = check_project_view(&graph, &graph_options(&cli_args, false)?)?;
         if issues > 0 {
           return Err(format!("{issues} module(s) are not in the expected state"));
         }
       }
+      Some(SubCommand::Verify(_)) => {
+        let graph = resolve_for_cli(&deps, &cli_args, false)?;
+        print_warnings(&graph);
+        let issues = verify_project_view(&graph, &graph_options(&cli_args, false)?)?;
+        if issues > 0 {
+          return Err(format!("{issues} module verification issue(s) found"));
+        }
+      }
+      Some(SubCommand::Tree(_)) => {
+        let graph = resolve_for_cli(&deps, &cli_args, false)?;
+        print_warnings(&graph);
+        print_tree(&graph);
+      }
+      Some(SubCommand::Why(opts)) => {
+        let graph = resolve_for_cli(&deps, &cli_args, false)?;
+        print_warnings(&graph);
+        print_why(&graph, &normalize_package_name(&opts.package)?)?;
+      }
+      Some(SubCommand::Version(opts)) => {
+        handle_version_command(deps, &cli_args.input, opts)?;
+      }
       Some(SubCommand::Reset(_)) => {
-        reset_dependency_status(&deps, &cli_args)?;
+        let graph = resolve_for_cli(&deps, &cli_args, true)?;
+        print_warnings(&graph);
+        let graph_options = graph_options(&cli_args, true)?;
+        install_project_view(&graph, &graph_options)?;
+        println!(
+          "restored {} module link(s) under {}",
+          graph.modules.len(),
+          graph_options.project_root.join(".calcit/modules").display()
+        );
       }
       Some(SubCommand::Download(dep_names)) => {
         unreachable!("already handled: {:?}", dep_names);
       }
       None => {
-        check_dependency_status(&deps, &cli_args, true)?;
         download_deps(deps.dependencies, cli_args)?;
       }
     }
@@ -190,218 +249,57 @@ pub fn main() -> Result<(), String> {
 }
 
 fn download_deps(deps: HashMap<Arc<str>, Arc<str>>, options: TopLevelCaps) -> Result<(), String> {
-  // ~/.config/calcit/modules/
-  let clone_target = if options.local_debug {
-    println!("{}", "  [DEBUG] local debug mode, cloning to test-modules/".yellow());
-    ".config/calcit/test-modules"
-  } else {
-    ".config/calcit/modules"
+  let package = PackageDeps {
+    version: None,
+    calcit_version: None,
+    dependencies: deps,
   };
-  let modules_dir = dirs::home_dir().ok_or("no config dir")?.join(clone_target);
-
-  if !modules_dir.exists() {
-    fs::create_dir_all(&modules_dir).map_err(|e| e.to_string())?;
-    dim_println(format!("created dir: {modules_dir:?}"));
-  }
-
-  let mut children = vec![];
-
-  for (org_and_folder, version) in deps {
-    // cloned
-
-    let org_and_folder = org_and_folder.clone();
-    let options = options.to_owned();
-    let modules_dir = modules_dir.clone();
-
-    // TODO too many threads do not make it faster though
-    let options2 = options.clone();
-    let ret = thread::spawn(move || {
-      let ret = handle_path(modules_dir, version, &options2, org_and_folder);
-      if let Err(e) = ret {
-        err_println(format!("{e}\n"));
-      }
-    });
-    children.push(ret);
-  }
-  for child in children {
-    child.join().unwrap();
-  }
-
+  let graph = resolve_for_cli(&package, &options, !options.ci)?;
+  print_warnings(&graph);
+  let graph_options = graph_options(&options, !options.ci)?;
+  install_project_view(&graph, &graph_options)?;
+  println!(
+    "installed {} module(s) into {}",
+    graph.modules.len(),
+    graph_options.project_root.join(".calcit/modules").display()
+  );
   Ok(())
 }
 
+fn graph_options(options: &TopLevelCaps, build_native: bool) -> Result<GraphOptions, String> {
+  let input = PathBuf::from(&options.input);
+  let absolute_input = if input.is_absolute() {
+    input
+  } else {
+    std::env::current_dir().map_err(|e| e.to_string())?.join(input)
+  };
+  let project_root = absolute_input
+    .parent()
+    .ok_or_else(|| format!("cannot determine project directory from {}", absolute_input.display()))?
+    .to_path_buf();
+  Ok(GraphOptions {
+    project_root,
+    modules_dir: modules_dir(options)?,
+    ci: options.ci,
+    strict: options.strict,
+    build_native,
+  })
+}
+
+fn resolve_for_cli(deps: &PackageDeps, options: &TopLevelCaps, build_native: bool) -> Result<ResolvedGraph, String> {
+  resolve_graph(deps, &graph_options(options, build_native)?)
+}
+
 fn modules_dir(options: &TopLevelCaps) -> Result<PathBuf, String> {
+  if let Some(path) = std::env::var_os("CALCIT_MODULES_DIR") {
+    return Ok(PathBuf::from(path));
+  }
   let dir = if options.local_debug {
     ".config/calcit/test-modules"
   } else {
     ".config/calcit/modules"
   };
   Ok(dirs::home_dir().ok_or("no config dir")?.join(dir))
-}
-
-fn check_dependency_status(deps: &PackageDeps, options: &TopLevelCaps, warn_only: bool) -> Result<usize, String> {
-  let modules_dir = modules_dir(options)?;
-  let mut issues = 0;
-  for (org_and_folder, version) in &deps.dependencies {
-    let folder = module_folder(org_and_folder)?;
-    let folder_path = modules_dir.join(folder);
-    if !folder_path.exists() {
-      issues += 1;
-      println!("{}", format!("- {org_and_folder} not found (expected {version})").red());
-      continue;
-    }
-    let repo = GitRepo { dir: folder_path.clone() };
-    let changes = wrap_module_error(repo.status_porcelain(), org_and_folder, &folder_path, "read working tree status")?;
-    let head = wrap_module_error(repo.current_head(), org_and_folder, &folder_path, "read current git head")?;
-    if !changes.is_empty() {
-      issues += 1;
-      let message = format!(
-        "! {org_and_folder} has local modifications (expected {version}, at {})",
-        head.get_name()
-      );
-      if warn_only {
-        eprintln!("{}", message.yellow());
-      } else {
-        println!("{}", message.yellow());
-      }
-    } else if head.get_name() != **version {
-      issues += 1;
-      println!(
-        "{}",
-        format!("! {org_and_folder} is at {}, expected {version}", head.get_name()).yellow()
-      );
-    } else {
-      println!("{}", format!("√ {org_and_folder} at {version}").dimmed());
-    }
-  }
-  Ok(issues)
-}
-
-fn reset_dependency_status(deps: &PackageDeps, options: &TopLevelCaps) -> Result<(), String> {
-  let modules_dir = modules_dir(options)?;
-  for org_and_folder in deps.dependencies.keys() {
-    let folder = module_folder(org_and_folder)?;
-    let folder_path = modules_dir.join(folder);
-    if !folder_path.exists() {
-      continue;
-    }
-    let repo = GitRepo { dir: folder_path.clone() };
-    let changes = wrap_module_error(repo.status_porcelain(), org_and_folder, &folder_path, "read working tree status")?;
-    if changes.is_empty() {
-      continue;
-    }
-    if !changes.iter().any(|change| !change.starts_with("?? ")) {
-      println!("untracked files remain in {}", org_and_folder.yellow());
-      continue;
-    }
-    wrap_module_error(repo.reset_hard(), org_and_folder, &folder_path, "reset local changes")?;
-    println!("reset {}", org_and_folder.green());
-  }
-  Ok(())
-}
-
-fn wrap_module_error<T>(result: Result<T, String>, org_and_folder: &str, folder_path: &Path, action: &str) -> Result<T, String> {
-  result.map_err(|e| format!("failed to {action} module `{org_and_folder}` at `{}`\n{e}", folder_path.display()))
-}
-
-fn handle_path(modules_dir: PathBuf, version: Arc<str>, options: &TopLevelCaps, org_and_folder: Arc<str>) -> Result<(), String> {
-  // check if exists
-  let folder = module_folder(&org_and_folder)?;
-  // split with / into (org,folder)
-
-  let folder_path = modules_dir.join(folder);
-  let build_file = folder_path.join("build.sh");
-  let git_repo = GitRepo { dir: folder_path.clone() };
-  if folder_path.exists() {
-    // println!("module {} exists", folder);
-    // check branch
-    let current_head = wrap_module_error(git_repo.current_head(), &org_and_folder, &folder_path, "read current git head")?;
-
-    if current_head.get_name() == *version {
-      dim_println(format!("√ found {} of {}", gray(&version), gray(folder)));
-      if let GitHead::Branch(branch) = current_head
-        && options.pull_branch
-      {
-        dim_println(format!("↺ pulling {} at version {}", gray(&org_and_folder), gray(&version)));
-        wrap_module_error(git_repo.pull(&branch), &org_and_folder, &folder_path, "pull branch")?;
-        dim_println(format!("pulled {} at {}", gray(folder), gray(&version)));
-
-        // if there's a build.sh file in the folder, run it
-        if build_file.exists() {
-          let build_msg = wrap_module_error(call_build_script(&folder_path), &org_and_folder, &folder_path, "run build.sh")?;
-          dim_println(format!("ran build script for {}", gray(&org_and_folder)));
-          dim_println(build_msg);
-        }
-      }
-      return Ok(());
-    }
-    // let msg = format!("module {} is at version {:?}, but required {}", folder, current_head, version);
-    // println!("  {}", msg.yellow());
-
-    // load latest tags
-    wrap_module_error(git_repo.fetch(), &org_and_folder, &folder_path, "fetch tags")?;
-    // try if tag or branch exists in git history
-    let has_target = wrap_module_error(
-      git_repo.check_branch_or_tag(&version, folder),
-      &org_and_folder,
-      &folder_path,
-      "check target branch or tag",
-    )?;
-    if !has_target {
-      dim_println(format!("↺ fetching {} at version {}", gray(&org_and_folder), gray(&version)));
-      wrap_module_error(git_repo.fetch(), &org_and_folder, &folder_path, "fetch tags")?;
-      dim_println(format!("fetched {} at version {}", gray(&org_and_folder), gray(&version)));
-      // fetch git repo and checkout target version
-    }
-    wrap_module_error(
-      git_repo.checkout(&version),
-      &org_and_folder,
-      &folder_path,
-      &format!("checkout version `{version}`"),
-    )?;
-    dim_println(format!("√ checked out {} of {}", gray(&version), gray(&org_and_folder)));
-
-    let current_head = wrap_module_error(git_repo.current_head(), &org_and_folder, &folder_path, "read current git head")?;
-    if let GitHead::Branch(branch) = current_head
-      && options.pull_branch
-    {
-      dim_println(format!("↺ pulling {} at version {}", gray(&org_and_folder), gray(&version)));
-      wrap_module_error(git_repo.pull(&branch), &org_and_folder, &folder_path, "pull branch")?;
-      dim_println(format!("pulled {} at {}", gray(folder), gray(&version)));
-    }
-
-    // if there's a build.sh file in the folder, run it
-    if build_file.exists() {
-      let build_msg = wrap_module_error(call_build_script(&folder_path), &org_and_folder, &folder_path, "run build.sh")?;
-      dim_println(format!("ran build script for {}", gray(&org_and_folder)));
-      dim_println(build_msg);
-    }
-  } else {
-    let url = if options.ci {
-      format!("https://github.com/{org_and_folder}.git")
-    } else {
-      format!("git@github.com:{org_and_folder}.git")
-    };
-    dim_println(format!("↺ cloning {} at version {}", gray(&org_and_folder), gray(&version)));
-    wrap_module_error(
-      GitRepo::clone_to(&modules_dir, &url, &version, options.ci),
-      &org_and_folder,
-      &folder_path,
-      &format!("clone version `{version}`"),
-    )?;
-    // println!("downloading {} at version {}", url, version);
-    dim_println(format!("downloaded {} at version {}", gray(&org_and_folder), gray(&version)));
-
-    if !options.ci {
-      // if there's a build.sh file in the folder, run it
-      if build_file.exists() {
-        let build_msg = wrap_module_error(call_build_script(&folder_path), &org_and_folder, &folder_path, "run build.sh")?;
-        dim_println(format!("ran build script for {}", gray(&org_and_folder)));
-        dim_println(build_msg);
-      }
-    }
-  }
-  Ok(())
 }
 
 pub const CALCIT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -417,7 +315,7 @@ struct TopLevelCaps {
   #[argh(subcommand)]
   subcommand: Option<SubCommand>,
 
-  /// pull branch in the repo
+  /// deprecated compatibility flag; branch refs resolve remotely
   #[argh(switch)]
   pull_branch: bool,
   /// CI mode loads shallow repo via HTTPS
@@ -426,6 +324,10 @@ struct TopLevelCaps {
   /// debug mode, clone to test-modules/
   #[argh(switch)]
   local_debug: bool,
+
+  /// reject branch and version-conflict warnings
+  #[argh(switch)]
+  strict: bool,
 
   /// input file
   #[argh(positional, default = "\"deps.cirru\".to_owned()")]
@@ -441,9 +343,17 @@ enum SubCommand {
   Download(DownloadCaps),
   Add(AddCaps),
   Remove(RemoveCaps),
+  /// show the resolved recursive dependency graph
+  Tree(TreeCaps),
+  /// explain why a module is present
+  Why(WhyCaps),
+  /// read or update the package version in deps.cirru
+  Version(VersionCaps),
   /// check installed modules for local modifications and version mismatches
   Status(StatusCaps),
-  /// discard tracked local modifications in installed modules
+  /// verify store contents, project links, and native receipts
+  Verify(VerifyCaps),
+  /// rebuild the project module links from resolved immutable store entries
   Reset(ResetCaps),
 }
 
@@ -453,9 +363,67 @@ enum SubCommand {
 struct StatusCaps {}
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
-/// discard tracked local modifications in installed modules
+/// verify store contents, project links, and native receipts
+#[argh(subcommand, name = "verify")]
+struct VerifyCaps {}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// rebuild the project module links from resolved immutable store entries
 #[argh(subcommand, name = "reset")]
 struct ResetCaps {}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// show the resolved recursive dependency graph
+#[argh(subcommand, name = "tree")]
+struct TreeCaps {}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// explain why a module is present in the resolved graph
+#[argh(subcommand, name = "why")]
+struct WhyCaps {
+  /// package in owner/repo form
+  #[argh(positional)]
+  package: String,
+}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// read or update the package version in deps.cirru
+#[argh(subcommand, name = "version")]
+struct VersionCaps {
+  #[argh(subcommand)]
+  command: VersionSubcommand,
+}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand)]
+enum VersionSubcommand {
+  Get(VersionGetCaps),
+  Set(VersionSetCaps),
+  Bump(VersionBumpCaps),
+}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// print the package version
+#[argh(subcommand, name = "get")]
+struct VersionGetCaps {}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// set the package version
+#[argh(subcommand, name = "set")]
+struct VersionSetCaps {
+  /// exact SemVer version
+  #[argh(positional)]
+  version: String,
+}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// bump the package version
+#[argh(subcommand, name = "bump")]
+struct VersionBumpCaps {
+  /// one of major, minor, or patch
+  #[argh(positional)]
+  level: String,
+}
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 /// upgrade dependencies
@@ -508,24 +476,12 @@ struct RemoveCaps {
   packages: Vec<String>,
 }
 
-fn dim_println(msg: String) {
-  if msg.chars().nth(1) == Some(' ') {
-    println!("{}", msg.truecolor(128, 128, 128));
-  } else {
-    println!("  {}", msg.truecolor(128, 128, 128));
-  }
-}
-
 fn err_println(msg: String) {
   if msg.chars().nth(1) == Some(' ') {
     println!("{}", msg.truecolor(255, 80, 80));
   } else {
     println!("  {}", msg.replace('\n', "\n  ").truecolor(255, 80, 80));
   }
-}
-
-fn gray(msg: &str) -> ColoredString {
-  msg.truecolor(172, 172, 172)
 }
 
 fn indent4(msg: &str) -> String {
@@ -584,7 +540,8 @@ fn valid_module_component(component: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-  use super::{module_folder, normalize_package_name};
+  use super::{PackageDeps, module_folder, normalize_package_name};
+  use cirru_edn::Edn;
 
   #[test]
   fn module_names_are_canonical_before_path_use() {
@@ -602,12 +559,36 @@ mod tests {
     );
     assert!(normalize_package_name("calcit-lang/respo.calcit/extra").is_err());
   }
+
+  #[test]
+  fn missing_dependencies_field_is_an_empty_graph() {
+    let deps: PackageDeps = Edn::Map(cirru_edn::EdnMapView::default()).try_into().unwrap();
+    assert!(deps.dependencies.is_empty());
+  }
+
+  #[test]
+  fn write_deps_preserves_package_version() {
+    let path = std::env::temp_dir().join(format!("calcit-caps-version-{}.cirru", std::process::id()));
+    let deps = PackageDeps {
+      version: Some("1.2.3".to_string()),
+      calcit_version: Some("0.13.12".to_string()),
+      dependencies: Default::default(),
+    };
+    super::write_deps_file(path.to_str().unwrap(), &deps).unwrap();
+    let parsed = cirru_edn::parse(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    let restored: PackageDeps = parsed.try_into().unwrap();
+    assert_eq!(restored.version.as_deref(), Some("1.2.3"));
+    std::fs::remove_file(path).unwrap();
+  }
 }
 
 fn write_deps_file(deps_file: &str, deps: &PackageDeps) -> Result<(), String> {
   let mut updated_edn = Edn::Map(cirru_edn::EdnMapView::default());
 
   if let Edn::Map(ref mut map) = updated_edn {
+    if let Some(ref version) = deps.version {
+      map.insert(Edn::tag("version"), Edn::str(version.as_str()));
+    }
     if let Some(ref version) = deps.calcit_version {
       map.insert(Edn::tag("calcit-version"), Edn::str(version.as_str()));
     }
@@ -721,22 +702,29 @@ fn outdated_tags(deps: PackageDeps, deps_file: &str, auto_yes: bool) -> Result<b
 }
 
 fn show_package_versions(org_and_folder: Arc<str>, version: Arc<str>) -> Result<Option<String>, String> {
-  let folder = module_folder(&org_and_folder)?;
-  let folder_path = dirs::home_dir().ok_or("no config dir")?.join(".config/calcit/modules").join(folder);
-  let git_repo = GitRepo { dir: folder_path.clone() };
-  if folder_path.exists() {
-    git_repo.fetch()?;
-
-    // get latest tag and timestamp
-    let latest_tag = git_repo.latest_tag()?;
-    let latest_timestamp = git_repo.timestamp(&latest_tag)?;
-
-    // get expected tag and timestamp
-    let expected_timestamp = git_repo.timestamp(&version)?;
-
-    let outdated = expected_timestamp < latest_timestamp;
-
-    if outdated {
+  let url = format!("https://github.com/{org_and_folder}.git");
+  let output = Command::new("git")
+    .args(["ls-remote", "--tags", "--refs", &url])
+    .output()
+    .map_err(|e| format!("failed to inspect tags for {org_and_folder}: {e}"))?;
+  if !output.status.success() {
+    return Err(format!(
+      "failed to inspect tags for {org_and_folder}: {}",
+      String::from_utf8_lossy(&output.stderr).trim()
+    ));
+  }
+  let latest = String::from_utf8_lossy(&output.stdout)
+    .lines()
+    .filter_map(|line| line.split_once("refs/tags/").map(|(_, tag)| tag))
+    .filter_map(|tag| {
+      Version::parse(tag.strip_prefix('v').unwrap_or(tag))
+        .ok()
+        .map(|parsed| (tag.to_string(), parsed))
+    })
+    .max_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+  if let Some((latest_tag, latest_version)) = latest {
+    let current = Version::parse(version.strip_prefix('v').unwrap_or(&version));
+    if current.as_ref().is_ok_and(|current| current < &latest_version) {
       print_column(org_and_folder.yellow(), version.yellow(), latest_tag.yellow(), "Outdated".yellow());
       Ok(Some(latest_tag))
     } else {
@@ -744,7 +732,7 @@ fn show_package_versions(org_and_folder: Arc<str>, version: Arc<str>) -> Result<
       Ok(None)
     }
   } else {
-    print_column(org_and_folder.red(), version.red(), "not found".red(), "-".red());
+    print_column(org_and_folder.yellow(), version.yellow(), "no SemVer tags".yellow(), "-".yellow());
     Ok(None)
   }
 }
@@ -867,6 +855,85 @@ fn sync_calcit_procs_package() -> Result<(), String> {
       "`yarn up @calcit/procs` exited with status {}",
       status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
     ))
+  }
+}
+
+fn handle_version_command(mut deps: PackageDeps, deps_file: &str, opts: &VersionCaps) -> Result<(), String> {
+  match &opts.command {
+    VersionSubcommand::Get(_) => {
+      let legacy = legacy_snapshot_version(deps_file)?;
+      let version = deps.version.as_deref().or(legacy.as_deref()).ok_or_else(|| {
+        format!(
+          "no :version declared in {deps_file} or its project snapshot; initialize it with `caps {deps_file} version set <version>`"
+        )
+      })?;
+      if deps.version.is_none() {
+        eprintln!("[Warn] reading legacy snapshot :version; migrate it with `caps {deps_file} version set {version}`");
+      }
+      println!("{version}");
+    }
+    VersionSubcommand::Set(opts) => {
+      Version::parse(&opts.version).map_err(|e| format!("invalid SemVer version '{}': {e}", opts.version))?;
+      deps.version = Some(opts.version.clone());
+      write_package_version(deps_file, &opts.version)?;
+      println!("updated {deps_file} to {}", opts.version);
+    }
+    VersionSubcommand::Bump(opts) => {
+      let legacy = legacy_snapshot_version(deps_file)?;
+      let current = deps.version.as_deref().or(legacy.as_deref()).ok_or_else(|| {
+        format!(
+          "no :version declared in {deps_file} or its project snapshot; initialize it with `caps {deps_file} version set <version>`"
+        )
+      })?;
+      let mut version = Version::parse(current).map_err(|e| format!("invalid existing SemVer version '{current}': {e}"))?;
+      match opts.level.as_str() {
+        "major" => {
+          version.major += 1;
+          version.minor = 0;
+          version.patch = 0;
+        }
+        "minor" => {
+          version.minor += 1;
+          version.patch = 0;
+        }
+        "patch" => version.patch += 1,
+        other => return Err(format!("invalid bump level '{other}', expected major, minor, or patch")),
+      }
+      version.pre = semver::Prerelease::EMPTY;
+      version.build = semver::BuildMetadata::EMPTY;
+      deps.version = Some(version.to_string());
+      write_package_version(deps_file, &version.to_string())?;
+      println!("updated {deps_file} to {version}");
+    }
+  }
+  Ok(())
+}
+
+fn write_package_version(deps_file: &str, version: &str) -> Result<(), String> {
+  let content = fs::read_to_string(deps_file).map_err(|e| e.to_string())?;
+  let mut parsed = cirru_edn::parse(&content).map_err(|e| format!("failed to parse {deps_file}: {e}"))?;
+  let Edn::Map(ref mut map) = parsed else {
+    return Err(format!("expected map in {deps_file}"));
+  };
+  map.insert(Edn::tag("version"), Edn::str(version));
+  fs::write(deps_file, cirru_edn::format(&parsed, false)?).map_err(|e| e.to_string())
+}
+
+fn legacy_snapshot_version(deps_file: &str) -> Result<Option<String>, String> {
+  let deps_path = Path::new(deps_file);
+  let project_root = deps_path.parent().unwrap_or(Path::new("."));
+  let snapshot = [project_root.join("calcit.cirru"), project_root.join("compact.cirru")]
+    .into_iter()
+    .find(|path| path.exists());
+  let Some(snapshot) = snapshot else {
+    return Ok(None);
+  };
+  let content = fs::read_to_string(&snapshot).map_err(|e| format!("failed to read {}: {e}", snapshot.display()))?;
+  let parsed = cirru_edn::parse(&content).map_err(|e| format!("failed to parse {}: {e}", snapshot.display()))?;
+  match parsed.view_map()?.get_or_nil("version") {
+    Edn::Str(version) => Ok(Some(version.to_string())),
+    Edn::Nil => Ok(None),
+    value => Err(format!("invalid snapshot :version in {}: {value}", snapshot.display())),
   }
 }
 

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -702,18 +702,16 @@ fn outdated_tags(deps: PackageDeps, deps_file: &str, auto_yes: bool) -> Result<b
 }
 
 fn show_package_versions(org_and_folder: Arc<str>, version: Arc<str>) -> Result<Option<String>, String> {
-  let url = format!("https://github.com/{org_and_folder}.git");
-  let output = Command::new("git")
-    .env("GIT_TERMINAL_PROMPT", "0")
-    .args(["ls-remote", "--tags", "--refs", &url])
-    .output()
-    .map_err(|e| format!("failed to inspect tags for {org_and_folder}: {e}"))?;
-  if !output.status.success() {
-    return Err(format!(
-      "failed to inspect tags for {org_and_folder}: {}",
-      String::from_utf8_lossy(&output.stderr).trim()
-    ));
-  }
+  let https_url = format!("https://github.com/{org_and_folder}.git");
+  let output = match list_remote_tags(&https_url) {
+    Ok(output) => output,
+    Err(https_error) => {
+      let ssh_url = format!("git@github.com:{org_and_folder}.git");
+      list_remote_tags(&ssh_url).map_err(|ssh_error| {
+        format!("failed to inspect tags for {org_and_folder} over HTTPS and SSH:\n  HTTPS: {https_error}\n  SSH: {ssh_error}")
+      })?
+    }
+  };
   let latest = String::from_utf8_lossy(&output.stdout)
     .lines()
     .filter_map(|line| line.split_once("refs/tags/").map(|(_, tag)| tag))
@@ -735,6 +733,20 @@ fn show_package_versions(org_and_folder: Arc<str>, version: Arc<str>) -> Result<
   } else {
     print_column(org_and_folder.yellow(), version.yellow(), "no SemVer tags".yellow(), "-".yellow());
     Ok(None)
+  }
+}
+
+fn list_remote_tags(url: &str) -> Result<std::process::Output, String> {
+  let output = Command::new("git")
+    .env("GIT_TERMINAL_PROMPT", "0")
+    .env("GIT_SSH_COMMAND", "ssh -o BatchMode=yes")
+    .args(["ls-remote", "--tags", "--refs", url])
+    .output()
+    .map_err(|e| format!("failed to inspect {url}: {e}"))?;
+  if output.status.success() {
+    Ok(output)
+  } else {
+    Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
   }
 }
 

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -704,6 +704,7 @@ fn outdated_tags(deps: PackageDeps, deps_file: &str, auto_yes: bool) -> Result<b
 fn show_package_versions(org_and_folder: Arc<str>, version: Arc<str>) -> Result<Option<String>, String> {
   let url = format!("https://github.com/{org_and_folder}.git");
   let output = Command::new("git")
+    .env("GIT_TERMINAL_PROMPT", "0")
     .args(["ls-remote", "--tags", "--refs", &url])
     .output()
     .map_err(|e| format!("failed to inspect tags for {org_and_folder}: {e}"))?;

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -1,0 +1,1014 @@
+use crate::git::GitRepo;
+use crate::{CALCIT_VERSION, PackageDeps, call_build_script, module_folder};
+use cirru_edn::{Edn, EdnMapView};
+use colored::Colorize;
+use md5::{Digest, Md5};
+use semver::Version;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+
+const MAX_PARALLEL_RESOLVES: usize = 6;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DependencyRequest {
+  pub reference: String,
+  pub requested_by: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefKind {
+  Tag,
+  Branch,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedModule {
+  pub repository: String,
+  pub reference: String,
+  pub commit: String,
+  pub kind: RefKind,
+  pub source: PathBuf,
+  pub link_target: PathBuf,
+  pub dependencies: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedGraph {
+  pub root: BTreeMap<String, String>,
+  pub modules: BTreeMap<String, ResolvedModule>,
+  pub requests: BTreeMap<String, BTreeSet<DependencyRequest>>,
+  pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphOptions {
+  pub project_root: PathBuf,
+  pub modules_dir: PathBuf,
+  pub ci: bool,
+  pub strict: bool,
+  pub build_native: bool,
+}
+
+pub fn resolve_graph(root_deps: &PackageDeps, options: &GraphOptions) -> Result<ResolvedGraph, String> {
+  let root = sorted_dependencies(root_deps);
+  validate_module_folders(root.keys())?;
+  let mut selections = BTreeMap::<String, String>::new();
+  let mut stable_result = None;
+  let mut cache = BTreeMap::<(String, String), ResolvedModule>::new();
+
+  for _ in 0..256 {
+    let pass = resolve_pass(&root, &selections, options, &mut cache)?;
+    if pass.selections == selections {
+      let final_pass = resolve_pass(&root, &pass.selections, options, &mut cache)?;
+      stable_result = Some(final_pass);
+      break;
+    }
+    selections = pass.selections;
+  }
+
+  let pass = stable_result.ok_or_else(|| "dependency resolution did not converge after 256 passes".to_string())?;
+  let mut modules = pass.modules;
+  validate_module_folders(modules.keys())?;
+
+  if options.build_native {
+    for module in modules.values_mut() {
+      module.link_target = prepare_native_realization(module, options)?;
+    }
+  }
+
+  let warnings = collect_warnings(&root, &pass.requests, &modules);
+  if options.strict && !warnings.is_empty() {
+    return Err(format!("strict dependency resolution rejected warnings:\n{}", warnings.join("\n")));
+  }
+
+  Ok(ResolvedGraph {
+    root,
+    modules,
+    requests: pass.requests,
+    warnings,
+  })
+}
+
+struct ResolvePass {
+  selections: BTreeMap<String, String>,
+  modules: BTreeMap<String, ResolvedModule>,
+  requests: BTreeMap<String, BTreeSet<DependencyRequest>>,
+}
+
+fn resolve_pass(
+  root: &BTreeMap<String, String>,
+  previous: &BTreeMap<String, String>,
+  options: &GraphOptions,
+  cache: &mut BTreeMap<(String, String), ResolvedModule>,
+) -> Result<ResolvePass, String> {
+  let mut requests = BTreeMap::<String, BTreeSet<DependencyRequest>>::new();
+  for (repository, reference) in root {
+    requests.entry(repository.clone()).or_default().insert(DependencyRequest {
+      reference: reference.clone(),
+      requested_by: None,
+    });
+  }
+
+  let selected_items = previous
+    .iter()
+    .chain(root.iter().filter(|(repository, _)| !previous.contains_key(*repository)))
+    .map(|(repository, selected)| (repository.clone(), selected.clone()))
+    .collect::<Vec<_>>();
+  let mut modules = BTreeMap::<String, ResolvedModule>::new();
+  let mut missing = Vec::new();
+  for (repository, selected) in selected_items {
+    let cache_key = (repository.clone(), selected.clone());
+    if let Some(module) = cache.get(&cache_key) {
+      modules.insert(repository, module.clone());
+    } else {
+      missing.push((repository, selected));
+    }
+  }
+
+  for batch in missing.chunks(MAX_PARALLEL_RESOLVES) {
+    let handles = batch
+      .iter()
+      .map(|(repository, selected)| {
+        let repository = repository.clone();
+        let selected = selected.clone();
+        let options = options.clone();
+        thread::spawn(move || {
+          let result = materialize_module(&repository, &selected, &options);
+          (repository, selected, result)
+        })
+      })
+      .collect::<Vec<_>>();
+    for handle in handles {
+      let (repository, selected, result) = handle
+        .join()
+        .map_err(|_| "dependency resolver worker panicked while inspecting a module".to_string())?;
+      let module = result?;
+      cache.insert((repository.clone(), selected), module.clone());
+      modules.insert(repository, module);
+    }
+  }
+
+  for (repository, module) in &modules {
+    for (dependency, reference) in &module.dependencies {
+      requests.entry(dependency.clone()).or_default().insert(DependencyRequest {
+        reference: reference.clone(),
+        requested_by: Some(format!("{}@{}", repository, module.reference)),
+      });
+    }
+  }
+
+  let mut selections = BTreeMap::new();
+  for (repository, module_requests) in &requests {
+    selections.insert(
+      repository.clone(),
+      select_reference(repository, module_requests, root.get(repository))?,
+    );
+  }
+
+  Ok(ResolvePass {
+    selections,
+    modules,
+    requests,
+  })
+}
+
+fn select_reference(
+  repository: &str,
+  requests: &BTreeSet<DependencyRequest>,
+  root_reference: Option<&String>,
+) -> Result<String, String> {
+  let refs = requests.iter().map(|request| request.reference.as_str()).collect::<BTreeSet<_>>();
+  if refs.len() == 1 {
+    return Ok(refs.iter().next().expect("one dependency ref").to_string());
+  }
+
+  let versions = refs
+    .iter()
+    .map(|reference| parse_tag_version(reference).map(|version| ((*reference).to_string(), version)))
+    .collect::<Option<Vec<_>>>();
+  if let Some(mut versions) = versions {
+    versions.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+    return Ok(versions.last().expect("non-empty versions").0.clone());
+  }
+
+  let mut published_versions = refs
+    .iter()
+    .filter_map(|reference| parse_tag_version(reference).map(|version| ((*reference).to_string(), version)))
+    .collect::<Vec<_>>();
+  if !published_versions.is_empty() {
+    published_versions.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+    return Ok(published_versions.last().expect("non-empty published versions").0.clone());
+  }
+
+  if let Some(root_reference) = root_reference {
+    return Ok(root_reference.clone());
+  }
+
+  let details = requests
+    .iter()
+    .map(|request| {
+      format!(
+        "  {} requested by {}",
+        request.reference,
+        request.requested_by.as_deref().unwrap_or("root")
+      )
+    })
+    .collect::<Vec<_>>()
+    .join("\n");
+  Err(format!(
+    "cannot choose between incomparable refs for {repository}; add a direct root dependency to decide:\n{details}"
+  ))
+}
+
+fn parse_tag_version(reference: &str) -> Option<Version> {
+  Version::parse(reference.strip_prefix('v').unwrap_or(reference)).ok()
+}
+
+fn materialize_module(repository: &str, reference: &str, options: &GraphOptions) -> Result<ResolvedModule, String> {
+  let (owner, repo) = repository
+    .split_once('/')
+    .ok_or_else(|| format!("invalid repository {repository}"))?;
+  let temp_root = options.modules_dir.join(".store/tmp");
+  fs::create_dir_all(&temp_root).map_err(|e| format!("failed to create {}: {e}", temp_root.display()))?;
+  let temp_path = temp_root.join(format!(
+    "clone-{}-{}-{}",
+    std::process::id(),
+    sanitize(repository),
+    sanitize(reference)
+  ));
+  if temp_path.exists() {
+    fs::remove_dir_all(&temp_path).map_err(|e| format!("failed to clean {}: {e}", temp_path.display()))?;
+  }
+
+  eprintln!("resolving {repository}@{reference}");
+  let remote = resolve_remote_ref(repository, reference, options.ci)?;
+  let source = options
+    .modules_dir
+    .join(".store/git")
+    .join(owner)
+    .join(repo)
+    .join(&remote.commit)
+    .join("source");
+  if source.exists() {
+    validate_store_source(repository, &source, &remote.commit)?;
+    let dependencies = read_module_dependencies(&source)?;
+    return Ok(ResolvedModule {
+      repository: repository.to_string(),
+      reference: reference.to_string(),
+      commit: remote.commit,
+      kind: remote.kind,
+      link_target: source.clone(),
+      source,
+      dependencies,
+    });
+  }
+  GitRepo::clone_to_path(&temp_path, &remote.url, reference, true)
+    .map_err(|e| format!("failed to clone {repository}@{reference}: {e}"))?;
+  let temp_repo = GitRepo { dir: temp_path.clone() };
+  let commit = temp_repo.head_commit()?;
+  if commit != remote.commit {
+    return Err(format!(
+      "remote ref changed while cloning {repository}@{reference}: resolved {} but cloned {commit}; retry the command",
+      remote.commit
+    ));
+  }
+  let source = options
+    .modules_dir
+    .join(".store/git")
+    .join(owner)
+    .join(repo)
+    .join(&commit)
+    .join("source");
+  if source.exists() {
+    fs::remove_dir_all(&temp_path).map_err(|e| format!("failed to clean {}: {e}", temp_path.display()))?;
+    validate_store_source(repository, &source, &commit)?;
+  } else {
+    let parent = source.parent().ok_or_else(|| format!("invalid store path {}", source.display()))?;
+    fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    if let Err(error) = fs::rename(&temp_path, &source) {
+      if source.exists() {
+        fs::remove_dir_all(&temp_path).map_err(|e| format!("failed to clean {} after concurrent install: {e}", temp_path.display()))?;
+        validate_store_source(repository, &source, &commit)?;
+      } else {
+        return Err(format!(
+          "failed to move {} into store {}: {error}",
+          temp_path.display(),
+          source.display()
+        ));
+      }
+    }
+  }
+
+  let dependencies = read_module_dependencies(&source)?;
+  Ok(ResolvedModule {
+    repository: repository.to_string(),
+    reference: reference.to_string(),
+    commit,
+    kind: remote.kind,
+    link_target: source.clone(),
+    source,
+    dependencies,
+  })
+}
+
+fn validate_store_source(repository: &str, source: &Path, expected_commit: &str) -> Result<(), String> {
+  let repo = GitRepo { dir: source.to_path_buf() };
+  let actual_commit = repo.head_commit().map_err(|e| {
+    format!(
+      "failed to inspect immutable store entry for {repository} at {}: {e}",
+      source.display()
+    )
+  })?;
+  if actual_commit != expected_commit {
+    return Err(format!(
+      "immutable store entry for {repository} at {} has commit {actual_commit}, expected {expected_commit}; move the damaged entry aside and reinstall",
+      source.display()
+    ));
+  }
+  let changes = repo.status_porcelain().map_err(|e| {
+    format!(
+      "failed to inspect immutable store entry for {repository} at {}: {e}",
+      source.display()
+    )
+  })?;
+  if !changes.is_empty() {
+    return Err(format!(
+      "immutable store entry for {repository} at {} has local changes ({}); move the damaged entry aside and reinstall",
+      source.display(),
+      changes.join(", ")
+    ));
+  }
+  Ok(())
+}
+
+struct RemoteRef {
+  kind: RefKind,
+  commit: String,
+  url: String,
+}
+
+fn resolve_remote_ref(repository: &str, reference: &str, ci: bool) -> Result<RemoteRef, String> {
+  let https_url = format!("https://github.com/{repository}.git");
+  match inspect_remote_ref(&https_url, reference) {
+    Ok(remote) => Ok(remote),
+    Err(https_error) if !ci => {
+      let ssh_url = format!("git@github.com:{repository}.git");
+      inspect_remote_ref(&ssh_url, reference).map_err(|ssh_error| {
+        format!("failed to resolve {repository}@{reference} over HTTPS and SSH:\n  HTTPS: {https_error}\n  SSH: {ssh_error}")
+      })
+    }
+    Err(error) => Err(error),
+  }
+}
+
+fn inspect_remote_ref(url: &str, reference: &str) -> Result<RemoteRef, String> {
+  let tag_ref = format!("refs/tags/{reference}");
+  let peeled_tag_ref = format!("refs/tags/{reference}^{{}}");
+  let branch_ref = format!("refs/heads/{reference}");
+  let output = Command::new("git")
+    .env("GIT_TERMINAL_PROMPT", "0")
+    .args(["ls-remote", url, tag_ref.as_str(), peeled_tag_ref.as_str(), branch_ref.as_str()])
+    .output()
+    .map_err(|e| format!("failed to inspect remote ref {url}@{reference}: {e}"))?;
+  if !output.status.success() {
+    return Err(format!(
+      "failed to inspect remote ref {url}@{reference}: {}",
+      String::from_utf8_lossy(&output.stderr).trim()
+    ));
+  }
+  let stdout = String::from_utf8_lossy(&output.stdout);
+  let refs = stdout
+    .lines()
+    .filter_map(|line| line.split_once('\t'))
+    .map(|(commit, name)| (name, commit))
+    .collect::<BTreeMap<_, _>>();
+  let tag_commit = refs.get(peeled_tag_ref.as_str()).or_else(|| refs.get(tag_ref.as_str()));
+  let branch_commit = refs.get(branch_ref.as_str());
+  match (tag_commit, branch_commit) {
+    (Some(commit), None) => Ok(RemoteRef {
+      kind: RefKind::Tag,
+      commit: (*commit).to_string(),
+      url: url.to_string(),
+    }),
+    (None, Some(commit)) => Ok(RemoteRef {
+      kind: RefKind::Branch,
+      commit: (*commit).to_string(),
+      url: url.to_string(),
+    }),
+    (Some(_), Some(_)) => Err(format!(
+      "ambiguous Git ref {reference} exists as both a tag and branch in {url}; rename one ref"
+    )),
+    (None, None) => Err(format!("Git ref {reference} was not found in {url}")),
+  }
+}
+
+fn read_module_dependencies(source: &Path) -> Result<BTreeMap<String, String>, String> {
+  let deps_path = source.join("deps.cirru");
+  if !deps_path.exists() {
+    return Ok(BTreeMap::new());
+  }
+  let content = fs::read_to_string(&deps_path).map_err(|e| format!("failed to read {}: {e}", deps_path.display()))?;
+  let parsed = cirru_edn::parse(&content).map_err(|e| format!("failed to parse {}: {e}", deps_path.display()))?;
+  let deps: PackageDeps = parsed.try_into().map_err(|e| format!("invalid {}: {e}", deps_path.display()))?;
+  Ok(sorted_dependencies(&deps))
+}
+
+fn sorted_dependencies(deps: &PackageDeps) -> BTreeMap<String, String> {
+  deps
+    .dependencies
+    .iter()
+    .map(|(repository, reference)| (repository.to_string(), reference.to_string()))
+    .collect()
+}
+
+fn validate_module_folders<'a>(repositories: impl Iterator<Item = &'a String>) -> Result<(), String> {
+  let mut folders = BTreeMap::<String, String>::new();
+  for repository in repositories {
+    let folder = module_folder(repository)?.to_string();
+    if let Some(existing) = folders.insert(folder.clone(), repository.clone())
+      && existing != *repository
+    {
+      return Err(format!(
+        "module folder collision: {existing} and {repository} both map to .calcit/modules/{folder}"
+      ));
+    }
+  }
+  Ok(())
+}
+
+fn collect_warnings(
+  root: &BTreeMap<String, String>,
+  requests: &BTreeMap<String, BTreeSet<DependencyRequest>>,
+  modules: &BTreeMap<String, ResolvedModule>,
+) -> Vec<String> {
+  let mut warnings = vec![];
+  for (repository, module) in modules {
+    match module.kind {
+      RefKind::Branch => warnings.push(format!(
+        "warning: {repository}@{} is a branch and currently resolves to {}",
+        module.reference, module.commit
+      )),
+      RefKind::Tag if parse_tag_version(&module.reference).is_none() => warnings.push(format!(
+        "warning: {repository}@{} is a reproducible tag but not a SemVer version",
+        module.reference
+      )),
+      RefKind::Tag => {}
+    }
+    if let Some(module_requests) = requests.get(repository) {
+      let distinct = module_requests.iter().map(|request| &request.reference).collect::<BTreeSet<_>>();
+      if distinct.len() > 1 {
+        let reason =
+          if root.get(repository) == Some(&module.reference) && distinct.iter().any(|value| parse_tag_version(value).is_none()) {
+            "root override"
+          } else if distinct.iter().any(|value| parse_tag_version(value).is_none()) {
+            "published SemVer preferred over mutable ref"
+          } else {
+            "highest requested SemVer"
+          };
+        let sources = module_requests
+          .iter()
+          .map(|request| format!("{} by {}", request.reference, request.requested_by.as_deref().unwrap_or("root")))
+          .collect::<Vec<_>>()
+          .join(", ");
+        warnings.push(format!(
+          "warning: selected {repository}@{} ({reason}); requested {sources}",
+          module.reference
+        ));
+      }
+    }
+  }
+  warnings
+}
+
+pub fn install_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Result<(), String> {
+  let calcit_dir = options.project_root.join(".calcit");
+  let temp_root = calcit_dir.join("tmp");
+  fs::create_dir_all(&temp_root).map_err(|e| format!("failed to create {}: {e}", temp_root.display()))?;
+  let local_ignore = calcit_dir.join(".gitignore");
+  if !local_ignore.exists() {
+    fs::write(&local_ignore, "*\n").map_err(|e| format!("failed to write {}: {e}", local_ignore.display()))?;
+  }
+  let next_modules = temp_root.join(format!("modules-{}", std::process::id()));
+  if next_modules.exists() {
+    fs::remove_dir_all(&next_modules).map_err(|e| format!("failed to clean {}: {e}", next_modules.display()))?;
+  }
+  fs::create_dir_all(&next_modules).map_err(|e| format!("failed to create {}: {e}", next_modules.display()))?;
+  for module in graph.modules.values() {
+    let folder = module_folder(&module.repository)?;
+    create_dir_link(&module.link_target, &next_modules.join(folder))?;
+  }
+
+  let modules_path = calcit_dir.join("modules");
+  let backup = temp_root.join(format!("modules-backup-{}", std::process::id()));
+  if backup.exists() {
+    fs::remove_dir_all(&backup).map_err(|e| format!("failed to clean {}: {e}", backup.display()))?;
+  }
+  if fs::symlink_metadata(&modules_path).is_ok() {
+    fs::rename(&modules_path, &backup).map_err(|e| format!("failed to stage old module view: {e}"))?;
+  }
+  if let Err(error) = fs::rename(&next_modules, &modules_path) {
+    if backup.exists() {
+      let _ = fs::rename(&backup, &modules_path);
+    }
+    return Err(format!("failed to activate project module view: {error}"));
+  }
+  if let Err(error) = write_state(graph, &calcit_dir.join("caps-state.cirru")) {
+    fs::remove_dir_all(&modules_path).map_err(|e| format!("{error}; also failed to remove new module view: {e}"))?;
+    if backup.exists() {
+      fs::rename(&backup, &modules_path).map_err(|e| format!("{error}; also failed to restore old module view: {e}"))?;
+    }
+    return Err(error);
+  }
+  if backup.exists() {
+    fs::remove_dir_all(&backup).map_err(|e| format!("failed to clean old module view: {e}"))?;
+  }
+  Ok(())
+}
+
+pub fn check_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Result<usize, String> {
+  let modules_path = options.project_root.join(".calcit/modules");
+  let mut issues = 0;
+  for module in graph.modules.values() {
+    let folder = module_folder(&module.repository)?;
+    let link = modules_path.join(folder);
+    if fs::symlink_metadata(&link).is_err() {
+      println!("{}", format!("- {} is not linked", module.repository).red());
+      issues += 1;
+      continue;
+    }
+    let actual = fs::canonicalize(&link).map_err(|e| format!("failed to resolve {}: {e}", link.display()))?;
+    let expected =
+      fs::canonicalize(&module.link_target).map_err(|e| format!("failed to resolve {}: {e}", module.link_target.display()))?;
+    let realization_root = module
+      .source
+      .parent()
+      .map(|parent| parent.join("realizations"))
+      .and_then(|path| fs::canonicalize(path).ok());
+    let is_known_realization = realization_root.as_ref().is_some_and(|root| actual.starts_with(root));
+    if actual != expected && !is_known_realization {
+      println!(
+        "{}",
+        format!(
+          "! {} points to {}, expected {}",
+          module.repository,
+          actual.display(),
+          expected.display()
+        )
+        .yellow()
+      );
+      issues += 1;
+    } else {
+      println!("{}", format!("√ {} at {}", module.repository, module.reference).dimmed());
+    }
+  }
+  Ok(issues)
+}
+
+pub fn verify_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Result<usize, String> {
+  let modules_path = options.project_root.join(".calcit/modules");
+  let mut issues = 0;
+  for module in graph.modules.values() {
+    let repo = GitRepo {
+      dir: module.source.clone(),
+    };
+    let commit = repo
+      .head_commit()
+      .map_err(|e| format!("failed to inspect {}: {e}", module.source.display()))?;
+    if commit != module.commit {
+      println!(
+        "{}",
+        format!("! {} store commit is {commit}, expected {}", module.repository, module.commit).red()
+      );
+      issues += 1;
+    }
+    let changes = repo
+      .status_porcelain()
+      .map_err(|e| format!("failed to inspect {}: {e}", module.source.display()))?;
+    if !changes.is_empty() {
+      println!(
+        "{}",
+        format!("! {} immutable source has local changes: {}", module.repository, changes.join(", ")).red()
+      );
+      issues += 1;
+    }
+    let expected_target = expected_link_target(module)?;
+    let link = modules_path.join(module_folder(&module.repository)?);
+    if fs::symlink_metadata(&link).is_err() {
+      println!("{}", format!("- {} is not linked", module.repository).red());
+      issues += 1;
+      continue;
+    }
+    let actual = fs::canonicalize(&link).map_err(|e| format!("failed to resolve {}: {e}", link.display()))?;
+    if !expected_target.exists() {
+      println!(
+        "{}",
+        format!(
+          "! {} has no native realization for the current ABI/toolchain; run caps to build it",
+          module.repository
+        )
+        .red()
+      );
+      issues += 1;
+      continue;
+    }
+    let expected = fs::canonicalize(&expected_target).map_err(|e| format!("failed to resolve {}: {e}", expected_target.display()))?;
+    if actual != expected {
+      println!(
+        "{}",
+        format!(
+          "! {} points to {}, expected {}",
+          module.repository,
+          actual.display(),
+          expected.display()
+        )
+        .red()
+      );
+      issues += 1;
+    }
+    if expected_target != module.source {
+      let receipt = expected_target.join(".calcit-native.cirru");
+      let dylibs = expected_target.join("dylibs");
+      if !receipt.exists() || !dylibs.exists() {
+        println!(
+          "{}",
+          format!(
+            "! {} native realization is missing its receipt or dylibs directory",
+            module.repository
+          )
+          .red()
+        );
+        issues += 1;
+      } else {
+        let extension = match std::env::consts::OS {
+          "macos" => "dylib",
+          "windows" => "dll",
+          _ => "so",
+        };
+        let libraries = fs::read_dir(&dylibs)
+          .map_err(|e| format!("failed to read {}: {e}", dylibs.display()))?
+          .filter_map(Result::ok)
+          .map(|entry| entry.path())
+          .filter(|path| path.extension().is_some_and(|value| value == extension))
+          .collect::<Vec<_>>();
+        if libraries.is_empty() {
+          println!(
+            "{}",
+            format!("! {} has no .{extension} library under dylibs/", module.repository).red()
+          );
+          issues += 1;
+        }
+        for library in libraries {
+          let output = Command::new(std::env::current_exe().map_err(|e| e.to_string())?)
+            .arg("__verify-native")
+            .arg(&library)
+            .output()
+            .map_err(|e| format!("failed to start native verifier for {}: {e}", library.display()))?;
+          if !output.status.success() {
+            println!(
+              "{}",
+              format!(
+                "! {} failed native verification for {}: {}",
+                module.repository,
+                library.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+              )
+              .red()
+            );
+            issues += 1;
+          }
+        }
+      }
+    }
+  }
+  if issues == 0 {
+    println!("verified {} module(s)", graph.modules.len());
+  }
+  Ok(issues)
+}
+
+pub fn verify_native_library(path: &Path) -> Result<(), String> {
+  type VersionFn = fn() -> String;
+  let library = unsafe { libloading::Library::new(path) }.map_err(|e| format!("failed to load {}: {e}", path.display()))?;
+  let abi: libloading::Symbol<VersionFn> =
+    unsafe { library.get(b"abi_version") }.map_err(|e| format!("failed to read abi_version from {}: {e}", path.display()))?;
+  let actual_abi = abi();
+  if actual_abi != calcit::FFI_ABI_VERSION {
+    return Err(format!(
+      "FFI ABI mismatch in {}: found {actual_abi}, expected {}",
+      path.display(),
+      calcit::FFI_ABI_VERSION
+    ));
+  }
+  let edn: libloading::Symbol<VersionFn> =
+    unsafe { library.get(b"edn_version") }.map_err(|e| format!("failed to read edn_version from {}: {e}", path.display()))?;
+  let actual_edn = edn();
+  if actual_edn != cirru_edn::version() {
+    return Err(format!(
+      "cirru_edn mismatch in {}: found {actual_edn}, expected {}",
+      path.display(),
+      cirru_edn::version()
+    ));
+  }
+  Ok(())
+}
+
+#[cfg(unix)]
+fn create_dir_link(target: &Path, link: &Path) -> Result<(), String> {
+  std::os::unix::fs::symlink(target, link).map_err(|e| format!("failed to link {} -> {}: {e}", link.display(), target.display()))
+}
+
+#[cfg(windows)]
+fn create_dir_link(target: &Path, link: &Path) -> Result<(), String> {
+  std::os::windows::fs::symlink_dir(target, link).map_err(|e| format!("failed to link {} -> {}: {e}", link.display(), target.display()))
+}
+
+fn write_state(graph: &ResolvedGraph, state_path: &Path) -> Result<(), String> {
+  let mut root = EdnMapView::default();
+  let mut modules = EdnMapView::default();
+  for (repository, module) in &graph.modules {
+    let mut info = EdnMapView::default();
+    info.insert(Edn::tag("ref"), Edn::str(module.reference.as_str()));
+    info.insert(Edn::tag("commit"), Edn::str(module.commit.as_str()));
+    info.insert(Edn::tag("path"), Edn::str(module.link_target.to_string_lossy().as_ref()));
+    modules.insert(Edn::str(repository.as_str()), Edn::Map(info));
+  }
+  root.insert(Edn::tag("modules"), Edn::Map(modules));
+  root.insert(
+    Edn::tag("warnings"),
+    Edn::List(
+      graph
+        .warnings
+        .iter()
+        .map(|warning| Edn::str(warning.as_str()))
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+  );
+  let content = cirru_edn::format(&Edn::Map(root), false)?;
+  let temp = state_path.with_extension(format!("cirru.{}.tmp", std::process::id()));
+  fs::write(&temp, content).map_err(|e| format!("failed to write {}: {e}", temp.display()))?;
+  fs::rename(&temp, state_path).map_err(|e| format!("failed to activate {}: {e}", state_path.display()))
+}
+
+fn prepare_native_realization(module: &ResolvedModule, options: &GraphOptions) -> Result<PathBuf, String> {
+  if !module.source.join("build.sh").exists() {
+    return Ok(module.source.clone());
+  }
+  let realization = expected_link_target(module)?;
+  let build_key = realization.file_name().and_then(|name| name.to_str()).unwrap_or("unknown");
+  let receipt = realization.join(".calcit-native.cirru");
+  if receipt.exists() {
+    return Ok(realization);
+  }
+  let temp =
+    options
+      .project_root
+      .join(".calcit/tmp")
+      .join(format!("native-{}-{}", std::process::id(), module_folder(&module.repository)?));
+  if temp.exists() {
+    fs::remove_dir_all(&temp).map_err(|e| format!("failed to clean {}: {e}", temp.display()))?;
+  }
+  copy_tree(&module.source, &temp)?;
+  eprintln!(
+    "building native module {}@{} ({}) with {}",
+    module.repository,
+    module.reference,
+    module.commit,
+    temp.join("build.sh").display()
+  );
+  call_build_script(&temp)?;
+  let dylibs = temp.join("dylibs");
+  if !dylibs.exists() || fs::read_dir(&dylibs).map_err(|e| e.to_string())?.next().is_none() {
+    return Err(format!("native module {} did not produce files under dylibs/", module.repository));
+  }
+  fs::write(
+    temp.join(".calcit-native.cirru"),
+    format!(
+      "{{}} (:module |{}) (:commit |{}) (:calcit-version |{}) (:ffi-abi |{}) (:cirru-edn |{}) (:build-key |{})\n",
+      module.repository,
+      module.commit,
+      CALCIT_VERSION,
+      calcit::FFI_ABI_VERSION,
+      cirru_edn::version(),
+      build_key
+    ),
+  )
+  .map_err(|e| format!("failed to write native receipt: {e}"))?;
+  if let Some(parent) = realization.parent() {
+    fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+  }
+  if realization.exists() {
+    fs::remove_dir_all(&temp).map_err(|e| format!("failed to clean {}: {e}", temp.display()))?;
+  } else if let Err(error) = fs::rename(&temp, &realization) {
+    if realization.exists() {
+      fs::remove_dir_all(&temp).map_err(|e| format!("failed to clean {} after concurrent native build: {e}", temp.display()))?;
+    } else {
+      return Err(format!("failed to store native realization: {error}"));
+    }
+  }
+  Ok(realization)
+}
+
+fn expected_link_target(module: &ResolvedModule) -> Result<PathBuf, String> {
+  if !module.source.join("build.sh").exists() {
+    return Ok(module.source.clone());
+  }
+  let target = rust_target_identity();
+  let build_input = format!(
+    "{target}\ncalcit={CALCIT_VERSION}\nffi-abi={}\ncirru-edn={}\ncommit={}",
+    calcit::FFI_ABI_VERSION,
+    cirru_edn::version(),
+    module.commit
+  );
+  let build_key = hex::encode(Md5::digest(build_input.as_bytes()));
+  let commit_root = module
+    .source
+    .parent()
+    .ok_or_else(|| format!("invalid source path {}", module.source.display()))?;
+  Ok(commit_root.join("realizations").join(build_key))
+}
+
+fn rust_target_identity() -> String {
+  Command::new("rustc")
+    .arg("-vV")
+    .output()
+    .ok()
+    .filter(|output| output.status.success())
+    .map(|output| String::from_utf8_lossy(&output.stdout).replace('\n', "-"))
+    .unwrap_or_else(|| format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH))
+}
+
+fn copy_tree(source: &Path, target: &Path) -> Result<(), String> {
+  fs::create_dir_all(target).map_err(|e| format!("failed to create {}: {e}", target.display()))?;
+  for entry in fs::read_dir(source).map_err(|e| format!("failed to read {}: {e}", source.display()))? {
+    let entry = entry.map_err(|e| e.to_string())?;
+    if entry.file_name() == ".git" || entry.file_name() == "target" {
+      continue;
+    }
+    let source_path = entry.path();
+    let target_path = target.join(entry.file_name());
+    let kind = entry.file_type().map_err(|e| e.to_string())?;
+    if kind.is_dir() {
+      copy_tree(&source_path, &target_path)?;
+    } else if kind.is_file() {
+      fs::copy(&source_path, &target_path)
+        .map_err(|e| format!("failed to copy {} to {}: {e}", source_path.display(), target_path.display()))?;
+    } else if kind.is_symlink() {
+      return Err(format!(
+        "native module source contains unsupported symlink {}; replace it with a regular file or directory",
+        source_path.display()
+      ));
+    } else {
+      return Err(format!(
+        "native module source contains unsupported file type at {}",
+        source_path.display()
+      ));
+    }
+  }
+  Ok(())
+}
+
+pub fn print_warnings(graph: &ResolvedGraph) {
+  for warning in &graph.warnings {
+    eprintln!("{}", warning.yellow());
+  }
+}
+
+pub fn print_tree(graph: &ResolvedGraph) {
+  println!("root");
+  let mut seen = BTreeSet::new();
+  for (index, repository) in graph.root.keys().enumerate() {
+    let last = index + 1 == graph.root.len();
+    print_tree_module(graph, repository, "", last, &mut seen);
+  }
+}
+
+fn print_tree_module(graph: &ResolvedGraph, repository: &str, prefix: &str, last: bool, seen: &mut BTreeSet<String>) {
+  let branch = if last { "└─" } else { "├─" };
+  let Some(module) = graph.modules.get(repository) else {
+    println!("{prefix}{branch} {repository} (missing)");
+    return;
+  };
+  let repeated = !seen.insert(repository.to_string());
+  println!(
+    "{prefix}{branch} {}@{}{}",
+    repository,
+    module.reference,
+    if repeated { " (*)" } else { "" }
+  );
+  if repeated {
+    return;
+  }
+  let next_prefix = format!("{prefix}{}", if last { "   " } else { "│  " });
+  for (index, dependency) in module.dependencies.keys().enumerate() {
+    print_tree_module(graph, dependency, &next_prefix, index + 1 == module.dependencies.len(), seen);
+  }
+}
+
+pub fn print_why(graph: &ResolvedGraph, target: &str) -> Result<(), String> {
+  if !graph.modules.contains_key(target) {
+    return Err(format!("module {target} is not in the resolved dependency graph"));
+  }
+  for root in graph.root.keys() {
+    if let Some(path) = shortest_path(graph, root, target) {
+      println!("{}", path.join(" -> "));
+    }
+  }
+  if let Some(requests) = graph.requests.get(target) {
+    println!("requests:");
+    for request in requests {
+      println!("  {} by {}", request.reference, request.requested_by.as_deref().unwrap_or("root"));
+    }
+  }
+  Ok(())
+}
+
+fn shortest_path(graph: &ResolvedGraph, root: &str, target: &str) -> Option<Vec<String>> {
+  let mut queue = std::collections::VecDeque::from([vec![root.to_string()]]);
+  let mut seen = BTreeSet::new();
+  while let Some(path) = queue.pop_front() {
+    let current = path.last()?;
+    if current == target {
+      return Some(path);
+    }
+    if !seen.insert(current.clone()) {
+      continue;
+    }
+    if let Some(module) = graph.modules.get(current) {
+      for child in module.dependencies.keys() {
+        let mut next = path.clone();
+        next.push(child.clone());
+        queue.push_back(next);
+      }
+    }
+  }
+  None
+}
+
+fn sanitize(value: &str) -> String {
+  value
+    .chars()
+    .map(|ch| {
+      if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+        ch
+      } else {
+        '-'
+      }
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{DependencyRequest, parse_tag_version, select_reference};
+  use std::collections::BTreeSet;
+
+  fn request(reference: &str, requested_by: Option<&str>) -> DependencyRequest {
+    DependencyRequest {
+      reference: reference.to_string(),
+      requested_by: requested_by.map(str::to_string),
+    }
+  }
+
+  #[test]
+  fn selects_highest_requested_semver() {
+    let requests = BTreeSet::from([request("0.9.2", Some("a@1.0.0")), request("0.10.0", None)]);
+    assert_eq!(
+      select_reference("org/repo", &requests, Some(&"0.10.0".to_string())),
+      Ok("0.10.0".to_string())
+    );
+    assert!(parse_tag_version("v1.2.3").is_some());
+  }
+
+  #[test]
+  fn incomparable_refs_need_root_decision() {
+    let requests = BTreeSet::from([request("main", Some("a@1.0.0")), request("next", Some("b@1.0.0"))]);
+    assert!(select_reference("org/repo", &requests, None).is_err());
+    assert_eq!(
+      select_reference("org/repo", &requests, Some(&"main".to_string())),
+      Ok("main".to_string())
+    );
+  }
+
+  #[test]
+  fn published_tag_wins_over_transitive_branch() {
+    let requests = BTreeSet::from([request("0.0.6", Some("stable@1.0.0")), request("main", Some("legacy@1.0.0"))]);
+    assert_eq!(select_reference("org/repo", &requests, None), Ok("0.0.6".to_string()));
+  }
+
+  #[test]
+  fn highest_published_tag_wins_over_lower_root_tag() {
+    let requests = BTreeSet::from([
+      request("0.16.32", None),
+      request("0.16.67", Some("newer@1.0.0")),
+      request("main", Some("legacy@1.0.0")),
+    ]);
+    assert_eq!(
+      select_reference("org/repo", &requests, Some(&"0.16.32".to_string())),
+      Ok("0.16.67".to_string())
+    );
+  }
+}

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -722,7 +722,20 @@ fn create_dir_link(target: &Path, link: &Path) -> Result<(), String> {
 
 #[cfg(windows)]
 fn create_dir_link(target: &Path, link: &Path) -> Result<(), String> {
-  std::os::windows::fs::symlink_dir(target, link).map_err(|e| format!("failed to link {} -> {}: {e}", link.display(), target.display()))
+  let junction = Command::new("cmd").args(["/C", "mklink", "/J"]).arg(link).arg(target).output();
+  if let Ok(output) = junction
+    && output.status.success()
+  {
+    return Ok(());
+  }
+
+  std::os::windows::fs::symlink_dir(target, link).map_err(|error| {
+    format!(
+      "failed to create junction or directory symlink {} -> {}: {error}",
+      link.display(),
+      target.display()
+    )
+  })
 }
 
 fn write_state(graph: &ResolvedGraph, state_path: &Path) -> Result<(), String> {

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -6,7 +6,7 @@ use md5::{Digest, Md5};
 use semver::Version;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::thread;
 
@@ -22,6 +22,24 @@ pub struct DependencyRequest {
 pub enum RefKind {
   Tag,
   Branch,
+  Commit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectModuleMode {
+  Link,
+  #[cfg(windows)]
+  Copy,
+}
+
+impl ProjectModuleMode {
+  fn as_str(self) -> &'static str {
+    match self {
+      Self::Link => "link",
+      #[cfg(windows)]
+      Self::Copy => "copy",
+    }
+  }
 }
 
 #[derive(Debug, Clone)]
@@ -233,8 +251,9 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
     .ok_or_else(|| format!("invalid repository {repository}"))?;
   let temp_root = options.modules_dir.join(".store/tmp");
   fs::create_dir_all(&temp_root).map_err(|e| format!("failed to create {}: {e}", temp_root.display()))?;
+  let identity = hex::encode(Md5::digest(format!("{repository}\n{reference}").as_bytes()));
   let temp_path = temp_root.join(format!(
-    "clone-{}-{}-{}",
+    "clone-{}-{}-{}-{identity}",
     std::process::id(),
     sanitize(repository),
     sanitize(reference)
@@ -265,7 +284,7 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
       dependencies,
     });
   }
-  GitRepo::clone_to_path(&temp_path, &remote.url, reference, true)
+  GitRepo::clone_to_path(&temp_path, &remote.url, reference, &remote.kind, true)
     .map_err(|e| format!("failed to clone {repository}@{reference}: {e}"))?;
   let temp_repo = GitRepo { dir: temp_path.clone() };
   let commit = temp_repo.head_commit()?;
@@ -351,6 +370,13 @@ struct RemoteRef {
 }
 
 fn resolve_remote_ref(repository: &str, reference: &str, ci: bool) -> Result<RemoteRef, String> {
+  if is_full_commit_hash(reference) {
+    return Ok(RemoteRef {
+      kind: RefKind::Commit,
+      commit: reference.to_ascii_lowercase(),
+      url: format!("https://github.com/{repository}.git"),
+    });
+  }
   let https_url = format!("https://github.com/{repository}.git");
   match inspect_remote_ref(&https_url, reference) {
     Ok(remote) => Ok(remote),
@@ -362,6 +388,10 @@ fn resolve_remote_ref(repository: &str, reference: &str, ci: bool) -> Result<Rem
     }
     Err(error) => Err(error),
   }
+}
+
+fn is_full_commit_hash(reference: &str) -> bool {
+  matches!(reference.len(), 40 | 64) && reference.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn inspect_remote_ref(url: &str, reference: &str) -> Result<RemoteRef, String> {
@@ -455,6 +485,10 @@ fn collect_warnings(
         "warning: {repository}@{} is a reproducible tag but not a SemVer version",
         module.reference
       )),
+      RefKind::Commit => warnings.push(format!(
+        "warning: {repository}@{} is a pinned commit without SemVer release metadata",
+        module.reference
+      )),
       RefKind::Tag => {}
     }
     if let Some(module_requests) = requests.get(repository) {
@@ -496,9 +530,11 @@ pub fn install_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Re
     fs::remove_dir_all(&next_modules).map_err(|e| format!("failed to clean {}: {e}", next_modules.display()))?;
   }
   fs::create_dir_all(&next_modules).map_err(|e| format!("failed to create {}: {e}", next_modules.display()))?;
+  let mut view_modes = BTreeMap::new();
   for module in graph.modules.values() {
     let folder = module_folder(&module.repository)?;
-    create_dir_link(&module.link_target, &next_modules.join(folder))?;
+    let mode = create_dir_link(&module.link_target, &next_modules.join(folder))?;
+    view_modes.insert(module.repository.clone(), mode);
   }
 
   let modules_path = calcit_dir.join("modules");
@@ -515,7 +551,7 @@ pub fn install_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Re
     }
     return Err(format!("failed to activate project module view: {error}"));
   }
-  if let Err(error) = write_state(graph, &calcit_dir.join("caps-state.cirru")) {
+  if let Err(error) = write_state(graph, &view_modes, &calcit_dir.join("caps-state.cirru")) {
     fs::remove_dir_all(&modules_path).map_err(|e| format!("{error}; also failed to remove new module view: {e}"))?;
     if backup.exists() {
       fs::rename(&backup, &modules_path).map_err(|e| format!("{error}; also failed to restore old module view: {e}"))?;
@@ -540,19 +576,33 @@ pub fn check_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Resu
       continue;
     }
     let actual = fs::canonicalize(&link).map_err(|e| format!("failed to resolve {}: {e}", link.display()))?;
-    let expected =
-      fs::canonicalize(&module.link_target).map_err(|e| format!("failed to resolve {}: {e}", module.link_target.display()))?;
-    let realization_root = module
-      .source
-      .parent()
-      .map(|parent| parent.join("realizations"))
-      .and_then(|path| fs::canonicalize(path).ok());
-    let is_known_realization = realization_root.as_ref().is_some_and(|root| actual.starts_with(root));
-    if actual != expected && !is_known_realization {
+    let expected_target = expected_link_target(module)?;
+    if !expected_target.exists() {
       println!(
         "{}",
         format!(
-          "! {} points to {}, expected {}",
+          "! {} has no native realization for the current ABI/toolchain; run caps to build it",
+          module.repository
+        )
+        .yellow()
+      );
+      issues += 1;
+      continue;
+    }
+    let expected = fs::canonicalize(&expected_target).map_err(|e| format!("failed to resolve {}: {e}", expected_target.display()))?;
+    if actual != expected {
+      let mode = if fs::symlink_metadata(&link)
+        .map(|metadata| metadata.file_type().is_symlink())
+        .unwrap_or(false)
+      {
+        "link"
+      } else {
+        "copy"
+      };
+      println!(
+        "{}",
+        format!(
+          "! {} uses a non-shared {mode} at {}, expected {}",
           module.repository,
           actual.display(),
           expected.display()
@@ -629,55 +679,47 @@ pub fn verify_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Res
       issues += 1;
     }
     if expected_target != module.source {
-      let receipt = expected_target.join(".calcit-native.cirru");
-      let dylibs = expected_target.join("dylibs");
-      if !receipt.exists() || !dylibs.exists() {
-        println!(
-          "{}",
-          format!(
-            "! {} native realization is missing its receipt or dylibs directory",
-            module.repository
-          )
-          .red()
-        );
-        issues += 1;
-      } else {
-        let extension = match std::env::consts::OS {
-          "macos" => "dylib",
-          "windows" => "dll",
-          _ => "so",
-        };
-        let libraries = fs::read_dir(&dylibs)
-          .map_err(|e| format!("failed to read {}: {e}", dylibs.display()))?
-          .filter_map(Result::ok)
-          .map(|entry| entry.path())
-          .filter(|path| path.extension().is_some_and(|value| value == extension))
-          .collect::<Vec<_>>();
-        if libraries.is_empty() {
-          println!(
-            "{}",
-            format!("! {} has no .{extension} library under dylibs/", module.repository).red()
-          );
+      match verify_native_receipt(module, &expected_target) {
+        Err(error) => {
+          println!("{}", format!("! {} native receipt is invalid: {error}", module.repository).red());
           issues += 1;
         }
-        for library in libraries {
-          let output = Command::new(std::env::current_exe().map_err(|e| e.to_string())?)
-            .arg("__verify-native")
-            .arg(&library)
-            .output()
-            .map_err(|e| format!("failed to start native verifier for {}: {e}", library.display()))?;
-          if !output.status.success() {
+        Ok(libraries) => {
+          let extension = match std::env::consts::OS {
+            "macos" => "dylib",
+            "windows" => "dll",
+            _ => "so",
+          };
+          let libraries = libraries
+            .into_iter()
+            .filter(|path| path.extension().is_some_and(|value| value == extension))
+            .collect::<Vec<_>>();
+          if libraries.is_empty() {
             println!(
               "{}",
-              format!(
-                "! {} failed native verification for {}: {}",
-                module.repository,
-                library.display(),
-                String::from_utf8_lossy(&output.stderr).trim()
-              )
-              .red()
+              format!("! {} has no .{extension} library under dylibs/", module.repository).red()
             );
             issues += 1;
+          }
+          for library in libraries {
+            let output = Command::new(std::env::current_exe().map_err(|e| e.to_string())?)
+              .arg("__verify-native")
+              .arg(&library)
+              .output()
+              .map_err(|e| format!("failed to start native verifier for {}: {e}", library.display()))?;
+            if !output.status.success() {
+              println!(
+                "{}",
+                format!(
+                  "! {} failed native verification for {}: {}",
+                  module.repository,
+                  library.display(),
+                  String::from_utf8_lossy(&output.stderr).trim()
+                )
+                .red()
+              );
+              issues += 1;
+            }
           }
         }
       }
@@ -716,29 +758,34 @@ pub fn verify_native_library(path: &Path) -> Result<(), String> {
 }
 
 #[cfg(unix)]
-fn create_dir_link(target: &Path, link: &Path) -> Result<(), String> {
-  std::os::unix::fs::symlink(target, link).map_err(|e| format!("failed to link {} -> {}: {e}", link.display(), target.display()))
+fn create_dir_link(target: &Path, link: &Path) -> Result<ProjectModuleMode, String> {
+  std::os::unix::fs::symlink(target, link)
+    .map(|_| ProjectModuleMode::Link)
+    .map_err(|e| format!("failed to link {} -> {}: {e}", link.display(), target.display()))
 }
 
 #[cfg(windows)]
-fn create_dir_link(target: &Path, link: &Path) -> Result<(), String> {
+fn create_dir_link(target: &Path, link: &Path) -> Result<ProjectModuleMode, String> {
   let junction = Command::new("cmd").args(["/C", "mklink", "/J"]).arg(link).arg(target).output();
   if let Ok(output) = junction
     && output.status.success()
   {
-    return Ok(());
+    return Ok(ProjectModuleMode::Link);
   }
 
-  std::os::windows::fs::symlink_dir(target, link).map_err(|error| {
-    format!(
-      "failed to create junction or directory symlink {} -> {}: {error}",
-      link.display(),
-      target.display()
-    )
-  })
+  match std::os::windows::fs::symlink_dir(target, link) {
+    Ok(()) => Ok(ProjectModuleMode::Link),
+    Err(link_error) => copy_tree(target, link).map(|_| ProjectModuleMode::Copy).map_err(|copy_error| {
+      format!(
+        "failed to create junction or directory symlink {} -> {} ({link_error}); copy fallback also failed: {copy_error}",
+        link.display(),
+        target.display()
+      )
+    }),
+  }
 }
 
-fn write_state(graph: &ResolvedGraph, state_path: &Path) -> Result<(), String> {
+fn write_state(graph: &ResolvedGraph, view_modes: &BTreeMap<String, ProjectModuleMode>, state_path: &Path) -> Result<(), String> {
   let mut root = EdnMapView::default();
   let mut modules = EdnMapView::default();
   for (repository, module) in &graph.modules {
@@ -746,6 +793,9 @@ fn write_state(graph: &ResolvedGraph, state_path: &Path) -> Result<(), String> {
     info.insert(Edn::tag("ref"), Edn::str(module.reference.as_str()));
     info.insert(Edn::tag("commit"), Edn::str(module.commit.as_str()));
     info.insert(Edn::tag("path"), Edn::str(module.link_target.to_string_lossy().as_ref()));
+    if let Some(mode) = view_modes.get(repository) {
+      info.insert(Edn::tag("view-mode"), Edn::str(mode.as_str()));
+    }
     modules.insert(Edn::str(repository.as_str()), Edn::Map(info));
   }
   root.insert(Edn::tag("modules"), Edn::Map(modules));
@@ -766,7 +816,7 @@ fn write_state(graph: &ResolvedGraph, state_path: &Path) -> Result<(), String> {
   fs::rename(&temp, state_path).map_err(|e| format!("failed to activate {}: {e}", state_path.display()))
 }
 
-fn prepare_native_realization(module: &ResolvedModule, options: &GraphOptions) -> Result<PathBuf, String> {
+fn prepare_native_realization(module: &ResolvedModule, _options: &GraphOptions) -> Result<PathBuf, String> {
   if !module.source.join("build.sh").exists() {
     return Ok(module.source.clone());
   }
@@ -774,13 +824,14 @@ fn prepare_native_realization(module: &ResolvedModule, options: &GraphOptions) -
   let build_key = realization.file_name().and_then(|name| name.to_str()).unwrap_or("unknown");
   let receipt = realization.join(".calcit-native.cirru");
   if receipt.exists() {
+    verify_native_receipt(module, &realization)?;
     return Ok(realization);
   }
-  let temp =
-    options
-      .project_root
-      .join(".calcit/tmp")
-      .join(format!("native-{}-{}", std::process::id(), module_folder(&module.repository)?));
+  let realization_parent = realization
+    .parent()
+    .ok_or_else(|| format!("invalid native realization path {}", realization.display()))?;
+  fs::create_dir_all(realization_parent).map_err(|e| format!("failed to create {}: {e}", realization_parent.display()))?;
+  let temp = realization_parent.join(format!(".tmp-native-{}-{}", std::process::id(), module_folder(&module.repository)?));
   if temp.exists() {
     fs::remove_dir_all(&temp).map_err(|e| format!("failed to clean {}: {e}", temp.display()))?;
   }
@@ -797,22 +848,7 @@ fn prepare_native_realization(module: &ResolvedModule, options: &GraphOptions) -
   if !dylibs.exists() || fs::read_dir(&dylibs).map_err(|e| e.to_string())?.next().is_none() {
     return Err(format!("native module {} did not produce files under dylibs/", module.repository));
   }
-  fs::write(
-    temp.join(".calcit-native.cirru"),
-    format!(
-      "{{}} (:module |{}) (:commit |{}) (:calcit-version |{}) (:ffi-abi |{}) (:cirru-edn |{}) (:build-key |{})\n",
-      module.repository,
-      module.commit,
-      CALCIT_VERSION,
-      calcit::FFI_ABI_VERSION,
-      cirru_edn::version(),
-      build_key
-    ),
-  )
-  .map_err(|e| format!("failed to write native receipt: {e}"))?;
-  if let Some(parent) = realization.parent() {
-    fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
-  }
+  write_native_receipt(module, &temp, build_key)?;
   if realization.exists() {
     fs::remove_dir_all(&temp).map_err(|e| format!("failed to clean {}: {e}", temp.display()))?;
   } else if let Err(error) = fs::rename(&temp, &realization) {
@@ -842,6 +878,185 @@ fn expected_link_target(module: &ResolvedModule) -> Result<PathBuf, String> {
     .parent()
     .ok_or_else(|| format!("invalid source path {}", module.source.display()))?;
   Ok(commit_root.join("realizations").join(build_key))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativeArtifact {
+  relative_path: String,
+  size: u64,
+  md5: String,
+}
+
+fn write_native_receipt(module: &ResolvedModule, realization: &Path, build_key: &str) -> Result<(), String> {
+  let artifacts = collect_native_artifacts(realization)?;
+  let mut receipt = EdnMapView::default();
+  receipt.insert(Edn::tag("module"), Edn::str(module.repository.as_str()));
+  receipt.insert(Edn::tag("commit"), Edn::str(module.commit.as_str()));
+  receipt.insert(Edn::tag("calcit-version"), Edn::str(CALCIT_VERSION));
+  receipt.insert(Edn::tag("ffi-abi"), Edn::str(calcit::FFI_ABI_VERSION));
+  receipt.insert(Edn::tag("cirru-edn"), Edn::str(cirru_edn::version()));
+  receipt.insert(Edn::tag("build-key"), Edn::str(build_key));
+  receipt.insert(
+    Edn::tag("artifacts"),
+    Edn::List(
+      artifacts
+        .values()
+        .map(|artifact| {
+          Edn::map_from_iter([
+            (Edn::tag("path"), Edn::str(artifact.relative_path.as_str())),
+            (Edn::tag("size"), Edn::Number(artifact.size as f64)),
+            (Edn::tag("md5"), Edn::str(artifact.md5.as_str())),
+          ])
+        })
+        .collect::<Vec<_>>()
+        .into(),
+    ),
+  );
+  let content = cirru_edn::format(&Edn::Map(receipt), false)?;
+  fs::write(realization.join(".calcit-native.cirru"), content).map_err(|e| format!("failed to write native receipt: {e}"))
+}
+
+fn verify_native_receipt(module: &ResolvedModule, realization: &Path) -> Result<Vec<PathBuf>, String> {
+  let receipt_path = realization.join(".calcit-native.cirru");
+  let content = fs::read_to_string(&receipt_path).map_err(|e| format!("failed to read {}: {e}", receipt_path.display()))?;
+  let receipt = cirru_edn::parse(&content)
+    .map_err(|e| format!("failed to parse {}: {e}", receipt_path.display()))?
+    .view_map()?;
+  let expected_build_key = realization.file_name().and_then(|name| name.to_str()).unwrap_or("unknown");
+  for (key, expected) in [
+    ("module", module.repository.as_str()),
+    ("commit", module.commit.as_str()),
+    ("calcit-version", CALCIT_VERSION),
+    ("ffi-abi", calcit::FFI_ABI_VERSION),
+    ("cirru-edn", cirru_edn::version()),
+    ("build-key", expected_build_key),
+  ] {
+    let actual = receipt
+      .tag_get(key)
+      .ok_or_else(|| format!("receipt is missing :{key}"))?
+      .read_string()?;
+    if actual != expected {
+      return Err(format!("receipt :{key} is {actual:?}, expected {expected:?}"));
+    }
+  }
+
+  let declared = receipt
+    .tag_get("artifacts")
+    .ok_or_else(|| "receipt is missing :artifacts".to_string())?
+    .view_list()?
+    .0
+    .iter()
+    .map(native_artifact_from_edn)
+    .collect::<Result<Vec<_>, _>>()?;
+  let declared = declared
+    .into_iter()
+    .map(|artifact| {
+      if !is_safe_artifact_path(&artifact.relative_path) {
+        return Err(format!(
+          "receipt artifact path {:?} is not a safe relative dylibs path",
+          artifact.relative_path
+        ));
+      }
+      Ok((artifact.relative_path.clone(), artifact))
+    })
+    .collect::<Result<BTreeMap<_, _>, String>>()?;
+  if declared.len() != receipt.tag_get("artifacts").expect("artifacts was read above").view_list()?.0.len() {
+    return Err("receipt has duplicate artifact paths".to_string());
+  }
+  let actual = collect_native_artifacts(realization)?;
+  if actual != declared {
+    return Err("receipt artifacts do not match the current dylibs contents".to_string());
+  }
+  Ok(actual.keys().map(|relative_path| realization.join(relative_path)).collect())
+}
+
+fn native_artifact_from_edn(value: &Edn) -> Result<NativeArtifact, String> {
+  let map = value.view_map()?;
+  let relative_path = map
+    .tag_get("path")
+    .ok_or_else(|| "receipt artifact is missing :path".to_string())?
+    .read_string()?;
+  let size = map
+    .tag_get("size")
+    .ok_or_else(|| "receipt artifact is missing :size".to_string())?
+    .read_number()?;
+  if size < 0.0 || size.fract().abs() > f64::EPSILON || size > u64::MAX as f64 {
+    return Err(format!("receipt artifact size must be a non-negative integer, got {size}"));
+  }
+  let md5 = map
+    .tag_get("md5")
+    .ok_or_else(|| "receipt artifact is missing :md5".to_string())?
+    .read_string()?;
+  if md5.len() != 32 || !md5.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+    return Err(format!("receipt artifact md5 is invalid: {md5:?}"));
+  }
+  Ok(NativeArtifact {
+    relative_path,
+    size: size as u64,
+    md5: md5.to_ascii_lowercase(),
+  })
+}
+
+fn is_safe_artifact_path(value: &str) -> bool {
+  let path = Path::new(value);
+  !path.is_absolute() && path.starts_with("dylibs") && path.components().all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn collect_native_artifacts(realization: &Path) -> Result<BTreeMap<String, NativeArtifact>, String> {
+  let root = fs::canonicalize(realization).map_err(|e| format!("failed to resolve {}: {e}", realization.display()))?;
+  let dylibs = realization.join("dylibs");
+  let dylibs_metadata =
+    fs::symlink_metadata(&dylibs).map_err(|e| format!("native realization is missing {}: {e}", dylibs.display()))?;
+  if !dylibs_metadata.is_dir() || dylibs_metadata.file_type().is_symlink() {
+    return Err(format!("{} must be a real directory, not a symlink", dylibs.display()));
+  }
+  let mut artifacts = BTreeMap::new();
+  collect_native_artifact_dir(realization, &root, &dylibs, &mut artifacts)?;
+  if artifacts.is_empty() {
+    return Err(format!("native realization has no artifacts under {}", dylibs.display()));
+  }
+  Ok(artifacts)
+}
+
+fn collect_native_artifact_dir(
+  realization: &Path,
+  canonical_root: &Path,
+  directory: &Path,
+  artifacts: &mut BTreeMap<String, NativeArtifact>,
+) -> Result<(), String> {
+  for entry in fs::read_dir(directory).map_err(|e| format!("failed to read {}: {e}", directory.display()))? {
+    let entry = entry.map_err(|e| format!("failed to read native artifact entry: {e}"))?;
+    let path = entry.path();
+    let metadata = fs::symlink_metadata(&path).map_err(|e| format!("failed to inspect {}: {e}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+      return Err(format!("native artifact {} must not be a symlink", path.display()));
+    }
+    if metadata.is_dir() {
+      collect_native_artifact_dir(realization, canonical_root, &path, artifacts)?;
+    } else if metadata.is_file() {
+      let canonical_path = fs::canonicalize(&path).map_err(|e| format!("failed to resolve {}: {e}", path.display()))?;
+      if !canonical_path.starts_with(canonical_root) {
+        return Err(format!("native artifact {} escapes {}", path.display(), realization.display()));
+      }
+      let relative_path = path
+        .strip_prefix(realization)
+        .map_err(|e| format!("failed to make artifact path relative for {}: {e}", path.display()))?
+        .to_string_lossy()
+        .replace('\\', "/");
+      let content = fs::read(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+      artifacts.insert(
+        relative_path.clone(),
+        NativeArtifact {
+          relative_path,
+          size: metadata.len(),
+          md5: hex::encode(Md5::digest(&content)),
+        },
+      );
+    } else {
+      return Err(format!("native artifact {} has an unsupported file type", path.display()));
+    }
+  }
+  Ok(())
 }
 
 fn rust_target_identity() -> String {
@@ -976,8 +1191,12 @@ fn sanitize(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-  use super::{DependencyRequest, parse_tag_version, select_reference};
+  use super::{
+    DependencyRequest, RefKind, ResolvedModule, is_full_commit_hash, parse_tag_version, select_reference, verify_native_receipt,
+    write_native_receipt,
+  };
   use std::collections::BTreeSet;
+  use std::fs;
 
   fn request(reference: &str, requested_by: Option<&str>) -> DependencyRequest {
     DependencyRequest {
@@ -1023,5 +1242,37 @@ mod tests {
       select_reference("org/repo", &requests, Some(&"0.16.32".to_string())),
       Ok("0.16.67".to_string())
     );
+  }
+
+  #[test]
+  fn accepts_only_full_commit_hashes() {
+    assert!(is_full_commit_hash("0123456789abcdef0123456789abcdef01234567"));
+    assert!(!is_full_commit_hash("0123456789abcdef"));
+    assert!(!is_full_commit_hash("g123456789abcdef0123456789abcdef01234567"));
+  }
+
+  #[test]
+  fn native_receipt_rejects_changed_artifacts() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-receipt-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    let realization = root.join("build-key");
+    let dylibs = realization.join("dylibs");
+    fs::create_dir_all(&dylibs).unwrap();
+    let library = dylibs.join("libdemo.so");
+    fs::write(&library, b"first build").unwrap();
+    let module = ResolvedModule {
+      repository: "calcit-lang/demo".to_string(),
+      reference: "0.1.0".to_string(),
+      commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+      kind: RefKind::Tag,
+      source: root.join("source"),
+      link_target: realization.clone(),
+      dependencies: Default::default(),
+    };
+    write_native_receipt(&module, &realization, "build-key").unwrap();
+    assert_eq!(verify_native_receipt(&module, &realization).unwrap(), vec![library.clone()]);
+    fs::write(&library, b"modified build").unwrap();
+    assert!(verify_native_receipt(&module, &realization).is_err());
+    fs::remove_dir_all(root).unwrap();
   }
 }

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -512,8 +512,8 @@ mod tests {
         "{{}} (:package |{package})\n  :configs $ {{}} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!) (:version |0.0.1)\n    :modules $ []\n  :files $ {{}}\n"
       )
     };
-    fs::write(project.join(".calcit/modules/demo/calcit.cirru"), "invalid snapshot").unwrap();
-    fs::write(project.join(".calcit/modules/demo/compact.cirru"), snapshot("project-demo")).unwrap();
+    fs::write(project.join(".calcit/modules/demo/compact.cirru"), "invalid snapshot").unwrap();
+    fs::write(project.join(".calcit/modules/demo/calcit.cirru"), snapshot("project-demo")).unwrap();
     fs::write(global.join("demo/calcit.cirru"), snapshot("global-demo")).unwrap();
 
     let loaded = load_module_silent("demo/", &project, &global).unwrap();

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -170,23 +170,32 @@ fn handle_modules(opts: &ConfigModulesCommand, input_path: &str) -> Result<(), S
 }
 
 fn load_module_silent(module_path: &str, base_dir: &Path, module_folder: &Path) -> Result<snapshot::Snapshot, String> {
-  let candidates = [
-    base_dir.join(module_path).join("calcit.cirru"),
-    base_dir.join(module_path).join("compact.cirru"),
-    module_folder.join(module_path).join("calcit.cirru"),
-    module_folder.join(module_path).join("compact.cirru"),
-  ];
-
-  for candidate in &candidates {
+  let mut last_error = None;
+  for (_, candidate, _) in calcit::resolve_module_snapshot_candidates(module_path, base_dir, module_folder) {
     if candidate.exists() {
-      let mut content = fs::read_to_string(candidate).map_err(|e| format!("Failed to read: {e}"))?;
+      let mut content = match fs::read_to_string(&candidate) {
+        Ok(content) => content,
+        Err(error) => {
+          last_error = Some(format!("Failed to read {}: {error}", candidate.display()));
+          continue;
+        }
+      };
       strip_shebang(&mut content);
-      let data = cirru_edn::parse(&content).map_err(|e| format!("Failed to parse: {e}"))?;
-      return snapshot::load_snapshot_data(&data, &candidate.to_string_lossy());
+      let data = match cirru_edn::parse(&content) {
+        Ok(data) => data,
+        Err(error) => {
+          last_error = Some(format!("Failed to parse {}: {error}", candidate.display()));
+          continue;
+        }
+      };
+      match snapshot::load_snapshot_data(&data, &candidate.to_string_lossy()) {
+        Ok(snapshot) => return Ok(snapshot),
+        Err(error) => last_error = Some(format!("Failed to load {}: {error}", candidate.display())),
+      }
     }
   }
 
-  Err(format!("Module not found: {module_path}"))
+  Err(last_error.unwrap_or_else(|| format!("Module not found: {module_path}")))
 }
 
 fn handle_version(opts: &ConfigVersionCommand, snapshot_file: &str) -> Result<(), String> {
@@ -490,6 +499,27 @@ fn handle_rm_type_slot(opts: &ConfigRmTypeSlotCommand, snapshot_file: &str) -> R
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn config_module_lookup_prefers_project_module_view() {
+    let root = std::env::temp_dir().join(format!("calcit-config-module-view-{}", std::process::id()));
+    let project = root.join("project");
+    let global = root.join("global");
+    fs::create_dir_all(project.join(".calcit/modules/demo")).unwrap();
+    fs::create_dir_all(global.join("demo")).unwrap();
+    let snapshot = |package: &str| {
+      format!(
+        "{{}} (:package |{package})\n  :configs $ {{}} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!) (:version |0.0.1)\n    :modules $ []\n  :files $ {{}}\n"
+      )
+    };
+    fs::write(project.join(".calcit/modules/demo/calcit.cirru"), "invalid snapshot").unwrap();
+    fs::write(project.join(".calcit/modules/demo/compact.cirru"), snapshot("project-demo")).unwrap();
+    fs::write(global.join("demo/calcit.cirru"), snapshot("global-demo")).unwrap();
+
+    let loaded = load_module_silent("demo/", &project, &global).unwrap();
+    assert_eq!(loaded.package, "project-demo");
+    fs::remove_dir_all(root).unwrap();
+  }
 
   #[test]
   fn type_slot_edn_mutation_preserves_unrelated_snapshot_data() {

--- a/src/bin/cli_handlers/docs.rs
+++ b/src/bin/cli_handlers/docs.rs
@@ -1471,6 +1471,12 @@ fn ensure_runtime_initialized() {
 }
 
 fn module_folder() -> Result<PathBuf, String> {
+  let project_modules = std::env::current_dir()
+    .map_err(|e| format!("Unable to get current directory: {e}"))?
+    .join(".calcit/modules");
+  if project_modules.exists() {
+    return Ok(project_modules);
+  }
   let home = std::env::var("HOME").map_err(|_| "Unable to get HOME environment variable".to_string())?;
   Ok(Path::new(&home).join(".config/calcit/modules/"))
 }

--- a/src/bin/cli_handlers/libs.rs
+++ b/src/bin/cli_handlers/libs.rs
@@ -5,6 +5,7 @@
 use calcit::cli_args::{LibsCommand, LibsSubcommand};
 use colored::Colorize;
 use serde::Deserialize;
+use std::path::PathBuf;
 
 use super::markdown_read::{RenderMarkdownOptions, render_markdown_sections};
 
@@ -57,6 +58,18 @@ struct ReadmeHeader<'a> {
   repository: Option<&'a str>,
   description: Option<&'a str>,
   file: Option<&'a str>,
+}
+
+fn local_module_dir(package: &str) -> Result<PathBuf, String> {
+  let project_path = std::env::current_dir()
+    .map_err(|e| format!("Failed to get current directory: {e}"))?
+    .join(".calcit/modules")
+    .join(package);
+  if project_path.exists() {
+    return Ok(project_path);
+  }
+  let home_dir = std::env::var("HOME").map_err(|_| "Failed to get HOME directory".to_string())?;
+  Ok(PathBuf::from(home_dir).join(".config/calcit/modules").join(package))
 }
 
 pub fn handle_libs_command(cmd: &LibsCommand) -> Result<(), String> {
@@ -166,9 +179,7 @@ fn handle_readme(
   let file_name = file.unwrap_or("README.md");
   println!("{}", format!("Looking for {file_name} in '{package}'...").dimmed());
 
-  // Try local directory first: ~/.config/calcit/modules/<package>/<file>
-  let home_dir = std::env::var("HOME").map_err(|_| "Failed to get HOME directory".to_string())?;
-  let local_path = format!("{home_dir}/.config/calcit/modules/{package}/{file_name}");
+  let local_path = local_module_dir(package)?.join(file_name);
 
   let render_readme = |content: &str| -> Result<(), String> {
     let no_match_error =
@@ -190,10 +201,11 @@ fn handle_readme(
   };
 
   if let Ok(content) = std::fs::read_to_string(&local_path) {
+    let local_path_display = local_path.display().to_string();
     print_readme_header(ReadmeHeader {
       package,
       source: Some("Local"),
-      path: Some(&local_path),
+      path: Some(&local_path_display),
       repository: None,
       description: None,
       file: None,
@@ -304,20 +316,20 @@ fn handle_search(keyword: &str) -> Result<(), String> {
 }
 
 fn handle_scan_md(module: &str) -> Result<(), String> {
-  let home_dir = std::env::var("HOME").map_err(|_| "Failed to get HOME directory".to_string())?;
-  let module_path = format!("{home_dir}/.config/calcit/modules/{module}");
+  let module_path = local_module_dir(module)?;
 
   // Check if directory exists
-  if !std::path::Path::new(&module_path).exists() {
-    return Err(format!("Module directory not found: {module_path}"));
+  if !module_path.exists() {
+    return Err(format!("Module directory not found: {}", module_path.display()));
   }
 
   println!("{}", format!("Scanning markdown files in '{module}'...").cyan().bold());
-  println!("{}: {}", "Path".dimmed(), module_path);
+  println!("{}: {}", "Path".dimmed(), module_path.display());
   println!();
 
   // Recursively scan for .md files
   let mut md_files = Vec::new();
+  let module_path = module_path.to_string_lossy();
   scan_directory(&module_path, &module_path, &mut md_files)?;
 
   if md_files.is_empty() {

--- a/src/bin/git/mod.rs
+++ b/src/bin/git/mod.rs
@@ -1,3 +1,4 @@
+use crate::caps_graph::RefKind;
 use std::{
   path::{Path, PathBuf},
   process::Command,
@@ -24,19 +25,32 @@ impl GitRepo {
   }
 
   /// Clone one ref into an explicit destination path.
-  pub fn clone_to_path(target: &Path, url: &str, version: &str, shallow: bool) -> Result<(), String> {
+  pub fn clone_to_path(target: &Path, url: &str, version: &str, kind: &RefKind, shallow: bool) -> Result<(), String> {
     let parent = target
       .parent()
       .ok_or_else(|| format!("missing parent directory for {}", target.display()))?;
-    let container = GitRepo { dir: parent.to_path_buf() };
     let target_name = target
       .file_name()
       .and_then(|name| name.to_str())
       .ok_or_else(|| format!("invalid clone target {}", target.display()))?;
-    if shallow {
-      container.run_command(&["clone", "--branch", version, "--depth", "1", url, target_name])?;
+    if matches!(kind, RefKind::Commit) {
+      let mut init = Command::new("git");
+      init.current_dir(parent).args(["init", target_name]);
+      run_noninteractive(&mut init)?;
+      let repo = GitRepo { dir: target.to_path_buf() };
+      repo.run_command(&["remote", "add", "origin", url])?;
+      let mut fetch = Command::new("git");
+      fetch.current_dir(target).args(["fetch", "--depth", "1", "origin", version]);
+      run_noninteractive(&mut fetch)?;
+      repo.run_command(&["checkout", "--detach", "FETCH_HEAD"])?;
     } else {
-      container.run_command(&["clone", "--branch", version, url, target_name])?;
+      let mut command = Command::new("git");
+      command.current_dir(parent).args(["clone", "--branch", version]);
+      if shallow {
+        command.args(["--depth", "1"]);
+      }
+      command.args([url, target_name]);
+      run_noninteractive(&mut command)?;
     }
     Ok(())
   }
@@ -59,5 +73,21 @@ impl GitRepo {
   pub fn status_porcelain(&self) -> Result<Vec<String>, String> {
     let output = self.run_command(&["status", "--porcelain"])?;
     Ok(output.lines().map(str::to_owned).collect())
+  }
+}
+
+fn run_noninteractive(command: &mut Command) -> Result<(), String> {
+  command
+    .env("GIT_TERMINAL_PROMPT", "0")
+    .env("GIT_SSH_COMMAND", "ssh -o BatchMode=yes");
+  let output = command.output().map_err(|e| e.to_string())?;
+  if output.status.success() {
+    Ok(())
+  } else {
+    Err(format!(
+      "{} from args {:?}",
+      String::from_utf8_lossy(&output.stderr).trim(),
+      command.get_args()
+    ))
   }
 }

--- a/src/bin/git/mod.rs
+++ b/src/bin/git/mod.rs
@@ -23,63 +23,22 @@ impl GitRepo {
     }
   }
 
-  pub fn checkout(&self, version: &str) -> Result<(), String> {
-    if self.run_command(&["checkout", version]).is_ok() {
-      return Ok(());
-    }
-
-    // A branch fetched into an existing module clone may only exist as a
-    // remote-tracking ref. `git checkout <branch>` cannot resolve that name
-    // until a local branch is created. `-B` works even for clones with a
-    // narrow/non-standard remote refspec, while still pointing the local
-    // branch at the explicitly fetched origin ref.
-    let remote_branch = format!("origin/{version}");
-    self.run_command(&["checkout", "-B", version, &remote_branch]).map(|_| ())
-  }
-
-  /// clone to directory
-  pub fn clone_to(dir: &Path, url: &str, version: &str, shallow: bool) -> Result<(), String> {
-    let container = GitRepo { dir: dir.to_path_buf() };
+  /// Clone one ref into an explicit destination path.
+  pub fn clone_to_path(target: &Path, url: &str, version: &str, shallow: bool) -> Result<(), String> {
+    let parent = target
+      .parent()
+      .ok_or_else(|| format!("missing parent directory for {}", target.display()))?;
+    let container = GitRepo { dir: parent.to_path_buf() };
+    let target_name = target
+      .file_name()
+      .and_then(|name| name.to_str())
+      .ok_or_else(|| format!("invalid clone target {}", target.display()))?;
     if shallow {
-      container.run_command(&["clone", "--branch", version, "--depth", "1", url])?;
+      container.run_command(&["clone", "--branch", version, "--depth", "1", url, target_name])?;
     } else {
-      container.run_command(&["clone", "--branch", version, url])?;
+      container.run_command(&["clone", "--branch", version, url, target_name])?;
     }
     Ok(())
-  }
-
-  /// get the current head of the repository
-  pub fn current_head(&self) -> Result<GitHead, String> {
-    let branch = self.run_command(&["branch", "--show-current"])?;
-    if branch.is_empty() {
-      // probably a tag
-      Ok(GitHead::Tag(self.describe_tag()?))
-    } else {
-      Ok(GitHead::Branch(branch))
-    }
-  }
-
-  /// get unix timestamp of the commit resolved from a ref/tag/sha
-  /// ```bash
-  /// git rev-list -n 1 <REF>
-  /// git show -s --format=%ct <COMMIT>
-  /// ```
-  pub fn timestamp(&self, sha: &str) -> Result<u32, String> {
-    let commit = self.run_command(&["rev-list", "-n", "1", sha])?;
-    let timestamp = self.run_command(&["show", "-s", "--format=%ct", commit.trim()])?;
-    let v = timestamp.trim().parse::<u32>().map_err(|e| e.to_string())?;
-    Ok(v)
-  }
-
-  /// get latest tag
-  /// ```bash
-  /// git describe --tags $(git rev-list --tags --max-count=1)
-  /// ```
-  /// fails when no tag is found
-  pub fn latest_tag(&self) -> Result<String, String> {
-    let rev_output = self.run_command(&["rev-list", "--tags", "--max-count=1"])?;
-    let tag = self.run_command(&["describe", "--tags", rev_output.trim()])?;
-    Ok(tag.trim().to_string())
   }
 
   /// get SHA of a tag or ref
@@ -92,62 +51,13 @@ impl GitRepo {
     Ok(sha.trim().to_string())
   }
 
-  pub fn check_branch_or_tag(&self, version: &str, folder: &str) -> Result<bool, String> {
-    let refs = [
-      format!("refs/tags/{version}"),
-      format!("refs/heads/{version}"),
-      format!("refs/remotes/origin/{version}"),
-    ];
-    for r in &refs {
-      if self.run_command(&["show-ref", "--verify", r]).is_ok() {
-        return Ok(true);
-      }
-    }
-    Err(format!("failed to check branch or tag `{version}` in `{folder}`"))
-  }
-
-  pub fn fetch(&self) -> Result<(), String> {
-    // Module versions may be development branches, not only release tags.
-    // Fetch remote branch refs explicitly: existing module clones can have a
-    // narrow fetch refspec, in which case `git fetch --tags` leaves a newly
-    // pushed branch invisible to `show-ref` and checkout.
-    self.run_command(&["fetch", "--prune", "origin", "--tags", "+refs/heads/*:refs/remotes/origin/*"])?;
-    Ok(())
-  }
-
-  pub fn describe_tag(&self) -> Result<String, String> {
-    let tag = self.run_command(&["describe", "--tags"])?.trim().to_string();
-    Ok(tag)
-  }
-
-  pub fn pull(&self, branch: &str) -> Result<(), String> {
-    self.run_command(&["pull", "origin", branch])?;
-    Ok(())
+  pub fn head_commit(&self) -> Result<String, String> {
+    self.rev_parse("HEAD")
   }
 
   /// Return paths changed from HEAD, including untracked files.
   pub fn status_porcelain(&self) -> Result<Vec<String>, String> {
     let output = self.run_command(&["status", "--porcelain"])?;
     Ok(output.lines().map(str::to_owned).collect())
-  }
-
-  /// Discard tracked changes in the working tree and index.
-  pub fn reset_hard(&self) -> Result<(), String> {
-    self.run_command(&["reset", "--hard", "HEAD"]).map(|_| ())
-  }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum GitHead {
-  Branch(String),
-  Tag(String),
-}
-
-impl GitHead {
-  pub fn get_name(&self) -> String {
-    match self {
-      GitHead::Branch(s) => s.to_string(),
-      GitHead::Tag(s) => s.to_string(),
-    }
   }
 }

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -49,7 +49,8 @@ pub fn set_trace_ffi(v: bool) {
     trace_ffi_event(
       "enable",
       format!(
-        "cwd={cwd} exe={exe} abi={ABI_VERSION} edn={edn_version} host={}",
+        "cwd={cwd} exe={exe} abi={} edn={edn_version} host={}",
+        calcit::FFI_ABI_VERSION,
         std::env::consts::OS
       ),
     );
@@ -133,9 +134,16 @@ fn ensure_abi_compatible(lib: &libloading::Library, lib_name: &str) -> Result<()
     )
   })?;
   let current = lookup_version();
-  trace_ffi_event("abi-version", format!("lib={lib_name} current={current} expected={ABI_VERSION}"));
-  if current != ABI_VERSION {
-    return CalcitErr::err_str(CalcitErrKind::Unexpected, format!("ABI versions mismatch: {current} {ABI_VERSION}")).map(|_| ());
+  trace_ffi_event(
+    "abi-version",
+    format!("lib={lib_name} current={current} expected={}", calcit::FFI_ABI_VERSION),
+  );
+  if current != calcit::FFI_ABI_VERSION {
+    return CalcitErr::err_str(
+      CalcitErrKind::Unexpected,
+      format!("ABI versions mismatch: {current} {}", calcit::FFI_ABI_VERSION),
+    )
+    .map(|_| ());
   }
 
   trace_ffi_event("lookup-edn-version", format!("lib={lib_name}"));
@@ -159,8 +167,6 @@ fn ensure_abi_compatible(lib: &libloading::Library, lib_name: &str) -> Result<()
   }
   Ok(())
 }
-
-const ABI_VERSION: &str = "0.0.9";
 
 static PLATFORM_APIS_INJECTED: AtomicBool = AtomicBool::new(false);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ fn module_path_candidates(path: &str) -> Vec<String> {
 fn materialize_module_path(file_path: &str, base_dir: &Path, module_folder: &Path) -> PathBuf {
   if file_path.starts_with("./") {
     base_dir.join(file_path)
-  } else if file_path.starts_with('/') {
+  } else if Path::new(file_path).is_absolute() {
     Path::new(file_path).to_owned()
   } else {
     module_folder.join(file_path)
@@ -160,7 +160,7 @@ fn materialize_module_path(file_path: &str, base_dir: &Path, module_folder: &Pat
 }
 
 fn module_roots_for_path(file_path: &str, base_dir: &Path, module_folder: &Path) -> Vec<PathBuf> {
-  if file_path.starts_with("./") || file_path.starts_with('/') {
+  if file_path.starts_with("./") || Path::new(file_path).is_absolute() {
     vec![module_folder.to_path_buf()]
   } else {
     let project_modules = base_dir.join(".calcit/modules");
@@ -175,7 +175,7 @@ fn module_roots_for_path(file_path: &str, base_dir: &Path, module_folder: &Path)
 fn module_candidate_display_path(file_path: &str, fullpath: &Path, module_folder: &Path) -> String {
   if file_path.starts_with("./") {
     file_path.to_string()
-  } else if file_path.starts_with('/') {
+  } else if Path::new(file_path).is_absolute() {
     if let Ok(stripped) = fullpath.strip_prefix(module_folder) {
       format!("<mods>/{}", stripped.display())
     } else {
@@ -254,6 +254,21 @@ mod module_resolution_tests {
     let candidates = resolve_module_snapshot_candidates("./util.cirru", &project, &global);
     assert_eq!(candidates.len(), 1);
     assert_eq!(candidates[0].1, project.join("./util.cirru"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn absolute_module_paths_do_not_use_project_module_view() {
+    let root = temp_root("absolute");
+    let project = root.join("project");
+    let global = root.join("global");
+    let module = root.join("external.cirru");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(&module, "absolute").unwrap();
+
+    let candidates = resolve_module_snapshot_candidates(module.to_str().unwrap(), &project, &global);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].1, module);
     fs::remove_dir_all(root).unwrap();
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use crate::util::string::strip_shebang;
 
 pub const DEFAULT_SNAPSHOT_FILE: &str = "calcit.cirru";
 pub const LEGACY_SNAPSHOT_FILE: &str = "compact.cirru";
+pub const FFI_ABI_VERSION: &str = "0.0.9";
 
 static QUIET_TOOL_OUTPUT: AtomicBool = AtomicBool::new(false);
 
@@ -158,6 +159,19 @@ fn materialize_module_path(file_path: &str, base_dir: &Path, module_folder: &Pat
   }
 }
 
+fn module_roots_for_path(file_path: &str, base_dir: &Path, module_folder: &Path) -> Vec<PathBuf> {
+  if file_path.starts_with("./") || file_path.starts_with('/') {
+    vec![module_folder.to_path_buf()]
+  } else {
+    let project_modules = base_dir.join(".calcit/modules");
+    if project_modules == module_folder {
+      vec![module_folder.to_path_buf()]
+    } else {
+      vec![project_modules, module_folder.to_path_buf()]
+    }
+  }
+}
+
 fn module_candidate_display_path(file_path: &str, fullpath: &Path, module_folder: &Path) -> String {
   if file_path.starts_with("./") {
     file_path.to_string()
@@ -174,12 +188,22 @@ fn module_candidate_display_path(file_path: &str, fullpath: &Path, module_folder
 
 pub fn resolve_module_snapshot_candidates(path: &str, base_dir: &Path, module_folder: &Path) -> Vec<(String, PathBuf, String)> {
   let candidates = module_path_candidates(path);
-  let mut items = candidates
+  let roots = module_roots_for_path(path, base_dir, module_folder);
+  let mut items = roots
     .iter()
-    .map(|candidate| {
-      let fullpath = materialize_module_path(candidate, base_dir, module_folder);
-      let display_path = module_candidate_display_path(candidate, &fullpath, module_folder);
-      (candidate.clone(), fullpath, display_path)
+    .flat_map(|root| {
+      candidates
+        .iter()
+        .map(|candidate| {
+          let fullpath = materialize_module_path(candidate, base_dir, root);
+          let display_path = if *root == module_folder {
+            module_candidate_display_path(candidate, &fullpath, module_folder)
+          } else {
+            format!("<project-mods>/{candidate}")
+          };
+          (candidate.clone(), fullpath, display_path)
+        })
+        .collect::<Vec<_>>()
     })
     .collect::<Vec<_>>();
 
@@ -191,6 +215,47 @@ pub fn resolve_module_snapshot_candidates(path: &str, base_dir: &Path, module_fo
 
   items.retain(|(_, fullpath, _)| fullpath.exists());
   items
+}
+
+#[cfg(test)]
+mod module_resolution_tests {
+  use super::resolve_module_snapshot_candidates;
+  use std::fs;
+  use std::path::PathBuf;
+
+  fn temp_root(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("calcit-module-resolution-{label}-{}", std::process::id()))
+  }
+
+  #[test]
+  fn project_module_view_precedes_legacy_global_modules() {
+    let root = temp_root("project-first");
+    let project = root.join("project");
+    let global = root.join("global");
+    fs::create_dir_all(project.join(".calcit/modules/demo")).unwrap();
+    fs::create_dir_all(global.join("demo")).unwrap();
+    fs::write(project.join(".calcit/modules/demo/compact.cirru"), "project").unwrap();
+    fs::write(global.join("demo/calcit.cirru"), "global").unwrap();
+
+    let candidates = resolve_module_snapshot_candidates("demo/", &project, &global);
+    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/compact.cirru"));
+    assert_eq!(candidates[0].2, "<project-mods>/demo/compact.cirru");
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn explicit_relative_modules_do_not_use_project_module_view() {
+    let root = temp_root("relative");
+    let project = root.join("project");
+    let global = root.join("global");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(project.join("util.cirru"), "relative").unwrap();
+
+    let candidates = resolve_module_snapshot_candidates("./util.cirru", &project, &global);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].1, project.join("./util.cirru"));
+    fs::remove_dir_all(root).unwrap();
+  }
 }
 
 pub fn resolve_module_snapshot_path(path: &str, base_dir: &Path, module_folder: &Path) -> (String, PathBuf, String) {


### PR DESCRIPTION
## Summary

- store Git modules by repository and resolved commit while exposing project-local links under `.calcit/modules/`
- recursively resolve `deps.cirru`, prefer the highest requested SemVer, and report branch/conflict provenance through `caps tree`, `why`, `status`, and `verify`
- move package version management to `caps version`, preserve legacy snapshot fallback, and make runtime/query/docs/config loading prefer the project module view
- isolate native builds into ABI/toolchain-keyed realizations and verify exported ABI/cirru_edn versions in a subprocess
- keep generated state, links, receipts, and temporary data within `.calcit/`

## Review follow-ups included

- make `caps reset` rebuild project links without mutating the shared immutable store
- validate existing store commits and cleanliness before reuse
- use non-interactive HTTPS discovery with SSH fallback and bounded parallel resolution
- avoid temporary clone collisions and tolerate concurrent store/realization creation
- make `cr config modules` share runtime candidate fallback semantics

## Verification

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (12/12)
- `git diff --check`

Real-project checks after fast-forwarding clean repositories:

- `lilac`: install, tree, status, verify, reset, query, and config module listing
- `guidebook`: resolved/installed 10 recursive modules; status/verify passed; `respo.core` loaded from project links
- `workflow`: built and verified the `calcit.std` native realization; project-linked MD5 FFI returned `900150983cd24fb0d6963f7d28e17f72` for `abc`

## Known follow-up

`tree`, `status`, and `verify` currently refresh remote refs. Bounded parallelism reduced the observed guidebook tree resolution from about 92s to 44s, but a state-backed offline/fast path should be added separately.