### PR TITLE
fix: scope recursive development dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.13"
+version = "0.13.14"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "calcit"
 autobins = false
-version = "0.13.13"
+version = "0.13.14"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Related examples and workflows:
   :dependencies $ {}
     |calcit-lang/memof |0.0.11
     |calcit-lang/lilac |main
+  :dev-dependencies $ {}
+    |calcit-lang/calcit-test |0.1.0
 ```
 
 Run `caps` to resolve the recursive dependency graph and install it. Immutable revisions are stored under
@@ -140,6 +142,10 @@ Different projects can therefore use different revisions without switching a sha
 Published SemVer tags are preferred. Branch refs remain supported for development, but `caps` warns with
 the resolved commit. When a graph requests several SemVer tags for one repository, the highest requested
 version is selected and reported.
+
+Root projects install both `:dependencies` and `:dev-dependencies`. Recursive resolution only follows
+`:dependencies`, so test and maintenance modules declared by a dependency do not leak into consumers.
+Use `caps add --dev <org/repo>@<ref>` and `caps remove --dev <org/repo>` to manage the development group.
 
 `:calcit-version` helps with version checks and provides hints in [CI](https://github.com/calcit-lang/setup-cr).
 

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -20,7 +20,15 @@ aliases:
   :dependencies $ {}
     |calcit-lang/memof |0.0.11
     |calcit-lang/lilac |main
+  :dev-dependencies $ {}
+    |calcit-lang/calcit-test |0.1.0
 ```
+
+Use `:dependencies` for modules required by consumers at runtime or compile time. Use
+`:dev-dependencies` only for the current project's tests, examples, documentation checks, and
+maintenance tasks. `caps` installs both groups for the root project, but recursive resolution reads
+only each dependency's `:dependencies`; a dependency's own `:dev-dependencies` never leaks into the
+consumer. Conflicting references for the same repository in both root groups are rejected.
 
 Run `caps` to recursively resolve and install the graph. Sources are stored by resolved commit under
 `~/.config/calcit/modules/.store/`. The project gets a local module view in `.calcit/modules/`, with
@@ -29,6 +37,16 @@ Run `caps` to recursively resolve and install the graph. Sources are stored by r
 SemVer tags are the recommended dependency refs. Branches are supported for development, but every
 resolution warns and prints the current commit. Conflicting SemVer tags select the highest version actually
 requested by the graph and emit a warning that lists the request sources.
+
+Manage development dependencies explicitly:
+
+```bash
+caps add --dev calcit-lang/calcit-test@0.1.0
+caps remove --dev calcit-lang/calcit-test
+```
+
+`caps outdated` and `caps upgrade --all` inspect both root groups and preserve each declaration's
+group.
 
 To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename: `compact.cirru`):
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -508,9 +508,16 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
   run: |
     cr calcit.cirru edit format
     git diff --exit-code -- calcit.cirru
-    cr calcit.cirru --check-only
-    cr calcit.cirru --entry test --check-only
-    cr calcit.cirru --warn-dyn-method --check-only
+    # `cr config show` lists every configured :entries item, including default.
+    while IFS= read -r entry; do
+      if [ "$entry" = "default" ]; then
+        cr calcit.cirru --check-only
+        cr calcit.cirru --warn-dyn-method --check-only
+      else
+        cr calcit.cirru --entry "$entry" --check-only
+        cr calcit.cirru --entry "$entry" --warn-dyn-method --check-only
+      fi
+    done < <(cr calcit.cirru config show | awk '/^Snapshot Entries:/{in_entries=1; next} in_entries && /^  [^ ]/{print $1}')
     mkdir -p .calcit/upgrade
     cr calcit.cirru analyze check-types --summary-only --format json > .calcit/upgrade/check-types.json
     cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic,code-nil --intent unresolved,declared-optional --summary-only --format json > .calcit/upgrade/weak-types.json

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -18,13 +18,40 @@ related:
 
 # Calcit 项目升级手册（Respo / Lilac）
 
-本手册只关注**项目升级流程**，不展开开发实现细节。类库/module 发布前的完整证据矩阵见 [Calcit 类库项目验收与质量门禁](library-quality.md)。
+本手册面向需要从旧版 Calcit 逐步迁移到当前版本的项目。它不能保证旧代码无需修改就一次通过；
+它保证的是：先保留可回滚基线，再用 Calcit CLI 把依赖、Snapshot、配置、类型和行为问题分层暴露，
+每一层通过后再收紧下一层，避免把所有失败混在一次升级里。类库/module 发布前的完整证据矩阵见
+[Calcit 类库项目验收与质量门禁](library-quality.md)。
 
 适用对象：通过 Calcit CLI 运行并产出 JS 的项目（例如 Respo）。
+
+升级完成的标准不是“`caps upgrade --all` 执行成功”，而是：
+
+- 新版 `cr` / `caps` 已固定到本地和 CI，且 `deps.cirru`、`@calcit/procs` 版本链路一致；
+- 每个声明支持的 entry 都通过 `--check-only`，并完成对应 native / JS 行为测试；
+- `check-types`、`weak-types`、`deprecated` 已生成可复查报告，存量债务有 baseline，新增债务被阻断；
+- examples、Markdown 示例、项目测试与真实消费者回归覆盖了公开能力。
 
 ---
 
 ## 1）升级前检查位置
+
+### 先建立可回滚基线
+
+不要在未提交的业务修改上直接同时升级 CLI、依赖、Snapshot 和类型。先确认工作区状态，创建升级分支，
+并记录旧工具链下确实成功的命令、entry 和构建产物：
+
+```bash
+git status --short
+git switch -c upgrade/calcit-latest
+cr --version
+cr compact.cirru                # 替换为旧项目原本可成功执行的入口命令
+yarn test                       # 替换为项目原有的测试/构建命令
+```
+
+如果旧项目当前就不能通过原有测试，应先把失败记录为已知基线；不要把它误归因于新版类型系统。
+Snapshot 文件迁移、依赖升级和类型修复建议分别提交，任何阶段都能单独回退和比较。
+不要要求旧 CLI 支持本文后续介绍的所有新版子命令；这些校验应在 Step A 更新工具后再执行。
 
 升级前先检查以下文件与配置是否齐全：
 
@@ -45,66 +72,30 @@ related:
 - `calcit.cirru` — 存放完整 AST 快照，内容包含全部编译信息（带所有代码位置、类型标注等）
 - `compact.cirru` — 存放精简代码，是人工读写的主要文件
 
-当前推荐去掉旧的双文件模式，把精简 Snapshot 直接保存在 `calcit.cirru` 中，方便 `cr` 命令直接读取使用。迁移方式：
+当前推荐去掉旧的双文件模式，把精简 Snapshot 直接保存在 `calcit.cirru` 中，方便 `cr` 命令直接读取使用。
+如果两个文件同时存在，不要仅凭文件名猜测哪个是有效源码；先在旧版本下分别检查 Git 历史、文件体积、
+项目脚本和实际运行入口。确认 `compact.cirru` 是当前可运行的精简 Snapshot 后再迁移：
 
 1. 确认 `compact.cirru` 是项目实际精简化代码，`calcit.cirru` 是完整 AST 快照（差异通常很大）
-2. 将 `compact.cirru` 内容直接覆盖到 `calcit.cirru`（或者删除 `calcit.cirru` 后重命名 `compact.cirru` 为 `calcit.cirru`）
-3. 提交时删除旧的快照文件（确保不再跟踪 `calcit.cirru` 的旧快照内容）
-4. 后续所有 `cr` 命令都基于单一的 `calcit.cirru` 运行，不再生成快照文件
+2. 先在独立提交或临时分支中将 `compact.cirru` 复制/重命名为 `calcit.cirru`，不要和业务逻辑修复混在一起
+3. 执行 `cr calcit.cirru edit format`，审阅 diff，再对新的 `calcit.cirru` 运行 `--check-only` 和原有 entry/构建测试
+4. 新旧入口行为一致后再删除旧文件并提交；后续所有 `cr` 命令都显式基于单一的 `calcit.cirru`
 
