### PR TITLE
Guide agents toward typed Struct field access

### DIFF
--- a/calcit/test-algebra.cirru
+++ b/calcit/test-algebra.cirru
@@ -91,7 +91,8 @@
               assert-traits bf AlgebraApply
               let
                   b2 $ .apply b1 bf
-                assert= 12 $ &struct:get b2 :value
+                do (assert-type b2 AlgebraBox)
+                  assert= 12 $ :value b2
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -105,7 +106,8 @@
                   b2 $ .bind b1
                     fn (x)
                       %{} AlgebraBox $ :value (+ x 20)
-                assert= 25 $ &struct:get b2 :value
+                do (assert-type b2 AlgebraBox)
+                  assert= 25 $ :value b2
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -118,7 +120,8 @@
               let
                   b2 $ .map b1
                     fn (x) (+ x 10)
-                assert= 12 $ &struct:get b2 :value
+                do (assert-type b2 AlgebraBox)
+                  assert= 12 $ :value b2
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
@@ -132,7 +135,8 @@
               assert-traits b2 AlgebraMappend
               let
                   b3 $ .mappend b1 b2
-                assert= 7 $ &struct:get b3 :value
+                do (assert-type b3 AlgebraBox)
+                  assert= 7 $ :value b3
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/test-doc-smoke.cirru
+++ b/calcit/test-doc-smoke.cirru
@@ -78,8 +78,8 @@
           :code $ quote
             defn test-native-impl-new-dot-method () $ let
                 DotImpl $ &impl::new DocTrait
-                  :: .label $ fn (x)
-                    str-spaced |native-dot $ &struct:get x :name
+                  :: .label $ fn (x) (assert-type x DocPerson0)
+                    str-spaced |native-dot $ :name x
                 DotPerson $ impl-traits DocPerson0 DotImpl
                 p $ %{} DotPerson (:name |Bob)
               assert= (%some DocTrait) (impl-origin DotImpl)

--- a/calcit/test-struct.cirru
+++ b/calcit/test-struct.cirru
@@ -216,19 +216,13 @@
               &let
                 kitty $ %{} Cat (:name |kitty) (:color :red)
                 assert= :Cat $ &struct:get-name kitty
-                assert= :red $ &struct:get kitty :color
+                assert= :red $ :color kitty
                 assert= true $ = (&struct:definition kitty) Cat
                 assert= true $ struct-def? (&struct:definition kitty)
                 assert= true $ &struct:matches? kitty
                   %{} (&struct:definition kitty) (:name |kitty) (:color :red)
                 assert= (&struct:to-map kitty) (&{} :name |kitty :color :red)
                 assert= 2 $ &struct:count kitty
-                assert=
-                  &struct:get kitty $ &struct:field-tag kitty 0
-                  &struct:nth kitty 0
-                assert=
-                  &struct:get kitty $ &struct:field-tag kitty 1
-                  &struct:nth kitty 1
                 assert= true $ &struct:contains? kitty (&struct:field-tag kitty 0)
                 assert= true $ &struct:contains? kitty (&struct:field-tag kitty 1)
                 assert= true $ &struct:contains? kitty :color
@@ -241,7 +235,7 @@
                   %{} Cat (:name |kitty) (:color :red)
                 &let
                   persian $ &struct:extend-as kitty :Persian :age 10
-                  assert= 10 $ &struct:get persian :age
+                  assert= 10 $ &struct:nth persian 0
                   assert= :Persian $ &struct:get-name persian
           :examples $ []
           :schema $ :: 'Fn
@@ -325,7 +319,7 @@
                 assert= 20 $ :age p1
                 assert= 20 $ :age p2
                 assert= 23 $ :age p3
-                assert= 23 $ &struct:get p3 :age
+                assert= 23 $ :age p3
                 assert= :struct $ type-of p1
                 assert= (&struct:to-map p1)
                   {} (:name |Chen) (:age 20) (:position :mainland)

--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -138,19 +138,19 @@
         |myfoo:foo $ %{} 'CodeEntry (:doc "|method implementation for MyFoo/:foo")
           :code $ quote
             defn myfoo:foo (p)
-              str "|foo " $ &struct:get p :name
+              str "|foo " $ :name p
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Dynamic)
-              :args $ [] 'Dynamic
+            {} (:return 'String)
+              :args $ [] 'test-traits.main/Person0
         |myfoo:foo2 $ %{} 'CodeEntry (:doc "|method implementation for MyFooImpl2/:foo")
           :code $ quote
             defn myfoo:foo2 (p)
-              str "|foo2 " $ &struct:get p :name
+              str "|foo2 " $ :name p
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Dynamic)
-              :args $ [] 'Dynamic
+            {} (:return 'String)
+              :args $ [] 'test-traits.main/Person0
         |myzap:a $ %{} 'CodeEntry (:doc "|method implementation for MyZapA/:zap")
           :code $ quote
             defn myzap:a (_x) |zapA

--- a/calcit/test-types-inference.cirru
+++ b/calcit/test-types-inference.cirru
@@ -308,7 +308,7 @@
               assert-type p $ :: Person
               &inspect-type p
               let
-                  name-v $ &struct:get p :name
+                  name-v $ :name p
                 assert-type name-v String
                 &inspect-type name-v
               let

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -49,7 +49,8 @@ cr query modules
 git -C '<module-directory>' remote get-url origin
 # 将 origin 规范化为 OWNER/REPO 后，确认目标确实是对应 GitHub 仓库。
 gh repo view OWNER/REPO --json nameWithOwner,url
-gh issue create --repo OWNER/REPO --title '<concise problem title>' --body-file /tmp/calcit-issue.md
+mkdir -p .calcit/snippets
+gh issue create --repo OWNER/REPO --title '<concise problem title>' --body-file .calcit/snippets/calcit-issue.md
 ```
 
 `gh issue create --repo OWNER/REPO` 可显式提交到**非当前仓库**；不要依赖 cwd 或当前 Git remote 推断目标。若模块目录没有自己的 GitHub origin，先根据其路径、模块元数据、发布页或维护文档找出权威仓库；仍无法确认归属时，报告这一阻塞并向用户确认，不能把 Issue 猜测性地投到核心仓库。
@@ -60,7 +61,7 @@ Issue 正文至少包括：最小 Snapshot/snippet 或步骤、实际与预期�
 
 ```bash
 cr query config
-cr /tmp/demo.cirru query config
+cr .calcit/snippets/demo.cirru query config
 ```
 
 当 cwd、`calcit.cirru` / `compact.cirru` 或多个 Snapshot 可能混淆时，先选定文件，并在后续查询、mutation、验证中始终显式传同一个路径（如 `cr ./calcit.cirru ...`）。非默认 Snapshot 会包含在 `Command:` 回显中；默认值为减少噪音会省略，需要审计展开后的全部默认选项时加 `--verbose`。路径仍可能经过 alias 解析，必要时结合 `query config` 确认项目身份。
@@ -354,6 +355,8 @@ update-in data ([] :profile :visits)
 
 这样可以让缺失、默认值和失败在类型上分开，而不是继续依赖 `nil` 或组件临时的 `read-field` 函数。
 
+已知具名 Struct 的字段读取一律写成 `(:field value)`（接收者优先的 invoke 简写为 `value.:field`），不要在应用代码中生成 `&struct:get`。检查器会验证字段、返回声明类型，并把读取自动降为 `&struct:nth value <index>`；直接写低层 primitive 会隐藏源码中的类型意图，并触发 `W_STRUCT_RAW_ACCESS`。如果 `(:field value)` 报 `W_REQUIRED_STRUCT_FIELD_TYPE`，应补全 schema、先 narrow/unwrap，不能改写成 `&struct:get` 绕过分析。只有可复用 `defimpl` 尚未绑定具体 Struct 的实现体以及 core/runtime 底层代码，才把 `&struct:get` 作为明确的动态边界。
+
 ### 5.4 CLI 的 `quote` 是代码/数据边界
 
 所有接收 AST 的 Cirru 文本输入都必须让 `quote` **恰好包住一个节点**；提交 mutation 时 CLI 会剥离这个 transport wrapper。JSON 数组 AST 是兼容输入，不需要 `quote`，但不要手写大型 JSON AST。
@@ -372,7 +375,7 @@ empty list/map: quote $ []      /    quote $ {}
 | 输入方式              | 适用场景                             |
 | --------------------- | ------------------------------------ |
 | `--code 'quote ...'`  | 简短单行输入                         |
-| `--file <file>`       | 需要复用、审阅或 transaction 的输入 |
+| `--file <file>`       | 需要复用、审阅或 transaction 的输入；临时文件放 `.calcit/snippets/` |
 | 省略两者，从 stdin 读 | 一次性多行内容，避免 Shell 转义      |
 
 修改命令没有 `--stdin` 参数。多行内容直接省略 `--file/--code`：
@@ -384,6 +387,8 @@ quote $ if ready?
   render-loading
 END
 ```
+
+不要把仓库相关的 snippet 放进全局 `/tmp`；它脱离项目生命周期，也容易被 Agent 在后续命令中误用。需要落盘时先 `mkdir -p .calcit/snippets`，并确认 `.calcit/` 已加入项目 `.gitignore`。CLI 收到 `/tmp/...` 或 `/private/tmp/...` 的 Snapshot/`--file` 路径时会在 stderr 给出这一迁移提示，不污染 JSON stdout。
 
 ### 5.5 写入前先解析，写入后再做语义检查
 

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -355,7 +355,7 @@ update-in data ([] :profile :visits)
 
 这样可以让缺失、默认值和失败在类型上分开，而不是继续依赖 `nil` 或组件临时的 `read-field` 函数。
 
-已知具名 Struct 的字段读取一律写成 `(:field value)`（接收者优先的 invoke 简写为 `value.:field`），不要在应用代码中生成 `&struct:get`。检查器会验证字段、返回声明类型，并把读取自动降为 `&struct:nth value <index>`；直接写低层 primitive 会隐藏源码中的类型意图，并触发 `W_STRUCT_RAW_ACCESS`。如果 `(:field value)` 报 `W_REQUIRED_STRUCT_FIELD_TYPE`，应补全 schema、先 narrow/unwrap，不能改写成 `&struct:get` 绕过分析。只有可复用 `defimpl` 尚未绑定具体 Struct 的实现体以及 core/runtime 底层代码，才把 `&struct:get` 作为明确的动态边界。
+已知具名 Struct 的字段读取一律写成 `(:field value)`（接收者优先的 invoke 简写为 `value.:field`），不要在应用代码中生成 `&struct:get`。检查器会验证字段、返回声明类型，并把读取自动降为 `&struct:nth value <index>`；直接写低层 primitive 会隐藏源码中的类型意图，并触发 `W_STRUCT_RAW_ACCESS`。如果 `(:field value)` 报 `W_REQUIRED_STRUCT_FIELD_TYPE`，应补全 schema、先 narrow/unwrap，不能改写成 `&struct:get` 绕过分析。若诊断中的接收者只剩未限定的 `'Router` 一类 nominal TypeRef，应恢复或显式写成 `'app.schema/Router`，并检查声明所在依赖是否正确加载；嵌套字段声明中的同 namespace 短类型会由检查器自动保留声明 namespace。只有可复用 `defimpl` 尚未绑定具体 Struct 的实现体以及 core/runtime 底层代码，才把 `&struct:get` 作为明确的动态边界。`W_STRUCT_*` 属于项目源码迁移提示，不会要求调用方修改已安装依赖中的旧实现。
 
 ### 5.4 CLI 的 `quote` 是代码/数据边界
 

--- a/docs/features/enums.md
+++ b/docs/features/enums.md
@@ -97,7 +97,7 @@ let
     p $ %{} Point (:x 1) (:y 2)
     shape $ %:: Shape :point p
   assert-type shape Shape
-  assert= 1 $ &struct:get (&enum:nth shape 1) :x
+  assert= 1 $ :x (&enum:nth shape 1)
 ```
 
 Applied generic structs also work in enum payloads:
@@ -110,9 +110,10 @@ let
       :empty
     value $ %:: Wrapped :box
       %{} Box $ :value 1
-    boxed $ &enum:nth value 1
   assert-type value $ :: 'Wrapped :number
-  assert= 1 $ &struct:get boxed :value
+  assert= 1 $ match value
+    (:box boxed) (:value boxed)
+    (:empty) 0
 ```
 
 When you annotate an enum payload with a struct type, `%::` validates both the variant tag and the payload value at runtime. Applied struct payload types must use the correct generic arity.

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -66,10 +66,10 @@ let
           :generics $ [] 'T
           :args $ [] 'T
           :return :string
-    MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p)
-        str "|foo " $ &struct:get p :name
     Person0 $ defstruct Person (:name :string)
