### PR TITLE
feat: add native static quality gate

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -406,7 +406,7 @@ cr cirru show-guide
 按从便宜到昂贵的顺序形成闭环：
 
 1. 结构：`cursor show` 或 `tree show`，确认实际 subtree。
-2. 语义：`query type-at ... --format json`，运行 `analyze check-types --summary-only`；看到 `W_TYPE_COVERAGE_GAPS` 后继续执行 `analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only`，再对命中范围去掉 `--summary-only` 查看 path、impact 与 suggestion。
+2. 语义：`query type-at ... --format json`，运行 `analyze check-types --summary-only`；看到 `W_TYPE_COVERAGE_GAPS` 后继续执行 `analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only`，再对命中范围去掉 `--summary-only` 查看 path、impact 与 suggestion。项目门禁使用 `analyze quality`（零容忍）或 `analyze quality --baseline <reviewed.json>`（存量债务），不要再拼接多个 JSON 后交给 JavaScript 比较。
 3. definition：`analyze check-examples --ns <ns> --def <def>`；存在 definition-attached tests 时运行 `cr test <ns>/<def>`。
 4. 项目：运行 `cr test` 及仓库规定的 entry 和测试；默认 `cr test` 只发现当前输入 snapshot 定义的命名空间，不触发 `calcit-core.cirru` 或外部模块中的测试。变更范围明确时可先用 `cr test --affected <ns>/<def>` 做静态依赖筛选，但提交前仍按仓库要求执行全量门禁。CI/Agent 按 tag 或 affected 筛选时加 `--require-match`，避免空选择误报成功；大套件可加 `--summary-only --format json` 保持 stdout 紧凑可解析。只有项目目标是 JavaScript 时才运行对应的 `cr js` codegen。
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -9,11 +9,14 @@ aliases:
   - "assert-type"
   - "compile-time checks"
   - "weak types"
+  - "quality gate"
+  - "type baseline"
 entry_for:
   - "assert-type"
   - "cr analyze check-types"
   - "cr analyze weak-types"
   - "cr analyze deprecated"
+  - "cr analyze quality"
 id: core/features/static-analysis
 related:
   - core/run/library-quality
@@ -43,6 +46,7 @@ The static analysis system provides:
 - **Type annotations** - Optional type hints for function parameters and return values
 - **Compile-time warnings** - Catches errors before code execution
 - **Completion warnings** - Keeps scaffolded `todo!` paths visible to Agents
+- **CI quality gate**: `cr analyze quality --baseline config/calcit-quality.json`
 - **Composable runtime assertions** - `assert-type` and `assert-traits` can validate values at runtime and return original values for chaining
 
 ## Static Project Reports
@@ -58,6 +62,13 @@ cr analyze weak-types --ns app.main
 
 # Deprecated API calls, including the source definition and exact code path
 cr analyze deprecated --ns app.main
+
+# Enforce zero type/weak-type/deprecated debt with a non-zero failure exit
+cr analyze quality
+
+# Bootstrap and enforce a reviewed baseline for an existing project
+cr analyze quality --write-baseline config/calcit-quality.json
+cr analyze quality --baseline config/calcit-quality.json
 
 # Focus only on unresolved type debt
 cr analyze weak-types --ns app.main --intent unresolved
@@ -98,6 +109,8 @@ For one definition, `cr query context '<ns/def>' --format json` embeds the same 
 For one expression, `cr query type-at '<ns/def>' --path code@... --format json` preprocesses only static program metadata and returns inferred type, expected type, typed bindings, confidence, method candidates, and diagnostics. It does not run the application entry. Paths use the same stable Snapshot coordinates returned by structural query commands.
 
 These analysis commands run as static Snapshot readers: they load configured modules and core metadata but do not preprocess or execute the application entry. With `--format json`, stdout is one versioned JSON envelope containing a stable scope revision, filters, summary, and definition-level rows; startup/command messages stay on stderr.
+
+`analyze quality` combines the release-facing metrics from `check-types`, `weak-types --only schema-dynamic,code-dynamic,code-nil --intent unresolved,declared-optional`, and `deprecated`. With no baseline it is a zero-debt gate. `--baseline <file>` compares against a committed baseline and exits non-zero on regression; `--write-baseline <file>` atomically writes a reviewed native baseline. Native baselines keep budgets per definition, so improving one definition cannot hide new debt in another. For migration, `--baseline` also accepts the older flat eight-metric JSON shape (`typeNone`, `typeNotFull`, `schemaDynamic`, `codeDynamic`, `codeNil`, `unresolved`, `declaredOptional`, `deprecatedCalls`). Scope flags (`--ns`, `--ns-prefix`, `--deps`) are recorded in native baselines and must match when they are enforced.
 
 `analyze deprecated` scans calls to definitions tagged `:deprecated`. It reports every calling definition and a stable `code@...` path, and includes the target definition's documentation so migrations can be automated without maintaining a second hard-coded legacy API list. Use `--summary-only --format json` for migration gates that only need aggregate counts.
 

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -91,26 +91,20 @@ cr calcit.cirru analyze weak-types \
 - 有限的异构值：使用 enum，而不是用 `:dynamic` 绕过检查。
 - JS FFI、global state 或 macro 边界确实无法静态确定：保持边界窄，并显式声明 `:features $ #{} :js-ffi`；进入 typed code 前 validate/convert。
 