-> 如果项目中还存在旧的 `calcit.cirru` 快照文件，迁移后可以删除。`cr` 命令行不再依赖快照文件——它直接读取 `calcit.cirru` 中的精简代码运行。`cr edit` / `cr tree` 的修改直接保存在 `calcit.cirru`。`.gitattributes` 中 `calcit.cirru -diff linguist-generated` 标记也可以移除。`.gitignore` 中的 `compact.cirru` 则应改为忽略旧快照文件名。
+> `cr` 仍然读取 Snapshot，只是当前约定把精简 Snapshot 直接命名为 `calcit.cirru`；不要把它理解为
+> “不再依赖 Snapshot”。`cr edit` / `cr tree` 会直接修改该文件。确认迁移完成后，可以移除旧的
+> `.gitattributes` generated 标记和过时的双文件生成脚本；不要把仍可能承载源码的文件直接加入 ignore。
 
 ---
 
 ## 2）标准升级流程（建议顺序）
-
-### 类型标注语法迁移
-
-新版本把 schema 类型的推荐写法统一为 quoted symbol：`'String`、`'Number`、`'List`、`'Ref`、`'Fn` 和 `'Dynamic`。旧的 `:string`、`:number`、`:list`、`:ref`、`:fn`、`:dynamic` 仍可加载，以便平滑升级；普通 tag 数据（例如 enum variant `:ok`、struct field key 和 schema 的 `:return`/`:kind` key）不会被改变。
-
-在完成依赖升级后执行：
-
-```bash
-cr calcit.cirru edit format
-cr calcit.cirru --check-only
-```
-
-`edit format` 会只改写 schema、`hint-fn`、`assert-type`、`unsafe-coerce`、`defstruct` 和 `defenum` 等类型位置，并将 entry schema 重新序列化为 canonical symbols；它不会猜测或加强实际类型契约。提交前检查 diff，尤其是具有手写 tag 数据的宏或 DSL。
-
-### Struct / Enum 数据模型命名迁移
-
-新数据模型明确区分定义和值：`defstruct` 返回 `StructDef`，`defenum` 返回
-`EnumDef`；实例类型分别是 `Struct` 和 `Enum`。没有具名定义的临时值使用
-`%{} _ ...` 和 `%:: _ ...`。旧的 record / tuple 公开名称会产生
-`W_REMOVED_DATA_API`，诊断中同时给出替代写法；新 Snapshot 不再写出
-`:record`、`:tuple`、`Record` 或 `Tuple`。
-
-常用迁移如下：
-
-| 旧写法 | 新写法 |
-| --- | --- |
-| `record?` | `struct?`（值）或 `struct-def?`（定义） |
-| `tuple?` | `enum?`（值）或 `enum-def?`（定义） |
-| `record-struct` | `struct-definition` |
-| `tuple-enum` | `enum-definition` |
-| `record-with` / `record-match` | `struct-with` / `struct-match` |
-| `&record:*` / `&tuple:*` | 对应的 `&struct:*` / `&enum:*`；定义元数据使用 `&struct-def:*` / `&enum-def:*` |
-
-Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field` 和
-`.field` 直接返回字段声明类型，不再自动包装 `Option<T>`。不存在的字段会在
-静态检查阶段报告，运行期也会抛出普通错误；升级业务代码时应删除这类访问后的
-`.unwrap`。Map 等动态容器的访问仍返回 `Option<T>`，`get-in` 也继续保留
-可失败路径语义，不能批量删除其 unwrap。
-
-推荐先执行 `cr calcit.cirru --check-only`，按诊断逐项替换，再运行完整 JS
-回归。不要先全局删除 `.unwrap`；只处理接收者已被推断为 Struct 且字段在
-`defstruct` 中声明的访问。
 
 下面流程按“先确认版本，再对齐工具链，再更新依赖，最后按 CI 链路验证”的顺序执行。
 
 ### 快速命令清单
 
 ```bash
+# 安装/更新用户工具；本地和 CI 必须使用同一版本链路
+cargo install calcit --bin cr --bin caps --force
 cr --version
 caps upgrade --all
 caps
@@ -114,6 +105,9 @@ yarn install
 yarn install --immutable
 cr calcit.cirru edit format
 cr calcit.cirru --check-only
+cr calcit.cirru --warn-dyn-method --check-only
+cr calcit.cirru analyze deprecated --summary-only --format json
+cr calcit.cirru analyze weak-types --intent unresolved,declared-optional --summary-only --format json
 cr calcit.cirru
 yarn vite build --base=./
 ```
@@ -123,10 +117,14 @@ yarn vite build --base=./
 ### Step A：确认 Calcit CLI 版本
 
 ```bash
+cargo install calcit --bin cr --bin caps --force
 cr --version
+caps --help
 ```
 
-说明：一般本机已经是较新版本，但升级前先确认一遍，避免后续误判。
+说明：`cr` 和 `caps` 是同一 Calcit 发布链路中的用户工具，应一起更新。不要先用旧 `caps` 改依赖，
+再用新 `cr` 判断结果；也不要只更新本机而让 CI 继续安装旧版。若团队通过其他受控方式分发二进制，
+使用该方式即可，但要记录实际版本，并确认 `caps --help` 已包含项目需要的新选项。
 
 > ⚠️ 注意 CI 中 `calcit-lang/setup-cr` 的版本：旧版本（如 `0.0.8`）安装的 `cr` 可能不识别 `calcit.cirru`。升级后若 CI 报 `"compact.cirru does not exist"`，请升级 `setup-cr` 版本。最新版本请查阅 [setup-cr releases](https://github.com/calcit-lang/setup-cr/releases)。
 
@@ -142,6 +140,15 @@ cr --version
 
 先把这些基础版本与工具链约定对齐，再继续更新依赖，能减少后面重复改 lockfile 或 CI 的次数。
 
+非常旧的项目如果仍使用 `package.cirru`，先把它重命名为 `deps.cirru` 并单独提交；新版 `caps`
+会拒绝旧文件名并给出迁移提示。不要同时保留两份依赖清单，否则项目脚本和维护者可能更新不同文件。
+
+更新依赖前先读取当前 Agent/CLI 指南，避免沿用旧命令边界：
+
+```bash
+cr docs agents --full
+```
+
 ### Step C：检查并更新 `deps.cirru`
 
 先审计依赖分组。新版 `caps` 对根项目同时安装 `:dependencies` 和
@@ -150,12 +157,9 @@ cr --version
 迁到 `:dev-dependencies`，避免递归依赖图继续无边界扩张：
 
 ```cirru
-{}
-  :calcit-version |0.13.13
-  :dependencies $ {}
-    |calcit-lang/respo.calcit |0.16.67
-  :dev-dependencies $ {}
-    |calcit-lang/calcit-test |0.1.0
+{} (:calcit-version |0.13.13)
+  :dependencies $ {} (|calcit-lang/respo.calcit |0.16.67)
+  :dev-dependencies $ {} (|calcit-lang/calcit-test |0.1.0)
 ```
 
 可以用 `caps add --dev <org/repo>@<ref>` 和 `caps remove --dev <org/repo>` 管理开发依赖。
@@ -169,6 +173,11 @@ caps upgrade --all
 对应分组中的依赖版本与 `:calcit-version`；如果确实发生升级，还会顺带执行一次
 `yarn up @calcit/procs`，把 JS 运行时包同步到当前 Calcit 版本链路。
 
+如果依赖清单本来已经是最新、但 `package.json` 中的 `@calcit/procs` 仍旧，`caps upgrade --all`
+可能没有产生更新动作。此时应显式执行 `yarn up @calcit/procs`，审阅 `package.json` / `yarn.lock`，
+并确认安装后的包版本与当前 Calcit 发布链路相符；不要只根据 caps 的 “Already up to date” 判断
+JS runtime 已同步。
+
 如果你只想批量把旧版本提升到最新标签，也可以继续用：
 
 ```bash
