### PR TITLE
fix: require project version in deps.cirru

### DIFF
--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -16,6 +16,7 @@ aliases:
 
 ```cirru
 {}
+  :version |0.1.0
   :calcit-version |0.9.18
   :dependencies $ {}
     |calcit-lang/memof |0.0.11
@@ -90,8 +91,9 @@ caps version set 1.2.3
 caps version bump patch
 ```
 
-During migration, the snapshot `:version` field remains supported by `cr`; `caps version` only manages the
-dependency metadata file and does not rewrite the snapshot automatically. `cr config version` / `cr config set version`
+The project version belongs in `deps.cirru :version`. If it is missing, `caps` invocations that read the file print a
+migration warning; initialize it with `caps version set <version>`. `caps version get` and `caps version bump` fail when the
+field is missing, even if a legacy `calcit.cirru :version` field exists. `cr config version` / `cr config set version`
 are deprecated — use `caps version` instead.
 
 ### Outdated

--- a/docs/run/project-structure.md
+++ b/docs/run/project-structure.md
@@ -1,6 +1,6 @@
 ---
 title: "项目结构：calcit.cirru 与 deps.cirru"
-summary: "calcit.cirru 的 EDN 结构说明（:package、:version、:entries、:files、:modules）以及 deps.cirru 的版本管理"
+summary: "calcit.cirru 的 EDN 结构说明（:package、:entries、:files、:modules）以及 deps.cirru 的版本管理"
 scope: "core"
 kind: "reference"
 category: "run"
@@ -24,7 +24,6 @@ Agent 切到新窗口时，优先把 `calcit.cirru`（兼容旧文件名 `compac
 ```cirru.no-check
 {}
   :package |my-app
-  :version |0.1.0
   :entries $ {}
     :default $ {}
       :mode :js