-`check-types` 与 `weak-types` 是报告命令：发现 debt 时会产生诊断，但不会仅凭命中数量自动采用你的发布策略。严格 CI 应读取单个 JSON stdout，并拒绝 unresolved 数量增加：
+`check-types` 与 `weak-types` 是定位报告；`analyze quality` 是带非零失败退出的发布门禁。新类库直接使用零容忍：
 
 ```bash
-mkdir -p .calcit
-cr calcit.cirru analyze weak-types \
-  --only schema-dynamic,code-dynamic \
-  --intent unresolved \
-  --summary-only \
-  --format json > .calcit/weak-types.json
-node --input-type=commonjs -e '
-  const report = require("./.calcit/weak-types.json");
-  const unresolved = report.data.summary.intents.unresolved;
-  if (unresolved !== 0) {
-    console.error(`unresolved dynamic debt: ${unresolved}`);
-    process.exit(1);
-  }
-'
+cr calcit.cirru analyze quality
 ```
 
-新类库推荐以 `data.summary.intents.unresolved == 0` 为目标。存量类库可以把脚本中的零替换为一份明确 baseline，先阻止回归，再逐步降低；不要用 ignore warning 或批量 `:dynamic` 让数字看起来通过。`.calcit/` 是项目本地状态目录，应保持在 `.gitignore` 中。
+存量类库先审阅现状并生成 baseline，再在 CI 中阻止回归：
+
+```bash
+cr calcit.cirru analyze quality --write-baseline config/calcit-quality.json
+cr calcit.cirru analyze quality --baseline config/calcit-quality.json
+```
+
+baseline 按 definition 保存独立预算，某处清债不能抵消另一处新增债务。后续只应降低 baseline；不要用 ignore warning 或批量 `:dynamic` 让数字看起来通过。需要机器报告时追加 `--format json`，stdout 仍是单个 JSON envelope。
 
 ## 3. API examples 与文档
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -472,8 +472,8 @@ cr calcit.cirru --entry test --warn-dyn-method --check-only
 - `--check-only` 和实际 native/JS codegen：预处理错误或 warning 会阻断并非零退出，必须修到通过；
 - `check-examples`、`docs check-md` 和 `cr test`：所选示例/测试失败时阻断；测试应加
   `--require-match`，避免过滤条件拼错后“零测试通过”；
-- `check-types`、`weak-types`、`deprecated`：是静态报告命令，有命中不等于非零退出；CI 必须解析
-  `--format json` 的 summary 并与零目标或已审阅 baseline 比较。
+- `check-types`、`weak-types`、`deprecated`：是静态定位报告，有命中不等于非零退出；`analyze quality`
+  聚合它们的发布指标，并按零目标或已审阅 baseline 返回失败退出码。
 
 老项目不必在第一次升级提交中把所有历史 dynamic 清零，但必须先让报告可重复，再阻止新增债务：
 
@@ -489,23 +489,22 @@ baseline 不要只保存一个总数。类型覆盖至少比较 `levels.none` �
 和 `intents.declared-optional`，再比较 `deprecated` 的 `summary.calls`。否则一种债务增加、另一种
 减少时，相同的总数会掩盖回归。
 
-可用下面命令生成三份机器报告；它们的 stdout 都是单个 JSON，进度与提示写到 stderr：
+新项目直接执行零容忍门禁：
 
 ```bash
-mkdir -p .calcit/upgrade
-cr calcit.cirru analyze check-types --summary-only --format json \
-  > .calcit/upgrade/check-types.json
-cr calcit.cirru analyze weak-types \
-  --only schema-dynamic,code-dynamic,code-nil \
-  --intent unresolved,declared-optional \
-  --summary-only --format json \
-  > .calcit/upgrade/weak-types.json
-cr calcit.cirru analyze deprecated --summary-only --format json \
-  > .calcit/upgrade/deprecated.json
+cr calcit.cirru analyze quality
 ```
 
-`.calcit/upgrade/` 可以作为本地迁移证据目录并保持在 `.gitignore`；真正用于 CI 的 baseline 数值或
-脚本应放在仓库跟踪的配置中，并在 PR 中解释每次变化。
+存量项目先审阅现状并生成原生 baseline，再在 CI 中执行比较：
+
+```bash
+cr calcit.cirru analyze quality --write-baseline config/calcit-quality.json
+cr calcit.cirru analyze quality --baseline config/calcit-quality.json
+```
+
+原生 baseline 记录 scope、汇总指标和每个 definition 的独立预算。新增 definition 默认预算为零；
+一个 definition 的改善不能掩盖另一个 definition 的回归。`--write-baseline` 会原子写入文件，
+但 baseline 仍需人工审阅并随仓库提交，每次提高都要在 PR 中解释。
 
 例如把首次审阅后的上限提交为 `config/calcit-upgrade-baseline.json`：
 
@@ -516,15 +515,17 @@ cr calcit.cirru analyze deprecated --summary-only --format json \
   "schemaDynamic": 21,
   "codeDynamic": 0,
   "codeNil": 22,
