### PR TITLE
feat: add transparent union types

### DIFF
--- a/RFCs/08-19-transparent-union-types-rfc.md
+++ b/RFCs/08-19-transparent-union-types-rfc.md
@@ -1,0 +1,522 @@
+# RFC: `deftype` 具名透明联合类型与控制流收窄
+
+状态：Partial（MVP 第 1 轮已实现）
+日期：2026-08-19
+关联：`02-04-runtime-traits-plan.md`、`04-15-match-syntax-rfc.md`、`05-31-generic-where-bounds-mfs.md`、`06-01-generic-binding-unification-rfc.md`、`07-26-static-semantic-analysis-rfc.md`、`08-18-calcit-typed-js-ffi-boundary-rfc.md`
+
+## 1. 摘要
+
+本 RFC 提议新增 `deftype`，用于声明**具名、透明、无运行时包装**的联合类型，并补齐围绕联合类型的控制流收窄能力。
+
+首要用例是 Respo 虚拟 DOM：`Component` 与 `Element` 是两个不同的 Struct，但 `tree`、`children`、diff 与 effect 遍历都需要把它们当作同一类节点传递。当前只能把这些位置声明成 `Dynamic`，或使用 `defenum` 再包一层 constructor。前者失去字段安全，后者改变数据表示并给 DSL 增加构造、解包噪音。
+
+目标写法：
+
+```cirru.no-check
+deftype RespoNode
+  or 'Component 'Element
+```
+
+`Component` 和 `Element` 的值可以直接进入 `RespoNode` 位置，运行时仍保持原有 Struct 表示。代码通过 `struct-match`、`type-match?` 或带 `:narrows` 契约的 predicate 恢复具体成员类型。
+
+### 当前实施范围（2026-08-19）
+
+已落地第一轮 MVP：`deftype Name (or ...)` 是编译期透明声明，并在声明点拒绝无效成员；裸 `TypeRef` 在赋值检查和 Struct 字段运行时验证处展开为成员集合；现有 `&struct:matches?` 的 true branch 和 `struct-match` binder 会获得匹配 Struct 的具体类型。`struct-match` 对 transparent union 检查非成员/重复分支与覆盖完整性。运行时没有 union wrapper，也没有新的 JS ABI。
+
+尚未实现的部分保持为本 RFC 的后续阶段：`_` branch 的剩余 union、公共 `type-match?`、用户 `:narrows` guard、参数化 `deftype`，以及 data-shape/严格 EDN decode 对 union 的支持。
+
+## 2. 设计判断
+
+### 2.1 `deftype` 与 `defenum` 分工
+
+`defenum` 继续表示需要运行时 tag、payload arity 和构造器身份的代数数据类型：
+
+```cirru.no-check
+defenum RequestState
+  (:idle)
+  (:loading)
+  (:failed 'String)
+```
+
+`deftype` 表示已有类型之间的静态集合，不产生新的值构造器：
+
+```cirru.no-check
+deftype RespoNode
+  or 'Component 'Element
+```
+
+两者分别对应两种不同需求：
+
+- `defenum`：值本身需要携带“属于哪个 variant”的新表示；
+- `deftype`：值已经有可靠的运行时身份，只需要描述“这个位置允许哪些类型”。
+
+### 2.2 `deftype` 与 trait 分工
+
+Trait 描述开放的能力集合，适合算法只依赖共同方法的场景；联合类型描述封闭的数据备选，适合分支后读取各自字段的场景。
+
+Respo renderer 需要区分 `Component` 与 `Element`，并读取完全不同的字段，因此核心节点应使用联合类型。DOM FFI 只关心对象支持哪些字段和方法，应继续使用 `:kind :external-object` trait。
+
+若联合类型的所有成员都实现同一个 trait，联合值可以满足该 trait bound；这不把 union 自动转换成新的 runtime trait object。
+
+### 2.3 与 Rust、MoonBit 经验的关系
+
+本设计沿用 Rust/MoonBit 的两条经验：
+
+1. 封闭的数据分支应由编译器进行穷尽性与分支类型检查；
+2. 开放扩展和行为分派交给 trait/interface，不用一套机制同时承担两种职责。
+
+Calcit 的差异是保留动态语言的数据表示：`deftype` 不要求像 Rust/MoonBit enum 一样重新包装已有值。它更接近一个具名的静态 sum，但每个成员仍使用自身的 nominal runtime identity。
+
+## 3. 语法
+
+### 3.1 基本形式
+
+`deftype` 接收名称和一个类型表达式。MVP 只开放 `or` 类型表达式：
+
+```cirru.no-check
+deftype RespoNode
+  or 'Component 'Element
+
+deftype AttrValue
+  or 'String 'Number 'Bool 'EventHandler
+```
+
+这里采用普通前缀语法，没有引入 `A | B` 之类的中缀 token。对应 AST 形状稳定为：
+
+```json
+["deftype", "RespoNode", ["or", "'Component", "'Element"]]
+```
+
+较长的声明可以使用 Cirru 的 `,` splice 保持同一个 `or` 表达式：
+
+```cirru.no-check
+deftype DomPropValue $ or
+  , 'String
+  , 'Number
+  , 'Bool
+  , 'EventHandler
+```
+
+推荐短 union 保持单行 RHS；只有成员较多时使用上面的展开写法。
+
+### 3.2 类型引用
+
+其他 schema 使用普通 nominal 引用，不展开成员：
+
+```cirru.no-check
+defstruct Component (:name 'Tag)
+  :tree $ :: 'Optional 'RespoNode
+
+defn render-node (node)
+  struct-match node
+    Component component
+      :tree component
+    Element element
+      :children element
+
+:: 'Fn $ {}
+  :args $ [] 'RespoNode
+  :return 'Unit
+```
+
+`RespoNode` 在 public schema、诊断和类型自省中保留名字；只有匹配和归一化时才读取成员集合。
+
+### 3.3 泛型边界
+
+MVP 不开放参数化 `deftype`，避免同时引入 alias 参数替换、递归 kind 检查和高阶类型问题。以下能力留作独立扩展：
+
+```cirru.no-check
+; Future, not part of MVP.
+deftype ScalarOr (T)
+  or 'T 'String 'Number
+```
+
+现有参数化 `defenum`、Struct 和容器类型不受影响。
+
+## 4. 静态语义
+
+### 4.1 名义名称，透明成员
+
+`RespoNode` 是具名定义，工具和 schema 不应在输出中随意展开为匿名集合。但赋值关系按照成员透明计算：
+
+- `Component` 可以赋给 `RespoNode`；
+- `Element` 可以赋给 `RespoNode`；
+- `RespoNode` 不能在未收窄时赋给 `Component`；
+- union `A` 可以赋给 union `B`，当且仅当 `A` 的每个成员都能赋给 `B`；
+- union 与成员的匹配必须保持方向性，不能因为其中一侧是宽类型而双向通过。
+
+这与集合包含关系一致：实际值的可能集合必须是目标类型允许集合的子集。
+
+### 4.2 归一化
+
+解析 `or` 时执行：
+
+1. 解析 namespace-qualified TypeRef；
+2. 展平嵌套 union；
+3. 按 nominal identity 去重；
+4. 拒绝零成员和单成员 union，单类型别名不属于 MVP；
+5. 拒绝直接或间接只由 alias 构成的循环；
+6. 允许通过 Struct/Enum 字段形成递归数据图；
+7. union 出现 `Dynamic` 时给出错误，因为 `or Dynamic T` 等价于丢失整个约束。
+
+例如 `Component.tree -> Optional<RespoNode>` 与 `RespoNode -> Component | Element` 是合法递归；`deftype A (or 'B)`、`deftype B (or 'A)` 不是。
+
+### 4.3 构造与返回
+
+`deftype` 不生成 constructor，也不改变 `%{}`、`%::` 或字面量：
+
+```cirru.no-check
+let
+    component $ %{} Component (:name :root)
+    element $ %{} Element (:name :div)
+    nodes $ [] component element
+  render-all nodes
+```
+
+当 `render-all` 的参数声明为 `List<RespoNode>` 时，list literal 与 `conj`/`append` 的泛型统一应允许成员提升到 union。
+
+MVP 不从任意不同分支自动合成匿名 union。只有存在以下证据时才提升到具名 union：
+
+- 函数参数或返回 schema；
+- 容器的期望元素类型；
+- `assert-type`；
+- 已有 local 类型；
+- 明确的 `deftype` 定义引用。
+
+这样避免一次普通 `if` 把整个程序推断成不断增长的匿名类型集合。
+
+### 4.4 未收窄操作
+
+union 值未收窄前只能执行所有成员都安全支持的操作：
+
+- 可以传给接受该 union 或更宽 union 的函数；
+- 可以执行所有成员共同满足的 trait bound/method；
+- 不允许直接读取某个成员独有的 Struct 字段；
+- 不因为多个 Struct 恰好有同名字段就默认进行 structural field merge。
+
+最后一条是有意限制。共同字段合并会引入字段 variance、optional 与写操作规则，MVP 先要求显式收窄。
+
+## 5. 控制流收窄
+
+仅有 union 声明不足以替代 `Dynamic`。必须让运行时判定产生静态证据，而且证据要能通过 `if`、`cond`、`and` 和 pattern matching 传播。
+
+### 5.1 `struct-match`
+
+Phase 1 直接增强现有 `struct-match`，不新增 Respo 专用 accessor：
+
+```cirru.no-check
+defn node-name (node)
+  struct-match node
+    Component component
+      :name component
+    Element element
+      :name element
+```
+
+若 scrutinee 是 `RespoNode`：
+
+- `Component` 分支 binder 类型为 `Component`；
+- `Element` 分支 binder 类型为 `Element`；
+- pattern 必须是 union 的 Struct 成员；
+- 所有成员已覆盖时不要求 `_`；
+- 缺少成员且没有 `_` 时给出穷尽性诊断；
+- `_` binder 保留尚未覆盖成员组成的剩余 union，而不是退化成 `Dynamic`。
+
+这项能力应修复当前 `struct-match` runtime 能匹配、但分支 binder 仍缺少具体静态类型的问题。
+
+### 5.2 `type-match?`
+
+新增公共 predicate `type-match?`，参数顺序保持 value-first：
+
+```cirru.no-check
+if
+  type-match? node Component
+  :tree node
+  nil
+```
+
+它同时承担运行时判定与编译器可识别的 narrowing primitive：
+
+- true branch：`node` 收窄到 `Component`；
+- false branch：从原 union 排除 `Component`；
+- 第二个参数必须是静态可解析的具体类型定义；
+- external-object trait 只有静态证据，没有可靠 runtime identity，不允许用于该 predicate；
+- 参数化容器只检查外层 runtime kind，不声称验证内部元素类型。
+
+底层可复用现有 `&struct:matches?`、Enum definition identity 和 builtin kind 判定，但业务代码不应直接依赖这些 primitive 的组合。
+
+### 5.3 用户定义 type guard
+
+为了保留 `component?`、`element?` 这类领域名称，函数 schema 新增 `:narrows`：
+
+```cirru.no-check
+defn component? (value)
+  type-match? value Component
+
+:: 'Fn $ {}
+  :args $ [] 'RespoNode
+  :return 'Bool
+  :narrows $ {}
+    0 'Component
+```
+
+key 是从零开始的参数位置，value 是 true 分支证明的目标类型。规则如下：
+
+- 被标记函数必须返回 `Bool`；
+- 目标类型必须是对应参数声明类型的成员或子类型；
+- 编译器必须验证函数体是可证明等价的 guard；MVP 不提供绕过验证的 trusted 标记；
+- 普通函数不能仅靠 schema 谎称 narrowing；
+- false 分支从原 union 排除目标类型。
+
+MVP 只接受函数体直接调用 `type-match?` 的可验证 guard。组合 guard 和用户自定义验证器留到后续，避免把 `:narrows` 变成另一种 `unsafe-coerce`。
+
+### 5.4 逻辑表达式传播
+
+`and` 必须按从左到右的短路语义传播 true evidence：
+
+```cirru.no-check
+if
+  and
+    component? old-tree
+    component? new-tree
+  compare-components old-tree new-tree
+  nil
+```
+
+调用 `compare-components` 时，两个 local 都是 `Component`。`or` 的 true 分支通常只得到多个可能性的 union，false 分支则累积排除证据。
+
+`cond` 每个后续分支继承前面 predicate 为 false 的排除结果：
+
+```cirru.no-check
+cond
+    component? node
+    render-component node
+  (element? node)
+    render-element node
+```
+
+当 `node` 是 `Component | Element` 时，第二个 condition 进入前已经排除了 `Component`；`element?` 再确认具体类型。实现应保存每个 local 的 positive/negative type set，而不是只记录单个覆盖类型。
+
+## 6. 通用类型匹配
+
+`struct-match` 足以覆盖 Respo 的第一阶段。为了让 union 能包含 Struct、Enum 和 builtin 类型，后续增加原生 `match-type`：
+
+```cirru.no-check
+match-type value
+  Component component
+    :tree component
+  Element element
+    :children element
+  String text
+    count text
+```
+
+每个 arm 是 `Type binder body...`，符合 Cirru 现有缩进结构，不需要把 pattern 和 body 包进多层括号。
+
+`match-type` 的职责是按具体 runtime type identity 分支；Enum 内部 variant 仍交给现有 `match`。例如先由 `match-type` 确认值属于某个 Enum definition，再在分支内用 `match` 解构 variant。
+
+Phase 1 不要求实现 `match-type`；但 `deftype` 的 IR 与 exhaustiveness API 不应锁死为 Struct-only。
+
+## 7. 与 Optional、Option 和 nil 的关系
+
+union 不隐式包含 `nil`。缺失值继续由现有类型表达：
+
+```cirru.no-check
+defstruct Component (:name 'Tag)
+  :tree $ :: 'Optional 'RespoNode
+```
+
+迁移期可以使用 `Optional<RespoNode>` 保持现有 nil 表示。新 API 若要显式表达业务分支，仍优先使用 `Option<RespoNode>`。
+
+不建议声明 `RespoNode = Component | Element | Unit` 来偷渡 nullable 语义，因为这会把“没有节点”和“函数无返回值”混在一起。
+
+## 8. 与 trait 和 FFI 的边界
+
+### 8.1 普通 runtime trait
+
+若 union 所有成员 nominally implement `RenderNode`，则：
+
+- `RespoNode` 可以满足 `T: RenderNode`；
+- `.method` 继续根据实际 Struct/Enum 的 impl 分派；
+- 任一成员缺少 impl 时，整个 union 不满足该 trait；
+- 多成员同名 inherent method 不构成 trait 证据。
+
+这使 union 与 runtime trait 互补，而不是竞争两套多态模型。
+
+### 8.2 external-object trait
+
+DOM FFI 继续直接返回小型 external trait，例如 `DomElement`、`DomInput`、`DomKeyboardEvent`。不要用 union 模拟 DOM interface inheritance，也不要把宿主对象与 Respo 内部节点放进同一个 union。
+
+External trait 是 codegen-only 静态证据，不能参与 `type-match?` runtime narrowing。宿主 API 的字符串相关重载，例如 `keydown -> KeyboardEvent`，优先通过专用 wrapper 表达，不在 union 系统中增加 dependent typing。
+
+## 9. 表示与实现建议
+
+### 9.1 类型表示
+
+建议新增两层表示：
+
+- `Calcit::TypeUnion` 或等价 definition value：保存名称、namespace、RHS 和 nominal identity；
+- `CalcitTypeAnnotation::UnionRef`：保留具名引用以及按需解析后的规范化成员。
+
+不要在普通值上增加 `Calcit::UnionValue`。`Component` 值仍然是 `Calcit::Struct`，`Element` 值也仍然是 `Calcit::Struct`。
+
+`type-of RespoNode` 可返回 `:type-def`，`type-of component` 仍返回 `:struct`。类型自省后续可增加 `&type:members`；MVP 只需要编译器内部 lookup。
+
+### 9.2 解析与生命周期
+
+`deftype` 应与 `defstruct`、`defenum` 一样保持 top-level definition identity，并参与 snapshot/schema 解析。RHS 解析必须延迟到 namespace definitions 可见后，支持 Struct 字段与 union 之间的递归引用。
+
+JS/native/WASM 均不需要为 union value 新增 ABI。主要后端工作是：
+
+- 保留或擦除 type definition metadata；
+- lower `type-match?` 与 `match-type`；
+- 在 codegen 前完成字段访问和 method candidate 校验。
+
+### 9.3 类型匹配实现
+
+建议把 assignability 写成方向明确的关系：
+
+```text
+is_assignable(actual, expected)
+```
+
+核心 union 规则：
+
+```text
+member M -> union U      iff M -> any member of U
+union A  -> union B      iff every member of A -> B
+union U  -> non-union T  iff every member of U -> T
+```
+
+最后一条通常只有 union 归一化后所有成员都可赋给同一个 trait/宽类型时成立，不能作为 downcast。
+
+现有 `Dynamic` 兼容规则不能用来证明 union member。若 strict schema 中 `Dynamic` 与具体成员双向匹配，联合类型仍会退化成无约束；这部分应与静态语义 RFC 一起改成方向性边界规则。
+
+## 10. 诊断
+
+建议新增稳定诊断码：
+
+| Code | 条件 | 建议 |
+| --- | --- | --- |
+| `E_UNION_EMPTY` | `or` 没有成员 | 至少声明两个具体类型 |
+| `E_UNION_SINGLE_MEMBER` | MVP 中只有一个成员 | 直接使用该类型 |
+| `E_UNION_DYNAMIC_MEMBER` | union 包含 `Dynamic` | 移除 `Dynamic` 或保留整个位置为显式动态边界 |
+| `E_UNION_ALIAS_CYCLE` | alias-only 循环 | 通过 Struct/Enum 字段建立递归 |
+| `W_UNION_REQUIRES_NARROWING` | 对 union 读取成员独有字段 | 使用 `struct-match`、`type-match?` 或可信 guard |
+| `W_UNION_NON_EXHAUSTIVE` | match 缺少成员 | 补齐 arm 或 `_` |
+| `W_INVALID_NARROWS_CONTRACT` | `:narrows` 与函数体/参数不一致 | 改成直接 `type-match?` guard |
+
+诊断应显示 union 名称和剩余成员，例如：
+
+```text
+W_UNION_REQUIRES_NARROWING: `RespoNode` may be Component | Element;
+field `:tree` only exists on Component. Narrow `node` before access.
+```
+
+## 11. Respo 迁移目标
+
+第一轮迁移只改类型关系，不重写 renderer 架构：
+
+1. 声明 `RespoNode = Component | Element`；
+2. 把 `Component.tree`、renderer/diff/effect 参数改为 `RespoNode` 或 `Optional<RespoNode>`；
+3. 增强 `struct-match` binder narrowing；
+4. 给 `component?`、`element?` 增加可验证 `:narrows`；
+5. 删除 `as-component`、`as-element` 以及对应的 `&struct:nth` accessor；
+6. 再分别为属性值、style 值、coord key 和事件值声明小型 union；
+7. DOM host object 保持 external trait，不与 `RespoNode` union 混用。
+
+预期 diff 主干可以保持当前数据导向写法：
+
+```cirru.no-check
+cond
+    and
+      component? old-tree
+      component? new-tree
+    diff-components old-tree new-tree
+  (and (element? old-tree) (element? new-tree))
+    diff-elements old-tree new-tree
+```
+
+这里不需要 runtime enum wrapper，也不需要把整个 diff 算法改写成 trait virtual methods。
+
+## 12. 实施阶段
+
+### Phase A：`deftype` 与 assignability
+
+- parser/snapshot 能加载 `deftype Name (or ...)`；
+- 新增具名 union annotation 与 definition lookup；
+- 实现成员到 union、union 到 union 的方向性匹配；
+- 支持 Fn 参数/返回、Struct 字段和容器 expected type；
+- `check-types`、`analyze weak-types` 和类型打印保留 union 名称。
+
+### Phase B：`struct-match` 静态收窄
+
+- branch binder 得到具体 Struct 类型；
+- 对 union 做成员合法性和穷尽性检查；
+- `_` 分支获得剩余 union；
+- 字段读取正常 lower 到受检 `&struct:nth`。
+
+完成 A+B 后，Respo 已可移除大部分 `Dynamic -> Component/Element` adapter。
+
+### Phase C：predicate 与 flow facts
+
+- 实现 `type-match?`；
+- 实现可验证 `:narrows`；
+- 在 `if`、`cond`、`and`、`or` 中传播 positive/negative member sets；
+- 让多个 local 的 evidence 可以同时存在。
+
+### Phase D：通用匹配与共同能力
+
+- 实现 `match-type`；
+- union 对共同 trait bound 的满足检查；
+- 按真实项目需要评估共同只读字段，不默认开放；
+- 再评估参数化 `deftype` 与匿名 union inference。
+
+## 13. 验收标准
+
+至少覆盖以下测试：
+
+1. `Component`、`Element` 都能传入 `RespoNode` 参数；
+2. 其他 Struct 不能传入；
+3. `List<RespoNode>` 可构造异构列表，元素读取仍是 `RespoNode`；
+4. 未收窄访问 `:tree` 给出稳定诊断；
+5. `struct-match` 两个 branch binder 分别拥有具体 Struct 类型；
+6. 完整分支无穷尽性告警，缺少分支会告警；
+7. `component?` true/false 分支分别保留包含/排除证据；
+8. `and` 能同时收窄 old/new 两个 local；
+9. `or Dynamic Component` 被拒绝；
+10. union 值运行时表示、相等性、hash 和序列化与原成员完全一致；
+11. native 与 JS 的 `type-match?` 结果一致；
+12. external-object trait 不被误当成可运行时判定的 union member。
+
+## 14. 不采用的方案
+
+### 14.1 保持 `Dynamic`，依靠 accessor
+
+这会让 `as-component` 和 `&struct:nth` 只隐藏类型缺失，不提供运行时验证，也无法让容器、返回值和递归字段形成稳定关系。
+
+### 14.2 只使用 runtime trait object
+
+Trait 适合共同方法，但 Respo diff 需要按具体节点种类读取不同字段，并同时比较 old/new 两个值。把全部逻辑改成 virtual methods 会引入大量 accessor 或双分派，复杂度高于封闭 union。
+
+### 14.3 使用 `defenum` 包装已有 Struct
+
+该方案类型安全，但每个节点都要额外构造和解包：
+
+```cirru.no-check
+defenum RespoNode
+  (:component 'Component)
+  (:element 'Element)
+```
+
+这会改变 Respo 当前数据表示、相等性路径和 DSL 输出。`deftype` 的目标正是获得相同的静态分支能力，而不引入这层运行时包装。
+
+### 14.4 自动把不同分支推断为匿名 union
+
+全局自动合成会让 union 随控制流不断增长，并使错误信息缺少稳定领域名称。MVP 只在具名 expected type 已知时提升。
+
+## 15. 结论
+
+要在不依赖 `Dynamic` 的前提下保持 Calcit/Respo 的数据导向风格，`deftype` 是基础能力，flow narrowing 是不可分割的另一半。只实现声明而不实现 `struct-match` binder、predicate guard 和逻辑传播，最终仍会回到手写 cast/accessor。
+
+建议按 A+B 先打通 RespoNode，再实现 C；`match-type`、参数化 alias 和更积极的推断放到真实迁移数据证明有必要之后。

