### PR TITLE
deprecate: cr config version in favor of caps version

### DIFF
--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -91,7 +91,8 @@ caps version bump patch
 ```
 
 During migration, the snapshot `:version` field remains supported by `cr`; `caps version` only manages the
-dependency metadata file and does not rewrite the snapshot automatically.
+dependency metadata file and does not rewrite the snapshot automatically. `cr config version` / `cr config set version`
+are deprecated — use `caps version` instead.
 
 ### Outdated
 

--- a/docs/run/project-structure.md
+++ b/docs/run/project-structure.md
@@ -52,7 +52,7 @@ Agent 切到新窗口时，优先把 `calcit.cirru`（兼容旧文件名 `compac
 字段职责可以快速记成：
 
 - `:package`：包名边界（影响哪些 namespace 允许被 `cr edit` 修改）。
-- `:version`：项目版本，独立于各运行入口。
+- `:version`：项目版本的 snapshot 镜像字段，迁移期保留给旧版 `cr` 读取；权威版本号请维护在 `deps.cirru :version`（用 `caps version get/set/bump` 管理）。
 - `:entries`：全部运行入口；不指定 `--entry` 时使用 `:default`。
 - `:mode`：入口的默认运行后端，只接受 `:native` 或 `:js`。
 - `:description`：entry 用途的简短语义说明；只提供给人和工具阅读，不影响运行。
@@ -116,8 +116,11 @@ project source.
 
 给 Agent 一个最小心智就够：
 
-- `deps.cirru`：声明"要下载哪些外部模块 + 期望的 calcit 版本"。
+- `deps.cirru`：声明"要下载哪些外部模块 + 期望的 calcit 版本 + 项目发布版本（`:version`）"。
 - `calcit.cirru`（兼容旧文件名 `compact.cirru`）：声明"运行时要加载哪些模块（`:modules`）+ 项目代码快照（`:files`）"。
+
+版本号以 `deps.cirru :version` 为权威，用 `caps version get/set/bump` 管理；`calcit.cirru :version`
+只是迁移期兼容镜像，`cr config version` / `cr config set version` 已废弃，请改用 `caps version`。
 
 常见升级动作（最少命令）：
 

