### PR TITLE
feat: add architecture scaffold and todo placeholders

### DIFF
--- a/RFCs/07-26-agent-machine-protocol-rfc.md
+++ b/RFCs/07-26-agent-machine-protocol-rfc.md
@@ -18,49 +18,56 @@ Calcit 的源码、定义元数据与编辑对象本来就是 Cirru EDN 树。Ag
 - 不以 LSP 为前置条件；只有重复解析已被基准证明确实成为瓶颈，且 LSP 的映射收益超过维护成本时，才评估薄适配层。
 - 本 RFC 不改变 snapshot 的 EDN 存储形式，也不引入 workspace。
 
-## 3. Typed result 与 JSON envelope
+## 3. Typed result 与机器 renderer
 
-每个命令先产生 typed result，再由 human/JSON renderer 输出；禁止从人类文本反向解析机器数据。
+每个命令先产生 typed result，再由 human/Cirru EDN/JSON renderer 输出；禁止从人类文本反向解析机器数据。
 
-```json
-{
-  "schema_version": 1,
-  "command": "query.context",
-  "revision": "opaque-content-hash",
-  "data": {},
-  "diagnostics": [],
-  "next": []
-}
+方向更新（2026-08-14）：Calcit 自身的 Symbol、Tag、Set、Enum/Struct 和 quoted Cirru AST 在 Cirru EDN 中可以无损表达，因此新增加的丰富机器协议应优先定义 `--format edn`，并把它作为权威 schema。JSON 的优势是 `JSON.parse`、`jq`、LSP/MCP adapter 和既有 Agent 脚本兼容，不是表达 Calcit 数据的必要条件；已有 `--format json` 契约继续稳定支持，但定位为 compatibility projection，不再反向限制 typed result。
+
+- `--format edn` 时 stdout 只能是一个带 schema version 的 Cirru EDN value；
+- `--format json` 时 stdout 仍只能是一个 JSON value；非 JSON 原生类型使用稳定 tagged encoding；
+- 新字段先定义 EDN 形状，再定义 JSON 投影；
+- 现有只支持 JSON 的命令渐进增加 EDN renderer，不做破坏式切换。
+
+```cirru
+{}
+  :schema-version 1
+  :command :query.context
+  :revision |opaque-content-hash
+  :data $ {}
+  :diagnostics $ []
+  :next $ []
 ```
 
 规则：
 
-- `--format json` 时 stdout 只能是一个 JSON value；日志、tips 与 command echo 一律去 stderr；
+- `--format edn` / `--format json` 时 stdout 都只能是一个 value；日志、tips 与 command echo 一律去 stderr；
 - `revision` 是不透明内容 hash，不承诺可读或跨项目一致；
-- 缺失信息用 `null` 或空集合表达，不依赖缺失字段或自然语言推断；
+- EDN 缺失信息用 `nil` 或空集合表达，不依赖缺失字段或自然语言推断；JSON projection 对应使用 `null`；
 - 有界列表携带 `truncated`、`next_cursor` 或可继续查询的 handle；
 - 保留兼容期 `--json`，但内部等价于 `--format json`；
-- 结果 schema 只能向后兼容地增加可选字段；破坏性变更升级 `schema_version`。
+- 结果 schema 只能向后兼容地增加可选字段；破坏性变更升级 `:schema-version`，JSON projection 使用 `schema_version`。
 
 ## 4. 统一 Definition Descriptor
 
 query、docs、静态分析与 builtin fallback 应从同一只读描述视图组装结果：
 
-```json
-{
-  "id": "calcit.core/to-js-data",
-  "revision": "...",
-  "kind": "proc",
-  "source": { "scope": "core", "definition": "calcit.core/to-js-data" },
-  "schema": null,
-  "inferred_type": null,
-  "doc": "...",
-  "examples": [],
-  "tags": ["js-ffi"],
-  "dependencies": [],
-  "usages": [],
-  "diagnostics": []
-}
+```cirru
+{}
+  :id 'calcit.core/to-js-data
+  :revision |...
+  :kind :proc
+  :source $ {}
+    :scope :core
+    :definition 'calcit.core/to-js-data
+  :schema nil
+  :inferred-type nil
+  :doc |...
+  :examples $ []
+  :tags $ #{} :js-ffi
+  :dependencies $ []
+  :usages $ []
+  :diagnostics $ []
 ```
 
 它是 provider 组合出的只读 view，不应变成 runtime 与 query 层互相依赖的巨型数据结构。builtin 与 source-backed definition 必须落入同一结果模型。
@@ -70,10 +77,10 @@ query、docs、静态分析与 builtin fallback 应从同一只读描述视图�
 优先完善以下只读命令，而不是新增多套近似查询：
 
 ```bash
-cr capabilities --format json
-cr query context <ns/def> --budget 2500 --format json
-cr query type <type-or-definition> --format json
-cr query type-at <ns/def> --path code@3.2 --format json
+cr capabilities --format edn
+cr query context <ns/def> --budget 2500 --format edn
+cr query type <type-or-definition> --format edn
+cr query type-at <ns/def> --path code@3.2 --format edn
 ```
 
 `capabilities` 返回命令、参数/结果 schema、只读性、幂等性和支持的格式，使 Agent 不必加载所有 CLI help。
@@ -91,11 +98,12 @@ cr query type-at <ns/def> --path code@3.2 --format json
 3. editor/LSP 映射不把行号变成新的事实来源；
 4. 有明确维护者承担协议兼容、进程恢复和跨平台测试。
 
-届时优先实现 `cr serve --stdio`，复用本 RFC JSON result；LSP/MCP 只是其上的薄映射。LSP 的 document symbol、references、hover、versioned diagnostics 与 workspace edit 可以借鉴，但内部身份仍是 definition/tree 语义。
+届时优先实现 `cr serve --stdio`，复用本 RFC typed result；stdio transport 可协商 EDN 或兼容 JSON，LSP/MCP 只是其上的薄映射。LSP 的 document symbol、references、hover、versioned diagnostics 与 workspace edit 可以借鉴，但内部身份仍是 definition/tree 语义。
 
 ## 7. 验收
 
-- JSON stdout 可由 `JSON.parse` 直接解析，且版本、命令、revision、data、diagnostics 一致；
+- Cirru EDN stdout 可无损 round-trip Symbol、Tag、Set、Quote、Enum/Struct，且版本、命令、revision、data、diagnostics 一致；
+- compatibility JSON stdout 仍可由 `JSON.parse` 直接解析，已有调用方不被破坏；
 - Agent 能用一次 `context` 和一次可选展开完成一个 definition 的理解；
 - 对相同 revision 的重复只读调用结果稳定；
 - `yarn check-agent-interface` 覆盖并记录耗时、stdout bytes、失败原因；

--- a/RFCs/07-26-agent-machine-protocol-rfc.md
+++ b/RFCs/07-26-agent-machine-protocol-rfc.md
@@ -73,6 +73,26 @@ the projection reconstructs an EDN value equivalent to the source; a successful
 round-trip tests, while JSON fixtures protect compatibility for `jq`, LSP/MCP
 adapters and existing scripts.
 
+最小语义 fixture（`typed-value/nested-v1`）如下；测试同时检查 decode 后的 EDN
+等价性，而不是只检查 JSON 文本可解析：
+
+```cirru.no-check
+{}
+  :value $ :: :ok
+    {}
+      :name 'calcit/demo
+      :items $ #{} :ready
+      :empty $ []
+      :missing nil
+```
+
+```json
+{"value":{"$type":"enum","variant":"ok","type":null,"items":[{"$type":"struct","name":"","fields":{"name":{"$type":"symbol","value":"calcit/demo"},"items":{"$type":"set","items":[{"$type":"tag","value":"ready"}]},"empty":[],"missing":null}}]}}
+```
+
+实现应为 EDN/JSON 各保留一组同构 fixture，并至少覆盖该嵌套案例、空 Set/空
+List、`nil`、Quote 和带类型名的 Enum/Struct。
+
 ## 4. 统一 Definition Descriptor
 
 query、docs、静态分析与 builtin fallback 应从同一只读描述视图组装结果：
@@ -145,6 +165,10 @@ EDN；若客户端只声明 `:json`，服务端选择 JSON；无法满足时返�
 上述 typed-value projection。LSP/MCP 只是其上的薄映射；LSP 的 document symbol、
 references、hover、versioned diagnostics 与 workspace edit 可以借鉴，但内部身份
 仍是 definition/tree 语义。
+
+握手 fixture 至少包含两组等价请求：一组声明 `:format :edn` 并逐行传输 EDN，
+另一组声明 `:format :json` 并逐行传输 JSON；两组都必须得到相同语义的
+`:request-id`、`:ok`、`:result`/`:error` 响应。
 
 ## 7. 验收
 

--- a/RFCs/07-26-agent-machine-protocol-rfc.md
+++ b/RFCs/07-26-agent-machine-protocol-rfc.md
@@ -48,6 +48,31 @@ Calcit 的源码、定义元数据与编辑对象本来就是 Cirru EDN 树。Ag
 - 保留兼容期 `--json`，但内部等价于 `--format json`；
 - 结果 schema 只能向后兼容地增加可选字段；破坏性变更升级 `:schema-version`，JSON projection 使用 `schema_version`。
 
+### 3.1 JSON compatibility projection
+
+JSON 只是 EDN typed result 的兼容投影，不能把 Calcit 值压扁成容易歧义的
+字符串或普通数组。projection 使用稳定的 tagged shape；对象字段使用
+snake_case，集合保持顺序，Set 额外携带 `set` 标签以区别普通数组：
+
+| Cirru EDN | JSON projection |
+|---|---|
+| Symbol `foo/bar` | `{"$type":"symbol","value":"foo/bar"}` |
+| Tag `:ok` | `{"$type":"tag","value":"ok"}` |
+| Set `#{:a :b}` | `{"$type":"set","items":[...]}` |
+| Quote `quote (...)` | `{"$type":"quote","value":...}` |
+| anonymous Enum `:: :call a b` | `{"$type":"enum","variant":"call","type":null,"items":[...]}` |
+| Struct | `{"$type":"struct","name":"...","fields":{...}}` |
+| nested value | recursively apply the same mapping |
+| `nil` | JSON `null` |
+| empty collection | tagged empty collection, never `null` |
+
+Implementations must include semantic fixtures for every row, including nested
+values and `nil` versus empty collections. A fixture passes only when decoding
+the projection reconstructs an EDN value equivalent to the source; a successful
+`JSON.parse` alone is insufficient. The EDN renderer remains the reference for
+round-trip tests, while JSON fixtures protect compatibility for `jq`, LSP/MCP
+adapters and existing scripts.
+
 ## 4. 统一 Definition Descriptor
 
 query、docs、静态分析与 builtin fallback 应从同一只读描述视图组装结果：
@@ -98,7 +123,28 @@ cr query type-at <ns/def> --path code@3.2 --format edn
 3. editor/LSP 映射不把行号变成新的事实来源；
 4. 有明确维护者承担协议兼容、进程恢复和跨平台测试。
 
-届时优先实现 `cr serve --stdio`，复用本 RFC typed result；stdio transport 可协商 EDN 或兼容 JSON，LSP/MCP 只是其上的薄映射。LSP 的 document symbol、references、hover、versioned diagnostics 与 workspace edit 可以借鉴，但内部身份仍是 definition/tree 语义。
+届时优先实现 `cr serve --stdio`，复用本 RFC typed result。stdio 使用一行一个
+请求、一行一个响应的 framing；每一行必须是一个完整 EDN value，或在握手后是
+一个完整 JSON value，禁止把日志写入 stdout。客户端首先发送：
+
+```cirru.no-check
+{}
+  :protocol |calcit-agent/1
+  :format :edn
+  :request-id |hello-1
+```
+
+服务端响应同样带 `:request-id` 与最终选择的 `:format`。当前实现应优先选择
+EDN；若客户端只声明 `:json`，服务端选择 JSON；无法满足时返回结构化错误并
+关闭会话。后续请求使用 `:request-id`、`:command`、`:params`，响应使用
+`:ok`、`:result`、`:diagnostics`；错误使用 `:ok false`、`:error {:code ...
+:message ... :details ...}`，EDN/JSON 两种格式字段语义完全一致。stdio 同样
+遵守“一次响应一个 stdout value”，stderr 才能承载日志和进度信息。
+
+协议 fixture 必须覆盖 EDN 握手、JSON 握手、格式不支持错误、请求/响应关联和
+上述 typed-value projection。LSP/MCP 只是其上的薄映射；LSP 的 document symbol、
+references、hover、versioned diagnostics 与 workspace edit 可以借鉴，但内部身份
+仍是 definition/tree 语义。
 
 ## 7. 验收
 

--- a/RFCs/07-28-persistent-tree-cursor-rfc.md
+++ b/RFCs/07-28-persistent-tree-cursor-rfc.md
@@ -19,9 +19,9 @@ Calcit 源码以 EDN tree 保存，数字 path 只是某个 snapshot revision �
 ```cirru
 {}
   :schema-version 4
-  :active :main
+  :active :default
   :cursors $ {}
-    :main $ {}
+    :default $ {}
       :snapshot |calcit.cirru
       :target |app.main/render!
       :section :code

--- a/RFCs/07-28-persistent-tree-cursor-rfc.md
+++ b/RFCs/07-28-persistent-tree-cursor-rfc.md
@@ -144,7 +144,7 @@ cr edit split-def @cursor --path @cursor --name render-items
 
 `cursor show` 默认调用 Cirru Parser 0.2.15 的 `focus_cirru_preview_with_options`，通过 `CirruFocusOptions` 在 definition 级展示副本中折叠无关分支、保留 definition 的 head/name/参数，并直接使用 `CURSOR` marker。Calcit 不再遍历重写 `'FOCUSED` 或手工拼接 definition header；该依赖使用精确版本约束，防止全局安装忽略 lockfile 时出现未经验证的展示语义漂移。目标表达式只在展示副本中渲染为：
 
-```cirru
+```cirru.no-check
 CURSOR
   map items $ fn (item)
     render-item item
@@ -248,6 +248,24 @@ snapshot 与 cursor 是两个文件，无法依靠单次 rename 同时提交。�
 
 当前状态只有一个 active cursor。原子 rename 保证文件完整性，但不提供多个进程共享同一 Snapshot 时的语义并发控制；并行 Agent 应使用独立 worktree/Snapshot，或改用带 precondition 的 transaction 与显式路径。marks 只能隔离导航位置，不能解决并发源码写入，因此不作为并发安全方案。
 
+兼容性更新（2026-08-14）：CLI 仍只操作 `:active` 指向的 cursor，但 cursor 文档读写会保留该名称以及 `:cursors` map 中其他合法条目，不再在保存 active state 时把 map 收缩为固定的 `:main`。新建 sidecar 的默认名称改为 `:default`，读取旧 `:main` 不受影响。这只为未来 cursor user 排除有损迁移障碍，尚不提供 user 选择、lease、心跳或并发写保护。
+
+### 6.1 下一阶段：cursor user
+
+CLI 将引入项目本地 `cursor user`，取代进程间共享的 active selection：
+
+```bash
+cr --cursor-user agent-a cursor show
+CALCIT_CURSOR_USER=agent-b cr tree show @cursor --path @cursor
+cr cursor show # 未指定时使用 default
+```
+
+解析优先级为 `--cursor-user` > `CALCIT_CURSOR_USER` > `default`。`@cursor`、history、stack、anchor、marks、last-query 和 clipboard 全部按 user 隔离；`cursor whoami/users` 提供发现接口。
+
+后续持久化推荐使用 `.calcit/cursors/<user>.cirru`，而不是让多个进程 read-modify-rename 同一个 `:users` map；否则即使文件写入原子，仍会丢失另一个 user 的并发导航更新。`cursor users` 通过目录发现，v1-v4 的 active entry 迁入 `default` 文件，其他合法 named entry 迁入对应 user 文件。
+
+source mutation 只立即迁移发起 user 的 cursor/anchor/marks；其他 user 下次访问时按 definition revision、same-path fingerprint 或唯一 fingerprint 懒惰恢复，无法恢复则标 stale。cursor activity、lease 和 overlap warning 不进入第一版；任务重叠由 orchestrator 比较 work item write-set，写入正确性依赖 Snapshot/definition revision precondition。完整边界见 `08-14-architecture-scaffold-rfc.md` 第 7 节。
+
 ## 7. 第一阶段实现范围
 
 1. Cirru EDN cursor 状态的读取、v1-v3→v4 兼容、旧路径一次性迁移、校验、64 KiB 上限和原子写入；
@@ -263,7 +281,7 @@ snapshot 与 cursor 是两个文件，无法依靠单次 rename 同时提交。�
 11. leaf/expression search 都支持 `--filter @cursor` 与 `--start-path @cursor`，并继续支持 `--set-cursor`。
 12. 单一 sibling region anchor、最多 16 个 named marks，以及只保存参数的 last query / `query next/prev`。
 
-transaction 内逐 operation 的 cursor preview、多 active cursor、region 批量 mutation，以及跨 definition 的 clipboard 引用策略在后续阶段接入；未接入的 mutation 必须让 cursor/anchor/marks 在下次使用时经过 stale 校验，不能绕过 fingerprint。
+transaction 内逐 operation 的 cursor preview、多 cursor user、region 批量 mutation，以及跨 definition 的 clipboard 引用策略在后续阶段接入；未接入的 mutation 必须让 cursor/anchor/marks 在下次使用时经过 stale 校验，不能绕过 fingerprint。
 
 ## 8. 验收
 

--- a/RFCs/08-14-architecture-scaffold-rfc.md
+++ b/RFCs/08-14-architecture-scaffold-rfc.md
@@ -302,6 +302,7 @@ Cirru EDN stdout 是单个 map：
   :dry-run true
   :snapshot-revision |md5:current
   :proposed-revision |md5:proposed
+  :new-snapshot-revision |md5:applied
   :normalized-plan $ {}
     :roots $ #{} 'app.order/submit-order!
     :definitions $ {}
