### PR TITLE
docs: document dependency intent audits

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -77,6 +77,10 @@ cr -v
 cr query config
 cr query ns
 cr query modules
+# Dependency intent audit (when deps.cirru uses dev-dependencies):
+caps tree
+# Choose a module from the tree, then explain its root/transitive path:
+caps why '<owner/repo>'
 # 从 query ns 的输出中选择真实 namespace，再执行：
 cr query defs '<namespace>'
 ```
@@ -85,6 +89,31 @@ cr query defs '<namespace>'
 - `query ns`：先发现 namespace，不要猜 `<ns>`。
 - `query defs <ns>`：从真实定义名中选择 target。
 - `query modules`：确认依赖边界；不要修改已安装依赖目录来代替当前项目修改。
+- `caps tree` / `caps why`：审计 `deps.cirru` 的已解析下载图和传递来源；它们不分析
+  Calcit 源码，因此不能单独证明模块是否被某个 entry、测试或 Markdown 示例实际使用。
+
+### 1.1 依赖分组审计：runtime、development 与源码使用是三件事
+
+`deps.cirru` 的 `:dependencies` 是消费者在运行或编译时需要的模块；
+`:dev-dependencies` 仅供当前项目的测试、examples、Markdown 检查和维护任务使用。根项目会安装
+两组，递归解析某个模块时只读取它自己的 `:dependencies`。先直接阅读 `deps.cirru` 的两个根分组，
+再用下面流程审计；不要仅凭模块出现在 `.calcit/modules/` 就把它判为 runtime 依赖：
+
+```bash
+caps tree
+caps why '<owner/repo>'
+cr calcit.cirru config modules
+cr calcit.cirru config modules --entry '<entry-name>'
+cr calcit.cirru --check-only
+cr calcit.cirru --entry '<entry-name>' --check-only
+cr calcit.cirru docs check-md README.md --entry calcit.cirru --failures-only
+```
+
+`caps tree` 和 `caps why` 回答“该仓库为什么被依赖解析器安装”；目前它们会合并显示两个根分组，
+所以根归属仍以 `deps.cirru` 为准。`config modules` 回答“某个 entry 配置加载哪些模块”；每个 named
+entry 都是独立配置，不能假设其模块继承 default。`--check-only` 只验证所选 entry 的可达预处理路径，
+而 `docs check-md` 默认只带 default entry 的模块；有测试或文档专用模块时，须显式选择相应 entry 或
+重复传入 `--dep`。动态加载、未调用的公开 API 和外部消费者不在这些静态结果的证明范围内。
 
 读取源码优先使用 human/Cirru 输出；只有需要稳定字段、自动分支或静态证据时才使用 `--format json`。`--format json` 承诺 stdout 为单个 JSON envelope；某些命令的 `--json` 只是在人类输出后附加 JSON，具体以子命令 `--help` 为准。
 

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -106,6 +106,7 @@ cr calcit.cirru config modules
 cr calcit.cirru config modules --entry '<entry-name>'
 cr calcit.cirru --check-only
 cr calcit.cirru --entry '<entry-name>' --check-only
+# Here --entry is the snapshot filename, not a named entry:
 cr calcit.cirru docs check-md README.md --entry calcit.cirru --failures-only
 ```
 
@@ -114,6 +115,9 @@ cr calcit.cirru docs check-md README.md --entry calcit.cirru --failures-only
 entry 都是独立配置，不能假设其模块继承 default。`--check-only` 只验证所选 entry 的可达预处理路径，
 而 `docs check-md` 默认只带 default entry 的模块；有测试或文档专用模块时，须显式选择相应 entry 或
 重复传入 `--dep`。动态加载、未调用的公开 API 和外部消费者不在这些静态结果的证明范围内。