+    MyFooImpl $ defimpl MyFooImpl MyFoo
+      .foo $ fn (p) (assert-type p Person0)
+        str "|foo " $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   p .foo
@@ -99,14 +99,14 @@ let
           :return :string
     Person0 $ defstruct Person (:name :string)
     ShowImpl $ defimpl ShowImpl ShowTrait
-      .show $ fn (p)
-        str |Person: $ &struct:get p :name
+      .show $ fn (p) (assert-type p Person0)
+        str |Person: $ :name p
     EqImpl $ defimpl EqImpl EqTrait
-      .eq $ fn (p)
-        str |eq: $ &struct:get p :name
+      .eq $ fn (p) (assert-type p Person0)
+        str |eq: $ :name p
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p)
-        str |foo: $ &struct:get p :name
+      .foo $ fn (p) (assert-type p Person0)
+        str |foo: $ :name p
     Person $ impl-traits Person0 ShowImpl EqImpl MyFooImpl
     p $ %{} Person (:name |Alice)
   [] (p .show) (p .foo)
@@ -126,8 +126,8 @@ let
           :return :string
     Person0 $ defstruct Person (:name :string)
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p)
-        str-spaced |foo $ &struct:get p :name
+      .foo $ fn (p) (assert-type p Person0)
+        str-spaced |foo $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -357,7 +357,7 @@ let
       hint-fn $ {}
         :args $ [] 'User
         :return :string
-      &struct:get u :name
+      :name u
   get-name $ %{} User (:name |Alice)
 ```
 

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -427,7 +427,8 @@ Anonymous structs still have a runtime field set, but they do not carry the
 declaration needed for typed required-field access. Do not use them as a way to
 bypass field analysis in application code. Convert/rewrite the value to an
 expected named Struct before reading fields. `&struct:get` remains available
-only to core/runtime code that intentionally implements a dynamic boundary.
+only to core/runtime code or an explicit reusable `defimpl` that intentionally
+implements a dynamic boundary.
 The following block deliberately demonstrates that low-level runtime behavior;
 using the same call in application code produces a typed-access warning.
 

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -50,7 +50,7 @@ let
         :generics $ [] 'T
         :args $ [] (:: 'Box 'T)
         :return 'T
-      &struct:get box :value
+      :value box
     b $ %{} Box (:value 1)
   assert-type b $ :: 'Box :number
   assert= 1 $ keep b
@@ -68,7 +68,7 @@ let
       {} $ 'T Show
       :value 'T
     box $ %{} ShownBox (:value 1)
-    item $ &struct:get box :value
+    item $ :value box
   assert-type box $ :: 'ShownBox 'Number
   assert= |1 $ item .show
 ```
@@ -307,25 +307,18 @@ let
         {}
           :args $ [] 'T
           :return :nil
-      .rename $ :: :fn
-        {}
-          :generics $ [] 'T
-          :args $ [] 'T :string
-          :return 'T
     BirdShape $ defstruct BirdShape (:name :string)
     BirdImpl $ defimpl BirdImpl BirdTrait
       .show $ fn (self)
         ; defimpl bodies are reusable before a concrete Struct is attached,
         ; so low-level access is explicit at this dynamic implementation boundary.
+        ; Do not copy this form into typed application code.
         println $ &struct:get self :name
-      .rename $ fn (self name) (assoc self :name name)
     Bird $ impl-traits BirdShape BirdImpl
     b $ %{} Bird (:name |Sparrow)
   assert-traits b BirdTrait
   b .show
-  let
-      b2 $ b .rename |Eagle
-    println $ &struct:get b2 :name
+  println $ :name b
 ```
 
 ## Common Use Cases
@@ -359,7 +352,7 @@ let
       hint-fn $ {}
         :args $ [] 'User
         :return :string
-      &struct:get user :name
+      :name user
   println $ get-user-name
     %{} User (:name |John) (:age 30) (:email |john@example.com)
 
@@ -411,11 +404,13 @@ Fields are automatically sorted alphabetically, matching the field ordering of n
 
 ### Accessing Fields
 
-Anonymous structs still have a fixed field set, but they do not carry a named
-type declaration. Use the explicit low-level accessor until the value has been
-rewritten to an expected named Struct:
+Anonymous structs still have a runtime field set, but they do not carry the
+declaration needed for typed required-field access. Do not use them as a way to
+bypass field analysis in application code. Convert/rewrite the value to an
+expected named Struct before reading fields. `&struct:get` remains available
+only to core/runtime code that intentionally implements a dynamic boundary.
 
-```cirru
+```cirru.no-check
 let
     r $ %{} _ (:x 10) (:y 20)
   println $ &struct:get r :x

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -130,6 +130,25 @@ Use `get` for maps and indexed collections when absence is intentional; it
 always returns `Option<T>`. Struct fields do not use `get`, which keeps the two
 contracts visibly distinct in source code.
 
+Nested nominal fields keep the namespace where their declaration was written.
+This means a concise same-namespace field type such as `'Router` remains
+statically resolvable even when the outer Struct flows into another namespace:
+
+```cirru.no-check
+defstruct Router (:name 'String)
+defstruct ClientStore (:router 'Router)
+
+defn router-name (store)
+  hint-fn $ {}
+    :args $ [] 'app.schema/ClientStore
+    :return 'String
+  :name $ :router store
+```
+
+If a diagnostic still shows an unresolved short receiver such as `'Router`, fix
+or qualify the schema/dependency reference. Do not replace the typed read with
+`&struct:get`; that only hides the missing declaration context.
+
 Loose/anonymous structs (`?{}` or `%{} _ ...`) also cannot be read through the
 required field accessor until an expected named Struct type rewrites them. This
 prevents an undeclared field from silently becoming `Dynamic` and forces the
@@ -409,6 +428,8 @@ declaration needed for typed required-field access. Do not use them as a way to
 bypass field analysis in application code. Convert/rewrite the value to an
 expected named Struct before reading fields. `&struct:get` remains available
 only to core/runtime code that intentionally implements a dynamic boundary.
+The following block deliberately demonstrates that low-level runtime behavior;
+using the same call in application code produces a typed-access warning.
 
 ```cirru.no-check
 let
@@ -470,6 +491,6 @@ When the static analysis system knows a value's struct type, the preprocessor re
 These rewrites are automatic and transparent. To benefit from them, provide type annotations via `:schema` or `hint-fn` so the preprocessor can resolve struct types.
 
 Struct intentionally has no public `.nth` method: positional field order is not
-a cross-backend API contract. Use field-name `get`, which returns the declared
-field type directly. Only generated, statically checked access uses internal
-`&struct:nth`.
+a cross-backend API contract. Use `(:field value)` or `value.:field`, which
+returns the declared field type directly. Only generated, statically checked
+access uses internal `&struct:nth`.

--- a/docs/features/traits.md
+++ b/docs/features/traits.md
@@ -52,8 +52,8 @@ let
           :return 'String
     Person0 $ defstruct Person (:name 'String)
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p)
-        str-spaced |foo $ &struct:get p :name
+      .foo $ fn (p) (assert-type p Person0)
+        str-spaced |foo $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   p .foo
@@ -82,8 +82,8 @@ let
           :args $ [] 'T
           :return 'String
     MyFooImplA $ defimpl MyFooImplA MyFooA
-      .foo $ fn (p)
-        str-spaced |foo $ &struct:get p :name
+      .foo $ fn (p) (assert-type p PersonA0)
+        str-spaced |foo $ :name p
     PersonA $ impl-traits PersonA0 MyFooImplA
     p $ %{} PersonA (:name |Alice)
   p .foo
@@ -103,8 +103,8 @@ let
           :return 'String
     Person0 $ defstruct Person (:name 'String)
     ImplB $ defimpl ImplB MyFoo
-      :: :foo $ fn (p)
-        str |B: $ &struct:get p :name
+      :: :foo $ fn (p) (assert-type p Person0)
+        str |B: $ :name p
     PersonB $ impl-traits Person0 ImplB
     pb $ %{} PersonB (:name |Bob)
   pb .foo
@@ -157,14 +157,14 @@ let
           :generics $ [] 'T
           :args $ [] 'T
           :return 'String
+    StructDef0 $ defstruct StructDef (:name 'String)
     ImplA $ defimpl ImplA MyFoo
-      .foo $ fn (p)
-        str |A: $ &struct:get p :name
+      .foo $ fn (p) (assert-type p StructDef0)
+        str |A: $ :name p
     MyBar $ deftrait MyBar (.bar 'Fn)
     ImplB $ defimpl ImplB MyBar
-      .bar $ fn (p)
-        str |B: $ &struct:get p :name
-    StructDef0 $ defstruct StructDef (:name 'String)
+      .bar $ fn (p) (assert-type p StructDef0)
+        str |B: $ :name p
     StructDef $ impl-traits StructDef0 ImplA ImplB
     x $ %{} StructDef (:name |test)
   x .foo
@@ -184,10 +184,10 @@ do (; struct example)
             :generics $ [] 'T
             :args $ [] 'T
             :return 'String
-      MyFooImpl $ defimpl MyFooImpl MyFoo
-        .foo $ fn (p)
-          str-spaced |foo $ &struct:get p :name
       Person0 $ defstruct Person (:name 'String)
+      MyFooImpl $ defimpl MyFooImpl MyFoo
+        .foo $ fn (p) (assert-type p Person0)
+          str-spaced |foo $ :name p
       Person $ impl-traits Person0 MyFooImpl
       p $ %{} Person (:name |Alice)
     p .foo
@@ -325,8 +325,8 @@ let
           :return 'String
     Person0 $ defstruct Person (:name 'String)
     MyFooImpl $ defimpl MyFooImpl MyFoo
-      .foo $ fn (p)
-        str-spaced |foo $ &struct:get p :name
+      .foo $ fn (p) (assert-type p Person0)
+        str-spaced |foo $ :name p
     Person $ impl-traits Person0 MyFooImpl
     p $ %{} Person (:name |Alice)
   assert-traits p MyFoo

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -191,6 +191,7 @@ let
 - Method call: `xs .map inc` when the receiver type is known; prefix `.map xs inc` remains compatible for dynamic boundaries
 - Required named-Struct field access: use `(:name value)` or receiver-first `value.:name`; the checker validates the declared type and lowers it to indexed access
 - Optional Map lookup: use `get` and handle its `Option`; do not use `&struct:get` as application syntax
+- An unresolved short nominal receiver such as `'Router` means its declaration context was lost; qualify the schema (for example `'app.schema/Router`) instead of hiding the diagnostic with `&struct:get`
 - Trait/impl declarations prefer dot method keys like `.foo`; legacy tag keys like `:foo` remain compatible but emit a default warning in `deftrait`/`defimpl`
 
 ## File Structure

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -189,7 +189,8 @@ let
 ### Method & Access Syntax
 
 - Method call: `xs .map inc` when the receiver type is known; prefix `.map xs inc` remains compatible for dynamic boundaries
-- Tag access (map key): prefer `obj.:name` over legacy `(:name obj)`
+- Required named-Struct field access: use `(:name value)` or receiver-first `value.:name`; the checker validates the declared type and lowers it to indexed access
+- Optional Map lookup: use `get` and handle its `Option`; do not use `&struct:get` as application syntax
 - Trait/impl declarations prefer dot method keys like `.foo`; legacy tag keys like `:foo` remain compatible but emit a default warning in `deftrait`/`defimpl`
 
 ## File Structure
@@ -288,7 +289,7 @@ let
 - `%{}?` - create a partial struct (unset fields default to nil)
 - `&%{}` - low-level struct constructor (flat key-value pairs, no type check)
 - `struct-with` - update multiple declared fields
-- `&struct:get` - get a required declared field
+- `&struct:get` - internal/dynamic-boundary field lookup; normal typed code must use `(:field value)`
 - `&struct:assoc` - set a declared field (low-level)
 - `struct-definition` - get the definition as `Option<StructDef>`
 - `&struct:matches?` - type check
@@ -356,9 +357,10 @@ let
 Nested updates are nominal as well: `update-in` passes `Option<T>` to its
 updater, and `dissoc-in` treats an empty path as a no-op. Public lookup and
 positional APIs (`get`, `get-in`, `first`, `last`, and collection `nth`) return
-`Option<T>`. Accessing a statically known struct field with `get`, `:field`, or
-`.field` returns the field's declared type directly; an undeclared field is a
-diagnostic, not `nil`. Struct has no public positional `.nth`.
+`Option<T>`. Accessing a statically known struct field with `(:field value)` or
+receiver-first `value.:field` returns the field's declared type directly and is
+lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
+`get` does not read Struct fields, and Struct has no public positional `.nth`.
 
 ### Threading Macros
 

--- a/docs/run/agent-advanced.md
+++ b/docs/run/agent-advanced.md
@@ -33,6 +33,8 @@ entry_for:
 
 当**同时省略 `--file` 和 `--code`** 时，命令默认从 stdin 读取。无需 Shell 转义，不需临时文件——这是极力推荐的高级重构方式。
 
+确实需要复用或审阅 `--file` 输入时，在项目内使用 `.calcit/snippets/<name>`，并让 `.calcit/` 保持在 `.gitignore`；不要为仓库相关输入使用全局 `/tmp`。CLI 会在 stderr 提示迁移 `/tmp/...` 与 `/private/tmp/...` 路径。
+
 ### 统一查询命令
 
 ```bash

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -80,7 +80,7 @@ The positional input may point to a standalone dependency file. Its parent direc
 root even when no `calcit.cirru` exists:
 
 ```bash
-caps /tmp/demo/deps.cirru
+caps ./demo/deps.cirru
 ```
 
 New projects may keep their package version in `deps.cirru` and manage it with:

--- a/editing-history/20260816-0046-typed-struct-agent-guidance.md
+++ b/editing-history/20260816-0046-typed-struct-agent-guidance.md
@@ -1,0 +1,7 @@
+# 2026-08-16 Agent 的 Struct 字段访问与临时文件引导
+
+- 已知具名 Struct 的应用代码应使用 `(:field value)` 或 receiver-first `value.:field` invoke 语法；检查器会保留字段声明类型，并继续降为索引访问。
+- 直接使用 `&struct:get` 现在会报告 `W_STRUCT_RAW_ACCESS`；接收者无法静态解析时报告更严格的 `W_STRUCT_DYNAMIC_RAW_ACCESS`。可复用 `defimpl` 与 core/runtime 动态边界保持兼容。
+- 本地 `let` 中的 `defstruct` / `defenum` 现在可解析函数参数、`assert-type`、泛型 enum 构造及 `match` payload 的名义类型，避免类型退化为 `Dynamic` 后迫使代码绕过检查。
+- CLI 收到 `/tmp/...` 或 `/private/tmp/...` 的 Snapshot/`--file` 路径时在 stderr 提示使用项目内 `.calcit/snippets/`，并提醒将 `.calcit/` 保持在 `.gitignore`；查询命令的 stdout 协议不受影响。
+- Agent、Struct、Enum、Trait 与 quick reference 文档和相关 Snapshot 回归均改为优先展示类型化字段访问。

--- a/editing-history/20260816-0115-nested-struct-type-context.md
+++ b/editing-history/20260816-0115-nested-struct-type-context.md
@@ -1,0 +1,19 @@
+# 嵌套 Struct 类型的声明上下文与迁移告警边界
+
+## 背景
+
+issue #357 在 cumulo-reel 的完整依赖图中暴露出 `W_REQUIRED_STRUCT_FIELD_TYPE` 误报：`ClientStore` 的 `:router` 字段在声明处写作同 namespace 的短类型 `'Router`，字段类型流入调用方后只剩未限定 `TypeRef("Router")`，无法再次解析为 `cumulo-reel.schema/Router`。正确的 `:name router` 因而失败，促使调用方用 `&struct:get` 绕过检查。
+
+## 修改要点
+
+- 从具名 Struct 读取字段类型时，按 Struct 定义所在 namespace 解析字段类型体内的短 `TypeRef`，并递归处理泛型参数、集合、函数、Optional 等复合类型。
+- 函数参数 schema 进入函数体时，同样先解析词法局部类型，再解析声明 namespace、import alias/refer 与 core 类型；带源码引号的局部引用会在 lookup 前规范化。
+- `&struct:get` 的迁移告警只针对项目源码中的 literal tag 字段访问；普通执行、query/static-analysis 与 docs snippet 入口都保留项目 namespace 集合。加载依赖、动态 key、core/runtime 与可复用 `defimpl` 保留低层边界，避免旧依赖阻塞项目迁移。
+- 未解析 nominal receiver 的诊断会明确要求恢复或限定 schema，而不是建议用 raw accessor 隐藏问题。
+- `/tmp` 提示区分主 Snapshot 与 `--file` scratch 输入：Snapshot 应留在项目根目录保证相对模块解析，`.calcit/snippets/` 只用于项目本地临时代码。
+
+## 回归证据
+
+- 单测覆盖同 namespace 嵌套 Struct 字段、带引号局部 TypeRef、未解析 nominal 诊断、动态 key 与依赖 namespace 告警边界。
+- 在 cumulo-reel issue 提交者对应提交的副本中，把 Router/Session 的七处 raw 访问恢复为 tag 语法；`query type-at` 得到精确的 `'cumulo-reel.schema/Router`，项目自身不再出现相关 required-field 误报。
+- `cargo clippy -- -D warnings`、`cargo test`、`yarn compile`、`yarn check-agent-interface`、`yarn check-all` 与相关 Markdown snippet 检查通过。

--- a/editing-history/20260816-0126-typed-struct-review-followup.md
+++ b/editing-history/20260816-0126-typed-struct-review-followup.md
@@ -1,0 +1,6 @@
+# Typed Struct review follow-up
+
+- 匿名 Struct 文档同时列出 core/runtime 与显式可复用 `defimpl` 两类低层动态边界，避免文档规则比实际检查器更窄。
+- 将 lexical-local 与 declaration-namespace 两套 TypeRef 解析改为共享 `map_type_refs_for_body` 遍历器；差异仅留在 TypeRef 回调，List/Map/Set/Ref/Optional/JsNullish/Variadic/Fn/Struct/Enum 的递归结构只维护一份。
+- 保留原有解析顺序和 fallback：先递归处理类型参数，再执行局部或 namespace 解析；无法解析时仍保留原始 TypeRef 名称。
+- 重点回归带引号局部类型和跨 namespace 嵌套 Struct 字段，防止维护性重构改变 issue #357 的行为。

--- a/src/bin/cli_handlers/common.rs
+++ b/src/bin/cli_handlers/common.rs
@@ -2,6 +2,7 @@
 
 use cirru_parser::Cirru;
 use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 
 // Error message constants
@@ -161,6 +162,23 @@ pub fn print_cli_warning_block(message: &str) {
   }
 }
 