@@ -361,7 +362,7 @@ CLI 只负责产生结构化 work items。parent agent 或外部 orchestrator �
 
 ```cirru
 {}
-  :id 'order-submission/implement-validate-order
+  :id 'order-submission/implement/app.order/validate-order
   :plan-id |md5:plan
   :target 'app.order/validate-order
   :base-snapshot-revision |md5:scaffolded
@@ -378,7 +379,8 @@ CLI 只负责产生结构化 work items。parent agent 或外部 orchestrator �
 
 规则：
 
-- work item ID 与 target 稳定，不包含运行时 Agent 名称；
+- work item ID 包含完整 FQN，与 target 稳定且不包含运行时 Agent 名称；
+- `base-snapshot-revision` 指向 scaffold 应用后的 Snapshot revision；dry-run 使用 proposed revision；
 - `write-set` 表示默认允许修改的 definition；parent 扩大范围时必须显式处理重叠；
 - cursor user 是执行 Agent 的导航身份，由 parent 分配，不属于 architecture；
 - call graph 邻接不代表 write-set 重叠；第一版不计算强制 batch；

--- a/RFCs/08-14-architecture-scaffold-rfc.md
+++ b/RFCs/08-14-architecture-scaffold-rfc.md
@@ -1,0 +1,532 @@
+# RFC: 基于 definition graph 的功能架构脚手架
+
+状态：Draft  
+日期：2026-08-14  
+关联：`08-14-todo-placeholder-rfc.md`、`03-05-function-schema-dual-track-rfc.md`、`05-12-program-diff-rfc.md`、`07-26-safe-structured-editing-rfc.md`、`07-28-persistent-tree-cursor-rfc.md`
+
+## 1. 概要
+
+新增面向 Agent 的功能级架构模式：一次提交一份用 Cirru EDN 描述的 definition graph，CLI 检查已有 definition、schema、namespace 和依赖边，再以单个原子 transaction 创建整组函数或数据定义的脚手架，并输出可以分发给多个 Agent 的实现工作项。
+
+建议命令：
+
+```bash
+cr edit scaffold --file docs/architectures/order-submission.cirru --dry-run --format edn
+cr edit scaffold --file docs/architectures/order-submission.cirru --expect-revision '<revision>'
+```
+
+它与现有编辑原语的关系是：
+
+- `edit def` 仍是提交一个完整 definition 的最小原语；
+- `edit transaction` 仍负责一组结构化修改的原子提交；
+- `edit scaffold` 是 architecture overlay 到普通 edit operations 的 planner/compiler，不单独发明另一套 Snapshot writer；
+- architecture 声明一组期望存在的 definition、接口和 planned edges，不要求同时完成实现；
+- scaffold graph 同时包含待创建、项目内已有和 external definition；apply 只生成缺失项，不覆盖已有实现；
+- 已有 definition 继续参与 kind/schema 匹配、doc 差异预览、graph 展示和任务上下文；
+- 一次 scaffold apply 要么整体写入成功，要么不改变 Snapshot；
+- CLI 输出 work items，但不在进程内启动或管理 Agent。
+
+“架构”在本 RFC 中是对 Snapshot 的结构化 desired-state overlay，不是新的运行时语义。生成结果仍是普通 `CodeEntry`；actual call graph、diagnostics、implementation status 和 task batches 都是可重新计算的派生视图。
+
+## 2. 设计原则与范围
+
+Calcit Snapshot 可以视为结构化程序数据库：
+
+| 层 | 内容 | 性质 |
+|----|------|------|
+| Program Snapshot | namespace、definition、doc/schema/code/examples | 程序事实来源 |
+| Architecture overlay | 期望 definition 与 planned edges | 实现期设计契约 |
+| Semantic operation | 带 precondition 的结构化编辑 | 可提交变更 |
+| Derived view | tree、call graph、work items、drift、diagnostics | 随时重算 |
+| Cursor state | 每个 CLI user 的导航与 clipboard | 本地临时状态 |
+
+第一版优先打通以下闭环：
+
+```text
+architecture
+  -> normalize and reconcile
+  -> atomic scaffold
+  -> work items
+  -> Agents implement definitions
+  -> parent serially applies changes
+  -> type/test/call-graph verification
+```
+
+第一版不尝试：
+
+- 自动生成完整业务逻辑；
+- 根据自然语言猜测 schema；
+- 自动解决不兼容的已有 definition；
+- 在同一 Snapshot 上提供多个写进程的并发安全；
+- 在 CLI 内启动、租约管理或监控 Agent；
+- 用 cursor activity 充当任务锁或写入正确性机制；
+- 实现 definition-level semantic patch merge；
+- 以 planned graph 宣称实际实现一定遵守所有边。
+
+多 Agent 的第一版并行发生在“实现内容的产出”，最终 Snapshot 修改仍由 parent/coordinator 串行提交。这样先复用现有 transaction/revision 能力，避免为了调度器、锁和 merge 协议阻塞 architecture 流程。
+
+## 3. 输入模型：平面规范，树形展示
+
+### 3.1 为什么 canonical model 是平面图
+
+调用关系适合按入口向下展示，但真实程序存在共享依赖、递归和环。若把嵌套 tree 作为权威存储，就必须处理重复完整声明、`:ref` 合并和树中环编码。
+
+第一版因此直接采用平面 canonical model：
+
+- `:definitions` 是以 FQN Symbol 为 key 的 map；
+- `:edges` 是 typed edge 的 set；
+- `:roots` 是入口 definition set；
+- map/set 的顺序不参与语义；
+- human renderer 从 graph 投影出 call tree，对重复节点标 `[seen]`，对环标 `[circular]`；
+- 嵌套 tree 输入可以作为后续语法糖增加，但不得形成第二种内部模型。
+
+definition identity 统一使用 Cirru EDN Symbol，例如 `'app.order/submit-order!`，不在输入中把 FQN 表达成普通 String，再由 parser 隐式转换。
+
+### 3.2 Cirru EDN v1
+
+```cirru
+{}
+  :schema-version 1
+  :feature 'order-submission
+  :doc "|Validate, persist, and notify for a submitted order."
+  :roots $ #{} 'app.order/submit-order!
+  :definitions $ {}
+    'app.order/submit-order! $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Validate one order and persist it when accepted."
+      :params $ [] 'order 'context
+      :schema $ :: :fn
+        {}
+          :args $ [] 'Order 'RequestContext
+          :return 'OrderResult
+    'app.order/validate-order $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Return normalized order data or validation errors."
+      :params $ [] 'order
+      :schema $ :: :fn
+        {}
+          :args $ [] 'Order
+          :return $ :: :tuple :ok 'Order
+    'app.order/persist-order! $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Persist an accepted order."
+      :params $ [] 'order 'context
+      :schema $ :: :fn
+        {}
+          :args $ [] 'Order 'RequestContext
+          :return $ :: :tuple :ok 'OrderId
+    'app.order/order-total $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Calculate the total payable amount."
+      :params $ [] 'order
+      :schema $ :: :fn
+        {}
+          :args $ [] 'Order
+          :return :number
+    'app.order/OrderResult $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Public result returned by order submission."
+      :schema 'OrderResult
+      :code $ quote
+        defenum OrderResult
+          :accepted OrderId
+          :rejected ValidationError
+    'app.db/save-record! $ {}
+      :mode :external
+      :kind :fn
+      :schema $ :: :fn
+        {}
+          :args $ [] 'Order 'RequestContext
+          :return $ :: :tuple :ok 'OrderId
+  :edges $ #{}
+    :: :call 'app.order/submit-order! 'app.order/validate-order
+    :: :call 'app.order/submit-order! 'app.order/persist-order!
+    :: :type 'app.order/submit-order! 'app.order/OrderResult
+    :: :call 'app.order/validate-order 'app.order/order-total
+    :: :call 'app.order/persist-order! 'app.db/save-record!
+```
+
+`:schema` 直接使用当前 `CodeEntry.:schema` 的 canonical EDN，不加 `quote`。只有 `:code` 保存 Cirru AST，因此使用 `quote`。
+
+### 3.3 顶层字段
+
+| 字段 | 必需 | 含义 |
+|------|------|------|
+| `:schema-version` | 是 | architecture 输入版本，第一版为 `1` |
+| `:feature` | 是 | 稳定的 feature Symbol，用于报告与 plan identity |
+| `:doc` | 否 | 功能目标和边界说明 |
+| `:roots` | 是 | 一个或多个入口 definition Symbol |
+| `:definitions` | 是 | FQN Symbol 到 definition declaration 的 map |
+| `:edges` | 否 | typed edge set；缺省为空 set |
+
+planner 对 canonicalized architecture 计算 `plan-id` 内容 hash。`plan-id` 用于报告、work item 和 drift 对应，不写入运行时语义。
+
+### 3.4 definition declaration
+
+| 字段 | `:fn` | `:data` | 说明 |
+|------|-------|---------|------|
+| `:mode` | 必需 | 必需 | `:ensure` 表示项目中应存在；`:external` 表示只验证、不创建 |
+| `:kind` | 必需 | 必需 | 第一版为 `:fn` 或 `:data` |
+| `:doc` | ensure 必需 | ensure 必需 | 创建时写入 `CodeEntry.doc`；已有节点只比较、不覆盖 |
+| `:schema` | 必需 | 必需 | 当前 canonical annotation；已有节点作为兼容性断言 |
+| `:params` | ensure fn 必需 | 禁止 | Cirru EDN Symbol list；数量必须与 schema 对应 |
+| `:code` | 可选 | 第一版必需 | function 缺省时生成 TODO stub；data 暂不猜测语法形状 |
+| `:tags` | 可选 | 可选 | 创建时并入 `CodeEntry.tags` |
+| `:examples` | 可选 | 可选 | 创建时写入 `CodeEntry.examples`，用于提供行为契约 |
+
+`:mode :ensure` 是“存在或复用”，不是“强制覆盖成声明内容”。当同名 definition 已存在时，planner 同时保留 existing/planned 视图并执行兼容性检查。
+
+### 3.5 typed edges
+
+第一版 edge 是匿名 enum 实例：
+
+```cirru
+:: :call 'caller/a 'callee/b
+:: :type 'consumer/a 'types/T
+```
+
+- `:call` 是 edge tag，表示计划中的直接函数调用；
+- `:type` 是 edge tag，表示 schema 或数据层依赖；
+- edge 两端都必须出现在 `:definitions`；
+- target 可以是 `:ensure` 或 `:external`；
+- 第一版只实现 `:call` 与 `:type`，未来再兼容增加其他 edge kind。
+
+typed edge 是 architecture 意图，不直接写入 `CodeEntry`，也不在 TODO body 中伪造不可执行调用。actual call/type dependency 由实现后的程序重新分析。
+
+call graph 不是 task dependency graph。atomic scaffold 已经先建立全部名称、schema 和 stub，因此 caller 通常可以只依赖接口并行实现。SCC、叶子优先和拓扑层只作为未来调度建议，不成为第一版 work item 的硬约束。
+
+### 3.6 function stub
+
+无 `:code` 的 ensure function 生成普通 definition：
+
+```cirru
+defn validate-order (order)
+  todo! "|implement app.order/validate-order; planned calls: app.order/order-total"
+```
+
+要求：
+
+- 名称和参数来自声明，不从 doc/schema 猜测；
+- `:params` 每一项必须是 `Edn::Symbol`，不接受 String/Tag 隐式转换；
+- body 使用 compiler-known `todo!`，internal Never 可满足声明返回类型；
+- 静态检查产生带 definition/path 的 `W_TODO`，运行时抵达则明确失败；
+- TODO 文本仅提供人类上下文，机器关系仍以 typed edges 为准；
+- stub 带 `:scaffold` tag；完成实现后由编辑命令或检查器移除；
+- schema、doc、examples、tags 和 code 在同一次 Snapshot 写入中提交；
+- scaffold apply 接受本次新 stub 的 expected `W_TODO`，完成门禁仍在 TODO 尚存时失败。
+
+具体行为见 `08-14-todo-placeholder-rfc.md`。
+
+## 4. CLI 与 reconciliation
+
+### 4.1 主命令
+
+```bash
+cr edit scaffold --file <architecture.cirru> [options]
+```
+
+第一版参数：
+
+```text
+--code <cirru-edn>              小型单值输入
+--file <path>                   推荐的可审阅输入文件
+--dry-run                       只规范化、检查和报告
+--expect-revision <hash>        Snapshot 级 stale-write 防护
+--format human|edn|json         默认 human；EDN 是规范机器格式
+```
+
+第一版固定采用“compatible existing 复用、hard conflict 拒绝、缺失 function 生成 TODO stub”，不为唯一策略增加开关。scaffold 也不提供 `--overwrite`；批量覆盖已有 definition 属于 reconciliation/semantic patch，而不是脚手架生成。
+
+### 4.2 执行阶段
+
+1. 读取并验证 Cirru EDN；
+2. canonicalize definitions、roots、typed edges，计算 `plan-id`；
+3. 读取一次 Snapshot，计算 snapshot revision；
+4. 验证 ensure namespace 可编辑，external 可从 project/dependency/core 解析；
+5. 将节点分类为 `create`、`reuse-pending`、`reuse-complete` 或 `external`；
+6. 比较 existing/planned kind、schema、doc，并产生 diagnostics；
+7. 把全部 create 节点编译成现有 edit/transaction operation；
+8. 在内存 Snapshot 应用、解析并预处理受影响 definitions；
+9. 生成 normalized plan、reconciliation、operations、work items 和 proposed revision；
+10. dry-run 到此结束；apply 复用 transaction staged write 与 atomic rename；
+11. 成功后只维护当前 CLI user 的 cursor，并建议首个实现 target。
+
+parse、输入自冲突、不可编辑 namespace、无法解析的 external、缺失 edge endpoint 或具体类型冲突都在写入前结束。warning 不阻止 apply，但机器结果必须结构化返回。
+
+### 4.3 已有 definition
+
+已有 definition 是 graph 的一等节点。planner 并列保存 current fact 与 architecture expectation：
+
+- tree 中保留节点及其 planned edges，状态标为 `reuse-pending` 或 `reuse-complete`；
+- 记录 `origin`：`project`、`dependency` 或 `core`；
+- `existing` 保存当前 doc/schema/kind；
+- `planned` 保存 architecture doc/schema/kind；
+- apply 不修改已有 code/doc/schema/examples/tags；
+- compatible existing 节点已经提供接口；若仍带 `:scaffold` tag 或 scaffold TODO，则标为 `reuse-pending` 并继续生成稳定 work item，否则标为 `reuse-complete`；
+- conflict 默认拒绝整次 apply。
+
+`reuse-pending` 使 architecture workflow 可以中断后恢复：apply 后重新 dry-run 不会因为 definition 已经存在而丢失待实现任务。完成 definition 必须替换 TODO body 并移除 `:scaffold` tag；planner 随后才不再输出该 work item。
+
+第一版兼容规则保持保守：
+
+| 情况 | 默认行为 | 级别 |
+|------|----------|------|
+| canonical schema 与 kind 完全相同，且已完成 | `reuse-complete` | info |
+| canonical schema 与 kind 完全相同，仍有 scaffold/TODO | `reuse-pending`，继续输出 work item | info |
+| existing Dynamic、planned concrete | 复用，不自动收窄 | warning |
+| planned Dynamic、existing concrete | 复用已有强约束 | warning |
+| 参数数量或 kind 不兼容 | 不写入 | conflict |
+| 两边均 concrete 但 schema 不同 | 不写入 | conflict |
+| doc 不同 | 保留 existing，展示差异 | warning |
+| external 在 project 中存在 | 解析为 existing external | info |
+| ensure 实际来自 dependency/core | 提示改为 external | conflict |
+
+不要在 scaffold 中发明子类型系统；未来只复用统一 type unification。
+
+### 4.4 机器结果
+
+Cirru EDN stdout 是单个 map：
+
+```cirru
+{}
+  :schema-version 1
+  :ok true
+  :command :edit-scaffold
+  :feature 'order-submission
+  :plan-id |md5:plan
+  :dry-run true
+  :snapshot-revision |md5:current
+  :proposed-revision |md5:proposed
+  :normalized-plan $ {}
+    :roots $ #{} 'app.order/submit-order!
+    :definitions $ {}
+    :edges $ #{}
+  :reconciliation $ {}
+    'app.order/validate-order $ {}
+      :status :reuse-complete
+      :origin :project
+      :existing $ {}
+        :doc "|Existing validation entry."
+        :schema :dynamic
+      :planned $ {}
+        :doc "|Return normalized order data or validation errors."
+        :schema $ :: :fn
+          {}
+            :args $ [] 'Order
+            :return $ :: :tuple :ok 'Order
+      :diff $ #{} :doc :schema
+  :operations $ []
+  :work-items $ []
+  :diagnostics $ []
+```
+
+human renderer 从同一 typed result 展示 call tree、create/reuse-pending/reuse-complete/external 统计和字段差异。EDN 是规范机器格式；JSON 只作为现有 `JSON.parse`、`jq`、LSP/MCP adapter 和历史脚本的 compatibility projection。两种机器 renderer 的 stdout 都只能包含一个 value，日志与 command echo 走 stderr。
+
+## 5. 与 actual call graph 的关系
+
+architecture graph 是意图，actual call graph 是从已有代码提取的事实。二者共享 definition identity、typed edge 基本形状和 tree renderer，但不共享语义类型。
+
+- scaffold 前，architecture graph 可以描述尚不存在的程序；
+- scaffold 后，TODO stub 的 actual call edges 可以为空并标记 pending；
+- 实现后，可比较 planned `:call` edge 与 actual direct call edge；
+- `:type` edge 应与 schema/type dependency 分析比较；
+- drift 是派生报告，不自动修改 architecture 或代码。
+
+实现上抽出无状态 graph formatter/statistics；scaffold parser 不依赖全局 `PROGRAM_CODE_DATA`。
+
+## 6. 多 Agent 实现流程
+
+### 6.1 第一版协作模型
+
+CLI 只负责产生结构化 work items。parent agent 或外部 orchestrator 负责分发：
+
+1. scaffold apply 原子创建所有缺失接口和 TODO stub；
+2. 每个 create 或 reuse-pending function 形成一个默认 work item；
+3. parent 把互不重叠的 target 分配给 subagent；
+4. subagent 基于稳定 schema/doc/edges/examples 产出 definition 实现；
+5. parent 使用现有 `edit def` 或 `edit transaction` 串行写回 Snapshot；
+6. 每次写回使用最新 Snapshot revision，并运行按影响范围选择的检查；
+7. 全部 work item 完成后检查残留 `W_TODO`、类型、测试和 graph drift。
+
+这种模型允许并行完成代码设计和实现，但只保留一个 Snapshot writer。它不需要第一版实现 daemon、lease、共享锁或三方 AST merge。
+
+### 6.2 work item
+
+默认 work item 至少包含：
+
+```cirru
+{}
+  :id 'order-submission/implement-validate-order
+  :plan-id |md5:plan
+  :target 'app.order/validate-order
+  :base-snapshot-revision |md5:scaffolded
+  :write-set $ #{} 'app.order/validate-order
+  :doc "|Return normalized order data or validation errors."
+  :schema $ :: :fn
+    {}
+      :args $ [] 'Order
+      :return $ :: :tuple :ok 'Order
+  :planned-edges $ #{}
+    :: :call 'app.order/validate-order 'app.order/order-total
+  :examples $ []
+```
+
+规则：
+
+- work item ID 与 target 稳定，不包含运行时 Agent 名称；
+- `write-set` 表示默认允许修改的 definition；parent 扩大范围时必须显式处理重叠；
+- cursor user 是执行 Agent 的导航身份，由 parent 分配，不属于 architecture；
+- call graph 邻接不代表 write-set 重叠；第一版不计算强制 batch；
+- reuse-complete/external 节点不产生实现 work item，但会进入相邻 target 的上下文；
+- reuse-pending 节点在重复 dry-run/apply 后继续产生相同 ID 的 work item，直到 TODO 与 scaffold tag 被清理；
+- namespace import/config/test 等共享修改由 parent 集中处理，或在未来作为独立 typed operation 建模。
+
+### 6.3 后续 semantic patch
+
+Snapshot-level `--expect-revision` 安全但保守：两个 Agent 修改不同 definition，也会因全局 revision 变化而需要重新读取。流程走通后，可增加 definition-level semantic patch：
+
+```cirru
+{}
+  :target 'app.order/validate-order
+  :expect-definition-revision |md5:base-definition
+  :operation :replace-code
+  :code $ quote ...
+```
+
+新 definition 使用 `:expect :absent`。parent/coordinator 在最新 Snapshot 上串行 apply：互不相交的 patch 可自动接受，同一 definition 的重叠修改精确拒绝。
+
+这是后续优化，不阻塞第一版。即使加入 semantic patch，物理 Snapshot 写入仍保持 single writer；并发发生在 patch 产出，而不是最终 rename。
+
+## 7. Cursor user 的边界
+
+cursor user 用于区分 CLI 导航状态，不是 work item owner、权限身份或并发锁。parent 可以为 subagent 设置：
+
+```bash
+cr --cursor-user agent-a cursor set app.order/validate-order --path @0
+CALCIT_CURSOR_USER=agent-b cr cursor show
+cr cursor show # fallback: default
+```
+
+解析优先级仍为 `--cursor-user` > `CALCIT_CURSOR_USER` > `default`。
+
+第一版 architecture/scaffold 不依赖完整 cursor user 实现。scaffold 成功后只维护发起命令的当前 cursor；其他 user 在下次访问自己的 cursor 时按 revision/fingerprint 懒惰校验，不要求一次 source mutation 重写所有 user 状态。
+
+后续若实现多 user 持久化，推荐每 user 一个文件，而不是所有进程改同一个 `:users` map：
+
+```text
+.calcit/cursors/default.cirru
+.calcit/cursors/agent-a.cirru
+.calcit/cursors/agent-b.cirru
+```
+
+这样 navigation/clipboard 不会因共享 sidecar 的 read-modify-rename 发生 lost update。`cursor users` 可通过目录发现；每个文件仍使用 atomic rename。旧 v1-v4 sidecar 可在显式迁移时把 active entry 写入 `default`，其他合法 named entry 写入同名 user 文件。
+
+activity/overlap warning、lease 和 heartbeat 暂不实现。任务重叠优先由 parent 比较 work item `write-set`，写入正确性继续依赖 revision/precondition。
+
+## 8. 原子性与失败恢复
+
+scaffold 复用 transaction 原则：
+
+- 输入解析、reconciliation 和全部 conflict 检查先于写入；
+- 所有 create operation 在一个内存 Snapshot 中应用；
+- staging 后再次确认 `--expect-revision`；
+- Snapshot 通过同目录 staged file 和 atomic rename 提交；
+- Snapshot 成功后才维护当前 user cursor；
+- cursor 保存失败报告“源码已提交、cursor 未更新”，不得伪装为整体回滚；
+- 相同 architecture 再次 apply 必须保持 Snapshot 幂等，ensure 节点成为 reuse-pending 或 reuse-complete；
+- architecture 输入、work items 和 cursor activity 不写入运行时 Snapshot。
+
+第一版不尝试跨 Snapshot/cursor 文件做单一原子提交，也不支持同 Snapshot 多 writer。
+
+## 9. Architecture 文件生命周期
+
+需要纳入版本控制、作为可审阅设计契约的 architecture 文件，推荐放入：
+
+```text
+docs/architectures/<feature>.cirru
+```
+
+CLI 仍接受任意 `--file`。目录只是约定，不由第一版自动创建、归档或删除。`.calcit/` 只保留 cursor 等本地临时状态，不作为需要落库的 architecture plan 位置。
+
+- implementation 期间可以纳入版本控制，作为可审阅设计契约；
+- normalized content hash 形成 `plan-id`；
+- status、diagnostics、work items、actual graph 和 activity 均不回写 architecture 文件；
+- 功能完成后，项目可以归档或删除一次性 plan；
+- 若长期保留，它才承担 planned-vs-actual drift contract。
+
+第一版只保证 plan 可重复 dry-run/apply，不实现 plan registry 或生命周期管理。
+
+## 10. 分阶段实现
+
+### Phase 0：规范与兼容基础
+
+- RFC、canonical schema 和可解析 Cirru EDN fixture；
+- 修正所有示例为当前 unquoted `:: :fn` schema；
+- cursor v4 无损保留 named entries，新建默认名称使用 `default`；
+- 抽出可复用 Snapshot revision、staged commit 和 typed result renderer。
+
+### Phase 1：dry-run planner
+
+- 平面 definitions/typed edges parser 与 canonicalization；
+- Symbol FQN、root/edge 完整性和 plan-id；
+- existing/external/kind/schema/doc reconciliation，以及可恢复的 reuse-pending 状态；
+- human/EDN graph、diagnostics、operations 和一-definition-per-item work items；
+- JSON compatibility projection；
+- 不写 Snapshot 的单元与 CLI 协议测试。
+
+当前实现进度（2026-08-14）：`cr edit scaffold` 已支持 `--file`、`--code` 或 stdin 输入，以及 `human`、`edn`、`json` 输出。它验证 Symbol FQN/params、anonymous-enum edge、schema、roots/edge endpoint，计算 `plan-id`，对当前 Snapshot 做 create/reuse/external reconciliation，并输出 create operation 预览和 work items。`--dry-run` 保持只读；不带该 flag 时，会在同目录 staged file 中创建全部缺失的 `:ensure` definition，写入 doc/schema、`:scaffold` tag 和 function `todo!` stub，复核 revision 后以 atomic rename 提交。已有 definition 从不被覆盖；成功 apply 后会触发既有 cursor 后置校验。dependency/core external lookup、definition-level patch 和 per-user cursor 仍留在后续阶段。
+
+### Phase 2：atomic scaffold apply（基础版本已实现）
+
+- `todo!`、`W_TODO`、function/data `CodeEntry` operation 生成；
+- 复用 staged Snapshot、revision precondition 和 atomic write；
+- apply 后调用现有 cursor 后置校验；
+- 已覆盖幂等 apply、部分 conflict 零写入和 function stub 原子创建；
+- internal `Never` 的完整 branch/generic inference 和 cursor partial-success reporting 仍待后续统一控制流分析。
+
+### Phase 3：分布式实现闭环
+
+- parent/subagent 使用 work item 的推荐流程和文档；
+- definition 实现完成时移除 scaffold tag/TODO；
+- 残留 TODO、类型、examples/tests 和 actual graph 检查；
+- Respo 等真实项目 Snapshot 副本回归；
+- 验证多个 subagent 并行产出、parent 串行应用的完整 feature。
+
+### Phase 4：按实际需要演进
+
+- definition-level semantic patch/precondition；
+- `ensure-import` 等可合并 namespace operation；
+- per-user cursor 文件与 lazy revalidation；
+- planned/actual graph drift；
+- SCC/batch 建议、更丰富 edge kind；
+- 只有基准或真实冲突证明必要时，才评估 writer coordinator/daemon。
+
+## 11. 验收标准
+
+- 一个 Cirru EDN plan 可声明多个 root、共享依赖、external、递归和 typed edges；
+- definition ID 与 params 使用 Symbol，schema 使用当前 canonical unquoted EDN；
+- map/set 顺序不影响 normalized plan-id；
+- dry-run 不修改 Snapshot/cursor，EDN stdout 是单个可解析 value；
+- 已有 definition 在 tree/reconciliation 中可见，包含 origin、existing/planned 和字段差异；
+- compatible existing definition 被复用且不覆盖，具体 kind/schema 冲突使整个 apply 零写入；
+- apply 一次创建全部缺失 definition，function stub 使用 `todo!` 并产生精确 `W_TODO`；
+- 再次 apply 同一输入保持 Snapshot 幂等，未完成的 reuse-pending work item 仍可恢复；
+- 每个待实现 function 产生稳定 work item，含 target、write-set、schema、doc 和 planned edges；
+- work item 不绑定 cursor user，也不把 call adjacency 当成写入冲突；
+- parent 能把多个 work item 分发给 subagent，并通过现有 edit/transaction 串行写回；
+- 完成后可检查残留 TODO、类型、测试和 planned/actual call edge；
+- scaffold 成功后的 cursor revision/fingerprint 可验证，sidecar 失败报告 partial success；
+- `cargo fmt`、`cargo clippy -- -D warnings`、`cargo test`、`yarn compile`、`yarn check-agent-interface` 和 `yarn check-all` 通过。
+
+## 12. 待定问题
+
+1. `:params` 是否允许 destructuring？第一版只接受 Symbol list，复杂参数由显式 `:code` 提供。
+2. data definition 的 schema/code 一致性如何统一校验？应复用 struct/enum/trait preprocess，不做文本 token 比较。
+3. `:examples` 第一版是否直接写入 `CodeEntry.examples`，还是先只进入 work item？推荐能够通过现有 examples 校验时直接写入。
+4. semantic patch 的 typed operation 形状留到 Phase 4，第一版继续复用现有 transaction argument list。
+5. architecture 长期保留时，哪些 typed edge 算 hard drift contract？第一版只报告，不阻止普通 build。

