### PR TITLE
fix: address issues 344 and 346 migration regressions

### DIFF
--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -81,6 +81,39 @@ Snapshot 文件迁移、依赖升级和类型修复建议分别提交，任何�
 3. 执行 `cr calcit.cirru edit format`，审阅 diff，再对新的 `calcit.cirru` 运行 `--check-only` 和原有 entry/构建测试
 4. 新旧入口行为一致后再删除旧文件并提交；后续所有 `cr` 命令都显式基于单一的 `calcit.cirru`
 
+如果新版 `cr` 连旧的完整 `calcit.cirru` 都无法反序列化，就不能先对它执行 `edit format`。先确认旁边的
+`compact.cirru` 能在旧工具链运行，并从 Git 状态/历史确认它是最后的有效精简源码；然后用可恢复的步骤重建：
+
+```bash
+cp calcit.cirru calcit.full-snapshot.backup.cirru
+cp compact.cirru calcit.cirru
+cr calcit.cirru edit format
+git diff -- calcit.cirru
+cr calcit.cirru --check-only
+```
+
+不要删除备份或旧文件，直到所有 entry 与原有 native/JS 测试均通过。现在反序列化错误会带上失败的
+Snapshot 路径；如果同目录存在 `compact.cirru`，还会直接给出上述恢复方向。
+
+旧 namespace 里的 `:require-macros` 也必须在 Snapshot 规范化前处理。宏与普通值现在共用
+`:require` 规则，例如把：
+
+```cirru.no-check
+ns app.main
+  :require-macros
+    legacy.macros :refer $ defcomp
+```
+
+改为：
+
+```cirru.no-check
+ns app.main
+  :require
+    legacy.macros :refer $ defcomp
+```
+
+遇到旧写法时，加载阶段会明确报告 `:require-macros` 迁移提示，而不是只返回笼统的 invalid `ns` form。
+
 > `cr` 仍然读取 Snapshot，只是当前约定把精简 Snapshot 直接命名为 `calcit.cirru`；不要把它理解为
 > “不再依赖 Snapshot”。`cr edit` / `cr tree` 会直接修改该文件。确认迁移完成后，可以移除旧的
 > `.gitattributes` generated 标记和过时的双文件生成脚本；不要把仍可能承载源码的文件直接加入 ignore。