@@ -181,16 +190,21 @@ caps outdated --yes
 
 ```bash
 caps
+caps tree
+caps status
+caps verify
 ```
 
 说明：这一步才会按当前 `deps.cirru` 下载/同步模块内容。根项目的两个依赖分组都会安装，
-依赖模块的 `:dev-dependencies` 会在递归解析中排除。
+依赖模块的 `:dev-dependencies` 会在递归解析中排除。`tree` 用于审阅最终递归图，`status` 检查
+项目链接和期望版本，`verify` 进一步检查 immutable store、源码修改和 native 构建收据。分支 ref
+或版本冲突在迁移期可以先作为明确告警处理；准备固定 CI 时再用 `caps --strict --ci` 阻断这些告警。
 
 ### Step E：用 Yarn Berry 安装并校验
 
 ```bash
 corepack enable
-corepack prepare yarn@4.12.0 --activate
+corepack prepare yarn@4.12.0 --activate  # 示例；优先采用 packageManager 固定的版本
 yarn --version
 yarn install --immutable
 ```
@@ -219,7 +233,24 @@ cr calcit.cirru js && yarn vite build --base=./
 
 `cr calcit.cirru` 默认单次执行并选择 `entries.default`；指定 entry 时用 `--entry <name>`。entry 的 `:mode` 已决定 native 运行或 JS 生成，项目脚本与 CI 应优先依赖该配置。只有热更新才加 `-w` / `--watch`；显式 `js` 是兼容/定向 codegen 覆盖，不是每个 JS 项目的必需写法。
 
-`--check-only` 会同时预处理所选 entry 的 init/reload 定义，因此可以发现遗留的 `:reload-fn` 已不存在等旧配置问题。
+`--check-only` 会同时预处理所选 entry 的 init/reload 定义，因此可以发现遗留的 `:reload-fn`
+已不存在、调用参数/返回值不匹配、Struct/Enum 字段错误、trait 实现不完整等问题。它在预处理产生
+warning 时会非零退出，是类型逐渐严格过程中的主要编译门禁。named entry 不继承 default 配置，
+所以必须逐个执行，不能只验证 default：
+
+```bash
+cr calcit.cirru --check-only
+cr calcit.cirru --entry test --check-only
+cr calcit.cirru --entry production --check-only
+```
+
+旧项目若一次出现大量错误，按“配置/缺失定义 → deprecated API → nominal data/trait → 函数参数和
+返回值 → dynamic/nil debt”的顺序修复。每清完一类就提交并重跑所有 entry，避免用
+`&core:ignore-type-warning`、`--skip-arity-check` 或批量改成 `'Dynamic` 掩盖迁移问题。
+
+`--check-only` 的范围是所选 entry 可达的预处理路径，不等于“仓库中每个公开定义都已检查”。
+未被应用入口调用的类库 API 应由 definition-attached tests、`check-examples` 或真实消费者覆盖；
+不要因为 default entry 通过就跳过公开 namespace 和其他 entry。
 
 如果 `package.json` 里有编译、构建、测试相关脚本，也应本地执行一遍；没有额外脚本可跳过。若项目直接通过 Vite 构建，可执行：
 
@@ -242,7 +273,54 @@ yarn <script-name>
 
 ## 3）近期项目结构与类型迁移
 
-### 3.1 统一 entries
+这一节必须在 Step A–E 已完成、项目确实使用新版 `cr` 和新版依赖后执行。先运行一次
+`cr calcit.cirru edit format` 并单独审阅/提交规范化 diff，再根据 `--check-only` 和静态报告逐类
+修复语义问题；不要让自动格式化与大规模业务修复混在同一个不可审阅的提交中。
+
+### 3.1 类型标注语法规范化
+
+新版本把 schema 类型的推荐写法统一为 quoted symbol：`'String`、`'Number`、`'List`、`'Ref`、
+`'Fn` 和 `'Dynamic`。旧的 `:string`、`:number`、`:list`、`:ref`、`:fn`、`:dynamic` 仍可加载，
+以便平滑升级；普通 tag 数据（例如 enum variant `:ok`、struct field key 和 schema 的
+`:return`/`:kind` key）不会被改变。
+
+```bash
+cr calcit.cirru edit format
+git diff -- calcit.cirru
+cr calcit.cirru --check-only
+```
+
+`edit format` 只改写 schema、`hint-fn`、`assert-type`、`unsafe-coerce`、`defstruct` 和 `defenum`
+等类型位置，并将 entry schema 重新序列化为 canonical symbols；它不会猜测或加强实际类型契约。
+提交前检查 diff，尤其是具有手写 tag 数据的宏或 DSL。
+
+### 3.2 Struct / Enum 数据模型命名迁移
+
+新数据模型明确区分定义和值：`defstruct` 返回 `StructDef`，`defenum` 返回 `EnumDef`；实例类型
+分别是 `Struct` 和 `Enum`。没有具名定义的临时值使用 `%{} _ ...` 和 `%:: _ ...`。旧的
+record / tuple 公开名称会产生 `W_REMOVED_DATA_API`，诊断中同时给出替代写法；新 Snapshot 不再
+写出 `:record`、`:tuple`、`Record` 或 `Tuple`。
+
+常用迁移如下：
+
+| 旧写法 | 新写法 |
+| --- | --- |
+| `record?` | `struct?`（值）或 `struct-def?`（定义） |
+| `tuple?` | `enum?`（值）或 `enum-def?`（定义） |
+| `record-struct` | `struct-definition` |
+| `tuple-enum` | `enum-definition` |
+| `record-with` / `record-match` | `struct-with` / `struct-match` |
+| `&record:*` / `&tuple:*` | 对应的 `&struct:*` / `&enum:*`；定义元数据使用 `&struct-def:*` / `&enum-def:*` |
+
+Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field` 和 `.field` 直接返回字段声明
+类型，不再自动包装 `Option<T>`。不存在的字段会在静态检查阶段报告，运行期也会抛出普通错误；
+升级业务代码时应删除这类访问后的 `.unwrap`。Map 等动态容器的访问仍返回 `Option<T>`，
+`get-in` 也继续保留可失败路径语义，不能批量删除其 unwrap。
+
+推荐先执行 `cr calcit.cirru --check-only`，按诊断逐项替换，再运行完整 JS 回归。不要先全局删除
+`.unwrap`；只处理接收者已被推断为 Struct 且字段在 `defstruct` 中声明的访问。
+
+### 3.3 统一 entries
 
 顶层 `:configs` 是兼容输入，不应继续作为新配置写法。执行：
 
@@ -258,7 +336,7 @@ format 会把旧 `:configs` 迁移为 `:entries.default`，并输出 `W_LEGACY_C
 - `:init-fn` / `:reload-fn` 使用 definition symbol，而不是继续新增字符串值。
 - entry 用 `:description` 说明用途，便于维护者和 Agent 选择正确入口。
 
-### 3.2 Type slots
+### 3.4 Type slots
 
 类库用 `deftype-slot` 声明由应用提供的编译期类型时，每个使用该 slot 的 entry 都要单独绑定：
 
@@ -270,25 +348,103 @@ cr calcit.cirru config set-type-slot --entry test :dispatch-op app.test-schema/T
 
 未绑定 slot 会回退到 `:dynamic`，可能让 callback 检查和 method specialization 失去静态证据。升级后应逐 entry 检查，而不是只验证 default。
 