+pub fn global_temp_path_guidance(path: &str) -> Option<String> {
+  let path_ref = Path::new(path);
+  if !path_ref.is_absolute() || !(path_ref.starts_with("/tmp") || path_ref.starts_with("/private/tmp")) {
+    return None;
+  }
+
+  Some(format!(
+    "`{path}` is under a global temporary directory. For project-local Calcit scratch input, prefer `.calcit/snippets/<name>`; keep `.calcit/` in `.gitignore`. For one-off multi-line input, omit `--file`/`--code` and pipe stdin instead."
+  ))
+}
+
+pub fn warn_on_global_temp_path(path: &str) {
+  if let Some(message) = global_temp_path_guidance(path) {
+    print_cli_warning_block(&message);
+  }
+}
+
 pub fn emit_cli_output(content: &str, to_stderr: bool) {
   if to_stderr {
     eprint!("{content}");
@@ -210,6 +228,7 @@ pub fn read_code_input(file: &Option<String>, code: &Option<String>) -> Result<O
   validate_input_sources(&sources)?;
 
   if let Some(path) = file {
+    warn_on_global_temp_path(path);
     let content = fs::read_to_string(path).map_err(|e| format!("Failed to read file '{path}': {e}"))?;
     Ok(Some(content.trim().to_string()))
   } else if let Some(s) = code {
@@ -348,8 +367,8 @@ pub fn parse_input_to_cirru(raw: &str) -> Result<Cirru, String> {
 #[cfg(test)]
 mod tests {
   use super::{
-    format_path, format_path_with_separator, parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes, resolve_definition_lookup,
-    shell_quote,
+    format_path, format_path_with_separator, global_temp_path_guidance, parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes,
+    resolve_definition_lookup, shell_quote,
   };
   use cirru_parser::Cirru;
 
@@ -421,6 +440,18 @@ mod tests {
   #[test]
   fn quotes_shell_targets_with_single_quotes() {
     assert_eq!(shell_quote("app.main/element->node"), "'app.main/element->node'");
+  }
+
+  #[test]
+  fn global_tmp_path_guidance_points_to_project_local_snippets() {
+    for path in ["/tmp/change.cirru", "/private/tmp/change.cirru"] {
+      let guidance = global_temp_path_guidance(path).expect("global tmp path should be recognized");
+      assert!(guidance.contains(".calcit/snippets/<name>"));
+      assert!(guidance.contains("stdin"));
+    }
+
+    assert!(global_temp_path_guidance(".calcit/snippets/change.cirru").is_none());
+    assert!(global_temp_path_guidance("/tmp-project/change.cirru").is_none());
   }
 
   #[test]

--- a/src/bin/cli_handlers/common.rs
+++ b/src/bin/cli_handlers/common.rs
@@ -162,19 +162,36 @@ pub fn print_cli_warning_block(message: &str) {
   }
 }
 
-pub fn global_temp_path_guidance(path: &str) -> Option<String> {
+#[derive(Clone, Copy)]
+pub enum GlobalTempPathKind {
+  ScratchCode,
+  Snapshot,
+}
+
+pub fn global_temp_path_guidance(path: &str, kind: GlobalTempPathKind) -> Option<String> {
   let path_ref = Path::new(path);
   if !path_ref.is_absolute() || !(path_ref.starts_with("/tmp") || path_ref.starts_with("/private/tmp")) {
     return None;
   }
 
-  Some(format!(
-    "`{path}` is under a global temporary directory. For project-local Calcit scratch input, prefer `.calcit/snippets/<name>`; keep `.calcit/` in `.gitignore`. For one-off multi-line input, omit `--file`/`--code` and pipe stdin instead."
-  ))
+  Some(match kind {
+    GlobalTempPathKind::ScratchCode => format!(
+      "`{path}` is under a global temporary directory. For project-local Calcit scratch input, prefer `.calcit/snippets/<name>`; keep `.calcit/` in `.gitignore`. For one-off multi-line input, omit `--file`/`--code` and pipe stdin instead."
+    ),
+    GlobalTempPathKind::Snapshot => format!(
+      "snapshot `{path}` is under a global temporary directory. Keep `calcit.cirru` (or legacy `compact.cirru`) at the project root so relative module paths and project-local files resolve from the intended base directory. Use `.calcit/snippets/` only for scratch files passed with `--file`, not for the project snapshot."
+    ),
+  })
 }
 
 pub fn warn_on_global_temp_path(path: &str) {
-  if let Some(message) = global_temp_path_guidance(path) {
+  if let Some(message) = global_temp_path_guidance(path, GlobalTempPathKind::ScratchCode) {
+    print_cli_warning_block(&message);
+  }
+}
+
+pub fn warn_on_global_temp_snapshot_path(path: &str) {
+  if let Some(message) = global_temp_path_guidance(path, GlobalTempPathKind::Snapshot) {
     print_cli_warning_block(&message);
   }
 }
@@ -367,8 +384,8 @@ pub fn parse_input_to_cirru(raw: &str) -> Result<Cirru, String> {
 #[cfg(test)]
 mod tests {
   use super::{
-    format_path, format_path_with_separator, global_temp_path_guidance, parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes,
-    resolve_definition_lookup, shell_quote,
+    GlobalTempPathKind, format_path, format_path_with_separator, global_temp_path_guidance, parse_input_to_cirru, parse_path,
+    parse_quoted_cirru_nodes, resolve_definition_lookup, shell_quote,
   };
   use cirru_parser::Cirru;
 
@@ -445,13 +462,22 @@ mod tests {
   #[test]
   fn global_tmp_path_guidance_points_to_project_local_snippets() {
     for path in ["/tmp/change.cirru", "/private/tmp/change.cirru"] {
-      let guidance = global_temp_path_guidance(path).expect("global tmp path should be recognized");
+      let guidance = global_temp_path_guidance(path, GlobalTempPathKind::ScratchCode).expect("global tmp path should be recognized");
       assert!(guidance.contains(".calcit/snippets/<name>"));
       assert!(guidance.contains("stdin"));
     }
 
-    assert!(global_temp_path_guidance(".calcit/snippets/change.cirru").is_none());
-    assert!(global_temp_path_guidance("/tmp-project/change.cirru").is_none());
+    assert!(global_temp_path_guidance(".calcit/snippets/change.cirru", GlobalTempPathKind::ScratchCode).is_none());
+    assert!(global_temp_path_guidance("/tmp-project/change.cirru", GlobalTempPathKind::ScratchCode).is_none());
+  }
+
+  #[test]
+  fn global_tmp_snapshot_guidance_preserves_project_root() {
+    let guidance = global_temp_path_guidance("/tmp/project/calcit.cirru", GlobalTempPathKind::Snapshot)
+      .expect("global tmp snapshot should be recognized");
+    assert!(guidance.contains("project root"));
+    assert!(guidance.contains("relative module paths"));
+    assert!(guidance.contains("not for the project snapshot"));
   }
 
   #[test]

--- a/src/bin/cli_handlers/docs.rs
+++ b/src/bin/cli_handlers/docs.rs
@@ -1621,6 +1621,7 @@ fn prepare_program_for_snippet(
   program::clear_runtime_caches_for_reload(Arc::from("app.main"), Arc::from("app.main"), true)?;
 
   let mut snapshot = load_entry_snapshot_for_check_md(entry).map_err(|e| format!("check-md: failed to load entry `{entry}`: {e}"))?;
+  let mut project_namespaces = snapshot.files.keys().cloned().collect::<HashSet<_>>();
   let main_file = snapshot::create_file_from_snippet(code)?;
 
   for (k, v) in shared_files {
@@ -1628,6 +1629,8 @@ fn prepare_program_for_snippet(
   }
   // Insert snippet last so loaded modules cannot overwrite the markdown block under test.
   snapshot.files.insert(String::from("app.main"), main_file);
+  project_namespaces.insert(String::from("app.main"));
+  runner::preprocess::set_project_namespaces(&project_namespaces);
 
   {
     let mut prgm = program::PROGRAM_CODE_DATA.write().map_err(|_| "open program data".to_string())?;

--- a/src/bin/cli_handlers/mod.rs
+++ b/src/bin/cli_handlers/mod.rs
@@ -28,7 +28,7 @@ mod tree_mutation;
 pub use call_graph_diff::handle_call_graph_diff_command;
 pub use cirru::handle_cirru_command;
 pub use command_echo::{print_command_echo, should_echo_command};
-pub use common::warn_on_global_temp_path;
+pub use common::warn_on_global_temp_snapshot_path;
 pub use config::handle_config_command;
 pub use cursor::{handle_cursor_command, set_cursor_after_mode};
 pub use docs::handle_docs_command;

--- a/src/bin/cli_handlers/mod.rs
+++ b/src/bin/cli_handlers/mod.rs
@@ -28,6 +28,7 @@ mod tree_mutation;
 pub use call_graph_diff::handle_call_graph_diff_command;
 pub use cirru::handle_cirru_command;
 pub use command_echo::{print_command_echo, should_echo_command};
+pub use common::warn_on_global_temp_path;
 pub use config::handle_config_command;
 pub use cursor::{handle_cursor_command, set_cursor_after_mode};
 pub use docs::handle_docs_command;

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -2695,7 +2695,10 @@ fn load_main_snapshot(input_path: &str) -> Result<snapshot::Snapshot, String> {
     eprintln!("{e}");
     format!("Failed to parse file '{}'", resolved_input_path.display())
   })?;
-  snapshot::load_snapshot_data(&data, &resolved_input_str)
+  let snapshot = snapshot::load_snapshot_data(&data, &resolved_input_str)?;
+  let project_namespaces = snapshot.files.keys().cloned().collect::<HashSet<_>>();
+  runner::preprocess::set_project_namespaces(&project_namespaces);
+  Ok(snapshot)
 }
 
 /// Prefer the project Snapshot for metadata-only queries. Dependencies and

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -99,7 +99,7 @@ fn main() -> Result<(), String> {
 
 fn run_cli() -> Result<(), String> {
   let cli_args: ToplevelCalcit = argh::from_env();
-  cli_handlers::warn_on_global_temp_path(&cli_args.input);
+  cli_handlers::warn_on_global_temp_snapshot_path(&cli_args.input);
   calcit::project_state::set_active_project_directory_from_snapshot(&cli_args.input);
 
   cli_handlers::set_cursor_after_mode(&cli_args.cursor_after)?;
@@ -227,6 +227,7 @@ fn run_cli() -> Result<(), String> {
     {
       let main_file = snapshot::create_file_from_snippet(&buf)?;
       snapshot.files.insert(String::from("app.main"), main_file);
+      project_namespaces.insert(String::from("app.main"));
     }
 
     for module_path in &command.dep {
@@ -248,6 +249,7 @@ fn run_cli() -> Result<(), String> {
     {
       let main_file = snapshot::create_file_from_snippet(&snippet)?;
       snapshot.files.insert(String::from("app.main"), main_file);
+      project_namespaces.insert(String::from("app.main"));
     }
 
     for module_path in &command.dep {
@@ -313,6 +315,7 @@ fn run_cli() -> Result<(), String> {
   // calcit.core entries. This matters when developing and testing calcit-core.cirru
   // with an older globally installed `cr` binary.
   attach_missing_core_namespaces(&mut snapshot, core_snapshot);
+  runner::preprocess::set_project_namespaces(&project_namespaces);
 
   // Dynamic usage is a project-health signal, not a type-check failure. Keep
   // it on stderr so command stdout remains machine-readable for Agent/CI use.

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -99,6 +99,7 @@ fn main() -> Result<(), String> {
 
 fn run_cli() -> Result<(), String> {
   let cli_args: ToplevelCalcit = argh::from_env();
+  cli_handlers::warn_on_global_temp_path(&cli_args.input);
   calcit::project_state::set_active_project_directory_from_snapshot(&cli_args.input);
 
   cli_handlers::set_cursor_after_mode(&cli_args.cursor_after)?;

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -30,8 +30,8 @@ use type_rewriting::{
 
 use std::cell::Cell;
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, RwLock};
 use std::{cell::RefCell, vec};
 
 use cirru_edn::EdnTag;
@@ -42,6 +42,22 @@ pub(crate) type ScopeTypes = HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>;
 
 static WARN_DYN_METHOD: AtomicBool = AtomicBool::new(false);
 static VERBOSE_PREPROCESS: AtomicBool = AtomicBool::new(false);
+static PROJECT_NAMESPACES: LazyLock<RwLock<HashSet<Arc<str>>>> = LazyLock::new(|| RwLock::new(HashSet::new()));
+
+pub fn set_project_namespaces(namespaces: &HashSet<String>) {
+  let mut target = PROJECT_NAMESPACES.write().expect("write project namespaces");
+  target.clear();
+  target.extend(namespaces.iter().map(|ns| Arc::from(ns.as_str())));
+}
+
+fn should_emit_project_source_lint(file_ns: &str) -> bool {
+  let namespaces = PROJECT_NAMESPACES.read().expect("read project namespaces");
+  namespace_is_project_source(&namespaces, file_ns)
+}
+
+fn namespace_is_project_source(namespaces: &HashSet<Arc<str>>, file_ns: &str) -> bool {
+  namespaces.is_empty() || namespaces.contains(file_ns)
+}
 
 fn format_inspect_type_coord(coord: &[u16]) -> String {
   format!("@{}", coord.iter().map(u16::to_string).collect::<Vec<_>>().join("."))
@@ -664,8 +680,9 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
           .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
           .collect::<Vec<_>>(),
       );
-      let short_name = name.rsplit('/').next().unwrap_or(name.as_ref());
-      let local_type = scope_types.get(name).or_else(|| scope_types.get(short_name));
+      let lookup_name = name.trim_start_matches('\'').trim_start_matches(':');
+      let short_name = lookup_name.rsplit('/').next().unwrap_or(lookup_name);
+      let local_type = scope_types.get(lookup_name).or_else(|| scope_types.get(short_name));
       match local_type.map(AsRef::as_ref) {
         Some(CalcitTypeAnnotation::StructDef(struct_def)) => Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args)),
         Some(CalcitTypeAnnotation::Struct(struct_def, _)) | Some(CalcitTypeAnnotation::StructValue(struct_def)) => {
@@ -740,6 +757,105 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
         args
           .iter()
           .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+          .collect(),
+      ),
+    )),
+    _ => annotation,
+  }
+}
+
+/// Qualify nominal type references from the namespace where their declaration
+/// was written. Nested Struct fields often use concise forms such as
+/// `'Router`; once that field type flows into a caller in another namespace,
+/// retaining only `Router` is ambiguous and prevents required-field lowering.
+fn resolve_namespace_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, declaring_ns: &str) -> Arc<CalcitTypeAnnotation> {
+  match annotation.as_ref() {
+    CalcitTypeAnnotation::TypeRef(name, args) => {
+      let resolved_args = Arc::new(
+        args
+          .iter()
+          .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
+          .collect::<Vec<_>>(),
+      );
+      let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+      let qualified_name = if let Some((prefix, def)) = stripped.rsplit_once('/') {
+        if program::has_def_code(prefix, def) {
+          Arc::from(stripped)
+        } else if let Some(target_ns) = program::lookup_ns_target_in_import(declaring_ns, prefix) {
+          Arc::from(format!("{target_ns}/{def}"))
+        } else {
+          Arc::from(stripped)
+        }
+      } else if program::has_def_code(declaring_ns, stripped) {
+        Arc::from(format!("{declaring_ns}/{stripped}"))
+      } else if let Some(target_ns) = program::lookup_def_target_in_import(declaring_ns, stripped) {
+        Arc::from(format!("{target_ns}/{stripped}"))
+      } else if program::has_def_code(calcit::CORE_NS, stripped) {
+        Arc::from(format!("{}/{stripped}", calcit::CORE_NS))
+      } else {
+        name.clone()
+      };
+      Arc::new(CalcitTypeAnnotation::TypeRef(qualified_name, resolved_args))
+    }
+    CalcitTypeAnnotation::List(inner) => Arc::new(CalcitTypeAnnotation::List(resolve_namespace_type_refs_for_body(
+      inner.clone(),
+      declaring_ns,
+    ))),
+    CalcitTypeAnnotation::Map(key, value) => Arc::new(CalcitTypeAnnotation::Map(
+      resolve_namespace_type_refs_for_body(key.clone(), declaring_ns),
+      resolve_namespace_type_refs_for_body(value.clone(), declaring_ns),
+    )),
+    CalcitTypeAnnotation::Set(inner) => Arc::new(CalcitTypeAnnotation::Set(resolve_namespace_type_refs_for_body(
+      inner.clone(),
+      declaring_ns,
+    ))),
+    CalcitTypeAnnotation::Ref(inner) => Arc::new(CalcitTypeAnnotation::Ref(resolve_namespace_type_refs_for_body(
+      inner.clone(),
+      declaring_ns,
+    ))),
+    CalcitTypeAnnotation::Optional(inner) => Arc::new(CalcitTypeAnnotation::Optional(resolve_namespace_type_refs_for_body(
+      inner.clone(),
+      declaring_ns,
+    ))),
+    CalcitTypeAnnotation::JsNullish(inner) => Arc::new(CalcitTypeAnnotation::JsNullish(resolve_namespace_type_refs_for_body(
+      inner.clone(),
+      declaring_ns,
+    ))),
+    CalcitTypeAnnotation::Variadic(inner) => Arc::new(CalcitTypeAnnotation::Variadic(resolve_namespace_type_refs_for_body(
+      inner.clone(),
+      declaring_ns,
+    ))),
+    CalcitTypeAnnotation::Fn(signature) => Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: signature.generics.clone(),
+      where_bounds: signature.where_bounds.clone(),
+      arg_types: signature
+        .arg_types
+        .iter()
+        .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
+        .collect(),
+      return_type: resolve_namespace_type_refs_for_body(signature.return_type.clone(), declaring_ns),
+      fn_kind: signature.fn_kind,
+      rest_type: signature
+        .rest_type
+        .as_ref()
+        .map(|rest| resolve_namespace_type_refs_for_body(rest.clone(), declaring_ns)),
+      features: signature.features.clone(),
+    }))),
+    CalcitTypeAnnotation::Struct(struct_def, args) => Arc::new(CalcitTypeAnnotation::Struct(
+      struct_def.clone(),
+      Arc::new(
+        args
+          .iter()
+          .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
+          .collect(),
+      ),
+    )),
+    CalcitTypeAnnotation::Enum(enum_def, args) => Arc::new(CalcitTypeAnnotation::Enum(
+      enum_def.clone(),
+      Arc::new(
+        args
+          .iter()
+          .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
           .collect(),
       ),
     )),
@@ -2692,7 +2808,8 @@ fn warn_on_raw_struct_field_access(
   call_stack: &CallStackList,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
-  if file_ns == calcit::CORE_NS
+  if !should_emit_project_source_lint(file_ns)
+    || file_ns == calcit::CORE_NS
     || call_stack
       .0
       .iter()
@@ -2701,7 +2818,10 @@ fn warn_on_raw_struct_field_access(
     return;
   }
 
-  let field_text = field.lisp_str();
+  let Calcit::Tag(field_tag) = field else {
+    return;
+  };
+  let field_text = format!(":{}", field_tag.ref_str());
   let receiver_type = resolve_type_value(receiver, scope_types);
   let (code, message) = match receiver_type.as_deref().and_then(CalcitTypeAnnotation::resolve_to_struct) {
     Some(_) => (
@@ -2710,6 +2830,18 @@ fn warn_on_raw_struct_field_access(
         "[Warn] direct `&struct:get` for field `{field_text}` in {file_ns} bypasses the typed source syntax. Use `({field_text} value)` or `value.{field_text}` so the checker exposes the declared field type and lowers the read to indexed `&struct:nth` access"
       ),
     ),
+    None if matches!(receiver_type.as_deref(), Some(CalcitTypeAnnotation::TypeRef(..))) => {
+      let type_text = receiver_type
+        .as_deref()
+        .map(CalcitTypeAnnotation::to_brief_string)
+        .unwrap_or_else(|| ":unknown".to_owned());
+      (
+        "W_STRUCT_DYNAMIC_RAW_ACCESS",
+        format!(
+          "[Warn] direct `&struct:get` for field `{field_text}` in {file_ns} has unresolved nominal receiver `{type_text}`. Its declaration namespace or dependency could not be recovered, so the field cannot be checked or specialized. Keep/restore a qualified schema such as `'app.schema/Type`, then use `({field_text} value)` or `value.{field_text}`; do not use `&struct:get` to hide an unresolved TypeRef"
+        ),
+      )
+    }
     None => {
       let type_text = receiver_type
         .as_deref()
@@ -5281,12 +5413,14 @@ pub fn preprocess_defn(
           .map(|(idx, arg_type)| {
             let substituted = arg_type.substitute_type_vars(&body_type_bindings);
             let positional = unwrap_named_body_parameter_type(substituted, param_symbols.get(idx));
-            resolve_local_type_refs_for_body(positional, &body_types)
+            let local = resolve_local_type_refs_for_body(positional, &body_types);
+            resolve_namespace_type_refs_for_body(local, ctx.file_ns)
           })
           .chain(fn_annot.rest_type.iter().map(|rest_type| {
-            Arc::new(CalcitTypeAnnotation::Variadic(resolve_local_type_refs_for_body(
-              rest_type.substitute_type_vars(&body_type_bindings),
-              &body_types,
+            let local = resolve_local_type_refs_for_body(rest_type.substitute_type_vars(&body_type_bindings), &body_types);
+            Arc::new(CalcitTypeAnnotation::Variadic(resolve_namespace_type_refs_for_body(
+              local,
+              ctx.file_ns,
             )))
           }))
           .collect::<Vec<_>>();
@@ -7669,18 +7803,85 @@ mod tests {
   }
 
   #[test]
-  fn local_struct_definition_resolves_parameter_type_refs() {
+  fn quoted_local_struct_definition_resolves_parameter_type_refs() {
     let box_def = Arc::new(CalcitStructDef::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]));
     let mut scope_types = ScopeTypes::new();
     scope_types.insert(Arc::from("Box"), Arc::new(CalcitTypeAnnotation::StructDef(box_def.clone())));
     let number = Arc::new(CalcitTypeAnnotation::Number);
-    let annotation = Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("Box"), Arc::new(vec![number.clone()])));
+    let annotation = Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("'Box"), Arc::new(vec![number.clone()])));
 
     let resolved = resolve_local_type_refs_for_body(annotation, &scope_types);
 
     assert!(
       matches!(resolved.as_ref(), CalcitTypeAnnotation::Struct(def, args) if def == &box_def && args.as_slice() == [number]),
       "local defstruct should become a concrete applied Struct annotation, got {resolved}"
+    );
+  }
+
+  #[test]
+  fn nested_struct_field_type_inherits_the_declaring_namespace() {
+    let _guard = lock_preprocess_test_state();
+    calcit::register_program_lookups(program::lookup_runtime_ready, program::lookup_def_code, program::lookup_def_schema);
+
+    let ns = "tests.nested-struct-owner";
+    let mut router_def = CalcitStructDef::from_fields(EdnTag::from("Router"), vec![EdnTag::from("name")]);
+    router_def.field_types = Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone()]);
+    let mut store_def = CalcitStructDef::from_fields(EdnTag::from("ClientStore"), vec![EdnTag::from("router")]);
+    store_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("Router"), Arc::new(vec![])))]);
+
+    program::PROGRAM_CODE_DATA.write().expect("open program code").insert(
+      Arc::from(ns),
+      program::ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([
+          (
+            Arc::from("Router"),
+            program::ProgramDefEntry {
+              code: Calcit::StructDef(router_def.clone()),
+              schema: crate::calcit::DYNAMIC_TYPE.clone(),
+              doc: Arc::from(""),
+              examples: vec![],
+              ffi: None,
+            },
+          ),
+          (
+            Arc::from("ClientStore"),
+            program::ProgramDefEntry {
+              code: Calcit::StructDef(store_def.clone()),
+              schema: crate::calcit::DYNAMIC_TYPE.clone(),
+              doc: Arc::from(""),
+              examples: vec![],
+              ffi: None,
+            },
+          ),
+        ]),
+      },
+    );
+    program::write_runtime_ready(ns, "Router", Calcit::StructDef(router_def)).expect("register Router runtime metadata");
+    program::write_runtime_ready(ns, "ClientStore", Calcit::StructDef(store_def)).expect("register ClientStore runtime metadata");
+
+    let store_type = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from(format!("{ns}/ClientStore")),
+      Arc::new(vec![]),
+    ));
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("store")),
+      sym: Arc::from("store"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.consumer"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: store_type,
+    });
+
+    let inferred = infer_struct_field_type(&receiver, "router", &ScopeTypes::new());
+    assert!(
+      matches!(
+        inferred.as_deref(),
+        Some(CalcitTypeAnnotation::TypeRef(name, args)) if name.as_ref() == format!("{ns}/Router") && args.is_empty()
+      ),
+      "nested field should resolve relative to its owner, got {inferred:?}"
     );
   }
 
@@ -7744,6 +7945,80 @@ mod tests {
     assert_eq!(warnings.len(), 1);
     assert_eq!(warnings[0].code(), Some("W_STRUCT_DYNAMIC_RAW_ACCESS"));
     assert!(warnings[0].message().contains("Add/narrow a named Struct schema"));
+  }
+
+  #[test]
+  fn raw_struct_access_explains_unresolved_nominal_receivers() {
+    let head = Calcit::Proc(CalcitProc::NativeStructGet);
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("router")),
+      sym: Arc::from("router"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.consumer"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("Router"), Arc::new(vec![]))),
+    });
+    let args = CalcitList::from(&[receiver, Calcit::Tag(EdnTag::from("name"))][..]);
+    let warnings = RefCell::new(vec![]);
+
+    check_struct_field_access(
+      &head,
+      &args,
+      &ScopeTypes::new(),
+      "tests.consumer",
+      &CallStackList::default(),
+      &warnings,
+    );
+
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].code(), Some("W_STRUCT_DYNAMIC_RAW_ACCESS"));
+    assert!(warnings[0].message().contains("unresolved nominal receiver `'Router`"));
+    assert!(warnings[0].message().contains("qualified schema such as `'app.schema/Type`"));
+  }
+
+  #[test]
+  fn dynamic_raw_struct_field_keys_do_not_suggest_tag_syntax() {
+    let head = Calcit::Proc(CalcitProc::NativeStructGet);
+    let receiver = Calcit::Symbol {
+      sym: Arc::from("value"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.struct"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+    };
+    let field = Calcit::Symbol {
+      sym: Arc::from("field"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.struct"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+    };
+    let args = CalcitList::from(&[receiver, field][..]);
+    let warnings = RefCell::new(vec![]);
+
+    check_struct_field_access(
+      &head,
+      &args,
+      &ScopeTypes::new(),
+      "tests.struct",
+      &CallStackList::default(),
+      &warnings,
+    );
+
+    assert!(warnings.borrow().is_empty());
+  }
+
+  #[test]
+  fn project_source_lints_exclude_loaded_module_namespaces() {
+    let namespaces = HashSet::from([Arc::from("app.main"), Arc::from("app.comp")]);
+    assert!(namespace_is_project_source(&namespaces, "app.comp"));
+    assert!(!namespace_is_project_source(&namespaces, "respo.core"));
+    assert!(namespace_is_project_source(&HashSet::new(), "tests.default"));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -667,9 +667,11 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
       let short_name = name.rsplit('/').next().unwrap_or(name.as_ref());
       let local_type = scope_types.get(name).or_else(|| scope_types.get(short_name));
       match local_type.map(AsRef::as_ref) {
+        Some(CalcitTypeAnnotation::StructDef(struct_def)) => Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args)),
         Some(CalcitTypeAnnotation::Struct(struct_def, _)) | Some(CalcitTypeAnnotation::StructValue(struct_def)) => {
           Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args))
         }
+        Some(CalcitTypeAnnotation::EnumDef(enum_def)) => Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args)),
         Some(CalcitTypeAnnotation::Enum(enum_def, _)) | Some(CalcitTypeAnnotation::EnumValue(enum_def)) => {
           Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args))
         }
