### PR TITLE
fix: address post-merge review feedback

### DIFF
--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -89,9 +89,15 @@ cp calcit.cirru calcit.full-snapshot.backup.cirru
 cp compact.cirru compact.migration-backup.cirru
 $EDITOR compact.cirru
 # 在每个 ns 规则中将 :require-macros 改为 :require，并确认不再有旧 clause
-if rg ':require-macros' compact.cirru; then
+if rg -q ':require-macros' compact.cirru; then
   echo '请先逐个迁移 compact.cirru 中的 :require-macros 规则'
   exit 1
+else
+  status=$?
+  if [ "$status" -ne 1 ]; then
+    echo '无法检查 compact.cirru 中的 :require-macros 规则'
+    exit "$status"
+  fi
 fi
 cp compact.cirru calcit.cirru
 cr calcit.cirru edit format

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -86,13 +86,21 @@ Snapshot 文件迁移、依赖升级和类型修复建议分别提交，任何�
 
 ```bash
 cp calcit.cirru calcit.full-snapshot.backup.cirru
+cp compact.cirru compact.migration-backup.cirru
+$EDITOR compact.cirru
+# 在每个 ns 规则中将 :require-macros 改为 :require，并确认不再有旧 clause
+if rg ':require-macros' compact.cirru; then
+  echo '请先逐个迁移 compact.cirru 中的 :require-macros 规则'
+  exit 1
+fi
 cp compact.cirru calcit.cirru
 cr calcit.cirru edit format
 git diff -- calcit.cirru
 cr calcit.cirru --check-only
 ```
 
-不要删除备份或旧文件，直到所有 entry 与原有 native/JS 测试均通过。现在反序列化错误会带上失败的
+若 `rg` 没有匹配，才继续复制和格式化；如果仍有匹配，应逐个编辑 namespace 规则，而不是用全局替换，
+以免改动代码字符串中的同名文本。不要删除备份或旧文件，直到所有 entry 与原有 native/JS 测试均通过。现在反序列化错误会带上失败的
 Snapshot 路径；如果同目录存在 `compact.cirru`，还会直接给出上述恢复方向。
 
 旧 namespace 里的 `:require-macros` 也必须在 Snapshot 规范化前处理。宏与普通值现在共用