--- a/RFCs/08-14-todo-placeholder-rfc.md
+++ b/RFCs/08-14-todo-placeholder-rfc.md
@@ -1,0 +1,172 @@
+# RFC: `todo!` 未实现占位表达式与静态提醒
+
+状态：Draft  
+日期：2026-08-14  
+关联：`08-14-architecture-scaffold-rfc.md`、`03-05-function-schema-dual-track-rfc.md`、`07-26-static-semantic-analysis-rfc.md`
+
+## 1. 概要
+
+新增与 Rust `todo!()` 对应的 Calcit 占位表达式：
+
+```cirru
+defn validate-order (order)
+  todo! "|implement order validation"
+```
+
+`todo!` 表示“此路径刻意尚未实现”，同时满足三类契约：
+
+- 类型检查：可出现在任意期望返回类型的位置，不产生返回类型 mismatch；
+- 静态诊断：产生带精确 definition/path 的 `W_TODO`，提醒 Agent 仍有未完成工作；
+- 运行时：一旦执行到该路径，native/JS 明确抛出 TODO error，WASM 执行 `unreachable` trap。
+
+它不是 `raise` 的别名。`raise` 表示程序设计中的普通异常路径，静态分析不应据此推断代码未完成；`todo!` 表示开发状态，必须能被结构化查询和完成门禁识别。
+
+## 2. 表面语法
+
+第一版支持零或一个 String 参数：
+
+```cirru.no-check
+todo!
+todo! "|implement app.order/validate-order"
+```
+
+约束：
+
+- 名称使用 `todo!`；`!` 是 Calcit 命名约定的一部分，不采用 Rust 括号宏语法；
+- message 省略时使用稳定默认文本 `TODO: implementation is pending`；
+- message 必须是静态 String literal，保证 analyzer 无需执行代码即可输出原因；
+- 多参数、Tag、动态拼接或 metadata map 第一版拒绝，避免占位表达式演变成日志 API；
+- scaffold 需要携带 planned calls 时，将它们格式化进静态 message，同时仍以 architecture graph 作为机器可读来源。
+
+## 3. 类型语义
+
+### 3.1 Never/bottom
+
+目标语义中，`todo!` 的表达式类型是内部 `Never`（bottom type），不是 `Unit` 或任意伪造的业务类型：
+
+```cirru
+defn load-user (id)
+  ; schema return: User
+  todo! "|load user"
+```
+
+规则：
+
+- actual `Never` 满足任意 expected type，因此不产生 `W_FN_RETURN_TYPE_MISMATCH`；
+- `if` / `match` 的一个分支为 `Never`、另一分支为 `T` 时，整体推断为 `T`；
+- `Never` 不参与泛型变量绑定，不把 `T` 推断成 `Never`；
+- `Never` 没有运行时 value，也不能构造或存入 collection；
+- 第一阶段只作为 compiler internal annotation；不承诺用户可在 schema 中显式写 `'Never`。
+
+当前基础实现以 compiler-known diverging proc 的 `Dynamic` 返回签名避免伪造的返回类型 mismatch，同时由 `W_TODO` 保留“未完成”信息；它尚未改变 `if`/泛型的类型 join。完整 `Never` 是下一阶段的类型系统工作，届时替换该内部表示，而不改变表面语法或诊断协议。
+
+### 3.2 与控制流的关系
+
+`todo!` 是 diverging expression。preprocessor 在它之后仍可保留源码用于展示，但控制流和类型 join 不要求该表达式返回。第一版不借此实现完整的 unreachable-code warning；这可以在未来与 `raise`、`quit!` 的控制流分析统一处理。
+
+## 4. 静态诊断
+
+每个 `todo!` 产生：
+
+```text
+[W_TODO] TODO remains in `app.order/validate-order`: implement order validation
+  at app.order/validate-order @3
+```
+
+Cirru EDN diagnostic 至少包含：
+
+```cirru
+{}
+  :code :W_TODO
+  :severity :warning
+  :namespace 'app.order
+  :definition 'validate-order
+  :path $ [] 3
+  :message "|implement order validation"
+```
+
+诊断策略：
+
+- `W_TODO` 是 completion warning，不是 type warning；同一位置不得再产生伪造的返回类型 mismatch；
+- scaffold dry-run/apply 把它列入 expected warnings，不把新 stub 当成 apply conflict；
+- `cr --check-only` 遵循当前严格 warning 策略：可创建 scaffold，但仍有 reachable TODO 时检查返回非零，Agent 不能宣称功能完成；
+- `cr analyze check-types` 扫描所选 Snapshot definition，将 TODO 数量和 diagnostics 纳入 human/Cirru EDN 报告，即使节点暂时不从 entry 可达；
+- 后续若引入 warning severity/allow-list，`W_TODO` 的默认 completion gate 仍应为 deny，显式探索性运行才允许降级；
+- Cirru EDN stdout 保持单个 value；JSON 只作为现有工具兼容投影，human warning 与普通命令提示走 stderr。
+
+## 5. 运行时与 codegen
+
+即使静态门禁通常会先发现 TODO，各后端仍必须定义一致的防御行为：
+
+| 后端 | 行为 |
+|------|------|
+| native | 返回 `CalcitErrKind::Effect`，message 以 `TODO:` 为前缀并附 call stack |
+| JavaScript | 生成 `throw new Error("TODO: ...")` |
+| WASM | 在可选 host log 后执行 `unreachable`；第一版至少保证 trap，不返回伪值 |
+| IR | 保留明确的 todo/diverge 节点，不能降为 `nil` |
+
+`try` 是否能捕获 native/JS TODO 第一版沿用普通 runtime error 机制；静态 `W_TODO` 不因外层存在 `try` 而消失，因为捕获异常不代表实现已经完成。
+
+## 6. 实现形态
+
+推荐将 `todo!` 作为 compiler-known builtin/syntax，而不是 calcit-core 普通函数：
+
+- parser/name resolution 能稳定识别，不受局部同名 binding 影响；
+- type inference 可直接返回 internal `Never`；
+- preprocessor 能在表达式位置产生精确 `W_TODO`；
+- JS/WASM codegen 可直接生成 diverging operation；IR 的显式 todo/diverge 节点留在后续实现；
+- runtime 不需要用普通 `raise` 猜测某段字符串是否以 TODO 开头。
+
+当前实现采用 `CalcitProc::Todo`：preprocessor 对它生成精确 `W_TODO`，Dynamic signature 仅作为完整 `Never` 前的临时内部兼容表示，不能把 warning 当作可忽略的普通动态边界。
+
+## 7. 与 scaffold 的关系
+
+architecture scaffold 默认生成：
+
+```cirru
+defn validate-order (order)
+  todo! "|implement app.order/validate-order; planned calls: app.order/order-total"
+```
+
+- doc/schema/params 正常写入 `CodeEntry`；
+- `:scaffold` tag 与 `W_TODO` 分工：tag 表示 definition 来源，warning 表示代码中仍存在未实现路径；
+- 完成实现时必须移除对应 `todo!`；是否同时自动移除 `:scaffold` tag 由 scaffold completion check 决定；
+- planned edges 仍来自 architecture graph，不把 message 当成可解析协议；
+- 实际 call graph 在实现前可以没有 planned calls，drift report 应把这种缺失标记为 `pending`，而不是伪造不可执行调用。
+
+## 8. 分阶段实现
+
+### Phase A：基础可用版本（已实现）
+
+- 注册 `todo!`；
+- native runtime TODO effect；
+- 精确 `W_TODO` preprocessing diagnostic；
+- function schema return context 测试；
+- 完整 internal Never/bottom、branch/generic 规则留给后续控制流分析。
+
+### Phase B：分析与后端
+
+- `analyze check-types` 全 Snapshot TODO 扫描及 Cirru EDN machine result；
+- JS/WASM codegen 已实现；IR 的显式 todo/diverge 节点仍待实现；
+- `--check-only`、eval、test 和 codegen warning 行为测试；
+- Agent 文档与 error-handling 文档。
+
+### Phase C：scaffold 接入
+
+- scaffold 默认 `--stub todo`；
+- generated/expected warning 分类；
+- TODO 清零和 `:scaffold` tag 完成检查；
+- architecture drift 的 pending edge 表达。
+
+## 9. 验收
+
+- `todo!` 可作为 `'Number`、`'String`、Struct、Enum、generic 和 `Unit` 函数的返回表达式，不产生类型 mismatch；
+- `if condition (todo! "|left") 1` 推断为 Number；
+- 每处 TODO 都产生一个带稳定 `W_TODO`、FQN、path 和 message 的 diagnostic；
+- `analyze check-types` 能发现当前 entry 不可达 definition 内的 TODO；
+- scaffold apply 可成功创建 TODO stub，但完成门禁不会在 `W_TODO` 尚存时通过；
+- native、JS、WASM 执行到 TODO 时均中止，不返回 `nil` 或默认值；
+- `raise "|TODO..."` 不产生 `W_TODO`，普通异常语义保持不变；
+- shadowing 或同名用户 definition 不会被误判为 compiler TODO；
+- Cirru EDN stdout 保持单个 value，兼容 JSON renderer 不改变该纯净度契约；
+- 全部核心、CLI、JS 和 WASM 回归通过。

--- a/RFCs/08-14-todo-placeholder-rfc.md
+++ b/RFCs/08-14-todo-placeholder-rfc.md
@@ -94,6 +94,11 @@ Cirru EDN diagnostic 至少包含：
 - 后续若引入 warning severity/allow-list，`W_TODO` 的默认 completion gate 仍应为 deny，显式探索性运行才允许降级；
 - Cirru EDN stdout 保持单个 value；JSON 只作为现有工具兼容投影，human warning 与普通命令提示走 stderr。
 
+参数契约也由 compiler-known proc 统一执行：`todo!` 只接受零个参数，或一个
+静态 String literal；非 literal 参数和多余参数在 preprocessing 阶段分别报告
+Type/Arity 错误并阻止 codegen。native、JavaScript、WASM backend 仍保留同样的
+校验作为防御性边界，不把非法调用静默降级为 unconditional trap。
+
 ## 5. 运行时与 codegen
 
 即使静态门禁通常会先发现 TODO，各后端仍必须定义一致的防御行为：

--- a/RFCs/README.md
+++ b/RFCs/README.md
@@ -1,6 +1,6 @@
 # RFC 整理索引
 
-更新时间：2026-08-08
+更新时间：2026-08-14
 
 ## 目录原则
 
@@ -39,6 +39,8 @@
 | `07-28-git-module-store-rfc.md`                     | Draft         | 保持 `deps.cirru` 与 Git 模块路径，以 tag 为最佳实践并使用 pnpm 式全局目录存储；不引入 registry、lockfile、workspace 或多版本。 |
 | `07-28-project-tooling-contract-rfc.md`             | Draft         | 在既有 `cr` 子命令上补强单项目工具契约，保持 EDN 树形事实来源。                                                        |
 | `07-28-persistent-tree-cursor-rfc.md`               | Draft         | `.calcit/` 本地状态、虚拟 cursor、region/marks/last-query、结构化 clipboard 与 path 迁移。                            |
+| `08-14-architecture-scaffold-rfc.md`                | Implemented   | Cirru EDN architecture graph、existing-definition reconciliation、atomic scaffold apply、work items 与多 Agent 分工边界。 |
+| `08-14-todo-placeholder-rfc.md`                      | Partial       | compiler-known `todo!`、`W_TODO` 与 native/JS/WASM 中止行为已落地；完整 Never/control-flow inference 后续实现。 |
 | `08-04-strict-cirru-edn-decoding-rfc.md`            | Implemented   | Phase 1：`parse-cirru-edn-as` 严格类型化反序列化、无 Dynamic 的 `EdnDecoderGraph`、名义身份与 Native/JS 一致性。    |
 | `08-05-systematic-nil-reduction-rfc.md`              | Partial       | 类型驱动减少 nil：先拆分可省略参数与 nullable 值，再迁移至 Option/Result 并逐步收紧 typed code。                  |
 | `08-08-cross-backend-host-ffi-contracts-rfc.md`      | Draft         | 统一 JS/native/WASM/WASI 的逻辑 FFI 契约与诊断，ABI transport 保持 backend-specific；首个完整 shape consumer 为 JS/DOM。 |

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -117,6 +117,34 @@ path 使用从零开始的 child index：`@3.2` 表示先取 definition 根 list
 
 同一个 Snapshot 的写命令必须串行执行，包括 `config`、`edit`、`tree` 和 cursor mutation；两个进程同时读取再保存会发生最后写入覆盖。需要并行时使用独立 Snapshot/worktree，需要同一文件内的原子多步修改时使用 transaction 和 `--expect-revision`。
 
+### Feature-level architecture scaffold
+
+当任务包含多个相互调用的 definition 时，先把架构写入版本控制中的
+`docs/architectures/<feature>.cirru`，再运行 scaffold planner：
+
+```bash
+cr calcit.cirru edit scaffold --file docs/architectures/order.cirru \
+  --dry-run --format edn
+```
+
+Architecture plan 是 Cirru EDN 数据：definition FQN 和 `:params` 使用
+Symbol，调用/类型关系使用 `:: :call` / `:: :type` anonymous enum，不能用
+混合类型的 `[]` 表示。先查看 `reconciliation`、warnings 与 work items；
+已有 definition 仍会出现在结果中。只有确认 revision 后才 apply：
+
+```bash
+cr calcit.cirru edit scaffold --file docs/architectures/order.cirru \
+  --expect-revision md5:... --format edn
+```
+
+apply 只创建缺失的 `:ensure` definition，不覆盖已有 code/doc/schema。新建
+函数带 `:scaffold` tag 和 `todo!`，因此会产生 `W_TODO`；它们是待分配的
+work items，不是已经完成的实现。父 Agent 可以并行分发 work item，但第一
+版仍应在最新 Snapshot 上串行合并实现，使用 revision/write-set 防止陈旧写入。
+
+Architecture 计划放在 `docs/`，而 `.calcit/` 只保存本机 cursor、error 和
+snippets 等临时状态；不要把需要评审的设计落进隐藏目录。
+
 ## 3. 高频黄金路径：查询 → 编辑 → 验证
 
 下面是需要替换 `<...>` 占位符的任务模板，不能原样执行。target、needle 和 replacement 必须来自当前项目及用户目标。先看搜索结果中的 `[#N]`，确认后再用同一序号设置 cursor：

