### PR TITLE
fix: silence test-only Clippy warnings

### DIFF
--- a/RFCs/08-19-transparent-union-types-rfc.md
+++ b/RFCs/08-19-transparent-union-types-rfc.md
@@ -33,9 +33,9 @@ deftype RespoNode
 
 ```cirru.no-check
 defenum RequestState
-  (:idle)
-  (:loading)
-  (:failed 'String)
+  :idle
+  :loading
+  :failed 'String
 ```
 
 `deftype` 表示已有类型之间的静态集合，不产生新的值构造器：
@@ -505,8 +505,8 @@ Trait 适合共同方法，但 Respo diff 需要按具体节点种类读取不�
 
 ```cirru.no-check
 defenum RespoNode
-  (:component 'Component)
-  (:element 'Element)
+  :component 'Component
+  :element 'Element
 ```
 
 这会改变 Respo 当前数据表示、相等性路径和 DSL 输出。`deftype` 的目标正是获得相同的静态分支能力，而不引入这层运行时包装。

--- a/history/202608191418-rfc-defenum-syntax.md
+++ b/history/202608191418-rfc-defenum-syntax.md
@@ -1,0 +1,4 @@
+# Correct transparent-union RFC enum examples
+
+- Removed redundant parentheses from line-oriented `defenum` variants in the transparent-union RFC.
+- Verified the `RequestState` and `RespoNode` examples with `cr cirru parse -e`.