+
+注意：`config modules --entry` 与顶层 `--entry` 选择 named entry；`docs check-md --entry` 则选择用于
+检查的 snapshot 文件（如 `calcit.cirru` 或 `compact.cirru`），两者不是同一种参数。
 
 读取源码优先使用 human/Cirru 输出；只有需要稳定字段、自动分支或静态证据时才使用 `--format json`。`--format json` 承诺 stdout 为单个 JSON envelope；某些命令的 `--json` 只是在人类输出后附加 JSON，具体以子命令 `--help` 为准。
 

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -82,6 +82,38 @@ store commits, local source modifications, and native realization receipts. `cle
 the newest materialized revision of each module under `module-caches/`, plus any revision still linked by
 a registered project view, and removes the remaining older ones.
 
+### Auditing dependency intent
+
+Use the dependency manifest together with the graph, rather than treating installation as proof that an
+application entry uses a module:
+
+```bash
+# Inspect the two root groups in deps.cirru, then resolve the graph and one module's path.
+caps tree
+caps why calcit-lang/memof
+
+# Inspect the module list for each relevant executable entry.
+cr calcit.cirru config modules
+cr calcit.cirru config modules --entry test
+
+# Validate the reachable paths for those entries.
+cr calcit.cirru --check-only
+cr calcit.cirru --entry test --check-only
+```
+
+`caps tree` and `caps why` explain resolver reachability: why a repository is installed and which
+transitive dependency requests selected its revision. They do not inspect Calcit calls, macros, test
+metadata, or Markdown snippets. They also currently merge root `:dependencies` and
+`:dev-dependencies` in their display, so use `deps.cirru` as the authority for a root module's declared
+group. An installed module is therefore not automatically a runtime dependency: it can be a development
+module, a module configured only for another entry, or a module retained for a documentation check.
+
+Named entries do not inherit the default entry's modules. Audit each entry that CI or a release supports.
+For Markdown code, `cr docs check-md` defaults to modules from the default entry; use an explicit
+`--entry <snapshot>` and repeat `--dep <module-path>` for additional documentation-only modules. These
+checks provide static evidence for selected paths, not a guarantee about dynamic loading or external
+consumer usage.
+
 The positional input may point to a standalone dependency file. Its parent directory becomes the project
 root even when no `calcit.cirru` exists:
 

--- a/history/202608131340-agent-dependency-intent-audit.md
+++ b/history/202608131340-agent-dependency-intent-audit.md
@@ -17,6 +17,5 @@
 
 ## Validation
 
-- `cr docs format-md docs/CalcitAgent.md --check`
-- `cr docs format-md docs/run/load-deps.md --check`
 - `cr docs check-md docs/run/load-deps.md --entry calcit/test.cirru --failures-only`
+- `cr docs check-md docs/CalcitAgent.md --entry calcit/test.cirru --failures-only`

--- a/history/202608131340-agent-dependency-intent-audit.md
+++ b/history/202608131340-agent-dependency-intent-audit.md
@@ -1,0 +1,22 @@
+# Make dependency-boundary audits discoverable to agents
+
+## Knowledge points
+
+- `:dependencies`, `:dev-dependencies`, configured entry modules, and statically reachable source paths
+  answer different questions. An installed module must not be classified as runtime-only from its presence
+  under `.calcit/modules/`.
+- Inspect root declaration intent in `deps.cirru`; use `caps tree` and `caps why <owner/repo>` to explain
+  the resolved recursive graph. The current display combines both root groups, so it cannot be the
+  authority for runtime versus development declaration intent.
+- Use `cr config modules [--entry <name>]` to inspect each selected entry's module configuration, then
+  run `cr --check-only` for default and every release/CI entry. Named entries do not inherit default
+  modules.
+- `docs check-md` defaults to modules from the default entry. Documentation-only dependencies require
+  appropriate explicit module paths through repeatable `--dep`; these checks, like entry preprocessing,
+  are static evidence and do not prove dynamic loading or external consumer use.
+
+## Validation
+
+- `cr docs format-md docs/CalcitAgent.md --check`
+- `cr docs format-md docs/run/load-deps.md --check`
+- `cr docs check-md docs/run/load-deps.md --entry calcit/test.cirru --failures-only`

--- a/history/202608171611-dependency-audit-review.md
+++ b/history/202608171611-dependency-audit-review.md
@@ -1,0 +1,4 @@
+# Address dependency audit documentation review
+
+- Clarified that `docs check-md --entry` takes a snapshot filename, unlike named-entry selection in `config modules` and top-level `--check-only`.
+- Recorded Markdown validation for both changed dependency-audit documents.


### PR DESCRIPTION
## Summary

- document the distinction between runtime and development dependencies
- explain the limits of `caps tree` / `caps why` and how to audit each Calcit entry
- document static checks for entry reachability and Markdown-only dependencies

This branch was rebased onto the latest `main` after PR #365. The documentation keeps the current project-local module view and `module-caches/` behavior from `main`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --bin cr cli_handlers::docs::tests`
- `cr docs graph check`
- `cr calcit/test.cirru docs check-md docs/run/load-deps.md --entry calcit/test.cirru --failures-only`
- `cr calcit/test.cirru docs check-md docs/CalcitAgent.md --entry calcit/test.cirru --failures-only`
- `yarn compile`
- `yarn check-all`