@@ -1421,7 +1423,7 @@ fn preprocess_list_call(
         let mut current_args = CalcitList::from(ys.drop_left());
         // Core helpers such as `get` resolve to ordinary functions, so validate
         // their statically known struct fields in this branch as well.
-        check_struct_field_access(&head_form, &current_args, scope_types, file_ns, check_warnings);
+        check_struct_field_access(&head_form, &current_args, scope_types, file_ns, call_stack, check_warnings);
         warn_on_nominal_enum_legacy_absence_use(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         warn_on_legacy_js_nullish_predicate(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         let mut any_rewritten = false;
@@ -1733,7 +1735,7 @@ fn preprocess_list_call(
         // Check for struct field access after processing arguments
         let processed_args = CalcitList::from(ys.drop_left()); // Skip the head, convert to CalcitList
         validate_method_call(&head_form, &processed_args, scope_types, call_stack)?;
-        check_struct_field_access(&head_form, &processed_args, scope_types, file_ns, check_warnings);
+        check_struct_field_access(&head_form, &processed_args, scope_types, file_ns, call_stack, check_warnings);
         check_struct_update_fields(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
         check_struct_method_args(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
         check_typed_js_field_operation(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
@@ -2598,6 +2600,7 @@ fn check_struct_field_access(
   args: &CalcitList,
   scope_types: &ScopeTypes,
   file_ns: &str,
+  call_stack: &CallStackList,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
   // Check if this is a call to &struct:get
@@ -2607,6 +2610,7 @@ fn check_struct_field_access(
       && let (Some(struct_arg), Some(field_arg)) = (args.first(), args.get(1))
     {
       check_field_in_struct(struct_arg, field_arg, scope_types, file_ns, check_warnings);
+      warn_on_raw_struct_field_access(struct_arg, field_arg, scope_types, file_ns, call_stack, check_warnings);
     }
   }
   // Also check calcit.core imports that perform required struct field access.
@@ -2617,6 +2621,7 @@ fn check_struct_field_access(
       && let (Some(struct_arg), Some(field_arg)) = (args.first(), args.get(1))
     {
       check_field_in_struct(struct_arg, field_arg, scope_types, file_ns, check_warnings);
+      warn_on_raw_struct_field_access(struct_arg, field_arg, scope_types, file_ns, call_stack, check_warnings);
     }
     if &**ns == calcit::CORE_NS
       && &**def == "get"
@@ -2677,6 +2682,55 @@ fn check_struct_field_access(
       check_field_in_struct(struct_arg, &field_tag, scope_types, file_ns, check_warnings);
     }
   }
+}
+
+fn warn_on_raw_struct_field_access(
+  receiver: &Calcit,
+  field: &Calcit,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  call_stack: &CallStackList,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  if file_ns == calcit::CORE_NS
+    || call_stack
+      .0
+      .iter()
+      .any(|frame| matches!(frame.kind, StackKind::Macro) && frame.def.as_ref() == "defimpl")
+  {
+    return;
+  }
+
+  let field_text = field.lisp_str();
+  let receiver_type = resolve_type_value(receiver, scope_types);
+  let (code, message) = match receiver_type.as_deref().and_then(CalcitTypeAnnotation::resolve_to_struct) {
+    Some(_) => (
+      "W_STRUCT_RAW_ACCESS",
+      format!(
+        "[Warn] direct `&struct:get` for field `{field_text}` in {file_ns} bypasses the typed source syntax. Use `({field_text} value)` or `value.{field_text}` so the checker exposes the declared field type and lowers the read to indexed `&struct:nth` access"
+      ),
+    ),
+    None => {
+      let type_text = receiver_type
+        .as_deref()
+        .map(CalcitTypeAnnotation::to_brief_string)
+        .unwrap_or_else(|| ":unknown".to_owned());
+      (
+        "W_STRUCT_DYNAMIC_RAW_ACCESS",
+        format!(
+          "[Warn] direct `&struct:get` for field `{field_text}` in {file_ns} has receiver type `{type_text}`, so the field cannot be statically checked or specialized. Add/narrow a named Struct schema, then use `({field_text} value)` or `value.{field_text}`; reserve `&struct:get` for an intentional reusable `defimpl` or core/runtime boundary"
+        ),
+      )
+    }
+  };
+
+  gen_check_warning_code_at(
+    message,
+    code,
+    file_ns,
+    field.get_location().or_else(|| receiver.get_location()),
+    check_warnings,
+  );
 }
 
 /// Validate statically known struct updates before they are rewritten to the indexed runtime procs.
@@ -4815,10 +4869,12 @@ fn resolve_enum_type_for_match(
   };
   let stripped = name.trim_start_matches('\'').trim_start_matches(':');
   let short_name = stripped.rsplit('/').next().unwrap_or(stripped);
-  if let Some(local_type) = scope_types.get(stripped).or_else(|| scope_types.get(short_name))
-    && let Some(enum_def) = local_type.resolve_to_enum()
-  {
-    return Some(enum_def);
+  if let Some(local_type) = scope_types.get(stripped).or_else(|| scope_types.get(short_name)) {
+    match local_type.as_ref() {
+      CalcitTypeAnnotation::EnumDef(enum_def) => return Some(enum_def.as_ref().to_owned()),
+      _ if let Some(enum_def) = local_type.resolve_to_enum() => return Some(enum_def),
+      _ => {}
+    }
   }
   let (target_ns, target_def) = if let Some((ns, def)) = stripped.rsplit_once('/') {
     (Arc::from(ns), Arc::from(def))
@@ -5013,6 +5069,7 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
                 .and_then(|e| e.find_variant_by_name(pat_tag))
                 .and_then(|v| v.payload_types().get(bind_idx).cloned())
                 .map(|payload| payload.substitute_type_vars(&enum_bindings))
+                .map(|payload| resolve_local_type_refs_for_body(payload, &body_types))
                 .unwrap_or_else(|| crate::calcit::DYNAMIC_TYPE.clone());
 
               let local = Calcit::Local(CalcitLocal {
@@ -5663,9 +5720,18 @@ pub fn preprocess_assert_type(
     _ => type_form.to_owned(),
   };
 
+  let local_nominal_type = match type_form {
+    Calcit::Symbol { sym, .. } if !sym.starts_with('\'') => ctx.scope_types.get(sym).and_then(|type_info| match type_info.as_ref() {
+      CalcitTypeAnnotation::StructDef(struct_def) => Some(Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), Arc::new(vec![])))),
+      CalcitTypeAnnotation::EnumDef(enum_def) => Some(Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), Arc::new(vec![])))),
+      _ => None,
+    }),
+    _ => None,
+  };
+
   let asserted_target = target_form;
   if let Calcit::Local(local) = &asserted_target {
-    let asserted_type = CalcitTypeAnnotation::parse_type_annotation_form(&asserted_type_form);
+    let asserted_type = local_nominal_type.unwrap_or_else(|| CalcitTypeAnnotation::parse_type_annotation_form(&asserted_type_form));
     let current_type = resolve_type_value(&asserted_target, ctx.scope_types).unwrap_or_else(|| local.type_info.clone());
     let type_entry = if current_type.as_ref().matches_annotation(asserted_type.as_ref())
       && annotation_dynamic_weight(current_type.as_ref()) < annotation_dynamic_weight(asserted_type.as_ref())
@@ -6662,6 +6728,31 @@ mod tests {
   }
 
   #[test]
+  fn assert_type_resolves_local_struct_definitions() {
+    let expr = Cirru::List(vec![Cirru::leaf("assert-type"), Cirru::leaf("x"), Cirru::leaf("LocalPerson")]);
+    let code = code_to_calcit(&expr, "tests.assert", "main", vec![]).expect("parse cirru");
+    let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
+    scope_defs.insert(Arc::from("x"));
+    scope_defs.insert(Arc::from("LocalPerson"));
+    let struct_def = Arc::new(CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("name")]));
+    let mut scope_types: ScopeTypes = ScopeTypes::new();
+    scope_types.insert(
+      Arc::from("LocalPerson"),
+      Arc::new(CalcitTypeAnnotation::StructDef(struct_def.clone())),
+    );
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default();
+
+    let resolved =
+      preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.assert", &warnings, &stack).expect("preprocess assert-type");
+
+    assert!(
+      matches!(resolve_type_value(&resolved, &scope_types).as_deref(), Some(CalcitTypeAnnotation::Struct(def, args)) if def == &struct_def && args.is_empty()),
+      "a local StructDef in type position should become its instance type, got {resolved}"
+    );
+  }
+
+  #[test]
   fn inspect_type_locations_use_at_paths_without_brackets() {
     assert_eq!(format_inspect_type_coord(&[3, 5, 1]), "@3.5.1");
   }
@@ -7555,20 +7646,11 @@ mod tests {
       vec![EdnTag::from("age"), EdnTag::from("name")],
     ))));
 
-    // Test expression: (assert-type user <struct-type>) (&struct:get user :name)
-    let expr = Cirru::List(vec![
-      Cirru::leaf("&let"),
-      Cirru::List(vec![Cirru::leaf("user"), Cirru::leaf("nil")]),
-      Cirru::List(vec![
-        Cirru::leaf("assert-type"),
-        Cirru::leaf("user"),
-        Cirru::leaf("struct-type"), // placeholder, will be replaced
-      ]),
-      Cirru::List(vec![Cirru::leaf("&struct:get"), Cirru::leaf("user"), Cirru::leaf(":name")]),
-    ]);
+    let expr = Cirru::List(vec![Cirru::leaf("&struct:get"), Cirru::leaf("user"), Cirru::leaf(":name")]);
 
     let code = code_to_calcit(&expr, "tests.struct", "demo", vec![]).expect("parse cirru");
-    let scope_defs: HashSet<Arc<str>> = HashSet::new();
+    let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
+    scope_defs.insert(Arc::from("user"));
     let mut scope_types: ScopeTypes = ScopeTypes::new();
 
     // Manually insert the struct type for testing
@@ -7577,12 +7659,111 @@ mod tests {
     let warnings = RefCell::new(vec![]);
     let stack = CallStackList::default();
 
-    // This should not produce warnings since :name exists
     let _resolved =
       preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.struct", &warnings, &stack).expect("preprocess should succeed");
 
-    // Currently no warnings expected for valid field access
-    // In future, we'll check warnings.borrow().is_empty()
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].code(), Some("W_STRUCT_RAW_ACCESS"));
+    assert!(warnings[0].message().contains("Use `(:name value)`"));
+  }
+
+  #[test]
+  fn local_struct_definition_resolves_parameter_type_refs() {
+    let box_def = Arc::new(CalcitStructDef::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]));
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(Arc::from("Box"), Arc::new(CalcitTypeAnnotation::StructDef(box_def.clone())));
+    let number = Arc::new(CalcitTypeAnnotation::Number);
+    let annotation = Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("Box"), Arc::new(vec![number.clone()])));
+
+    let resolved = resolve_local_type_refs_for_body(annotation, &scope_types);
+
+    assert!(
+      matches!(resolved.as_ref(), CalcitTypeAnnotation::Struct(def, args) if def == &box_def && args.as_slice() == [number]),
+      "local defstruct should become a concrete applied Struct annotation, got {resolved}"
+    );
+  }
+
+  #[test]
+  fn match_resolves_local_enum_definitions_with_applied_args() {
+    use crate::calcit::{CalcitEnumDef, CalcitStructValue};
+
+    let generic: Arc<str> = Arc::from("T");
+    let enum_struct = CalcitStructDef {
+      name: EdnTag::from("Wrapped"),
+      fields: Arc::new(vec![EdnTag::from("empty"), EdnTag::from("some")]),
+      field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(), crate::calcit::DYNAMIC_TYPE.clone()]),
+      generics: Arc::new(vec![generic.clone()]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    };
+    let enum_def = Arc::new(
+      CalcitEnumDef::from_struct(CalcitStructValue {
+        struct_ref: Arc::new(enum_struct),
+        values: Arc::new(vec![
+          Calcit::from(CalcitList::default()),
+          Calcit::from(vec![CalcitTypeAnnotation::TypeVar(generic).to_calcit()]),
+        ]),
+      })
+      .expect("valid local enum fixture"),
+    );
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(Arc::from("Wrapped"), Arc::new(CalcitTypeAnnotation::EnumDef(enum_def.clone())));
+    let type_ref = CalcitTypeAnnotation::TypeRef(Arc::from("Wrapped"), Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]));
+
+    assert_eq!(
+      resolve_enum_type_for_match(&type_ref, "tests.enum", &scope_types),
+      Some(enum_def.as_ref().to_owned())
+    );
+  }
+
+  #[test]
+  fn raw_struct_access_requires_static_evidence_outside_defimpl() {
+    let head = Calcit::Proc(CalcitProc::NativeStructGet);
+    let receiver = Calcit::Symbol {
+      sym: Arc::from("value"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.struct"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+    };
+    let args = CalcitList::from(&[receiver, Calcit::Tag(EdnTag::from("name"))][..]);
+    let warnings = RefCell::new(vec![]);
+
+    check_struct_field_access(
+      &head,
+      &args,
+      &ScopeTypes::new(),
+      "tests.struct",
+      &CallStackList::default(),
+      &warnings,
+    );
+
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].code(), Some("W_STRUCT_DYNAMIC_RAW_ACCESS"));
+    assert!(warnings[0].message().contains("Add/narrow a named Struct schema"));
+  }
+
+  #[test]
+  fn reusable_defimpl_may_use_explicit_raw_struct_access() {
+    let head = Calcit::Proc(CalcitProc::NativeStructGet);
+    let receiver = Calcit::Symbol {
+      sym: Arc::from("value"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.struct"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+    };
+    let args = CalcitList::from(&[receiver, Calcit::Tag(EdnTag::from("name"))][..]);
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default().extend(calcit::CORE_NS, "defimpl", StackKind::Macro, &Calcit::Nil, &[]);
+
+    check_struct_field_access(&head, &args, &ScopeTypes::new(), "tests.struct", &stack, &warnings);
+
+    assert!(warnings.borrow().is_empty());
   }
 
   #[test]
@@ -7617,7 +7798,7 @@ mod tests {
     );
     let warnings = RefCell::new(vec![]);
 
-    check_struct_field_access(&head, &args, &scope_types, "tests.struct", &warnings);
+    check_struct_field_access(&head, &args, &scope_types, "tests.struct", &CallStackList::default(), &warnings);
 
     let warnings = warnings.borrow();
     assert_eq!(warnings.len(), 1);

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -667,64 +667,38 @@ fn resolve_where_bound_type_for_body(bound: &crate::calcit::CalcitGenericBound, 
   }
 }
 
-/// Resolve named types declared in the same lexical scope, such as a `defstruct`
-/// bound by an enclosing `let`. Program-level `TypeRef` resolution cannot see
-/// those definitions, so retaining the symbolic reference would make otherwise
-/// precise function parameters fall back to `Dynamic` inside the body.
-fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope_types: &ScopeTypes) -> Arc<CalcitTypeAnnotation> {
+fn map_type_refs_for_body<F>(annotation: Arc<CalcitTypeAnnotation>, resolve_type_ref: &F) -> Arc<CalcitTypeAnnotation>
+where
+  F: Fn(&Arc<str>, Arc<Vec<Arc<CalcitTypeAnnotation>>>) -> Arc<CalcitTypeAnnotation>,
+{
   match annotation.as_ref() {
     CalcitTypeAnnotation::TypeRef(name, args) => {
       let resolved_args = Arc::new(
         args
           .iter()
-          .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+          .map(|arg| map_type_refs_for_body(arg.clone(), resolve_type_ref))
           .collect::<Vec<_>>(),
       );
-      let lookup_name = name.trim_start_matches('\'').trim_start_matches(':');
-      let short_name = lookup_name.rsplit('/').next().unwrap_or(lookup_name);
-      let local_type = scope_types.get(lookup_name).or_else(|| scope_types.get(short_name));
-      match local_type.map(AsRef::as_ref) {
-        Some(CalcitTypeAnnotation::StructDef(struct_def)) => Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args)),
-        Some(CalcitTypeAnnotation::Struct(struct_def, _)) | Some(CalcitTypeAnnotation::StructValue(struct_def)) => {
-          Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args))
-        }
-        Some(CalcitTypeAnnotation::EnumDef(enum_def)) => Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args)),
-        Some(CalcitTypeAnnotation::Enum(enum_def, _)) | Some(CalcitTypeAnnotation::EnumValue(enum_def)) => {
-          Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args))
-        }
-        Some(CalcitTypeAnnotation::Trait(trait_def)) if resolved_args.is_empty() => {
-          Arc::new(CalcitTypeAnnotation::Trait(trait_def.clone()))
-        }
-        _ => Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args)),
-      }
+      resolve_type_ref(name, resolved_args)
     }