--- a/RFCs/README.md
+++ b/RFCs/README.md
@@ -1,6 +1,6 @@
 # RFC 整理索引
 
-更新时间：2026-08-18
+更新时间：2026-08-19
 
 ## 目录原则
 
@@ -45,6 +45,7 @@
 | `08-05-systematic-nil-reduction-rfc.md`              | Partial       | 类型驱动减少 nil：先拆分可省略参数与 nullable 值，再迁移至 Option/Result 并逐步收紧 typed code。                  |
 | `08-08-cross-backend-host-ffi-contracts-rfc.md`      | Draft         | 统一 JS/native/WASM/WASI 的逻辑 FFI 契约与诊断，ABI transport 保持 backend-specific；首个完整 shape consumer 为 JS/DOM。 |
 | `08-18-calcit-typed-js-ffi-boundary-rfc.md`           | Draft         | 在现有 Struct/Enum/Fn/trait 上补齐 JS capability gate 与 target validation；FFI metadata 不进入普通 trait 匹配和泛型推断。 |
+| `08-19-transparent-union-types-rfc.md`                 | Partial       | `deftype Name (or ...)` 具名透明联合类型、`struct-match`/predicate flow narrowing，以及与 runtime trait、external-object trait 的分工。 |
 
 ## 已执行的清理
 