@@ -319,6 +352,42 @@ Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field`
 
 推荐先执行 `cr calcit.cirru --check-only`，按诊断逐项替换，再运行完整 JS 回归。不要先全局删除
 `.unwrap`；只处理接收者已被推断为 Struct 且字段在 `defstruct` 中声明的访问。
+
+#### Option 返回 API 对照
+
+以下 API 不再用 `nil` 或 `-1` 表示缺失。把结果直接传给算术、字符串或集合函数时，诊断会显示完整的
+`Option<T>` 推断类型，并建议用 `option:unwrap-or` 或 `tag-match` 显式处理：
+
+| API | 当前返回类型 | 迁移注意点 |
+| --- | --- | --- |
+| `find-index` | `Option<Number>` | 不再用 `-1`；索引运算前先处理 `%none` |
+| `first` / `last` | `Option<T>` | 空集合和空字符串可能没有元素 |
+| `nth` | `Option<T>` | 越界是 `%none`；不要把结果直接当元素值 |
+| `get` | `Option<T>` | Map/List 等可缺失查找返回 Option；已知 Struct 的声明字段直接返回字段类型 |
+| `get-in` | `Option<T>`（开放动态路径常为 `Option<Dynamic>`） | 任一路径缺失都是 `%none` |
+| `get-env` | `Option<String>` | 未设置的环境变量是 `%none` |
+
+```cirru
+let
+    xs $ [] 1 2 3
+    predicate $ fn (x) = x 2
+    idx $ find-index xs predicate
+    safe-idx $ option:unwrap-or idx 0
+  &+ safe-idx 1
+
+match (get-env |APP_MODE)
+  (:some mode) $ println mode
+  (:none) $ println |development
+```
+
+只有业务语义确实有合理默认值时才用 `unwrap-or`；需要区分“缺失”和“存在”时保留两个分支。
+
+#### `.trim` / `.blank?` 接收者迁移
+
+`.trim` 与 `.blank?` 只对静态推断为 String 的接收者可用。若错误写成 `unknown method .trim for map`，
+重点不是给 Map 增加方法，而是先修正数据流：当前接收者已被推断成 Map。可将接收者收紧/转换为 String，
+或改成 `(trim receiver)` / `(blank? receiver)` 获取直接的参数类型诊断。新的 unknown-method 错误会同时写出
+实际接收者类型和这两个函数形式；不要用 `unsafe-coerce` 掩盖业务数据类型错误。
 
 ### 3.3 统一 entries
 

--- a/editing-history/20260815-2302-issue-344-346.md
+++ b/editing-history/20260815-2302-issue-344-346.md
@@ -1,0 +1,7 @@
+# Issue 344 / 346 修复记录
+
+- `cr` CLI 主流程改为在 32 MiB 专用线程栈中运行，避免 Cumulo.org 等深层宏/依赖预处理在默认主线程栈上触发 stack overflow。
+- Option 返回类型不匹配诊断显示完整 `Option<T>`，并给出 `option:unwrap-or` 与模式匹配建议；补充 `find-index`、`first`、`last`、`nth`、`get`、`get-in`、`get-env` 升级说明。
+- `.trim` / `.blank?` 的未知方法错误补充接收者类型和函数形式迁移提示。
+- 旧 `:require-macros` 导入、不可反序列化的完整 Snapshot 增加明确恢复提示；升级文档补充 `compact.cirru` 恢复流程。
+- 回归覆盖 Option 诊断、`:require-macros`、Snapshot 恢复提示和字符串方法提示；Cumulo.org 默认 8 MiB 栈回归、全量 Rust/JS/WASM/Agent 检查均通过。

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -82,7 +82,22 @@ fn attach_missing_core_namespaces(snapshot: &mut snapshot::Snapshot, core_snapsh
   }
 }
 
+const CLI_STACK_SIZE: usize = 32 * 1024 * 1024;
+
 fn main() -> Result<(), String> {
+  let worker = std::thread::Builder::new()
+    .name("calcit-cli".to_owned())
+    .stack_size(CLI_STACK_SIZE)
+    .spawn(run_cli)
+    .map_err(|error| format!("Failed to start Calcit CLI worker: {error}"))?;
+
+  match worker.join() {
+    Ok(result) => result,
+    Err(payload) => std::panic::resume_unwind(payload),
+  }
+}
+
+fn run_cli() -> Result<(), String> {
   let cli_args: ToplevelCalcit = argh::from_env();
   calcit::project_state::set_active_project_directory_from_snapshot(&cli_args.input);
 

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -201,6 +201,28 @@ fn option_migration_source_calls_fail_during_preprocessing() {
 }
 
 #[test]
+fn option_returning_api_type_mismatches_include_unwrap_and_match_help() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries("do\n  &+ (find-index ([] 1 2) $ fn (x) = x 2) 1\n  starts-with? (get-env |HOME) |/");
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("Option-returning API examples should preprocess with migration warnings");
+
+    let warnings = warnings.borrow();
+    for inferred in ["Option<:number>", "Option<:string>"] {
+      let warning = warnings
+        .iter()
+        .find(|warning| warning.code() == Some("W_PROC_ARG_TYPE_MISMATCH") && warning.message().contains(inferred))
+        .unwrap_or_else(|| panic!("missing mismatch for {inferred}; warnings: {warnings:?}"));
+      assert!(warning.message().contains("inferred type"), "warning: {warning:?}");
+      assert!(warning.message().contains("option:unwrap-or"), "warning: {warning:?}");
+      assert!(warning.message().contains("tag-match"), "warning: {warning:?}");
+    }
+  });
+}
+
+#[test]
 fn required_struct_field_access_does_not_fall_back_to_option_lookup() {
   run_with_large_stack(|| {
     let entries = load_snippet_entries(

--- a/src/program.rs
+++ b/src/program.rs
@@ -761,39 +761,51 @@ pub fn validate_import_rules(rules: &[Cirru]) -> Result<Vec<String>, String> {
 
 fn extract_import_map(nodes: &Cirru, ns_name: &str) -> Result<HashMap<Arc<str>, Arc<ImportRule>>, String> {
   match nodes {
-    Cirru::List(xs) => match xs.as_slice() {
-      [head, Cirru::Leaf(_declared_ns)] if head.eq_leaf("ns") || head.eq_leaf(":ns") => Ok(HashMap::new()),
-      [head, Cirru::Leaf(_declared_ns), Cirru::List(require_nodes)] if head.eq_leaf("ns") || head.eq_leaf(":ns") => {
-        if require_nodes.first().is_none_or(|node| !node.eq_leaf(":require")) {
-          return Err(format!(
-            "invalid ns clause in namespace '{ns_name}': expected `:require`, got {}",
-            Cirru::List(require_nodes.clone())
-          ));
-        }
+    Cirru::List(xs) => {
+      if xs
+        .iter()
+        .skip(2)
+        .any(|node| matches!(node, Cirru::List(items) if items.first().is_some_and(|head| head.eq_leaf(":require-macros"))))
+      {
+        return Err(format!(
+          "legacy `:require-macros` in namespace '{ns_name}' is no longer supported; move macro imports into the ordinary `:require` clause, for example `foo.macros :refer $ macro-name` (macros and values now share import rules)"
+        ));
+      }
 
-        let rules = &require_nodes[1..];
-        let warnings = validate_import_rules(rules).map_err(|e| format!("in namespace '{ns_name}': {e}"))?;
-        for warning in warnings {
-          eprintln!("[Warn] in namespace '{ns_name}': {warning}");
-        }
-        let mut import_map: HashMap<Arc<str>, Arc<ImportRule>> = HashMap::with_capacity(rules.len());
-        for rule_node in rules {
-          for (target, rule) in extract_import_rule(rule_node).map_err(|e| format!("in namespace '{ns_name}': {e}"))? {
-            import_map.insert(target, rule);
+      match xs.as_slice() {
+        [head, Cirru::Leaf(_declared_ns)] if head.eq_leaf("ns") || head.eq_leaf(":ns") => Ok(HashMap::new()),
+        [head, Cirru::Leaf(_declared_ns), Cirru::List(require_nodes)] if head.eq_leaf("ns") || head.eq_leaf(":ns") => {
+          if require_nodes.first().is_none_or(|node| !node.eq_leaf(":require")) {
+            return Err(format!(
+              "invalid ns clause in namespace '{ns_name}': expected `:require`, got {}",
+              Cirru::List(require_nodes.clone())
+            ));
           }
+
+          let rules = &require_nodes[1..];
+          let warnings = validate_import_rules(rules).map_err(|e| format!("in namespace '{ns_name}': {e}"))?;
+          for warning in warnings {
+            eprintln!("[Warn] in namespace '{ns_name}': {warning}");
+          }
+          let mut import_map: HashMap<Arc<str>, Arc<ImportRule>> = HashMap::with_capacity(rules.len());
+          for rule_node in rules {
+            for (target, rule) in extract_import_rule(rule_node).map_err(|e| format!("in namespace '{ns_name}': {e}"))? {
+              import_map.insert(target, rule);
+            }
+          }
+          Ok(import_map)
         }
-        Ok(import_map)
+        _ => {
+          let preview = cirru_parser::format(std::slice::from_ref(nodes), true.into()).unwrap_or_else(|_| format!("{nodes:?}"));
+          let preview_short = if preview.chars().count() > 200 {
+            format!("{}...", preview.chars().take(200).collect::<String>())
+          } else {
+            preview
+          };
+          Err(format!("invalid ns form in '{ns_name}':\n{preview_short}"))
+        }
       }
-      _ => {
-        let preview = cirru_parser::format(std::slice::from_ref(nodes), true.into()).unwrap_or_else(|_| format!("{nodes:?}"));
-        let preview_short = if preview.chars().count() > 200 {
-          format!("{}...", preview.chars().take(200).collect::<String>())
-        } else {
-          preview
-        };
-        Err(format!("invalid ns form in '{ns_name}':\n{preview_short}"))
-      }
-    },
+    }
     Cirru::Leaf(_) => Err(format!(
       "invalid ns form in '{ns_name}': expected `(ns {ns_name})` (legacy `:ns` is also accepted) with an optional `:require` clause, got {nodes}"
     )),

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -157,6 +157,23 @@ fn namespace_validation_rejects_unknown_clause() {
 }
 
 #[test]
+fn namespace_validation_explains_require_macros_migration() {
+  let ns_form = cirru_list(vec![
+    cirru_leaf("ns"),
+    cirru_leaf("app.main"),
+    cirru_list(vec![
+      cirru_leaf(":require-macros"),
+      import_rule("legacy.macros", ":refer", cirru_list(vec![cirru_leaf("defcomp")])),
+    ]),
+  ]);
+  let error = extract_import_map(&ns_form, "app.main").expect_err("legacy macro imports should report a migration error");
+
+  assert!(error.contains("legacy `:require-macros`"), "error: {error}");
+  assert!(error.contains("ordinary `:require`"), "error: {error}");
+  assert!(error.contains("macros and values now share import rules"), "error: {error}");
+}
+
+#[test]
 fn namespace_validation_accepts_legacy_colon_ns_form() {
   let ns_form = cirru_list(vec![cirru_leaf(":ns"), cirru_leaf("app.main")]);
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -4108,6 +4108,18 @@ fn find_method_entry_with_impl<'a>(
   None
 }
 
+fn append_string_method_receiver_hint(mut message: String, method_name: &str, type_desc: &str) -> String {
+  let replacement = match method_name {
+    "trim" => "trim",
+    "blank?" => "blank?",
+    _ => return message,
+  };
+  message.push_str(&format!(
+    ". String API hint: `.{method_name}` requires a String receiver, but this receiver was inferred as `{type_desc}`; fix or narrow the receiver type, or use `({replacement} receiver)` for direct argument-type diagnostics"
+  ));
+  message
+}
+
 fn validate_method_call(
   head: &Calcit,
   args: &CalcitList,
@@ -4145,7 +4157,11 @@ fn validate_method_call(
     let type_desc = describe_type(type_value.as_ref());
     return Err(CalcitErr::use_msg_stack_location(
       CalcitErrKind::Type,
-      format!("unknown method `.{method_name}` for {type_desc}. Available methods: {methods_list}"),
+      append_string_method_receiver_hint(
+        format!("unknown method `.{method_name}` for {type_desc}. Available methods: {methods_list}"),
+        method_name,
+        &type_desc,
+      ),
       call_stack,
       head.get_location(),
     ));
@@ -4176,7 +4192,11 @@ fn validate_method_call(
   let type_desc = describe_type(type_value.as_ref());
   Err(CalcitErr::use_msg_stack_location(
     CalcitErrKind::Type,
-    format!("unknown method `.{method_name}` for {type_desc}. Available methods: {methods_list}"),
+    append_string_method_receiver_hint(
+      format!("unknown method `.{method_name}` for {type_desc}. Available methods: {methods_list}"),
+      method_name,
+      &type_desc,
+    ),
     call_stack,
     head.get_location(),
   ))
@@ -8792,6 +8812,19 @@ mod tests {
         "error should mention the struct type: {msg}"
       );
     }
+  }
+
+  #[test]
+  fn string_method_receiver_hint_names_inferred_type_and_function_form() {
+    let message = append_string_method_receiver_hint(
+      "unknown method `.trim` for map<:tag,:string>".to_owned(),
+      "trim",
+      "map<:tag,:string>",
+    );
+
+    assert!(message.contains("requires a String receiver"), "message: {message}");
+    assert!(message.contains("inferred as `map<:tag,:string>`"), "message: {message}");
+    assert!(message.contains("`(trim receiver)`"), "message: {message}");
   }
 
   #[test]

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -53,6 +53,16 @@ fn append_js_ffi_type_hint(mut message: String, actual_type: &str) -> String {
   message
 }
 
+fn append_option_migration_hint(mut message: String, actual_type: &CalcitTypeAnnotation) -> String {
+  if actual_type.is_option_type() {
+    message.push_str(&format!(
+      "; inferred type `{}` is an Option rather than its payload; use `option:unwrap-or` for a safe default or `tag-match` to handle both variants before passing it here",
+      actual_type.to_brief_string()
+    ));
+  }
+  message
+}
+
 fn check_generic_trait_bounds(ctx: &CheckContext<'_>, bindings: &HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>) {
   if ctx.where_bounds.is_empty() {
     return;
@@ -142,9 +152,10 @@ impl<'a> CheckContext<'a> {
     &self,
     arg_idx: usize,
     expected_str: &str,
-    actual_str: &str,
+    actual_type: &CalcitTypeAnnotation,
     make_warning: impl Fn(usize, &str, &str, String) -> String,
   ) {
+    let actual_str = actual_type.to_brief_string();
     let expr_str = format!(
       "{} {}",
       self.head_form,
@@ -156,7 +167,10 @@ impl<'a> CheckContext<'a> {
       .and_then(Calcit::get_location)
       .or_else(|| self.call_location.clone());
     gen_check_warning_code_at(
-      append_js_ffi_type_hint(make_warning(arg_idx, expected_str, actual_str, expr_str), actual_str),
+      append_js_ffi_type_hint(
+        append_option_migration_hint(make_warning(arg_idx, expected_str, &actual_str, expr_str), actual_type),
+        &actual_str,
+      ),
       self.warning_code,
       self.file_ns,
       warning_location,
@@ -196,8 +210,7 @@ where
           && !actual_type.as_ref().matches_with_bindings(inner_type.as_ref(), &mut bindings)
         {
           let expected_str = inner_type.as_ref().to_brief_string();
-          let actual_str = actual_type.as_ref().to_brief_string();
-          ctx.emit_warning(idx + rest_idx + 1, &expected_str, &actual_str, &make_warning);
+          ctx.emit_warning(idx + rest_idx + 1, &expected_str, actual_type.as_ref(), &make_warning);
         }
       }
       return; // Done after variadic
@@ -207,8 +220,7 @@ where
       && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
     {
       let expected_str = expected_type.as_ref().to_brief_string();
-      let actual_str = actual_type.as_ref().to_brief_string();
-      ctx.emit_warning(idx + 1, &expected_str, &actual_str, &make_warning);
+      ctx.emit_warning(idx + 1, &expected_str, actual_type.as_ref(), &make_warning);
     }
   }
 
@@ -326,10 +338,13 @@ pub(crate) fn check_proc_arg_types(
       let actual_str = actual_type.as_ref().to_brief_string();
       let warning_location = arg.get_location().or_else(|| call_location.clone());
       gen_check_warning_code_at(
-        format!(
-          "[Warn] Proc `{}` arg {} expects type `{expected_str}`, but got `{actual_str}` in call at {file_ns}/{def_name}",
-          proc.as_ref(),
-          idx + 1
+        append_option_migration_hint(
+          format!(
+            "[Warn] Proc `{}` arg {} expects type `{expected_str}`, but got `{actual_str}` in call at {file_ns}/{def_name}",
+            proc.as_ref(),
+            idx + 1
+          ),
+          actual_type.as_ref(),
         ),
         "W_PROC_ARG_TYPE_MISMATCH",
         file_ns,
@@ -377,10 +392,13 @@ pub(crate) fn check_core_fn_arg_types(
       let actual_str = actual_type.as_ref().to_brief_string();
       let warning_location = arg.get_location().or_else(|| call_location.clone());
       gen_check_warning_code_at(
-        format!(
-          "[Warn] Function `calcit.core/{}` arg {} expects type `:number`, but got `{actual_str}` in call at {file_ns}/{def_name}",
-          fn_info.name,
-          idx + 1
+        append_option_migration_hint(
+          format!(
+            "[Warn] Function `calcit.core/{}` arg {} expects type `:number`, but got `{actual_str}` in call at {file_ns}/{def_name}",
+            fn_info.name,
+            idx + 1
+          ),
+          actual_type.as_ref(),
         ),
         "W_CORE_FN_ARG_TYPE_MISMATCH",
         file_ns,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1860,8 +1860,32 @@ fn parse_entries_with_context(data: &Edn, require_mode: bool) -> Result<HashMap<
   Ok(entries)
 }
 
-/// parse snapshot
+fn legacy_snapshot_recovery_hint(path: &str) -> Option<String> {
+  let snapshot_path = Path::new(path);
+  let compact_path = snapshot_path.parent()?.join("compact.cirru");
+  if snapshot_path.file_name()?.to_str()? == "calcit.cirru" && compact_path.is_file() {
+    Some(format!(
+      "A sibling `{}` exists. If it is the last runnable compact Snapshot, back up this `calcit.cirru`, copy `compact.cirru` over it, then run `cr calcit.cirru edit format` before `cr calcit.cirru --check-only`.",
+      compact_path.display()
+    ))
+  } else {
+    None
+  }
+}
+
+/// Parse a Snapshot while preserving the source path in deserialization errors.
 pub fn load_snapshot_data(data: &Edn, path: &str) -> Result<Snapshot, String> {
+  load_snapshot_data_inner(data, path).map_err(|error| {
+    let mut message = format!("Failed to load Snapshot `{path}`: {error}");
+    if let Some(hint) = legacy_snapshot_recovery_hint(path) {
+      message.push_str("\nLegacy Snapshot recovery: ");
+      message.push_str(&hint);
+    }
+    message
+  })
+}
+
+fn load_snapshot_data_inner(data: &Edn, path: &str) -> Result<Snapshot, String> {
   let data = data.view_map()?;
   let pkg: Arc<str> = data.get_or_nil("package").try_into()?;
   let mut files: HashMap<String, FileInSnapShot> = parse_files_with_context(&data.get_or_nil("files"))?;
@@ -2524,6 +2548,26 @@ mod tests {
       .into_iter()
       .next()
       .expect("test Cirru should contain one expression")
+  }
+
+  #[test]
+  fn snapshot_load_error_names_source_and_compact_recovery_path() {
+    let root = std::env::temp_dir().join(format!("calcit-legacy-snapshot-recovery-{}", std::process::id()));
+    fs::create_dir_all(&root).expect("create legacy snapshot fixture directory");
+    let snapshot_path = root.join("calcit.cirru");
+    let compact_path = root.join("compact.cirru");
+    fs::write(&snapshot_path, "legacy full snapshot").expect("write full snapshot marker");
+    fs::write(&compact_path, "compact snapshot").expect("write compact snapshot marker");
+
+    let error = load_snapshot_data(&Edn::Nil, snapshot_path.to_str().expect("utf-8 temp path"))
+      .expect_err("invalid legacy snapshot data should fail with recovery guidance");
+
+    assert!(error.contains(snapshot_path.to_str().unwrap()), "error: {error}");
+    assert!(error.contains(compact_path.to_str().unwrap()), "error: {error}");
+    assert!(error.contains("cr calcit.cirru edit format"), "error: {error}");
+    assert!(error.contains("cr calcit.cirru --check-only"), "error: {error}");
+
+    fs::remove_dir_all(root).expect("remove legacy snapshot fixture directory");
   }
 
   fn revision_test_entry(tags: &[&str]) -> CodeEntry {


### PR DESCRIPTION
## Summary

- Prevent check-only stack overflow on deep macro/dependency preprocessing by running the CLI on a 32 MiB worker stack.
- Improve Option migration diagnostics with inferred Option<T> details and safe unwrap/pattern-match guidance.
- Add targeted guidance for legacy :require-macros, legacy Snapshot recovery, and string method receiver mismatches.
- Expand the upgrade guide and add focused regression coverage.

## Validation

- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-agent-interface (12/12)
- yarn check-all
- Cumulo.org check-only on the default 8176 KiB shell stack

Closes #344
Closes #346