-    CalcitTypeAnnotation::List(inner) => Arc::new(CalcitTypeAnnotation::List(resolve_local_type_refs_for_body(
-      inner.clone(),
-      scope_types,
-    ))),
+    CalcitTypeAnnotation::List(inner) => Arc::new(CalcitTypeAnnotation::List(map_type_refs_for_body(inner.clone(), resolve_type_ref))),
     CalcitTypeAnnotation::Map(key, value) => Arc::new(CalcitTypeAnnotation::Map(
-      resolve_local_type_refs_for_body(key.clone(), scope_types),
-      resolve_local_type_refs_for_body(value.clone(), scope_types),
+      map_type_refs_for_body(key.clone(), resolve_type_ref),
+      map_type_refs_for_body(value.clone(), resolve_type_ref),
     )),
-    CalcitTypeAnnotation::Set(inner) => Arc::new(CalcitTypeAnnotation::Set(resolve_local_type_refs_for_body(
+    CalcitTypeAnnotation::Set(inner) => Arc::new(CalcitTypeAnnotation::Set(map_type_refs_for_body(inner.clone(), resolve_type_ref))),
+    CalcitTypeAnnotation::Ref(inner) => Arc::new(CalcitTypeAnnotation::Ref(map_type_refs_for_body(inner.clone(), resolve_type_ref))),
+    CalcitTypeAnnotation::Optional(inner) => Arc::new(CalcitTypeAnnotation::Optional(map_type_refs_for_body(
       inner.clone(),
-      scope_types,
+      resolve_type_ref,
     ))),
-    CalcitTypeAnnotation::Ref(inner) => Arc::new(CalcitTypeAnnotation::Ref(resolve_local_type_refs_for_body(
+    CalcitTypeAnnotation::JsNullish(inner) => Arc::new(CalcitTypeAnnotation::JsNullish(map_type_refs_for_body(
       inner.clone(),
-      scope_types,
+      resolve_type_ref,
     ))),
-    CalcitTypeAnnotation::Optional(inner) => Arc::new(CalcitTypeAnnotation::Optional(resolve_local_type_refs_for_body(
+    CalcitTypeAnnotation::Variadic(inner) => Arc::new(CalcitTypeAnnotation::Variadic(map_type_refs_for_body(
       inner.clone(),
-      scope_types,
-    ))),
-    CalcitTypeAnnotation::JsNullish(inner) => Arc::new(CalcitTypeAnnotation::JsNullish(resolve_local_type_refs_for_body(
-      inner.clone(),
-      scope_types,
-    ))),
-    CalcitTypeAnnotation::Variadic(inner) => Arc::new(CalcitTypeAnnotation::Variadic(resolve_local_type_refs_for_body(
-      inner.clone(),
-      scope_types,
+      resolve_type_ref,
     ))),
     CalcitTypeAnnotation::Fn(signature) => Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
       generics: signature.generics.clone(),
@@ -732,14 +706,14 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
       arg_types: signature
         .arg_types
         .iter()
-        .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+        .map(|arg| map_type_refs_for_body(arg.clone(), resolve_type_ref))
         .collect(),
-      return_type: resolve_local_type_refs_for_body(signature.return_type.clone(), scope_types),
+      return_type: map_type_refs_for_body(signature.return_type.clone(), resolve_type_ref),
       fn_kind: signature.fn_kind,
       rest_type: signature
         .rest_type
         .as_ref()
-        .map(|rest| resolve_local_type_refs_for_body(rest.clone(), scope_types)),
+        .map(|rest| map_type_refs_for_body(rest.clone(), resolve_type_ref)),
       features: signature.features.clone(),
     }))),
     CalcitTypeAnnotation::Struct(struct_def, args) => Arc::new(CalcitTypeAnnotation::Struct(
@@ -747,7 +721,7 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
       Arc::new(
         args
           .iter()
-          .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+          .map(|arg| map_type_refs_for_body(arg.clone(), resolve_type_ref))
           .collect(),
       ),
     )),
@@ -756,7 +730,7 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
       Arc::new(
         args
           .iter()
-          .map(|arg| resolve_local_type_refs_for_body(arg.clone(), scope_types))
+          .map(|arg| map_type_refs_for_body(arg.clone(), resolve_type_ref))
           .collect(),
       ),
     )),
@@ -764,103 +738,58 @@ fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope
   }
 }
 
+/// Resolve named types declared in the same lexical scope, such as a `defstruct`
+/// bound by an enclosing `let`. Program-level `TypeRef` resolution cannot see
+/// those definitions, so retaining the symbolic reference would make otherwise
+/// precise function parameters fall back to `Dynamic` inside the body.
+fn resolve_local_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, scope_types: &ScopeTypes) -> Arc<CalcitTypeAnnotation> {
+  map_type_refs_for_body(annotation, &|name, resolved_args| {
+    let lookup_name = name.trim_start_matches('\'').trim_start_matches(':');
+    let short_name = lookup_name.rsplit('/').next().unwrap_or(lookup_name);
+    let local_type = scope_types.get(lookup_name).or_else(|| scope_types.get(short_name));
+    match local_type.map(AsRef::as_ref) {
+      Some(CalcitTypeAnnotation::StructDef(struct_def)) => Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args)),
+      Some(CalcitTypeAnnotation::Struct(struct_def, _)) | Some(CalcitTypeAnnotation::StructValue(struct_def)) => {
+        Arc::new(CalcitTypeAnnotation::Struct(struct_def.clone(), resolved_args))
+      }
+      Some(CalcitTypeAnnotation::EnumDef(enum_def)) => Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args)),
+      Some(CalcitTypeAnnotation::Enum(enum_def, _)) | Some(CalcitTypeAnnotation::EnumValue(enum_def)) => {
+        Arc::new(CalcitTypeAnnotation::Enum(enum_def.clone(), resolved_args))
+      }
+      Some(CalcitTypeAnnotation::Trait(trait_def)) if resolved_args.is_empty() => {
+        Arc::new(CalcitTypeAnnotation::Trait(trait_def.clone()))
+      }
+      _ => Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args)),
+    }
+  })
+}
+
 /// Qualify nominal type references from the namespace where their declaration
 /// was written. Nested Struct fields often use concise forms such as
 /// `'Router`; once that field type flows into a caller in another namespace,
 /// retaining only `Router` is ambiguous and prevents required-field lowering.
 fn resolve_namespace_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, declaring_ns: &str) -> Arc<CalcitTypeAnnotation> {
-  match annotation.as_ref() {
-    CalcitTypeAnnotation::TypeRef(name, args) => {
-      let resolved_args = Arc::new(
-        args
-          .iter()
-          .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
-          .collect::<Vec<_>>(),
-      );
-      let stripped = name.trim_start_matches('\'').trim_start_matches(':');
-      let qualified_name = if let Some((prefix, def)) = stripped.rsplit_once('/') {
-        if program::has_def_code(prefix, def) {
-          Arc::from(stripped)
-        } else if let Some(target_ns) = program::lookup_ns_target_in_import(declaring_ns, prefix) {
-          Arc::from(format!("{target_ns}/{def}"))
-        } else {
-          Arc::from(stripped)
-        }
-      } else if program::has_def_code(declaring_ns, stripped) {
-        Arc::from(format!("{declaring_ns}/{stripped}"))
-      } else if let Some(target_ns) = program::lookup_def_target_in_import(declaring_ns, stripped) {
-        Arc::from(format!("{target_ns}/{stripped}"))
-      } else if program::has_def_code(calcit::CORE_NS, stripped) {
-        Arc::from(format!("{}/{stripped}", calcit::CORE_NS))
+  map_type_refs_for_body(annotation, &|name, resolved_args| {
+    let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+    let qualified_name = if let Some((prefix, def)) = stripped.rsplit_once('/') {
+      if program::has_def_code(prefix, def) {
+        Arc::from(stripped)
+      } else if let Some(target_ns) = program::lookup_ns_target_in_import(declaring_ns, prefix) {
+        Arc::from(format!("{target_ns}/{def}"))
       } else {
-        name.clone()
-      };
-      Arc::new(CalcitTypeAnnotation::TypeRef(qualified_name, resolved_args))
-    }
-    CalcitTypeAnnotation::List(inner) => Arc::new(CalcitTypeAnnotation::List(resolve_namespace_type_refs_for_body(
-      inner.clone(),
-      declaring_ns,
-    ))),
-    CalcitTypeAnnotation::Map(key, value) => Arc::new(CalcitTypeAnnotation::Map(
-      resolve_namespace_type_refs_for_body(key.clone(), declaring_ns),
-      resolve_namespace_type_refs_for_body(value.clone(), declaring_ns),
-    )),
-    CalcitTypeAnnotation::Set(inner) => Arc::new(CalcitTypeAnnotation::Set(resolve_namespace_type_refs_for_body(
-      inner.clone(),
-      declaring_ns,
-    ))),
-    CalcitTypeAnnotation::Ref(inner) => Arc::new(CalcitTypeAnnotation::Ref(resolve_namespace_type_refs_for_body(
-      inner.clone(),
-      declaring_ns,
-    ))),
-    CalcitTypeAnnotation::Optional(inner) => Arc::new(CalcitTypeAnnotation::Optional(resolve_namespace_type_refs_for_body(
-      inner.clone(),
-      declaring_ns,
-    ))),
-    CalcitTypeAnnotation::JsNullish(inner) => Arc::new(CalcitTypeAnnotation::JsNullish(resolve_namespace_type_refs_for_body(
-      inner.clone(),
-      declaring_ns,
-    ))),
-    CalcitTypeAnnotation::Variadic(inner) => Arc::new(CalcitTypeAnnotation::Variadic(resolve_namespace_type_refs_for_body(
-      inner.clone(),
-      declaring_ns,
-    ))),
-    CalcitTypeAnnotation::Fn(signature) => Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
-      generics: signature.generics.clone(),
-      where_bounds: signature.where_bounds.clone(),
-      arg_types: signature
-        .arg_types
-        .iter()
-        .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
-        .collect(),
-      return_type: resolve_namespace_type_refs_for_body(signature.return_type.clone(), declaring_ns),
-      fn_kind: signature.fn_kind,
-      rest_type: signature
-        .rest_type
-        .as_ref()
-        .map(|rest| resolve_namespace_type_refs_for_body(rest.clone(), declaring_ns)),
-      features: signature.features.clone(),
-    }))),
-    CalcitTypeAnnotation::Struct(struct_def, args) => Arc::new(CalcitTypeAnnotation::Struct(
-      struct_def.clone(),
-      Arc::new(
-        args
-          .iter()
-          .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
-          .collect(),
-      ),
-    )),
-    CalcitTypeAnnotation::Enum(enum_def, args) => Arc::new(CalcitTypeAnnotation::Enum(
-      enum_def.clone(),
-      Arc::new(
-        args
-          .iter()
-          .map(|arg| resolve_namespace_type_refs_for_body(arg.clone(), declaring_ns))
-          .collect(),
-      ),
-    )),
-    _ => annotation,
-  }
+        Arc::from(stripped)
+      }
+    } else if program::has_def_code(declaring_ns, stripped) {
+      Arc::from(format!("{declaring_ns}/{stripped}"))
+    } else if let Some(target_ns) = program::lookup_def_target_in_import(declaring_ns, stripped) {
+      Arc::from(format!("{target_ns}/{stripped}"))
+    } else if program::has_def_code(calcit::CORE_NS, stripped) {
+      Arc::from(format!("{}/{stripped}", calcit::CORE_NS))
+    } else {
+      name.clone()
+    };
+    Arc::new(CalcitTypeAnnotation::TypeRef(qualified_name, resolved_args))
+  })
 }
 
 fn unwrap_named_body_parameter_type(annotation: Arc<CalcitTypeAnnotation>, parameter: Option<&Arc<str>>) -> Arc<CalcitTypeAnnotation> {

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -28,7 +28,8 @@ use cirru_edn::EdnTag;
 
 use super::{
   ScopeTypes, find_method_entry_for_type, find_trait_field_type, find_trait_method_type, get_impls_from_type,
-  resolve_local_type_refs_for_body, resolve_trait_def_from_source_code, tag_annotation, trait_is_external_object, trait_list_from_type,
+  resolve_local_type_refs_for_body, resolve_namespace_type_refs_for_body, resolve_trait_def_from_source_code, tag_annotation,
+  trait_is_external_object, trait_list_from_type,
 };
 
 // ---------------------------------------------------------------------------
@@ -1461,13 +1462,13 @@ fn resolve_struct_field_type_by_index(type_info: &CalcitTypeAnnotation, idx: usi
       ))
     }
     CalcitTypeAnnotation::TypeRef(_, args) => {
-      let struct_def = type_info.resolve_to_struct()?;
+      let (struct_def, definition_ref) = type_info.resolve_to_struct_with_ref()?;
       let field_type = struct_def.field_types.get(idx)?.clone();
-      Some(substitute_declared_generics(
-        struct_def.generics.as_ref(),
-        args.as_ref(),
-        field_type.as_ref(),
-      ))
+      let resolved = substitute_declared_generics(struct_def.generics.as_ref(), args.as_ref(), field_type.as_ref());
+      Some(match definition_ref {
+        Some((declaring_ns, _)) => resolve_namespace_type_refs_for_body(resolved, &declaring_ns),
+        None => resolved,
+      })
     }
     _ => None,
   }

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -28,7 +28,7 @@ use cirru_edn::EdnTag;
 
 use super::{
   ScopeTypes, find_method_entry_for_type, find_trait_field_type, find_trait_method_type, get_impls_from_type,
-  resolve_trait_def_from_source_code, tag_annotation, trait_is_external_object, trait_list_from_type,
+  resolve_local_type_refs_for_body, resolve_trait_def_from_source_code, tag_annotation, trait_is_external_object, trait_list_from_type,
 };
 
 // ---------------------------------------------------------------------------