--- a/editing-history/20260815-0243-deprecate-config-version.md
+++ b/editing-history/20260815-0243-deprecate-config-version.md
@@ -1,0 +1,11 @@
+# Deprecate cr config version in favor of caps version
+
+- Version authority already lives in `deps.cirru :version`, managed by
+  `caps version get/set/bump`; the snapshot `:version` is a migration mirror.
+- `cr config version` / `cr config set version` now emit a deprecation notice
+  pointing to `caps version`, while keeping the legacy write path working.
+- CLI help text for `ConfigVersionCommand` and `ConfigSetCommand` marks the
+  `version` key as deprecated.
+- Docs updated: `docs/run/project-structure.md` documents `:version` as the
+  snapshot mirror with `deps.cirru` authoritative; `docs/run/load-deps.md`
+  mentions the deprecated commands.

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -199,8 +199,13 @@ fn load_module_silent(module_path: &str, base_dir: &Path, module_folder: &Path) 
 }
 
 fn handle_version(opts: &ConfigVersionCommand, snapshot_file: &str) -> Result<(), String> {
+  let replacement = match opts.value.as_deref() {
+    None => "`caps version get`".to_owned(),
+    Some(v @ ("patch" | "minor" | "major")) => format!("`caps version bump {v}`"),
+    Some(v) => format!("`caps version set {v}`"),
+  };
   eprintln!(
-    "[Deprecated] `cr config version` manages the snapshot mirror of the project version; prefer `caps version get/set/bump`, which manages `deps.cirru :version` as the authoritative source"
+    "[Deprecated] `cr config version` manages the snapshot mirror of the project version; prefer {replacement}, which manages `deps.cirru :version` as the authoritative source"
   );
   match &opts.value {
     None => {
@@ -257,8 +262,12 @@ fn handle_set(opts: &ConfigSetCommand, snapshot_file: &str) -> Result<(), String
       format!("{} Set [{entry_label}] description = '{}'", "✓".green(), opts.value)
     }
     "version" => {
+      let replacement = match opts.value.as_str() {
+        "patch" | "minor" | "major" => format!("`caps version bump {}`", opts.value),
+        _ => "`caps version set <version>`".to_owned(),
+      };
       eprintln!(
-        "[Deprecated] `cr config set version` writes the snapshot mirror; prefer `caps version set` to manage `deps.cirru :version` as the authoritative source"
+        "[Deprecated] `cr config set version` writes the snapshot mirror; prefer {replacement} to manage `deps.cirru :version` as the authoritative source"
       );
       if opts.entry.is_some() {
         return Err("Project version is top-level; omit `--entry` when setting it".to_owned());

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -199,6 +199,9 @@ fn load_module_silent(module_path: &str, base_dir: &Path, module_folder: &Path) 
 }
 
 fn handle_version(opts: &ConfigVersionCommand, snapshot_file: &str) -> Result<(), String> {
+  eprintln!(
+    "[Deprecated] `cr config version` manages the snapshot mirror of the project version; prefer `caps version get/set/bump`, which manages `deps.cirru :version` as the authoritative source"
+  );
   match &opts.value {
     None => {
       // Show current version
@@ -254,6 +257,9 @@ fn handle_set(opts: &ConfigSetCommand, snapshot_file: &str) -> Result<(), String
       format!("{} Set [{entry_label}] description = '{}'", "✓".green(), opts.value)
     }
     "version" => {
+      eprintln!(
+        "[Deprecated] `cr config set version` writes the snapshot mirror; prefer `caps version set` to manage `deps.cirru :version` as the authoritative source"
+      );
       if opts.entry.is_some() {
         return Err("Project version is top-level; omit `--entry` when setting it".to_owned());
       }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -2388,6 +2388,7 @@ pub enum ConfigSubcommand {
   /// list entry-level type-slot bindings
   TypeSlots(ConfigTypeSlotsCommand),
   /// show or bump the project version (omit value to show; use patch|minor|major to bump; or pass a semver string)
+  /// [Deprecated] prefer `caps version get/set/bump` which manages `deps.cirru :version`
   Version(ConfigVersionCommand),
   /// set a configuration key to a value (mode, init-fn, reload-fn, description, version)
   Set(ConfigSetCommand),
@@ -2430,7 +2431,7 @@ pub struct ConfigTypeSlotsCommand {
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 #[argh(subcommand, name = "version")]
-/// show or bump the project version
+/// [Deprecated] show or bump the snapshot-mirrored project version; prefer `caps version get/set/bump` to manage `deps.cirru :version`
 pub struct ConfigVersionCommand {
   /// patch | minor | major to bump, or a semver string to set explicitly; omit to show current version
   #[argh(positional)]
@@ -2444,7 +2445,7 @@ pub struct ConfigSetCommand {
   /// apply to a named entry (e.g. "test"); defaults to "default" (version is always project-level)
   #[argh(option)]
   pub entry: Option<String>,
-  /// config key: mode, init-fn, reload-fn, description, version
+  /// config key: mode, init-fn, reload-fn, description, version ([Deprecated] prefer `caps version`)
   #[argh(positional)]
   pub key: String,
   /// config value; for "version" accepts semver string or patch|minor|major


### PR DESCRIPTION
## Summary

The authoritative project version already lives in `deps.cirru :version`, managed by `caps version get/set/bump`. The snapshot `:version` in `calcit.cirru` is a migration mirror. This PR aligns the CLI and docs with that reality.

## Changes

- `cr config version` / `cr config set version` now emit a `[Deprecated]` notice pointing to `caps version`, while keeping the legacy snapshot write path working.
- CLI help text marks the `version` key as deprecated.
- Docs: `docs/run/project-structure.md` documents `:version` as the snapshot mirror with `deps.cirru` authoritative; `docs/run/load-deps.md` notes the deprecated commands.
- Editing-history note added.

## Verification

`cargo test --lib`, `cargo clippy -- -D warnings`, `yarn check-agent-interface`, `yarn try-core-tests`, `yarn try-rs` all pass.