--- a/calcit/test-struct.cirru
+++ b/calcit/test-struct.cirru
@@ -103,11 +103,27 @@
               :args $ [] 'test-struct.main/Point2D
         |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn main! () (test-struct) (test-methods) (test-match) (test-polymorphism) (test-edn) (test-struct-with) (test-partial-struct) (test-loose-struct-rewrite) (test-map-to-struct) (test-postfix) (do true)
+            defn main! () (test-struct) (test-methods) (test-match) (test-transparent-union) (test-polymorphism) (test-edn) (test-struct-with) (test-partial-struct) (test-loose-struct-rewrite) (test-map-to-struct) (test-postfix) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
+        |NamedStruct $ %{} 'CodeEntry (:doc "|Transparent union used by typed struct-match tests.")
+          :code $ quote
+            deftype NamedStruct
+              or 'Cat 'City
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |read-named-struct-name $ %{} 'CodeEntry (:doc "|Reads a shared field after struct-match narrows a transparent union.")
+          :code $ quote
+            defn read-named-struct-name (node)
+              struct-match node
+                Cat cat $ :name cat
+                City city $ :name city
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ [] 'NamedStruct
         |read-asserted-map-literal-store $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn read-asserted-map-literal-store (source)
@@ -206,6 +222,17 @@
                   A aa $ :a aa
                   B bb $ :b bb
                   _ o (println |others) :other
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
+        |test-transparent-union $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            fn () (log-title "|Testing transparent named union")
+              assert= |kitty $ read-named-struct-name
+                %{} Cat (:name |kitty) (:color :red)
+              assert= |Shanghai $ read-named-struct-name
+                %{} City (:name |Shanghai) (:province |Shanghai)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -490,6 +490,9 @@ impl GraphBuilder {
         }))
       }
       CalcitTypeAnnotation::TypeRef(name, args) => self.build_named(name, args, default_ns),