--- a/docs/features/error-handling.md
+++ b/docs/features/error-handling.md
@@ -147,12 +147,30 @@ assert= (+ 1 2) 3
 assert-type x :number
 ```
 
+## Marking unfinished paths with `todo!`
+
+Use the compiler-known `todo!` expression for an intentionally unfinished
+implementation, especially in scaffold-generated definitions:
+
+```cirru.no-check
+defn validate-order (order)
+  todo! "|implement order validation"
+```
+
+`todo!` accepts zero or one static String message. Static preprocessing emits a
+`W_TODO` warning with the definition and path, so normal check/codegen gates
+continue to report unfinished work. Reaching it at runtime raises a TODO effect;
+JavaScript throws an Error and WASM traps. It is not an alias for `raise`:
+`raise` is an ordinary application error path and does not mean that an Agent
+still needs to implement the code.
+
 ## Notes
 
 - `raise` accepts any value that can be converted to a string. String literals and tags work best.
 - Raising maps or complex data structures may produce unexpected results — use the Result enum pattern for structured error data.
 - `try` always produces a value: either the result of the body, or the result of the handler.
 - `assert` / `assert=` are for development-time invariants. They generate warnings (not runtime errors) during static analysis.
+- `todo!` is a completion warning and should be removed when the implementation is finished; do not use it for recoverable domain errors.
 
 ## See Also
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -113,7 +113,8 @@ defn load-user (id)
 
 Each occurrence emits `W_TODO` with the containing namespace, definition, and
 structural path. A static String literal is required for the message; invalid
-messages also emit `W_TODO_MESSAGE_LITERAL`. The placeholder is accepted in a
+messages or extra arguments are rejected as type/arity errors before codegen;
+they do not emit a completion warning. The placeholder is accepted in a
 declared return position without manufacturing a return-type mismatch, but the
 warning remains a completion-gate failure until the body is implemented.
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -42,6 +42,7 @@ The static analysis system provides:
 - **Type inference** - Automatically infers types from literals and expressions
 - **Type annotations** - Optional type hints for function parameters and return values
 - **Compile-time warnings** - Catches errors before code execution
+- **Completion warnings** - Keeps scaffolded `todo!` paths visible to Agents
 - **Composable runtime assertions** - `assert-type` and `assert-traits` can validate values at runtime and return original values for chaining
 
 ## Static Project Reports
@@ -99,6 +100,25 @@ For one expression, `cr query type-at '<ns/def>' --path code@... --format json` 
 These analysis commands run as static Snapshot readers: they load configured modules and core metadata but do not preprocess or execute the application entry. With `--format json`, stdout is one versioned JSON envelope containing a stable scope revision, filters, summary, and definition-level rows; startup/command messages stay on stderr.
 
 `analyze deprecated` scans calls to definitions tagged `:deprecated`. It reports every calling definition and a stable `code@...` path, and includes the target definition's documentation so migrations can be automated without maintaining a second hard-coded legacy API list. Use `--summary-only --format json` for migration gates that only need aggregate counts.
+
+### TODO completion warnings
+
+`todo!` is a compiler-known diverging placeholder for code that is intentionally
+not implemented yet:
+
+```cirru.no-check
+defn load-user (id)
+  todo! "|implement user lookup"
+```
+
+Each occurrence emits `W_TODO` with the containing namespace, definition, and
+structural path. A static String literal is required for the message; invalid
+messages also emit `W_TODO_MESSAGE_LITERAL`. The placeholder is accepted in a
+declared return position without manufacturing a return-type mismatch, but the
+warning remains a completion-gate failure until the body is implemented.
+
+`raise "|TODO..."` does not emit `W_TODO`, because ordinary exception behavior
+and implementation-completion status are separate concerns.
 
 `analyze.weak-types` uses protocol `schema_version: 2` because nil intent classes and `W_NIL_TYPE_DEBT` extend previously closed machine-readable enums. Consumers should reject v1 when they require the nil-contract fields rather than accepting the old version and failing on new intent values.
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -26,6 +26,22 @@ cr --help
 
 Quick note: `cr edit format` rewrites the target snapshot using canonical serialization without guessing semantic changes. It normalizes legacy namespace records and top-level `:configs`, and rewrites legacy schema type tags such as `:string` and `:ref` to quoted symbols such as `'String` and `'Ref` only in known type positions. Ordinary tag data stays unchanged. It then emits recoverable stderr advisories for legacy filenames, legacy `:any`, and unresolved dynamic type debt. Use `cr analyze weak-types` for exact paths and recommendations; format warnings do not turn the command into a type-quality gate.
 
+For feature-level planning, use `cr edit scaffold`. Its primary input is a
+Cirru EDN architecture plan, preferably stored under
+`docs/architectures/<feature>.cirru`:
+
+```bash
+cr calcit.cirru edit scaffold --file docs/architectures/order.cirru \
+  --dry-run --format edn
+cr calcit.cirru edit scaffold --file docs/architectures/order.cirru \
+  --expect-revision md5:... --format edn
+```
+
+`--dry-run` previews reconciliation and work items without writing. Apply mode
+atomically creates missing definitions only; existing definitions are reported
+with their planned/existing metadata and are never overwritten. EDN is the
+canonical machine format; JSON is a compatibility projection.
+
 ## Detailed Option Descriptions
 
 ### Input File

--- a/docs/run/edit-tree.md
+++ b/docs/run/edit-tree.md
@@ -174,6 +174,43 @@ cr calcit.cirru cursor clear-clipboard
 
 Use `cr calcit.cirru cursor clear` to remove the local selection and clipboard together. Transaction child operations deliberately do not mutate the real cursor file; after a committed transaction, the parent command revalidates or uniquely relocates the cursor against the final snapshot and warns if manual recovery is required.
 
+### Architecture Scaffold
+
+`cr edit scaffold` turns one feature-level architecture plan into a validated
+set of definition work items. The recommended source is Cirru EDN under
+`docs/architectures/`; the canonical graph uses Symbol FQNs in `:definitions`
+and homogeneous typed anonymous-enum edges such as
+`:: :call 'app.order/validate 'app.order/order-total`.
+
+Preview first:
+
+```bash
+cr calcit.cirru edit scaffold \
+  --file docs/architectures/order-submission.cirru \
+  --dry-run --format edn
+```
+
+Apply with a revision precondition:
+
+```bash
+cr calcit.cirru edit scaffold \
+  --file docs/architectures/order-submission.cirru \
+  --expect-revision md5:... --format edn
+```
+
+Scaffold reconciliation keeps existing definitions in the result. Compatible
+definitions become `reuse-complete` or `reuse-pending`; documentation and
+Dynamic-schema differences are warnings; concrete kind/schema conflicts reject
+the whole apply. Only missing `:ensure` definitions are created. Function stubs
+contain `todo!` and are marked `:scaffold`; data definitions must provide an
+explicit quoted `:code`.
+
+The apply stages the complete Snapshot, rechecks its revision, and commits with
+one atomic rename. A successful apply then revalidates the current cursor. The
+work item is the unit assigned to an Agent; the first workflow keeps Snapshot
+writes serial at the parent/coordinator even when implementation work is
+parallel.
+
 ### Atomic Transactions
 
 `cr edit transaction` applies existing `edit`, `tree`, and `config` mutations to a staged snapshot. The original snapshot is replaced only after every operation succeeds and the staged result can be loaded and serialized again. A failed operation, stale revision, or `--dry-run` leaves the original file unchanged.

--- a/docs/run/project-structure.md
+++ b/docs/run/project-structure.md
@@ -87,6 +87,31 @@ cr config set-type-slot --entry test :dispatch-op app.test-schema/TestOp
 cr config rm-type-slot :dispatch-op
 ```
 
+## Architecture plans and local Agent state
+
+Architecture plans that belong in version control should live under
+`docs/architectures/<feature>.cirru`. They describe a feature as a flat
+Cirru EDN `:definitions` map plus typed anonymous-enum edges, and can be
+reviewed independently from the generated Snapshot stubs:
+
+```bash
+cr calcit.cirru edit scaffold \
+  --file docs/architectures/order-submission.cirru \
+  --dry-run --format edn
+cr calcit.cirru edit scaffold \
+  --file docs/architectures/order-submission.cirru \
+  --expect-revision md5:...
+```
+
+`--dry-run` is read-only. An apply creates only missing `:ensure` definitions,
+preserving existing code/doc/schema and reporting compatible reuse or conflicts.
+Generated function definitions carry a `:scaffold` tag and `todo!` body so they
+remain visible to static checks and can be assigned as work items.
+
+`.calcit/` remains local transient state for cursor, error, and snippets. Do
+not store architecture plans there; do not commit cursor sidecars with the
+project source.
+
 ## `deps.cirru` 与运行时快照文件的关系
 
 给 Agent 一个最小心智就够：

--- a/editing-history/20260814-1412-architecture-scaffold-rfc-and-cursor-envelope.md
+++ b/editing-history/20260814-1412-architecture-scaffold-rfc-and-cursor-envelope.md
@@ -1,0 +1,46 @@
+# 功能架构脚手架 RFC 与 cursor envelope 兼容性
+
+## 背景
+
+单 definition 的 `cr edit def` 无法直接承载一个功能的调用结构、接口约束、已有节点复用和批量生成计划。未来多个 Agent 拆分实现时，还需要在不承诺同 Snapshot 并发写安全的前提下，确保 cursor sidecar 不会丢弃其他 cursor user 的位置数据。
+
+## 本次结论
+
+- 新增 `RFCs/08-14-architecture-scaffold-rfc.md`，建议以 `cr edit scaffold` 接收 Cirru EDN desired-state overlay；canonical model 是 Symbol FQN 到 declaration 的平面 map 加 typed anonymous-enum edge set（如 `:: :call from to`），tree 只作为展示或未来输入语法糖。
+- architecture declaration 包含 mode、kind、doc、当前 canonical schema、函数参数和可选 code/examples；已有 definition 默认复用，具体 schema/kind 冲突拒绝整次 apply。旧示例中的 quoted `:: 'Fn` 已修正为 unquoted `:: :fn`，只有 code AST 使用 quote。
+- 已有 definition 不会从 scaffold graph 中消失：planner 同时展示 existing/planned doc、schema、kind 和字段级 diff；apply 不覆盖现有内容，差异通过 info/warning/conflict diagnostics 报告。
+- 函数 `:params` 属于程序内部元数据，architecture Cirru EDN 使用 Symbol（如 `'order`），parser 不把 String/Tag 隐式转换成参数名。
+- scaffold stub 不再用普通 `raise`：新增 `08-14-todo-placeholder-rfc.md`，设计 compiler-known `todo!`、internal Never、`W_TODO` 和各后端的 diverging 行为；scaffold apply 可创建 stub，但 TODO 完成门禁仍失败。
+- scaffold 与 TODO 的规范机器结果改用 Cirru EDN，保留 Symbol/Tag/Set/Quote/schema 的数据身份；JSON 只作为既有 Agent、`jq` 和 LSP/MCP 工具的兼容 renderer。
+- 多 Agent 第一版采用“并行产出 definition 实现、parent/coordinator 串行写回 Snapshot”；CLI 只输出带 target/write-set/schema/doc/planned edges 的 work item，不启动 Agent，也不把 call graph 当成硬任务依赖。
+- reconciliation 区分 `create`、`reuse-pending`、`reuse-complete` 和 `external`；带 scaffold/TODO 的已有节点会在重复 dry-run 时继续产生稳定 work item，保证中断后可恢复。
+- definition-level semantic patch、`ensure-import` 和 SCC/batch 建议留到流程走通后；第一版继续复用 Snapshot revision、现有 edit/transaction 与 staged atomic write。
+- 第一版不暴露只有单一有效值的 `--stub`/`--existing` 策略开关，直接固定为 compatible reuse、hard conflict reject 和 TODO stub。
+- cursor 身份仍为 `--cursor-user` > `CALCIT_CURSOR_USER` > `default`，但 architecture 不再把 work item 绑定到 cursor user。未来多 user 推荐 `.calcit/cursors/<user>.cirru`，source mutation 只立即迁移当前 user，其他 user 下次访问时 lazy revalidate。当前新建 v4 sidecar 的默认 cursor key 先从 `main` 改为 `default`。
+- scaffold 只生成普通 `CodeEntry` stub，不增加运行时架构元数据；后续实现和 drift 检查继续复用现有 call graph、query、tree 和 cursor。
+- cursor v4 文件本来已有 `:active` 与 `:cursors` map，但 Rust 内存模型只保留 active state，任何保存都会把 map 收缩为固定 `:main`。
+- `CursorDocument` 现在保存实际 `active_name` 和其他 cursor state，序列化时合并写回，因此可无损 round-trip named cursors；CLI 行为仍只作用于 active entry。
+- architecture 文件实现期间可约定放在 `docs/architectures/<feature>.cirru` 并用 normalized content hash 形成 plan-id；派生的 status/work items/diagnostics 不回写 plan。`.calcit/` 只承载本地临时 cursor 状态。
+- 本轮没有实现 cursor user 选择、per-user 文件、semantic patch、lease、心跳或并发锁；这些都不阻塞 architecture → scaffold → work items → 串行整合的第一版闭环。
+
+## 验证
+
+- `cargo fmt --all -- --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-agent-interface`（12/12）
+- `yarn check-all`
+- `cargo test --bin cr cli_handlers::cursor::tests`（19/19，包含 `default` key 与 named cursor round-trip）
+- 用 `cr cirru parse-edn` 验证 RFC 中 architecture、machine result 与 work item 示例；带空格 doc 使用双引号保护 pipe string。
+- architecture result、TODO diagnostic、通用 machine envelope 与 Definition Descriptor 的 EDN 示例均通过 `cr cirru parse-edn`。
+
+新增/扩展的 cursor round-trip 测试覆盖非默认 active 名称和非 active cursor 条目的保存与恢复。
+
+## Scaffold 与 `todo!` 基础实现进度
+
+- 新增 `cr edit scaffold`；接受平面 architecture Cirru EDN，输出 human、canonical EDN 或 JSON compatibility projection。
+- parser 强制 FQN/params 使用 Symbol，edge 使用匿名 enum（`:: :call from to` / `:: :type from to`），拒绝误用异构 list 的 edge。
+- planner 验证 roots/edge endpoint、schema 与 namespace，reconcile 现有 definition，并输出 create/reuse-pending/reuse-complete/external、预览 operation 和带 plan/base revision/write-set 的 work item。
+- `--dry-run` 保持只读；apply 在 staged Snapshot 中一次创建全部缺失 `:ensure` definition，function 生成 `todo!` stub，写入 doc/schema/`:scaffold`，复核原 revision 后 atomic rename，绝不覆盖已有 definition。apply 成功后触发已有 cursor 后置校验。
+- 新增 compiler-known `todo!` proc：native effect 中断，preprocessor 产生 `W_TODO`，JS/WASM codegen 均显式中断。完整 Never/branch/generic inference、definition-level patch 和 external dependency/core lookup 仍待后续实现。