+  "unresolved": 43,
   "declaredOptional": 0,
   "deprecatedCalls": 0
 }
 ```
 
-然后由仓库脚本读取上述三份报告，对每个指标执行 `current <= baseline`。如果迁移把 `none` 改善为
+这个旧版扁平 shape 仍可直接传给 `analyze quality --baseline`，便于已有项目删除 Node 检查脚本后
+无缝迁移；重新执行 `--write-baseline` 会生成更严格的按 definition 格式。如果迁移把 `none` 改善为
 `partial`，`typeNone` 会下降且 `typeNotFull` 不变；改善为 `full` 时二者都会下降。确有类型债务在
 不同分类间迁移时，应在 PR 中解释并显式更新 baseline，而不是让一个总数相互抵消。baseline 归零后
-保留检查脚本，以阻止后续重新引入。
+保留 `analyze quality`，以阻止后续重新引入。
 
 ### 3.7 format 的边界
 
@@ -604,11 +605,7 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
         cr calcit.cirru --entry "$entry" --warn-dyn-method --check-only
       fi
     done < <(cr calcit.cirru config show | awk '/^Snapshot Entries:/{in_entries=1; next} in_entries && /^  [^ ]/{print $1}')
-    mkdir -p .calcit/upgrade
-    cr calcit.cirru analyze check-types --summary-only --format json > .calcit/upgrade/check-types.json
-    cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic,code-nil --intent unresolved,declared-optional --summary-only --format json > .calcit/upgrade/weak-types.json
-    cr calcit.cirru analyze deprecated --summary-only --format json > .calcit/upgrade/deprecated.json
-    node scripts/check-calcit-upgrade-baseline.mjs
+    cr calcit.cirru analyze quality --baseline config/calcit-quality.json
 
 - name: Run project tests
   run: |
@@ -620,11 +617,9 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
 
 说明：若项目依赖 `packageManager: "yarn@4.12.0"`，优先先执行 Corepack 激活，再让 CI 触发 Yarn。不要让 `setup-node` 的 Yarn cache 或其他 Yarn 调用早于 `corepack enable` / `corepack prepare`，否则可能误用 runner 上的全局 Yarn 1。 `caps --ci` 参数保证在 CI 加载模块时使用 HTTPS 协议，避免 CI 环境下的 SSH key 问题。
 
-注意：三个 `analyze` 命令只是展示机器报告，上面的示例还没有对 debt 数量作判断。迁移期应把
-summary 与仓库中已审阅的 baseline 比较，禁止数字上升；示例中的
-`scripts/check-calcit-upgrade-baseline.mjs` 是项目需要自行实现并纳入版本控制的比较脚本，不是 `cr`
-内建文件。清零后则要求 unresolved dynamic、
-unresolved/declared-optional nil debt 和 deprecated calls 均为 0。不要只依赖 analysis 命令退出码。
+注意：`check-types`、`weak-types`、`deprecated` 仍是展示报告，不按命中数量失败；CI 使用
+`analyze quality` 执行零目标或 baseline 策略。清零后则要求 unresolved dynamic、
+unresolved/declared-optional nil debt 和 deprecated calls 均为 0。
 `test --require-match` 会避免 tag 或 scope 写错后零测试仍退出成功。项目没有 named `test` entry 或
 definition-attached unit tests 时，应删除对应示例行并替换成项目真实测试命令，而不是机械照抄。
 

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -25,6 +25,23 @@ cr analyze check-types --summary-only
 cr analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --format json
 ```
 
+## 用原生 quality gate 阻止类型债务回归
+
+新项目直接要求所有发布指标归零：
+
+```bash
+cr calcit.cirru analyze quality
+```
+
+存量项目先审阅当前结果并写入 baseline，随后在 CI 中只执行比较命令：
+
+```bash
+cr calcit.cirru analyze quality --write-baseline config/calcit-quality.json
+cr calcit.cirru analyze quality --baseline config/calcit-quality.json
+```
+
+门禁同时覆盖未完整类型、unresolved Dynamic、未迁移的 nil/Optional 和 deprecated calls。原生 baseline 按 definition 保存预算，新债务不能被其他 definition 的改善抵消；`--write-baseline` 只用于明确审阅后的更新，不应作为每次 CI 的前置步骤。需要机器读取时追加 `--format json`，失败时 stdout 仍是单个 JSON，进度与错误摘要写入 stderr。
+
 ## Option / Result 组合
 
 优先让 `Option` / `Result` 的方法表达类型流，而不是逐层 `unwrap` 或调用

--- a/editing-history/20260816-2252-native-quality-gate.md
+++ b/editing-history/20260816-2252-native-quality-gate.md
@@ -1,0 +1,6 @@
+# 2026-08-16 原生静态质量门禁
+
+- 新增 `cr analyze quality`，一次聚合 type coverage、unresolved Dynamic、nil/Optional 迁移债务和 deprecated calls，并按零目标或 baseline 返回 CI 可用的失败退出码。
+- 兼容业务项目已有的八项扁平 JSON baseline；`--write-baseline` 生成带 scope 和 definition 级预算的原生格式，防止跨 definition 的清债掩盖新增回归。
+- human/JSON 报告统一提供 limit、delta 和 regression；失败 JSON 继续保证 stdout 为单个 envelope。
+- 在 `respo-markdown.calcit` 与 `calcit-theme.calcit` 的现有 baseline 上完成真实项目回归；提交前运行 `cargo fmt`、`cargo clippy -- -D warnings`、`cargo test`、`yarn compile`、`yarn check-agent-interface` 和 `yarn check-all`。

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -276,6 +276,30 @@ const scenarios = [
       }
     },
   },
+  {
+    name: "static quality gate failure",
+    args: [
+      "calcit/test.cirru",
+      "analyze",
+      "quality",
+      "--ns",
+      "app.main",
+      "--format",
+      "json",
+    ],
+    expectedStatus: 1,
+    check(result) {
+      if (result.schema_version !== 1 || result.command !== "analyze.quality") {
+        throw new Error("unexpected analyze.quality envelope");
+      }
+      if (result.data.passed !== false || result.data.mode !== "strict-zero") {
+        throw new Error("quality gate did not preserve strict failure semantics");
+      }
+      if (result.data.violations.length === 0 || result.diagnostics[0]?.code !== "E_STATIC_QUALITY_REGRESSION") {
+        throw new Error("quality gate failure lost regressions or structured diagnostics");
+      }
+    },
+  },
 ];
 
 const rows = [];