-### 3.3 旧 schema 与动态类型
+### 3.5 旧 schema 与动态类型
 
 `:any` 只保留为 `:dynamic` 的兼容拼写；新 schema 不应继续引入。`edit format` 会输出 `W_LEGACY_ANY` / `W_DYNAMIC_TYPE_DEBT`，但不会猜测并自动改写类型关系。执行：
 
 ```bash
 cr calcit.cirru analyze check-types --summary-only
 cr calcit.cirru analyze weak-types \
-  --only schema-dynamic,code-dynamic \
-  --intent unresolved \
+  --only schema-dynamic,code-dynamic,code-nil \
+  --intent unresolved,declared-optional \
   --summary-only
+cr calcit.cirru analyze deprecated --summary-only
 ```
 
-有命中时去掉 `--summary-only` 查看路径和建议。输入/输出共享类型时用 `:generics`，只约束能力时用 trait `:where`，collection/ref 保留类型参数，有限异构值使用 enum。真正的 JS FFI 边界应显式标记 `:features $ #{} :js-ffi`，并在进入 typed code 前 validate/convert。
+有命中时去掉 `--summary-only` 查看 definition、Snapshot path、impact、suggestion 和 deprecated
+目标文档。`check-types` 会把缺失或部分 schema（包括没有元素类型的 List/Map/Ref）列出来；
+`weak-types` 同时区分 unresolved dynamic、明确 JS FFI 边界、Unit nil 和旧 Optional 兼容债务；
+`deprecated` 按调用位置指出已废弃 API。输入/输出共享类型时用 `:generics`，只约束能力时用 trait
+`:where`，collection/ref 保留类型参数，有限异构值使用 enum。真正的 JS FFI 边界应显式标记
+`:features $ #{} :js-ffi`，并在进入 typed code 前 validate/convert。无返回值使用 `Unit`；业务缺失
+使用 `Option`，需要错误信息时使用 `Result`，不要让旧 `Optional<T>` 或裸 `nil` 无限保留。
 
-### 3.4 format 的边界
+再对每个 entry 开启动态方法告警：
+
+```bash
+cr calcit.cirru --warn-dyn-method --check-only
+cr calcit.cirru --entry test --warn-dyn-method --check-only
+```
+
+这个开关会暴露无法静态专门化的方法调用和未类型化的动态接收者。它不是第一步：先修复普通
+`--check-only`，再打开额外告警，否则旧项目的初始噪音可能掩盖真正的配置和 API 错误。
+
+### 3.6 存量项目的类型收紧策略
+
+三类命令的退出语义不同，不能只看命令是否成功：
+
+- `--check-only` 和实际 native/JS codegen：预处理错误或 warning 会阻断并非零退出，必须修到通过；
+- `check-examples`、`docs check-md` 和 `cr test`：所选示例/测试失败时阻断；测试应加
+  `--require-match`，避免过滤条件拼错后“零测试通过”；
+- `check-types`、`weak-types`、`deprecated`：是静态报告命令，有命中不等于非零退出；CI 必须解析
+  `--format json` 的 summary 并与零目标或已审阅 baseline 比较。
+
+老项目不必在第一次升级提交中把所有历史 dynamic 清零，但必须先让报告可重复，再阻止新增债务：
+
+1. 保存当前 JSON summary、Calcit 版本和 Snapshot revision，作为审阅过的 baseline；
+2. 先要求 `--check-only`、测试和行为构建全绿；
+3. CI 拒绝 unresolved dynamic、nil/Optional debt 或 deprecated call 数量上升；
+4. 按模块降低 baseline，降到 0 后改为零容忍；baseline 只能下降，不能无说明地更新；
+5. 对确实动态的 JS FFI 边界显式声明 `:features $ #{} :js-ffi`，不要用 ignore warning 伪造通过。
+
+baseline 不要只保存一个总数。类型覆盖至少比较 `levels.none` 和
+`levels.none + levels.partial`（未完全覆盖总数）：`none` 变成 `partial` 是进步，不应因为
+`partial` 单项上升而失败。弱类型则分别比较 `kinds.schema-dynamic` / `code-dynamic` / `code-nil`
+和 `intents.declared-optional`，再比较 `deprecated` 的 `summary.calls`。否则一种债务增加、另一种
+减少时，相同的总数会掩盖回归。
+
+可用下面命令生成三份机器报告；它们的 stdout 都是单个 JSON，进度与提示写到 stderr：
+
+```bash
+mkdir -p .calcit/upgrade
+cr calcit.cirru analyze check-types --summary-only --format json \
+  > .calcit/upgrade/check-types.json
+cr calcit.cirru analyze weak-types \
+  --only schema-dynamic,code-dynamic,code-nil \
+  --intent unresolved,declared-optional \
+  --summary-only --format json \
+  > .calcit/upgrade/weak-types.json
+cr calcit.cirru analyze deprecated --summary-only --format json \
+  > .calcit/upgrade/deprecated.json
+```
+
+`.calcit/upgrade/` 可以作为本地迁移证据目录并保持在 `.gitignore`；真正用于 CI 的 baseline 数值或
+脚本应放在仓库跟踪的配置中，并在 PR 中解释每次变化。
+
+例如把首次审阅后的上限提交为 `config/calcit-upgrade-baseline.json`：
+
+```json
+{
+  "typeNone": 4,
+  "typeNotFull": 22,
+  "schemaDynamic": 21,
+  "codeDynamic": 0,
+  "codeNil": 22,
+  "declaredOptional": 0,
+  "deprecatedCalls": 0
+}
+```
+
+然后由仓库脚本读取上述三份报告，对每个指标执行 `current <= baseline`。如果迁移把 `none` 改善为
+`partial`，`typeNone` 会下降且 `typeNotFull` 不变；改善为 `full` 时二者都会下降。确有类型债务在
+不同分类间迁移时，应在 PR 中解释并显式更新 baseline，而不是让一个总数相互抵消。baseline 归零后
+保留检查脚本，以阻止后续重新引入。
+
+### 3.7 format 的边界
 
 `cr edit format` 负责可解析性、canonical serialization 和已知旧结构迁移；它不是完整的语义 linter。告警写到 stderr 且不会阻止格式化。CI 需要在 format 后检查 `git diff`，并单独读取 `check-types` / `weak-types --format json` 来执行项目自己的质量阈值。
 
-### 3.5 Trait impl 从方法包迁移为 nominal impl
+### 3.8 Trait impl 从方法包迁移为 nominal impl
 
 旧代码可能把 tag 作为 `defimpl` 的 trait 参数：
 
@@ -353,15 +509,31 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
     cr calcit.cirru edit format
     git diff --exit-code -- calcit.cirru
     cr calcit.cirru --check-only