@@ -52,7 +51,7 @@ Agent 切到新窗口时，优先把 `calcit.cirru`（兼容旧文件名 `compac
 字段职责可以快速记成：
 
 - `:package`：包名边界（影响哪些 namespace 允许被 `cr edit` 修改）。
-- `:version`：项目版本的 snapshot 镜像字段，迁移期保留给旧版 `cr` 读取；权威版本号请维护在 `deps.cirru :version`（用 `caps version get/set/bump` 管理）。
+- `:version`：不再属于推荐的 Snapshot 配置；旧 Snapshot 可能仍带有该字段，但 `caps` 不会读取它。项目版本请维护在 `deps.cirru :version`（用 `caps version get/set/bump` 管理）。
 - `:entries`：全部运行入口；不指定 `--entry` 时使用 `:default`。
 - `:mode`：入口的默认运行后端，只接受 `:native` 或 `:js`。
 - `:description`：entry 用途的简短语义说明；只提供给人和工具阅读，不影响运行。
@@ -119,8 +118,8 @@ project source.
 - `deps.cirru`：声明"要下载哪些外部模块 + 期望的 calcit 版本 + 项目发布版本（`:version`）"。
 - `calcit.cirru`（兼容旧文件名 `compact.cirru`）：声明"运行时要加载哪些模块（`:modules`）+ 项目代码快照（`:files`）"。
 
-版本号以 `deps.cirru :version` 为权威，用 `caps version get/set/bump` 管理；`calcit.cirru :version`
-只是迁移期兼容镜像，`cr config version` / `cr config set version` 已废弃，请改用 `caps version`。
+版本号只以 `deps.cirru :version` 为权威，用 `caps version get/set/bump` 管理；`calcit.cirru :version`
+不会作为 `caps` 的回退来源。`cr config version` / `cr config set version` 已废弃，请改用 `caps version`。
 
 常见升级动作（最少命令）：
 

--- a/editing-history/20260815-2325-caps-version-migration.md
+++ b/editing-history/20260815-2325-caps-version-migration.md
@@ -1,0 +1,6 @@
+# Caps project-version migration
+
+- `caps` now warns whenever the selected `deps.cirru` has no `:version`, with the direct `caps ... version set` migration command.
+- `caps version get` and `caps version bump` no longer read the legacy `calcit.cirru`/`compact.cirru` `:version`; they error until `deps.cirru :version` is initialized.
+- Documentation now presents `deps.cirru :version` as the only project-version source and removes `:version` from the recommended Snapshot example.
+- Added a regression test proving a legacy Snapshot version cannot satisfy the `caps version` commands.

--- a/editing-history/20260815-2356-caps-review-comment.md
+++ b/editing-history/20260815-2356-caps-review-comment.md
@@ -1,0 +1,4 @@
+# Caps review follow-up
+
+- Corrected the migration hints in the missing-version warning and `caps version get/bump` errors to match the CLI's trailing input-file syntax: `caps version set <version> <deps-file>`.
+- Added regression assertions that both errors contain the copy/paste-safe command for a non-default dependency path.

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -143,7 +143,7 @@ pub fn main() -> Result<(), String> {
 
     if deps.version.is_none() {
       eprintln!(
-        "[Warn] {} has no :version; initialize the project version with `caps {} version set <version>`",
+        "[Warn] {} has no :version; initialize the project version with `caps version set <version> {}`",
         cli_args.input, cli_args.input
       );
     }
@@ -642,6 +642,10 @@ mod tests {
     .expect_err("missing deps.cirru version should reject version get");
     assert!(get_error.contains("no :version declared in"), "unexpected error: {get_error}");
     assert!(get_error.contains("deps.cirru"), "unexpected error: {get_error}");
+    assert!(
+      get_error.contains(&format!("caps version set <version> {deps_file}")),
+      "unexpected migration hint: {get_error}"
+    );
 
     let bump_error = handle_version_command(
       deps,
@@ -653,6 +657,10 @@ mod tests {
     .expect_err("missing deps.cirru version should reject version bump");
     assert!(bump_error.contains("no :version declared in"), "unexpected error: {bump_error}");
     assert!(bump_error.contains("deps.cirru"), "unexpected error: {bump_error}");
+    assert!(
+      bump_error.contains(&format!("caps version set <version> {deps_file}")),
+      "unexpected migration hint: {bump_error}"
+    );
 
     std::fs::remove_dir_all(root).unwrap();
   }
@@ -995,7 +1003,7 @@ fn handle_version_command(mut deps: PackageDeps, deps_file: &str, opts: &Version
       let version = deps
         .version
         .as_deref()
-        .ok_or_else(|| format!("no :version declared in {deps_file}; initialize it with `caps {deps_file} version set <version>`"))?;
+        .ok_or_else(|| format!("no :version declared in {deps_file}; initialize it with `caps version set <version> {deps_file}`"))?;
       println!("{version}");
     }
     VersionSubcommand::Set(opts) => {
@@ -1008,7 +1016,7 @@ fn handle_version_command(mut deps: PackageDeps, deps_file: &str, opts: &Version
       let current = deps
         .version
         .as_deref()
-        .ok_or_else(|| format!("no :version declared in {deps_file}; initialize it with `caps {deps_file} version set <version>`"))?;
+        .ok_or_else(|| format!("no :version declared in {deps_file}; initialize it with `caps version set <version> {deps_file}`"))?;
       let mut version = Version::parse(current).map_err(|e| format!("invalid existing SemVer version '{current}': {e}"))?;
       match opts.level.as_str() {
         "major" => {

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -141,6 +141,13 @@ pub fn main() -> Result<(), String> {
     })?;
     let deps: PackageDeps = parsed.try_into()?;
 
+    if deps.version.is_none() {
+      eprintln!(
+        "[Warn] {} has no :version; initialize the project version with `caps {} version set <version>`",
+        cli_args.input, cli_args.input
+      );
+    }
+
     if let Some(version) = &deps.calcit_version
       && version != CALCIT_VERSION
     {
@@ -580,7 +587,10 @@ fn valid_module_component(component: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-  use super::{PackageDeps, module_folder, normalize_package_name};
+  use super::{
+    PackageDeps, VersionBumpCaps, VersionCaps, VersionGetCaps, VersionSubcommand, handle_version_command, module_folder,
+    normalize_package_name,
+  };
   use cirru_edn::Edn;
   use std::collections::HashMap;
   use std::sync::Arc;
@@ -605,8 +615,46 @@ mod tests {
   #[test]
   fn missing_dependencies_field_is_an_empty_graph() {
     let deps: PackageDeps = Edn::Map(cirru_edn::EdnMapView::default()).try_into().unwrap();
+    assert!(deps.version.is_none());
     assert!(deps.dependencies.is_empty());
     assert!(deps.dev_dependencies.is_empty());
+  }
+
+  #[test]
+  fn version_commands_do_not_read_snapshot_version() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-version-migration-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    let deps_path = root.join("deps.cirru");
+    std::fs::write(&deps_path, "{} (:dependencies $ {})").unwrap();
+    // A legacy snapshot version must not be used as a fallback anymore.
+    std::fs::write(root.join("calcit.cirru"), "{} (:version |1.2.3)").unwrap();
+
+    let deps: PackageDeps = cirru_edn::parse("{} (:dependencies $ {})").unwrap().try_into().unwrap();
+    let deps_file = deps_path.to_str().unwrap();
+    let get_error = handle_version_command(
+      deps.clone(),
+      deps_file,
+      &VersionCaps {
+        command: VersionSubcommand::Get(VersionGetCaps {}),
+      },
+    )
+    .expect_err("missing deps.cirru version should reject version get");
+    assert!(get_error.contains("no :version declared in"), "unexpected error: {get_error}");
+    assert!(get_error.contains("deps.cirru"), "unexpected error: {get_error}");
+
+    let bump_error = handle_version_command(
+      deps,
+      deps_file,
+      &VersionCaps {
+        command: VersionSubcommand::Bump(VersionBumpCaps { level: "patch".to_owned() }),
+      },
+    )
+    .expect_err("missing deps.cirru version should reject version bump");
+    assert!(bump_error.contains("no :version declared in"), "unexpected error: {bump_error}");
+    assert!(bump_error.contains("deps.cirru"), "unexpected error: {bump_error}");
+
+    std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]
@@ -944,15 +992,10 @@ fn sync_calcit_procs_package() -> Result<(), String> {
 fn handle_version_command(mut deps: PackageDeps, deps_file: &str, opts: &VersionCaps) -> Result<(), String> {
   match &opts.command {
     VersionSubcommand::Get(_) => {
-      let legacy = legacy_snapshot_version(deps_file)?;
-      let version = deps.version.as_deref().or(legacy.as_deref()).ok_or_else(|| {
-        format!(
-          "no :version declared in {deps_file} or its project snapshot; initialize it with `caps {deps_file} version set <version>`"
-        )
-      })?;
-      if deps.version.is_none() {
-        eprintln!("[Warn] reading legacy snapshot :version; migrate it with `caps {deps_file} version set {version}`");
-      }
+      let version = deps
+        .version
+        .as_deref()
+        .ok_or_else(|| format!("no :version declared in {deps_file}; initialize it with `caps {deps_file} version set <version>`"))?;
       println!("{version}");
     }
     VersionSubcommand::Set(opts) => {
@@ -962,12 +1005,10 @@ fn handle_version_command(mut deps: PackageDeps, deps_file: &str, opts: &Version
       println!("updated {deps_file} to {}", opts.version);
     }
     VersionSubcommand::Bump(opts) => {
-      let legacy = legacy_snapshot_version(deps_file)?;
-      let current = deps.version.as_deref().or(legacy.as_deref()).ok_or_else(|| {
-        format!(
-          "no :version declared in {deps_file} or its project snapshot; initialize it with `caps {deps_file} version set <version>`"
-        )
-      })?;
+      let current = deps
+        .version
+        .as_deref()
+        .ok_or_else(|| format!("no :version declared in {deps_file}; initialize it with `caps {deps_file} version set <version>`"))?;
       let mut version = Version::parse(current).map_err(|e| format!("invalid existing SemVer version '{current}': {e}"))?;
       match opts.level.as_str() {
         "major" => {
@@ -1000,24 +1041,6 @@ fn write_package_version(deps_file: &str, version: &str) -> Result<(), String> {
   };
   map.insert(Edn::tag("version"), Edn::str(version));
   fs::write(deps_file, cirru_edn::format(&parsed, false)?).map_err(|e| e.to_string())
-}
-
-fn legacy_snapshot_version(deps_file: &str) -> Result<Option<String>, String> {
-  let deps_path = Path::new(deps_file);
-  let project_root = deps_path.parent().unwrap_or(Path::new("."));
-  let snapshot = [project_root.join("calcit.cirru"), project_root.join("compact.cirru")]
-    .into_iter()
-    .find(|path| path.exists());
-  let Some(snapshot) = snapshot else {
-    return Ok(None);
-  };
-  let content = fs::read_to_string(&snapshot).map_err(|e| format!("failed to read {}: {e}", snapshot.display()))?;
-  let parsed = cirru_edn::parse(&content).map_err(|e| format!("failed to parse {}: {e}", snapshot.display()))?;
-  match parsed.view_map()?.get_or_nil("version") {
-    Edn::Str(version) => Ok(Some(version.to_string())),
-    Edn::Nil => Ok(None),
-    value => Err(format!("invalid snapshot :version in {}: {value}", snapshot.display())),
-  }
 }
 
 fn print_column(pkg: ColoredString, expected: ColoredString, latest: ColoredString, hint: ColoredString) {


### PR DESCRIPTION
Implement project-version migration behavior for caps.\n\nChanges:\n- Warn whenever a caps command reads a deps.cirru without :version, with the direct version-set command in the warning.\n- Make caps version get/bump fail when deps.cirru :version is missing instead of reading legacy calcit.cirru/compact.cirru :version.\n- Update dependency and project-structure docs so deps.cirru :version is the sole project-version source.\n- Add a regression test covering a legacy snapshot version.\n\nValidation: cargo fmt --check, cargo clippy -- -D warnings, cargo test, yarn compile, yarn check-agent-interface, yarn check-all, and docs check-md for the updated docs.