+      CalcitTypeAnnotation::Union(_) => Err(unsupported_type(
+        "transparent union has multiple runtime data shapes; decode it after a concrete discriminator is available",
+      )),
       CalcitTypeAnnotation::TypeSlot(name) => match super::resolve_type_slot(name) {
         Some(resolved) => {
           let slot_key = name.to_string();

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -203,6 +203,38 @@ fn resolve_type_ref_as_schema(name: &str) -> Option<Arc<CalcitTypeAnnotation>> {
   lookup_schema_registered(ns, def)
 }
 
+/// Resolve a named `deftype Name (or ...)` declaration without changing the source-level
+/// annotation. `deftype` is intentionally transparent: callers keep a `TypeRef(Name)`, while
+/// matching expands it into this internal member list.
+fn resolve_type_ref_as_union_in_namespace(name: &str, default_ns: Option<&str>) -> Option<Arc<CalcitTypeAnnotation>> {
+  let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+  let lookup = |ns: &str, def: &str| lookup_def_code_registered(ns, def).and_then(|code| parse_deftype_union_code(&code));
+
+  if let Some((ns, def)) = stripped.rsplit_once('/') {
+    return lookup(ns, def);
+  }
+
+  default_ns
+    .and_then(|ns| lookup(ns, stripped))
+    .or_else(|| current_type_annotation_namespace().and_then(|ns| lookup(&ns, stripped)))
+    .or_else(|| lookup(CORE_NS, stripped))
+}
+
+fn resolve_type_ref_as_union(name: &str) -> Option<Arc<CalcitTypeAnnotation>> {
+  resolve_type_ref_as_union_in_namespace(name, None)
+}
+
+/// Expand a `deftype Name (or ...)` reference using the caller's namespace
+/// when the source annotation is unqualified. This is used by flow analysis;
+/// ordinary schema display retains the original `TypeRef`.
+pub(crate) fn resolve_transparent_union_type(annotation: &CalcitTypeAnnotation, default_ns: &str) -> Option<Arc<CalcitTypeAnnotation>> {
+  match annotation {
+    CalcitTypeAnnotation::Union(_) => Some(Arc::new(annotation.to_owned())),
+    CalcitTypeAnnotation::TypeRef(name, args) if args.is_empty() => resolve_type_ref_as_union_in_namespace(name, Some(default_ns)),
+    _ => None,
+  }
+}
+
 thread_local! {
   static IMPORT_RESOLUTION_STACK: RefCell<Vec<(Arc<str>, Arc<str>)>> = const { RefCell::new(vec![]) };
 }
@@ -315,6 +347,12 @@ pub enum CalcitTypeAnnotation {
   /// remain a symbolic reference instead of collapsing into a generic variable or eagerly
   /// resolving into a concrete struct/enum definition.
   TypeRef(Arc<str>, Arc<Vec<Arc<CalcitTypeAnnotation>>>),
+  /// A transparent union used internally after resolving a named `deftype ... (or ...)` declaration.
+  ///
+  /// Source schemas retain the named `TypeRef`; values are never wrapped in a union runtime
+  /// representation. Keeping this variant internal to type resolution lets assignability and
+  /// runtime struct-field validation reason over every allowed member.
+  Union(Arc<Vec<Arc<CalcitTypeAnnotation>>>),
   /// Trait type annotation for trait objects
   Trait(Arc<CalcitTrait>),
   /// Multiple trait constraints recorded in order
@@ -426,6 +464,18 @@ impl CalcitTypeAnnotation {
       Self::TypeRef(_, args) => {
         for arg in args.iter() {
           arg.validate_applied_type_args()?;
+        }
+        Ok(())
+      }
+      Self::Union(members) => {
+        if members.len() < 2 {
+          return Err("transparent union expects at least two member types".to_owned());
+        }
+        for member in members.iter() {
+          if matches!(member.as_ref(), Self::Dynamic) {
+            return Err("transparent union cannot contain Dynamic".to_owned());
+          }
+          member.validate_applied_type_args()?;
         }
         Ok(())
       }
@@ -2172,6 +2222,7 @@ impl CalcitTypeAnnotation {
         let rendered = traits.iter().map(|t| t.name.to_string()).collect::<Vec<_>>().join(" ");
         format!("traits {rendered}")
       }
+      Self::Union(members) => members.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>().join(" | "),
       Self::TypeVar(name) => format!("'{name}"),
       Self::TypeRef(name, args) => {
         if args.is_empty() {
@@ -2208,6 +2259,9 @@ impl CalcitTypeAnnotation {
         let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars(bindings)).collect();
         Arc::new(Self::TypeRef(name.clone(), Arc::new(new_args)))
       }
+      Self::Union(members) => Arc::new(Self::Union(Arc::new(
+        members.iter().map(|member| member.substitute_type_vars(bindings)).collect(),
+      ))),
       Self::List(inner) => Arc::new(Self::List(inner.substitute_type_vars(bindings))),
       Self::Map(k, v) => Arc::new(Self::Map(k.substitute_type_vars(bindings), v.substitute_type_vars(bindings))),
       Self::Set(inner) => Arc::new(Self::Set(inner.substitute_type_vars(bindings))),
@@ -2247,6 +2301,7 @@ impl CalcitTypeAnnotation {
     match self {
       Self::TypeVar(_) => true,
       Self::TypeRef(_, args) => args.iter().any(|a| a.contains_type_var()),
+      Self::Union(members) => members.iter().any(|member| member.contains_type_var()),
       Self::List(inner)
       | Self::Set(inner)
       | Self::Ref(inner)
@@ -2517,6 +2572,22 @@ impl CalcitTypeAnnotation {
   }
 
   pub(crate) fn matches_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
+    // Keep named `deftype` references in schemas and diagnostics, but expand them at the
+    // assignability boundary.  Resolve only bare applications for now: parameterized deftype
+    // is intentionally outside the MVP and must not silently drop type arguments.
+    if let Self::TypeRef(name, args) = self
+      && args.is_empty()
+      && let Some(resolved) = resolve_type_ref_as_union(name)
+    {
+      return resolved.matches_with_bindings(expected, bindings);
+    }
+    if let Self::TypeRef(name, args) = expected
+      && args.is_empty()
+      && let Some(resolved) = resolve_type_ref_as_union(name)
+    {
+      return self.matches_with_bindings(resolved.as_ref(), bindings);
+    }
+
     match (self, expected) {
       (_, Self::Dynamic) | (Self::Dynamic, _) => true,
       // Compatibility for annotations constructed by older embedders before
@@ -2524,6 +2595,26 @@ impl CalcitTypeAnnotation {
       (_, Self::Custom(expected)) if Self::custom_keyword_matches(expected, "any") => true,
       (Self::Custom(actual), _) if Self::custom_keyword_matches(actual, "any") => true,
       (Self::TypeVar(actual), Self::TypeVar(expected)) if actual == expected => true,
+      (Self::Union(actual_members), other) => {
+        let mut candidate_bindings = bindings.clone();
+        let accepted = actual_members
+          .iter()
+          .all(|member| member.matches_with_bindings(other, &mut candidate_bindings));
+        if accepted {
+          *bindings = candidate_bindings;
+        }
+        accepted
+      }
+      (other, Self::Union(expected_members)) => {
+        for member in expected_members.iter() {
+          let mut candidate_bindings = bindings.clone();
+          if other.matches_with_bindings(member, &mut candidate_bindings) {
+            *bindings = candidate_bindings;
+            return true;
+          }
+        }
+        false
+      }
       (actual, Self::TypeVar(var)) => match bindings.get(var) {
         Some(bound) if bound.as_ref() == actual => true,
         Some(bound) => {
@@ -2967,6 +3058,14 @@ impl CalcitTypeAnnotation {
           Calcit::List(Arc::new(CalcitList::from(items.as_slice())))
         }
       }
+      Self::Union(members) => {
+        let mut items = Vec::with_capacity(members.len() + 1);
+        items.push(Self::make_symbol("or"));
+        for member in members.iter() {
+          items.push(member.to_calcit());
+        }
+        Calcit::List(Arc::new(CalcitList::from(items.as_slice())))
+      }
       Self::Enum(enum_def, _) => Calcit::EnumDef((**enum_def).clone()),
       Self::StructDef(struct_def) => Calcit::StructDef((**struct_def).clone()),
       Self::EnumDef(enum_def) => Calcit::EnumDef((**enum_def).clone()),
@@ -3003,6 +3102,7 @@ impl CalcitTypeAnnotation {
           Edn::enum_value(name.trim_start_matches('\''), args.iter().map(|arg| arg.to_type_edn()).collect())
         }
       }
+      Self::Union(members) => Edn::enum_value("or", members.iter().map(|member| member.to_type_edn()).collect()),
       // Parameterized builtins – keep inner type if non-dynamic
       Self::List(inner) => {
         if matches!(inner.as_ref(), Self::Dynamic) {
@@ -3167,6 +3267,10 @@ impl CalcitTypeAnnotation {
           format!("type {name}<{rendered}>")
         }
       }
+      Self::Union(members) => format!(
+        "union<{}>",
+        members.iter().map(|member| member.describe()).collect::<Vec<_>>().join(", ")
+      ),
       Self::Enum(enum_def, args) => {
         if args.is_empty() {
           format!("enum {}", enum_def.name())
@@ -3208,15 +3312,16 @@ impl CalcitTypeAnnotation {
       Self::Dynamic => 21,
       Self::TypeVar(_) => 22,
       Self::TypeRef(_, _) => 23,
-      Self::Struct(_, _) => 24,
-      Self::Enum(_, _) => 25,
-      Self::Trait(_) => 26,
-      Self::TraitSet(_) => 27,
-      Self::Unit => 28,
-      Self::JsObject => 29,
-      Self::TypeSlot(_) => 30,
-      Self::StructDef(_) => 31,
-      Self::EnumDef(_) => 32,
+      Self::Union(_) => 24,
+      Self::Struct(_, _) => 25,
+      Self::Enum(_, _) => 26,
+      Self::Trait(_) => 27,
+      Self::TraitSet(_) => 28,
+      Self::Unit => 29,
+      Self::JsObject => 30,
+      Self::TypeSlot(_) => 31,
+      Self::StructDef(_) => 32,
+      Self::EnumDef(_) => 33,
     }
   }
 }
@@ -3386,6 +3491,95 @@ fn resolve_type_def_from_code(code: &Calcit) -> Option<Calcit> {
   None
 }
 
+/// Parse the source form of a transparent union declaration:
+///
+/// ```text
+/// deftype RespoNode
+///   or 'Component 'Element
+/// ```
+///
+/// The declaration itself deliberately has no runtime value.  This parser is used only by
+/// named `TypeRef` resolution, so source schemas keep the concise public name while matching
+/// sees the closed member set.
+fn parse_deftype_union_code(code: &Calcit) -> Option<Arc<CalcitTypeAnnotation>> {
+  if let Calcit::Thunk(thunk) = code {
+    return parse_deftype_union_code(thunk.get_code());
+  }
+  let Calcit::List(items) = code else {
+    return None;
+  };
+  if let Some(head) = items.first()
+    && (matches!(head, Calcit::Syntax(CalcitSyntax::Quote, _))
+      || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "quote")
+      || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "quote"))
+    && let Some(inner) = items.get(1)
+  {
+    return parse_deftype_union_code(inner);
+  }
+  if is_def_head(items.first()?)
+    && let Some(value) = items.get(2)
+  {
+    return parse_deftype_union_code(value);
+  }
+  if !is_deftype_head(items.first()?) || items.len() != 3 {
+    return None;
+  }
+
+  let union_form = items.get(2)?;
+  let Calcit::List(forms) = union_form else {
+    return None;
+  };
+  if !is_or_type_head(forms.first()?) || forms.len() < 3 {
+    return None;
+  }
+
+  fn collect_member(form: &Calcit, members: &mut Vec<Arc<CalcitTypeAnnotation>>) -> Option<()> {
+    if let Calcit::List(forms) = form
+      && forms.first().is_some_and(is_or_type_head)
+    {
+      if forms.len() < 3 {
+        return None;
+      }
+      for nested in forms.iter().skip(1) {
+        collect_member(nested, members)?;
+      }
+      return Some(());
+    }
+
+    let member = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[]);
+    if matches!(member.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::TypeVar(_))
+      || matches!(member.as_ref(), CalcitTypeAnnotation::TypeRef(name, args) if args.is_empty() && name.eq_ignore_ascii_case("dynamic"))
+    {
+      return None;
+    }
+    if !members.contains(&member) {
+      members.push(member);
+    }
+    Some(())
+  }
+
+  let mut members = Vec::with_capacity(forms.len() - 1);
+  for form in forms.iter().skip(1) {
+    collect_member(form, &mut members)?;
+  }
+  if members.len() < 2 {
+    return None;
+  }
+  Some(Arc::new(CalcitTypeAnnotation::Union(Arc::new(members))))
+}
+
+/// Validate the MVP `deftype` declaration at its definition site. Keeping the
+/// check here makes the macro a runtime no-op while sharing the exact parser
+/// used later by assignability and runtime field validation.
+pub(crate) fn validate_deftype_union_code(code: &Calcit) -> Result<(), String> {
+  parse_deftype_union_code(code)
+    .map(|_| ())
+    .ok_or_else(|| {
+      "deftype expects `(deftype Name (or MemberA MemberB ...))`; members must be concrete non-Dynamic types and there must be at least two distinct members"
+        .to_owned()
+    })
+}
+
 fn is_def_head(head: &Calcit) -> bool {
   matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "def")
     || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "def")
@@ -3404,6 +3598,16 @@ fn is_defstruct_head(head: &Calcit) -> bool {
 fn is_defenum_head(head: &Calcit) -> bool {
   matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "defenum")
     || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "defenum")
+}
+
+fn is_deftype_head(head: &Calcit) -> bool {
+  matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "deftype")
+    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "deftype")
+}
+
+fn is_or_type_head(head: &Calcit) -> bool {
+  matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "or")
+    || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "or")
 }
 
 fn is_struct_new_head(head: &Calcit) -> bool {
@@ -3738,6 +3942,39 @@ mod tests {
       ),
       "expected qualified type reference, got {parsed:?}"
     );
+  }
+
+  #[test]
+  fn parses_transparent_deftype_union_and_checks_each_member() {
+    let union_code = Calcit::from(vec![
+      symbol("deftype"),
+      symbol("RespoNode"),
+      Calcit::from(vec![symbol("or"), symbol("'Component"), symbol("'Element")]),
+    ]);
+    let union = parse_deftype_union_code(&union_code).expect("parse transparent union declaration");
+
+    assert!(matches!(
+      union.as_ref(),
+      CalcitTypeAnnotation::Union(members)
+        if members.len() == 2
+          && matches!(members[0].as_ref(), CalcitTypeAnnotation::TypeRef(name, args) if name.as_ref() == "Component" && args.is_empty())
+          && matches!(members[1].as_ref(), CalcitTypeAnnotation::TypeRef(name, args) if name.as_ref() == "Element" && args.is_empty())
+    ));
+
+    let component = CalcitTypeAnnotation::TypeRef(Arc::from("Component"), Arc::new(vec![]));
+    let element = CalcitTypeAnnotation::TypeRef(Arc::from("Element"), Arc::new(vec![]));
+    let other = CalcitTypeAnnotation::TypeRef(Arc::from("Text"), Arc::new(vec![]));
+    assert!(component.matches_annotation(union.as_ref()));
+    assert!(element.matches_annotation(union.as_ref()));
+    assert!(!other.matches_annotation(union.as_ref()));
+
+    let invalid_dynamic = Calcit::from(vec![
+      symbol("deftype"),
+      symbol("BadNode"),
+      Calcit::from(vec![symbol("or"), symbol("'Component"), symbol("'Dynamic")]),
+    ]);
+    assert!(parse_deftype_union_code(&invalid_dynamic).is_none());
+    assert!(validate_deftype_union_code(&invalid_dynamic).is_err());
   }
 
   #[test]