-    cr calcit.cirru analyze check-types --summary-only --format json
-    cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
+    cr calcit.cirru --entry test --check-only
+    cr calcit.cirru --warn-dyn-method --check-only
+    mkdir -p .calcit/upgrade
+    cr calcit.cirru analyze check-types --summary-only --format json > .calcit/upgrade/check-types.json
+    cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic,code-nil --intent unresolved,declared-optional --summary-only --format json > .calcit/upgrade/weak-types.json
+    cr calcit.cirru analyze deprecated --summary-only --format json > .calcit/upgrade/deprecated.json
+    node scripts/check-calcit-upgrade-baseline.mjs
+
+- name: Run project tests
+  run: |
+    cr calcit.cirru test --tag unit --require-match --summary-only --format json
+    cr calcit.cirru --entry test
 ```
 
 > ⚠️ `calcit-lang/setup-cr` 的版本决定了 CI 中安装的 `cr` 版本。旧版本（如 `0.0.8`）可能不识别 `calcit.cirru`，且不支持新版类型检查。建议保持 `@0.0.9` 或更新。最新版本请查阅 [setup-cr releases](https://github.com/calcit-lang/setup-cr/releases)。不要在 `caps --ci` 之前运行 `cr` 命令，否则会使用默认旧版模块缓存。
 
 说明：若项目依赖 `packageManager: "yarn@4.12.0"`，优先先执行 Corepack 激活，再让 CI 触发 Yarn。不要让 `setup-node` 的 Yarn cache 或其他 Yarn 调用早于 `corepack enable` / `corepack prepare`，否则可能误用 runner 上的全局 Yarn 1。 `caps --ci` 参数保证在 CI 加载模块时使用 HTTPS 协议，避免 CI 环境下的 SSH key 问题。
 
-注意：两个 analysis 命令会报告诊断，但不会替项目决定 debt 阈值。严格 CI 应解析 JSON summary，与零目标或已审阅 baseline 比较。
+注意：三个 `analyze` 命令只是展示机器报告，上面的示例还没有对 debt 数量作判断。迁移期应把
+summary 与仓库中已审阅的 baseline 比较，禁止数字上升；示例中的
+`scripts/check-calcit-upgrade-baseline.mjs` 是项目需要自行实现并纳入版本控制的比较脚本，不是 `cr`
+内建文件。清零后则要求 unresolved dynamic、
+unresolved/declared-optional nil debt 和 deprecated calls 均为 0。不要只依赖 analysis 命令退出码。
+`test --require-match` 会避免 tag 或 scope 写错后零测试仍退出成功。项目没有 named `test` entry 或
+definition-attached unit tests 时，应删除对应示例行并替换成项目真实测试命令，而不是机械照抄。
 
 ### 4.3 lockfile 迁移
 
@@ -381,12 +553,29 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
 3. `caps tree`（确认根开发依赖存在，同时传递模块的开发依赖未进入图）
 4. `yarn install --immutable`
 5. `cr calcit.cirru edit format` 后 `git diff --exit-code -- calcit.cirru`
-6. `cr calcit.cirru --check-only`
-7. 所有声明支持的 entry（默认 once；watch 另行验收）
-8. `check-types` 与 unresolved `weak-types` 基线
-9. 公开 namespace 的 `check-examples` 与 `docs check-md`
-10. JS 项目的 codegen 加 Node/Vite 行为测试，而不只是生成成功
-11. `package.json` 中与编译/构建相关的脚本
-12. 类库项目在 Respo 等真实消费者中的回归证据
+6. default 与每个 named entry 的 `--check-only`
+7. 每个 entry 的 `--warn-dyn-method --check-only`（普通检查全绿后启用）
+8. 所有声明支持的 entry 行为测试（默认 once；watch 另行验收）
+9. `check-types`、dynamic/nil `weak-types`、`deprecated` 的 JSON baseline 或零目标
+10. `cr test --require-match`、公开 namespace 的 `check-examples` 与 `docs check-md`
+11. JS 项目的 codegen 加 Node/Vite 行为测试，而不只是生成成功
+12. `package.json` 中与编译/构建相关的脚本
+13. 类库项目在 Respo 等真实消费者中的回归证据
+
+### 老项目失败时的定位顺序
+
+| 阶段 | 命令 | 主要发现 | 是否自动阻断 |
+| --- | --- | --- | --- |
+| 依赖图 | `caps tree/status/verify` | 递归版本、链接、store/native 收据 | 状态异常会阻断；普通图告警用 `--strict` 收紧 |
+| Snapshot 规范化 | `cr edit format` + `git diff` | 旧 configs/schema 拼写和规范化建议 | format 告警不阻断，diff 需人工审阅 |
+| entry 预处理 | `cr --entry ... --check-only` | 配置、缺失定义、参数/返回值、数据与 trait 类型错误 | 错误或 warning 均阻断 |
+| 动态分派 | `cr --warn-dyn-method --check-only` | 动态 receiver、无法专门化的方法与未类型化 FFI 访问 | warning 会随 check-only 阻断 |
+| 静态债务 | `analyze check-types/weak-types/deprecated --format json` | 覆盖率、dynamic、nil/Optional、废弃调用 | 报告本身不按命中数阻断，CI 比较 summary |
+| 示例与测试 | `check-examples`、`docs check-md`、`cr test --require-match` | API 示例、文档片段、definition-attached tests | 失败或未匹配测试时阻断 |
+| 行为与后端 | entry、Node/Vite、项目测试 | native/JS/FFI 的真实行为差异 | 由进程退出码阻断 |
+
+每次失败先查看终端诊断；需要完整运行栈时再看 `.calcit/error.cirru` 或执行
+`cr calcit.cirru query error`。针对单个定义可用 `cr query context <ns/def> --format json`，针对
+具体表达式可用诊断返回的 Snapshot path 调用 `cr query type-at <ns/def> --path code@... --format json`。
 
 call graph 的 `--show-unused` 只能作为 entry-relative 线索；公开 API 和替代入口可能被列为 unreachable，不能据此自动删除。

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -34,6 +34,7 @@ related:
 - 命令入口：`README`、项目脚本、CI workflow
 - Node 工具链：`package.json`、`yarn.lock`、Corepack/Yarn 版本
 - 注意 git fetch 检查最新历史, 避免基于老版本操作导致变更冲突
+- 依赖边界：运行/编译期需要的模块放在 `:dependencies`；只供当前项目测试、examples、文档检查和维护脚本使用的模块放在 `:dev-dependencies`
 - 结构化编辑优先使用 `cr edit` / `cr tree`；若直接改过 `calcit.cirru`（或旧文件名 `compact.cirru`），提交前执行一次 `cr calcit.cirru edit format`
 - 静态质量基线：`check-types`、`weak-types`、公开 namespace examples 与 Markdown 示例
 
@@ -143,11 +144,30 @@ cr --version
 
 ### Step C：检查并更新 `deps.cirru`
 
+先审计依赖分组。新版 `caps` 对根项目同时安装 `:dependencies` 和
+`:dev-dependencies`，但递归解析某个依赖模块时只读取它的 `:dependencies`，不会把该模块
+自己的开发依赖带入消费者。升级旧项目时，应把测试、examples、文档验证与维护工具专用模块
+迁到 `:dev-dependencies`，避免递归依赖图继续无边界扩张：
+
+```cirru
+{}
+  :calcit-version |0.13.13
+  :dependencies $ {}
+    |calcit-lang/respo.calcit |0.16.67
+  :dev-dependencies $ {}
+    |calcit-lang/calcit-test |0.1.0
+```
+
+可以用 `caps add --dev <org/repo>@<ref>` 和 `caps remove --dev <org/repo>` 管理开发依赖。
+同一个仓库不要以不同 ref 同时出现在两个分组；新版会直接拒绝这种歧义配置。
+
 ```bash
 caps upgrade --all
 ```
 
-说明：`caps upgrade --all` 会更新 `deps.cirru` 里的依赖版本与 `:calcit-version`；如果确实发生升级，还会顺带执行一次 `yarn up @calcit/procs`，把 JS 运行时包同步到当前 Calcit 版本链路。
+说明：`caps upgrade --all` 会检查 `:dependencies` 与根项目的 `:dev-dependencies`，更新
+对应分组中的依赖版本与 `:calcit-version`；如果确实发生升级，还会顺带执行一次
+`yarn up @calcit/procs`，把 JS 运行时包同步到当前 Calcit 版本链路。
 
 如果你只想批量把旧版本提升到最新标签，也可以继续用：
 
@@ -163,7 +183,8 @@ caps outdated --yes
 caps
 ```
 
-说明：这一步才会按当前 `deps.cirru` 下载/同步模块内容。
+说明：这一步才会按当前 `deps.cirru` 下载/同步模块内容。根项目的两个依赖分组都会安装，
+依赖模块的 `:dev-dependencies` 会在递归解析中排除。
 
 ### Step E：用 Yarn Berry 安装并校验
 
@@ -357,14 +378,15 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
 
 1. `cr --version`
 2. `caps upgrade --all`（确认无遗漏项或已按预期处理）