@@ -379,6 +387,9 @@ match (get-env |APP_MODE)
   (:some mode) $ println mode
   (:none) $ println |development
 ```
+
+上例使用推荐的原生 `match`；维护旧代码时也可以把同一组分支头替换为 `tag-match`，两者都能处理
+`Option` 的 `:some` / `:none`，但 `match` 额外提供穷举检查。
 
 只有业务语义确实有合理默认值时才用 `unwrap-or`；需要区分“缺失”和“存在”时保留两个分支。
 

--- a/editing-history/20260815-2315-review-followup-354.md
+++ b/editing-history/20260815-2315-review-followup-354.md
@@ -1,0 +1,6 @@
+# PR 354 review follow-up
+
+- Option 迁移提示现在只在实际值为 `Option<T>` 且目标参数不是 Option 时出现，避免对 `Option<T>` 与 `Option<U>` 的 payload 不匹配建议错误 unwrap。
+- Snapshot 恢复文档先要求在 `compact.cirru` 中逐个迁移 `:require-macros`，确认后再复制、format 和 check-only。
+- 字符串方法诊断测试改为通过 `validate_method_call` 走真实方法校验路径，并覆盖 Map 接收者的完整错误信息。
+- 文档明确推荐原生 `match`，同时说明旧代码可继续使用 `tag-match`；Copilot 关于 `std::fs` 的评论经核查为误报。

--- a/editing-history/20260815-2315-review-followup-354.md
+++ b/editing-history/20260815-2315-review-followup-354.md
@@ -2,5 +2,5 @@
 
 - Option 迁移提示现在只在实际值为 `Option<T>` 且目标参数不是 Option 时出现，避免对 `Option<T>` 与 `Option<U>` 的 payload 不匹配建议错误 unwrap。
 - Snapshot 恢复文档先要求在 `compact.cirru` 中逐个迁移 `:require-macros`，确认后再复制、format 和 check-only。
-- 字符串方法诊断测试改为通过 `validate_method_call` 走真实方法校验路径，并覆盖 Map 接收者的完整错误信息。
+- 字符串方法诊断测试改为通过 `validate_method_call` 走真实方法校验路径，并覆盖 `StructValue` `MapLike` 接收者的完整错误信息。
 - 文档明确推荐原生 `match`，同时说明旧代码可继续使用 `tag-match`；Copilot 关于 `std::fs` 的评论经核查为误报。

--- a/editing-history/20260815-2359-review-comment-355.md
+++ b/editing-history/20260815-2359-review-comment-355.md
@@ -1,0 +1,5 @@
+# PR 355 review comment follow-up
+
+- Hardened the snapshot migration `rg` guard: only the expected no-match status continues, while unavailable or unreadable checks stop the script; quiet mode avoids dumping all matches.
+- Corrected the prior history note to identify the `StructValue` `MapLike` receiver.
+- Aligned Option migration diagnostics with the upgrade guide by recommending native `match` while retaining legacy `tag-match` guidance, with regression coverage.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -217,6 +217,7 @@ fn option_returning_api_type_mismatches_include_unwrap_and_match_help() {
         .unwrap_or_else(|| panic!("missing mismatch for {inferred}; warnings: {warnings:?}"));
       assert!(warning.message().contains("inferred type"), "warning: {warning:?}");
       assert!(warning.message().contains("option:unwrap-or"), "warning: {warning:?}");
+      assert!(warning.message().contains("native `match`"), "warning: {warning:?}");
       assert!(warning.message().contains("tag-match"), "warning: {warning:?}");
     }
   });

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8816,15 +8816,91 @@ mod tests {
 
   #[test]
   fn string_method_receiver_hint_names_inferred_type_and_function_form() {
-    let message = append_string_method_receiver_hint(
-      "unknown method `.trim` for map<:tag,:string>".to_owned(),
-      "trim",
-      "map<:tag,:string>",
-    );
+    let receiver_type = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(
+      EdnTag::from("MapLike"),
+      vec![],
+    ))));
+    let head = Calcit::Method(Arc::from("trim"), calcit::MethodKind::Invoke(receiver_type.clone()));
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: 0,
+      sym: Arc::from("value"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.method"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: receiver_type,
+    });
+    let args = CalcitList::from(&[receiver][..]);
+
+    let error = validate_method_call(&head, &args, &ScopeTypes::new(), &CallStackList::default())
+      .expect_err("trim should reject a non-String receiver through method validation");
+    let message = error.to_string();
 
     assert!(message.contains("requires a String receiver"), "message: {message}");
-    assert!(message.contains("inferred as `map<:tag,:string>`"), "message: {message}");
+    assert!(message.contains("inferred as `struct MapLike`"), "message: {message}");
     assert!(message.contains("`(trim receiver)`"), "message: {message}");
+  }
+
+  #[test]
+  fn option_mismatch_between_nominal_payloads_does_not_suggest_unwrap() {
+    let option_number = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    let option_string = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),
+    ));
+    let fn_info = CalcitFn {
+      name: Arc::from("expects-option-number"),
+      def_ns: Arc::from("tests.option"),
+      def_ref: None,
+      usage: crate::calcit::CalcitFnUsageMeta::default(),
+      scope: Arc::new(CalcitScope::default()),
+      args: Arc::new(CalcitFnArgs::Args(vec![0])),
+      body: vec![Calcit::Nil],
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![option_number],
+      return_type: crate::calcit::DYNAMIC_TYPE.clone(),
+      rest_type: None,
+    };
+    let args = CalcitList::from(
+      &[Calcit::Local(CalcitLocal {
+        idx: 0,
+        sym: Arc::from("value"),
+        info: Arc::new(CalcitSymbolInfo {
+          at_ns: Arc::from("tests.option"),
+          at_def: Arc::from("demo"),
+        }),
+        location: None,
+        type_info: option_string,
+      })][..],
+    );
+    let head = Calcit::Import(CalcitImport {
+      ns: Arc::from("tests.option"),
+      def: Arc::from("expects-option-number"),
+      info: Arc::new(ImportInfo::NsReferDef {
+        at_ns: Arc::from("tests.option"),
+        at_def: Arc::from("demo"),
+      }),
+      def_id: None,
+    });
+    let warnings = RefCell::new(vec![]);
+    let call_info = CallTypeCheckInfo {
+      file_ns: "tests.option",
+      def_name: "demo",
+      call_location: None,
+    };
+
+    check_user_fn_arg_types(&fn_info, &head, &args, &ScopeTypes::new(), &call_info, &warnings);
+
+    let warnings = warnings.borrow();
+    let warning = warnings.first().expect("Option payload mismatch should warn");
+    assert_eq!(warning.code(), Some("W_FN_ARG_TYPE_MISMATCH"));
+    assert!(!warning.message().contains("option:unwrap-or"), "warning: {warning:?}");
+    assert!(!warning.message().contains("tag-match"), "warning: {warning:?}");
   }
 
   #[test]

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -60,7 +60,7 @@ fn append_option_migration_hint(
 ) -> String {
   if actual_type.is_option_type() && !expected_type.is_option_type() {
     message.push_str(&format!(
-      "; inferred type `{}` is an Option rather than its payload; use `option:unwrap-or` for a safe default or `tag-match` to handle both variants before passing it here",
+      "; inferred type `{}` is an Option rather than its payload; use `option:unwrap-or` for a safe default or native `match` (legacy `tag-match`) to handle both variants before passing it here",
       actual_type.to_brief_string()
     ));
   }

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -53,8 +53,12 @@ fn append_js_ffi_type_hint(mut message: String, actual_type: &str) -> String {
   message
 }
 
-fn append_option_migration_hint(mut message: String, actual_type: &CalcitTypeAnnotation) -> String {
-  if actual_type.is_option_type() {
+fn append_option_migration_hint(
+  mut message: String,
+  expected_type: &CalcitTypeAnnotation,
+  actual_type: &CalcitTypeAnnotation,
+) -> String {
+  if actual_type.is_option_type() && !expected_type.is_option_type() {
     message.push_str(&format!(
       "; inferred type `{}` is an Option rather than its payload; use `option:unwrap-or` for a safe default or `tag-match` to handle both variants before passing it here",
       actual_type.to_brief_string()
@@ -151,10 +155,11 @@ impl<'a> CheckContext<'a> {
   fn emit_warning(
     &self,
     arg_idx: usize,
-    expected_str: &str,
+    expected_type: &CalcitTypeAnnotation,
     actual_type: &CalcitTypeAnnotation,
     make_warning: impl Fn(usize, &str, &str, String) -> String,
   ) {
+    let expected_str = expected_type.to_brief_string();
     let actual_str = actual_type.to_brief_string();
     let expr_str = format!(
       "{} {}",
@@ -168,7 +173,11 @@ impl<'a> CheckContext<'a> {
       .or_else(|| self.call_location.clone());
     gen_check_warning_code_at(
       append_js_ffi_type_hint(
-        append_option_migration_hint(make_warning(arg_idx, expected_str, &actual_str, expr_str), actual_type),
+        append_option_migration_hint(
+          make_warning(arg_idx, &expected_str, &actual_str, expr_str),
+          expected_type,
+          actual_type,
+        ),
         &actual_str,
       ),
       self.warning_code,
@@ -209,8 +218,7 @@ where
         if let Some(actual_type) = resolve_type_value(rest_arg, ctx.scope_types)
           && !actual_type.as_ref().matches_with_bindings(inner_type.as_ref(), &mut bindings)
         {
-          let expected_str = inner_type.as_ref().to_brief_string();
-          ctx.emit_warning(idx + rest_idx + 1, &expected_str, actual_type.as_ref(), &make_warning);
+          ctx.emit_warning(idx + rest_idx + 1, inner_type.as_ref(), actual_type.as_ref(), &make_warning);
         }
       }
       return; // Done after variadic
@@ -219,8 +227,7 @@ where
     if let Some(actual_type) = resolve_type_value(arg, ctx.scope_types)
       && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
     {
-      let expected_str = expected_type.as_ref().to_brief_string();
-      ctx.emit_warning(idx + 1, &expected_str, actual_type.as_ref(), &make_warning);
+      ctx.emit_warning(idx + 1, expected_type.as_ref(), actual_type.as_ref(), &make_warning);
     }
   }
 
@@ -344,6 +351,7 @@ pub(crate) fn check_proc_arg_types(
             proc.as_ref(),
             idx + 1
           ),
+          expected_type.as_ref(),
           actual_type.as_ref(),
         ),
         "W_PROC_ARG_TYPE_MISMATCH",
@@ -398,6 +406,7 @@ pub(crate) fn check_core_fn_arg_types(
             fn_info.name,
             idx + 1
           ),
+          expected_type.as_ref(),
           actual_type.as_ref(),
         ),
         "W_CORE_FN_ARG_TYPE_MISMATCH",


### PR DESCRIPTION
Follow-up to #354 review comments.\n\nChanges:\n- Gate Option migration hints on an actual Option value with a non-Option expected type, with a regression for Option payload mismatches.\n- Fix snapshot recovery guidance to migrate :require-macros in compact.cirru before copying and formatting, with a shell guard.\n- Exercise string receiver diagnostics through validate_method_call and assert inferred type plus function-form guidance.\n- Clarify that the docs example uses native match while legacy code may use tag-match.\n\nThe Copilot std::fs comment was verified as a false positive because src/snapshot.rs already imports std::fs.\n\nValidation: cargo fmt --check, cargo clippy -- -D warnings, cargo test, yarn compile, yarn check-agent-interface, yarn check-all, and docs/run/upgrade.md check-md.