@@ -1360,7 +1360,10 @@ fn infer_enum_applied_args<'a>(
 
   for (payload, expected_type) in payload_args.zip(variant.payload_types().iter()) {
     let actual_type = resolve_type_value(payload, scope_types).unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
-    actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings);
+    let resolved_expected = resolve_local_type_refs_for_body(expected_type.clone(), scope_types);
+    actual_type
+      .as_ref()
+      .matches_with_bindings(resolved_expected.as_ref(), &mut bindings);
   }
 
   Some(
@@ -2024,6 +2027,55 @@ mod tests {
         if inferred.name() == enum_def.name()
           && matches!(args.first().map(AsRef::as_ref), Some(CalcitTypeAnnotation::Number))
     ));
+  }
+
+  #[test]
+  fn enum_constructor_resolves_local_generic_struct_payloads() {
+    let generic: Arc<str> = Arc::from("T");
+    let mut box_def = CalcitStructDef::from_fields(EdnTag::from("Box"), vec![EdnTag::from("value")]);
+    box_def.generics = Arc::new(vec![generic.clone()]);
+    box_def.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(generic.clone()))]);
+    let box_def = Arc::new(box_def);
+
+    let enum_struct = CalcitStructDef {
+      name: EdnTag::from("MaybeBox"),
+      fields: Arc::new(vec![EdnTag::from("empty"), EdnTag::from("box")]),
+      field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),
+      generics: Arc::new(vec![generic.clone()]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    };
+    let enum_def = CalcitEnumDef::from_struct(CalcitStructValue {
+      struct_ref: Arc::new(enum_struct),
+      values: Arc::new(vec![
+        Calcit::from(CalcitList::default()),
+        Calcit::from(vec![
+          CalcitTypeAnnotation::TypeRef(Arc::from("Box"), Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(generic))])).to_calcit(),
+        ]),
+      ]),
+    })
+    .expect("valid generic enum fixture");
+
+    let number = Arc::new(CalcitTypeAnnotation::Number);
+    let boxed_number = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("boxed")),
+      sym: Arc::from("boxed"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.enum"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::Struct(box_def.clone(), Arc::new(vec![number.clone()]))),
+    });
+    let payloads = [boxed_number];
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(Arc::from("Box"), Arc::new(CalcitTypeAnnotation::StructDef(box_def)));
+
+    assert_eq!(
+      infer_enum_applied_args(&enum_def, Some(&Calcit::Tag(EdnTag::from("box"))), payloads.iter(), &scope_types,),
+      Some(vec![number]),
+      "a local Box<T> payload should preserve T for the enclosing enum"
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- document `(:field value)` and `value.:field` as the normal typed Struct access forms, and migrate Agent-facing examples away from raw access
- warn on literal-tag `&struct:get` use in project source, with a stricter diagnostic when the receiver cannot be statically analyzed; preserve dynamic keys, dependencies, reusable `defimpl`, and core/runtime boundaries
- preserve the declaring namespace when nested Struct field types such as `'Router` flow into another namespace, and resolve local/quoted StructDef and EnumDef references through function bodies, generic enum construction, `match`, and `assert-type`
- warn on Snapshot and `--file` paths under `/tmp` or `/private/tmp`; keep project snapshots at the project root for relative module resolution and recommend `.calcit/snippets/` only for scratch code files

Fixes #357.

## Real-project regression

- reproduced #357 against the reported cumulo-reel dependency graph
- restored seven Router/Session reads from raw access to typed tag syntax in a local Snapshot copy
- `query type-at` now resolves the nested receiver as `'cumulo-reel.schema/Router`, and `:name router` has no required-field diagnostic
- the project-level raw-access migration lint does not force callers to migrate already-installed dependencies

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-agent-interface`
- `yarn check-all`
- `cr docs check-md` for every changed documentation page

## Note

`cargo clippy --all-targets -- -D warnings` additionally hits pre-existing Rust 1.97 `items_after_test_module` findings in `calcit_deps.rs`, `command_echo.rs`, and `lib.rs`; the repository-required Clippy command passes.