-3. `yarn install --immutable`
-4. `cr calcit.cirru edit format` 后 `git diff --exit-code -- calcit.cirru`
-5. `cr calcit.cirru --check-only`
-6. 所有声明支持的 entry（默认 once；watch 另行验收）
-7. `check-types` 与 unresolved `weak-types` 基线
-8. 公开 namespace 的 `check-examples` 与 `docs check-md`
-9. JS 项目的 codegen 加 Node/Vite 行为测试，而不只是生成成功
-10. `package.json` 中与编译/构建相关的脚本
-11. 类库项目在 Respo 等真实消费者中的回归证据
+3. `caps tree`（确认根开发依赖存在，同时传递模块的开发依赖未进入图）
+4. `yarn install --immutable`
+5. `cr calcit.cirru edit format` 后 `git diff --exit-code -- calcit.cirru`
+6. `cr calcit.cirru --check-only`
+7. 所有声明支持的 entry（默认 once；watch 另行验收）
+8. `check-types` 与 unresolved `weak-types` 基线
+9. 公开 namespace 的 `check-examples` 与 `docs check-md`
+10. JS 项目的 codegen 加 Node/Vite 行为测试，而不只是生成成功
+11. `package.json` 中与编译/构建相关的脚本
+12. 类库项目在 Respo 等真实消费者中的回归证据
 
 call graph 的 `--show-unused` 只能作为 entry-relative 线索；公开 API 和替代入口可能被列为 unreachable，不能据此自动删除。

--- a/history/202608131228-scope-development-dependencies.md
+++ b/history/202608131228-scope-development-dependencies.md
@@ -1,0 +1,24 @@
+# Scope development dependencies in recursive resolution
+
+## Knowledge points
+
+- `deps.cirru` now distinguishes consumer-facing `:dependencies` from root-only
+  `:dev-dependencies`.
+- A root project resolves and installs both groups. A materialized dependency module exposes only
+  its `:dependencies` to the recursive graph, preventing its tests, examples, documentation tools,
+  and maintenance modules from leaking into consumers.
+- The same repository may appear in both root groups only when both declarations use the same ref;
+  conflicting refs fail before installation or before `caps add` writes the file.
+- `caps add --dev` and `caps remove --dev` manage development dependencies. `caps outdated` and
+  `caps upgrade --all` inspect both root groups and update the declaration in its original group.
+- Upgrade guidance should ask projects to audit dependency intent, move project-only tooling into
+  `:dev-dependencies`, and confirm the resulting boundary with `caps tree`.
+
+## Validation
+
+- `cargo fmt`
+- `cargo clippy -- -D warnings`
+- `yarn compile`
+- `cargo test`
+- `yarn check-agent-interface`
+- `yarn check-all`

--- a/history/202608131228-scope-development-dependencies.md
+++ b/history/202608131228-scope-development-dependencies.md
@@ -13,6 +13,15 @@
   `caps upgrade --all` inspect both root groups and update the declaration in its original group.
 - Upgrade guidance should ask projects to audit dependency intent, move project-only tooling into
   `:dev-dependencies`, and confirm the resulting boundary with `caps tree`.
+- A legacy-project upgrade must be staged: record the old behavior, update `cr`/`caps`, migrate the
+  dependency graph and Snapshot, then run every entry through strict preprocessing before tightening
+  dynamic dispatch and static debt baselines.
+- `--check-only` is a blocking preprocessing gate, including warnings, but it covers the selected
+  entry's reachable path rather than every public definition. `check-types`, `weak-types`, and
+  `deprecated` are report commands whose JSON summaries require explicit CI comparison.
+- Type-debt baselines should compare separate categories instead of one total. For coverage, track
+  `none` and `none + partial` so progress from none to partial is accepted; track dynamic, nil,
+  Optional compatibility, and deprecated calls independently.
 
 ## Validation
 
@@ -22,3 +31,6 @@
 - `cargo test`
 - `yarn check-agent-interface`
 - `yarn check-all`
+- `cr docs format-md docs/run/upgrade.md --check`
+- `cr docs check-md docs/run/upgrade.md --entry calcit/test.cirru --failures-only`
+- `cr docs graph check` (with a temporary writable HOME/cache)

--- a/history/202608131258-audit-legacy-upgrade-playbook.md
+++ b/history/202608131258-audit-legacy-upgrade-playbook.md
@@ -1,0 +1,23 @@
+# Audit the legacy project upgrade playbook
+
+## Findings
+
+- An old project cannot safely treat dependency upgrade success as completion. The workflow must
+  preserve an old-toolchain behavior baseline and separate tool, dependency, Snapshot, type, and
+  behavior changes into reviewable stages.
+- New CLI validation has distinct failure semantics. `--check-only`, examples, Markdown checks, and
+  tests are blocking gates; static type/deprecation analysis emits reports that require explicit
+  JSON summary comparison in CI.
+- Strict preprocessing must run for every named entry, then run again with `--warn-dyn-method`.
+  Entry reachability does not replace tests/examples for public library definitions.
+- Gradual typing needs category-aware baselines for none/not-full coverage, dynamic locations,
+  nil/Optional debt, and deprecated calls. A single aggregate can hide category regressions.
+- Snapshot migration must verify which legacy file is authoritative and must not claim that Calcit
+  no longer depends on a Snapshot.
+
+## Documentation validation
+
+- `cr docs format-md docs/run/upgrade.md --check`
+- `cr docs check-md docs/run/upgrade.md --entry calcit/test.cirru --failures-only`
+- `cr docs graph check` with a temporary writable HOME/cache: 22 nodes, 51 edges
+- `git diff --check`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -27,6 +27,7 @@ struct PackageDeps {
   version: Option<String>,
   calcit_version: Option<String>,
   dependencies: HashMap<Arc<str>, Arc<str>>,
+  dev_dependencies: HashMap<Arc<str>, Arc<str>>,
 }
 
 impl TryFrom<Edn> for PackageDeps {
@@ -34,23 +35,8 @@ impl TryFrom<Edn> for PackageDeps {
 
   fn try_from(value: Edn) -> Result<Self, Self::Error> {
     let deps_info = value.view_map()?;
-    #[allow(clippy::mutable_key_type)]
-    let dict = match deps_info.get_or_nil("dependencies") {
-      Edn::Nil => cirru_edn::EdnMapView::default().0,
-      value => value.view_map()?.0,
-    };
-
-    let mut deps: HashMap<Arc<str>, Arc<str>> = HashMap::new();
-    for (k, v) in &dict {
-      match (k, v) {
-        (Edn::Str(k), Edn::Str(v)) => {
-          deps.insert(k.to_owned(), v.to_owned());
-        }
-        _ => {
-          return Err(format!("invalid dependency: {k} {v}"));
-        }
-      }
-    }
+    let dependencies = parse_dependency_group(&deps_info, "dependencies")?;
+    let dev_dependencies = parse_dependency_group(&deps_info, "dev-dependencies")?;
     let expected_version: Option<String> = match deps_info.get_or_nil("calcit-version") {
       Edn::Str(s) => Some((*s).to_owned()),
       Edn::Nil => None,
@@ -64,9 +50,45 @@ impl TryFrom<Edn> for PackageDeps {
     Ok(PackageDeps {
       version: package_version,
       calcit_version: expected_version,
-      dependencies: deps,
+      dependencies,
+      dev_dependencies,
     })
   }
+}
+
+impl PackageDeps {
+  fn root_dependencies(&self) -> Result<HashMap<Arc<str>, Arc<str>>, String> {
+    let mut root = self.dependencies.clone();
+    for (repository, reference) in &self.dev_dependencies {
+      if let Some(runtime_reference) = root.get(repository)
+        && runtime_reference != reference
+      {
+        return Err(format!(
+          "root dependency {repository} is declared in dependencies as {runtime_reference} and dev-dependencies as {reference}; keep one declaration or use the same ref"
+        ));
+      }
+      root.insert(repository.clone(), reference.clone());
+    }
+    Ok(root)
+  }
+}
+
+fn parse_dependency_group(deps_info: &cirru_edn::EdnMapView, field: &str) -> Result<HashMap<Arc<str>, Arc<str>>, String> {
+  #[allow(clippy::mutable_key_type)]
+  let dict = match deps_info.get_or_nil(field) {
+    Edn::Nil => cirru_edn::EdnMapView::default().0,
+    value => value.view_map()?.0,
+  };
+  let mut dependencies = HashMap::new();
+  for (key, value) in &dict {
+    match (key, value) {
+      (Edn::Str(key), Edn::Str(value)) => {
+        dependencies.insert(key.to_owned(), value.to_owned());
+      }
+      _ => return Err(format!("invalid {field} entry: {key} {value}")),
+    }
+  }
+  Ok(dependencies)
 }
 
 pub fn main() -> Result<(), String> {
@@ -96,7 +118,15 @@ pub fn main() -> Result<(), String> {
         Ok((org_and_folder.to_owned().into(), version.to_owned().into()))
       })
       .collect::<Result<_, String>>()?;
-    download_deps(dict, cli_args)?;
+    download_deps(
+      PackageDeps {
+        version: None,
+        calcit_version: None,
+        dependencies: dict,
+        dev_dependencies: Default::default(),
+      },
+      cli_args,
+    )?;
     return Ok(());
   }
 
@@ -130,7 +160,7 @@ pub fn main() -> Result<(), String> {
             format!("Failed to parse '{}'", cli_args.input)
           })?;
           let updated_deps: PackageDeps = parsed.try_into()?;
-          download_deps(updated_deps.dependencies, cli_args)?;
+          download_deps(updated_deps, cli_args)?;
         }
       }
       Some(SubCommand::Upgrade(opts)) => {
@@ -145,7 +175,7 @@ pub fn main() -> Result<(), String> {
             format!("Failed to parse '{}'", cli_args.input)
           })?;
           let updated_deps: PackageDeps = parsed.try_into()?;