@@ -291,8 +315,9 @@ for (const scenario of scenarios) {
   if (child.error) {
     throw child.error;
   }
-  if (child.status !== 0) {
-    throw new Error(`${scenario.name} failed (${child.status}):\n${child.stderr}`);
+  const expectedStatus = scenario.expectedStatus ?? 0;
+  if (child.status !== expectedStatus) {
+    throw new Error(`${scenario.name} returned ${child.status}, expected ${expectedStatus}:\n${child.stderr}`);
   }
 
   let parsed;

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -574,6 +574,15 @@ fn render_analyze_explanation(cmd: &AnalyzeCommand) -> Option<String> {
       }
       desc
     }
+    AnalyzeSubcommand::Quality(opts) => {
+      if let Some(path) = &opts.write_baseline {
+        format!("writes a per-definition static quality baseline to `{path}`")
+      } else if let Some(path) = &opts.baseline {
+        format!("enforces static quality budgets from `{path}`")
+      } else {
+        "enforces zero static type and deprecated API debt".to_string()
+      }
+    }
     AnalyzeSubcommand::EffectsGraph(opts) => {
       let mut desc = "builds effects dependency graph".to_string();
       if let Some(root) = &opts.root {
@@ -857,6 +866,15 @@ fn push_analyze(tokens: &mut Vec<String>, cmd: &AnalyzeCommand) {
       value "format" => &opts.format; default "human",
       switch "deps" => opts.deps,
       switch "summary-only" => opts.summary_only
+    ),
+    AnalyzeSubcommand::Quality(opts) => echo_items!(
+      tokens,
+      opt "ns" => opts.ns.as_deref(); default "none",
+      opt "ns-prefix" => opts.ns_prefix.as_deref(); default "none",
+      switch "deps" => opts.deps,
+      opt "baseline" => opts.baseline.as_deref(); default "strict-zero",
+      opt "write-baseline" => opts.write_baseline.as_deref(); default "none",
+      value "format" => &opts.format; default "human"
     ),
     AnalyzeSubcommand::EffectsGraph(opts) => echo_items!(
       tokens,
@@ -1239,6 +1257,7 @@ fn analyze_name(subcommand: &AnalyzeSubcommand) -> &'static str {
     AnalyzeSubcommand::CheckTypes(_) => "check-types",
     AnalyzeSubcommand::WeakTypes(_) => "weak-types",
     AnalyzeSubcommand::Deprecated(_) => "deprecated",
+    AnalyzeSubcommand::Quality(_) => "quality",
     AnalyzeSubcommand::EffectsGraph(_) => "effects-graph",
     AnalyzeSubcommand::JsEscape(_) => "js-escape",
     AnalyzeSubcommand::JsUnescape(_) => "js-unescape",

--- a/src/bin/cli_handlers/mod.rs
+++ b/src/bin/cli_handlers/mod.rs
@@ -25,6 +25,7 @@ mod tips;
 mod tree;
 mod tree_mutation;
 
+pub(crate) use atomic_write::stage_atomic_file;
 pub use call_graph_diff::handle_call_graph_diff_command;
 pub use cirru::handle_cirru_command;
 pub use command_echo::{print_command_echo, should_echo_command};

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -15,6 +15,8 @@ mod cli_handlers;
 
 #[path = "../deprecated_api.rs"]
 mod deprecated_api;
+#[path = "../quality_gate.rs"]
+mod quality_gate;
 #[path = "../type_coverage.rs"]
 mod type_coverage;
 
@@ -33,7 +35,7 @@ use calcit::calcit::{CalcitFnTypeAnnotation, CalcitTypeAnnotation, LocatedWarnin
 use calcit::call_stack::CallStackList;
 use calcit::cli_args::{
   AnalyzeSubcommand, CalcitCommand, CallGraphCommand, CheckTypesCommand, CountCallsCommand, DeprecatedCommand, EffectsGraphCommand,
-  TestCommand, ToplevelCalcit, WeakTypesCommand,
+  QualityCommand, TestCommand, ToplevelCalcit, WeakTypesCommand,
 };
 use calcit::snapshot::ChangesDict;
 use calcit::util::string::strip_shebang;
@@ -74,6 +76,29 @@ fn run_deprecated(options: &DeprecatedCommand, snapshot: &snapshot::Snapshot) ->
     other => return Err(format!("Unknown deprecated output format `{other}`. Expected `human` or `json`.")),
   }
   Ok(())
+}
+
+fn run_quality(options: &QualityCommand, snapshot: &snapshot::Snapshot) -> Result<(), String> {
+  if !matches!(options.format.as_str(), "human" | "text" | "json") {
+    return Err(format!(
+      "Unknown quality output format `{}`. Expected `human` or `json`.",
+      options.format
+    ));
+  }
+  let outcome = quality_gate::analyze_quality(options, snapshot)?;
+  match options.format.as_str() {
+    "human" | "text" => print!("{}", quality_gate::format_quality_report(&outcome)),
+    "json" => println!("{}", quality_gate::format_quality_json(&outcome)?),
+    _ => unreachable!("quality output format was validated before analysis"),
+  }
+  if outcome.passed {
+    Ok(())
+  } else {
+    Err(format!(
+      "Static quality gate failed with {} regression(s).",
+      outcome.violations.len()
+    ))
+  }
 }
 
 fn attach_missing_core_namespaces(snapshot: &mut snapshot::Snapshot, core_snapshot: snapshot::Snapshot) {
@@ -176,6 +201,10 @@ fn run_cli() -> Result<(), String> {
       AnalyzeSubcommand::Deprecated(options) => {
         let snapshot = cli_handlers::load_snapshot_for_static_analysis(&cli_args.input)?;
         return run_deprecated(options, &snapshot);
+      }
+      AnalyzeSubcommand::Quality(options) => {
+        let snapshot = cli_handlers::load_snapshot_for_static_analysis(&cli_args.input)?;
+        return run_quality(options, &snapshot);
       }
       _ => {}
     },
@@ -397,6 +426,7 @@ fn run_cli() -> Result<(), String> {
       AnalyzeSubcommand::CheckTypes(check_types_options) => run_check_types(check_types_options, &snapshot),
       AnalyzeSubcommand::WeakTypes(weak_type_options) => run_weak_types(weak_type_options, &snapshot),
       AnalyzeSubcommand::Deprecated(deprecated_options) => run_deprecated(deprecated_options, &snapshot),
+      AnalyzeSubcommand::Quality(quality_options) => run_quality(quality_options, &snapshot),
       AnalyzeSubcommand::EffectsGraph(effects_graph_options) => run_effects_graph(&entries, effects_graph_options),
       AnalyzeSubcommand::JsEscape(options) => run_js_escape(&options.symbol),
       AnalyzeSubcommand::JsUnescape(options) => run_js_unescape(&options.symbol),

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -183,7 +183,7 @@ pub struct ExecCommand {
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 #[argh(subcommand, name = "analyze")]
-/// analyze code structure and helpers (call-graph, call-graph-diff, count-calls, program-diff, check-examples, check-types, weak-types, deprecated, js-escape)
+/// analyze code structure and helpers (call-graph, call-graph-diff, count-calls, program-diff, check-examples, check-types, weak-types, deprecated, quality, js-escape)
 pub struct AnalyzeCommand {
   #[argh(subcommand)]
   pub subcommand: AnalyzeSubcommand,
@@ -208,6 +208,8 @@ pub enum AnalyzeSubcommand {
   WeakTypes(WeakTypesCommand),
   /// locate calls to definitions marked with the :deprecated tag
   Deprecated(DeprecatedCommand),
+  /// enforce type coverage, weak-type, and deprecated API quality budgets
+  Quality(QualityCommand),
   /// decompose entry into State / Transform / Effect graph
   EffectsGraph(EffectsGraphCommand),
   /// escape a Calcit symbol into JavaScript-safe identifier form
@@ -304,6 +306,30 @@ pub struct DeprecatedCommand {
   /// emit aggregate counts without per-definition details
   #[argh(switch, long = "summary-only")]
   pub summary_only: bool,
+}
+
+/// enforce static quality budgets or generate a reviewed baseline
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand, name = "quality")]
+pub struct QualityCommand {
+  /// exact namespace to analyze
+  #[argh(option)]
+  pub ns: Option<String>,
+  /// namespace prefix scope filter
+  #[argh(option)]
+  pub ns_prefix: Option<String>,
+  /// include dependency/core namespaces
+  #[argh(switch)]
+  pub deps: bool,
+  /// compare against a committed quality baseline JSON file
+  #[argh(option)]
+  pub baseline: Option<String>,
+  /// write a per-definition quality baseline JSON file and exit successfully
+  #[argh(option, long = "write-baseline")]
+  pub write_baseline: Option<String>,
+  /// output format: human (default) or json
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
 }
 
 /// check examples in namespace

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -1,0 +1,501 @@
+//! Native static-quality budgets for `cr analyze quality`.
+
+use std::collections::BTreeMap;
+use std::fmt::Write;
+use std::fs;
+use std::path::Path;
+
+use calcit::cli_args::{CheckTypesCommand, DeprecatedCommand, QualityCommand, WeakTypesCommand};
+use calcit::snapshot;
+use serde::{Deserialize, Serialize};
+
+use crate::deprecated_api;
+use crate::type_coverage::{self, CoverageLevel, WeakTypeIntent, WeakTypeKind};
+
+const QUALITY_BASELINE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct QualityMetrics {
+  pub type_none: usize,
+  pub type_not_full: usize,
+  pub schema_dynamic: usize,
+  pub code_dynamic: usize,
+  pub code_nil: usize,
+  pub unresolved: usize,
+  pub declared_optional: usize,
+  pub deprecated_calls: usize,
+}
+
+impl QualityMetrics {
+  fn values(&self) -> [(&'static str, usize); 8] {
+    [
+      ("typeNone", self.type_none),
+      ("typeNotFull", self.type_not_full),
+      ("schemaDynamic", self.schema_dynamic),
+      ("codeDynamic", self.code_dynamic),
+      ("codeNil", self.code_nil),
+      ("unresolved", self.unresolved),
+      ("declaredOptional", self.declared_optional),
+      ("deprecatedCalls", self.deprecated_calls),
+    ]
+  }
+
+  fn add_assign(&mut self, other: &Self) {
+    self.type_none += other.type_none;
+    self.type_not_full += other.type_not_full;
+    self.schema_dynamic += other.schema_dynamic;
+    self.code_dynamic += other.code_dynamic;
+    self.code_nil += other.code_nil;
+    self.unresolved += other.unresolved;
+    self.declared_optional += other.declared_optional;
+    self.deprecated_calls += other.deprecated_calls;
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct QualityScope {
+  pub namespace: Option<String>,
+  pub namespace_prefix: Option<String>,
+  pub include_dependencies: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct QualityBaseline {
+  schema_version: u32,
+  scope: QualityScope,
+  metrics: QualityMetrics,
+  definitions: BTreeMap<String, QualityMetrics>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QualityViolation {
+  pub definition: Option<String>,
+  pub metric: String,
+  pub actual: usize,
+  pub limit: usize,
+  pub delta: usize,
+}
+
+#[derive(Debug, Clone)]
+struct QualitySnapshot {
+  revision: String,
+  metrics: QualityMetrics,
+  definitions: BTreeMap<String, QualityMetrics>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QualityOutcome {
+  pub revision: String,
+  pub scope: QualityScope,
+  pub mode: String,
+  pub baseline_path: Option<String>,
+  pub metrics: QualityMetrics,
+  pub limits: Option<QualityMetrics>,
+  pub deltas: BTreeMap<String, i64>,
+  pub violations: Vec<QualityViolation>,
+  pub passed: bool,
+}
+
+fn quality_scope(options: &QualityCommand) -> QualityScope {
+  QualityScope {
+    namespace: options.ns.clone(),
+    namespace_prefix: options.ns_prefix.clone(),
+    include_dependencies: options.deps,
+  }
+}
+
+fn collect_quality_snapshot(options: &QualityCommand, snapshot: &snapshot::Snapshot) -> Result<QualitySnapshot, String> {
+  let check_options = CheckTypesCommand {
+    ns: options.ns.clone(),
+    ns_prefix: options.ns_prefix.clone(),
+    only: None,
+    format: "json".to_owned(),
+    deps: options.deps,
+    summary_only: false,
+  };
+  let weak_options = WeakTypesCommand {
+    ns: options.ns.clone(),
+    ns_prefix: options.ns_prefix.clone(),
+    only: Some("schema-dynamic,code-dynamic,code-nil".to_owned()),
+    intent: Some("unresolved,declared-optional".to_owned()),
+    format: "json".to_owned(),
+    deps: options.deps,
+    summary_only: false,
+  };
+  let deprecated_options = DeprecatedCommand {
+    ns: options.ns.clone(),
+    ns_prefix: options.ns_prefix.clone(),
+    format: "json".to_owned(),
+    deps: options.deps,
+    summary_only: false,
+  };
+
+  let coverage_rows = type_coverage::collect_type_coverage_rows(&check_options, snapshot)?;
+  let weak_rows = type_coverage::collect_weak_type_rows(&weak_options, snapshot)?;
+  let deprecated_rows = deprecated_api::collect_deprecated_api_rows(&deprecated_options, snapshot)?;
+  let revision_ids = coverage_rows
+    .iter()
+    .map(|row| (row.ns.clone(), row.def.clone()))
+    .collect::<Vec<_>>();
+  let revision = type_coverage::analysis_revision(snapshot, &revision_ids)?;
+  let mut definitions = BTreeMap::<String, QualityMetrics>::new();
+
+  for row in coverage_rows {
+    let metrics = definitions.entry(format!("{}/{}", row.ns, row.def)).or_default();
+    match row.level {
+      CoverageLevel::None => {
+        metrics.type_none = 1;
+        metrics.type_not_full = 1;
+      }
+      CoverageLevel::Partial => metrics.type_not_full = 1,
+      CoverageLevel::Full => {}
+    }
+  }
+
+  for row in weak_rows {
+    let metrics = definitions.entry(format!("{}/{}", row.ns, row.def)).or_default();
+    for occurrence in row.occurrences {
+      match occurrence.kind {
+        WeakTypeKind::SchemaDynamic => metrics.schema_dynamic += 1,
+        WeakTypeKind::CodeDynamic => metrics.code_dynamic += 1,
+        WeakTypeKind::CodeNil => metrics.code_nil += 1,
+      }
+      match occurrence.intent {
+        WeakTypeIntent::Unresolved => metrics.unresolved += 1,
+        WeakTypeIntent::DeclaredOptional => metrics.declared_optional += 1,
+        WeakTypeIntent::IntentionalJsFfi | WeakTypeIntent::DeclaredUnit => {}
+      }
+    }
+  }
+
+  for row in deprecated_rows {
+    definitions
+      .entry(format!("{}/{}", row.namespace, row.definition))
+      .or_default()
+      .deprecated_calls += row.uses.len();
+  }
+
+  let metrics = sum_metrics(definitions.values());
+  Ok(QualitySnapshot {
+    revision,
+    metrics,
+    definitions,
+  })
+}
+
+fn sum_metrics<'a>(items: impl IntoIterator<Item = &'a QualityMetrics>) -> QualityMetrics {
+  let mut total = QualityMetrics::default();
+  for item in items {
+    total.add_assign(item);
+  }
+  total
+}
+
+fn compare_metrics(actual: &QualityMetrics, limit: &QualityMetrics, definition: Option<&str>) -> Vec<QualityViolation> {
+  actual
+    .values()
+    .into_iter()
+    .zip(limit.values())
+    .filter(|((_, actual), (_, limit))| actual > limit)
+    .map(|((metric, actual), (_, limit))| QualityViolation {
+      definition: definition.map(str::to_owned),
+      metric: metric.to_owned(),
+      actual,
+      limit,
+      delta: actual - limit,
+    })
+    .collect()
+}
+
+fn compare_detailed_baseline(current: &QualitySnapshot, baseline: &QualityBaseline) -> Vec<QualityViolation> {
+  let mut violations = vec![];
+  for (definition, actual) in &current.definitions {
+    let limit = baseline.definitions.get(definition).cloned().unwrap_or_default();
+    violations.extend(compare_metrics(actual, &limit, Some(definition)));
+  }
+  violations.sort_by(|left, right| left.definition.cmp(&right.definition).then(left.metric.cmp(&right.metric)));
+  violations
+}
+
+fn metric_deltas(actual: &QualityMetrics, limit: &QualityMetrics) -> BTreeMap<String, i64> {
+  actual
+    .values()
+    .into_iter()
+    .zip(limit.values())
+    .map(|((metric, actual), (_, limit))| (metric.to_owned(), actual as i64 - limit as i64))
+    .collect()
+}
+
+fn read_baseline(path: &Path) -> Result<Result<QualityBaseline, QualityMetrics>, String> {
+  let content = fs::read_to_string(path).map_err(|error| format!("Failed to read quality baseline '{}': {error}", path.display()))?;
+  let value: serde_json::Value =
+    serde_json::from_str(&content).map_err(|error| format!("Failed to parse quality baseline '{}': {error}", path.display()))?;
+  if value.get("schemaVersion").is_some() {
+    let baseline: QualityBaseline =
+      serde_json::from_value(value).map_err(|error| format!("Invalid native quality baseline '{}': {error}", path.display()))?;
+    if baseline.schema_version != QUALITY_BASELINE_SCHEMA_VERSION {
+      return Err(format!(
+        "Unsupported quality baseline schemaVersion {} in '{}'; expected {}.",
+        baseline.schema_version,
+        path.display(),
+        QUALITY_BASELINE_SCHEMA_VERSION
+      ));
+    }
+    let summed = sum_metrics(baseline.definitions.values());
+    if summed != baseline.metrics {
+      return Err(format!(
+        "Invalid native quality baseline '{}': top-level metrics do not equal the per-definition totals.",
+        path.display()
+      ));
+    }
+    Ok(Ok(baseline))
+  } else {
+    let metrics: QualityMetrics =
+      serde_json::from_value(value).map_err(|error| format!("Invalid legacy quality baseline '{}': {error}", path.display()))?;
+    Ok(Err(metrics))
+  }
+}
+
+fn write_baseline(path: &Path, scope: &QualityScope, current: &QualitySnapshot) -> Result<(), String> {
+  let zero = QualityMetrics::default();
+  let baseline = QualityBaseline {
+    schema_version: QUALITY_BASELINE_SCHEMA_VERSION,
+    scope: scope.clone(),
+    metrics: current.metrics.clone(),
+    definitions: current
+      .definitions
+      .iter()
+      .filter(|(_, metrics)| *metrics != &zero)
+      .map(|(definition, metrics)| (definition.clone(), metrics.clone()))
+      .collect(),
+  };
+  let mut content = serde_json::to_string_pretty(&baseline)
+    .map_err(|error| format!("Failed to encode quality baseline '{}': {error}", path.display()))?;
+  content.push('\n');
+  let staged = crate::cli_handlers::stage_atomic_file(path, content.as_bytes(), "quality baseline")?;
+  staged.commit()
+}
+
+pub fn analyze_quality(options: &QualityCommand, snapshot: &snapshot::Snapshot) -> Result<QualityOutcome, String> {
+  if options.baseline.is_some() && options.write_baseline.is_some() {
+    return Err("`--baseline` and `--write-baseline` cannot be used together.".to_owned());
+  }
+
+  let scope = quality_scope(options);
+  let current = collect_quality_snapshot(options, snapshot)?;
+
+  if let Some(path) = &options.write_baseline {
+    write_baseline(Path::new(path), &scope, &current)?;
+    return Ok(QualityOutcome {
+      revision: current.revision,
+      scope,
+      mode: "write-baseline".to_owned(),
+      baseline_path: Some(path.clone()),
+      metrics: current.metrics,
+      limits: None,
+      deltas: BTreeMap::new(),
+      violations: vec![],
+      passed: true,
+    });
+  }
+
+  let (mode, baseline_path, limits, violations) = if let Some(path) = &options.baseline {
+    match read_baseline(Path::new(path))? {
+      Ok(baseline) => {
+        if baseline.scope != scope {
+          return Err(format!(
+            "Quality baseline scope does not match this command. Baseline: {:?}; current: {:?}. Use the same --ns/--ns-prefix/--deps flags or regenerate it.",
+            baseline.scope, scope
+          ));
+        }
+        let violations = compare_detailed_baseline(&current, &baseline);
+        ("native-baseline".to_owned(), Some(path.clone()), baseline.metrics, violations)
+      }
+      Err(legacy_limits) => {
+        let violations = compare_metrics(&current.metrics, &legacy_limits, None);
+        ("legacy-baseline".to_owned(), Some(path.clone()), legacy_limits, violations)
+      }
+    }
+  } else {
+    let limits = QualityMetrics::default();
+    let violations = compare_metrics(&current.metrics, &limits, None);
+    ("strict-zero".to_owned(), None, limits, violations)
+  };
+  let deltas = metric_deltas(&current.metrics, &limits);
+  let passed = violations.is_empty();
+
+  Ok(QualityOutcome {
+    revision: current.revision,
+    scope,
+    mode,
+    baseline_path,
+    metrics: current.metrics,
+    limits: Some(limits),
+    deltas,
+    violations,
+    passed,
+  })
+}
+
+fn format_scope(scope: &QualityScope) -> String {
+  if let Some(namespace) = &scope.namespace {
+    format!("namespace={namespace}")
+  } else if let Some(prefix) = &scope.namespace_prefix {
+    format!("namespace-prefix={prefix}")
+  } else if scope.include_dependencies {
+    "project+dependencies".to_owned()
+  } else {
+    "project".to_owned()
+  }
+}
+
+pub fn format_quality_report(outcome: &QualityOutcome) -> String {
+  let mut out = String::new();
+  if outcome.mode == "write-baseline" {
+    let _ = writeln!(out, "Static quality baseline written");
+  } else {
+    let _ = writeln!(out, "Static quality gate");
+  }
+  let _ = writeln!(out, "- mode: {}", outcome.mode);
+  let _ = writeln!(out, "- scope: {}", format_scope(&outcome.scope));
+  let _ = writeln!(out, "- revision: {}", outcome.revision);
+  if let Some(path) = &outcome.baseline_path {
+    let _ = writeln!(out, "- baseline: {path}");
+  }
+  let _ = writeln!(out, "- result: {}", if outcome.passed { "PASS" } else { "FAIL" });
+  let _ = writeln!(out, "- metrics:");
+  for (metric, actual) in outcome.metrics.values() {
+    if let Some(limits) = &outcome.limits {
+      let limit = limits
+        .values()
+        .into_iter()
+        .find_map(|(name, value)| (name == metric).then_some(value))
+        .unwrap_or_default();
+      let delta = actual as i64 - limit as i64;
+      let _ = writeln!(out, "  - {metric}: {actual} (limit {limit}, delta {delta:+})");
+    } else {
+      let _ = writeln!(out, "  - {metric}: {actual}");
+    }
+  }
+  if !outcome.violations.is_empty() {
+    let _ = writeln!(out, "- regressions:");
+    for violation in &outcome.violations {
+      let target = violation.definition.as_deref().unwrap_or("project total");
+      let _ = writeln!(
+        out,
+        "  - {target}: {} {} > {} (+{})",
+        violation.metric, violation.actual, violation.limit, violation.delta
+      );
+    }
+  }
+  out
+}
+
+pub fn format_quality_json(outcome: &QualityOutcome) -> Result<String, String> {
+  let diagnostics = if outcome.passed {
+    vec![]
+  } else {
+    vec![serde_json::json!({
+      "code": "E_STATIC_QUALITY_REGRESSION",
+      "phase": "analysis",
+      "severity": "error",
+      "message": format!("Static quality gate found {} regression(s).", outcome.violations.len()),
+      "suggestion": "Fix the reported definitions. Update a reviewed baseline only when the remaining debt is intentional and documented.",
+    })]
+  };
+  let envelope = serde_json::json!({
+    "schema_version": 1,
+    "command": "analyze.quality",
+    "revision": outcome.revision,
+    "data": {
+      "scope": outcome.scope,
+      "mode": outcome.mode,
+      "baseline": outcome.baseline_path,
+      "passed": outcome.passed,
+      "metrics": outcome.metrics,
+      "limits": outcome.limits,
+      "deltas": outcome.deltas,
+      "violations": outcome.violations,
+    },
+    "diagnostics": diagnostics,
+  });
+  serde_json::to_string_pretty(&envelope).map_err(|error| format!("Failed to encode quality JSON: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn metrics(schema_dynamic: usize) -> QualityMetrics {
+    QualityMetrics {
+      schema_dynamic,
+      ..QualityMetrics::default()
+    }
+  }
+
+  #[test]
+  fn legacy_baseline_accepts_the_business_project_shape() {
+    let source = r#"{
+      "typeNone": 68,
+      "typeNotFull": 100,
+      "schemaDynamic": 101,
+      "codeDynamic": 0,
+      "codeNil": 35,
+      "unresolved": 136,
+      "declaredOptional": 0,
+      "deprecatedCalls": 0
+    }"#;
+    let parsed: QualityMetrics = serde_json::from_str(source).expect("legacy baseline should parse");
+    assert_eq!(parsed.type_none, 68);
+    assert_eq!(parsed.schema_dynamic, 101);
+    assert_eq!(parsed.unresolved, 136);
+  }
+
+  #[test]
+  fn detailed_baseline_catches_debt_moved_between_definitions() {
+    let baseline = QualityBaseline {
+      schema_version: QUALITY_BASELINE_SCHEMA_VERSION,
+      scope: QualityScope {
+        namespace: None,
+        namespace_prefix: None,
+        include_dependencies: false,
+      },
+      metrics: metrics(1),
+      definitions: BTreeMap::from([("app/a".to_owned(), metrics(1)), ("app/b".to_owned(), metrics(0))]),
+    };
+    let current = QualitySnapshot {
+      revision: "md5:test".to_owned(),
+      metrics: metrics(1),
+      definitions: BTreeMap::from([("app/a".to_owned(), metrics(0)), ("app/b".to_owned(), metrics(1))]),
+    };
+
+    let violations = compare_detailed_baseline(&current, &baseline);
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0].definition.as_deref(), Some("app/b"));
+    assert_eq!(violations[0].metric, "schemaDynamic");
+  }
+
+  #[test]
+  fn metric_comparison_reports_only_regressions() {
+    let actual = QualityMetrics {
+      type_none: 1,
+      code_nil: 2,
+      ..QualityMetrics::default()
+    };
+    let limit = QualityMetrics {
+      type_none: 1,
+      code_nil: 1,
+      schema_dynamic: 3,
+      ..QualityMetrics::default()
+    };
+
+    let violations = compare_metrics(&actual, &limit, None);
+    assert_eq!(violations.len(), 1);
+    assert_eq!(violations[0].metric, "codeNil");
+    assert_eq!(violations[0].delta, 1);
+  }
+}


### PR DESCRIPTION
## Summary

- add `cr analyze quality` as a native CI gate for type coverage, weak type debt, nil/Optional migration debt, and deprecated API calls
- support strict-zero mode, the existing eight-metric flat baseline shape, and atomically generated native baselines
- store native budgets per definition so improvements elsewhere cannot hide a regression in another definition
- keep human and JSON reports aligned with limits, deltas, structured violations, and non-zero failure exits
- document greenfield, migration, CI, and Agent workflows and add the command to documentation discovery metadata

## Motivation

Recent Calcit upgrades in Respo/respo-markdown.calcit#29 and Cirru/calcit-theme.calcit#12 had to run three JSON reports and maintain the same Node comparison script. This moves that repeated policy into Calcit while preserving those projects' committed baseline files.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (13/13, including failing quality-gate JSON stdout)
- `yarn check-all`
- Markdown checks for the five updated guide/reference files
- existing baselines pass unchanged in fresh clones of respo-markdown.calcit and calcit-theme.calcit