--- a/editing-history/20260814-1640-architecture-scaffold-review-fixes.md
+++ b/editing-history/20260814-1640-architecture-scaffold-review-fixes.md
@@ -1,0 +1,21 @@
+# 2026-08-14 16:40 — architecture scaffold review fixes
+
+## Summary
+
+- Processed PR #351 review comments for scaffold reconciliation, metadata preservation, machine-result revisions/diffs, work-item identity, and writer concurrency.
+- Made explicit function code, tags, examples, and data code survive scaffold apply; generated `:scaffold` only for TODO function stubs.
+- Added empty-root validation, external target compatibility validation, per-definition diffs, proposed/applied revisions, and post-scaffold work-item revisions.
+- Added a destination writer lock around staged snapshot replacement and strengthened the named-cursor round-trip fixture with distinct states.
+- Enforced one `todo!` argument contract across preprocessing, JavaScript, WASM, and native boundaries; diagnostics now identify the containing definition and invalid messages use the argument location.
+- Expanded the machine-protocol RFC with canonical JSON tagged projections and stdio framing/negotiation fixtures, and aligned the cursor default example with `:default`.
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-agent-interface`
+- `yarn check-all`
+- `cr docs check-md` for all modified RFC and static-analysis documents
+

--- a/editing-history/20260814-1640-architecture-scaffold-review-fixes.md
+++ b/editing-history/20260814-1640-architecture-scaffold-review-fixes.md
@@ -8,6 +8,7 @@
 - Added a destination writer lock around staged snapshot replacement and strengthened the named-cursor round-trip fixture with distinct states.
 - Enforced one `todo!` argument contract across preprocessing, JavaScript, WASM, and native boundaries; diagnostics now identify the containing definition and invalid messages use the argument location.
 - Expanded the machine-protocol RFC with canonical JSON tagged projections and stdio framing/negotiation fixtures, and aligned the cursor default example with `:default`.
+- Added a concrete nested EDN/JSON typed-value fixture and equivalent EDN/JSON handshake fixture requirements.
 
 ## Validation
 
@@ -18,4 +19,3 @@
 - `yarn check-agent-interface`
 - `yarn check-all`
 - `cr docs check-md` for all modified RFC and static-analysis documents
-

--- a/editing-history/20260814-1700-fix-bare-empty-map-js-codegen.md
+++ b/editing-history/20260814-1700-fix-bare-empty-map-js-codegen.md
@@ -1,0 +1,10 @@
+# Bare empty-map JS codegen
+
+- A bare Cirru `{}` survives preprocessing as `CalcitProc::NativeMap`, rather
+  than as an already-created map value.
+- JS code generation must invoke that runtime constructor when it is used as a
+  value. Emitting the escaped proc name alone produced `$clt._$M_`, an alias
+  that the runtime does not export.
+- Keep a focused codegen test for the emitted `$clt._$n__$M_()` call. This
+  protects empty map values in typed struct constructors and ordinary calls
+  such as `merge {} other`.

--- a/editing-history/20260814-1710-map-codegen-callee-context.md
+++ b/editing-history/20260814-1710-map-codegen-callee-context.md
@@ -1,0 +1,9 @@
+# Empty-map codegen needs callee context
+
+- In JS codegen a bare `CalcitProc::NativeMap` must produce an empty map by
+  invoking the runtime constructor.
+- The same proc at the head of a list is the constructor callee and must not be
+  pre-invoked. Otherwise generated code becomes `map()(...entries)`.
+- Keep separate regression assertions for the bare value and an entry-bearing
+  map literal, and run the emitted-JS Node suite because unit output alone
+  cannot catch a callee/value context mix-up.

--- a/src/bin/cli_handlers/atomic_write.rs
+++ b/src/bin/cli_handlers/atomic_write.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub(crate) struct StagedFile {
   destination: PathBuf,
   temporary: PathBuf,
+  lock: PathBuf,
   committed: bool,
 }
 
@@ -41,6 +42,7 @@ impl StagedFile {
       )
     })?;
     self.committed = true;
+    let _ = fs::remove_file(&self.lock);
     Ok(())
   }
 }
@@ -49,6 +51,7 @@ impl Drop for StagedFile {
   fn drop(&mut self) {
     if !self.committed {
       let _ = fs::remove_file(&self.temporary);
+      let _ = fs::remove_file(&self.lock);
     }
   }
 }
@@ -78,6 +81,13 @@ pub(crate) fn stage_atomic_file(destination: &Path, content: &[u8], label: &str)
     .map_err(|error| format!("System clock error while staging {label}: {error}"))?
     .as_nanos();
   let file_name = destination.file_name().and_then(|value| value.to_str()).unwrap_or("calcit-state");
+  let lock = parent.join(format!(".{file_name}.lock"));
+  let _lock_file = OpenOptions::new().write(true).create_new(true).open(&lock).map_err(|error| {
+    format!(
+      "Failed to acquire writer lock for staged {label} destination '{}': {error}",
+      destination.display()
+    )
+  })?;
 
   for attempt in 0..32_u8 {
     let temporary = parent.join(format!(".{file_name}.{}.{nonce}.{attempt}.tmp", std::process::id()));
@@ -88,12 +98,14 @@ pub(crate) fn stage_atomic_file(destination: &Path, content: &[u8], label: &str)
     };
     if let Err(error) = file.write_all(content).and_then(|_| file.sync_all()) {
       let _ = fs::remove_file(&temporary);
+      let _ = fs::remove_file(&lock);
       return Err(format!("Failed to write staged {label} file '{}': {error}", temporary.display()));
     }
     if let Some(permissions) = &permissions
       && let Err(error) = fs::set_permissions(&temporary, permissions.clone())
     {
       let _ = fs::remove_file(&temporary);
+      let _ = fs::remove_file(&lock);
       return Err(format!(
         "Failed to preserve permissions on staged {label} file '{}': {error}",
         temporary.display()
@@ -102,9 +114,11 @@ pub(crate) fn stage_atomic_file(destination: &Path, content: &[u8], label: &str)
     return Ok(StagedFile {
       destination: destination.to_path_buf(),
       temporary,
+      lock,
       committed: false,
     });
   }
+  let _ = fs::remove_file(&lock);
   Err(format!(
     "Failed to allocate a unique staged {label} file in '{}'.",
     parent.display()

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -283,7 +283,7 @@ fn render_edit_explanation(cmd: &EditCommand) -> Option<String> {
     ),
     EditSubcommand::Scaffold(opts) => format!(
       "{} a definition-graph architecture scaffold",
-      if opts.dry_run { "previews" } else { "plans" }
+      if opts.dry_run { "previews" } else { "applies" }
     ),
     EditSubcommand::Def(opts) => {
       let desc = format!("adds/updates definition `{}`", opts.target);

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -281,6 +281,10 @@ fn render_edit_explanation(cmd: &EditCommand) -> Option<String> {
       "{} a staged edit transaction with revision checks",
       if opts.dry_run { "previews" } else { "applies" }
     ),
+    EditSubcommand::Scaffold(opts) => format!(
+      "{} a definition-graph architecture scaffold",
+      if opts.dry_run { "previews" } else { "plans" }
+    ),
     EditSubcommand::Def(opts) => {
       let desc = format!("adds/updates definition `{}`", opts.target);
       format!(
@@ -881,6 +885,15 @@ fn push_edit(tokens: &mut Vec<String>, cmd: &EditCommand) {
         value "format" => &opts.format; default "human"
       );
     }
+    EditSubcommand::Scaffold(opts) => {
+      echo_items!(
+        tokens,
+        code_input opts,
+        opt "expect-revision" => opts.expect_revision.as_deref(); default "none",
+        switch "dry-run" => opts.dry_run,
+        value "format" => &opts.format; default "human"
+      );
+    }
     EditSubcommand::Def(opts) => {
       echo_items!(tokens, pos "target" => &opts.target, code_input opts, switch "overwrite" => opts.overwrite)
     }
@@ -1236,6 +1249,7 @@ fn edit_name(subcommand: &EditSubcommand) -> &'static str {
   match subcommand {
     EditSubcommand::Format(_) => "format",
     EditSubcommand::Transaction(_) => "transaction",
+    EditSubcommand::Scaffold(_) => "scaffold",
     EditSubcommand::Def(_) => "def",
     EditSubcommand::MvDef(_) => "mv-def",
     EditSubcommand::RmDef(_) => "rm-def",

--- a/src/bin/cli_handlers/cursor.rs
+++ b/src/bin/cli_handlers/cursor.rs
@@ -22,7 +22,7 @@ use super::tree_mutation::{
 };
 
 const LEGACY_CURSOR_FILE: &str = ".calcit-cursor.cirru";
-const ACTIVE_CURSOR: &str = "main";
+const DEFAULT_CURSOR: &str = "default";
 const CURSOR_MAINTENANCE_ENV: &str = "CALCIT_CURSOR_MAINTENANCE";
 const CURSOR_SCHEMA_VERSION: u8 = 4;
 const CURSOR_HISTORY_LIMIT: usize = 32;
@@ -68,7 +68,9 @@ pub(crate) struct CursorLastQuery {
 
 #[derive(Debug, Clone, PartialEq)]
 struct CursorDocument {
+  active_name: String,
   active: CursorState,
+  inactive_cursors: BTreeMap<String, CursorState>,
   history: Vec<CursorState>,
   stack: Vec<CursorState>,
   anchor: Option<CursorState>,
@@ -181,7 +183,9 @@ fn set_cursor_selection_with_last_query(
   };
   refresh_cursor_state(&mut state, snapshot_file)?;
   let mut document = load_cursor_document_optional(snapshot_file)?.unwrap_or_else(|| CursorDocument {
+    active_name: DEFAULT_CURSOR.to_string(),
     active: state.clone(),
+    inactive_cursors: BTreeMap::new(),
     history: vec![],
     stack: vec![],
     anchor: None,
@@ -1740,17 +1744,20 @@ fn load_cursor_document_optional(snapshot_file: &str) -> Result<Option<CursorDoc
   {
     return Err(format!("Unsupported cursor schema version {version}."));
   }
-  let active = root
+  let active_name = root
     .tag_get("active")
     .ok_or("Cursor file is missing :active")?
     .read_tag_str()?
     .to_string();
   let cursors = root.tag_get("cursors").ok_or("Cursor file is missing :cursors")?.view_map()?;
-  let entry = cursors
-    .get(&Edn::tag(active.as_str()))
-    .ok_or_else(|| format!("Cursor file has no entry for active cursor :{active}"))?
-    .clone();
-  let active = cursor_state_from_edn(&entry)?;
+  let mut cursor_states = cursors
+    .0
+    .iter()
+    .map(|(name, value)| Ok((name.read_tag_str()?.to_string(), cursor_state_from_edn(value)?)))
+    .collect::<Result<BTreeMap<_, _>, String>>()?;
+  let active = cursor_states
+    .remove(&active_name)
+    .ok_or_else(|| format!("Cursor file has no entry for active cursor :{active_name}"))?;
   let history = optional_state_list(&root, "history")?;
   let stack = optional_state_list(&root, "stack")?;
   let anchor = match root.tag_get("anchor") {
@@ -1768,7 +1775,9 @@ fn load_cursor_document_optional(snapshot_file: &str) -> Result<Option<CursorDoc
   };
 
   Ok(Some(CursorDocument {
+    active_name,
     active,
+    inactive_cursors: cursor_states,
     history,
     stack,
     anchor,
@@ -1995,7 +2004,9 @@ fn cursor_last_query_to_edn(query: &CursorLastQuery) -> Edn {
 #[cfg(test)]
 fn save_cursor_state(snapshot_file: &str, state: &CursorState) -> Result<(), String> {
   let mut document = load_cursor_document_optional(snapshot_file)?.unwrap_or_else(|| CursorDocument {
+    active_name: DEFAULT_CURSOR.to_string(),
     active: state.clone(),
+    inactive_cursors: BTreeMap::new(),
     history: vec![],
     stack: vec![],
     anchor: None,
@@ -2008,13 +2019,19 @@ fn save_cursor_state(snapshot_file: &str, state: &CursorState) -> Result<(), Str
 }
 
 fn render_cursor_document(document: &CursorDocument) -> Result<String, String> {
+  let mut cursors = document.inactive_cursors.clone();
+  cursors.insert(document.active_name.clone(), document.active.clone());
   let mut content = cirru_edn::format(
     &Edn::map_from_iter([
       (Edn::tag("schema-version"), Edn::from(CURSOR_SCHEMA_VERSION)),
-      (Edn::tag("active"), Edn::tag(ACTIVE_CURSOR)),
+      (Edn::tag("active"), Edn::tag(document.active_name.as_str())),
       (
         Edn::tag("cursors"),
-        Edn::map_from_iter([(Edn::tag(ACTIVE_CURSOR), cursor_state_to_edn(&document.active))]),
+        Edn::map_from_iter(
+          cursors
+            .iter()
+            .map(|(name, state)| (Edn::tag(name.as_str()), cursor_state_to_edn(state))),
+        ),
       ),
       (
         Edn::tag("history"),
@@ -2135,8 +2152,8 @@ fn warn_cursor_gitignore(snapshot_file: &str) {
 #[cfg(test)]
 mod tests {
   use super::{
-    CursorClipboard, CursorDocument, CursorLastQuery, CursorState, RestoreSource, TreeCursorMutation, TreeOperation, apply_at_cursor,
-    barf_first, barf_last, build_cursor_preview, commit_cut_staged_files, commit_paste_staged_files, cursor_file_path,
+    CursorClipboard, CursorDocument, CursorLastQuery, CursorState, DEFAULT_CURSOR, RestoreSource, TreeCursorMutation, TreeOperation,
+    apply_at_cursor, barf_first, barf_last, build_cursor_preview, commit_cut_staged_files, commit_paste_staged_files, cursor_file_path,
     cursor_region_bounds, cursor_state_to_edn, duplicate_cursor, legacy_cursor_file_path, load_cursor_document, load_cursor_state,
     maintain_cursor_after_node_move, maintain_cursor_after_tree_mutation, move_cursor_across_siblings, move_cursor_depth_first,
     move_cursor_to_child, node_fingerprint, paste_cursor_clipboard, push_bounded, read_cursor_target, render_cursor_document,
@@ -2231,6 +2248,15 @@ mod tests {
       .expect("cursor state should parse")
       .view_map()
       .expect("cursor state should be a map");
+    assert_eq!(
+      root
+        .tag_get("active")
+        .expect("cursor active name should exist")
+        .read_tag_str()
+        .expect("cursor active name should be a tag")
+        .as_ref(),
+      DEFAULT_CURSOR,
+    );
     assert_eq!(
       root
         .tag_get("schema-version")
@@ -2347,7 +2373,7 @@ mod tests {
   }
 
   #[test]
-  fn cursor_document_round_trips_history_stack_and_clipboard() {
+  fn cursor_document_round_trips_named_cursors_history_stack_and_clipboard() {
     let fixture = TestCursorSnapshot::from_fixture();
     let snapshot_file = fixture.snapshot_string();
     let path = vec![48, 1];
@@ -2360,7 +2386,9 @@ mod tests {
       fingerprint: node_fingerprint(&node),
     };
     let document = CursorDocument {
+      active_name: "agent-a".to_string(),
       active: state.clone(),
+      inactive_cursors: BTreeMap::from([("agent-b".to_string(), state.clone())]),
       history: vec![state.clone()],
       stack: vec![state.clone()],
       anchor: Some(state.clone()),
@@ -2405,7 +2433,9 @@ mod tests {
       fingerprint: node_fingerprint(&node),
     };
     let document = CursorDocument {
+      active_name: DEFAULT_CURSOR.to_string(),
       active: state.clone(),
+      inactive_cursors: BTreeMap::new(),
       history: vec![],
       stack: vec![],
       anchor: None,

--- a/src/bin/cli_handlers/cursor.rs
+++ b/src/bin/cli_handlers/cursor.rs
@@ -2385,10 +2385,20 @@ mod tests {
       definition_revision: revision,
       fingerprint: node_fingerprint(&node),
     };
+    let inactive_path = vec![48, 0];
+    let (inactive_node, inactive_revision) =
+      read_cursor_target(&snapshot_file, "app.main/main!", &inactive_path).expect("inactive cursor target should exist");
+    let inactive_state = CursorState {
+      snapshot: snapshot_file.clone(),
+      target: "app.main/main!".to_string(),
+      path: inactive_path,
+      definition_revision: inactive_revision,
+      fingerprint: node_fingerprint(&inactive_node),
+    };
     let document = CursorDocument {
       active_name: "agent-a".to_string(),
       active: state.clone(),
-      inactive_cursors: BTreeMap::from([("agent-b".to_string(), state.clone())]),
+      inactive_cursors: BTreeMap::from([("agent-b".to_string(), inactive_state.clone())]),
       history: vec![state.clone()],
       stack: vec![state.clone()],
       anchor: Some(state.clone()),
@@ -2416,7 +2426,10 @@ mod tests {
     };
 
     save_cursor_document(&snapshot_file, &document).expect("cursor document should save");
-    assert_eq!(load_cursor_document(&snapshot_file).expect("cursor document should load"), document);
+    let loaded = load_cursor_document(&snapshot_file).expect("cursor document should load");
+    assert_eq!(loaded.active, state);
+    assert_eq!(loaded.inactive_cursors.get("agent-b"), Some(&inactive_state));
+    assert_eq!(loaded, document);
   }
 
   #[test]

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -46,6 +46,7 @@ use super::cursor::{
   maintain_cursor_after_split_definition, maintain_cursor_after_tree_mutation, resolve_active_cursor_reference,
   resolve_cursor_path_argument, resolve_cursor_target_argument,
 };
+use super::handle_scaffold_command;
 use super::tips::{Tips, command_guidance_enabled};
 use super::tree_mutation::{TreeCursorMutation, TreeOperation, adjusted_source_path_after_insertion, path_is_strict_descendant};
 
@@ -84,6 +85,7 @@ pub fn handle_edit_command(cmd: &EditCommand, snapshot_file: &str) -> Result<(),
   let result = match &resolved.subcommand {
     EditSubcommand::Format(opts) => handle_format(opts, snapshot_file),
     EditSubcommand::Transaction(opts) => handle_transaction(opts, snapshot_file),
+    EditSubcommand::Scaffold(opts) => handle_scaffold_command(opts, snapshot_file),
     EditSubcommand::Def(opts) => handle_def(opts, snapshot_file),
     EditSubcommand::MvDef(opts) => handle_mv_def(opts, snapshot_file),
     EditSubcommand::RmDef(opts) => handle_rm_def(opts, snapshot_file),
@@ -132,6 +134,7 @@ fn resolve_edit_cursor_references(cmd: &mut EditCommand, snapshot_file: &str) ->
     EditSubcommand::SplitDef(opts) => Some(&mut opts.target),
     EditSubcommand::Format(_)
     | EditSubcommand::Transaction(_)
+    | EditSubcommand::Scaffold(_)
     | EditSubcommand::AddNs(_)
     | EditSubcommand::RmNs(_)
     | EditSubcommand::Imports(_)
@@ -234,6 +237,9 @@ fn maintain_cursor_after_edit(cmd: &EditCommand, snapshot_file: &str) -> Result<
     }
     EditSubcommand::Transaction(opts) if !opts.dry_run => {
       maintain_cursor_after_any_mutation(snapshot_file, "validated after edit transaction")
+    }
+    EditSubcommand::Scaffold(opts) if !opts.dry_run => {
+      maintain_cursor_after_any_mutation(snapshot_file, "validated after scaffold apply")
     }
     _ => Ok(()),
   }

--- a/src/bin/cli_handlers/mod.rs
+++ b/src/bin/cli_handlers/mod.rs
@@ -18,6 +18,7 @@ mod libs;
 mod markdown_read;
 mod program_diff;
 mod query;
+mod scaffold;
 #[cfg(test)]
 mod test_support;
 mod tips;
@@ -35,6 +36,7 @@ pub use libs::handle_libs_command;
 pub use program_diff::handle_program_diff_command;
 pub use query::handle_query_command;
 pub(crate) use query::load_snapshot_for_static_analysis;
+pub(crate) use scaffold::handle_scaffold_command;
 pub use tips::{set_tips_level, suppress_command_guidance};
 pub use tree::handle_tree_command;
 // Re-export when needed by other modules; keep internal for now to avoid unused-import warnings

--- a/src/bin/cli_handlers/scaffold.rs
+++ b/src/bin/cli_handlers/scaffold.rs
@@ -1,0 +1,909 @@
+//! Definition-graph architecture scaffold planning.
+//!
+//! It validates the canonical Cirru EDN plan, reconciles it with one Snapshot,
+//! and emits a stable work-item view. A non-dry run atomically creates only
+//! missing `:ensure` definitions as tagged `todo!` stubs; it never rewrites
+//! existing definitions.
+
+use calcit::calcit::CalcitTypeAnnotation;
+use calcit::cli_args::EditScaffoldCommand;
+use calcit::snapshot::{self, CodeEntry, Snapshot, definition_revision, render_snapshot_content};
+use cirru_edn::{Edn, EdnListView, EdnMapView, EdnSetView, EdnTag};
+use cirru_parser::Cirru;
+use md5::{Digest, Md5};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use super::atomic_write::stage_atomic_file;
+use super::common::read_code_input;
+use super::edit::{check_ns_editable, load_snapshot, parse_target};
+
+const ARCHITECTURE_SCHEMA_VERSION: f64 = 1.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DefinitionMode {
+  Ensure,
+  External,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DefinitionKind {
+  Function,
+  Data,
+}
+
+impl DefinitionKind {
+  fn as_tag(self) -> &'static str {
+    match self {
+      Self::Function => "fn",
+      Self::Data => "data",
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ArchitectureEdge {
+  kind: String,
+  source: String,
+  target: String,
+}
+
+#[derive(Debug, Clone)]
+struct DefinitionSpec {
+  mode: DefinitionMode,
+  kind: DefinitionKind,
+  doc: Option<String>,
+  schema: Edn,
+  schema_annotation: Arc<CalcitTypeAnnotation>,
+  params: Vec<String>,
+  raw: Edn,
+}
+
+#[derive(Debug, Clone)]
+struct ArchitecturePlan {
+  feature: String,
+  doc: Option<String>,
+  roots: BTreeSet<String>,
+  definitions: BTreeMap<String, DefinitionSpec>,
+  edges: BTreeSet<ArchitectureEdge>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconciliationStatus {
+  Create,
+  ReusePending,
+  ReuseComplete,
+  External,
+}
+
+impl ReconciliationStatus {
+  fn as_tag(self) -> &'static str {
+    match self {
+      Self::Create => "create",
+      Self::ReusePending => "reuse-pending",
+      Self::ReuseComplete => "reuse-complete",
+      Self::External => "external",
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+struct ReconciliationEntry {
+  status: ReconciliationStatus,
+  origin: String,
+  existing: Option<Edn>,
+  planned: Edn,
+}
+
+#[derive(Debug, Clone)]
+struct WorkItem {
+  id: String,
+  plan_id: String,
+  base_snapshot_revision: String,
+  target: String,
+  schema: Edn,
+  doc: String,
+  params: Vec<String>,
+  planned_edges: Vec<ArchitectureEdge>,
+}
+
+#[derive(Debug, Clone)]
+struct ScaffoldPlanReport {
+  plan: ArchitecturePlan,
+  plan_id: String,
+  snapshot_revision: String,
+  reconciliation: BTreeMap<String, ReconciliationEntry>,
+  diagnostics: Vec<Edn>,
+  work_items: Vec<WorkItem>,
+}
+
+#[derive(Debug, Clone)]
+struct ScaffoldApplyResult {
+  changed: bool,
+  new_snapshot_revision: String,
+}
+
+pub(crate) fn handle_scaffold_command(opts: &EditScaffoldCommand, snapshot_file: &str) -> Result<(), String> {
+  if !matches!(opts.format.as_str(), "human" | "edn" | "json") {
+    return Err(format!(
+      "Unsupported scaffold format '{}'. Expected human, edn, or json.",
+      opts.format
+    ));
+  }
+
+  let raw = read_code_input(&opts.file, &opts.code)?
+    .ok_or("Architecture input required: use --file, --code, or pipe one Cirru EDN architecture map via stdin.")?;
+  let plan = parse_architecture_plan(&raw)?;
+
+  let snapshot_content =
+    fs::read_to_string(snapshot_file).map_err(|error| format!("Failed to read snapshot '{snapshot_file}': {error}"))?;
+  let snapshot_revision = content_revision(&snapshot_content);
+  if let Some(expected) = opts.expect_revision.as_deref()
+    && expected != snapshot_revision
+  {
+    return Err(format!(
+      "Snapshot revision mismatch: expected '{expected}', current revision is '{snapshot_revision}'. Re-run the query and rebuild the scaffold plan."
+    ));
+  }
+  let snapshot = load_snapshot(snapshot_file)?;
+  let report = reconcile_plan(plan, &snapshot, snapshot_revision)?;
+  let apply_result = if opts.dry_run {
+    ScaffoldApplyResult {
+      changed: false,
+      new_snapshot_revision: report.snapshot_revision.clone(),
+    }
+  } else {
+    apply_scaffold(&report, &snapshot, snapshot_file, &snapshot_content)?
+  };
+
+  match opts.format.as_str() {
+    "human" => print_human_report(&report, opts.dry_run, &apply_result),
+    "edn" => {
+      let rendered = cirru_edn::format(&report_to_edn(&report, opts.dry_run, &apply_result), true)
+        .map_err(|error| format!("Failed to render scaffold EDN result: {error}"))?;
+      println!("{rendered}");
+    }
+    "json" => {
+      let value = serde_json::to_value(report_to_edn(&report, opts.dry_run, &apply_result))
+        .map_err(|error| format!("Failed to render scaffold JSON result: {error}"))?;
+      println!(
+        "{}",
+        serde_json::to_string(&value).map_err(|error| format!("Failed to serialize scaffold JSON result: {error}"))?
+      );
+    }
+    _ => unreachable!("format is validated above"),
+  }
+  Ok(())
+}
+
+fn apply_scaffold(
+  report: &ScaffoldPlanReport,
+  snapshot: &Snapshot,
+  snapshot_file: &str,
+  original_content: &str,
+) -> Result<ScaffoldApplyResult, String> {
+  let mut staged_snapshot = snapshot.clone();
+  for (id, reconciliation) in &report.reconciliation {
+    if reconciliation.status != ReconciliationStatus::Create {
+      continue;
+    }
+    let spec = report
+      .plan
+      .definitions
+      .get(id)
+      .expect("reconciled definition must have a plan spec");
+    let (namespace, definition) = parse_target(id)?;
+    let file = staged_snapshot
+      .files
+      .get_mut(namespace)
+      .ok_or_else(|| format!("Namespace '{namespace}' disappeared before scaffold apply."))?;
+    if file.defs.contains_key(definition) {
+      return Err(format!(
+        "Definition '{id}' appeared before scaffold apply; no changes were written."
+      ));
+    }
+    file.defs.insert(definition.to_owned(), scaffold_entry(id, definition, spec)?);
+  }
+
+  let staged_content = render_snapshot_content(&staged_snapshot)?;
+  let changed = staged_content != original_content;
+  let new_snapshot_revision = content_revision(&staged_content);
+  if !changed {
+    return Ok(ScaffoldApplyResult {
+      changed,
+      new_snapshot_revision,
+    });
+  }
+
+  let staged = stage_atomic_file(Path::new(snapshot_file), original_content.as_bytes(), "scaffold snapshot")?;
+  staged.write_and_sync(staged_content.as_bytes(), "scaffold snapshot")?;
+  let current_content =
+    fs::read_to_string(snapshot_file).map_err(|error| format!("Failed to re-read snapshot '{snapshot_file}': {error}"))?;
+  if content_revision(&current_content) != report.snapshot_revision {
+    return Err(format!(
+      "Snapshot changed while scaffold was running: started at '{}', now '{}'. No scaffold changes were written.",
+      report.snapshot_revision,
+      content_revision(&current_content)
+    ));
+  }
+  staged.commit()?;
+  Ok(ScaffoldApplyResult {
+    changed,
+    new_snapshot_revision,
+  })
+}
+
+fn scaffold_entry(id: &str, definition: &str, spec: &DefinitionSpec) -> Result<CodeEntry, String> {
+  let code = match spec.kind {
+    DefinitionKind::Function => Cirru::List(vec![
+      Cirru::leaf("defn"),
+      Cirru::leaf(definition),
+      Cirru::List(spec.params.iter().map(|param| Cirru::leaf(param.as_str())).collect()),
+      Cirru::List(vec![Cirru::leaf("todo!"), Cirru::leaf(format!("|TODO(scaffold): implement {id}"))]),
+    ]),
+    DefinitionKind::Data => match spec.raw.view_map()?.tag_get("code") {
+      Some(Edn::Quote(code)) => code.clone(),
+      _ => return Err(format!("Architecture data definition '{id}' is missing validated quoted :code.")),
+    },
+  };
+  let mut entry = CodeEntry::from_code(code);
+  entry.doc = spec.doc.clone().unwrap_or_default();
+  entry.schema = spec.schema_annotation.clone();
+  entry.tags.insert(EdnTag::new("scaffold"));
+  Ok(entry)
+}
+
+fn parse_architecture_plan(raw: &str) -> Result<ArchitecturePlan, String> {
+  let root = cirru_edn::parse(raw).map_err(|error| format!("Failed to parse architecture Cirru EDN: {error}"))?;
+  let map = root
+    .view_map()
+    .map_err(|error| format!("Architecture root must be a map: {error}"))?;
+  let version = required_number(&map, "schema-version")?;
+  if (version - ARCHITECTURE_SCHEMA_VERSION).abs() > f64::EPSILON {
+    return Err(format!(
+      "Unsupported architecture schema version {version}. Expected {}.",
+      ARCHITECTURE_SCHEMA_VERSION as u8
+    ));
+  }
+  let feature = required_symbol(&map, "feature")?;
+  let doc = optional_string(&map, "doc")?;
+  let roots = required_symbol_set(&map, "roots")?;
+  let definitions_value = map.tag_get("definitions").ok_or("Architecture is missing :definitions")?;
+  let definitions_map = definitions_value
+    .view_map()
+    .map_err(|error| format!("Architecture :definitions must be a map: {error}"))?;
+  let mut definitions = BTreeMap::new();
+  for (id, value) in definitions_map.0.iter() {
+    let id = edn_symbol(id, "Architecture definition key")?;
+    if parse_target(&id).is_err() {
+      return Err(format!(
+        "Architecture definition key '{id}' must be a FQN in namespace/definition form."
+      ));
+    }
+    if definitions.insert(id.clone(), parse_definition_spec(&id, value)?).is_some() {
+      return Err(format!("Architecture repeats definition '{id}'."));
+    }
+  }
+  if definitions.is_empty() {
+    return Err("Architecture :definitions must not be empty.".to_string());
+  }
+  for root in &roots {
+    if !definitions.contains_key(root) {
+      return Err(format!("Architecture root '{root}' is not present in :definitions."));
+    }
+  }
+
+  let mut edges = BTreeSet::new();
+  if let Some(edges_value) = map.tag_get("edges") {
+    let Edn::Set(values) = edges_value else {
+      return Err("Architecture :edges must be a set of anonymous enum edges.".to_string());
+    };
+    for value in &values.0 {
+      let edge = parse_edge(value)?;
+      if !definitions.contains_key(&edge.source) || !definitions.contains_key(&edge.target) {
+        return Err(format!(
+          "Architecture edge :: :{} {} {} references a definition absent from :definitions.",
+          edge.kind, edge.source, edge.target
+        ));
+      }
+      edges.insert(edge);
+    }
+  }
+
+  Ok(ArchitecturePlan {
+    feature,
+    doc,
+    roots,
+    definitions,
+    edges,
+  })
+}
+
+fn parse_definition_spec(id: &str, value: &Edn) -> Result<DefinitionSpec, String> {
+  let map = value
+    .view_map()
+    .map_err(|error| format!("Architecture definition '{id}' must be a map: {error}"))?;
+  let mode = match required_tag(&map, "mode")?.as_str() {
+    "ensure" => DefinitionMode::Ensure,
+    "external" => DefinitionMode::External,
+    other => {
+      return Err(format!(
+        "Architecture definition '{id}' has unsupported :mode :{other}. Expected :ensure or :external."
+      ));
+    }
+  };
+  let kind = match required_tag(&map, "kind")?.as_str() {
+    "fn" => DefinitionKind::Function,
+    "data" => DefinitionKind::Data,
+    other => {
+      return Err(format!(
+        "Architecture definition '{id}' has unsupported :kind :{other}. Expected :fn or :data."
+      ));
+    }
+  };
+  let doc = optional_string(&map, "doc")?;
+  if mode == DefinitionMode::Ensure && doc.is_none() {
+    return Err(format!("Architecture definition '{id}' with :mode :ensure is missing :doc."));
+  }
+  let schema = map
+    .tag_get("schema")
+    .ok_or_else(|| format!("Architecture definition '{id}' is missing :schema."))?
+    .clone();
+  let schema_cirru =
+    snapshot::schema_edn_to_cirru(&schema).map_err(|error| format!("Architecture definition '{id}' has invalid :schema: {error}"))?;
+  let schema_annotation = snapshot::parse_schema_annotation_for_write(&schema_cirru)
+    .map_err(|error| format!("Architecture definition '{id}' has invalid :schema: {error}"))?;
+  let params = match map.tag_get("params") {
+    None => vec![],
+    Some(value) => symbol_list(value, &format!("Architecture definition '{id}' :params"))?,
+  };
+  if kind == DefinitionKind::Function && mode == DefinitionMode::Ensure && map.tag_get("params").is_none() {
+    return Err(format!("Architecture function '{id}' with :mode :ensure is missing :params."));
+  }
+  if kind == DefinitionKind::Function && mode == DefinitionMode::Ensure {
+    let fn_schema = CalcitTypeAnnotation::parse_fn_schema_from_edn(&schema)
+      .ok_or_else(|| format!("Architecture function '{id}' :schema must use the canonical `:: :fn` form."))?;
+    if fn_schema.rest_type.is_none() && fn_schema.arg_types.len() != params.len() {
+      return Err(format!(
+        "Architecture function '{id}' has {} :params entries but its schema declares {} fixed arguments.",
+        params.len(),
+        fn_schema.arg_types.len()
+      ));
+    }
+  }
+  if kind == DefinitionKind::Data && map.tag_get("params").is_some() {
+    return Err(format!("Architecture data definition '{id}' must not contain :params."));
+  }
+  if kind == DefinitionKind::Data && mode == DefinitionMode::Ensure && !matches!(map.tag_get("code"), Some(Edn::Quote(_))) {
+    return Err(format!(
+      "Architecture data definition '{id}' with :mode :ensure must provide quoted :code."
+    ));
+  }
+  if let Some(code) = map.tag_get("code")
+    && !matches!(code, Edn::Quote(_))
+  {
+    return Err(format!("Architecture definition '{id}' :code must be quoted Cirru AST."));
+  }
+
+  Ok(DefinitionSpec {
+    mode,
+    kind,
+    doc,
+    schema,
+    schema_annotation,
+    params,
+    raw: value.clone(),
+  })
+}
+
+fn parse_edge(value: &Edn) -> Result<ArchitectureEdge, String> {
+  let Edn::Enum(edge) = value else {
+    return Err("Architecture edges must be anonymous enum values such as `:: :call 'source/a 'target/b`.".to_string());
+  };
+  if edge.type_name.is_some() || edge.extra.len() != 2 {
+    return Err("Architecture edge must be an anonymous enum with exactly source and target Symbol payloads.".to_string());
+  }
+  let kind = edge.variant.to_string();
+  if !matches!(kind.as_str(), "call" | "type") {
+    return Err(format!("Architecture edge has unsupported tag :{kind}. Expected :call or :type."));
+  }
+  Ok(ArchitectureEdge {
+    kind,
+    source: edn_symbol(&edge.extra[0], "Architecture edge source")?,
+    target: edn_symbol(&edge.extra[1], "Architecture edge target")?,
+  })
+}
+
+fn reconcile_plan(plan: ArchitecturePlan, snapshot: &Snapshot, snapshot_revision: String) -> Result<ScaffoldPlanReport, String> {
+  let plan_id = plan_id(&plan)?;
+  let mut reconciliation = BTreeMap::new();
+  let mut diagnostics = vec![];
+  let mut work_items = vec![];
+
+  for (id, spec) in &plan.definitions {
+    let (namespace, definition) = parse_target(id)?;
+    let local_entry = snapshot.files.get(namespace).and_then(|file| file.defs.get(definition));
+    let (status, origin, existing) = match spec.mode {
+      DefinitionMode::External => {
+        let origin = if local_entry.is_some() { "project" } else { "external" };
+        (
+          ReconciliationStatus::External,
+          origin.to_string(),
+          local_entry.map(existing_entry_to_edn),
+        )
+      }
+      DefinitionMode::Ensure => {
+        check_ns_editable(snapshot, namespace)?;
+        if !snapshot.files.contains_key(namespace) {
+          return Err(format!(
+            "Architecture definition '{id}' targets missing namespace '{namespace}'. Create the namespace before scaffolding."
+          ));
+        }
+        match local_entry {
+          None => (ReconciliationStatus::Create, "project".to_string(), None),
+          Some(entry) => {
+            let existing_kind = code_entry_kind(entry);
+            if existing_kind != spec.kind {
+              return Err(format!(
+                "Architecture conflict for '{id}': existing kind :{} does not match planned kind :{}.",
+                existing_kind.as_tag(),
+                spec.kind.as_tag()
+              ));
+            }
+            if entry.schema.as_ref() != spec.schema_annotation.as_ref() {
+              let existing_dynamic = matches!(entry.schema.as_ref(), CalcitTypeAnnotation::Dynamic);
+              let planned_dynamic = matches!(spec.schema_annotation.as_ref(), CalcitTypeAnnotation::Dynamic);
+              if existing_dynamic || planned_dynamic {
+                diagnostics.push(diagnostic(
+                  "warning",
+                  "W_SCAFFOLD_DYNAMIC_SCHEMA",
+                  id,
+                  "Existing and planned schema differ because one side is Dynamic; scaffold will reuse the existing definition without narrowing it.",
+                ));
+              } else {
+                return Err(format!(
+                  "Architecture conflict for '{id}': existing schema does not match the planned schema."
+                ));
+              }
+            }
+            if spec.doc.as_deref().is_some_and(|doc| doc != entry.doc) {
+              diagnostics.push(diagnostic(
+                "warning",
+                "W_SCAFFOLD_DOC_DIFF",
+                id,
+                "Existing documentation differs from the planned documentation; scaffold will preserve the existing value.",
+              ));
+            }
+            let status = if entry_has_scaffold_todo(entry) {
+              ReconciliationStatus::ReusePending
+            } else {
+              ReconciliationStatus::ReuseComplete
+            };
+            (status, "project".to_string(), Some(existing_entry_to_edn(entry)))
+          }
+        }
+      }
+    };
+    reconciliation.insert(
+      id.clone(),
+      ReconciliationEntry {
+        status,
+        origin,
+        existing,
+        planned: spec.raw.clone(),
+      },
+    );
+    if spec.kind == DefinitionKind::Function && matches!(status, ReconciliationStatus::Create | ReconciliationStatus::ReusePending) {
+      let planned_edges = plan.edges.iter().filter(|edge| edge.source == *id).cloned().collect::<Vec<_>>();
+      work_items.push(WorkItem {
+        id: format!("{}/implement-{}", plan.feature, definition),
+        plan_id: plan_id.clone(),
+        base_snapshot_revision: snapshot_revision.clone(),
+        target: id.clone(),
+        schema: spec.schema.clone(),
+        doc: spec.doc.clone().unwrap_or_default(),
+        params: spec.params.clone(),
+        planned_edges,
+      });
+    }
+  }
+  Ok(ScaffoldPlanReport {
+    plan,
+    plan_id,
+    snapshot_revision,
+    reconciliation,
+    diagnostics,
+    work_items,
+  })
+}
+
+fn report_to_edn(report: &ScaffoldPlanReport, dry_run: bool, apply_result: &ScaffoldApplyResult) -> Edn {
+  let reconciliation = Edn::map_from_iter(report.reconciliation.iter().map(|(id, entry)| {
+    let mut fields = vec![
+      (Edn::tag("status"), Edn::tag(entry.status.as_tag())),
+      (Edn::tag("origin"), Edn::tag(entry.origin.as_str())),
+      (Edn::tag("planned"), entry.planned.clone()),
+    ];
+    if let Some(existing) = &entry.existing {
+      fields.push((Edn::tag("existing"), existing.clone()));
+    }
+    (Edn::Symbol(Arc::from(id.as_str())), Edn::map_from_iter(fields))
+  }));
+  let operations = report
+    .reconciliation
+    .iter()
+    .filter(|(_, entry)| entry.status == ReconciliationStatus::Create)
+    .map(|(id, _)| {
+      Edn::map_from_iter([
+        (Edn::tag("operation"), Edn::tag("create-definition")),
+        (Edn::tag("target"), Edn::Symbol(Arc::from(id.as_str()))),
+      ])
+    })
+    .collect::<Vec<_>>();
+  Edn::map_from_iter([
+    (Edn::tag("schema-version"), Edn::from(1)),
+    (Edn::tag("ok"), Edn::Bool(true)),
+    (Edn::tag("command"), Edn::tag("edit-scaffold")),
+    (Edn::tag("feature"), Edn::Symbol(Arc::from(report.plan.feature.as_str()))),
+    (Edn::tag("plan-id"), Edn::str(report.plan_id.as_str())),
+    (Edn::tag("dry-run"), Edn::Bool(dry_run)),
+    (Edn::tag("changed"), Edn::Bool(apply_result.changed)),
+    (Edn::tag("snapshot-revision"), Edn::str(report.snapshot_revision.as_str())),
+    (
+      Edn::tag("new-snapshot-revision"),
+      Edn::str(apply_result.new_snapshot_revision.as_str()),
+    ),
+    (Edn::tag("normalized-plan"), plan_to_edn(&report.plan)),
+    (Edn::tag("reconciliation"), reconciliation),
+    (Edn::tag("operations"), Edn::List(EdnListView(operations))),
+    (
+      Edn::tag("work-items"),
+      Edn::List(EdnListView(report.work_items.iter().map(work_item_to_edn).collect())),
+    ),
+    (Edn::tag("diagnostics"), Edn::List(EdnListView(report.diagnostics.clone()))),
+  ])
+}
+
+fn plan_to_edn(plan: &ArchitecturePlan) -> Edn {
+  let definitions = Edn::map_from_iter(
+    plan
+      .definitions
+      .iter()
+      .map(|(id, spec)| (Edn::Symbol(Arc::from(id.as_str())), spec.raw.clone())),
+  );
+  let roots = Edn::Set(EdnSetView(
+    plan
+      .roots
+      .iter()
+      .map(|root| Edn::Symbol(Arc::from(root.as_str())))
+      .collect::<HashSet<_>>(),
+  ));
+  let edges = Edn::Set(EdnSetView(plan.edges.iter().map(edge_to_edn).collect::<HashSet<_>>()));
+  let mut fields = vec![
+    (Edn::tag("schema-version"), Edn::from(1)),
+    (Edn::tag("feature"), Edn::Symbol(Arc::from(plan.feature.as_str()))),
+    (Edn::tag("roots"), roots),
+    (Edn::tag("definitions"), definitions),
+    (Edn::tag("edges"), edges),
+  ];
+  if let Some(doc) = &plan.doc {
+    fields.insert(2, (Edn::tag("doc"), Edn::str(doc.as_str())));
+  }
+  Edn::map_from_iter(fields)
+}
+
+fn work_item_to_edn(item: &WorkItem) -> Edn {
+  Edn::map_from_iter([
+    (Edn::tag("id"), Edn::Symbol(Arc::from(item.id.as_str()))),
+    (Edn::tag("plan-id"), Edn::str(item.plan_id.as_str())),
+    (Edn::tag("base-snapshot-revision"), Edn::str(item.base_snapshot_revision.as_str())),
+    (Edn::tag("target"), Edn::Symbol(Arc::from(item.target.as_str()))),
+    (
+      Edn::tag("write-set"),
+      Edn::Set(EdnSetView(HashSet::from([Edn::Symbol(Arc::from(item.target.as_str()))]))),
+    ),
+    (Edn::tag("doc"), Edn::str(item.doc.as_str())),
+    (
+      Edn::tag("params"),
+      Edn::List(EdnListView(
+        item.params.iter().map(|param| Edn::Symbol(Arc::from(param.as_str()))).collect(),
+      )),
+    ),
+    (Edn::tag("schema"), item.schema.clone()),
+    (
+      Edn::tag("planned-edges"),
+      Edn::Set(EdnSetView(item.planned_edges.iter().map(edge_to_edn).collect::<HashSet<_>>())),
+    ),
+  ])
+}
+
+fn edge_to_edn(edge: &ArchitectureEdge) -> Edn {
+  Edn::enum_value(
+    edge.kind.as_str(),
+    vec![
+      Edn::Symbol(Arc::from(edge.source.as_str())),
+      Edn::Symbol(Arc::from(edge.target.as_str())),
+    ],
+  )
+}
+
+fn existing_entry_to_edn(entry: &CodeEntry) -> Edn {
+  Edn::map_from_iter([
+    (Edn::tag("doc"), Edn::str(entry.doc.as_str())),
+    (Edn::tag("kind"), Edn::tag(code_entry_kind(entry).as_tag())),
+    (Edn::tag("schema"), snapshot::schema_annotation_to_edn(entry.schema.as_ref())),
+    (
+      Edn::tag("definition-revision"),
+      Edn::str(definition_revision(entry).unwrap_or_else(|_| "unavailable".to_string())),
+    ),
+  ])
+}
+
+fn diagnostic(level: &str, code: &str, definition: &str, message: &str) -> Edn {
+  Edn::map_from_iter([
+    (Edn::tag("level"), Edn::tag(level)),
+    (Edn::tag("code"), Edn::tag(code)),
+    (Edn::tag("definition"), Edn::Symbol(Arc::from(definition))),
+    (Edn::tag("message"), Edn::str(message)),
+  ])
+}
+
+fn plan_id(plan: &ArchitecturePlan) -> Result<String, String> {
+  let rendered =
+    cirru_edn::format(&plan_to_edn(plan), true).map_err(|error| format!("Failed to canonicalize architecture plan: {error}"))?;
+  Ok(content_revision(&rendered))
+}
+
+fn content_revision(content: &str) -> String {
+  let mut hasher = Md5::new();
+  hasher.update(content.as_bytes());
+  format!("md5:{:x}", hasher.finalize())
+}
+
+fn code_entry_kind(entry: &CodeEntry) -> DefinitionKind {
+  match &entry.code {
+    Cirru::List(items) if matches!(items.first(), Some(Cirru::Leaf(head)) if matches!(head.as_ref(), "defn" | "defmacro")) => {
+      DefinitionKind::Function
+    }
+    _ => DefinitionKind::Data,
+  }
+}
+
+fn entry_has_scaffold_todo(entry: &CodeEntry) -> bool {
+  entry.tags.iter().any(|tag| tag.ref_str() == "scaffold") || cirru_contains_leaf(&entry.code, "todo!")
+}
+
+fn cirru_contains_leaf(node: &Cirru, expected: &str) -> bool {
+  match node {
+    Cirru::Leaf(value) => value.as_ref() == expected,
+    Cirru::List(items) => items.iter().any(|item| cirru_contains_leaf(item, expected)),
+  }
+}
+
+fn print_human_report(report: &ScaffoldPlanReport, dry_run: bool, apply_result: &ScaffoldApplyResult) {
+  println!("{} scaffold", if dry_run { "Validated" } else { "Applied" });
+  println!("Feature: {}", report.plan.feature);
+  println!("Plan: {}", report.plan_id);
+  println!("Snapshot revision: {}", report.snapshot_revision);
+  for (id, entry) in &report.reconciliation {
+    println!("- {id} [{}]", entry.status.as_tag());
+  }
+  println!("Work items: {}", report.work_items.len());
+  for item in &report.work_items {
+    println!("  - {} ({})", item.target, item.id);
+  }
+  if !report.diagnostics.is_empty() {
+    println!("Warnings: {}", report.diagnostics.len());
+  }
+  println!("Changed: {}", apply_result.changed);
+  println!("New snapshot revision: {}", apply_result.new_snapshot_revision);
+}
+
+fn required_number(map: &EdnMapView, key: &str) -> Result<f64, String> {
+  map
+    .tag_get(key)
+    .ok_or_else(|| format!("Architecture is missing :{key}."))?
+    .read_number()
+}
+
+fn required_tag(map: &EdnMapView, key: &str) -> Result<String, String> {
+  Ok(
+    map
+      .tag_get(key)
+      .ok_or_else(|| format!("Architecture is missing :{key}."))?
+      .read_tag_str()?
+      .to_string(),
+  )
+}
+
+fn required_symbol(map: &EdnMapView, key: &str) -> Result<String, String> {
+  edn_symbol(
+    map.tag_get(key).ok_or_else(|| format!("Architecture is missing :{key}."))?,
+    &format!("Architecture :{key}"),
+  )
+}
+
+fn optional_string(map: &EdnMapView, key: &str) -> Result<Option<String>, String> {
+  match map.tag_get(key) {
+    None | Some(Edn::Nil) => Ok(None),
+    Some(Edn::Str(value)) => Ok(Some(value.to_string())),
+    Some(other) => Err(format!("Architecture :{key} must be a string, got {}.", other.type_name())),
+  }
+}
+
+fn required_symbol_set(map: &EdnMapView, key: &str) -> Result<BTreeSet<String>, String> {
+  let value = map.tag_get(key).ok_or_else(|| format!("Architecture is missing :{key}."))?;
+  let Edn::Set(values) = value else {
+    return Err(format!("Architecture :{key} must be a set of Symbols."));
+  };
+  values
+    .0
+    .iter()
+    .map(|value| edn_symbol(value, &format!("Architecture :{key}")))
+    .collect()
+}
+
+fn symbol_list(value: &Edn, context: &str) -> Result<Vec<String>, String> {
+  let values = value
+    .view_list()
+    .map_err(|error| format!("{context} must be a list of Symbols: {error}"))?;
+  values.0.iter().map(|value| edn_symbol(value, context)).collect()
+}
+
+fn edn_symbol(value: &Edn, context: &str) -> Result<String, String> {
+  match value {
+    Edn::Symbol(value) => Ok(value.to_string()),
+    other => Err(format!("{context} must be a Symbol, got {}.", other.type_name())),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{apply_scaffold, parse_architecture_plan, plan_id, reconcile_plan};
+  use crate::cli_handlers::edit::load_snapshot;
+  use crate::cli_handlers::test_support::TestProject;
+
+  const PLAN: &str = r#"
+{}
+  :schema-version 1
+  :feature 'sample
+  :roots $ #{} 'app.main/run!
+  :definitions $ {}
+    'app.main/run! $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Run sample."
+      :params $ [] 'value
+      :schema $ :: :fn
+        {}
+          :args $ [] :number
+          :return :number
+    'app.main/next-value $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Increment a value."
+      :params $ [] 'value
+      :schema $ :: :fn
+        {}
+          :args $ [] :number
+          :return :number
+  :edges $ #{}
+    :: :call 'app.main/run! 'app.main/next-value
+"#;
+
+  const DATA_PLAN: &str = r#"
+{}
+  :schema-version 1
+  :feature 'sample-data
+  :roots $ #{} 'app.main/scaffold-answer
+  :definitions $ {}
+    'app.main/scaffold-answer $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|An answer created by the scaffold."
+      :schema $ :: 'Number
+      :code $ quote (def scaffold-answer 42)
+"#;
+
+  #[test]
+  fn parses_flat_symbol_graph_and_has_stable_plan_id() {
+    let plan = parse_architecture_plan(PLAN).expect("plan should parse");
+    assert_eq!(plan.feature, "sample");
+    assert_eq!(plan.definitions.len(), 2);
+    assert_eq!(plan.edges.len(), 1);
+    assert_eq!(
+      plan_id(&plan).expect("plan id should render"),
+      plan_id(&plan).expect("plan id should be stable")
+    );
+  }
+
+  #[test]
+  fn rejects_list_edge_that_mixes_tag_and_symbols() {
+    let invalid = PLAN.replace(
+      ":: :call 'app.main/run! 'app.main/next-value",
+      "[] :call 'app.main/run! 'app.main/next-value",
+    );
+    let error = parse_architecture_plan(&invalid).expect_err("list edge should be rejected");
+    assert!(error.contains("anonymous enum"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn rejects_string_params_instead_of_symbols() {
+    let invalid = PLAN.replace("[] 'value", "[] |value");
+    let error = parse_architecture_plan(&invalid).expect_err("string params should be rejected");
+    assert!(error.contains("Symbol"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn missing_function_becomes_a_work_item_without_writing_snapshot() {
+    let fixture = TestProject::from_fixture();
+    let snapshot_file = fixture.snapshot_string();
+    let snapshot = load_snapshot(&snapshot_file).expect("fixture snapshot should load");
+    let original = std::fs::read_to_string(&snapshot_file).expect("fixture snapshot should be readable");
+    let report = reconcile_plan(
+      parse_architecture_plan(PLAN).expect("plan should parse"),
+      &snapshot,
+      "md5:test".to_string(),
+    )
+    .expect("plan should reconcile");
+    assert_eq!(report.work_items.len(), 2);
+    assert!(report.work_items.iter().all(|item| item.base_snapshot_revision == "md5:test"));
+    assert_eq!(
+      std::fs::read_to_string(&snapshot_file).expect("fixture snapshot should remain readable"),
+      original
+    );
+  }
+
+  #[test]
+  fn apply_creates_all_missing_todo_stubs_atomically() {
+    let fixture = TestProject::from_fixture();
+    let snapshot_file = fixture.snapshot_string();
+    let original = std::fs::read_to_string(&snapshot_file).expect("fixture snapshot should be readable");
+    let snapshot = load_snapshot(&snapshot_file).expect("fixture snapshot should load");
+    let report = reconcile_plan(
+      parse_architecture_plan(PLAN).expect("plan should parse"),
+      &snapshot,
+      super::content_revision(&original),
+    )
+    .expect("plan should reconcile");
+
+    let outcome = apply_scaffold(&report, &snapshot, &snapshot_file, &original).expect("scaffold should apply");
+    assert!(outcome.changed);
+    let applied = load_snapshot(&snapshot_file).expect("applied snapshot should load");
+    for definition in ["run!", "next-value"] {
+      let entry = applied
+        .files
+        .get("app.main")
+        .and_then(|file| file.defs.get(definition))
+        .expect("scaffolded definition should exist");
+      assert!(entry.tags.iter().any(|tag| tag.ref_str() == "scaffold"));
+      assert!(super::cirru_contains_leaf(&entry.code, "todo!"));
+    }
+  }
+
+  #[test]
+  fn apply_preserves_explicit_data_code() {
+    let fixture = TestProject::from_fixture();
+    let snapshot_file = fixture.snapshot_string();
+    let original = std::fs::read_to_string(&snapshot_file).expect("fixture snapshot should be readable");
+    let snapshot = load_snapshot(&snapshot_file).expect("fixture snapshot should load");
+    let report = reconcile_plan(
+      parse_architecture_plan(DATA_PLAN).expect("data plan should parse"),
+      &snapshot,
+      super::content_revision(&original),
+    )
+    .expect("data plan should reconcile");
+
+    apply_scaffold(&report, &snapshot, &snapshot_file, &original).expect("data scaffold should apply");
+    let applied = load_snapshot(&snapshot_file).expect("applied snapshot should load");
+    let entry = applied
+      .files
+      .get("app.main")
+      .and_then(|file| file.defs.get("scaffold-answer"))
+      .expect("scaffolded data should exist");
+    assert!(!super::cirru_contains_leaf(&entry.code, "todo!"));
+    assert!(super::cirru_contains_leaf(&entry.code, "42"));
+  }
+}

--- a/src/bin/cli_handlers/scaffold.rs
+++ b/src/bin/cli_handlers/scaffold.rs
@@ -8,7 +8,7 @@
 use calcit::calcit::CalcitTypeAnnotation;
 use calcit::cli_args::EditScaffoldCommand;
 use calcit::snapshot::{self, CodeEntry, Snapshot, definition_revision, render_snapshot_content};
-use cirru_edn::{Edn, EdnListView, EdnMapView, EdnSetView, EdnTag};
+use cirru_edn::{Edn, EdnListView, EdnMapView, EdnSetView, EdnTag, from_edn};
 use cirru_parser::Cirru;
 use md5::{Digest, Md5};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -58,6 +58,9 @@ struct DefinitionSpec {
   schema: Edn,
   schema_annotation: Arc<CalcitTypeAnnotation>,
   params: Vec<String>,
+  code: Option<Cirru>,
+  tags: Option<HashSet<EdnTag>>,
+  examples: Option<Vec<Cirru>>,
   raw: Edn,
 }
 
@@ -95,6 +98,7 @@ struct ReconciliationEntry {
   origin: String,
   existing: Option<Edn>,
   planned: Edn,
+  diff: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +110,7 @@ struct WorkItem {
   schema: Edn,
   doc: String,
   params: Vec<String>,
+  examples: Vec<Cirru>,
   planned_edges: Vec<ArchitectureEdge>,
 }
 
@@ -114,6 +119,7 @@ struct ScaffoldPlanReport {
   plan: ArchitecturePlan,
   plan_id: String,
   snapshot_revision: String,
+  proposed_snapshot_revision: String,
   reconciliation: BTreeMap<String, ReconciliationEntry>,
   diagnostics: Vec<Edn>,
   work_items: Vec<WorkItem>,
@@ -151,8 +157,8 @@ pub(crate) fn handle_scaffold_command(opts: &EditScaffoldCommand, snapshot_file:
   let report = reconcile_plan(plan, &snapshot, snapshot_revision)?;
   let apply_result = if opts.dry_run {
     ScaffoldApplyResult {
-      changed: false,
-      new_snapshot_revision: report.snapshot_revision.clone(),
+      changed: report.proposed_snapshot_revision != report.snapshot_revision,
+      new_snapshot_revision: report.proposed_snapshot_revision.clone(),
     }
   } else {
     apply_scaffold(&report, &snapshot, snapshot_file, &snapshot_content)?
@@ -237,21 +243,27 @@ fn apply_scaffold(
 
 fn scaffold_entry(id: &str, definition: &str, spec: &DefinitionSpec) -> Result<CodeEntry, String> {
   let code = match spec.kind {
-    DefinitionKind::Function => Cirru::List(vec![
-      Cirru::leaf("defn"),
-      Cirru::leaf(definition),
-      Cirru::List(spec.params.iter().map(|param| Cirru::leaf(param.as_str())).collect()),
-      Cirru::List(vec![Cirru::leaf("todo!"), Cirru::leaf(format!("|TODO(scaffold): implement {id}"))]),
-    ]),
-    DefinitionKind::Data => match spec.raw.view_map()?.tag_get("code") {
-      Some(Edn::Quote(code)) => code.clone(),
-      _ => return Err(format!("Architecture data definition '{id}' is missing validated quoted :code.")),
-    },
+    DefinitionKind::Function => spec.code.clone().unwrap_or_else(|| {
+      Cirru::List(vec![
+        Cirru::leaf("defn"),
+        Cirru::leaf(definition),
+        Cirru::List(spec.params.iter().map(|param| Cirru::leaf(param.as_str())).collect()),
+        Cirru::List(vec![Cirru::leaf("todo!"), Cirru::leaf(format!("|TODO(scaffold): implement {id}"))]),
+      ])
+    }),
+    DefinitionKind::Data => spec
+      .code
+      .clone()
+      .ok_or_else(|| format!("Architecture data definition '{id}' is missing validated quoted :code."))?,
   };
   let mut entry = CodeEntry::from_code(code);
   entry.doc = spec.doc.clone().unwrap_or_default();
   entry.schema = spec.schema_annotation.clone();
-  entry.tags.insert(EdnTag::new("scaffold"));
+  entry.tags = spec.tags.clone().unwrap_or_default();
+  entry.examples = spec.examples.clone().unwrap_or_default();
+  if spec.kind == DefinitionKind::Function && spec.code.is_none() {
+    entry.tags.insert(EdnTag::new("scaffold"));
+  }
   Ok(entry)
 }
 
@@ -270,6 +282,9 @@ fn parse_architecture_plan(raw: &str) -> Result<ArchitecturePlan, String> {
   let feature = required_symbol(&map, "feature")?;
   let doc = optional_string(&map, "doc")?;
   let roots = required_symbol_set(&map, "roots")?;
+  if roots.is_empty() {
+    return Err("Architecture :roots must contain at least one definition Symbol.".to_string());
+  }
   let definitions_value = map.tag_get("definitions").ok_or("Architecture is missing :definitions")?;
   let definitions_map = definitions_value
     .view_map()
@@ -387,6 +402,25 @@ fn parse_definition_spec(id: &str, value: &Edn) -> Result<DefinitionSpec, String
     return Err(format!("Architecture definition '{id}' :code must be quoted Cirru AST."));
   }
 
+  let code = match map.tag_get("code") {
+    Some(Edn::Quote(code)) => Some(code.clone()),
+    Some(_) => unreachable!("quoted code was validated above"),
+    None => None,
+  };
+  let tags = match map.tag_get("tags") {
+    None => None,
+    Some(value) => Some(
+      snapshot::parse_code_entry_tags_from_edn(value)
+        .map_err(|error| format!("Architecture definition '{id}' has invalid :tags: {error}"))?,
+    ),
+  };
+  let examples = match map.tag_get("examples") {
+    None => None,
+    Some(value) => {
+      Some(from_edn(value.clone()).map_err(|error| format!("Architecture definition '{id}' has invalid :examples: {error}"))?)
+    }
+  };
+
   Ok(DefinitionSpec {
     mode,
     kind,
@@ -394,6 +428,9 @@ fn parse_definition_spec(id: &str, value: &Edn) -> Result<DefinitionSpec, String
     schema,
     schema_annotation,
     params,
+    code,
+    tags,
+    examples,
     raw: value.clone(),
   })
 }
@@ -420,18 +457,23 @@ fn reconcile_plan(plan: ArchitecturePlan, snapshot: &Snapshot, snapshot_revision
   let plan_id = plan_id(&plan)?;
   let mut reconciliation = BTreeMap::new();
   let mut diagnostics = vec![];
-  let mut work_items = vec![];
 
   for (id, spec) in &plan.definitions {
     let (namespace, definition) = parse_target(id)?;
     let local_entry = snapshot.files.get(namespace).and_then(|file| file.defs.get(definition));
-    let (status, origin, existing) = match spec.mode {
+    let (status, origin, existing, diff) = match spec.mode {
       DefinitionMode::External => {
-        let origin = if local_entry.is_some() { "project" } else { "external" };
+        let entry = local_entry.ok_or_else(|| {
+          format!(
+            "Architecture external definition '{id}' could not be resolved in the current Snapshot; dependency/core lookup is not available for scaffold validation."
+          )
+        })?;
+        let diff = validate_existing_compatibility(id, spec, entry, &mut diagnostics)?;
         (
           ReconciliationStatus::External,
-          origin.to_string(),
-          local_entry.map(existing_entry_to_edn),
+          "project".to_string(),
+          Some(existing_entry_to_edn(entry)),
+          diff,
         )
       }
       DefinitionMode::Ensure => {
@@ -442,46 +484,20 @@ fn reconcile_plan(plan: ArchitecturePlan, snapshot: &Snapshot, snapshot_revision
           ));
         }
         match local_entry {
-          None => (ReconciliationStatus::Create, "project".to_string(), None),
+          None => (
+            ReconciliationStatus::Create,
+            "project".to_string(),
+            None,
+            BTreeSet::from(["definition".to_owned()]),
+          ),
           Some(entry) => {
-            let existing_kind = code_entry_kind(entry);
-            if existing_kind != spec.kind {
-              return Err(format!(
-                "Architecture conflict for '{id}': existing kind :{} does not match planned kind :{}.",
-                existing_kind.as_tag(),
-                spec.kind.as_tag()
-              ));
-            }
-            if entry.schema.as_ref() != spec.schema_annotation.as_ref() {
-              let existing_dynamic = matches!(entry.schema.as_ref(), CalcitTypeAnnotation::Dynamic);
-              let planned_dynamic = matches!(spec.schema_annotation.as_ref(), CalcitTypeAnnotation::Dynamic);
-              if existing_dynamic || planned_dynamic {
-                diagnostics.push(diagnostic(
-                  "warning",
-                  "W_SCAFFOLD_DYNAMIC_SCHEMA",
-                  id,
-                  "Existing and planned schema differ because one side is Dynamic; scaffold will reuse the existing definition without narrowing it.",
-                ));
-              } else {
-                return Err(format!(
-                  "Architecture conflict for '{id}': existing schema does not match the planned schema."
-                ));
-              }
-            }
-            if spec.doc.as_deref().is_some_and(|doc| doc != entry.doc) {
-              diagnostics.push(diagnostic(
-                "warning",
-                "W_SCAFFOLD_DOC_DIFF",
-                id,
-                "Existing documentation differs from the planned documentation; scaffold will preserve the existing value.",
-              ));
-            }
+            let diff = validate_existing_compatibility(id, spec, entry, &mut diagnostics)?;
             let status = if entry_has_scaffold_todo(entry) {
               ReconciliationStatus::ReusePending
             } else {
               ReconciliationStatus::ReuseComplete
             };
-            (status, "project".to_string(), Some(existing_entry_to_edn(entry)))
+            (status, "project".to_string(), Some(existing_entry_to_edn(entry)), diff)
           }
         }
       }
@@ -493,30 +509,112 @@ fn reconcile_plan(plan: ArchitecturePlan, snapshot: &Snapshot, snapshot_revision
         origin,
         existing,
         planned: spec.raw.clone(),
+        diff,
       },
     );
-    if spec.kind == DefinitionKind::Function && matches!(status, ReconciliationStatus::Create | ReconciliationStatus::ReusePending) {
-      let planned_edges = plan.edges.iter().filter(|edge| edge.source == *id).cloned().collect::<Vec<_>>();
-      work_items.push(WorkItem {
-        id: format!("{}/implement-{}", plan.feature, definition),
+  }
+
+  let mut staged_snapshot = snapshot.clone();
+  for (id, reconciliation) in &reconciliation {
+    if reconciliation.status != ReconciliationStatus::Create {
+      continue;
+    }
+    let spec = plan.definitions.get(id).expect("reconciled definition must have a plan spec");
+    let (namespace, definition) = parse_target(id)?;
+    staged_snapshot
+      .files
+      .get_mut(namespace)
+      .expect("editable namespace was validated during reconciliation")
+      .defs
+      .insert(definition.to_owned(), scaffold_entry(id, definition, spec)?);
+  }
+  let staged_content = render_snapshot_content(&staged_snapshot)?;
+  let proposed_snapshot_revision = content_revision(&staged_content);
+  let work_items = plan
+    .definitions
+    .iter()
+    .filter_map(|(id, spec)| {
+      let entry = reconciliation.get(id)?;
+      if spec.kind != DefinitionKind::Function
+        || !matches!(entry.status, ReconciliationStatus::Create | ReconciliationStatus::ReusePending)
+      {
+        return None;
+      }
+      Some(WorkItem {
+        id: format!("{}/implement/{id}", plan.feature),
         plan_id: plan_id.clone(),
-        base_snapshot_revision: snapshot_revision.clone(),
+        base_snapshot_revision: proposed_snapshot_revision.clone(),
         target: id.clone(),
         schema: spec.schema.clone(),
         doc: spec.doc.clone().unwrap_or_default(),
         params: spec.params.clone(),
-        planned_edges,
-      });
-    }
-  }
+        examples: spec.examples.clone().unwrap_or_default(),
+        planned_edges: plan.edges.iter().filter(|edge| edge.source == *id).cloned().collect(),
+      })
+    })
+    .collect();
   Ok(ScaffoldPlanReport {
     plan,
     plan_id,
     snapshot_revision,
+    proposed_snapshot_revision,
     reconciliation,
     diagnostics,
     work_items,
   })
+}
+
+fn validate_existing_compatibility(
+  id: &str,
+  spec: &DefinitionSpec,
+  entry: &CodeEntry,
+  diagnostics: &mut Vec<Edn>,
+) -> Result<BTreeSet<String>, String> {
+  let existing_kind = code_entry_kind(entry);
+  if existing_kind != spec.kind {
+    return Err(format!(
+      "Architecture conflict for '{id}': existing kind :{} does not match planned kind :{}.",
+      existing_kind.as_tag(),
+      spec.kind.as_tag()
+    ));
+  }
+  let mut diff = BTreeSet::new();
+  if entry.schema.as_ref() != spec.schema_annotation.as_ref() {
+    let existing_dynamic = matches!(entry.schema.as_ref(), CalcitTypeAnnotation::Dynamic);
+    let planned_dynamic = matches!(spec.schema_annotation.as_ref(), CalcitTypeAnnotation::Dynamic);
+    if existing_dynamic || planned_dynamic {
+      diagnostics.push(diagnostic(
+        "warning",
+        "W_SCAFFOLD_DYNAMIC_SCHEMA",
+        id,
+        "Existing and planned schema differ because one side is Dynamic; scaffold will reuse the existing definition without narrowing it.",
+      ));
+    } else {
+      return Err(format!(
+        "Architecture conflict for '{id}': existing schema does not match the planned schema."
+      ));
+    }
+    diff.insert("schema".to_owned());
+  }
+  if spec.doc.as_deref().is_some_and(|doc| doc != entry.doc) {
+    diagnostics.push(diagnostic(
+      "warning",
+      "W_SCAFFOLD_DOC_DIFF",
+      id,
+      "Existing documentation differs from the planned documentation; scaffold will preserve the existing value.",
+    ));
+    diff.insert("doc".to_owned());
+  }
+  if spec.tags.as_ref().is_some_and(|tags| tags != &entry.tags) {
+    diff.insert("tags".to_owned());
+  }
+  if spec.examples.as_ref().is_some_and(|examples| examples != &entry.examples) {
+    diff.insert("examples".to_owned());
+  }
+  if spec.code.as_ref().is_some_and(|code| code != &entry.code) {
+    diff.insert("code".to_owned());
+  }
+  Ok(diff)
 }
 
 fn report_to_edn(report: &ScaffoldPlanReport, dry_run: bool, apply_result: &ScaffoldApplyResult) -> Edn {
@@ -525,6 +623,10 @@ fn report_to_edn(report: &ScaffoldPlanReport, dry_run: bool, apply_result: &Scaf
       (Edn::tag("status"), Edn::tag(entry.status.as_tag())),
       (Edn::tag("origin"), Edn::tag(entry.origin.as_str())),
       (Edn::tag("planned"), entry.planned.clone()),
+      (
+        Edn::tag("diff"),
+        Edn::Set(EdnSetView(entry.diff.iter().map(|field| Edn::tag(field.as_str())).collect())),
+      ),
     ];
     if let Some(existing) = &entry.existing {
       fields.push((Edn::tag("existing"), existing.clone()));
@@ -551,6 +653,7 @@ fn report_to_edn(report: &ScaffoldPlanReport, dry_run: bool, apply_result: &Scaf
     (Edn::tag("dry-run"), Edn::Bool(dry_run)),
     (Edn::tag("changed"), Edn::Bool(apply_result.changed)),
     (Edn::tag("snapshot-revision"), Edn::str(report.snapshot_revision.as_str())),
+    (Edn::tag("proposed-revision"), Edn::str(report.proposed_snapshot_revision.as_str())),
     (
       Edn::tag("new-snapshot-revision"),
       Edn::str(apply_result.new_snapshot_revision.as_str()),
@@ -613,6 +716,10 @@ fn work_item_to_edn(item: &WorkItem) -> Edn {
     ),
     (Edn::tag("schema"), item.schema.clone()),
     (
+      Edn::tag("examples"),
+      Edn::List(EdnListView(item.examples.iter().cloned().map(Edn::from).collect())),
+    ),
+    (
       Edn::tag("planned-edges"),
       Edn::Set(EdnSetView(item.planned_edges.iter().map(edge_to_edn).collect::<HashSet<_>>())),
     ),
@@ -632,6 +739,14 @@ fn edge_to_edn(edge: &ArchitectureEdge) -> Edn {
 fn existing_entry_to_edn(entry: &CodeEntry) -> Edn {
   Edn::map_from_iter([
     (Edn::tag("doc"), Edn::str(entry.doc.as_str())),
+    (
+      Edn::tag("examples"),
+      Edn::List(EdnListView(entry.examples.iter().cloned().map(Edn::from).collect())),
+    ),
+    (
+      Edn::tag("tags"),
+      Edn::Set(EdnSetView(entry.tags.iter().map(|tag| Edn::Tag(tag.clone())).collect())),
+    ),
     (Edn::tag("kind"), Edn::tag(code_entry_kind(entry).as_tag())),
     (Edn::tag("schema"), snapshot::schema_annotation_to_edn(entry.schema.as_ref())),
     (
@@ -849,7 +964,12 @@ mod tests {
     )
     .expect("plan should reconcile");
     assert_eq!(report.work_items.len(), 2);
-    assert!(report.work_items.iter().all(|item| item.base_snapshot_revision == "md5:test"));
+    assert!(
+      report
+        .work_items
+        .iter()
+        .all(|item| item.base_snapshot_revision == report.proposed_snapshot_revision)
+    );
     assert_eq!(
       std::fs::read_to_string(&snapshot_file).expect("fixture snapshot should remain readable"),
       original

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -407,6 +407,7 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     NativeInspectType => Ok(Calcit::Nil), // Handled in preprocessing phase
     NativeAssertTraits => meta::assert_traits(args, call_stack),
     Raise => effects::raise(args),
+    Todo => effects::todo(args),
     Quit => effects::quit(args),
     GetEnv => effects::get_env(args),
     UnixTimeMs => effects::unix_time_ms(args),

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -32,6 +32,19 @@ pub fn raise(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   CalcitErr::err_str(CalcitErrKind::Effect, s)
 }
 
+/// Runtime endpoint for the compiler-known `todo!` placeholder.
+///
+/// Unlike `raise`, this has a fixed shape so preprocessing can reliably emit
+/// W_TODO and tools can identify unfinished scaffolded definitions.
+pub fn todo(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  match xs {
+    [] => CalcitErr::err_str(CalcitErrKind::Effect, "TODO: implementation is pending"),
+    [Calcit::Str(message)] => CalcitErr::err_str(CalcitErrKind::Effect, format!("TODO: {message}")),
+    [_] => CalcitErr::err_str(CalcitErrKind::Type, "todo! expects an optional string message"),
+    _ => CalcitErr::err_str(CalcitErrKind::Arity, "todo! expects 0~1 arguments"),
+  }
+}
+
 pub fn init_effects_states() {
   // trigger lazy instant
   let _eff = STARTED_INSTANT.read().expect("read instant");
@@ -232,5 +245,23 @@ pub fn write_file(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       let hint = format_proc_examples_hint(&CalcitProc::WriteFile).unwrap_or_default();
       CalcitErr::err_str_with_hint(CalcitErrKind::Arity, msg, hint)
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::todo;
+  use crate::calcit::Calcit;
+
+  #[test]
+  fn todo_runtime_error_has_a_stable_prefix() {
+    let error = todo(&[Calcit::new_str("finish this")]).expect_err("todo must not return a value");
+    assert!(error.to_string().contains("TODO: finish this"));
+  }
+
+  #[test]
+  fn todo_runtime_error_has_a_default_message() {
+    let error = todo(&[]).expect_err("todo must not return a value");
+    assert!(error.to_string().contains("TODO: implementation is pending"));
   }
 }

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -106,6 +106,8 @@ pub enum CalcitProc {
   NativeAssertTraits,
   #[strum(serialize = "raise")]
   Raise,
+  #[strum(serialize = "todo!")]
+  Todo,
   #[strum(serialize = "quit!")]
   Quit,
   #[strum(serialize = "&get-env")]
@@ -1332,6 +1334,13 @@ impl CalcitProc {
         return_type: dynamic_tag(),
         arg_types: vec![variadic_dynamic()],
       }),
+      Todo => Some(ProcTypeSignature {
+        // `todo!` is a diverging compiler-known placeholder. Dynamic keeps it
+        // assignable to any declared return type while the static W_TODO
+        // diagnostic prevents it from being silently forgotten.
+        return_type: dynamic_tag(),
+        arg_types: vec![some_tag("string")],
+      }),
       Quit => Some(ProcTypeSignature {
         return_type: some_tag("nil"),
         arg_types: vec![some_tag("number")],
@@ -1434,7 +1443,7 @@ impl CalcitProc {
     match self {
       GenerateId | Range | NativeListRange => 2,
       NativeInspectMethods | NativeInspectType | Trim | NativeStrSlice | Sort | NativeListSort | NativeListSlice | NativeStructNth
-      | ReadDir | GetEnv | ParseCirruEdn | FormatCirru | FormatCirruEdn => 1,
+      | ReadDir | GetEnv | ParseCirruEdn | FormatCirru | FormatCirruEdn | Todo => 1,
       _ => 0,
     }
   }
@@ -1502,6 +1511,7 @@ mod tests {
 
     for (proc, expected) in [
       (CalcitProc::GenerateId, ProcArity { min: 0, max: Some(2) }),
+      (CalcitProc::Todo, ProcArity { min: 0, max: Some(1) }),
       (CalcitProc::Range, ProcArity { min: 1, max: Some(3) }),
       (CalcitProc::NativeListRange, ProcArity { min: 1, max: Some(3) }),
       (CalcitProc::NativeInspectMethods, ProcArity { min: 1, max: Some(2) }),

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -1249,6 +1249,8 @@ pub enum EditSubcommand {
   Format(EditFormatCommand),
   /// apply multiple existing edit/tree/config commands against one staged snapshot
   Transaction(EditTransactionCommand),
+  /// validate a definition-graph architecture plan and preview scaffold work
+  Scaffold(EditScaffoldCommand),
   /// add or update a definition
   Def(EditDefCommand),
   /// move a definition to another namespace
@@ -1319,6 +1321,27 @@ pub struct EditTransactionCommand {
   #[argh(switch, long = "dry-run")]
   pub dry_run: bool,
   /// output format: human (default) or json
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
+}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand, name = "scaffold")]
+/// preview or atomically create a definition-graph architecture scaffold
+pub struct EditScaffoldCommand {
+  /// read architecture Cirru EDN from file
+  #[argh(option)]
+  pub file: Option<String>,
+  /// architecture Cirru EDN as inline text
+  #[argh(option, long = "code")]
+  pub code: Option<String>,
+  /// require the snapshot content to match this revision before planning
+  #[argh(option, long = "expect-revision")]
+  pub expect_revision: Option<String>,
+  /// validate and preview the scaffold without replacing the snapshot
+  #[argh(switch, long = "dry-run")]
+  pub dry_run: bool,
+  /// output format: human (default), edn, or json
   #[argh(option, default = "String::from(\"human\")")]
   pub format: String,
 }

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -335,8 +335,7 @@ fn to_js_code(
       }
       Calcit::Local(CalcitLocal { sym, .. }) => Ok(escape_var(sym)),
       // A bare `{}` is represented as the NativeMap proc in the preprocessed
-      // tree. Unlike ordinary proc values it must be evaluated here, otherwise
-      // the generated module refers to the non-existent `$clt._$M_` binding.
+      // tree. Unlike ordinary proc values it must be evaluated here.
       Calcit::Proc(CalcitProc::NativeMap) => {
         let proc_prefix = get_proc_prefix(ns);
         Ok(format!("{proc_prefix}{}()", escape_var(CalcitProc::NativeMap.as_ref())))
@@ -686,7 +685,15 @@ fn gen_call_code(
     Calcit::Proc(_) => {
       let (prelude, args_code) =
         gen_call_args_with_temps(&body, ns, local_defs, file_imports, tags, return_label.is_some(), inline_all)?;
-      let call_code = format!("{}({})", to_js_code(&head, ns, local_defs, file_imports, tags, None)?, args_code);
+      // `to_js_code(NativeMap)` evaluates a bare map. In call position we need
+      // the constructor itself, otherwise map literals with entries become a
+      // call of an already-created empty map.
+      let callee = if matches!(head, Calcit::Proc(CalcitProc::NativeMap)) {
+        format!("{proc_prefix}{}", escape_var(CalcitProc::NativeMap.as_ref()))
+      } else {
+        to_js_code(&head, ns, local_defs, file_imports, tags, None)?
+      };
+      let call_code = format!("{callee}({args_code})");
       Ok(wrap_call_with_prelude(prelude, call_code, return_label, detect_await(&body)))
     }
     Calcit::Symbol { sym: s, .. } | Calcit::Registered(s) => {
@@ -2428,5 +2435,21 @@ mod tests {
     .expect("bare empty map should compile");
 
     assert_eq!(code, "$clt._$n__$M_()");
+  }
+
+  #[test]
+  fn map_literal_with_entries_keeps_the_runtime_constructor_as_callee() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let form = Calcit::List(Arc::new(CalcitList::from(&[
+      Calcit::Proc(CalcitProc::NativeMap),
+      Calcit::Tag(EdnTag::from("value")),
+      Calcit::Number(1.0),
+    ])));
+
+    let code = to_js_code(&form, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("map literal should compile");
+
+    assert_eq!(code, "$clt._$n__$M_(_t_.value, 1)");
   }
 }

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -334,6 +334,13 @@ fn to_js_code(
         }
       }
       Calcit::Local(CalcitLocal { sym, .. }) => Ok(escape_var(sym)),
+      // A bare `{}` is represented as the NativeMap proc in the preprocessed
+      // tree. Unlike ordinary proc values it must be evaluated here, otherwise
+      // the generated module refers to the non-existent `$clt._$M_` binding.
+      Calcit::Proc(CalcitProc::NativeMap) => {
+        let proc_prefix = get_proc_prefix(ns);
+        Ok(format!("{proc_prefix}{}()", escape_var(CalcitProc::NativeMap.as_ref())))
+      }
       Calcit::Proc(s) => {
         let proc_prefix = get_proc_prefix(ns);
         // println!("gen proc {} under {}", s, ns,);
@@ -2402,5 +2409,24 @@ mod tests {
     let code = to_js_code(&form, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("eval should compile");
 
     assert_eq!(code, "$clt.eval(code)");
+  }
+
+  #[test]
+  fn bare_empty_map_uses_the_runtime_constructor() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+
+    let code = to_js_code(
+      &Calcit::Proc(CalcitProc::NativeMap),
+      "tests.emit-js",
+      &local_defs,
+      &file_imports,
+      &tags,
+      None,
+    )
+    .expect("bare empty map should compile");
+
+    assert_eq!(code, "$clt._$n__$M_()");
   }
 }

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -603,8 +603,12 @@ fn gen_call_code(
       }
     }
     Calcit::Proc(CalcitProc::Todo) => {
+      if body.len() > 1 {
+        return Err(format!("todo! expects 0~1 arguments, got {}", body.len()));
+      }
       let message = match body.first() {
-        Some(message) => to_js_code(message, ns, local_defs, file_imports, tags, None)?,
+        Some(Calcit::Str(message)) => serde_json::to_string(message.as_ref()).map_err(|error| error.to_string())?,
+        Some(_) => return Err("todo! expects an optional static String message".to_owned()),
         None => String::from("\"implementation is pending\""),
       };
       let has_await = detect_await(&body);

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -602,6 +602,18 @@ fn gen_call_code(
         None => Err(format!("raise expected 1~2 arguments, got: {body}")),
       }
     }
+    Calcit::Proc(CalcitProc::Todo) => {
+      let message = match body.first() {
+        Some(message) => to_js_code(message, ns, local_defs, file_imports, tags, None)?,
+        None => String::from("\"implementation is pending\""),
+      };
+      let has_await = detect_await(&body);
+      let ret = format!("throw new Error(`TODO: ${{{message}}}`);");
+      match return_label {
+        Some(_) => Ok(ret),
+        _ => Ok(make_fn_wrapper(&ret, has_await)),
+      }
+    }
     // deftype-slot is preprocessing-only; it has no JS runtime effect.
     Calcit::Proc(CalcitProc::DeftypeSlot) => Ok(format!("{return_code}null")),
     Calcit::Proc(CalcitProc::WithTypeSlot) => Err("internal compiler error: with-type-slot escaped preprocessing".to_owned()),

--- a/src/codegen/emit_js/args.rs
+++ b/src/codegen/emit_js/args.rs
@@ -158,7 +158,7 @@ fn is_complex_syntax(x: &Calcit) -> bool {
           | CalcitSyntax::DefWasmImport
           | CalcitSyntax::Defmacro
       ),
-      Some(Calcit::Proc(CalcitProc::Raise)) => true,
+      Some(Calcit::Proc(CalcitProc::Raise | CalcitProc::Todo)) => true,
       _ => false,
     },
     _ => false,

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1960,10 +1960,23 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     }
 
     // Raise — terminates execution
-    CalcitProc::Raise | CalcitProc::Todo => {
-      // `raise` and `todo!` abort the program; emit a WASM unreachable trap.
-      // Any preceding args are evaluated for side effects but discarded.
+    CalcitProc::Raise => {
+      // `raise` aborts the program; any args are evaluated for side effects but discarded.
       for arg in args {
+        emit_expr(ctx, arg)?;
+        ctx.emit(Instruction::Drop);
+      }
+      ctx.emit(Instruction::Unreachable);
+      Ok(())
+    }
+    CalcitProc::Todo => {
+      if args.len() > 1 {
+        return Err(format!("todo! expects 0~1 arguments, got {}", args.len()));
+      }
+      if args.first().is_some_and(|arg| !matches!(arg, Calcit::Str(_))) {
+        return Err("todo! expects an optional static String message".to_owned());
+      }
+      if let Some(arg) = args.first() {
         emit_expr(ctx, arg)?;
         ctx.emit(Instruction::Drop);
       }

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1960,8 +1960,8 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     }
 
     // Raise — terminates execution
-    CalcitProc::Raise => {
-      // `raise` aborts the program; emit WASM unreachable trap.
+    CalcitProc::Raise | CalcitProc::Todo => {
+      // `raise` and `todo!` abort the program; emit a WASM unreachable trap.
       // Any preceding args are evaluated for side effects but discarded.
       for arg in args {
         emit_expr(ctx, arg)?;

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -875,7 +875,12 @@ pub fn preprocess_expr(
           let def_ns = &info.at_ns;
           let at_def = &info.at_def;
           // println!("def {} - {} {} {}", def, def_ns, file_ns, at_def);
-          if scope_defs.contains(def) {
+          // `todo!` is a compiler-known completion marker, not a normal
+          // callable binding. Keep it recognizable even when a local happens
+          // to use the same name, so scaffold completion checks stay sound.
+          if def.as_ref() == "todo!" {
+            Ok(Calcit::Proc(CalcitProc::Todo))
+          } else if scope_defs.contains(def) {
             let type_info = scope_types.get(def).cloned().unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
             Ok(Calcit::Local(CalcitLocal {
               idx: CalcitLocal::track_sym(def),
@@ -1848,6 +1853,29 @@ fn preprocess_list_call(
         // Check Proc argument types if available
         if let Some(Calcit::Proc(proc)) = ys.first() {
           let processed_args = CalcitList::from(ys.drop_left());
+          if matches!(proc, CalcitProc::Todo) {
+            let message = match processed_args.first() {
+              None => ": implementation is pending".to_owned(),
+              Some(Calcit::Str(message)) => format!(": {message}"),
+              Some(_) => {
+                gen_check_warning_code_at(
+                  format!("[Warn] TODO placeholder in {file_ns}/{def_name} requires a static String message"),
+                  "W_TODO_MESSAGE_LITERAL",
+                  file_ns,
+                  call_location.clone(),
+                  check_warnings,
+                );
+                String::new()
+              }
+            };
+            gen_check_warning_code_at(
+              format!("[Warn] TODO placeholder in {file_ns}/{def_name}{message}"),
+              "W_TODO",
+              file_ns,
+              call_location.clone(),
+              check_warnings,
+            );
+          }
           check_proc_arg_types(
             proc,
             &processed_args,
@@ -8838,6 +8866,110 @@ mod tests {
     assert!(
       warning_msg.contains("number") || warning_msg.contains(":number"),
       "warning should mention actual type: {warning_msg}"
+    );
+  }
+
+  #[test]
+  fn todo_placeholder_emits_todo_warning_without_return_type_mismatch() {
+    use crate::data::cirru::code_to_calcit;
+    use cirru_parser::Cirru;
+
+    let expr = Cirru::List(vec![
+      Cirru::leaf("defn"),
+      Cirru::leaf("unfinished"),
+      Cirru::List(vec![]),
+      Cirru::List(vec![
+        Cirru::leaf("hint-fn"),
+        Cirru::List(vec![
+          Cirru::leaf("{}"),
+          Cirru::List(vec![Cirru::leaf(":return"), Cirru::leaf(":string")]),
+        ]),
+      ]),
+      Cirru::List(vec![Cirru::leaf("todo!"), Cirru::leaf("|write this")]),
+    ]);
+    let code = code_to_calcit(&expr, "tests.todo", "unfinished", vec![]).expect("parse todo expression");
+    let mut scope_types = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+
+    preprocess_expr(
+      &code,
+      &HashSet::new(),
+      &mut scope_types,
+      "tests.todo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess todo expression");
+
+    let warning_messages = warnings.borrow().iter().map(ToString::to_string).collect::<Vec<_>>();
+    assert!(
+      warning_messages
+        .iter()
+        .any(|message| message.contains("W_TODO") && message.contains("write this")),
+      "todo warning missing: {warning_messages:?}"
+    );
+    assert!(
+      !warning_messages.iter().any(|message| message.contains("W_FN_RETURN_TYPE_MISMATCH")),
+      "todo should be accepted for any declared return type: {warning_messages:?}"
+    );
+  }
+
+  #[test]
+  fn todo_placeholder_cannot_be_shadowed_by_a_local_binding() {
+    use crate::data::cirru::code_to_calcit;
+    use cirru_parser::Cirru;
+
+    let code =
+      code_to_calcit(&Cirru::List(vec![Cirru::leaf("todo!")]), "tests.todo", "shadowed", vec![]).expect("parse todo expression");
+    let scope_defs = HashSet::from([Arc::from("todo!")]);
+    let mut scope_types = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+    let processed = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut scope_types,
+      "tests.todo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess todo expression");
+
+    assert!(
+      matches!(processed, Calcit::List(ref items) if matches!(items.first(), Some(Calcit::Proc(CalcitProc::Todo)))),
+      "todo should remain a compiler-known proc: {processed}"
+    );
+    assert!(warnings.borrow().iter().any(|warning| warning.to_string().contains("W_TODO")));
+  }
+
+  #[test]
+  fn todo_placeholder_requires_a_static_string_message() {
+    use crate::data::cirru::code_to_calcit;
+    use cirru_parser::Cirru;
+
+    let code = code_to_calcit(
+      &Cirru::List(vec![Cirru::leaf("todo!"), Cirru::leaf("1")]),
+      "tests.todo",
+      "message",
+      vec![],
+    )
+    .expect("parse todo expression");
+    let mut scope_types = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+    preprocess_expr(
+      &code,
+      &HashSet::new(),
+      &mut scope_types,
+      "tests.todo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess todo expression");
+
+    assert!(
+      warnings
+        .borrow()
+        .iter()
+        .any(|warning| warning.to_string().contains("W_TODO_MESSAGE_LITERAL"))
     );
   }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1854,22 +1854,37 @@ fn preprocess_list_call(
         if let Some(Calcit::Proc(proc)) = ys.first() {
           let processed_args = CalcitList::from(ys.drop_left());
           if matches!(proc, CalcitProc::Todo) {
+            if processed_args.len() > 1 {
+              return Err(CalcitErr::use_msg_stack_location(
+                CalcitErrKind::Arity,
+                format!("todo! expects 0~1 arguments, got {}", processed_args.len()),
+                call_stack,
+                call_location.clone(),
+              ));
+            }
+            if let Some(message) = processed_args.first()
+              && !matches!(message, Calcit::Str(_))
+            {
+              let argument_location = message.get_location().or_else(|| call_location.clone());
+              return Err(CalcitErr::use_msg_stack_location(
+                CalcitErrKind::Type,
+                "todo! expects an optional static String message",
+                call_stack,
+                argument_location,
+              ));
+            }
+            let enclosing_def = call_location
+              .as_ref()
+              .map(|location| location.def.as_ref())
+              .or_else(|| call_stack.0.first().map(|frame| frame.def.as_ref()))
+              .unwrap_or(def_name.as_ref());
             let message = match processed_args.first() {
               None => ": implementation is pending".to_owned(),
               Some(Calcit::Str(message)) => format!(": {message}"),
-              Some(_) => {
-                gen_check_warning_code_at(
-                  format!("[Warn] TODO placeholder in {file_ns}/{def_name} requires a static String message"),
-                  "W_TODO_MESSAGE_LITERAL",
-                  file_ns,
-                  call_location.clone(),
-                  check_warnings,
-                );
-                String::new()
-              }
+              Some(_) => unreachable!("invalid todo! message was rejected above"),
             };
             gen_check_warning_code_at(
-              format!("[Warn] TODO placeholder in {file_ns}/{def_name}{message}"),
+              format!("[Warn] TODO placeholder in {file_ns}/{enclosing_def}{message}"),
               "W_TODO",
               file_ns,
               call_location.clone(),
@@ -8955,7 +8970,7 @@ mod tests {
     .expect("parse todo expression");
     let mut scope_types = ScopeTypes::new();
     let warnings = RefCell::new(vec![]);
-    preprocess_expr(
+    let error = preprocess_expr(
       &code,
       &HashSet::new(),
       &mut scope_types,
@@ -8963,14 +8978,9 @@ mod tests {
       &warnings,
       &CallStackList::default(),
     )
-    .expect("preprocess todo expression");
-
-    assert!(
-      warnings
-        .borrow()
-        .iter()
-        .any(|warning| warning.to_string().contains("W_TODO_MESSAGE_LITERAL"))
-    );
+    .expect_err("non-literal todo! message should be rejected before code generation");
+    assert!(error.to_string().contains("static String"), "unexpected error: {error}");
+    assert!(warnings.borrow().is_empty(), "invalid todo! should not emit a completion warning");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add Cirru EDN architecture scaffold planning and atomic apply workflow
- add compiler-aware todo! placeholders with TODO warnings and runtime/codegen behavior
- document architecture plans, cursor users, machine protocols, and agent workflow

## Validation

- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-agent-interface
- yarn check-all
- docs check-md for updated documentation and RFC examples

## Notes

The internal Never return type remains a follow-up; the current todo! implementation uses the dynamic return path while preserving static TODO diagnostics.