-          download_deps(updated_deps.dependencies, cli_args)?;
+          download_deps(updated_deps, cli_args)?;
         }
       }
       Some(SubCommand::Add(opts)) => {
@@ -164,14 +194,18 @@ pub fn main() -> Result<(), String> {
             (package, version.strip_prefix('@').filter(|version| !version.is_empty()))
           });
           let org_and_folder = normalize_package_name(package)?;
-          updated_deps
-            .dependencies
-            .insert(org_and_folder.into(), inline_version.unwrap_or(&opts.version).to_owned().into());
+          let target = if opts.dev {
+            &mut updated_deps.dev_dependencies
+          } else {
+            &mut updated_deps.dependencies
+          };
+          target.insert(org_and_folder.into(), inline_version.unwrap_or(&opts.version).to_owned().into());
         }
 
+        updated_deps.root_dependencies()?;
         write_deps_file(&cli_args.input, &updated_deps)?;
         println!("updated {}", cli_args.input.green());
-        download_deps(updated_deps.dependencies, cli_args)?;
+        download_deps(updated_deps, cli_args)?;
       }
       Some(SubCommand::Remove(opts)) => {
         if opts.packages.is_empty() {
@@ -181,12 +215,17 @@ pub fn main() -> Result<(), String> {
         let mut updated_deps = deps;
         for raw in &opts.packages {
           let org_and_folder = normalize_package_name(raw)?;
-          updated_deps.dependencies.remove(org_and_folder.as_str());
+          let target = if opts.dev {
+            &mut updated_deps.dev_dependencies
+          } else {
+            &mut updated_deps.dependencies
+          };
+          target.remove(org_and_folder.as_str());
         }
 
         write_deps_file(&cli_args.input, &updated_deps)?;
         println!("updated {}", cli_args.input.green());
-        download_deps(updated_deps.dependencies, cli_args)?;
+        download_deps(updated_deps, cli_args)?;
       }
       Some(SubCommand::Status(_)) => {
         let graph = resolve_for_cli(&deps, &cli_args, false)?;
@@ -232,7 +271,7 @@ pub fn main() -> Result<(), String> {
         unreachable!("already handled: {:?}", dep_names);
       }
       None => {
-        download_deps(deps.dependencies, cli_args)?;
+        download_deps(deps, cli_args)?;
       }
     }
 
@@ -248,13 +287,8 @@ pub fn main() -> Result<(), String> {
   }
 }
 
-fn download_deps(deps: HashMap<Arc<str>, Arc<str>>, options: TopLevelCaps) -> Result<(), String> {
-  let package = PackageDeps {
-    version: None,
-    calcit_version: None,
-    dependencies: deps,
-  };
-  let graph = resolve_for_cli(&package, &options, !options.ci)?;
+fn download_deps(deps: PackageDeps, options: TopLevelCaps) -> Result<(), String> {
+  let graph = resolve_for_cli(&deps, &options, !options.ci)?;
   print_warnings(&graph);
   let graph_options = graph_options(&options, !options.ci)?;
   install_project_view(&graph, &graph_options)?;
@@ -465,6 +499,9 @@ struct AddCaps {
   /// version/branch written to deps.cirru
   #[argh(option, short = 'r', default = "\"main\".to_string()")]
   version: String,
+  /// add packages to dev-dependencies
+  #[argh(switch)]
+  dev: bool,
 }
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
@@ -474,6 +511,9 @@ struct RemoveCaps {
   /// packages in format `org/repo` or github URL
   #[argh(positional)]
   packages: Vec<String>,
+  /// remove packages from dev-dependencies
+  #[argh(switch)]
+  dev: bool,
 }
 
 fn err_println(msg: String) {
@@ -542,6 +582,8 @@ fn valid_module_component(component: &str) -> bool {
 mod tests {
   use super::{PackageDeps, module_folder, normalize_package_name};
   use cirru_edn::Edn;
+  use std::collections::HashMap;
+  use std::sync::Arc;
 
   #[test]
   fn module_names_are_canonical_before_path_use() {
@@ -564,6 +606,15 @@ mod tests {
   fn missing_dependencies_field_is_an_empty_graph() {
     let deps: PackageDeps = Edn::Map(cirru_edn::EdnMapView::default()).try_into().unwrap();
     assert!(deps.dependencies.is_empty());
+    assert!(deps.dev_dependencies.is_empty());
+  }
+
+  #[test]
+  fn parses_development_dependencies_separately() {
+    let parsed = cirru_edn::parse("{} (:dependencies $ {} (|org/runtime |1.0.0)) (:dev-dependencies $ {} (|org/test |main))").unwrap();
+    let deps: PackageDeps = parsed.try_into().unwrap();
+    assert_eq!(deps.dependencies.get("org/runtime").map(AsRef::as_ref), Some("1.0.0"));
+    assert_eq!(deps.dev_dependencies.get("org/test").map(AsRef::as_ref), Some("main"));
   }
 
   #[test]
@@ -573,11 +624,13 @@ mod tests {
       version: Some("1.2.3".to_string()),
       calcit_version: Some("0.13.12".to_string()),
       dependencies: Default::default(),
+      dev_dependencies: HashMap::from([(Arc::from("calcit-lang/test"), Arc::from("main"))]),
     };
     super::write_deps_file(path.to_str().unwrap(), &deps).unwrap();
     let parsed = cirru_edn::parse(&std::fs::read_to_string(&path).unwrap()).unwrap();
     let restored: PackageDeps = parsed.try_into().unwrap();
     assert_eq!(restored.version.as_deref(), Some("1.2.3"));
+    assert_eq!(restored.dev_dependencies.get("calcit-lang/test").map(AsRef::as_ref), Some("main"));
     std::fs::remove_file(path).unwrap();
   }
 }
@@ -598,6 +651,14 @@ fn write_deps_file(deps_file: &str, deps: &PackageDeps) -> Result<(), String> {
       deps_map.insert(Edn::str(&**k), Edn::str(&**v));
     }
     map.insert(Edn::tag("dependencies"), Edn::Map(deps_map));
+
+    if !deps.dev_dependencies.is_empty() {
+      let mut dev_deps_map = cirru_edn::EdnMapView::default();
+      for (k, v) in &deps.dev_dependencies {
+        dev_deps_map.insert(Edn::str(&**k), Edn::str(&**v));
+      }
+      map.insert(Edn::tag("dev-dependencies"), Edn::Map(dev_deps_map));
+    }
   }
 
   let updated_content = cirru_edn::format(&updated_edn, false)?;
@@ -633,7 +694,7 @@ fn outdated_tags(deps: PackageDeps, deps_file: &str, auto_yes: bool) -> Result<b
   let mut outdated_packages = Vec::new();
   let mut children = vec![];
 
-  for (org_and_folder, version) in &deps.dependencies {
+  for (org_and_folder, version) in deps.root_dependencies()? {
     let org_and_folder_clone = org_and_folder.clone();
     let version_clone = version.clone();
     let ret = thread::spawn(move || {
@@ -644,7 +705,7 @@ fn outdated_tags(deps: PackageDeps, deps_file: &str, auto_yes: bool) -> Result<b
       }
       ret.ok()
     });
-    children.push((org_and_folder.clone(), version.clone(), ret));
+    children.push((org_and_folder, version, ret));
   }
 
   for (org_and_folder, version, child) in children {
@@ -773,7 +834,12 @@ fn update_deps_file(
 
   // Update the dependencies in the parsed structure
   for (org_and_folder, _old_version, new_version) in outdated_packages {
-    deps.dependencies.insert(org_and_folder.clone(), new_version.clone().into());
+    if let Some(version) = deps.dependencies.get_mut(org_and_folder) {
+      *version = new_version.clone().into();
+    }
+    if let Some(version) = deps.dev_dependencies.get_mut(org_and_folder) {
+      *version = new_version.clone().into();
+    }
   }
 
   write_deps_file(deps_file, &deps)
@@ -784,7 +850,7 @@ fn upgrade_packages(deps: PackageDeps, deps_file: &str, opts: &UpgradeCaps) -> R
   let mut children = vec![];
 
   let targets: Vec<Arc<str>> = if opts.all {
-    deps.dependencies.keys().cloned().collect()
+    deps.root_dependencies()?.keys().cloned().collect()
   } else {
     opts
       .packages
@@ -798,7 +864,11 @@ fn upgrade_packages(deps: PackageDeps, deps_file: &str, opts: &UpgradeCaps) -> R
   }
 
   for org_and_folder in &targets {
-    if let Some(version) = deps.dependencies.get(org_and_folder) {
+    if let Some(version) = deps
+      .dependencies
+      .get(org_and_folder)
+      .or_else(|| deps.dev_dependencies.get(org_and_folder))
+    {
       let org_and_folder_clone = org_and_folder.clone();
       let version_clone = version.clone();
       let ret = thread::spawn(move || {

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 use std::thread;
 
 const MAX_PARALLEL_RESOLVES: usize = 6;
@@ -71,7 +72,7 @@ pub struct GraphOptions {
 }
 
 pub fn resolve_graph(root_deps: &PackageDeps, options: &GraphOptions) -> Result<ResolvedGraph, String> {
-  let root = sorted_dependencies(root_deps);
+  let root = sorted_root_dependencies(root_deps)?;
   validate_module_folders(root.keys())?;
   let mut selections = BTreeMap::<String, String>::new();
   let mut stable_result = None;
@@ -443,15 +444,18 @@ fn read_module_dependencies(source: &Path) -> Result<BTreeMap<String, String>, S
   let content = fs::read_to_string(&deps_path).map_err(|e| format!("failed to read {}: {e}", deps_path.display()))?;
   let parsed = cirru_edn::parse(&content).map_err(|e| format!("failed to parse {}: {e}", deps_path.display()))?;
   let deps: PackageDeps = parsed.try_into().map_err(|e| format!("invalid {}: {e}", deps_path.display()))?;
-  Ok(sorted_dependencies(&deps))
+  Ok(sorted_dependencies(&deps.dependencies))
 }
 
-fn sorted_dependencies(deps: &PackageDeps) -> BTreeMap<String, String> {
+fn sorted_dependencies(deps: &std::collections::HashMap<Arc<str>, Arc<str>>) -> BTreeMap<String, String> {
   deps
-    .dependencies
     .iter()
     .map(|(repository, reference)| (repository.to_string(), reference.to_string()))
     .collect()
+}
+
+fn sorted_root_dependencies(deps: &PackageDeps) -> Result<BTreeMap<String, String>, String> {
+  Ok(sorted_dependencies(&deps.root_dependencies()?))
 }
 
 fn validate_module_folders<'a>(repositories: impl Iterator<Item = &'a String>) -> Result<(), String> {
@@ -1192,11 +1196,13 @@ fn sanitize(value: &str) -> String {
 #[cfg(test)]
 mod tests {
   use super::{
-    DependencyRequest, RefKind, ResolvedModule, is_full_commit_hash, parse_tag_version, select_reference, verify_native_receipt,
-    write_native_receipt,
+    DependencyRequest, RefKind, ResolvedModule, is_full_commit_hash, parse_tag_version, read_module_dependencies, select_reference,
+    sorted_root_dependencies, verify_native_receipt, write_native_receipt,
   };
-  use std::collections::BTreeSet;
+  use crate::PackageDeps;
+  use std::collections::{BTreeSet, HashMap};
   use std::fs;
+  use std::sync::Arc;
 
   fn request(reference: &str, requested_by: Option<&str>) -> DependencyRequest {
     DependencyRequest {
@@ -1229,6 +1235,46 @@ mod tests {
   fn published_tag_wins_over_transitive_branch() {
     let requests = BTreeSet::from([request("0.0.6", Some("stable@1.0.0")), request("main", Some("legacy@1.0.0"))]);
     assert_eq!(select_reference("org/repo", &requests, None), Ok("0.0.6".to_string()));
+  }
+
+  #[test]
+  fn root_includes_development_dependencies() {
+    let deps = PackageDeps {
+      version: None,
+      calcit_version: None,
+      dependencies: HashMap::from([(Arc::from("org/runtime"), Arc::from("1.0.0"))]),
+      dev_dependencies: HashMap::from([(Arc::from("org/test"), Arc::from("main"))]),
+    };
+    let root = sorted_root_dependencies(&deps).unwrap();
+    assert_eq!(root.get("org/runtime").map(String::as_str), Some("1.0.0"));
+    assert_eq!(root.get("org/test").map(String::as_str), Some("main"));
+  }
+
+  #[test]
+  fn transitive_module_excludes_development_dependencies() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-transitive-dev-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+      root.join("deps.cirru"),
+      "{} (:dependencies $ {} (|org/runtime |1.0.0)) (:dev-dependencies $ {} (|org/test |main))",
+    )
+    .unwrap();
+    let dependencies = read_module_dependencies(&root).unwrap();
+    assert_eq!(dependencies.get("org/runtime").map(String::as_str), Some("1.0.0"));
+    assert!(!dependencies.contains_key("org/test"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn conflicting_root_dependency_groups_are_rejected() {
+    let deps = PackageDeps {
+      version: None,
+      calcit_version: None,
+      dependencies: HashMap::from([(Arc::from("org/shared"), Arc::from("1.0.0"))]),
+      dev_dependencies: HashMap::from([(Arc::from("org/shared"), Arc::from("main"))]),
+    };
+    assert!(sorted_root_dependencies(&deps).is_err());
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- parse and persist separate `dependencies` and `dev-dependencies` groups in `deps.cirru`
- install both groups for the root project while excluding dependency modules’ development dependencies from recursive resolution
- add `caps add/remove --dev`, cover conflict and graph-scope boundaries, and update README/load/upgrade guidance

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-agent-interface` (12/12; timing and stdout byte metrics recorded)
- `yarn check-all`