### PR TITLE
feat: decode runtime maps into typed structs

### DIFF
--- a/calcit/test-edn.cirru
+++ b/calcit/test-edn.cirru
@@ -32,6 +32,13 @@
             defstruct Person (:name 'String) (:age 'Number)
           :examples $ []
           :schema $ :: 'Dynamic
+        |Response $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstruct Response (:code 'Number)
+              :message $ :: 'Option 'String
+              :body 'Dynamic
+          :examples $ []
+          :schema $ :: 'Dynamic
         |Team $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Team $ :members (:: 'List Person)
@@ -45,6 +52,7 @@
               test-typed-edn
               test-imported-typed-edn
               test-top-level-typed-edn
+              test-runtime-map-decode
           :examples $ []
           :schema $ :: 'Dynamic
         |reload! $ %{} 'CodeEntry (:doc |)
@@ -156,6 +164,42 @@
             defn test-imported-typed-edn () $ assert=
               %{} External $ :label |linked
               parse-cirru-edn-as "|%{} :External (:label |linked)" External
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-runtime-map-decode $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-runtime-map-decode () $ let
+                response $ decode-map-as
+                  {} (:code 200) (:message |ok)
+                    :body $ {} (:kind :json)
+                  , Response
+                no-message $ decode-map-as
+                  {} (:code 204)
+                    :body $ {} (:kind :json)
+                  , Response
+                prewrapped $ decode-map-as
+                  {} (:code 201)
+                    :message $ %some |already
+                    :body $ {} (:kind :json)
+                  , Response
+              assert= 200 $ :code response
+              assert= (%some |ok) (:message response)
+              assert= (%none) (:message no-message)
+              assert= (%some |already) (:message prewrapped)
+              assert= true $ try
+                do
+                  decode-map-as
+                    {} $ :message |ok
+                    , Response
+                  , false
+                fn (_error) true
+              assert= true $ try
+                do
+                  decode-map-as
+                    {} (:code 200) (:extra true)
+                    , Response
+                  , false
+                fn (_error) true
           :examples $ []
           :schema $ :: 'Dynamic
         |test-symbol $ %{} 'CodeEntry (:doc |)

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -18,6 +18,7 @@ The runtime APIs are:
 
 - `parse-cirru-edn text [type-options]`
 - `parse-cirru-edn-as text TypeExpr`
+- `decode-map-as value TypeExpr`
 - `format-cirru-edn value`
 
 `parse-cirru-edn` is the dynamic API: its result is `Dynamic`, and its optional type map only restores nominal identity. Use `parse-cirru-edn-as` when persisted or external data must enter typed application code.
@@ -51,6 +52,26 @@ parse-cirru-edn-as failed at $.friends[2].age: expected number, got string
 ```
 
 The failure is raised like `parse-cirru-edn` errors and can be handled with `try`.
+
+## Decoding runtime maps into Structs
+
+`decode-map-as` is the companion for data that has already crossed a host boundary and is now a Calcit Map, such as a JSON object returned by a JavaScript FFI. It derives the target shape at compile time and returns the declared type, so it is the typed replacement for ad-hoc map readers and runtime schema libraries.
+
+It converts a Map to a nominal Struct recursively, rejects unknown keys and missing required fields, and reports the path of a bad nested value. A missing `Option<T>` field becomes `%none`; a present raw `T` becomes `%some T`. Already-wrapped `%some` and `%none` values are also accepted.
+
+```cirru.no-run
+defstruct Response (:code 'Number)
+  :message $ :: 'Option 'String
+  :body 'Dynamic
+
+; `raw` may be { :code 200, :message |ok, :body ... }
+; the result is Response(:code 200, :message (%some |ok), :body ...)
+; omitting :message produces (%none)
+```
+
+Unlike the closed text decoder, `decode-map-as` permits an explicitly declared `Dynamic` leaf for an open payload such as an HTTP response body. Keep it at the boundary and decode it again into a closed Struct/Enum before application logic depends on it. The root input must be a Map; it never treats `nil` as an empty map or silently supplies required fields.
+
+The syntax is available for native execution and JavaScript code generation. The current WASM backend does not yet support either typed EDN decoder.
 
 Map and Set iteration order is not a semantic guarantee. The formatter applies a stable order for readable, reproducible output; callers must not use that order as application data.
 

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -55,7 +55,7 @@ The failure is raised like `parse-cirru-edn` errors and can be handled with `try
 
 ## Decoding runtime maps into Structs
 
-`decode-map-as` is the companion for data that has already crossed a host boundary and is now a Calcit Map, such as a JSON object returned by a JavaScript FFI. It derives the target shape at compile time and returns the declared type, so it is the typed replacement for ad-hoc map readers and runtime schema libraries.
+`decode-map-as` is the companion for data that has already crossed a host boundary and is now an evaluated Calcit value, such as a JSON object returned by a JavaScript FFI. It derives the target shape at compile time and returns the declared type, so it is the typed replacement for ad-hoc map readers and runtime schema libraries. Struct targets consume maps, while list, map, enum, ref, and scalar targets are decoded recursively as well.
 
 It converts a Map to a nominal Struct recursively, rejects unknown keys and missing required fields, and reports the path of a bad nested value. A missing `Option<T>` field becomes `%none`; a present raw `T` becomes `%some T`. Already-wrapped `%some` and `%none` values are also accepted.
 
@@ -69,7 +69,7 @@ defstruct Response (:code 'Number)
 ; omitting :message produces (%none)
 ```
 
-Unlike the closed text decoder, `decode-map-as` permits an explicitly declared `Dynamic` leaf for an open payload such as an HTTP response body. Keep it at the boundary and decode it again into a closed Struct/Enum before application logic depends on it. The root input must be a Map; it never treats `nil` as an empty map or silently supplies required fields.
+Unlike the closed text decoder, `decode-map-as` permits an explicitly declared `Dynamic` leaf for an open payload such as an HTTP response body. Keep it at the boundary and decode it again into a closed Struct/Enum before application logic depends on it. It never treats `nil` as an empty map or silently supplies required fields. Native and JavaScript support this syntax; the WASM backend does not currently support typed decoder syntaxes.
 
 The syntax is available for native execution and JavaScript code generation. The current WASM backend does not yet support either typed EDN decoder.
 

--- a/history/202608131607-runtime-map-decoder.md
+++ b/history/202608131607-runtime-map-decoder.md
@@ -1,0 +1,13 @@
+# Runtime map decoder for typed boundary data
+
+## Change summary
+
+- Added `decode-map-as value TypeExpr`, a compile-time-derived decoder for an already-evaluated Calcit Map.
+- The decoder constructs nominal Struct values recursively, rejects unknown keys and missing required fields, and reports nested failure paths.
+- Struct fields declared as `Option<T>` accept raw `T`, preserve an already-wrapped `%some`/`%none`, and become `%none` when the source field is absent.
+- `Dynamic` is allowed only as an explicit runtime-boundary leaf for this decoder; the existing text-based `parse-cirru-edn-as` remains a closed-data decoder and continues to reject it.
+- Native and JavaScript backends share the graph ABI and tests. WASM continues to reject both typed EDN decoder syntaxes explicitly.
+
+## Knowledge point
+
+Runtime Maps are not Cirru EDN: they do not carry nominal Struct identity and commonly represent optional data by omitted keys. A typed boundary decoder must therefore perform map-to-Struct construction, enforce required fields, and lift omitted or raw optional values into nominal `Option` variants. Reusing the closed EDN decoder without these rules silently permits invalid Structs or forces callers back to ad-hoc dynamic map readers.

--- a/history/202608131625-core-decode-map-as-metadata.md
+++ b/history/202608131625-core-decode-map-as-metadata.md
@@ -3,8 +3,9 @@
 ## Change summary
 
 - Added the `decode-map-as` runtime syntax to the core snapshot metadata with builtin/internal/meta/syntax tags and a typed boundary schema.
-- Added a reusable `RuntimeMapResponse` Struct fixture for core examples and tests.
-- Added a passing example plus definition-attached unit tests covering recursive Struct decoding, omitted `Option` fields becoming `%none`, pre-wrapped `%some`, and explicit Dynamic payload preservation.
+- Added reusable `RuntimeMapMeta` and `RuntimeMapResponse` Struct fixtures for core examples and tests.
+- Added a passing example plus definition-attached unit tests covering recursive Struct decoding through an Option field, omitted `Option` fields becoming `%none`, pre-wrapped `%some`, and explicit Dynamic payload preservation.
+- Documented the native/JavaScript support boundary and kept WASM behavior explicit.
 
 ## Knowledge point
 

--- a/history/202608131625-core-decode-map-as-metadata.md
+++ b/history/202608131625-core-decode-map-as-metadata.md
@@ -1,0 +1,11 @@
+# Document `decode-map-as` in calcit-core
+
+## Change summary
+
+- Added the `decode-map-as` runtime syntax to the core snapshot metadata with builtin/internal/meta/syntax tags and a typed boundary schema.
+- Added a reusable `RuntimeMapResponse` Struct fixture for core examples and tests.
+- Added a passing example plus definition-attached unit tests covering recursive Struct decoding, omitted `Option` fields becoming `%none`, pre-wrapped `%some`, and explicit Dynamic payload preservation.
+
+## Knowledge point
+
+Compiler syntax and core snapshot metadata are separate surfaces. Adding a Rust/JS builtin is incomplete until `calcit-core.cirru` exposes its documentation, examples, schema, and tests; otherwise `cr docs`, `cr test`, and downstream agents cannot discover or verify the feature.

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -641,6 +641,7 @@ pub fn handle_syntax(
     AssertType => syntax::assert_type(nodes, scope, file_ns, call_stack),
     UnsafeCoerce => syntax::unsafe_coerce(nodes, scope, file_ns, call_stack),
     ParseCirruEdnAs => syntax::parse_cirru_edn_as(nodes, scope, file_ns, call_stack),
+    DecodeMapAs => syntax::decode_map_as(nodes, scope, file_ns, call_stack),
     AssertTraits => syntax::assert_traits(nodes, scope, file_ns, call_stack),
     Match => syntax::syntax_match(nodes, scope, file_ns, call_stack),
   }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -698,7 +698,7 @@ pub fn decode_map_as(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call
   if expr.len() != 2 && expr.len() != 3 {
     return CalcitErr::err_nodes(
       CalcitErrKind::Arity,
-      "decode-map-as expected a map and a type expression, but received:",
+      "decode-map-as expected a value and a type expression, but received:",
       &expr.to_vec(),
     );
   }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -694,6 +694,48 @@ pub fn parse_cirru_edn_as(
   })
 }
 
+pub fn decode_map_as(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  if expr.len() != 2 && expr.len() != 3 {
+    return CalcitErr::err_nodes(
+      CalcitErrKind::Arity,
+      "decode-map-as expected a map and a type expression, but received:",
+      &expr.to_vec(),
+    );
+  }
+  let input = runner::evaluate_expr(&expr[0], scope, file_ns, call_stack)?;
+  let decoder = match expr.get(2) {
+    Some(handle) => crate::calcit::data_shape::DataShapeGraph::from_calcit_handle(handle).ok_or_else(|| {
+      CalcitErr::use_msg_stack_location(
+        CalcitErrKind::Unexpected,
+        "decode-map-as received an invalid internal data shape".to_owned(),
+        call_stack,
+        expr.get(1).and_then(Calcit::get_location),
+      )
+    })?,
+    None => {
+      let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(&expr[1], &[]);
+      Arc::new(
+        crate::calcit::data_shape::DataShapeGraph::build_open(target.as_ref(), file_ns).map_err(|error| {
+          CalcitErr::use_msg_stack_location(
+            CalcitErrKind::Type,
+            format!("decode-map-as cannot derive a runtime map decoder: {error}"),
+            call_stack,
+            expr.get(1).and_then(Calcit::get_location),
+          )
+        })?,
+      )
+    }
+  };
+  crate::data::edn_decode::decode_map(decoder.as_ref(), &input).map_err(|error| {
+    CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      format!("decode-map-as failed at {}: {}", error.path, error.message),
+      call_stack,
+      expr.first().and_then(Calcit::get_location),
+    )
+  })
+}
+
 pub fn assert_traits(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if expr.len() < 2 {
     return CalcitErr::err_nodes(

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -26,6 +26,9 @@ pub(crate) struct DataShapeGraph {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DataShapeNode {
+  /// An intentionally open value at a runtime data boundary. Closed EDN
+  /// shapes never contain this node.
+  Dynamic,
   Unit,
   Bool,
   Number,
@@ -35,6 +38,13 @@ pub(crate) enum DataShapeNode {
   Buffer,
   CirruQuote,
   Optional(usize),
+  /// A nominal `Option<T>` accepted from an ordinary runtime value. Missing
+  /// struct fields become `%none`; present raw values become `%some value`.
+  MapOption {
+    nominal: Arc<CalcitEnumDef>,
+    nominal_path: Option<(Arc<str>, Arc<str>)>,
+    inner: usize,
+  },
   List(usize),
   Set(usize),
   Map {
@@ -99,15 +109,27 @@ struct GraphBuilder {
   nominal_nodes: HashMap<String, usize>,
   resolving_aliases: HashSet<String>,
   resolving_slots: HashSet<String>,
+  allow_dynamic: bool,
 }
 
 impl DataShapeGraph {
   pub(crate) fn build(target: &CalcitTypeAnnotation, default_ns: &str) -> Result<Self, DataShapeError> {
+    Self::build_with_options(target, default_ns, false)
+  }
+
+  /// Builds a decoder shape for a runtime Calcit map. This intentionally
+  /// permits explicit Dynamic leaves and lifts raw option fields.
+  pub(crate) fn build_open(target: &CalcitTypeAnnotation, default_ns: &str) -> Result<Self, DataShapeError> {
+    Self::build_with_options(target, default_ns, true)
+  }
+
+  fn build_with_options(target: &CalcitTypeAnnotation, default_ns: &str, allow_dynamic: bool) -> Result<Self, DataShapeError> {
     let mut builder = GraphBuilder {
       nodes: vec![],
       nominal_nodes: HashMap::new(),
       resolving_aliases: HashSet::new(),
       resolving_slots: HashSet::new(),
+      allow_dynamic,
     };
     let root = builder.build_type(target, default_ns)?;
     let nodes = builder
@@ -160,7 +182,9 @@ impl DataShapeGraph {
     let mut paths = Vec::new();
     for node in &self.nodes {
       let path = match node {
-        DataShapeNode::Struct { nominal_path, .. } | DataShapeNode::Enum { nominal_path, .. } => nominal_path,
+        DataShapeNode::Struct { nominal_path, .. }
+        | DataShapeNode::Enum { nominal_path, .. }
+        | DataShapeNode::MapOption { nominal_path, .. } => nominal_path,
         _ => continue,
       };
       if let Some(path) = path
@@ -210,6 +234,17 @@ impl DataShapeGraph {
           self.validate_node_value(*inner, value, path, depth + 1)
         }
       }
+      DataShapeNode::Dynamic => Ok(()),
+      DataShapeNode::MapOption { nominal, inner, .. } => match value {
+        Calcit::Enum(enum_value) if enum_value.sum_type.as_ref().is_some_and(|actual| actual.name() == nominal.name()) => {
+          match (enum_value.tag.as_ref(), enum_value.extra.as_slice()) {
+            (Calcit::Tag(tag), []) if tag.ref_str() == "none" => Ok(()),
+            (Calcit::Tag(tag), [item]) if tag.ref_str() == "some" => self.validate_node_value(*inner, item, path, depth + 1),
+            _ => Err(DataShapeValueError::at(path, "invalid Option value")),
+          }
+        }
+        _ => Err(shape_kind_mismatch(path, "Option", value)),
+      },
       DataShapeNode::List(inner) => {
         let Calcit::List(values) = value else {
           return Err(shape_kind_mismatch(path, "list", value));
@@ -330,7 +365,9 @@ impl DataShapeGraph {
 impl DataShapeNode {
   fn child_nodes(&self) -> Vec<usize> {
     match self {
+      Self::Dynamic => vec![],
       Self::Optional(inner) | Self::List(inner) | Self::Set(inner) | Self::Ref(inner) => vec![*inner],
+      Self::MapOption { inner, .. } => vec![*inner],
       Self::Map { key, value } => vec![*key, *value],
       Self::Struct { fields, .. } => fields.iter().map(|(_, node)| *node).collect(),
       Self::Enum { variants, .. } => variants.iter().flat_map(|(_, payloads)| payloads.iter().copied()).collect(),
@@ -338,8 +375,9 @@ impl DataShapeNode {
     }
   }
 
-  fn expected_kind(&self) -> &str {
+  pub(crate) fn expected_kind(&self) -> &str {
     match self {
+      Self::Dynamic => "dynamic",
       Self::Unit => "nil",
       Self::Bool => "bool",
       Self::Number => "number",
@@ -348,6 +386,7 @@ impl DataShapeNode {
       Self::Tag => "tag",
       Self::Buffer => "buffer",
       Self::CirruQuote => "cirru-quote",
+      Self::MapOption { .. } => "Option",
       Self::Optional(_) => "optional value",
       Self::List(_) => "list",
       Self::Set(_) => "set",
@@ -423,6 +462,22 @@ impl GraphBuilder {
       CalcitTypeAnnotation::StructDef(_) | CalcitTypeAnnotation::EnumDef(_) => Err(unsupported_type(
         "type-definition values are not closed application data; use the corresponding Struct or Enum instance type",
       )),
+      CalcitTypeAnnotation::TypeRef(name, args) if self.allow_dynamic && target.is_option_type() => {
+        let Some(inner) = args.first() else {
+          return Err(DataShapeError::new("Option requires one type argument"));
+        };
+        let (ns, def) = qualify_type_ref(name, default_ns);
+        let qualified = CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), args.clone());
+        let Some(nominal) = qualified.resolve_to_enum() else {
+          return Err(DataShapeError::new("Option must resolve to calcit.core/Option"));
+        };
+        let inner = self.build_type(inner, default_ns)?;
+        Ok(self.push(DataShapeNode::MapOption {
+          nominal: Arc::new(nominal),
+          nominal_path: Some((ns, def)),
+          inner,
+        }))
+      }
       CalcitTypeAnnotation::TypeRef(name, args) => self.build_named(name, args, default_ns),
       CalcitTypeAnnotation::TypeSlot(name) => match super::resolve_type_slot(name) {
         Some(resolved) => {
@@ -436,6 +491,7 @@ impl GraphBuilder {
         }
         None => Err(DataShapeError::new(format!("unbound type slot `*{name}`"))),
       },
+      CalcitTypeAnnotation::Dynamic if self.allow_dynamic => Ok(self.push(DataShapeNode::Dynamic)),
       CalcitTypeAnnotation::Dynamic => Err(unsupported_type("Dynamic is forbidden in a closed data shape")),
       CalcitTypeAnnotation::TypeVar(name) => Err(unsupported_type(&format!("generic variable '{name} is not bound"))),
       CalcitTypeAnnotation::AnonymousEnum => Err(unsupported_type("anonymous enum has no declared enum schema")),
@@ -633,6 +689,7 @@ fn shape_fingerprint(root: usize, nodes: &[DataShapeNode]) -> String {
   for (node_id, node) in nodes.iter().enumerate() {
     hasher.update(format!("#{node_id}:").as_bytes());
     match node {
+      DataShapeNode::Dynamic => hasher.update(b"dynamic;"),
       DataShapeNode::Unit => hasher.update(b"unit;"),
       DataShapeNode::Bool => hasher.update(b"bool;"),
       DataShapeNode::Number => hasher.update(b"number;"),
@@ -642,6 +699,14 @@ fn shape_fingerprint(root: usize, nodes: &[DataShapeNode]) -> String {
       DataShapeNode::Buffer => hasher.update(b"buffer;"),
       DataShapeNode::CirruQuote => hasher.update(b"cirru-quote;"),
       DataShapeNode::Optional(inner) => hasher.update(format!("optional:{inner};").as_bytes()),
+      DataShapeNode::MapOption {
+        nominal,
+        nominal_path,
+        inner,
+      } => {
+        update_nominal_fingerprint(&mut hasher, "map-option", nominal.name().ref_str(), nominal_path.as_ref(), &[]);
+        hasher.update(format!("inner:{inner};").as_bytes());
+      }
       DataShapeNode::List(inner) => hasher.update(format!("list:{inner};").as_bytes()),
       DataShapeNode::Set(inner) => hasher.update(format!("set:{inner};").as_bytes()),
       DataShapeNode::Map { key, value } => hasher.update(format!("map:{key}:{value};").as_bytes()),

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -236,7 +236,12 @@ impl DataShapeGraph {
       }
       DataShapeNode::Dynamic => Ok(()),
       DataShapeNode::MapOption { nominal, inner, .. } => match value {
-        Calcit::Enum(enum_value) if enum_value.sum_type.as_ref().is_some_and(|actual| actual.name() == nominal.name()) => {
+        Calcit::Enum(enum_value)
+          if enum_value
+            .sum_type
+            .as_ref()
+            .is_some_and(|actual| Arc::ptr_eq(actual, nominal) || actual.name() == nominal.name()) =>
+        {
           match (enum_value.tag.as_ref(), enum_value.extra.as_slice()) {
             (Calcit::Tag(tag), []) if tag.ref_str() == "none" => Ok(()),
             (Calcit::Tag(tag), [item]) if tag.ref_str() == "some" => self.validate_node_value(*inner, item, path, depth + 1),
@@ -467,6 +472,12 @@ impl GraphBuilder {
           return Err(DataShapeError::new("Option requires one type argument"));
         };
         let (ns, def) = qualify_type_ref(name, default_ns);
+        if ns.as_ref() != super::CORE_NS || def.as_ref() != "Option" {
+          return Err(DataShapeError::new("Option must resolve to calcit.core/Option"));
+        }
+        if inner.is_option_type() {
+          return Err(DataShapeError::new("nested Option<Option<T>> is not supported by decode-map-as"));
+        }
         let qualified = CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), args.clone());
         let Some(nominal) = qualified.resolve_to_enum() else {
           return Err(DataShapeError::new("Option must resolve to calcit.core/Option"));

--- a/src/calcit/syntax_name.rs
+++ b/src/calcit/syntax_name.rs
@@ -84,6 +84,9 @@ pub enum CalcitSyntax {
   /// Parse Cirru EDN and deeply validate/construct the declared closed type.
   #[strum(serialize = "parse-cirru-edn-as")]
   ParseCirruEdnAs,
+  /// Decode an evaluated Calcit Map into a declared typed data shape.
+  #[strum(serialize = "decode-map-as")]
+  DecodeMapAs,
   /// placeholder for trait requirement assertions
   #[strum(serialize = "assert-traits")]
   AssertTraits,
@@ -167,6 +170,11 @@ impl CalcitSyntax {
       ParseCirruEdnAs => Some(SyntaxTypeSignature {
         param_names: vec!["text", "type"],
         param_types: vec![Arc::new(CalcitTypeAnnotation::String), dyn_t.clone()],
+        return_type: dyn_t.clone(),
+      }),
+      DecodeMapAs => Some(SyntaxTypeSignature {
+        param_names: vec!["value", "type"],
+        param_types: vec![dyn_t.clone(), dyn_t.clone()],
         return_type: dyn_t.clone(),
       }),
       AssertTraits => Some(SyntaxTypeSignature {

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2867,6 +2867,14 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
+        |RuntimeMapResponse $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstruct RuntimeMapResponse (:code 'Number)
+              :message $ :: 'Option 'String
+              :body 'Dynamic
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :data :internal
         |Serialize $ %{} 'CodeEntry (:doc "|Core trait: Serialize")
           :code $ quote
             deftrait Serialize $ .serialize
@@ -3778,6 +3786,48 @@
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
+        |decode-map-as $ %{} 'CodeEntry (:doc "|Decode an evaluated Calcit Map into a typed Struct or other closed data shape. Syntax: (decode-map-as value TypeExpr). Struct fields are checked recursively; unknown keys and missing required fields fail with a path. Missing Option fields become %none and present raw values become %some. Explicit Dynamic leaves are allowed only at this runtime boundary. Use this instead of ad-hoc read-field or Lilac validators for host/JSON maps.")
+          :code $ quote (def decode-map-as &runtime-implementation)
+          :examples $ []
+            quote $ let
+                response $ decode-map-as
+                  {} (:code 200) (:message |ok)
+                    :body $ {} (:kind :json)
+                  , RuntimeMapResponse
+              assert= 200 $ :code response
+              assert= (%some |ok) (:message response)
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] 'Dynamic 'Dynamic
+          :tags $ #{} :builtin :internal :meta :syntax
+          :tests $ []
+            %{} 'TestEntry (:name |decodes-struct-and-option)
+              :code $ quote
+                do $ let
+                    response $ decode-map-as
+                      {} (:code 200) (:message |ok)
+                        :body $ {} (:kind :json)
+                      , RuntimeMapResponse
+                    missing $ decode-map-as
+                      {} (:code 204)
+                        :body $ {} (:kind :json)
+                      , RuntimeMapResponse
+                  assert= 200 $ :code response
+                  assert= (%some |ok) (:message response)
+                  assert= (%none) (:message missing)
+              :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |preserves-dynamic-and-prewrapped-option)
+              :code $ quote
+                do $ let
+                    response $ decode-map-as
+                      {} (:code 201)
+                        :message $ %some |already
+                        :body $ {} (:kind :json)
+                      , RuntimeMapResponse
+                  assert= 201 $ :code response
+                  assert= (%some |already) (:message response)
+                  assert= true $ map? (:body response)
+              :tags $ #{} :core :unit
         |def $ %{} 'CodeEntry (:doc "|special macro to expose value to definition")
           :code $ quote
             defmacro def (_name x) x
@@ -6186,23 +6236,6 @@
               :generics $ [] 'T 'U
               :return $ :: 'Option 'U
           :tags $ #{} :internal
-        |option:or-else $ %{} 'CodeEntry (:doc "|Return the current Option when it is :some, otherwise evaluate a fallback Option-producing function.")
-          :code $ quote
-            defn option:or-else (opt fallback)
-              tag-match opt
-                (:some _) opt
-                (:none) (fallback)
-          :examples $ []
-            quote $ assert= (%some 2)
-              option:or-else (%none)
-                fn () (%some 2)
-          :schema $ :: 'Fn
-            {}
-              :args $ [] (:: 'Option 'T)
-                :: 'Fn $ {} (:return $ :: 'Option 'T) (:args $ [])
-              :generics $ [] 'T
-              :return $ :: 'Option 'T
-          :tags $ #{} :internal
         |option:fold $ %{} 'CodeEntry (:doc "|Eliminate an Option by evaluating on-none for none or on-some with the payload.")
           :code $ quote
             defn option:fold (opt on-none on-some)
@@ -6257,6 +6290,25 @@
             {} (:return 'Bool)
               :args $ [] (:: 'Option 'T)
               :generics $ [] 'T
+          :tags $ #{} :internal
+        |option:or-else $ %{} 'CodeEntry (:doc "|Return the current Option when it is :some, otherwise evaluate a fallback Option-producing function.")
+          :code $ quote
+            defn option:or-else (opt fallback)
+              tag-match opt
+                (:some _) opt
+                (:none) (fallback)
+          :examples $ []
+            quote $ assert= (%some 2)
+              option:or-else (%none)
+                fn () $ %some 2
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Option 'T)
+                :: 'Fn $ {}
+                  :args $ []
+                  :return $ :: 'Option 'T
+              :generics $ [] 'T
+              :return $ :: 'Option 'T
           :tags $ #{} :internal
         |option:some? $ %{} 'CodeEntry (:doc "|Returns true when an Option is :some.")
           :code $ quote
@@ -6689,23 +6741,6 @@
               :generics $ [] 'T 'U 'E
               :return $ :: 'Result 'U 'E
           :tags $ #{} :internal
-        |result:or-else $ %{} 'CodeEntry (:doc "|Return the current Result when it is :ok, otherwise evaluate a fallback Result-producing function.")
-          :code $ quote
-            defn result:or-else (res fallback)
-              tag-match res
-                (:ok _) res
-                (:err _) (fallback)
-          :examples $ []
-            quote $ assert= (%ok 2)
-              result:or-else (%err |missing)
-                fn () (%ok 2)
-          :schema $ :: 'Fn
-            {}
-              :args $ [] (:: 'Result 'T 'E)
-                :: 'Fn $ {} (:return $ :: 'Result 'T 'E) (:args $ [])
-              :generics $ [] 'T 'E
-              :return $ :: 'Result 'T 'E
-          :tags $ #{} :internal
         |result:err? $ %{} 'CodeEntry (:doc "|Returns true when a Result is :err.")
           :code $ quote
             defn result:err? (res)
@@ -6770,6 +6805,25 @@
             {} (:return 'Bool)
               :args $ [] (:: 'Result 'T 'E)
               :generics $ [] 'T 'E
+          :tags $ #{} :internal
+        |result:or-else $ %{} 'CodeEntry (:doc "|Return the current Result when it is :ok, otherwise evaluate a fallback Result-producing function.")
+          :code $ quote
+            defn result:or-else (res fallback)
+              tag-match res
+                (:ok _) res
+                (:err _) (fallback)
+          :examples $ []
+            quote $ assert= (%ok 2)
+              result:or-else (%err |missing)
+                fn () $ %ok 2
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Result 'T 'E)
+                :: 'Fn $ {}
+                  :args $ []
+                  :return $ :: 'Result 'T 'E
+              :generics $ [] 'T 'E
+              :return $ :: 'Result 'T 'E
           :tags $ #{} :internal
         |result:unwrap-or $ %{} 'CodeEntry (:doc "|Returns the :ok payload, or the fallback for :err.")
           :code $ quote

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2867,11 +2867,17 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
+        |RuntimeMapMeta $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstruct RuntimeMapMeta $ :kind 'Tag
+          :examples $ []
+          :schema $ :: 'Dynamic
         |RuntimeMapResponse $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct RuntimeMapResponse (:code 'Number)
               :message $ :: 'Option 'String
               :body 'Dynamic
+              :meta $ :: 'Option RuntimeMapMeta
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :data :internal
@@ -3786,7 +3792,7 @@
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number
-        |decode-map-as $ %{} 'CodeEntry (:doc "|Decode an evaluated Calcit Map into a typed Struct or other closed data shape. Syntax: (decode-map-as value TypeExpr). Struct fields are checked recursively; unknown keys and missing required fields fail with a path. Missing Option fields become %none and present raw values become %some. Explicit Dynamic leaves are allowed only at this runtime boundary. Use this instead of ad-hoc read-field or Lilac validators for host/JSON maps.")
+        |decode-map-as $ %{} 'CodeEntry (:doc "||Decode an evaluated Calcit value into a typed Struct or other closed data shape. Syntax: (decode-map-as value TypeExpr). Struct fields are checked recursively; unknown keys and missing required fields fail with a path. Missing Option fields become %none and present raw values become %some. Explicit Dynamic leaves are allowed only at this runtime boundary. Use this instead of ad-hoc read-field or Lilac validators for host/JSON maps. Native and JavaScript support this syntax; WASM does not currently support typed decoder syntaxes.")
           :code $ quote (def decode-map-as &runtime-implementation)
           :examples $ []
             quote $ let
@@ -3796,6 +3802,13 @@
                   , RuntimeMapResponse
               assert= 200 $ :code response
               assert= (%some |ok) (:message response)
+            quote $ assert=
+              %some $ %{} RuntimeMapMeta (:kind :nested)
+              :meta $ decode-map-as
+                {} (:code 202)
+                  :meta $ {} (:kind :nested)
+                  :body $ {} (:kind :json)
+                , RuntimeMapResponse
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ [] 'Dynamic 'Dynamic
@@ -3827,6 +3840,23 @@
                   assert= 201 $ :code response
                   assert= (%some |already) (:message response)
                   assert= true $ map? (:body response)
+              :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |nested-struct-option)
+              :code $ quote
+                do
+                  assert= 202 $ :code
+                    decode-map-as
+                      {} (:code 202)
+                        :meta $ {} (:kind :nested)
+                        :body $ {} (:kind :json)
+                      , RuntimeMapResponse
+                  assert=
+                    %some $ %{} RuntimeMapMeta (:kind :nested)
+                    :meta $ decode-map-as
+                      {} (:code 202)
+                        :meta $ {} (:kind :nested)
+                        :body $ {} (:kind :json)
+                      , RuntimeMapResponse
               :tags $ #{} :core :unit
         |def $ %{} 'CodeEntry (:doc "|special macro to expose value to definition")
           :code $ quote

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -555,6 +555,22 @@ fn gen_call_code(
           }
           _ => Err(format!("parse-cirru-edn-as expected a string and a type expression, got: {body}")),
         },
+        CalcitSyntax::DecodeMapAs => match (body.first(), body.get(1)) {
+          (Some(value), Some(type_form)) if body.len() == 2 || body.len() == 3 => {
+            let graph = match body.get(2).and_then(DataShapeGraph::from_calcit_handle) {
+              Some(graph) => graph,
+              None => {
+                let target = calcit::CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
+                Arc::new(DataShapeGraph::build_open(target.as_ref(), ns).map_err(|error| error.to_string())?)
+              }
+            };
+            let graph_code = data_shape_graph_to_js(graph.as_ref(), ns, file_imports)?;
+            let value_code = to_js_code(value, ns, local_defs, file_imports, tags, None)?;
+            let call_code = format!("{}decode_map_as({value_code}, {graph_code})", get_proc_prefix(ns));
+            Ok(wrap_call_with_prelude(String::new(), call_code, return_label, detect_await(&body)))
+          }
+          _ => Err(format!("decode-map-as expected a map and a type expression, got: {body}")),
+        },
         CalcitSyntax::AssertTraits => Ok(format!("{return_code}null")),
         CalcitSyntax::Match => gen_match_code(&body, local_defs, xs, ns, file_imports, tags, return_label),
         _ => {
@@ -890,6 +906,7 @@ fn data_shape_graph_to_js(graph: &DataShapeGraph, current_ns: &str, file_imports
   let mut nodes = Vec::with_capacity(graph.nodes.len());
   for node in &graph.nodes {
     let code = match node {
+      DataShapeNode::Dynamic => String::from("{kind:\"dynamic\"}"),
       DataShapeNode::Unit => String::from("{kind:\"unit\"}"),
       DataShapeNode::Bool => String::from("{kind:\"bool\"}"),
       DataShapeNode::Number => String::from("{kind:\"number\"}"),
@@ -899,6 +916,10 @@ fn data_shape_graph_to_js(graph: &DataShapeGraph, current_ns: &str, file_imports
       DataShapeNode::Buffer => String::from("{kind:\"buffer\"}"),
       DataShapeNode::CirruQuote => String::from("{kind:\"cirru-quote\"}"),
       DataShapeNode::Optional(inner) => format!("{{kind:\"optional\",inner:{inner}}}"),
+      DataShapeNode::MapOption { nominal_path, inner, .. } => {
+        let nominal = nominal_ref_to_js(nominal_path.as_ref(), current_ns, file_imports)?;
+        format!("{{kind:\"map-option\",nominal:{nominal},inner:{inner}}}")
+      }
       DataShapeNode::List(inner) => format!("{{kind:\"list\",inner:{inner}}}"),
       DataShapeNode::Set(inner) => format!("{{kind:\"set\",inner:{inner}}}"),
       DataShapeNode::Map { key, value } => format!("{{kind:\"map\",key:{key},value:{value}}}"),

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -569,7 +569,7 @@ fn gen_call_code(
             let call_code = format!("{}decode_map_as({value_code}, {graph_code})", get_proc_prefix(ns));
             Ok(wrap_call_with_prelude(String::new(), call_code, return_label, detect_await(&body)))
           }
-          _ => Err(format!("decode-map-as expected a map and a type expression, got: {body}")),
+          _ => Err(format!("decode-map-as expected a value and a type expression, got: {body}")),
         },
         CalcitSyntax::AssertTraits => Ok(format!("{return_code}null")),
         CalcitSyntax::Match => gen_match_code(&body, local_defs, xs, ns, file_imports, tags, return_label),

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1119,6 +1119,7 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
         }
         emit_expr(ctx, &args_list[0])
       }
+      CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::DecodeMapAs => Err(format!("{syn} is not yet supported in WASM codegen")),
       CalcitSyntax::Defn => {
         // A `fn`/`defn` form in value position creates a closure capturing outer variables.
         // Closures with captured upvalues can't be represented as static WASM function

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -30,6 +30,7 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u16>) -> Resul
       "defwasm-import" => Ok(Calcit::Syntax(CalcitSyntax::DefWasmImport, ns.into())),
       "unsafe-coerce" => Ok(Calcit::Syntax(CalcitSyntax::UnsafeCoerce, ns.into())),
       "parse-cirru-edn-as" => Ok(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, ns.into())),
+      "decode-map-as" => Ok(Calcit::Syntax(CalcitSyntax::DecodeMapAs, ns.into())),
       "assert-traits" => Ok(Calcit::Syntax(CalcitSyntax::AssertTraits, ns.into())),
       "" => Err(String::from("Empty string is invalid")),
       // anonymous enum constructor syntax
@@ -327,6 +328,17 @@ mod tests {
       panic!("expected list");
     };
     assert!(matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _))));
+  }
+
+  #[test]
+  fn parses_runtime_map_decode_as_syntax() {
+    let expr = Cirru::List(vec![Cirru::leaf("decode-map-as"), Cirru::leaf("value"), Cirru::leaf("Response")]);
+
+    let calcit = code_to_calcit(&expr, "tests.ns", "demo", vec![]).expect("parse runtime map decoder");
+    let Calcit::List(items) = calcit else {
+      panic!("expected list");
+    };
+    assert!(matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::DecodeMapAs, _))));
   }
 
   #[test]

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -41,6 +41,266 @@ pub(crate) fn decode(shape: &DataShapeGraph, input: &Edn) -> Result<Calcit, EdnD
   Ok(value)
 }
 
+/// Decode an already-evaluated Calcit value at an application boundary. This
+/// is deliberately distinct from Cirru EDN: named structs accept maps and
+/// nominal `Option<T>` fields accept their raw payloads.
+pub(crate) fn decode_map(shape: &DataShapeGraph, input: &Calcit) -> Result<Calcit, EdnDecodeError> {
+  let value = MapDecoder { shape }.decode_node(shape.root, input, "$", 0)?;
+  shape.validate_value(&value).map_err(|error| {
+    EdnDecodeError::at(
+      &error.path,
+      format!("internal runtime-map decoder invariant failed: {}", error.message),
+    )
+  })?;
+  Ok(value)
+}
+
+struct MapDecoder<'a> {
+  shape: &'a DataShapeGraph,
+}
+
+impl MapDecoder<'_> {
+  fn decode_node(&self, node_id: usize, input: &Calcit, path: &str, depth: usize) -> Result<Calcit, EdnDecodeError> {
+    if depth > MAX_DECODE_DEPTH {
+      return Err(EdnDecodeError::at(path, format!("decode nesting exceeds {MAX_DECODE_DEPTH}")));
+    }
+    let node = self
+      .shape
+      .nodes
+      .get(node_id)
+      .ok_or_else(|| EdnDecodeError::at(path, format!("invalid data shape node #{node_id}")))?;
+    match node {
+      DataShapeNode::Dynamic => Ok(input.to_owned()),
+      DataShapeNode::Unit => {
+        if matches!(input, Calcit::Nil) {
+          Ok(Calcit::Nil)
+        } else {
+          Err(map_kind_mismatch(path, "nil", input))
+        }
+      }
+      DataShapeNode::Bool => {
+        if matches!(input, Calcit::Bool(_)) {
+          Ok(input.to_owned())
+        } else {
+          Err(map_kind_mismatch(path, "bool", input))
+        }
+      }
+      DataShapeNode::Number => {
+        if matches!(input, Calcit::Number(_)) {
+          Ok(input.to_owned())
+        } else {
+          Err(map_kind_mismatch(path, "number", input))
+        }
+      }
+      DataShapeNode::String => {
+        if matches!(input, Calcit::Str(_)) {
+          Ok(input.to_owned())
+        } else {
+          Err(map_kind_mismatch(path, "string", input))
+        }
+      }
+      DataShapeNode::Symbol => {
+        if matches!(input, Calcit::Symbol { .. }) {
+          Ok(input.to_owned())
+        } else {
+          Err(map_kind_mismatch(path, "symbol", input))
+        }
+      }
+      DataShapeNode::Tag => {
+        if matches!(input, Calcit::Tag(_)) {
+          Ok(input.to_owned())
+        } else {
+          Err(map_kind_mismatch(path, "tag", input))
+        }
+      }
+      DataShapeNode::Buffer => {
+        if matches!(input, Calcit::Buffer(_)) {
+          Ok(input.to_owned())
+        } else {
+          Err(map_kind_mismatch(path, "buffer", input))
+        }
+      }
+      DataShapeNode::CirruQuote => {
+        if matches!(input, Calcit::CirruQuote(_)) {
+          Ok(input.to_owned())
+        } else {
+          Err(map_kind_mismatch(path, "cirru-quote", input))
+        }
+      }
+      DataShapeNode::Optional(inner) => {
+        if matches!(input, Calcit::Nil) {
+          Ok(Calcit::Nil)
+        } else {
+          self.decode_node(*inner, input, path, depth + 1)
+        }
+      }
+      DataShapeNode::MapOption { nominal, inner, .. } => {
+        if let Calcit::Enum(enum_value) = input
+          && enum_value.sum_type.as_ref().is_some_and(|actual| actual.name() == nominal.name())
+        {
+          return match (enum_value.tag.as_ref(), enum_value.extra.as_slice()) {
+            (Calcit::Tag(tag), []) if tag.ref_str() == "none" => Ok(input.to_owned()),
+            (Calcit::Tag(tag), [item]) if tag.ref_str() == "some" => Ok(Calcit::Enum(CalcitEnumValue {
+              tag: enum_value.tag.clone(),
+              extra: vec![self.decode_node(*inner, item, path, depth + 1)?],
+              sum_type: Some(nominal.clone()),
+            })),
+            _ => Err(EdnDecodeError::at(path, "invalid Option value")),
+          };
+        }
+        let payload = self.decode_node(*inner, input, path, depth + 1)?;
+        Ok(Calcit::Enum(CalcitEnumValue {
+          tag: Arc::new(Calcit::Tag(cirru_edn::EdnTag::new("some"))),
+          extra: vec![payload],
+          sum_type: Some(nominal.clone()),
+        }))
+      }
+      DataShapeNode::List(inner) => {
+        let Calcit::List(items) = input else {
+          return Err(map_kind_mismatch(path, "list", input));
+        };
+        let mut values = Vec::with_capacity(items.len());
+        for (idx, item) in items.iter().enumerate() {
+          values.push(self.decode_node(*inner, item, &format!("{path}[{idx}]"), depth + 1)?);
+        }
+        Ok(Calcit::List(Arc::new(CalcitList::Vector(values))))
+      }
+      DataShapeNode::Set(inner) => {
+        let Calcit::Set(items) = input else {
+          return Err(map_kind_mismatch(path, "set", input));
+        };
+        let mut values = rpds::HashTrieSet::new_sync();
+        for item in items {
+          let decoded = self.decode_node(*inner, item, &format!("{path}.item"), depth + 1)?;
+          if values.contains(&decoded) {
+            return Err(EdnDecodeError::at(path, "duplicate decoded set value"));
+          }
+          values.insert_mut(decoded);
+        }
+        Ok(Calcit::Set(values))
+      }
+      DataShapeNode::Map { key, value } => {
+        let Calcit::Map(items) = input else {
+          return Err(map_kind_mismatch(path, "map", input));
+        };
+        let mut values = rpds::HashTrieMap::new_sync();
+        for (raw_key, raw_value) in items {
+          let decoded_key = self.decode_node(*key, raw_key, &format!("{path}.key"), depth + 1)?;
+          let decoded_value = self.decode_node(*value, raw_value, &format!("{path}.value"), depth + 1)?;
+          if values.contains_key(&decoded_key) {
+            return Err(EdnDecodeError::at(path, "duplicate decoded map key"));
+          }
+          values.insert_mut(decoded_key, decoded_value);
+        }
+        Ok(Calcit::Map(values))
+      }
+      DataShapeNode::Struct { nominal, fields, .. } => {
+        let Calcit::Map(items) = input else {
+          return Err(map_kind_mismatch(path, &format!("map for struct :{}", nominal.name), input));
+        };
+        let mut seen_fields = HashSet::new();
+        for key in items.keys() {
+          let name = match key {
+            Calcit::Tag(tag) => tag.ref_str(),
+            Calcit::Str(text) => text,
+            _ => return Err(EdnDecodeError::at(path, "struct map keys must be tags or strings")),
+          };
+          if !fields.iter().any(|(field, _)| field.ref_str() == name) {
+            return Err(EdnDecodeError::at(
+              path,
+              format!("struct :{} has unknown field :{name}", nominal.name),
+            ));
+          }
+          if !seen_fields.insert(name) {
+            return Err(EdnDecodeError::at(
+              path,
+              format!("struct :{} has duplicate field :{name}", nominal.name),
+            ));
+          }
+        }
+        let mut values = Vec::with_capacity(fields.len());
+        for (field, child) in fields {
+          let raw = items
+            .get(&Calcit::Tag(field.clone()))
+            .or_else(|| items.get(&Calcit::Str(Arc::from(field.ref_str()))));
+          match (raw, self.shape.nodes.get(*child)) {
+            (Some(value), _) => values.push(self.decode_node(*child, value, &format!("{path}.{}", field.ref_str()), depth + 1)?),
+            (None, Some(DataShapeNode::MapOption { nominal, .. })) => values.push(Calcit::Enum(CalcitEnumValue {
+              tag: Arc::new(Calcit::Tag(cirru_edn::EdnTag::new("none"))),
+              extra: vec![],
+              sum_type: Some(nominal.clone()),
+            })),
+            (None, _) => {
+              return Err(EdnDecodeError::at(
+                path,
+                format!("struct :{} is missing required field :{}", nominal.name, field.ref_str()),
+              ));
+            }
+          }
+        }
+        Ok(Calcit::Struct(CalcitStructValue {
+          struct_ref: nominal.clone(),
+          values: Arc::new(values),
+        }))
+      }
+      DataShapeNode::Enum { nominal, variants, .. } => {
+        let Calcit::Enum(enum_value) = input else {
+          return Err(map_kind_mismatch(path, &format!("enum :{}", nominal.name()), input));
+        };
+        let Some(actual_nominal) = enum_value.sum_type.as_ref() else {
+          return Err(EdnDecodeError::at(path, format!("expected nominal enum :{}", nominal.name())));
+        };
+        if !Arc::ptr_eq(actual_nominal, nominal) {
+          return Err(EdnDecodeError::at(
+            path,
+            format!("expected enum :{}, got :{}", nominal.name(), actual_nominal.name()),
+          ));
+        }
+        let Calcit::Tag(tag) = enum_value.tag.as_ref() else {
+          return Err(EdnDecodeError::at(path, "enum variant is not a tag"));
+        };
+        let Some((_, payload_nodes)) = variants.iter().find(|(candidate, _)| candidate == tag) else {
+          return Err(EdnDecodeError::at(path, format!("enum :{} has no variant :{tag}", nominal.name())));
+        };
+        if enum_value.extra.len() != payload_nodes.len() {
+          return Err(EdnDecodeError::at(
+            path,
+            format!(
+              "enum :{} variant :{tag} expects {} payload(s), got {}",
+              nominal.name(),
+              payload_nodes.len(),
+              enum_value.extra.len()
+            ),
+          ));
+        }
+        let mut values = Vec::with_capacity(payload_nodes.len());
+        for (idx, (payload_node, item)) in payload_nodes.iter().zip(enum_value.extra.iter()).enumerate() {
+          values.push(self.decode_node(*payload_node, item, &format!("{path}.payload[{idx}]"), depth + 1)?);
+        }
+        Ok(Calcit::Enum(CalcitEnumValue {
+          tag: enum_value.tag.clone(),
+          extra: values,
+          sum_type: Some(nominal.clone()),
+        }))
+      }
+      DataShapeNode::Ref(_) => {
+        self
+          .shape
+          .validate_node_value(node_id, input, path, depth)
+          .map_err(|error| EdnDecodeError::at(&error.path, error.message))?;
+        Ok(input.to_owned())
+      }
+    }
+  }
+}
+
+fn map_kind_mismatch(path: &str, expected: &str, actual: &Calcit) -> EdnDecodeError {
+  EdnDecodeError::at(
+    path,
+    format!("expected {expected}, got {}", crate::calcit::brief_type_of_value(actual)),
+  )
+}
+
 struct Decoder<'a> {
   shape: &'a DataShapeGraph,
 }
@@ -55,6 +315,10 @@ impl Decoder<'_> {
     };
 
     match node {
+      DataShapeNode::Dynamic | DataShapeNode::MapOption { .. } => Err(EdnDecodeError::at(
+        path,
+        "internal decoder error: open runtime-map node is unavailable for Cirru EDN",
+      )),
       DataShapeNode::Unit => match input {
         Edn::Nil => Ok(Calcit::Nil),
         _ => Err(kind_mismatch(path, "nil", input)),
@@ -305,6 +569,126 @@ mod tests {
       where_bounds: Arc::new(vec![]),
       impls: vec![],
     })
+  }
+
+  fn option_enum() -> Arc<CalcitEnumDef> {
+    let prototype = CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef {
+        name: EdnTag::new("Option"),
+        fields: Arc::new(vec![EdnTag::new("none"), EdnTag::new("some")]),
+        field_types: Arc::new(vec![
+          Arc::new(CalcitTypeAnnotation::Dynamic),
+          Arc::new(CalcitTypeAnnotation::Dynamic),
+        ]),
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        impls: vec![],
+      }),
+      values: Arc::new(vec![
+        Calcit::List(Arc::new(CalcitList::default())),
+        Calcit::List(Arc::new(CalcitList::Vector(vec![Calcit::Number(0.0)]))),
+      ]),
+    };
+    Arc::new(CalcitEnumDef::from_struct(prototype).expect("option enum"))
+  }
+
+  #[test]
+  fn runtime_map_decode_requires_fields_lifts_option_and_rejects_unknown_keys() {
+    let response = Arc::new(CalcitStructDef {
+      name: EdnTag::new("Response"),
+      fields: Arc::new(vec![EdnTag::new("code"), EdnTag::new("message"), EdnTag::new("body")]),
+      field_types: Arc::new(vec![
+        Arc::new(CalcitTypeAnnotation::Number),
+        Arc::new(CalcitTypeAnnotation::Dynamic),
+        Arc::new(CalcitTypeAnnotation::Dynamic),
+      ]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    let option = option_enum();
+    let shape = DataShapeGraph::from_nodes(
+      0,
+      vec![
+        DataShapeNode::Struct {
+          nominal: response.clone(),
+          nominal_path: None,
+          type_args: Arc::new(vec![]),
+          fields: vec![(EdnTag::new("code"), 1), (EdnTag::new("message"), 2), (EdnTag::new("body"), 4)],
+        },
+        DataShapeNode::Number,
+        DataShapeNode::MapOption {
+          nominal: option.clone(),
+          nominal_path: None,
+          inner: 3,
+        },
+        DataShapeNode::String,
+        DataShapeNode::Dynamic,
+      ],
+    )
+    .expect("response shape");
+    let raw = Calcit::Map(
+      rpds::HashTrieMap::new_sync()
+        .insert(Calcit::Tag(EdnTag::new("code")), Calcit::Number(200.0))
+        .insert(Calcit::Tag(EdnTag::new("message")), Calcit::Str(Arc::from("ok")))
+        .insert(Calcit::Tag(EdnTag::new("body")), Calcit::Map(Default::default())),
+    );
+    let decoded = decode_map(&shape, &raw).expect("decode response");
+    let Calcit::Struct(response_value) = decoded else {
+      panic!("expected response struct")
+    };
+    assert_eq!(response_value.values[0], Calcit::Number(200.0));
+    assert!(
+      matches!(&response_value.values[1], Calcit::Enum(value) if value.tag.as_ref() == &Calcit::Tag(EdnTag::new("some")) && value.sum_type.as_ref().is_some_and(|actual| Arc::ptr_eq(actual, &option)))
+    );
+    let no_message = Calcit::Map(
+      rpds::HashTrieMap::new_sync()
+        .insert(Calcit::Tag(EdnTag::new("code")), Calcit::Number(204.0))
+        .insert(Calcit::Tag(EdnTag::new("body")), Calcit::Map(Default::default())),
+    );
+    let Calcit::Struct(no_message_value) = decode_map(&shape, &no_message).expect("decode missing Option") else {
+      panic!("expected response struct")
+    };
+    assert!(
+      matches!(&no_message_value.values[1], Calcit::Enum(value) if value.tag.as_ref() == &Calcit::Tag(EdnTag::new("none")) && value.extra.is_empty() && value.sum_type.as_ref().is_some_and(|actual| Arc::ptr_eq(actual, &option)))
+    );
+    let prewrapped = Calcit::Map(
+      rpds::HashTrieMap::new_sync()
+        .insert(Calcit::Tag(EdnTag::new("code")), Calcit::Number(201.0))
+        .insert(
+          Calcit::Tag(EdnTag::new("message")),
+          Calcit::Enum(CalcitEnumValue {
+            tag: Arc::new(Calcit::Tag(EdnTag::new("some"))),
+            extra: vec![Calcit::Str(Arc::from("already"))],
+            sum_type: Some(option.clone()),
+          }),
+        )
+        .insert(Calcit::Tag(EdnTag::new("body")), Calcit::Map(Default::default())),
+    );
+    let Calcit::Struct(prewrapped_value) = decode_map(&shape, &prewrapped).expect("decode Option") else {
+      panic!("expected response struct")
+    };
+    assert!(
+      matches!(&prewrapped_value.values[1], Calcit::Enum(value) if value.tag.as_ref() == &Calcit::Tag(EdnTag::new("some")) && value.extra == [Calcit::Str(Arc::from("already"))] && value.sum_type.as_ref().is_some_and(|actual| Arc::ptr_eq(actual, &option)))
+    );
+    let missing = Calcit::Map(rpds::HashTrieMap::new_sync());
+    assert!(
+      decode_map(&shape, &missing)
+        .expect_err("missing required code")
+        .message
+        .contains("missing required field :code")
+    );
+    let unknown = Calcit::Map(
+      rpds::HashTrieMap::new_sync()
+        .insert(Calcit::Tag(EdnTag::new("code")), Calcit::Number(200.0))
+        .insert(Calcit::Tag(EdnTag::new("extra")), Calcit::Bool(true)),
+    );
+    assert!(
+      decode_map(&shape, &unknown)
+        .expect_err("unknown key")
+        .message
+        .contains("unknown field :extra")
+    );
   }
 
   #[test]

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -46,12 +46,14 @@ pub(crate) fn decode(shape: &DataShapeGraph, input: &Edn) -> Result<Calcit, EdnD
 /// nominal `Option<T>` fields accept their raw payloads.
 pub(crate) fn decode_map(shape: &DataShapeGraph, input: &Calcit) -> Result<Calcit, EdnDecodeError> {
   let value = MapDecoder { shape }.decode_node(shape.root, input, "$", 0)?;
-  shape.validate_value(&value).map_err(|error| {
-    EdnDecodeError::at(
-      &error.path,
-      format!("internal runtime-map decoder invariant failed: {}", error.message),
-    )
-  })?;
+  if cfg!(debug_assertions) {
+    shape.validate_value(&value).map_err(|error| {
+      EdnDecodeError::at(
+        &error.path,
+        format!("internal runtime-map decoder invariant failed: {}", error.message),
+      )
+    })?;
+  }
   Ok(value)
 }
 
@@ -136,7 +138,13 @@ impl MapDecoder<'_> {
       }
       DataShapeNode::MapOption { nominal, inner, .. } => {
         if let Calcit::Enum(enum_value) = input
-          && enum_value.sum_type.as_ref().is_some_and(|actual| actual.name() == nominal.name())
+          // Runtime values reconstructed from snapshots may carry a distinct Arc for the
+          // canonical core Option declaration; the canonical type path is enforced while
+          // building the graph, so retain the nominal name fallback here.
+          && enum_value
+            .sum_type
+            .as_ref()
+            .is_some_and(|actual| Arc::ptr_eq(actual, nominal) || actual.name() == nominal.name())
         {
           return match (enum_value.tag.as_ref(), enum_value.extra.as_slice()) {
             (Calcit::Tag(tag), []) if tag.ref_str() == "none" => Ok(input.to_owned()),
@@ -283,12 +291,21 @@ impl MapDecoder<'_> {
           sum_type: Some(nominal.clone()),
         }))
       }
-      DataShapeNode::Ref(_) => {
-        self
-          .shape
-          .validate_node_value(node_id, input, path, depth)
-          .map_err(|error| EdnDecodeError::at(&error.path, error.message))?;
-        Ok(input.to_owned())
+      DataShapeNode::Ref(inner) => {
+        let Calcit::Ref(_, value_and_listeners) = input else {
+          return Err(map_kind_mismatch(path, "ref", input));
+        };
+        let inner_value = value_and_listeners
+          .lock()
+          .map_err(|_| EdnDecodeError::at(path, "cannot read poisoned ref"))?
+          .0
+          .clone();
+        Ok(quick_build_atom(self.decode_node(
+          *inner,
+          &inner_value,
+          &format!("{path}.value"),
+          depth + 1,
+        )?))
       }
     }
   }

--- a/src/program.rs
+++ b/src/program.rs
@@ -322,8 +322,10 @@ fn collect_compiled_dep_keys(code: &Calcit, deps: &mut Vec<(Arc<str>, Arc<str>)>
       }
     }
     Calcit::List(xs) => {
-      if matches!(xs.first(), Some(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _)))
-        && let Some(graph) = xs.get(3).and_then(DataShapeGraph::from_calcit_handle)
+      if matches!(
+        xs.first(),
+        Some(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::DecodeMapAs, _))
+      ) && let Some(graph) = xs.get(3).and_then(DataShapeGraph::from_calcit_handle)
       {
         deps.extend(graph.nominal_paths());
       }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5611,7 +5611,7 @@ pub fn preprocess_decode_map_as(
   if args.len() != 2 {
     return Err(CalcitErr::use_msg_stack_location(
       CalcitErrKind::Arity,
-      format!("{head} expected a map value and a type expression, got {}", args.len()),
+      format!("{head} expected a value and a type expression, got {}", args.len()),
       ctx.call_stack,
       args.first().and_then(Calcit::get_location),
     ));

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1616,6 +1616,10 @@ fn preprocess_list_call(
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           preprocess_parse_cirru_edn_as(name, name_ns, &args, &mut ctx)
         }
+        CalcitSyntax::DecodeMapAs => {
+          let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
+          preprocess_decode_map_as(name, name_ns, &args, &mut ctx)
+        }
         CalcitSyntax::AssertTraits => {
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           preprocess_assert_traits(name, name_ns, &args, &mut ctx)
@@ -5593,6 +5597,46 @@ pub fn preprocess_parse_cirru_edn_as(
   Ok(Calcit::from(vec![
     Calcit::Syntax(head.to_owned(), Arc::from(head_ns)),
     text_form,
+    type_form.to_owned(),
+    decoder.into_calcit_handle(),
+  ]))
+}
+
+pub fn preprocess_decode_map_as(
+  head: &CalcitSyntax,
+  head_ns: &str,
+  args: &CalcitList,
+  ctx: &mut PreprocessContext,
+) -> Result<Calcit, CalcitErr> {
+  if args.len() != 2 {
+    return Err(CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Arity,
+      format!("{head} expected a map value and a type expression, got {}", args.len()),
+      ctx.call_stack,
+      args.first().and_then(Calcit::get_location),
+    ));
+  }
+  let value_form = preprocess_expr(
+    args.first().expect("validated decode-map-as value"),
+    ctx.scope_defs,
+    ctx.scope_types,
+    ctx.file_ns,
+    ctx.check_warnings,
+    ctx.call_stack,
+  )?;
+  let type_form = args.get(1).expect("validated decode-map-as type");
+  let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
+  let decoder = crate::calcit::data_shape::DataShapeGraph::build_open(target.as_ref(), ctx.file_ns).map_err(|error| {
+    CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      format!("decode-map-as cannot derive a runtime map decoder: {error}"),
+      ctx.call_stack,
+      type_form.get_location(),
+    )
+  })?;
+  Ok(Calcit::from(vec![
+    Calcit::Syntax(head.to_owned(), Arc::from(head_ns)),
+    value_form,
     type_form.to_owned(),
     decoder.into_calcit_handle(),
   ]))

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -585,7 +585,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           .get(2)
           .map(|form| CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[])),
 
-        Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, _) => xs
+        Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::DecodeMapAs, _) => xs
           .get(2)
           .map(|form| CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[])),
 
@@ -1754,22 +1754,24 @@ mod tests {
   }
 
   #[test]
-  fn strict_edn_decode_expression_has_declared_closed_type() {
+  fn typed_decode_expression_has_declared_target_type() {
     let target = Calcit::Enum(calcit::CalcitEnumValue {
       tag: Arc::new(Calcit::tag("list")),
       extra: vec![Calcit::tag("number")],
       sum_type: None,
     });
-    let expression = Calcit::from(vec![
-      Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, Arc::from(calcit::CORE_NS)),
-      Calcit::Str(Arc::from("[] 1 2")),
-      target,
-    ]);
+    for syntax in [CalcitSyntax::ParseCirruEdnAs, CalcitSyntax::DecodeMapAs] {
+      let expression = Calcit::from(vec![
+        Calcit::Syntax(syntax, Arc::from(calcit::CORE_NS)),
+        Calcit::Str(Arc::from("[] 1 2")),
+        target.clone(),
+      ]);
 
-    assert!(matches!(
-      infer_static_type_from_expr(&expression).as_deref(),
-      Some(CalcitTypeAnnotation::List(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
-    ));
+      assert!(matches!(
+        infer_static_type_from_expr(&expression).as_deref(),
+        Some(CalcitTypeAnnotation::List(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
+      ));
+    }
   }
 
   #[test]

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1897,7 +1897,10 @@ const decode_runtime_map_node = (graph: DataShapeGraph, nodeId: number, input: a
     case "dynamic":
       return input;
     case "map-option": {
-      if (input instanceof CalcitEnumValue && input.enumPrototype?.name() === node.nominal.name()) {
+      if (
+        input instanceof CalcitEnumValue &&
+        (input.enumPrototype === node.nominal || input.enumPrototype?.name() === node.nominal.name())
+      ) {
         const tag: CalcitValue = input.tag;
         if (!(tag instanceof CalcitTag)) map_decode_error(path, "Option variant is not a tag");
         const tag_name = (tag as CalcitTag).value;
@@ -1970,15 +1973,40 @@ const decode_runtime_map_node = (graph: DataShapeGraph, nodeId: number, input: a
       });
       return new CalcitSliceMap(entries.flat());
     }
+    case "optional":
+      return input == null ? null : decode_runtime_map_node(graph, node.inner, input, path, depth + 1);
+    case "ref":
+      if (!(input instanceof CalcitRef)) return map_decode_error(path, `expected atom, got ${typed_edn_kind(input)}`);
+      return atom(decode_runtime_map_node(graph, node.inner, input.value, `${path}.value`, depth + 1));
+    case "enum": {
+      if (!(input instanceof CalcitEnumValue) || input.enumPrototype == null) {
+        return map_decode_error(path, `expected enum :${node.nominal.name()}, got ${typed_edn_kind(input)}`);
+      }
+      const actualEnumName = enum_prototype_name(input.enumPrototype);
+      if (actualEnumName !== node.nominal.name()) {
+        return map_decode_error(path, `expected enum :${node.nominal.name()}, got enum :${actualEnumName}`);
+      }
+      if (!(input.tag instanceof CalcitTag)) return map_decode_error(path, `enum :${node.nominal.name()} variant must be a tag`);
+      const inputTag = input.tag as CalcitTag;
+      const variant = node.variants.find((candidate) => candidate.tag === inputTag.value);
+      if (variant == null) return map_decode_error(path, `enum :${node.nominal.name()} has no variant :${inputTag.value}`);
+      if (variant.payload.length !== input.extra.length) {
+        return map_decode_error(
+          path,
+          `enum :${node.nominal.name()} variant :${variant.tag} expects ${variant.payload.length} payload(s), got ${input.extra.length}`
+        );
+      }
+      const values = variant.payload.map((payloadNode, idx) =>
+        decode_runtime_map_node(graph, payloadNode, input.extra[idx], `${path}.payload[${idx}]`, depth + 1)
+      );
+      return new CalcitEnumValue(newTag(variant.tag), values, node.nominal);
+    }
     default:
       return decode_typed_edn_node(graph, nodeId, input, path, depth);
   }
 };
 
 export let decode_map_as = (value: CalcitValue, graph: DataShapeGraph): CalcitValue => {
-  if (!(value instanceof CalcitMap || value instanceof CalcitSliceMap)) {
-    throw new Error(`decode-map-as expected a map, got ${typed_edn_kind(value)}`);
-  }
   if (graph.version !== 1) throw new Error(`decode-map-as expected data shape ABI version 1, got ${graph.version}`);
   if (typeof graph.fingerprint !== "string" || graph.fingerprint.length === 0) {
     throw new Error("decode-map-as expected a non-empty data shape fingerprint");

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1676,9 +1676,10 @@ export let parse_cirru_edn = (code: string, options: CalcitValue) => {
 };
 
 type DataShapeNode =
-  | { kind: "unit" | "bool" | "number" | "string" | "symbol" | "tag" | "buffer" | "cirru-quote" }
+  | { kind: "unit" | "bool" | "number" | "string" | "symbol" | "tag" | "buffer" | "cirru-quote" | "dynamic" }
   | { kind: "optional" | "list" | "set" | "ref"; inner: number }
   | { kind: "map"; key: number; value: number }
+  | { kind: "map-option"; nominal: CalcitEnumDef; inner: number }
   | { kind: "struct"; nominal: CalcitStructDef; fields: Array<[string, number]> }
   | { kind: "enum"; nominal: CalcitEnumDef; variants: Array<{ tag: string; payload: number[] }> };
 
@@ -1881,6 +1882,108 @@ export let parse_cirru_edn_as = (code: string, graph: DataShapeGraph): CalcitVal
     throw new Error(`parse-cirru-edn-as failed to parse Cirru EDN: ${message}`);
   }
   return decode_typed_edn_node(graph, graph.root, input, "$", 0) as CalcitValue;
+};
+
+const map_decode_error = (path: string, message: string): never => {
+  throw new Error(`decode-map-as failed at ${path}: ${message}`);
+};
+
+const decode_runtime_map_node = (graph: DataShapeGraph, nodeId: number, input: any, path: string, depth: number): any => {
+  if (depth > 1024) map_decode_error(path, "decode nesting exceeds 1024");
+  const node = graph.nodes[nodeId];
+  if (node == null) map_decode_error(path, `invalid data shape node #${nodeId}`);
+
+  switch (node.kind) {
+    case "dynamic":
+      return input;
+    case "map-option": {
+      if (input instanceof CalcitEnumValue && input.enumPrototype?.name() === node.nominal.name()) {
+        const tag: CalcitValue = input.tag;
+        if (!(tag instanceof CalcitTag)) map_decode_error(path, "Option variant is not a tag");
+        const tag_name = (tag as CalcitTag).value;
+        if (tag_name === "none" && input.extra.length === 0) return input;
+        if (tag_name === "some" && input.extra.length === 1) {
+          return new CalcitEnumValue(tag as CalcitTag, [decode_runtime_map_node(graph, node.inner, input.extra[0], path, depth + 1)], node.nominal);
+        }
+        return map_decode_error(path, "invalid Option value");
+      }
+      return new CalcitEnumValue(newTag("some"), [decode_runtime_map_node(graph, node.inner, input, path, depth + 1)], node.nominal);
+    }
+    case "struct": {
+      if (!(input instanceof CalcitMap || input instanceof CalcitSliceMap)) {
+        return map_decode_error(path, `expected map for struct :${node.nominal.name.value}, got ${typed_edn_kind(input)}`);
+      }
+      const entries = new Map<string, any>();
+      input.pairs().forEach(([key, value]) => {
+        const name = key instanceof CalcitTag ? key.value : typeof key === "string" ? key : null;
+        if (name == null) map_decode_error(path, "struct map keys must be tags or strings");
+        if (!node.fields.some(([field]) => field === name)) {
+          map_decode_error(path, `struct :${node.nominal.name.value} has unknown field :${name}`);
+        }
+        if (entries.has(name)) map_decode_error(path, `struct :${node.nominal.name.value} has duplicate field :${name}`);
+        entries.set(name, value);
+      });
+      const decoded = new Map<string, any>();
+      node.fields.forEach(([field, child]) => {
+        if (entries.has(field)) {
+          decoded.set(field, decode_runtime_map_node(graph, child, entries.get(field), `${path}.${field}`, depth + 1));
+        } else {
+          const fieldNode = graph.nodes[child];
+          if (fieldNode?.kind === "map-option") {
+            decoded.set(field, new CalcitEnumValue(newTag("none"), [], fieldNode.nominal));
+          } else {
+            map_decode_error(path, `struct :${node.nominal.name.value} is missing required field :${field}`);
+          }
+        }
+      });
+      const values = node.nominal.fields.map((field) => decoded.get(field.value));
+      return new CalcitStructValue(node.nominal.name, node.nominal.fields, values, node.nominal);
+    }
+    case "list": {
+      if (!(input instanceof CalcitList || input instanceof CalcitSliceList)) {
+        return map_decode_error(path, `expected list, got ${typed_edn_kind(input)}`);
+      }
+      return new CalcitSliceList(Array.from(input.items()).map((value, idx) => decode_runtime_map_node(graph, node.inner, value, `${path}[${idx}]`, depth + 1)));
+    }
+    case "set": {
+      if (!(input instanceof CalcitSet || input instanceof TypedEdnSetView)) {
+        return map_decode_error(path, `expected set, got ${typed_edn_kind(input)}`);
+      }
+      const values: any[] = [];
+      const source = input instanceof TypedEdnSetView ? input.items : input.values();
+      source.forEach((value) => {
+        const decoded = decode_runtime_map_node(graph, node.inner, value, `${path}.item`, depth + 1);
+        if (values.some((item) => _$n__$e_(item, decoded))) map_decode_error(path, "duplicate decoded set value");
+        values.push(decoded);
+      });
+      return new CalcitSet(values);
+    }
+    case "map": {
+      if (!(input instanceof CalcitMap || input instanceof CalcitSliceMap)) {
+        return map_decode_error(path, `expected map, got ${typed_edn_kind(input)}`);
+      }
+      const entries: any[] = [];
+      input.pairs().forEach(([key, value]) => {
+        const decodedKey = decode_runtime_map_node(graph, node.key, key, `${path}.key`, depth + 1);
+        if (entries.some(([existing]) => _$n__$e_(existing, decodedKey))) map_decode_error(path, "duplicate decoded map key");
+        entries.push([decodedKey, decode_runtime_map_node(graph, node.value, value, `${path}.value`, depth + 1)]);
+      });
+      return new CalcitSliceMap(entries.flat());
+    }
+    default:
+      return decode_typed_edn_node(graph, nodeId, input, path, depth);
+  }
+};
+
+export let decode_map_as = (value: CalcitValue, graph: DataShapeGraph): CalcitValue => {
+  if (!(value instanceof CalcitMap || value instanceof CalcitSliceMap)) {
+    throw new Error(`decode-map-as expected a map, got ${typed_edn_kind(value)}`);
+  }
+  if (graph.version !== 1) throw new Error(`decode-map-as expected data shape ABI version 1, got ${graph.version}`);
+  if (typeof graph.fingerprint !== "string" || graph.fingerprint.length === 0) {
+    throw new Error("decode-map-as expected a non-empty data shape fingerprint");
+  }
+  return decode_runtime_map_node(graph, graph.root, value, "$", 0) as CalcitValue;
 };
 
 const json_to_calcit = (value: any): CalcitValue => {


### PR DESCRIPTION
## Summary
- add `decode-map-as` for recursively decoding Calcit Maps into nominal typed Structs
- reject unknown/missing required fields and lift omitted/raw `Option<T>` fields to nominal `%none`/`%some`
- implement native and JavaScript runtime/codegen support with explicit WASM unsupported behavior

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-agent-interface`
- `yarn check-all`
- `cr calcit/test-edn.cirru --check-only` and JS + Node regression
- `cr docs check-md docs/data/edn.md --entry calcit/test.cirru`