### PR TITLE
fix: load modules from project view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,11 +89,11 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -206,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,12 +222,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -237,11 +242,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -320,16 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +375,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "im_ternary_tree"
@@ -484,9 +489,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest",
@@ -993,12 +998,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.256.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
 dependencies = [
  "leb128fmt",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.18"
+version = "0.13.19"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "calcit"
 autobins = false
-version = "0.13.18"
+version = "0.13.19"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ notify = "8.0.0"
 notify-debouncer-mini = "0.7.0"
 walkdir = "2.5.0"
 hex = "0.4.3"
-md-5 = "0.10.6"
+md-5 = "0.11.0"
 rpds = "1.2.1"
 im_ternary_tree = "0.0.20"
 # im_ternary_tree = { path = "/Users/chenyong/repo/calcit-lang/ternary-tree.rs" }
@@ -41,7 +41,7 @@ ureq = "3.3.0"
 rmp-serde = "1.3.0"
 semver = "1.0.28"
 regex = "1.13.1"
-wasm-encoder = { version = "0.246.2", default-features = false }
+wasm-encoder = { version = "0.256.0", default-features = false }
 
 [build-dependencies]
 cirru_edn = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ To load modules, use `:modules` configuration and the runtime snapshot file `cal
     :modules $ [] |memof/calcit.cirru |lilac/
 ```
 
-Paths defined in `:modules` first load from the snapshot directory's `.calcit/modules/`, then fall back to
-`~/.config/calcit/modules/`, i.e. `.calcit/modules/memof/calcit.cirru` or the legacy global path.
+Paths defined in `:modules` load from the snapshot directory's `.calcit/modules/`, e.g.
+`.calcit/modules/memof/calcit.cirru`. Run `caps` to materialize or refresh that project-local view.
 
 Modules ending with `/` are automatically suffixed with `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Related examples and workflows:
 Run `caps` to resolve the recursive dependency graph and install it. Immutable revisions are stored under
 `~/.config/calcit/module-caches/`, while the current project receives links under `.calcit/modules/`.
 Different projects can therefore use different revisions without switching a shared checkout. Existing
-project module links are the only runtime module source.
+project module links are the only runtime source for package-style module paths; explicit relative and
+absolute paths retain their normal direct resolution.
 
 Published SemVer tags are preferred. Branch refs remain supported for development, but `caps` warns with
 the resolved commit. When a graph requests several SemVer tags for one repository, the highest requested

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Related examples and workflows:
 ```
 
 Run `caps` to resolve the recursive dependency graph and install it. Immutable revisions are stored under
-`~/.config/calcit/modules/versions/`, while the current project receives links under `.calcit/modules/`.
+`~/.config/calcit/module-caches/`, while the current project receives links under `.calcit/modules/`.
 Different projects can therefore use different revisions without switching a shared checkout. Existing
 project module links are the only runtime module source.
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ Related examples and workflows:
 ```
 
 Run `caps` to resolve the recursive dependency graph and install it. Immutable revisions are stored under
-`~/.config/calcit/modules/.store/`, while the current project receives links under `.calcit/modules/`.
+`~/.config/calcit/modules/versions/`, while the current project receives links under `.calcit/modules/`.
 Different projects can therefore use different revisions without switching a shared checkout. Existing
-`~/.config/calcit/modules/<repo>/` checkouts remain a runtime fallback during migration.
+project module links are the only runtime module source.
 
 Published SemVer tags are preferred. Branch refs remain supported for development, but `caps` warns with
 the resolved commit. When a graph requests several SemVer tags for one repository, the highest requested

--- a/RFCs/07-28-git-module-store-rfc.md
+++ b/RFCs/07-28-git-module-store-rfc.md
@@ -55,8 +55,8 @@ Calcit 继续使用 GitHub repository + Git ref 管理模块，不建设 registr
 
 ```text
 ~/.config/calcit/modules/
-  .store/git/<owner>/<repo>/<commit>/source/
-  .store/git/<owner>/<repo>/<commit>/realizations/<build-key>/
+  versions/git/<owner>/<repo>/<commit>/source/
+  versions/git/<owner>/<repo>/<commit>/realizations/<build-key>/
   <repo>/                                  # legacy clone，迁移期保留
 
 <project>/
@@ -64,7 +64,7 @@ Calcit 继续使用 GitHub repository + Git ref 管理模块，不建设 registr
   .calcit/
     caps-state.cirru
     modules/
-      <repo> -> ~/.config/calcit/modules/.store/.../source/
+      <repo> -> ~/.config/calcit/modules/versions/.../source/
       <native-repo> -> .../realizations/<build-key>/
     tmp/
 ```
@@ -99,7 +99,7 @@ basename 建立项目链接。如果依赖图里出现 `owner-a/utils` 与 `owne
 
 `caps` 按以下顺序修改本机状态：
 
-1. 在 store 的 `.store/tmp/` 下创建临时目录，解析 ref、下载 source（与 store 同文件系统，保证 rename 原子）；项目侧临时 project view 写入 `.calcit/tmp/`；
+1. 在 store 的 `versions/tmp/` 下创建临时目录，解析 ref、下载 source（与 store 同文件系统，保证 rename 原子）；项目侧临时 project view 写入 `.calcit/tmp/`；
 2. 完成递归依赖图和版本选择；
 3. 完成需要的 native realization 与验证；
 4. 写入临时 project view；

--- a/RFCs/07-28-git-module-store-rfc.md
+++ b/RFCs/07-28-git-module-store-rfc.md
@@ -50,21 +50,24 @@ Calcit 继续使用 GitHub repository + Git ref 管理模块，不建设 registr
 
 ## 3. 目录模型
 
-当前正式路径是 `~/.config/calcit/modules/`。新 store 放在它下面，避免再引入
-一套顶级目录；路径解析应集中到一个 helper，后续再考虑 XDG 或其他平台差异。
+`~/.config/calcit/modules/` 保留给 legacy module root；新的不可变 store 使用它的
+同级路径 `~/.config/calcit/module-caches/`。路径解析应集中到一个 helper，后续再
+考虑 XDG 或其他平台差异。
 
 ```text
-~/.config/calcit/modules/
-  versions/git/<owner>/<repo>/<commit>/source/
-  versions/git/<owner>/<repo>/<commit>/realizations/<build-key>/
-  <repo>/                                  # legacy clone，迁移期保留
+~/.config/calcit/
+  modules/
+    <repo>/                                # legacy clone，迁移期保留
+  module-caches/
+    git/<owner>/<repo>/<commit>/source/
+    git/<owner>/<repo>/<commit>/realizations/<build-key>/
 
 <project>/
   deps.cirru
   .calcit/
     caps-state.cirru
     modules/
-      <repo> -> ~/.config/calcit/modules/versions/.../source/
+      <repo> -> ~/.config/calcit/module-caches/.../source/
       <native-repo> -> .../realizations/<build-key>/
     tmp/
 ```
@@ -99,7 +102,7 @@ basename 建立项目链接。如果依赖图里出现 `owner-a/utils` 与 `owne
 
 `caps` 按以下顺序修改本机状态：
 
-1. 在 store 的 `versions/tmp/` 下创建临时目录，解析 ref、下载 source（与 store 同文件系统，保证 rename 原子）；项目侧临时 project view 写入 `.calcit/tmp/`；
+1. 在 store 的 `~/.config/calcit/module-caches/tmp/` 下创建临时目录，解析 ref、下载 source（与 store 同文件系统，保证 rename 原子）；项目侧临时 project view 写入 `.calcit/tmp/`；
 2. 完成递归依赖图和版本选择；
 3. 完成需要的 native realization 与验证；
 4. 写入临时 project view；

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -58,8 +58,9 @@ To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename
       :modules $ [] |memof/calcit.cirru |lilac/
 ```
 
-Paths defined in `:modules` first use `<project>/.calcit/modules/` and then the legacy
-`~/.config/calcit/modules/` fallback. Existing snapshot `:modules` values do not need to change.
+Paths defined in `:modules` are loaded only through `<project>/.calcit/modules/`. `caps` creates
+this project view as links to the matching immutable revisions in the global store; it is therefore
+an error to run a project before its dependencies have been installed with `caps`.
 
 Modules that end with `/` are automatically suffixed with `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
 

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -32,7 +32,7 @@ only each dependency's `:dependencies`; a dependency's own `:dev-dependencies` n
 consumer. Conflicting references for the same repository in both root groups are rejected.
 
 Run `caps` to recursively resolve and install the graph. Sources are stored by resolved commit under
-`~/.config/calcit/modules/.store/`. The project gets a local module view in `.calcit/modules/`, with
+`~/.config/calcit/modules/versions/`. The project gets a local module view in `.calcit/modules/`, with
 `caps-state.cirru`, temporary files, and other generated state kept under `.calcit/`.
 
 SemVer tags are the recommended dependency refs. Branches are supported for development, but every
@@ -71,11 +71,13 @@ caps tree
 caps why calcit-lang/memof
 caps status
 caps verify
+caps clean
 ```
 
 `tree` displays selected recursive revisions, while `why` prints one shortest path from every root
 dependency and all direct version requests. `status` checks project links; `verify` also checks immutable
-store commits, local source modifications, and native realization receipts.
+store commits, local source modifications, and native realization receipts. `clean` is global: it retains
+the newest materialized revision of each module under `versions/` and removes older ones.
 
 The positional input may point to a standalone dependency file. Its parent directory becomes the project
 root even when no `calcit.cirru` exists:
@@ -120,7 +122,9 @@ caps status
 ```
 
 Use `caps verify` for the stronger immutable-store and native-receipt checks. Shared
-store revisions should not be edited directly; reinstall a damaged revision instead.
+store revisions should not be edited directly; reinstall a damaged revision instead. `caps` overwrites
+`~/.config/calcit/modules/AGENTS.md` on every invocation with the workflow for changing a dependency:
+use its Git repository, commit the change, publish a new tag, then update `deps.cirru` and reinstall.
 
 `caps reset` rebuilds the current project's `.calcit/modules/` links from the resolved immutable
 store entries:
@@ -162,6 +166,7 @@ Commands:
   status            check installed module versions and local modifications
   verify            verify store contents, project links, and native receipts
   reset             rebuild project links from immutable store entries
+  clean             remove old immutable revisions from the global module cache
   version           read or update the package version in deps.cirru
 ```
 

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -77,7 +77,8 @@ caps clean
 `tree` displays selected recursive revisions, while `why` prints one shortest path from every root
 dependency and all direct version requests. `status` checks project links; `verify` also checks immutable
 store commits, local source modifications, and native realization receipts. `clean` is global: it retains
-the newest materialized revision of each module under `module-caches/` and removes older ones.
+the newest materialized revision of each module under `module-caches/`, plus any revision still linked by
+a registered project view, and removes the remaining older ones.
 
 The positional input may point to a standalone dependency file. Its parent directory becomes the project
 root even when no `calcit.cirru` exists:

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -34,6 +34,8 @@ consumer. Conflicting references for the same repository in both root groups are
 Run `caps` to recursively resolve and install the graph. Sources are stored by resolved commit under
 `~/.config/calcit/module-caches/`. The project gets a local module view in `.calcit/modules/`, with
 `caps-state.cirru`, temporary files, and other generated state kept under `.calcit/`.
+Package-style module paths resolve only through that project view. Explicit relative paths still resolve
+from the snapshot directory, and absolute paths resolve directly.
 
 SemVer tags are the recommended dependency refs. Branches are supported for development, but every
 resolution warns and prints the current commit. Conflicting SemVer tags select the highest version actually

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -32,7 +32,7 @@ only each dependency's `:dependencies`; a dependency's own `:dev-dependencies` n
 consumer. Conflicting references for the same repository in both root groups are rejected.
 
 Run `caps` to recursively resolve and install the graph. Sources are stored by resolved commit under
-`~/.config/calcit/modules/versions/`. The project gets a local module view in `.calcit/modules/`, with
+`~/.config/calcit/module-caches/`. The project gets a local module view in `.calcit/modules/`, with
 `caps-state.cirru`, temporary files, and other generated state kept under `.calcit/`.
 
 SemVer tags are the recommended dependency refs. Branches are supported for development, but every
@@ -77,7 +77,7 @@ caps clean
 `tree` displays selected recursive revisions, while `why` prints one shortest path from every root
 dependency and all direct version requests. `status` checks project links; `verify` also checks immutable
 store commits, local source modifications, and native realization receipts. `clean` is global: it retains
-the newest materialized revision of each module under `versions/` and removes older ones.
+the newest materialized revision of each module under `module-caches/` and removes older ones.
 
 The positional input may point to a standalone dependency file. Its parent directory becomes the project
 root even when no `calcit.cirru` exists:
@@ -123,7 +123,7 @@ caps status
 
 Use `caps verify` for the stronger immutable-store and native-receipt checks. Shared
 store revisions should not be edited directly; reinstall a damaged revision instead. `caps` overwrites
-`~/.config/calcit/modules/AGENTS.md` on every invocation with the workflow for changing a dependency:
+`~/.config/calcit/module-caches/AGENTS.md` on every invocation with the workflow for changing a dependency:
 use its Git repository, commit the change, publish a new tag, then update `deps.cirru` and reinstall.
 
 `caps reset` rebuilds the current project's `.calcit/modules/` links from the resolved immutable

--- a/editing-history/202608171118-project-module-runtime-resolution.md
+++ b/editing-history/202608171118-project-module-runtime-resolution.md
@@ -1,0 +1,6 @@
+# Project module runtime resolution
+
+- `caps` already stores immutable dependency revisions in `~/.config/calcit/modules/.store/` and builds the project's `.calcit/modules/` link view.
+- Runtime loaders must consume only that project view. Retaining a global module fallback can silently run a dependency revision that was not selected by the project's dependency graph.
+- Centralize the project module directory calculation in `calcit::project_module_folder`, then use it for normal execution, WASM codegen, queries, configuration inspection, markdown checks, call-graph comparison, and the Cirru integration harness.
+- Keep explicitly relative and absolute module paths working; only package-style module paths are constrained to the project view.

--- a/editing-history/202608171133-visible-module-versions-and-cleanup.md
+++ b/editing-history/202608171133-visible-module-versions-and-cleanup.md
@@ -1,6 +1,6 @@
 # Visible module versions and cache cleanup
 
 - Store immutable module revisions under `~/.config/calcit/modules/versions/` instead of a hidden `.store/` directory, retaining the owner, repository, and resolved commit in the path.
-- Write `metadata.txt` beside each cached revision so the requested reference remains inspectable and global cleanup can select the highest SemVer release without a network request.
+- Write `metadata.txt` beside each cached revision so the requested reference remains inspectable and global cleanup can select the highest SemVer release without a network request. When one commit is observed through multiple refs, retain the highest observed SemVer ref for cleanup ordering.
 - Add `caps clean` as an explicit global cleanup command. It preserves one newest revision per module (SemVer takes precedence; materialization time breaks non-SemVer ties) and removes older revision directories.
 - Rewrite `~/.config/calcit/modules/AGENTS.md` on each `caps` invocation. The guide treats `versions/` as immutable cache data and directs dependency changes through a repository commit, new tag, dependency update, and reinstall.

--- a/editing-history/202608171133-visible-module-versions-and-cleanup.md
+++ b/editing-history/202608171133-visible-module-versions-and-cleanup.md
@@ -1,0 +1,6 @@
+# Visible module versions and cache cleanup
+
+- Store immutable module revisions under `~/.config/calcit/modules/versions/` instead of a hidden `.store/` directory, retaining the owner, repository, and resolved commit in the path.
+- Write `metadata.txt` beside each cached revision so the requested reference remains inspectable and global cleanup can select the highest SemVer release without a network request.
+- Add `caps clean` as an explicit global cleanup command. It preserves one newest revision per module (SemVer takes precedence; materialization time breaks non-SemVer ties) and removes older revision directories.
+- Rewrite `~/.config/calcit/modules/AGENTS.md` on each `caps` invocation. The guide treats `versions/` as immutable cache data and directs dependency changes through a repository commit, new tag, dependency update, and reinstall.

--- a/editing-history/202608171140-module-caches-root.md
+++ b/editing-history/202608171140-module-caches-root.md
@@ -1,0 +1,5 @@
+# Module caches root
+
+- Move the global immutable cache from the nested `modules/versions/` proposal to the clearer sibling path `~/.config/calcit/module-caches/`.
+- Keep `~/.config/calcit/modules/` reserved for the legacy module root and per-project link vocabulary; `module-caches/AGENTS.md` is the authoritative generated guidance for cached revisions.
+- Derive the cache root as a sibling of `CALCIT_MODULES_DIR`, so custom test and CI roots preserve the same `modules/` plus `module-caches/` layout.

--- a/editing-history/202608171200-module-cache-review-follow-up.md
+++ b/editing-history/202608171200-module-cache-review-follow-up.md
@@ -1,0 +1,5 @@
+# Module cache review follow-up
+
+- Scope `cr docs` module documentation and scope discovery to the current project's `.calcit/modules/` directory, removing the final global fallback.
+- Register each successfully materialized project module view in `module-caches/projects/`; global cleanup preserves every cached revision that remains linked by one of those views.
+- When a cached commit is later resolved through a SemVer tag, refresh its metadata with the highest observed SemVer ref so cleanup ordering stays correct.

--- a/editing-history/202608171205-release-0-13-19.md
+++ b/editing-history/202608171205-release-0-13-19.md
@@ -1,0 +1,4 @@
+# Release 0.13.19
+
+- Publish the project-scoped module resolution, visible `module-caches` store, safe cleanup, and documentation fixes from PR #364.
+- Keep Cargo and npm package versions synchronized at `0.13.19` for the direct PR-branch release.

--- a/editing-history/202608171215-module-path-resolution-docs.md
+++ b/editing-history/202608171215-module-path-resolution-docs.md
@@ -1,0 +1,4 @@
+# Module path resolution documentation
+
+- Clarify that project-local `.calcit/modules/` links are mandatory only for package-style module paths.
+- Preserve the documented behavior of explicit relative paths (resolved from the snapshot) and absolute paths (resolved directly).

--- a/editing-history/202608171230-update-release-dependencies.md
+++ b/editing-history/202608171230-update-release-dependencies.md
@@ -1,0 +1,4 @@
+# Update release dependencies
+
+- Refresh `md-5` and `wasm-encoder` to the requested current compatible releases.
+- Refresh the transitive `generic-array` lockfile entry where the resolver permits, then validate the compiler, code generators, and tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.18",
+  "version": "0.13.19",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -1,7 +1,7 @@
 //! CLI tool to download packages from github,
 //! packages are defined in `deps.cirru` file
 //!
-//! immutable source revisions are stored under `~/.config/calcit/modules/.store/` and
+//! immutable source revisions are stored under `~/.config/calcit/modules/versions/` and
 //! linked into each project's `.calcit/modules/` view.
 
 mod caps_graph;
@@ -103,8 +103,18 @@ pub fn main() -> Result<(), String> {
   }
 
   let cli_args: TopLevelCaps = argh::from_env();
+  let global_modules_dir = modules_dir(&cli_args)?;
+  write_modules_agents(&global_modules_dir)?;
   if cli_args.pull_branch {
     eprintln!("[Warn] --pull-branch is deprecated; branch refs are always resolved from the remote");
+  }
+  if matches!(&cli_args.subcommand, Some(SubCommand::Clean(_))) {
+    let cleanup = clean_version_store(&global_modules_dir)?;
+    println!(
+      "cleaned global module cache: kept {} newest revision(s) for {} module(s), removed {} old revision(s)",
+      cleanup.kept, cleanup.modules, cleanup.removed
+    );
+    return Ok(());
   }
   if let Some(SubCommand::Download(dep_names)) = &cli_args.subcommand {
     if dep_names.packages.is_empty() {
@@ -278,6 +288,9 @@ pub fn main() -> Result<(), String> {
       Some(SubCommand::Download(dep_names)) => {
         unreachable!("already handled: {:?}", dep_names);
       }
+      Some(SubCommand::Clean(_)) => {
+        unreachable!("already handled before reading deps.cirru");
+      }
       None => {
         download_deps(deps, cli_args)?;
       }
@@ -397,6 +410,8 @@ enum SubCommand {
   Verify(VerifyCaps),
   /// rebuild the project module links from resolved immutable store entries
   Reset(ResetCaps),
+  /// remove old immutable revisions from the global module cache
+  Clean(CleanCaps),
 }
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
@@ -413,6 +428,11 @@ struct VerifyCaps {}
 /// rebuild the project module links from resolved immutable store entries
 #[argh(subcommand, name = "reset")]
 struct ResetCaps {}
+
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+/// remove old immutable revisions from the global module cache, keeping the newest revision per module
+#[argh(subcommand, name = "clean")]
+struct CleanCaps {}
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 /// show the resolved recursive dependency graph

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -111,7 +111,7 @@ pub fn main() -> Result<(), String> {
   if matches!(&cli_args.subcommand, Some(SubCommand::Clean(_))) {
     let cleanup = clean_version_store(&global_modules_dir)?;
     println!(
-      "cleaned global module cache: kept {} newest revision(s) for {} module(s), removed {} old revision(s)",
+      "cleaned global module cache: kept {} newest or linked revision(s) for {} module(s), removed {} old revision(s)",
       cleanup.kept, cleanup.modules, cleanup.removed
     );
     return Ok(());

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -1,7 +1,7 @@
 //! CLI tool to download packages from github,
 //! packages are defined in `deps.cirru` file
 //!
-//! immutable source revisions are stored under `~/.config/calcit/modules/versions/` and
+//! immutable source revisions are stored under `~/.config/calcit/module-caches/` and
 //! linked into each project's `.calcit/modules/` view.
 
 mod caps_graph;

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -1,7 +1,8 @@
 //! CLI tool to download packages from github,
 //! packages are defined in `deps.cirru` file
 //!
-//! files are stored in `~/.config/calcit/modules/`.
+//! immutable source revisions are stored under `~/.config/calcit/modules/.store/` and
+//! linked into each project's `.calcit/modules/` view.
 
 mod caps_graph;
 mod git;

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -14,6 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_PARALLEL_RESOLVES: usize = 6;
 const MODULE_CACHE_DIR: &str = "module-caches";
+const PROJECT_VIEW_REGISTRY_DIR: &str = "projects";
 const VERSION_STORE_METADATA: &str = "metadata.txt";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -81,6 +82,7 @@ pub struct StoreCleanup {
   pub removed: usize,
 }
 
+/// Rewrites the cache-local instructions that explain how cached modules are maintained.
 pub fn write_modules_agents(modules_dir: &Path) -> Result<(), String> {
   let cache_root = module_cache_root(modules_dir);
   fs::create_dir_all(&cache_root).map_err(|e| format!("failed to create {}: {e}", cache_root.display()))?;
@@ -95,12 +97,13 @@ make the change through its normal Git workflow, commit it, publish a new SemVer
 consumer's `deps.cirru`, and run `caps` again. For local experiments, use an explicit relative
 module path instead of modifying the cache.
 
-`caps clean` is a global cache cleanup: it keeps only the newest materialized revision of each
-module. Run `caps` in projects that still need an older dependency revision after cleanup.
+`caps clean` is a global cache cleanup: it keeps the newest materialized revision of each module
+and any revision still linked by a registered project view.
 "#;
   fs::write(cache_root.join("AGENTS.md"), content).map_err(|e| format!("failed to write {}/AGENTS.md: {e}", cache_root.display()))
 }
 
+/// Removes unreferenced, non-current revisions while preserving the newest revision per module.
 pub fn clean_version_store(modules_dir: &Path) -> Result<StoreCleanup, String> {
   let git_root = module_cache_root(modules_dir).join("git");
   if !git_root.exists() {
@@ -116,6 +119,7 @@ pub fn clean_version_store(modules_dir: &Path) -> Result<StoreCleanup, String> {
     kept: 0,
     removed: 0,
   };
+  let active_targets = active_project_view_targets(modules_dir)?;
   for owner in read_directories(&git_root)? {
     for repository in read_directories(&owner)? {
       let revisions = read_directories(&repository)?
@@ -131,6 +135,10 @@ pub fn clean_version_store(modules_dir: &Path) -> Result<StoreCleanup, String> {
       cleanup.kept += 1;
       for revision in revisions {
         if revision.path == newest {
+          continue;
+        }
+        if revision_is_linked_by_project_view(&revision.path, &active_targets) {
+          cleanup.kept += 1;
           continue;
         }
         fs::remove_dir_all(&revision.path)
@@ -167,6 +175,54 @@ impl PartialOrd for StoredRevision {
 
 fn module_cache_root(modules_dir: &Path) -> PathBuf {
   modules_dir.parent().unwrap_or(modules_dir).join(MODULE_CACHE_DIR)
+}
+
+fn register_project_view(options: &GraphOptions) -> Result<(), String> {
+  let project_root = fs::canonicalize(&options.project_root).unwrap_or_else(|_| options.project_root.clone());
+  let registry = module_cache_root(&options.modules_dir).join(PROJECT_VIEW_REGISTRY_DIR);
+  fs::create_dir_all(&registry).map_err(|e| format!("failed to create {}: {e}", registry.display()))?;
+  let identifier = hex::encode(Md5::digest(project_root.to_string_lossy().as_bytes()));
+  let path = registry.join(format!("{identifier}.path"));
+  fs::write(&path, format!("{}\n", project_root.display())).map_err(|e| format!("failed to write {}: {e}", path.display()))
+}
+
+fn active_project_view_targets(modules_dir: &Path) -> Result<Vec<PathBuf>, String> {
+  let registry = module_cache_root(modules_dir).join(PROJECT_VIEW_REGISTRY_DIR);
+  if !registry.exists() {
+    return Ok(vec![]);
+  }
+  let mut targets = vec![];
+  for entry in fs::read_dir(&registry).map_err(|e| format!("failed to read {}: {e}", registry.display()))? {
+    let entry = entry.map_err(|e| format!("failed to read project view entry: {e}"))?;
+    if !entry
+      .file_type()
+      .map_err(|e| format!("failed to inspect {}: {e}", entry.path().display()))?
+      .is_file()
+    {
+      continue;
+    }
+    let project_root = match fs::read_to_string(entry.path()) {
+      Ok(value) if !value.trim().is_empty() => PathBuf::from(value.trim()),
+      Ok(_) => continue,
+      Err(error) => return Err(format!("failed to read {}: {error}", entry.path().display())),
+    };
+    let modules = project_root.join(".calcit/modules");
+    if !modules.is_dir() {
+      continue;
+    }
+    for module in fs::read_dir(&modules).map_err(|e| format!("failed to read {}: {e}", modules.display()))? {
+      let module = module.map_err(|e| format!("failed to read project module entry: {e}"))?;
+      if let Ok(target) = fs::canonicalize(module.path()) {
+        targets.push(target);
+      }
+    }
+  }
+  Ok(targets)
+}
+
+fn revision_is_linked_by_project_view(revision: &Path, active_targets: &[PathBuf]) -> bool {
+  let revision = fs::canonicalize(revision).unwrap_or_else(|_| revision.to_path_buf());
+  active_targets.iter().any(|target| target.starts_with(&revision))
 }
 
 fn read_directories(path: &Path) -> Result<Vec<PathBuf>, String> {
@@ -473,14 +529,23 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
 fn ensure_store_metadata(source: &Path, repository: &str, reference: &str, commit: &str) -> Result<(), String> {
   let root = source.parent().ok_or_else(|| format!("invalid store path {}", source.display()))?;
   let metadata = root.join(VERSION_STORE_METADATA);
-  if metadata.exists() {
-    return Ok(());
-  }
+  let retained_reference = fs::read_to_string(&metadata)
+    .ok()
+    .and_then(|content| metadata_value(&content, "reference"))
+    .map_or_else(|| reference.to_string(), |existing| preferred_store_reference(&existing, reference));
   fs::write(
     &metadata,
-    format!("repository = {repository}\nreference = {reference}\ncommit = {commit}\n"),
+    format!("repository = {repository}\nreference = {retained_reference}\ncommit = {commit}\n"),
   )
   .map_err(|e| format!("failed to write {}: {e}", metadata.display()))
+}
+
+fn preferred_store_reference(existing: &str, observed: &str) -> String {
+  match (parse_tag_version(existing), parse_tag_version(observed)) {
+    (None, Some(_)) => observed.to_string(),
+    (Some(current), Some(candidate)) if candidate > current => observed.to_string(),
+    _ => existing.to_string(),
+  }
 }
 
 fn validate_store_source(repository: &str, source: &Path, expected_commit: &str) -> Result<(), String> {
@@ -714,6 +779,7 @@ pub fn install_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Re
   if backup.exists() {
     fs::remove_dir_all(&backup).map_err(|e| format!("failed to clean old module view: {e}"))?;
   }
+  register_project_view(options)?;
   Ok(())
 }
 
@@ -1345,8 +1411,9 @@ fn sanitize(value: &str) -> String {
 #[cfg(test)]
 mod tests {
   use super::{
-    DependencyRequest, RefKind, ResolvedModule, clean_version_store, is_full_commit_hash, parse_tag_version, read_module_dependencies,
-    select_reference, sorted_root_dependencies, verify_native_receipt, write_modules_agents, write_native_receipt,
+    DependencyRequest, RefKind, ResolvedModule, clean_version_store, ensure_store_metadata, is_full_commit_hash, parse_tag_version,
+    read_module_dependencies, select_reference, sorted_root_dependencies, verify_native_receipt, write_modules_agents,
+    write_native_receipt,
   };
   use crate::PackageDeps;
   use std::collections::{BTreeSet, HashMap};
@@ -1492,6 +1559,55 @@ mod tests {
     assert_eq!(cleanup.removed, 1);
     assert!(!root.join("module-caches/git/org/demo/old").exists());
     assert!(root.join("module-caches/git/org/demo/new/source").exists());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[cfg(unix)]
+  #[test]
+  fn clean_keeps_revisions_linked_by_registered_project_views() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-clean-linked-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    let modules_dir = root.join("modules");
+    let cache = root.join("module-caches/git/org/demo");
+    for (commit, version) in [("old", "1.2.0"), ("new", "1.10.0")] {
+      let revision = cache.join(commit);
+      fs::create_dir_all(revision.join("source")).unwrap();
+      fs::write(
+        revision.join("metadata.txt"),
+        format!("repository = org/demo\nreference = {version}\ncommit = {commit}\n"),
+      )
+      .unwrap();
+    }
+    let project = root.join("project");
+    let project_modules = project.join(".calcit/modules");
+    fs::create_dir_all(&project_modules).unwrap();
+    std::os::unix::fs::symlink(cache.join("old/source"), project_modules.join("demo")).unwrap();
+    let registry = root.join("module-caches/projects");
+    fs::create_dir_all(&registry).unwrap();
+    fs::write(registry.join("project.path"), format!("{}\n", project.display())).unwrap();
+
+    let cleanup = clean_version_store(&modules_dir).unwrap();
+    assert_eq!(cleanup.modules, 1);
+    assert_eq!(cleanup.kept, 2);
+    assert_eq!(cleanup.removed, 0);
+    assert!(cache.join("old/source").exists());
+    assert!(cache.join("new/source").exists());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn store_metadata_retains_the_highest_observed_semver_reference() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-metadata-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    let source = root.join("revision/source");
+    fs::create_dir_all(&source).unwrap();
+
+    ensure_store_metadata(&source, "org/demo", "main", "same-commit").unwrap();
+    ensure_store_metadata(&source, "org/demo", "1.10.0", "same-commit").unwrap();
+    ensure_store_metadata(&source, "org/demo", "1.2.0", "same-commit").unwrap();
+
+    let metadata = fs::read_to_string(root.join("revision/metadata.txt")).unwrap();
+    assert!(metadata.contains("reference = 1.10.0"));
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -10,8 +10,11 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_PARALLEL_RESOLVES: usize = 6;
+const VERSION_STORE_DIR: &str = "versions";
+const VERSION_STORE_METADATA: &str = "metadata.txt";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DependencyRequest {
@@ -69,6 +72,137 @@ pub struct GraphOptions {
   pub ci: bool,
   pub strict: bool,
   pub build_native: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoreCleanup {
+  pub modules: usize,
+  pub kept: usize,
+  pub removed: usize,
+}
+
+pub fn write_modules_agents(modules_dir: &Path) -> Result<(), String> {
+  fs::create_dir_all(modules_dir).map_err(|e| format!("failed to create {}: {e}", modules_dir.display()))?;
+  let content = r#"# Calcit module cache
+
+This directory is managed by `caps`. Its `versions/` subtree is a shared, immutable cache of
+resolved module revisions. Project snapshots load modules through their own
+`<project>/.calcit/modules/` links, not by importing this cache directly.
+
+Do not edit a cached module in place. To change a dependency, clone or open its source repository,
+make the change through its normal Git workflow, commit it, publish a new SemVer tag, update the
+consumer's `deps.cirru`, and run `caps` again. For local experiments, use an explicit relative
+module path instead of modifying the cache.
+
+`caps clean` is a global cache cleanup: it keeps only the newest materialized revision of each
+module. Run `caps` in projects that still need an older dependency revision after cleanup.
+"#;
+  fs::write(modules_dir.join("AGENTS.md"), content).map_err(|e| format!("failed to write {}/AGENTS.md: {e}", modules_dir.display()))
+}
+
+pub fn clean_version_store(modules_dir: &Path) -> Result<StoreCleanup, String> {
+  let git_root = version_store_root(modules_dir).join("git");
+  if !git_root.exists() {
+    return Ok(StoreCleanup {
+      modules: 0,
+      kept: 0,
+      removed: 0,
+    });
+  }
+
+  let mut cleanup = StoreCleanup {
+    modules: 0,
+    kept: 0,
+    removed: 0,
+  };
+  for owner in read_directories(&git_root)? {
+    for repository in read_directories(&owner)? {
+      let revisions = read_directories(&repository)?
+        .into_iter()
+        .filter(|revision| is_store_revision(revision))
+        .map(stored_revision)
+        .collect::<Result<Vec<_>, _>>()?;
+      if revisions.is_empty() {
+        continue;
+      }
+      cleanup.modules += 1;
+      let newest = revisions.iter().max().expect("non-empty revisions").path.clone();
+      cleanup.kept += 1;
+      for revision in revisions {
+        if revision.path == newest {
+          continue;
+        }
+        fs::remove_dir_all(&revision.path)
+          .map_err(|e| format!("failed to remove old module revision {}: {e}", revision.path.display()))?;
+        cleanup.removed += 1;
+      }
+    }
+  }
+  Ok(cleanup)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StoredRevision {
+  path: PathBuf,
+  version: Option<Version>,
+  modified: SystemTime,
+}
+
+impl Ord for StoredRevision {
+  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    self
+      .version
+      .cmp(&other.version)
+      .then_with(|| self.modified.cmp(&other.modified))
+      .then_with(|| self.path.cmp(&other.path))
+  }
+}
+
+impl PartialOrd for StoredRevision {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+fn version_store_root(modules_dir: &Path) -> PathBuf {
+  modules_dir.join(VERSION_STORE_DIR)
+}
+
+fn read_directories(path: &Path) -> Result<Vec<PathBuf>, String> {
+  let mut items = fs::read_dir(path)
+    .map_err(|e| format!("failed to read {}: {e}", path.display()))?
+    .filter_map(Result::ok)
+    .filter_map(|entry| entry.file_type().ok().filter(|kind| kind.is_dir()).map(|_| entry.path()))
+    .collect::<Vec<_>>();
+  items.sort();
+  Ok(items)
+}
+
+fn is_store_revision(path: &Path) -> bool {
+  fs::symlink_metadata(path.join("source"))
+    .map(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink())
+    .unwrap_or(false)
+}
+
+fn stored_revision(path: PathBuf) -> Result<StoredRevision, String> {
+  let reference = fs::read_to_string(path.join(VERSION_STORE_METADATA))
+    .ok()
+    .and_then(|content| metadata_value(&content, "reference"));
+  let modified = fs::metadata(&path).and_then(|metadata| metadata.modified()).unwrap_or(UNIX_EPOCH);
+  Ok(StoredRevision {
+    path,
+    version: reference.as_deref().and_then(parse_tag_version),
+    modified,
+  })
+}
+
+fn metadata_value(content: &str, name: &str) -> Option<String> {
+  content.lines().find_map(|line| {
+    line
+      .split_once('=')
+      .filter(|(key, _)| key.trim() == name)
+      .map(|(_, value)| value.trim().to_string())
+  })
 }
 
 pub fn resolve_graph(root_deps: &PackageDeps, options: &GraphOptions) -> Result<ResolvedGraph, String> {
@@ -250,7 +384,7 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
   let (owner, repo) = repository
     .split_once('/')
     .ok_or_else(|| format!("invalid repository {repository}"))?;
-  let temp_root = options.modules_dir.join(".store/tmp");
+  let temp_root = version_store_root(&options.modules_dir).join("tmp");
   fs::create_dir_all(&temp_root).map_err(|e| format!("failed to create {}: {e}", temp_root.display()))?;
   let identity = hex::encode(Md5::digest(format!("{repository}\n{reference}").as_bytes()));
   let temp_path = temp_root.join(format!(
@@ -267,13 +401,15 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
   let remote = resolve_remote_ref(repository, reference, options.ci)?;
   let source = options
     .modules_dir
-    .join(".store/git")
+    .join(VERSION_STORE_DIR)
+    .join("git")
     .join(owner)
     .join(repo)
     .join(&remote.commit)
     .join("source");
   if source.exists() {
     validate_store_source(repository, &source, &remote.commit)?;
+    ensure_store_metadata(&source, repository, reference, &remote.commit)?;
     let dependencies = read_module_dependencies(&source)?;
     return Ok(ResolvedModule {
       repository: repository.to_string(),
@@ -297,7 +433,8 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
   }
   let source = options
     .modules_dir
-    .join(".store/git")
+    .join(VERSION_STORE_DIR)
+    .join("git")
     .join(owner)
     .join(repo)
     .join(&commit)
@@ -322,6 +459,8 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
     }
   }
 
+  ensure_store_metadata(&source, repository, reference, &commit)?;
+
   let dependencies = read_module_dependencies(&source)?;
   Ok(ResolvedModule {
     repository: repository.to_string(),
@@ -332,6 +471,19 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
     source,
     dependencies,
   })
+}
+
+fn ensure_store_metadata(source: &Path, repository: &str, reference: &str, commit: &str) -> Result<(), String> {
+  let root = source.parent().ok_or_else(|| format!("invalid store path {}", source.display()))?;
+  let metadata = root.join(VERSION_STORE_METADATA);
+  if metadata.exists() {
+    return Ok(());
+  }
+  fs::write(
+    &metadata,
+    format!("repository = {repository}\nreference = {reference}\ncommit = {commit}\n"),
+  )
+  .map_err(|e| format!("failed to write {}: {e}", metadata.display()))
 }
 
 fn validate_store_source(repository: &str, source: &Path, expected_commit: &str) -> Result<(), String> {
@@ -1196,8 +1348,8 @@ fn sanitize(value: &str) -> String {
 #[cfg(test)]
 mod tests {
   use super::{
-    DependencyRequest, RefKind, ResolvedModule, is_full_commit_hash, parse_tag_version, read_module_dependencies, select_reference,
-    sorted_root_dependencies, verify_native_receipt, write_native_receipt,
+    DependencyRequest, RefKind, ResolvedModule, clean_version_store, is_full_commit_hash, parse_tag_version, read_module_dependencies,
+    select_reference, sorted_root_dependencies, verify_native_receipt, write_modules_agents, write_native_receipt,
   };
   use crate::PackageDeps;
   use std::collections::{BTreeSet, HashMap};
@@ -1319,6 +1471,44 @@ mod tests {
     assert_eq!(verify_native_receipt(&module, &realization).unwrap(), vec![library.clone()]);
     fs::write(&library, b"modified build").unwrap();
     assert!(verify_native_receipt(&module, &realization).is_err());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn clean_keeps_the_latest_semver_revision_for_each_module() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-clean-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    for (commit, version) in [("old", "1.2.0"), ("new", "1.10.0")] {
+      let revision = root.join("versions/git/org/demo").join(commit);
+      fs::create_dir_all(revision.join("source")).unwrap();
+      fs::write(
+        revision.join("metadata.txt"),
+        format!("repository = org/demo\nreference = {version}\ncommit = {commit}\n"),
+      )
+      .unwrap();
+    }
+
+    let cleanup = clean_version_store(&root).unwrap();
+    assert_eq!(cleanup.modules, 1);
+    assert_eq!(cleanup.kept, 1);
+    assert_eq!(cleanup.removed, 1);
+    assert!(!root.join("versions/git/org/demo/old").exists());
+    assert!(root.join("versions/git/org/demo/new/source").exists());
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn module_cache_agents_file_is_overwritten_with_release_workflow() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-agents-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("AGENTS.md"), "stale").unwrap();
+
+    write_modules_agents(&root).unwrap();
+    let content = fs::read_to_string(root.join("AGENTS.md")).unwrap();
+    assert!(content.contains("Do not edit a cached module in place."));
+    assert!(content.contains("publish a new SemVer tag"));
+    assert!(!content.contains("stale"));
     fs::remove_dir_all(root).unwrap();
   }
 }

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -13,7 +13,7 @@ use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const MAX_PARALLEL_RESOLVES: usize = 6;
-const VERSION_STORE_DIR: &str = "versions";
+const MODULE_CACHE_DIR: &str = "module-caches";
 const VERSION_STORE_METADATA: &str = "metadata.txt";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -82,11 +82,12 @@ pub struct StoreCleanup {
 }
 
 pub fn write_modules_agents(modules_dir: &Path) -> Result<(), String> {
-  fs::create_dir_all(modules_dir).map_err(|e| format!("failed to create {}: {e}", modules_dir.display()))?;
+  let cache_root = module_cache_root(modules_dir);
+  fs::create_dir_all(&cache_root).map_err(|e| format!("failed to create {}: {e}", cache_root.display()))?;
   let content = r#"# Calcit module cache
 
-This directory is managed by `caps`. Its `versions/` subtree is a shared, immutable cache of
-resolved module revisions. Project snapshots load modules through their own
+This directory is managed by `caps` as a shared, immutable cache of resolved module revisions.
+Project snapshots load modules through their own
 `<project>/.calcit/modules/` links, not by importing this cache directly.
 
 Do not edit a cached module in place. To change a dependency, clone or open its source repository,
@@ -97,11 +98,11 @@ module path instead of modifying the cache.
 `caps clean` is a global cache cleanup: it keeps only the newest materialized revision of each
 module. Run `caps` in projects that still need an older dependency revision after cleanup.
 "#;
-  fs::write(modules_dir.join("AGENTS.md"), content).map_err(|e| format!("failed to write {}/AGENTS.md: {e}", modules_dir.display()))
+  fs::write(cache_root.join("AGENTS.md"), content).map_err(|e| format!("failed to write {}/AGENTS.md: {e}", cache_root.display()))
 }
 
 pub fn clean_version_store(modules_dir: &Path) -> Result<StoreCleanup, String> {
-  let git_root = version_store_root(modules_dir).join("git");
+  let git_root = module_cache_root(modules_dir).join("git");
   if !git_root.exists() {
     return Ok(StoreCleanup {
       modules: 0,
@@ -164,8 +165,8 @@ impl PartialOrd for StoredRevision {
   }
 }
 
-fn version_store_root(modules_dir: &Path) -> PathBuf {
-  modules_dir.join(VERSION_STORE_DIR)
+fn module_cache_root(modules_dir: &Path) -> PathBuf {
+  modules_dir.parent().unwrap_or(modules_dir).join(MODULE_CACHE_DIR)
 }
 
 fn read_directories(path: &Path) -> Result<Vec<PathBuf>, String> {
@@ -384,7 +385,7 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
   let (owner, repo) = repository
     .split_once('/')
     .ok_or_else(|| format!("invalid repository {repository}"))?;
-  let temp_root = version_store_root(&options.modules_dir).join("tmp");
+  let temp_root = module_cache_root(&options.modules_dir).join("tmp");
   fs::create_dir_all(&temp_root).map_err(|e| format!("failed to create {}: {e}", temp_root.display()))?;
   let identity = hex::encode(Md5::digest(format!("{repository}\n{reference}").as_bytes()));
   let temp_path = temp_root.join(format!(
@@ -399,9 +400,7 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
 
   eprintln!("resolving {repository}@{reference}");
   let remote = resolve_remote_ref(repository, reference, options.ci)?;
-  let source = options
-    .modules_dir
-    .join(VERSION_STORE_DIR)
+  let source = module_cache_root(&options.modules_dir)
     .join("git")
     .join(owner)
     .join(repo)
@@ -431,9 +430,7 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
       remote.commit
     ));
   }
-  let source = options
-    .modules_dir
-    .join(VERSION_STORE_DIR)
+  let source = module_cache_root(&options.modules_dir)
     .join("git")
     .join(owner)
     .join(repo)
@@ -1478,8 +1475,9 @@ mod tests {
   fn clean_keeps_the_latest_semver_revision_for_each_module() {
     let root = std::env::temp_dir().join(format!("calcit-caps-clean-{}", std::process::id()));
     let _ = fs::remove_dir_all(&root);
+    let modules_dir = root.join("modules");
     for (commit, version) in [("old", "1.2.0"), ("new", "1.10.0")] {
-      let revision = root.join("versions/git/org/demo").join(commit);
+      let revision = root.join("module-caches/git/org/demo").join(commit);
       fs::create_dir_all(revision.join("source")).unwrap();
       fs::write(
         revision.join("metadata.txt"),
@@ -1488,12 +1486,12 @@ mod tests {
       .unwrap();
     }
 
-    let cleanup = clean_version_store(&root).unwrap();
+    let cleanup = clean_version_store(&modules_dir).unwrap();
     assert_eq!(cleanup.modules, 1);
     assert_eq!(cleanup.kept, 1);
     assert_eq!(cleanup.removed, 1);
-    assert!(!root.join("versions/git/org/demo/old").exists());
-    assert!(root.join("versions/git/org/demo/new/source").exists());
+    assert!(!root.join("module-caches/git/org/demo/old").exists());
+    assert!(root.join("module-caches/git/org/demo/new/source").exists());
     fs::remove_dir_all(root).unwrap();
   }
 
@@ -1501,11 +1499,12 @@ mod tests {
   fn module_cache_agents_file_is_overwritten_with_release_workflow() {
     let root = std::env::temp_dir().join(format!("calcit-caps-agents-{}", std::process::id()));
     let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
-    fs::write(root.join("AGENTS.md"), "stale").unwrap();
+    let modules_dir = root.join("modules");
+    fs::create_dir_all(root.join("module-caches")).unwrap();
+    fs::write(root.join("module-caches/AGENTS.md"), "stale").unwrap();
 
-    write_modules_agents(&root).unwrap();
-    let content = fs::read_to_string(root.join("AGENTS.md")).unwrap();
+    write_modules_agents(&modules_dir).unwrap();
+    let content = fs::read_to_string(root.join("module-caches/AGENTS.md")).unwrap();
     assert!(content.contains("Do not edit a cached module in place."));
     assert!(content.contains("publish a new SemVer tag"));
     assert!(!content.contains("stale"));

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -128,9 +128,7 @@ fn handle_modules(opts: &ConfigModulesCommand, input_path: &str) -> Result<(), S
   let snapshot = load_snapshot_for_display(input_path)?;
 
   let base_dir = Path::new(input_path).parent().unwrap_or(Path::new("."));
-  let module_folder = dirs::home_dir()
-    .map(|buf| buf.as_path().join(".config/calcit/modules/"))
-    .unwrap_or_else(|| Path::new(".").to_owned());
+  let module_folder = calcit::project_module_folder(base_dir);
 
   let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
   let (label, modules) = {
@@ -531,7 +529,7 @@ mod tests {
     fs::write(project.join(".calcit/modules/demo/calcit.cirru"), snapshot("project-demo")).unwrap();
     fs::write(global.join("demo/calcit.cirru"), snapshot("global-demo")).unwrap();
 
-    let loaded = load_module_silent("demo/", &project, &global).unwrap();
+    let loaded = load_module_silent("demo/", &project, &calcit::project_module_folder(&project)).unwrap();
     assert_eq!(loaded.package, "project-demo");
     fs::remove_dir_all(root).unwrap();
   }

--- a/src/bin/cli_handlers/cursor.rs
+++ b/src/bin/cli_handlers/cursor.rs
@@ -1534,7 +1534,7 @@ fn node_fingerprint(node: &Cirru) -> String {
   let encoded = cirru_to_json_value(node).to_string();
   let mut hasher = Md5::new();
   hasher.update(encoded.as_bytes());
-  format!("md5:{:x}", hasher.finalize())
+  format!("md5:{}", hex::encode(hasher.finalize()))
 }
 
 fn read_cursor_context(snapshot_file: &str, target: &str, path: &[usize]) -> Result<(Cirru, Cirru, String), String> {

--- a/src/bin/cli_handlers/docs.rs
+++ b/src/bin/cli_handlers/docs.rs
@@ -759,7 +759,7 @@ fn load_module_docs_from_dir(modules_dir: &Path, module_filter: Option<&str>) ->
     && !seen_modules.contains(filter)
   {
     return Err(format!(
-      "Module '{filter}' not found under {modules_dir:?}. Use 'cr docs list --module <module>' or inspect ~/.config/calcit/modules/."
+      "Module '{filter}' not found under {modules_dir:?}. Run `caps` to materialize the current project's .calcit/modules/ view."
     ));
   }
 
@@ -767,7 +767,7 @@ fn load_module_docs_from_dir(modules_dir: &Path, module_filter: Option<&str>) ->
 }
 
 fn load_module_docs(module_filter: Option<&str>) -> Result<Vec<GuideDoc>, String> {
-  let modules_dir = module_folder()?;
+  let modules_dir = current_project_module_folder()?;
   load_module_docs_from_dir(&modules_dir, module_filter)
 }
 
@@ -782,10 +782,14 @@ fn collect_docs_for_query(module_filter: Option<&str>) -> Result<Vec<GuideDoc>, 
 }
 
 fn list_doc_scopes() -> Result<Vec<String>, String> {
-  let modules_dir = module_folder()?;
+  let modules_dir = current_project_module_folder()?;
+  list_doc_scopes_from_dir(&modules_dir)
+}
+
+fn list_doc_scopes_from_dir(modules_dir: &Path) -> Result<Vec<String>, String> {
   let mut scopes = vec!["calcit".to_string()];
 
-  for entry in fs::read_dir(&modules_dir).map_err(|e| format!("Failed to read modules directory {modules_dir:?}: {e}"))? {
+  for entry in fs::read_dir(modules_dir).map_err(|e| format!("Failed to read modules directory {modules_dir:?}: {e}"))? {
     let entry = entry.map_err(|e| format!("Failed to read modules directory entry: {e}"))?;
     let path = entry.path();
     if !path.is_dir() {
@@ -1470,15 +1474,9 @@ fn ensure_runtime_initialized() {
   });
 }
 
-fn module_folder() -> Result<PathBuf, String> {
-  let project_modules = std::env::current_dir()
-    .map_err(|e| format!("Unable to get current directory: {e}"))?
-    .join(".calcit/modules");
-  if project_modules.exists() {
-    return Ok(project_modules);
-  }
-  let home = std::env::var("HOME").map_err(|_| "Unable to get HOME environment variable".to_string())?;
-  Ok(Path::new(&home).join(".config/calcit/modules/"))
+fn current_project_module_folder() -> Result<PathBuf, String> {
+  let project_root = std::env::current_dir().map_err(|e| format!("Unable to get current directory: {e}"))?;
+  Ok(calcit::project_module_folder(&project_root))
 }
 
 fn collect_check_md_module_paths(entry: &str, deps: &[String]) -> Result<Vec<String>, String> {

--- a/src/bin/cli_handlers/docs.rs
+++ b/src/bin/cli_handlers/docs.rs
@@ -1569,7 +1569,7 @@ fn load_shared_files_for_check_md(entry: &str, deps: &[String]) -> Result<HashMa
 
   let entry_path = PathBuf::from(entry);
   let base_dir = entry_path.parent().unwrap_or(Path::new("."));
-  let module_folder = module_folder()?;
+  let module_folder = calcit::project_module_folder(base_dir);
   let module_paths = collect_check_md_module_paths(entry, deps)?;
 
   let mut shared_files: HashMap<String, snapshot::FileInSnapShot> = HashMap::new();

--- a/src/bin/cli_handlers/docs_cache.rs
+++ b/src/bin/cli_handlers/docs_cache.rs
@@ -69,7 +69,7 @@ pub(crate) struct DocsCache {
 #[allow(dead_code)]
 pub(crate) fn content_hash(content: &str) -> String {
   let digest = Md5::digest(content.as_bytes());
-  format!("{digest:x}")
+  hex::encode(digest)
 }
 
 pub(crate) fn cache_root() -> Result<PathBuf, String> {

--- a/src/bin/cli_handlers/docs_tests.rs
+++ b/src/bin/cli_handlers/docs_tests.rs
@@ -1,7 +1,7 @@
 use super::{
   CirruCheckMode, GuideDoc, GuideDocFrontmatter, GuideDocScope, collect_check_md_module_paths, collect_docs_for_query,
   collect_search_results, extract_cirru_blocks, find_doc_by_query, format_markdown_cirru_blocks, handle_check_md, handle_format_md,
-  load_agents_document, load_entry_snapshot_for_check_md, load_module_docs_from_dir, parse_doc_frontmatter,
+  list_doc_scopes_from_dir, load_agents_document, load_entry_snapshot_for_check_md, load_module_docs_from_dir, parse_doc_frontmatter,
   parse_doc_knowledge_metadata, run_edn_parse_only, score_doc_query, score_doc_shape, validate_doc_frontmatter,
 };
 use std::fs;
@@ -157,6 +157,21 @@ fn load_module_docs_from_dir_errors_on_missing_module() {
 
   let err = load_module_docs_from_dir(&modules_dir, Some("missing.module")).unwrap_err();
   assert!(err.contains("Module 'missing.module' not found"));
+
+  fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn module_docs_do_not_fall_back_to_a_global_modules_directory() {
+  let root = unique_temp_dir("project-module-docs");
+  let project_modules = calcit::project_module_folder(&root);
+  let global_modules = root.join("global-modules");
+  write_file(&global_modules.join("global-only/Agents.md"), "# Global module\n");
+  fs::create_dir_all(&project_modules).unwrap();
+
+  let err = load_module_docs_from_dir(&project_modules, Some("global-only")).unwrap_err();
+  assert!(err.contains("Module 'global-only' not found"));
+  assert_eq!(list_doc_scopes_from_dir(&project_modules).unwrap(), vec!["calcit"]);
 
   fs::remove_dir_all(root).unwrap();
 }

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -447,7 +447,7 @@ struct TransactionReport {
 fn snapshot_content_revision(content: &str) -> String {
   let mut hasher = Md5::new();
   hasher.update(content.as_bytes());
-  format!("md5:{:x}", hasher.finalize())
+  format!("md5:{}", hex::encode(hasher.finalize()))
 }
 
 fn transaction_edn_arg(value: &cirru_edn::Edn) -> Result<String, String> {

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -2739,9 +2739,7 @@ fn load_snapshot_with_entry(input_path: &str, entry: Option<&str>) -> Result<sna
 
   // Load modules (dependencies) silently
   let base_dir = Path::new(input_path).parent().unwrap_or(Path::new("."));
-  let module_folder = dirs::home_dir()
-    .map(|buf| buf.as_path().join(".config/calcit/modules/"))
-    .unwrap_or_else(|| Path::new(".").to_owned());
+  let module_folder = calcit::project_module_folder(base_dir);
 
   for module_path in &modules_to_load {
     match load_module_silent(module_path, base_dir, &module_folder) {
@@ -3071,9 +3069,7 @@ fn handle_modules(input_path: &str) -> Result<(), String> {
   let snapshot = snapshot::load_snapshot_data(&data, input_path)?;
 
   let base_dir = Path::new(input_path).parent().unwrap_or(Path::new("."));
-  let module_folder = dirs::home_dir()
-    .map(|buf| buf.as_path().join(".config/calcit/modules/"))
-    .unwrap_or_else(|| Path::new(".").to_owned());
+  let module_folder = calcit::project_module_folder(base_dir);
 
   println!("{}", "Modules in project:".bold());
 

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -89,7 +89,7 @@ fn semantic_revision(parts: &[&str]) -> String {
     hasher.update((part.len() as u64).to_le_bytes());
     hasher.update(part.as_bytes());
   }
-  format!("md5:{:x}", hasher.finalize())
+  format!("md5:{}", hex::encode(hasher.finalize()))
 }
 
 #[derive(Debug, Serialize)]
@@ -4164,7 +4164,7 @@ fn snapshot_content_revision(input_path: &str) -> Result<String, String> {
   let content = fs::read(input_path).map_err(|error| format!("Failed to read snapshot revision from '{input_path}': {error}"))?;
   let mut hasher = Md5::new();
   hasher.update(&content);
-  Ok(format!("md5:{:x}", hasher.finalize()))
+  Ok(format!("md5:{}", hex::encode(hasher.finalize())))
 }
 
 fn cursor_last_query(

--- a/src/bin/cli_handlers/scaffold.rs
+++ b/src/bin/cli_handlers/scaffold.rs
@@ -774,7 +774,7 @@ fn plan_id(plan: &ArchitecturePlan) -> Result<String, String> {
 fn content_revision(content: &str) -> String {
   let mut hasher = Md5::new();
   hasher.update(content.as_bytes());
-  format!("md5:{:x}", hasher.finalize())
+  format!("md5:{}", hex::encode(hasher.finalize()))
 }
 
 fn code_entry_kind(entry: &CodeEntry) -> DefinitionKind {

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -40,7 +40,6 @@ use calcit::cli_args::{
 use calcit::snapshot::ChangesDict;
 use calcit::util::string::strip_shebang;
 use colored::Colorize;
-use dirs::home_dir;
 use notify::RecursiveMode;
 use notify_debouncer_mini::new_debouncer;
 
@@ -228,16 +227,6 @@ fn run_cli() -> Result<(), String> {
   let mut snapshot = snapshot::Snapshot::default(); // placeholder data
   let mut project_namespaces: HashSet<String> = HashSet::new();
 
-  let module_folder = home_dir()
-    .map(|buf| buf.as_path().join(".config/calcit/modules/"))
-    .expect("failed to load $HOME");
-  if !calcit::quiet_tool_output() {
-    eprintln!(
-      "{}",
-      format!("module folder: {}", module_folder.to_str().expect("extract path")).dimmed()
-    );
-  }
-
   if cli_args.disable_stack {
     call_stack::set_using_stack(false);
     if !calcit::quiet_tool_output() {
@@ -248,6 +237,10 @@ fn run_cli() -> Result<(), String> {
   let input_path = calcit::resolve_snapshot_path_alias(&PathBuf::from(&cli_args.input));
   let input_path_str = input_path.to_string_lossy().to_string();
   let base_dir = input_path.parent().expect("extract parent");
+  let module_folder = calcit::project_module_folder(base_dir);
+  if !calcit::quiet_tool_output() {
+    eprintln!("{}", format!("project module folder: {}", module_folder.display()).dimmed());
+  }
 
   if let Some(CalcitCommand::Exec(ref command)) = cli_args.subcommand {
     eval_once = true;

--- a/src/bin/cr_tests/cirru_suite.rs
+++ b/src/bin/cr_tests/cirru_suite.rs
@@ -24,9 +24,7 @@ fn load_and_run_cirru(path: &str) {
 
   // load modules (local .cirru files referenced in the snapshot config)
   let base_dir = Path::new(path).parent().expect("extract parent");
-  let module_folder = dirs::home_dir()
-    .map(|buf| buf.as_path().join(".config/calcit/modules/"))
-    .expect("failed to load $HOME");
+  let module_folder = calcit::project_module_folder(base_dir);
   for module_path in &snapshot.active_entry().expect("default entry").modules.clone() {
     let module_data = calcit::load_module(module_path, base_dir, &module_folder)
       .unwrap_or_else(|e| panic!("Failed to load module {module_path} for {path}: {e}"));

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -17,7 +17,6 @@ use calcit::call_stack::CallStackList;
 use calcit::util::string::strip_shebang;
 use calcit::{ProgramEntries, builtins, call_stack, codegen, program, runner, snapshot, util};
 use colored::Colorize;
-use dirs::home_dir;
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 /// Standalone WASM codegen command.
@@ -81,9 +80,7 @@ fn main() -> Result<(), String> {
   }
 
   let base_dir = input_path.parent().expect("extract parent");
-  let module_folder = home_dir()
-    .map(|buf| buf.as_path().join(".config/calcit/modules/"))
-    .expect("failed to load $HOME");
+  let module_folder = calcit::project_module_folder(base_dir);
 
   let module_paths = snapshot.active_entry()?.modules.clone();
   for module_path in &module_paths {

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -750,7 +750,7 @@ fn shape_fingerprint(root: usize, nodes: &[DataShapeNode]) -> String {
       }
     }
   }
-  format!("{:x}", hasher.finalize())
+  hex::encode(hasher.finalize())
 }
 
 fn update_nominal_fingerprint(

--- a/src/call_graph_diff.rs
+++ b/src/call_graph_diff.rs
@@ -48,9 +48,7 @@ pub fn analyze_call_graph_diff(cmd: &CallGraphDiffCommand, input_path: &str) -> 
   let snapshot_path = repo_rel_path.to_string_lossy().to_string();
 
   let base_dir = input_abs.parent().unwrap_or(cwd.as_path());
-  let module_folder = dirs::home_dir()
-    .map(|buf| buf.as_path().join(".config/calcit/modules/"))
-    .unwrap_or_else(|| Path::new(".").to_owned());
+  let module_folder = crate::project_module_folder(base_dir);
   let core_snapshot = crate::load_core_snapshot()?;
 
   let current_content = fs::read_to_string(&input_abs).map_err(|e| format!("Failed to read {}: {e}", input_abs.display()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,17 +159,13 @@ fn materialize_module_path(file_path: &str, base_dir: &Path, module_folder: &Pat
   }
 }
 
-fn module_roots_for_path(file_path: &str, base_dir: &Path, module_folder: &Path) -> Vec<PathBuf> {
-  if file_path.starts_with("./") || Path::new(file_path).is_absolute() {
-    vec![module_folder.to_path_buf()]
-  } else {
-    let project_modules = base_dir.join(".calcit/modules");
-    if project_modules == module_folder {
-      vec![module_folder.to_path_buf()]
-    } else {
-      vec![project_modules, module_folder.to_path_buf()]
-    }
-  }
+/// The module view installed for the project that owns a snapshot.
+///
+/// `caps` materializes this directory with links into its immutable global store. Runtime
+/// module loading must use this view rather than reaching into the store directly, so every
+/// project uses the revisions it resolved.
+pub fn project_module_folder(base_dir: &Path) -> PathBuf {
+  base_dir.join(".calcit/modules")
 }
 
 fn module_candidate_display_path(file_path: &str, fullpath: &Path, module_folder: &Path) -> String {
@@ -188,22 +184,12 @@ fn module_candidate_display_path(file_path: &str, fullpath: &Path, module_folder
 
 pub fn resolve_module_snapshot_candidates(path: &str, base_dir: &Path, module_folder: &Path) -> Vec<(String, PathBuf, String)> {
   let candidates = module_path_candidates(path);
-  let roots = module_roots_for_path(path, base_dir, module_folder);
-  let mut items = roots
+  let mut items = candidates
     .iter()
-    .flat_map(|root| {
-      candidates
-        .iter()
-        .map(|candidate| {
-          let fullpath = materialize_module_path(candidate, base_dir, root);
-          let display_path = if *root == module_folder {
-            module_candidate_display_path(candidate, &fullpath, module_folder)
-          } else {
-            format!("<project-mods>/{candidate}")
-          };
-          (candidate.clone(), fullpath, display_path)
-        })
-        .collect::<Vec<_>>()
+    .map(|candidate| {
+      let fullpath = materialize_module_path(candidate, base_dir, module_folder);
+      let display_path = module_candidate_display_path(candidate, &fullpath, module_folder);
+      (candidate.clone(), fullpath, display_path)
     })
     .collect::<Vec<_>>();
 
@@ -219,7 +205,7 @@ pub fn resolve_module_snapshot_candidates(path: &str, base_dir: &Path, module_fo
 
 #[cfg(test)]
 mod module_resolution_tests {
-  use super::resolve_module_snapshot_candidates;
+  use super::{project_module_folder, resolve_module_snapshot_candidates};
   use std::fs;
   use std::path::PathBuf;
 
@@ -228,7 +214,7 @@ mod module_resolution_tests {
   }
 
   #[test]
-  fn project_module_view_precedes_legacy_global_modules() {
+  fn project_module_view_is_the_only_root_for_named_modules() {
     let root = temp_root("project-first");
     let project = root.join("project");
     let global = root.join("global");
@@ -237,9 +223,26 @@ mod module_resolution_tests {
     fs::write(project.join(".calcit/modules/demo/compact.cirru"), "project").unwrap();
     fs::write(global.join("demo/calcit.cirru"), "global").unwrap();
 
-    let candidates = resolve_module_snapshot_candidates("demo/", &project, &global);
+    let module_folder = project_module_folder(&project);
+    let candidates = resolve_module_snapshot_candidates("demo/", &project, &module_folder);
     assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/compact.cirru"));
-    assert_eq!(candidates[0].2, "<project-mods>/demo/compact.cirru");
+    assert_eq!(candidates[0].2, "<mods>/demo/compact.cirru");
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn named_modules_do_not_fall_back_to_the_global_store() {
+    let root = temp_root("no-global-fallback");
+    let project = root.join("project");
+    let global = root.join("global");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(global.join("demo")).unwrap();
+    fs::write(global.join("demo/calcit.cirru"), "global").unwrap();
+
+    let module_folder = project_module_folder(&project);
+    let candidates = resolve_module_snapshot_candidates("demo/", &project, &module_folder);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/calcit.cirru"));
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -747,7 +747,7 @@ pub fn definition_revision(entry: &CodeEntry) -> Result<String, String> {
     update_part(&mut hasher, "ffi", rendered.as_bytes());
   }
 
-  Ok(format!("md5:{:x}", hasher.finalize()))
+  Ok(format!("md5:{}", hex::encode(hasher.finalize())))
 }
 
 impl TryFrom<Edn> for CodeEntry {

--- a/src/type_coverage.rs
+++ b/src/type_coverage.rs
@@ -2158,7 +2158,7 @@ pub(crate) fn analysis_revision(snapshot: &snapshot::Snapshot, definitions: &[(S
     hasher.update(id.as_bytes());
     hasher.update(revision.as_bytes());
   }
-  Ok(format!("md5:{:x}", hasher.finalize()))
+  Ok(format!("md5:{}", hex::encode(hasher.finalize())))
 }
 
 pub fn format_check_types_json(options: &CheckTypesCommand, snapshot: &snapshot::Snapshot) -> Result<String, String> {


### PR DESCRIPTION
## Summary

- Load modules exclusively from each project’s .calcit/modules link view, removing the legacy global runtime fallback.
- Store immutable Git module revisions in ~/.config/calcit/module-caches/, and refresh its AGENTS.md guide on every caps invocation.
- Add caps clean to keep the newest cached revision for each module and remove older revisions.

## Validation

- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- yarn check-all
- Respo workflow: caps verify with 8 project module links targeting module-caches