@@ -4832,6 +5069,10 @@ impl Hash for CalcitTypeAnnotation {
         name.hash(state);
         args.hash(state);
       }
+      Self::Union(members) => {
+        "union".hash(state);
+        members.hash(state);
+      }
       Self::Enum(enum_def, args) => {
         "enum".hash(state);
         enum_def.name().hash(state);
@@ -4901,6 +5142,7 @@ impl Ord for CalcitTypeAnnotation {
       (Self::Dynamic, Self::Dynamic) => Ordering::Equal,
       (Self::TypeVar(a), Self::TypeVar(b)) => a.cmp(b),
       (Self::TypeRef(a_name, a_args), Self::TypeRef(b_name, b_args)) => a_name.cmp(b_name).then_with(|| a_args.cmp(b_args)),
+      (Self::Union(a), Self::Union(b)) => a.cmp(b),
       (Self::Struct(a, _), Self::Struct(b, _)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
       (Self::Enum(a, _), Self::Enum(b, _)) => a.name().cmp(b.name()),
       (Self::StructDef(a), Self::StructDef(b)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
@@ -5236,6 +5478,7 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
       _ => false,
     },
     CalcitTypeAnnotation::TypeRef(expected_name, _) => match value {
+      _ if resolve_type_ref_as_union(expected_name).is_some_and(|union| value_matches_type_annotation(value, union.as_ref())) => true,
       Calcit::Struct(r) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, r.struct_ref.name.ref_str()),
       Calcit::Enum(t) => t
         .sum_type
@@ -5243,6 +5486,7 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
         .is_some_and(|st| CalcitTypeAnnotation::type_ref_name_matches(expected_name, st.name().ref_str())),
       _ => false,
     },
+    CalcitTypeAnnotation::Union(members) => members.iter().any(|member| value_matches_type_annotation(value, member.as_ref())),
     CalcitTypeAnnotation::StructDef(expected_struct) => match value {
       Calcit::StructDef(struct_def) => struct_def.name == expected_struct.name,
       _ => false,

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2349,7 +2349,7 @@
                         quasiquote $ if (&struct:matches? ~value ~pattern)
                           &let
                               ~ $ &list:nth pair 1
-                              , ~value
+                              , $ assert-type ~value ~pattern
                             ~@ $ &list:slice pair 2
                           &struct-match-internal ~value $ ~@ (&list:rest body)
           :examples $ []
@@ -4233,6 +4233,15 @@
           :schema $ :: 'Macro
             {} $ :args ([] 'Dynamic)
           :tags $ #{} :macro
+        |deftype $ %{} 'CodeEntry (:doc "|Declare a transparent named union type. Syntax: (deftype Name (or 'MemberA 'MemberB)). The declaration is compile-time-only and does not wrap runtime values.")
+          :code $ quote
+            defmacro deftype (_name _type-form) nil
+          :examples $ []
+            quote $ deftype RespoNode
+              or 'Component 'Element
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic 'Dynamic)
+          :tags $ #{} :macro :type
         |deftype-slot $ %{} 'CodeEntry (:doc "|Declare a named compile-time type slot supplied by a library. Syntax: (deftype-slot :slot-name). Applications should bind the slot for each entry with cr config set-type-slot; an unbound slot falls back to :dynamic.")
           :code $ quote &runtime-implementation
           :examples $ []

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1428,6 +1428,21 @@ fn preprocess_list_call(
 
   match head_value {
     Some(Calcit::Macro { info, .. }) => {
+      let source_call = Calcit::List(Arc::new(xs.to_owned()));
+      if info.def_ns.as_ref() == calcit::CORE_NS && info.name.as_ref() == "deftype" {
+        crate::calcit::type_annotation::validate_deftype_union_code(&source_call).map_err(|message| {
+          CalcitErr::use_msg_stack_location_with_code(
+            CalcitErrKind::Type,
+            message,
+            "E_DEFTYPE_DECLARATION",
+            call_stack,
+            call_location.clone(),
+          )
+        })?;
+      }
+      if info.def_ns.as_ref() == calcit::CORE_NS && info.name.as_ref() == "struct-match" {
+        validate_transparent_union_struct_match(&args, scope_types, file_ns, call_stack, call_location.clone())?;
+      }
       let mut current_values: Vec<Calcit> = args.to_vec();
 
       warn_on_trait_impl_method_tag_syntax(info.as_ref(), &args, file_ns, def_name.as_ref(), check_warnings);
@@ -1435,8 +1450,7 @@ fn preprocess_list_call(
       // println!("eval macro: {}", primes::CrListWrap(xs.to_owned()));
       // println!("macro... {} {}", x, CrListWrap(current_values.to_owned()));
 
-      let code = Calcit::List(Arc::new(xs.to_owned()));
-      let next_stack = call_stack.extend_owned(&info.def_ns, &info.name, StackKind::Macro, code, args.to_vec());
+      let next_stack = call_stack.extend_owned(&info.def_ns, &info.name, StackKind::Macro, source_call, args.to_vec());
 
       let mut body_scope = CalcitScope::default();
 
@@ -5125,6 +5139,132 @@ struct PredicateNarrowing {
   false_binding: Option<(Arc<str>, Arc<CalcitTypeAnnotation>)>,
 }
 
+/// Check the source-level branches before `struct-match` expands into nested
+/// `if`s. The generated form has lost the complete arm list, so this is the
+/// one place where we can report duplicate, foreign, and missing members of a
+/// transparent union precisely.
+fn validate_transparent_union_struct_match(
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  call_stack: &CallStackList,
+  location: Option<NodeLocation>,
+) -> Result<(), CalcitErr> {
+  let Some(receiver) = args.first() else {
+    return Ok(());
+  };
+  let Some(receiver_type) = resolve_type_value(receiver, scope_types) else {
+    return Ok(());
+  };
+  let Some(resolved_union) = crate::calcit::type_annotation::resolve_transparent_union_type(receiver_type.as_ref(), file_ns) else {
+    return Ok(());
+  };
+  let CalcitTypeAnnotation::Union(members) = resolved_union.as_ref() else {
+    return Ok(());
+  };
+
+  let fail = |message: String| {
+    CalcitErr::use_msg_stack_location_with_code(CalcitErrKind::Type, message, "E_STRUCT_MATCH_UNION", call_stack, location.clone())
+  };
+  let mut covered = BTreeSet::new();
+  let mut has_default = false;
+  let arms = args.iter().skip(1).collect::<Vec<_>>();
+  for (arm_index, arm) in arms.iter().enumerate() {
+    let Calcit::List(pair) = arm else {
+      // Leave basic arm-shape diagnostics to the macro, which has the
+      // established source wording for ordinary struct matches.
+      continue;
+    };
+    let Some(pattern) = pair.first() else {
+      continue;
+    };
+    if matches!(pattern, Calcit::Symbol { sym, .. } if sym.as_ref() == "_") {
+      if arm_index + 1 != arms.len() {
+        return Err(fail("struct-match `_` branch must be the final branch".to_owned()));
+      }
+      has_default = true;
+      continue;
+    }
+
+    let Some(pattern_type) = resolve_type_value(pattern, scope_types) else {
+      return Err(fail(format!(
+        "struct-match branch `{pattern}` cannot be resolved to a concrete Struct member of `{}`",
+        receiver_type.to_brief_string()
+      )));
+    };
+    let Some(pattern_def) = resolve_struct_type_for_match(pattern_type.as_ref(), file_ns, scope_types) else {
+      return Err(fail(format!(
+        "struct-match branch `{pattern}` is not a Struct member of `{}`",
+        receiver_type.to_brief_string()
+      )));
+    };
+    let pattern_struct = Arc::new(CalcitTypeAnnotation::Struct(Arc::new(pattern_def), Arc::new(vec![])));
+    let Some(member_index) = members.iter().position(|member| pattern_struct.matches_annotation(member.as_ref())) else {
+      return Err(fail(format!(
+        "struct-match branch `{pattern}` is not a member of transparent union `{}`",
+        receiver_type.to_brief_string()
+      )));
+    };
+    if !covered.insert(member_index) {
+      return Err(fail(format!(
+        "struct-match has duplicate branch `{pattern}` for transparent union `{}`",
+        receiver_type.to_brief_string()
+      )));
+    }
+  }
+
+  if !has_default && covered.len() != members.len() {
+    let remaining = members
+      .iter()
+      .enumerate()
+      .filter(|(idx, _)| !covered.contains(idx))
+      .map(|(_, member)| member.to_brief_string())
+      .collect::<Vec<_>>()
+      .join(", ");
+    return Err(fail(format!(
+      "struct-match does not cover transparent union `{}`; missing {remaining}, or add a final `_` branch",
+      receiver_type.to_brief_string()
+    )));
+  }
+
+  Ok(())
+}
+
+fn resolve_struct_type_for_match(type_ref: &CalcitTypeAnnotation, file_ns: &str, scope_types: &ScopeTypes) -> Option<CalcitStructDef> {
+  if let CalcitTypeAnnotation::StructDef(struct_def) = type_ref {
+    return Some(struct_def.as_ref().to_owned());
+  }
+  if let Some(struct_def) = type_ref.resolve_to_struct() {
+    return Some(struct_def);
+  }
+  let CalcitTypeAnnotation::TypeRef(name, _) = type_ref else {
+    return None;
+  };
+  let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+  let short_name = stripped.rsplit('/').next().unwrap_or(stripped);
+  if let Some(local_type) = scope_types.get(stripped).or_else(|| scope_types.get(short_name)) {
+    match local_type.as_ref() {
+      CalcitTypeAnnotation::StructDef(struct_def) => return Some(struct_def.as_ref().to_owned()),
+      _ if let Some(struct_def) = local_type.resolve_to_struct() => return Some(struct_def),
+      _ => {}
+    }
+  }
+  let (target_ns, target_def) = if let Some((ns, def)) = stripped.rsplit_once('/') {
+    (Arc::from(ns), Arc::from(def))
+  } else if program::has_def_code(file_ns, stripped) {
+    (Arc::from(file_ns), Arc::from(stripped))
+  } else if let Some(target_ns) = program::lookup_def_target_in_import(file_ns, stripped) {
+    (target_ns, Arc::from(stripped))
+  } else {
+    (Arc::from(calcit::CORE_NS), Arc::from(stripped))
+  };
+  match resolve_program_value_for_preprocess(&target_ns, &target_def, None) {
+    Some(Calcit::StructDef(struct_def)) => Some(struct_def),
+    Some(Calcit::Struct(struct_value)) => Some(struct_value.struct_ref.as_ref().to_owned()),
+    _ => None,
+  }
+}
+
 fn extract_predicate_bindings(cond_form: &Calcit, scope_types: &ScopeTypes) -> PredicateNarrowing {
   let empty = PredicateNarrowing {
     true_binding: None,
@@ -5133,9 +5273,6 @@ fn extract_predicate_bindings(cond_form: &Calcit, scope_types: &ScopeTypes) -> P
   let Calcit::List(items) = cond_form else {
     return empty;
   };
-  if items.len() != 2 {
-    return empty;
-  }
   let Some(pred_name) = (match items.first() {
     Some(Calcit::Symbol { sym, .. }) => Some(sym.as_ref()),
     Some(Calcit::Import(CalcitImport { def, .. })) => Some(def.as_ref()),
@@ -5144,6 +5281,33 @@ fn extract_predicate_bindings(cond_form: &Calcit, scope_types: &ScopeTypes) -> P
   }) else {
     return empty;
   };
+
+  // `struct-match` expands each nominal branch into this predicate.  The
+  // runtime check already identifies the exact `StructDef`; retain that fact
+  // while preprocessing the true branch so fields can be accessed without an
+  // `unsafe-coerce` or a second user-facing assertion.
+  if pred_name == "&struct:matches?" && items.len() == 3 {
+    let target = match items.get(1) {
+      Some(Calcit::Local(local)) => local,
+      _ => return empty,
+    };
+    let Some(asserted) = items.get(2).and_then(|pattern| resolve_type_value(pattern, scope_types)) else {
+      return empty;
+    };
+    let narrowed = match asserted.as_ref() {
+      CalcitTypeAnnotation::Struct(def, args) => Arc::new(CalcitTypeAnnotation::Struct(def.clone(), args.clone())),
+      CalcitTypeAnnotation::StructDef(def) => Arc::new(CalcitTypeAnnotation::Struct(def.clone(), Arc::new(vec![]))),
+      _ => return empty,
+    };
+    return PredicateNarrowing {
+      true_binding: Some((target.sym.to_owned(), narrowed)),
+      false_binding: None,
+    };
+  }
+
+  if items.len() != 2 {
+    return empty;
+  }
   let target = match items.get(1) {
     Some(t) => t,
     None => return empty,
@@ -6654,6 +6818,88 @@ mod tests {
       narrowing.true_binding,
       Some((name, inferred)) if name.as_ref() == "host" && matches!(inferred.as_ref(), CalcitTypeAnnotation::JsObject)
     ));
+  }
+
+  #[test]
+  fn struct_matches_predicate_narrows_a_union_local_to_the_branch_struct() {
+    let branch = CalcitStructDef::from_fields(EdnTag::new("Component"), vec![EdnTag::new("name")]);
+    let sym: Arc<str> = Arc::from("node");
+    let node = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&sym),
+      sym: sym.clone(),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.transparent-union"),
+        at_def: Arc::from("match-node"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::Union(Arc::new(vec![
+        Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("Component"), Arc::new(vec![]))),
+        Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("Element"), Arc::new(vec![]))),
+      ]))),
+    });
+    let predicate = Calcit::from(vec![
+      Calcit::Proc(CalcitProc::NativeStructMatches),
+      node,
+      Calcit::StructDef(branch.clone()),
+    ]);
+
+    let narrowing = extract_predicate_bindings(&predicate, &ScopeTypes::new());
+    assert!(matches!(
+      narrowing.true_binding,
+      Some((name, inferred))
+        if name.as_ref() == "node"
+          && matches!(inferred.as_ref(), CalcitTypeAnnotation::Struct(def, args) if def.as_ref() == &branch && args.is_empty())
+    ));
+    assert!(narrowing.false_binding.is_none());
+  }
+
+  #[test]
+  fn transparent_union_struct_match_requires_complete_unique_member_branches() {
+    let cat = Arc::new(CalcitStructDef::from_fields(EdnTag::new("Cat"), vec![EdnTag::new("name")]));
+    let city = Arc::new(CalcitStructDef::from_fields(EdnTag::new("City"), vec![EdnTag::new("name")]));
+    let node_type = Arc::new(CalcitTypeAnnotation::Union(Arc::new(vec![
+      Arc::new(CalcitTypeAnnotation::Struct(cat.clone(), Arc::new(vec![]))),
+      Arc::new(CalcitTypeAnnotation::Struct(city.clone(), Arc::new(vec![]))),
+    ])));
+    let node_sym: Arc<str> = Arc::from("node");
+    let node = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&node_sym),
+      sym: node_sym,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.transparent-union"),
+        at_def: Arc::from("match-node"),
+      }),
+      location: None,
+      type_info: node_type,
+    });
+    let arm = |pattern: Calcit| Calcit::from(vec![pattern, Calcit::Nil]);
+    let missing = CalcitList::from(&[node.clone(), arm(Calcit::StructDef(cat.as_ref().clone()))] as &[Calcit]);
+    let missing_error = validate_transparent_union_struct_match(
+      &missing,
+      &ScopeTypes::new(),
+      "tests.transparent-union",
+      &CallStackList::default(),
+      None,
+    )
+    .expect_err("missing City branch must be rejected");
+    assert!(missing_error.msg.contains("missing"), "{}", missing_error.msg);
+    assert!(missing_error.msg.contains("City"));
+
+    let duplicate = CalcitList::from(&[
+      node,
+      arm(Calcit::StructDef(cat.as_ref().clone())),
+      arm(Calcit::StructDef(cat.as_ref().clone())),
+      arm(Calcit::StructDef(city.as_ref().clone())),
+    ] as &[Calcit]);
+    let duplicate_error = validate_transparent_union_struct_match(
+      &duplicate,
+      &ScopeTypes::new(),
+      "tests.transparent-union",
+      &CallStackList::default(),
+      None,
+    )
+    .expect_err("duplicate Cat branch must be rejected");
+    assert!(duplicate_error.msg.contains("duplicate branch"));
   }
 
   #[test]


### PR DESCRIPTION
Summary: compile-time transparent deftype Name (or ...) unions without runtime wrappers; union-aware assignability, struct field validation, struct predicates, and struct-match; declaration and coverage diagnostics; RFC and end-to-end coverage.

Verification: cargo test (432 passed); cargo clippy --all-targets --all-features -- -D warnings; core unit tests (214 passed); Calcit snapshot check and run passed.