--- a/history/202608191430-transparent-union-review.md
+++ b/history/202608191430-transparent-union-review.md
@@ -1,0 +1,5 @@
+# Transparent union review fixes
+
+- Made test-only semantic-version helpers private to remove unnecessary crate visibility.
+- Added regression coverage for transparent-union struct matching through nominal fallback and imported namespace resolution when scope types are empty.
+- Full Rust tests and Clippy validation passed; the repository-wide agent-interface check still reports an existing deprecated `cr config version` scenario.

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -610,119 +610,6 @@ fn valid_module_component(component: &str) -> bool {
       .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
-#[cfg(test)]
-mod tests {
-  use super::{
-    PackageDeps, VersionBumpCaps, VersionCaps, VersionGetCaps, VersionSubcommand, handle_version_command, module_folder,
-    normalize_package_name,
-  };
-  use cirru_edn::Edn;
-  use std::collections::HashMap;
-  use std::sync::Arc;
-
-  #[test]
-  fn module_names_are_canonical_before_path_use() {
-    assert_eq!(module_folder("calcit-lang/respo.calcit"), Ok("respo.calcit"));
-    for invalid in ["../outside", "org/../outside", "org//repo", "org/repo/extra", "/tmp/repo"] {
-      assert!(module_folder(invalid).is_err(), "{invalid} should be rejected");
-    }
-  }
-
-  #[test]
-  fn normalized_package_names_reject_extra_path_segments() {
-    assert_eq!(
-      normalize_package_name("https://github.com/calcit-lang/respo.calcit.git"),
-      Ok("calcit-lang/respo.calcit".to_owned())
-    );
-    assert!(normalize_package_name("calcit-lang/respo.calcit/extra").is_err());
-  }
-
-  #[test]
-  fn missing_dependencies_field_is_an_empty_graph() {
-    let deps: PackageDeps = Edn::Map(cirru_edn::EdnMapView::default()).try_into().unwrap();
-    assert!(deps.version.is_none());
-    assert!(deps.dependencies.is_empty());
-    assert!(deps.dev_dependencies.is_empty());
-  }
-
-  #[test]
-  fn empty_package_version_is_treated_as_missing() {
-    let parsed = cirru_edn::parse("{} (:version ||)").unwrap();
-    let deps: PackageDeps = parsed.try_into().unwrap();
-    assert!(deps.version.is_none());
-  }
-
-  #[test]
-  fn version_commands_do_not_read_snapshot_version() {
-    let root = std::env::temp_dir().join(format!("calcit-caps-version-migration-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(&root).unwrap();
-    let deps_path = root.join("deps.cirru");
-    std::fs::write(&deps_path, "{} (:dependencies $ {})").unwrap();
-    // A legacy snapshot version must not be used as a fallback anymore.
-    std::fs::write(root.join("calcit.cirru"), "{} (:version |1.2.3)").unwrap();
-
-    let deps: PackageDeps = cirru_edn::parse("{} (:dependencies $ {})").unwrap().try_into().unwrap();
-    let deps_file = deps_path.to_str().unwrap();
-    let get_error = handle_version_command(
-      deps.clone(),
-      deps_file,
-      &VersionCaps {
-        command: VersionSubcommand::Get(VersionGetCaps {}),
-      },
-    )
-    .expect_err("missing deps.cirru version should reject version get");
-    assert!(get_error.contains("no :version declared in"), "unexpected error: {get_error}");
-    assert!(get_error.contains("deps.cirru"), "unexpected error: {get_error}");
-    assert!(
-      get_error.contains(&format!("caps version set <version> {deps_file}")),
-      "unexpected migration hint: {get_error}"
-    );
-
-    let bump_error = handle_version_command(
-      deps,
-      deps_file,
-      &VersionCaps {
-        command: VersionSubcommand::Bump(VersionBumpCaps { level: "patch".to_owned() }),
-      },
-    )
-    .expect_err("missing deps.cirru version should reject version bump");
-    assert!(bump_error.contains("no :version declared in"), "unexpected error: {bump_error}");
-    assert!(bump_error.contains("deps.cirru"), "unexpected error: {bump_error}");
-    assert!(
-      bump_error.contains(&format!("caps version set <version> {deps_file}")),
-      "unexpected migration hint: {bump_error}"
-    );
-
-    std::fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn parses_development_dependencies_separately() {
-    let parsed = cirru_edn::parse("{} (:dependencies $ {} (|org/runtime |1.0.0)) (:dev-dependencies $ {} (|org/test |main))").unwrap();
-    let deps: PackageDeps = parsed.try_into().unwrap();
-    assert_eq!(deps.dependencies.get("org/runtime").map(AsRef::as_ref), Some("1.0.0"));
-    assert_eq!(deps.dev_dependencies.get("org/test").map(AsRef::as_ref), Some("main"));
-  }
-
-  #[test]
-  fn write_deps_preserves_package_version() {
-    let path = std::env::temp_dir().join(format!("calcit-caps-version-{}.cirru", std::process::id()));
-    let deps = PackageDeps {
-      version: Some("1.2.3".to_string()),
-      calcit_version: Some("0.13.12".to_string()),
-      dependencies: Default::default(),
-      dev_dependencies: HashMap::from([(Arc::from("calcit-lang/test"), Arc::from("main"))]),
-    };
-    super::write_deps_file(path.to_str().unwrap(), &deps).unwrap();
-    let parsed = cirru_edn::parse(&std::fs::read_to_string(&path).unwrap()).unwrap();
-    let restored: PackageDeps = parsed.try_into().unwrap();
-    assert_eq!(restored.version.as_deref(), Some("1.2.3"));
-    assert_eq!(restored.dev_dependencies.get("calcit-lang/test").map(AsRef::as_ref), Some("main"));
-    std::fs::remove_file(path).unwrap();
-  }
-}
-
 fn write_deps_file(deps_file: &str, deps: &PackageDeps) -> Result<(), String> {
   let mut updated_edn = Edn::Map(cirru_edn::EdnMapView::default());
 
@@ -1085,4 +972,117 @@ fn write_package_version(deps_file: &str, version: &str) -> Result<(), String> {
 
 fn print_column(pkg: ColoredString, expected: ColoredString, latest: ColoredString, hint: ColoredString) {
   println!("{pkg:<32} {expected:<12} {latest:<12} {hint:<12}");
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{
+    PackageDeps, VersionBumpCaps, VersionCaps, VersionGetCaps, VersionSubcommand, handle_version_command, module_folder,
+    normalize_package_name,
+  };
+  use cirru_edn::Edn;
+  use std::collections::HashMap;
+  use std::sync::Arc;
+
+  #[test]
+  fn module_names_are_canonical_before_path_use() {
+    assert_eq!(module_folder("calcit-lang/respo.calcit"), Ok("respo.calcit"));
+    for invalid in ["../outside", "org/../outside", "org//repo", "org/repo/extra", "/tmp/repo"] {
+      assert!(module_folder(invalid).is_err(), "{invalid} should be rejected");
+    }
+  }
+
+  #[test]
+  fn normalized_package_names_reject_extra_path_segments() {
+    assert_eq!(
+      normalize_package_name("https://github.com/calcit-lang/respo.calcit.git"),
+      Ok("calcit-lang/respo.calcit".to_owned())
+    );
+    assert!(normalize_package_name("calcit-lang/respo.calcit/extra").is_err());
+  }
+
+  #[test]
+  fn missing_dependencies_field_is_an_empty_graph() {
+    let deps: PackageDeps = Edn::Map(cirru_edn::EdnMapView::default()).try_into().unwrap();
+    assert!(deps.version.is_none());
+    assert!(deps.dependencies.is_empty());
+    assert!(deps.dev_dependencies.is_empty());
+  }
+
+  #[test]
+  fn empty_package_version_is_treated_as_missing() {
+    let parsed = cirru_edn::parse("{} (:version ||)").unwrap();
+    let deps: PackageDeps = parsed.try_into().unwrap();
+    assert!(deps.version.is_none());
+  }
+
+  #[test]
+  fn version_commands_do_not_read_snapshot_version() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-version-migration-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    let deps_path = root.join("deps.cirru");
+    std::fs::write(&deps_path, "{} (:dependencies $ {})").unwrap();
+    // A legacy snapshot version must not be used as a fallback anymore.
+    std::fs::write(root.join("calcit.cirru"), "{} (:version |1.2.3)").unwrap();
+
+    let deps: PackageDeps = cirru_edn::parse("{} (:dependencies $ {})").unwrap().try_into().unwrap();
+    let deps_file = deps_path.to_str().unwrap();
+    let get_error = handle_version_command(
+      deps.clone(),
+      deps_file,
+      &VersionCaps {
+        command: VersionSubcommand::Get(VersionGetCaps {}),
+      },
+    )
+    .expect_err("missing deps.cirru version should reject version get");
+    assert!(get_error.contains("no :version declared in"), "unexpected error: {get_error}");
+    assert!(get_error.contains("deps.cirru"), "unexpected error: {get_error}");
+    assert!(
+      get_error.contains(&format!("caps version set <version> {deps_file}")),
+      "unexpected migration hint: {get_error}"
+    );
+
+    let bump_error = handle_version_command(
+      deps,
+      deps_file,
+      &VersionCaps {
+        command: VersionSubcommand::Bump(VersionBumpCaps { level: "patch".to_owned() }),
+      },
+    )
+    .expect_err("missing deps.cirru version should reject version bump");
+    assert!(bump_error.contains("no :version declared in"), "unexpected error: {bump_error}");
+    assert!(bump_error.contains("deps.cirru"), "unexpected error: {bump_error}");
+    assert!(
+      bump_error.contains(&format!("caps version set <version> {deps_file}")),
+      "unexpected migration hint: {bump_error}"
+    );
+
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn parses_development_dependencies_separately() {
+    let parsed = cirru_edn::parse("{} (:dependencies $ {} (|org/runtime |1.0.0)) (:dev-dependencies $ {} (|org/test |main))").unwrap();
+    let deps: PackageDeps = parsed.try_into().unwrap();
+    assert_eq!(deps.dependencies.get("org/runtime").map(AsRef::as_ref), Some("1.0.0"));
+    assert_eq!(deps.dev_dependencies.get("org/test").map(AsRef::as_ref), Some("main"));
+  }
+
+  #[test]
+  fn write_deps_preserves_package_version() {
+    let path = std::env::temp_dir().join(format!("calcit-caps-version-{}.cirru", std::process::id()));
+    let deps = PackageDeps {
+      version: Some("1.2.3".to_string()),
+      calcit_version: Some("0.13.12".to_string()),
+      dependencies: Default::default(),
+      dev_dependencies: HashMap::from([(Arc::from("calcit-lang/test"), Arc::from("main"))]),
+    };
+    super::write_deps_file(path.to_str().unwrap(), &deps).unwrap();
+    let parsed = cirru_edn::parse(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    let restored: PackageDeps = parsed.try_into().unwrap();
+    assert_eq!(restored.version.as_deref(), Some("1.2.3"));
+    assert_eq!(restored.dev_dependencies.get("calcit-lang/test").map(AsRef::as_ref), Some("main"));
+    std::fs::remove_file(path).unwrap();
+  }
 }

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -1365,25 +1365,6 @@ fn config_name(subcommand: &ConfigSubcommand) -> &'static str {
   }
 }
 
-#[cfg(test)]
-mod tests {
-  use super::{DEFAULT_ECHO_TOKEN_PREFIX, push_switch, push_value};
-
-  #[test]
-  fn default_command_echo_tokens_are_marked_without_hiding_real_parentheses() {
-    let mut tokens = vec![];
-    push_value(&mut tokens, "format", "human", Some("human"));
-    push_value(&mut tokens, "pattern", "(foo)", None);
-    push_switch(&mut tokens, "list", false);
-    push_switch(&mut tokens, "summary-only", true);
-
-    assert!(tokens[0].starts_with(DEFAULT_ECHO_TOKEN_PREFIX));
-    assert_eq!(tokens[1], "--pattern=(foo)");
-    assert!(tokens[2].starts_with(DEFAULT_ECHO_TOKEN_PREFIX));
-    assert_eq!(tokens[3], "--summary-only=ON");
-  }
-}
-
 fn push_config(tokens: &mut Vec<String>, cmd: &ConfigCommand) {
   match &cmd.subcommand {
     ConfigSubcommand::Show(opts) => echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none"),
@@ -1410,5 +1391,24 @@ fn push_config(tokens: &mut Vec<String>, cmd: &ConfigCommand) {
       echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none");
       echo_items!(tokens, pos "slot" => &opts.slot);
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{DEFAULT_ECHO_TOKEN_PREFIX, push_switch, push_value};
+
+  #[test]
+  fn default_command_echo_tokens_are_marked_without_hiding_real_parentheses() {
+    let mut tokens = vec![];
+    push_value(&mut tokens, "format", "human", Some("human"));
+    push_value(&mut tokens, "pattern", "(foo)", None);
+    push_switch(&mut tokens, "list", false);
+    push_switch(&mut tokens, "summary-only", true);
+
+    assert!(tokens[0].starts_with(DEFAULT_ECHO_TOKEN_PREFIX));
+    assert_eq!(tokens[1], "--pattern=(foo)");
+    assert!(tokens[2].starts_with(DEFAULT_ECHO_TOKEN_PREFIX));
+    assert_eq!(tokens[3], "--summary-only=ON");
   }
 }

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -2533,7 +2533,7 @@ fn handle_ns_doc(opts: &EditNsDocCommand, snapshot_file: &str) -> Result<(), Str
 // ═══════════════════════════════════════════════════════════════════════════════
 
 #[cfg(test)]
-pub(crate) fn parse_semver_value(v: &str) -> Result<Version, String> {
+fn parse_semver_value(v: &str) -> Result<Version, String> {
   if v.starts_with('|') {
     return Err(format!(
       "Invalid version '{v}': do not include the '|' Cirru string prefix; use bare semver, e.g. '0.0.17'"
@@ -2543,7 +2543,7 @@ pub(crate) fn parse_semver_value(v: &str) -> Result<Version, String> {
 }
 
 #[cfg(test)]
-pub(crate) fn bump_semver_value(current: &str, level: &str) -> Result<String, String> {
+fn bump_semver_value(current: &str, level: &str) -> Result<String, String> {
   let mut version = parse_semver_value(current)?;
   match level {
     "patch" => {

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -25,6 +25,7 @@ use cirru_edn::{Edn, EdnMapView, EdnStructView, EdnTag};
 use cirru_parser::Cirru;
 use colored::Colorize;
 use md5::{Digest, Md5};
+#[cfg(test)]
 use semver::Version;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
@@ -2528,9 +2529,10 @@ fn handle_ns_doc(opts: &EditNsDocCommand, snapshot_file: &str) -> Result<(), Str
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Semver helpers (pub(crate) so cr config can reuse them)
+// Semver helpers used by edit tests
 // ═══════════════════════════════════════════════════════════════════════════════
 
+#[cfg(test)]
 pub(crate) fn parse_semver_value(v: &str) -> Result<Version, String> {
   if v.starts_with('|') {
     return Err(format!(
@@ -2540,6 +2542,7 @@ pub(crate) fn parse_semver_value(v: &str) -> Result<Version, String> {
   Version::parse(v).map_err(|_| format!("Invalid version '{v}': expected semver format, e.g. '0.0.17'"))
 }
 
+#[cfg(test)]
 pub(crate) fn bump_semver_value(current: &str, level: &str) -> Result<String, String> {
   let mut version = parse_semver_value(current)?;
   match level {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,79 +203,6 @@ pub fn resolve_module_snapshot_candidates(path: &str, base_dir: &Path, module_fo
   items
 }
 
-#[cfg(test)]
-mod module_resolution_tests {
-  use super::{project_module_folder, resolve_module_snapshot_candidates};
-  use std::fs;
-  use std::path::PathBuf;
-
-  fn temp_root(label: &str) -> PathBuf {
-    std::env::temp_dir().join(format!("calcit-module-resolution-{label}-{}", std::process::id()))
-  }
-
-  #[test]
-  fn project_module_view_is_the_only_root_for_named_modules() {
-    let root = temp_root("project-first");
-    let project = root.join("project");
-    let global = root.join("global");
-    fs::create_dir_all(project.join(".calcit/modules/demo")).unwrap();
-    fs::create_dir_all(global.join("demo")).unwrap();
-    fs::write(project.join(".calcit/modules/demo/compact.cirru"), "project").unwrap();
-    fs::write(global.join("demo/calcit.cirru"), "global").unwrap();
-
-    let module_folder = project_module_folder(&project);
-    let candidates = resolve_module_snapshot_candidates("demo/", &project, &module_folder);
-    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/compact.cirru"));
-    assert_eq!(candidates[0].2, "<mods>/demo/compact.cirru");
-    fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn named_modules_do_not_fall_back_to_the_global_store() {
-    let root = temp_root("no-global-fallback");
-    let project = root.join("project");
-    let global = root.join("global");
-    fs::create_dir_all(&project).unwrap();
-    fs::create_dir_all(global.join("demo")).unwrap();
-    fs::write(global.join("demo/calcit.cirru"), "global").unwrap();
-
-    let module_folder = project_module_folder(&project);
-    let candidates = resolve_module_snapshot_candidates("demo/", &project, &module_folder);
-    assert_eq!(candidates.len(), 1);
-    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/calcit.cirru"));
-    fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn explicit_relative_modules_do_not_use_project_module_view() {
-    let root = temp_root("relative");
-    let project = root.join("project");
-    let global = root.join("global");
-    fs::create_dir_all(&project).unwrap();
-    fs::write(project.join("util.cirru"), "relative").unwrap();
-
-    let candidates = resolve_module_snapshot_candidates("./util.cirru", &project, &global);
-    assert_eq!(candidates.len(), 1);
-    assert_eq!(candidates[0].1, project.join("./util.cirru"));
-    fs::remove_dir_all(root).unwrap();
-  }
-
-  #[test]
-  fn absolute_module_paths_do_not_use_project_module_view() {
-    let root = temp_root("absolute");
-    let project = root.join("project");
-    let global = root.join("global");
-    let module = root.join("external.cirru");
-    fs::create_dir_all(&project).unwrap();
-    fs::write(&module, "absolute").unwrap();
-
-    let candidates = resolve_module_snapshot_candidates(module.to_str().unwrap(), &project, &global);
-    assert_eq!(candidates.len(), 1);
-    assert_eq!(candidates[0].1, module);
-    fs::remove_dir_all(root).unwrap();
-  }
-}
-
 pub fn resolve_module_snapshot_path(path: &str, base_dir: &Path, module_folder: &Path) -> (String, PathBuf, String) {
   resolve_module_snapshot_candidates(path, base_dir, module_folder)
     .into_iter()
@@ -370,4 +297,77 @@ pub fn load_module(path: &str, base_dir: &Path, module_folder: &Path) -> Result<
   }
 
   Err(last_error.unwrap_or_else(|| format!("expected Cirru snapshot for module path: {path}")))
+}
+
+#[cfg(test)]
+mod module_resolution_tests {
+  use super::{project_module_folder, resolve_module_snapshot_candidates};
+  use std::fs;
+  use std::path::PathBuf;
+
+  fn temp_root(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("calcit-module-resolution-{label}-{}", std::process::id()))
+  }
+
+  #[test]
+  fn project_module_view_is_the_only_root_for_named_modules() {
+    let root = temp_root("project-first");
+    let project = root.join("project");
+    let global = root.join("global");
+    fs::create_dir_all(project.join(".calcit/modules/demo")).unwrap();
+    fs::create_dir_all(global.join("demo")).unwrap();
+    fs::write(project.join(".calcit/modules/demo/compact.cirru"), "project").unwrap();
+    fs::write(global.join("demo/calcit.cirru"), "global").unwrap();
+
+    let module_folder = project_module_folder(&project);
+    let candidates = resolve_module_snapshot_candidates("demo/", &project, &module_folder);
+    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/compact.cirru"));
+    assert_eq!(candidates[0].2, "<mods>/demo/compact.cirru");
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn named_modules_do_not_fall_back_to_the_global_store() {
+    let root = temp_root("no-global-fallback");
+    let project = root.join("project");
+    let global = root.join("global");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(global.join("demo")).unwrap();
+    fs::write(global.join("demo/calcit.cirru"), "global").unwrap();
+
+    let module_folder = project_module_folder(&project);
+    let candidates = resolve_module_snapshot_candidates("demo/", &project, &module_folder);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/calcit.cirru"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn explicit_relative_modules_do_not_use_project_module_view() {
+    let root = temp_root("relative");
+    let project = root.join("project");
+    let global = root.join("global");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(project.join("util.cirru"), "relative").unwrap();
+
+    let candidates = resolve_module_snapshot_candidates("./util.cirru", &project, &global);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].1, project.join("./util.cirru"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn absolute_module_paths_do_not_use_project_module_view() {
+    let root = temp_root("absolute");
+    let project = root.join("project");
+    let global = root.join("global");
+    let module = root.join("external.cirru");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(&module, "absolute").unwrap();
+
+    let candidates = resolve_module_snapshot_candidates(module.to_str().unwrap(), &project, &global);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].1, module);
+    fs::remove_dir_all(root).unwrap();
+  }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6936,6 +6936,69 @@ mod tests {
   }
 
   #[test]
+  fn transparent_union_struct_match_resolves_nominal_and_imported_structs() {
+    let _guard = lock_preprocess_test_state();
+    calcit::register_program_lookups(program::lookup_runtime_ready, program::lookup_def_code, program::lookup_def_schema);
+
+    let nominal_ns = "tests.transparent-union-nominal";
+    let imported_ns = "tests.transparent-union-imported";
+    let consumer_ns = "tests.transparent-union-consumer";
+    let cat = Arc::new(CalcitStructDef::from_fields(EdnTag::new("Cat"), vec![EdnTag::new("name")]));
+    let city = Arc::new(CalcitStructDef::from_fields(EdnTag::new("City"), vec![EdnTag::new("name")]));
+
+    for (ns, name, definition) in [(nominal_ns, "Cat", cat.as_ref()), (nominal_ns, "City", city.as_ref())] {
+      program::write_runtime_ready(ns, name, Calcit::StructDef(definition.clone())).expect("register nominal Struct");
+    }
+    for (ns, name, definition) in [(imported_ns, "Cat", cat.as_ref()), (imported_ns, "City", city.as_ref())] {
+      program::write_runtime_ready(ns, name, Calcit::StructDef(definition.clone())).expect("register imported Struct");
+    }
+
+    let node_sym: Arc<str> = Arc::from("node");
+    let node_type = Arc::new(CalcitTypeAnnotation::Union(Arc::new(vec![
+      Arc::new(CalcitTypeAnnotation::Struct(cat.clone(), Arc::new(vec![]))),
+      Arc::new(CalcitTypeAnnotation::Struct(city.clone(), Arc::new(vec![]))),
+    ])));
+    let node = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&node_sym),
+      sym: node_sym,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from(nominal_ns),
+        at_def: Arc::from("match-node"),
+      }),
+      location: None,
+      type_info: node_type,
+    });
+    let arm = |pattern: Calcit| Calcit::from(vec![pattern, Calcit::Nil]);
+    let symbol = |name: &str| Calcit::Symbol {
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from(nominal_ns),
+        at_def: Arc::from("match-node"),
+      }),
+      location: None,
+    };
+
+    let nominal_branches = CalcitList::from(&[node.clone(), arm(symbol("Cat")), arm(symbol("City"))] as &[Calcit]);
+    validate_transparent_union_struct_match(&nominal_branches, &ScopeTypes::new(), nominal_ns, &CallStackList::default(), None)
+      .expect("nominal Struct branches should resolve without named scope types");
+
+    let imported_pattern = |name: &str| {
+      Calcit::Import(CalcitImport {
+        ns: Arc::from(imported_ns),
+        def: Arc::from(name),
+        info: Arc::new(ImportInfo::NsReferDef {
+          at_ns: Arc::from(consumer_ns),
+          at_def: Arc::from("match-node"),
+        }),
+        def_id: None,
+      })
+    };
+    let imported_branches = CalcitList::from(&[node, arm(imported_pattern("Cat")), arm(imported_pattern("City"))] as &[Calcit]);
+    validate_transparent_union_struct_match(&imported_branches, &ScopeTypes::new(), consumer_ns, &CallStackList::default(), None)
+      .expect("imported Struct branches should resolve by namespace");
+  }
+
+  #[test]
   fn nominal_options_warn_on_legacy_nil_and_enum_operations() {
     let core_head = |operation: &str| {
       Calcit::Import(CalcitImport {

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5186,7 +5186,19 @@ fn validate_transparent_union_struct_match(
       continue;
     }
 
-    let Some(pattern_type) = resolve_type_value(pattern, scope_types) else {
+    let pattern_type = resolve_type_value(pattern, scope_types).or_else(|| match pattern {
+      // `struct-match` receives its source arms before macro expansion. A
+      // qualified struct name can therefore still be a Symbol rather than a
+      // resolved program value. Keep it as a nominal TypeRef so the common
+      // resolver below can look up its StructDef, including across namespaces.
+      Calcit::Symbol { sym, .. } => Some(Arc::new(CalcitTypeAnnotation::TypeRef(sym.clone(), Arc::new(vec![])))),
+      Calcit::Import(import) => Some(Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from(format!("{}/{}", import.ns, import.def)),
+        Arc::new(vec![]),
+      ))),
+      _ => None,
+    });
+    let Some(pattern_type) = pattern_type else {
       return Err(fail(format!(
         "struct-match branch `{pattern}` cannot be resolved to a concrete Struct member of `{}`",
         receiver_type.to_brief_string()
@@ -6886,7 +6898,7 @@ mod tests {
     assert!(missing_error.msg.contains("City"));
 
     let duplicate = CalcitList::from(&[
-      node,
+      node.clone(),
       arm(Calcit::StructDef(cat.as_ref().clone())),
       arm(Calcit::StructDef(cat.as_ref().clone())),
       arm(Calcit::StructDef(city.as_ref().clone())),
@@ -6900,6 +6912,27 @@ mod tests {
     )
     .expect_err("duplicate Cat branch must be rejected");
     assert!(duplicate_error.msg.contains("duplicate branch"));
+
+    let symbol = |name: &str| Calcit::Symbol {
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.transparent-union"),
+        at_def: Arc::from("match-node"),
+      }),
+      location: None,
+    };
+    let mut named_scope_types = ScopeTypes::new();
+    named_scope_types.insert(Arc::from("Cat"), Arc::new(CalcitTypeAnnotation::StructDef(cat.clone())));
+    named_scope_types.insert(Arc::from("City"), Arc::new(CalcitTypeAnnotation::StructDef(city.clone())));
+    let named_branches = CalcitList::from(&[node, arm(symbol("Cat")), arm(symbol("City"))] as &[Calcit]);
+    validate_transparent_union_struct_match(
+      &named_branches,
+      &named_scope_types,
+      "tests.transparent-union",
+      &CallStackList::default(),
+      None,
+    )
+    .expect("symbolic Struct names should resolve through the local type scope");
   }
 
   #[test]


### PR DESCRIPTION
Moves test modules after production code and gates semver helpers/imports with `cfg(test)` where they are only used by tests. This removes strict Clippy warnings without changing runtime behavior.

Verified locally:
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`