### PR TITLE
docs: clarify Agent quality gate workflow

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -406,7 +406,7 @@ cr cirru show-guide
 按从便宜到昂贵的顺序形成闭环：
 
 1. 结构：`cursor show` 或 `tree show`，确认实际 subtree。
-2. 语义：`query type-at ... --format json`，运行 `analyze check-types --summary-only`；看到 `W_TYPE_COVERAGE_GAPS` 后继续执行 `analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only`，再对命中范围去掉 `--summary-only` 查看 path、impact 与 suggestion。项目门禁使用 `analyze quality`（零容忍）或 `analyze quality --baseline <reviewed.json>`（存量债务），不要再拼接多个 JSON 后交给 JavaScript 比较。
+2. 语义：`query type-at ... --format json`，运行 `analyze check-types --summary-only`；看到 `W_TYPE_COVERAGE_GAPS` 后继续执行 `analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only`，再对命中范围去掉 `--summary-only` 查看 path、impact 与 suggestion。项目门禁使用 `analyze quality`（零容忍）；存量债务先执行一次 `analyze quality --write-baseline config/calcit-quality.json`，人工审阅后把同一文件提交到仓库，CI 改执行 `analyze quality --baseline config/calcit-quality.json`。不要再拼接多个 JSON 后交给 JavaScript 比较。门禁失败时保留 `--format json` 的单一 envelope，并按其中的 definition/path 回到 `weak-types` 或 `query type-at` 定位。
 3. definition：`analyze check-examples --ns <ns> --def <def>`；存在 definition-attached tests 时运行 `cr test <ns>/<def>`。
 4. 项目：运行 `cr test` 及仓库规定的 entry 和测试；默认 `cr test` 只发现当前输入 snapshot 定义的命名空间，不触发 `calcit-core.cirru` 或外部模块中的测试。变更范围明确时可先用 `cr test --affected <ns>/<def>` 做静态依赖筛选，但提交前仍按仓库要求执行全量门禁。CI/Agent 按 tag 或 affected 筛选时加 `--require-match`，避免空选择误报成功；大套件可加 `--summary-only --format json` 保持 stdout 紧凑可解析。只有项目目标是 JavaScript 时才运行对应的 `cr js` codegen。
 

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -182,7 +182,7 @@ cr calcit.cirru docs check-md README.md --failures-only
 cr calcit.cirru --entry test
 ```
 
-在这条基础链路后追加仓库自己的 JS build、Node/Vite test、FFI build 和真实消费者 smoke test。发布门禁应比较 JSON 结果或 baseline，而不是只检查分析命令退出码。
+在这条基础链路后追加仓库自己的 JS build、Node/Vite test、FFI build 和真实消费者 smoke test。发布门禁统一执行 `analyze quality`：新类库要求零容忍，存量类库传入已审阅的 `--baseline`；该命令的非零退出码就是回归信号，`--format json` 只用于机器读取和保留定位证据。
 
 ## 8. 发布前记录
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -477,7 +477,7 @@ cr calcit.cirru --entry test --warn-dyn-method --check-only
 
 老项目不必在第一次升级提交中把所有历史 dynamic 清零，但必须先让报告可重复，再阻止新增债务：
 
-1. 保存当前 JSON summary、Calcit 版本和 Snapshot revision，作为审阅过的 baseline；
+1. 运行 `analyze quality --write-baseline <file>` 生成原生 baseline，人工审阅后与 Calcit 版本、Snapshot revision 一起记录；baseline 本身保存 scope、汇总指标和每个 definition 的预算；
 2. 先要求 `--check-only`、测试和行为构建全绿；
 3. CI 拒绝 unresolved dynamic、nil/Optional debt 或 deprecated call 数量上升；
 4. 按模块降低 baseline，降到 0 后改为零容忍；baseline 只能下降，不能无说明地更新；
@@ -644,7 +644,7 @@ definition-attached unit tests 时，应删除对应示例行并替换成项目�
 6. default 与每个 named entry 的 `--check-only`
 7. 每个 entry 的 `--warn-dyn-method --check-only`（普通检查全绿后启用）
 8. 所有声明支持的 entry 行为测试（默认 once；watch 另行验收）
-9. `check-types`、dynamic/nil `weak-types`、`deprecated` 的 JSON baseline 或零目标
+9. `analyze quality` 的 JSON baseline 或零目标（`check-types`、dynamic/nil `weak-types`、`deprecated` 仍作为定位报告）
 10. `cr test --require-match`、公开 namespace 的 `check-examples` 与 `docs check-md`
 11. JS 项目的 codegen 加 Node/Vite 行为测试，而不只是生成成功
 12. `package.json` 中与编译/构建相关的脚本

--- a/editing-history/20260816-2305-agent-quality-gate-docs.md
+++ b/editing-history/20260816-2305-agent-quality-gate-docs.md
@@ -1,0 +1,5 @@
+# 2026-08-16 23:05 Agent quality gate 文档澄清
+
+- 明确 Agent 首次建立原生 quality baseline、人工审阅后提交，以及 CI 使用 `--baseline` 比较的完整路径。
+- 说明 `analyze quality` 的非零退出码就是发布回归信号，JSON 输出仅用于机器读取和定位。
+- 修正升级与类库质量文档中旧的“拼接 JSON 比较”表述，保留各分析命令作为定位报告。


### PR DESCRIPTION
## Summary\n\n- document the first-time native baseline bootstrap and CI comparison path for Agents\n- make analyze quality's non-zero exit the explicit release regression signal\n- keep check-types, weak-types, and deprecated as detail reports\n\n## Validation\n\n- git diff --check\n- docs check-md for CalcitAgent.md, run/library-quality.md, and run/upgrade.md with --entry calcit/test.cirru