### PR TITLE
docs: propose type system ecosystem roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When installing from source, install the same public tools:
 cargo install --path . --bin cr --bin caps
 ```
 
-For new GitHub Actions workflows, use [setup-calcit](https://github.com/tiye/setup-calcit). Existing
+For new GitHub Actions workflows, use [setup-calcit](https://github.com/calcit-lang/setup-calcit). Existing
 [setup-cr](https://github.com/calcit-lang/setup-cr) workflow tags remain supported.
 
 ### Quick Start
@@ -119,7 +119,7 @@ Related examples and workflows:
 
 - [Minimal Calcit](https://github.com/calcit-lang/minimal-calcit/blob/main/README.md)
 - [Respo Calcit Workflow](https://github.com/calcit-lang/respo-calcit-workflow)
-- [setup-calcit](https://github.com/tiye/setup-calcit) for new GitHub Actions workflows
+- [setup-calcit](https://github.com/calcit-lang/setup-calcit) for new GitHub Actions workflows
 
 ### Modules
 
@@ -145,7 +145,7 @@ Root projects install both `:dependencies` and `:dev-dependencies`. Recursive re
 `:dependencies`, so test and maintenance modules declared by a dependency do not leak into consumers.
 Use `caps add --dev <org/repo>@<ref>` and `caps remove --dev <org/repo>` to manage the development group.
 
-`:calcit-version` helps with version checks and provides hints in [CI](https://github.com/tiye/setup-calcit).
+`:calcit-version` helps with version checks and provides hints in [CI](https://github.com/calcit-lang/setup-calcit).
 
 To load modules, use `:modules` configuration and the runtime snapshot file `calcit.cirru` (legacy: `compact.cirru`):
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ When installing from source, install the same public tools:
 cargo install --path . --bin cr --bin caps
 ```
 
-To use Calcit in GitHub Actions, try [setup-cr](https://github.com/calcit-lang/setup-cr).
+For new GitHub Actions workflows, use [setup-calcit](https://github.com/tiye/setup-calcit). Existing
+[setup-cr](https://github.com/calcit-lang/setup-cr) workflow tags remain supported.
 
 ### Quick Start
 
@@ -118,20 +119,16 @@ Related examples and workflows:
 
 - [Minimal Calcit](https://github.com/calcit-lang/minimal-calcit/blob/main/README.md)
 - [Respo Calcit Workflow](https://github.com/calcit-lang/respo-calcit-workflow)
-- [setup-cr](https://github.com/calcit-lang/setup-cr) for GitHub Actions
+- [setup-calcit](https://github.com/tiye/setup-calcit) for new GitHub Actions workflows
 
 ### Modules
 
 `deps.cirru` declares dependencies that need to download, which correspond to repositories on GitHub. Specify a branch or a tag:
 
 ```cirru
-{}
-  :calcit-version |0.9.11
-  :dependencies $ {}
-    |calcit-lang/memof |0.0.11
-    |calcit-lang/lilac |main
-  :dev-dependencies $ {}
-    |calcit-lang/calcit-test |0.1.0
+{} (:calcit-version |0.9.11)
+  :dependencies $ {} (|calcit-lang/memof |0.0.11) (|calcit-lang/lilac |main)
+  :dev-dependencies $ {} (|calcit-lang/calcit-test |0.1.0)
 ```
 
 Run `caps` to resolve the recursive dependency graph and install it. Immutable revisions are stored under
@@ -148,7 +145,7 @@ Root projects install both `:dependencies` and `:dev-dependencies`. Recursive re
 `:dependencies`, so test and maintenance modules declared by a dependency do not leak into consumers.
 Use `caps add --dev <org/repo>@<ref>` and `caps remove --dev <org/repo>` to manage the development group.
 
-`:calcit-version` helps with version checks and provides hints in [CI](https://github.com/calcit-lang/setup-cr).
+`:calcit-version` helps with version checks and provides hints in [CI](https://github.com/tiye/setup-calcit).
 
 To load modules, use `:modules` configuration and the runtime snapshot file `calcit.cirru` (legacy: `compact.cirru`):
 

--- a/RFCs/08-21-js-ffi-runtime-contract-validation-rfc.md
+++ b/RFCs/08-21-js-ffi-runtime-contract-validation-rfc.md
@@ -1,0 +1,284 @@
+# RFC：JS FFI 静态声明与运行时契约验证
+
+状态：Draft
+
+日期：2026-08-21
+
+## 摘要
+
+Calcit 的 JS FFI 已能用 `JsObject`、`JsNullish<T>`、完整 Fn schema、external-object trait
+和 `:features #{:js-ffi}` 描述边界，但“类型检查通过”目前主要证明 Calcit 侧的声明自洽，不能
+证明 JavaScript 宿主真的满足声明。
+
+本 RFC 补充静态类型与实际宿主之间的验证闭环：
+
+1. 将 host import、property/method、callback、exception、Promise 和 `unsafe-coerce` 视为需要
+   单独证据的 contract boundary；
+2. 在 `js-ffi` 库提供可复用的 guard/decoder/normalizer，不让每个应用自行断言；
+3. 为 Node 与 browser 建立正向、负向 runtime contract test；
+4. 将 unchecked host assertion 纳入原生质量报告，但不把 runtime test 冒充静态分析；
+5. 保持现有名义类型与 FFI metadata 设计，不引入 TypeScript 式结构类型系统。
+
+本 RFC 是 `08-18-calcit-typed-js-ffi-boundary-rfc.md` 的后续。前者解决“如何声明和授权”，
+本 RFC 解决“声明如何被宿主运行证据支持”。
+
+## 问题定义
+
+下面的代码可以在静态层拥有精确返回类型：
+
+```cirru.no-check
+defn viewport-width () $ unsafe-coerce js/window.innerWidth Number
+```
+
+但 schema 本身不能证明：
+
+- 当前 target 一定有 `window`；
+- `innerWidth` 存在且是 number；
+- npm 包仍导出声明中的 symbol；
+- 取出的函数是否需要 JavaScript `this`；
+- callback 会收到声明的参数；
+- Promise 不会 reject；
+- `null`/`undefined` 没有被误断言为普通值；
+- 已生成代码与当前 `@calcit/procs` runtime 相容。
+
+因此应明确：
+
+> FFI schema 是 Calcit 对宿主的契约声明，不是宿主事实的自动证明。
+
+在纯 Calcit typed code 中，“类型通过但发生普通类型错误”应被视为编译器问题；在 FFI 边界，
+同类失败首先说明 contract 没有被验证、第三方 API 漂移，或使用了显式 unsafe escape。
+
+## 失败分类
+
+| 类别 | 例子 | 首选发现阶段 |
+| --- | --- | --- |
+| target mismatch | browser binding 用于 Node | codegen 前静态检查 |
+| missing binding | npm named export 被移除 | module load/runtime contract test |
+| wrong primitive | 声明 Number，宿主返回 String | boundary guard |
+| nullish mismatch | `undefined` 被断言成 String | boundary guard/decoder |
+| object capability | method 不存在或不是 function | external-object assertion/test |
+| receiver loss | 取出 method 后无 `this` 调用 | lowering test |
+| callback mismatch | 宿主参数或 callback 返回值不符 | callback adapter contract test |
+| exception/rejection | API throw 或 Promise reject | adapter 转 Result + negative test |
+| runtime identity | 生成代码引用旧/缺失 proc | JS runtime identity test |
+
+静态分析应尽早拒绝可证明的问题；需要观察宿主值的问题由 boundary validation 和 runtime test
+承担。不能因为后者无法在编译期证明，就整体退回 `Dynamic`。
+
+## 设计原则
+
+### unsafe 必须可见
+
+`unsafe-coerce` 继续表示“维护者提供可信证据”，不偷偷增加运行时开销，也不伪装成 decoder。
+但 compiler/query/quality 必须能够报告：
+
+- source type；
+- target type；
+- definition 与 Snapshot path；
+- 所在函数是否具有 `:js-ffi`；
+- 是否位于被声明为 raw adapter 的 namespace/definition；
+- 是否紧邻一个已识别 guard/decoder。
+
+从宿主值直接 coercion 到 Struct/Enum、primitive 或精确 Fn schema 是高风险项。它可以存在，但
+必须被审计，且不能在普通业务 namespace 扩散。
+
+### guard、decoder、normalizer 分层
+
+`js-ffi` 提供三类可复用能力：
+
+1. **guard**：验证 primitive、nullish、array、function、必要字段/方法等浅层宿主事实；
+2. **decoder**：递归验证外部数据并返回 `Result<T, JsError>`；适合 JSON/object 数据；
+3. **normalizer**：捕获 exception/rejection，把宿主对象转换为 Struct/Enum/List/Map/Option/
+   Result/Unit。
+
+具体 API 名称可以在实现时确定，但语义必须区分：guard 证明一个有限事实，decoder 产生
+Calcit-owned data，`unsafe-coerce` 只接受维护者断言。
+
+`decode-map-as` / 严格 Cirru EDN decoder 已证明“按目标类型派生验证器”可行；JS object decoder
+应尽量复用同一 data-shape 规则和错误路径格式，而不是在 js-ffi 内维护另一套类型 AST。
+
+### external trait 是能力，不是完整对象验证
+
+external-object trait 声明调用者会使用的稳定字段和方法。对一个 `JsObject` 建立该 trait
+evidence 时，测试/调试模式至少可以验证：
+
+- 声明为 method 的成员存在且为 function；
+- 必需字段存在；
+- 可廉价验证的 primitive 字段类型正确；
+- writable metadata 不包含未知字段。
+
+这不是 TypeScript structural satisfaction，也不生成普通 runtime impl。宿主对象后续仍可能
+变化；真正需要稳定数据不变量时应复制并 decode 成 Struct/Enum。
+
+### exception 与 async 是契约的一部分
+
+可能 throw/reject 的 API 不得只声明成功返回类型。公共 adapter 返回
+`Result<T, JsError>`；不存在与失败分别用 `Option` 和 `Result` 表达。未 await 的 Promise 不以
+裸 `JsObject` 泄漏到业务层。
+
+## 编译器与分析改进
+
+### Host contract evidence
+
+在现有 `HostOperation`/FFI metadata 基础上，为边界产生统一 evidence：
+
+- binding target 与 host name；
+- operation kind：import/value/property/method/constructor/callback/await；
+- logical schema；
+- target：browser/node/neutral；
+- assertion kind：checked/decoded/unsafe；
+- definition/path。
+
+它是类型检查后的 contract analysis，不参与普通 `matches_with_bindings`、泛型统一或 trait
+candidate selection。
+
+### 诊断
+
+建议新增或稳定以下诊断：
+
+- `E_JS_FFI_TARGET_MISMATCH`：selected entry 与 binding target 冲突；
+- `E_JS_FFI_FEATURE_REQUIRED`：实现体没有授权 host operation；
+- `W_JS_FFI_UNCHECKED_COERCE`：宿主值直接转换到强类型且没有可见验证；
+- `W_JS_FFI_UNTESTED_BINDING`：公共 binding 没有 contract example/test evidence；
+- `E_JS_FFI_RUNTIME_CONTRACT`：调试/测试 guard 发现实际值与声明不一致。
+
+runtime error 至少携带 Calcit definition、host binding/member、expected、actual kind 和 entry
+target。不要只暴露 JavaScript `Cannot read properties of undefined`。
+
+### Quality 集成
+
+`analyze quality` 后续增加独立维度，例如 unchecked host assertions 与 untested public
+bindings。它们进入同一版本化 JSON/baseline 协议，不由项目自写 JS 扫描 generated code。
+
+quality 输出只声明“发现/未发现静态契约风险”，不能声称 Node/browser runtime tests 已执行。
+后端 test 仍是单独 CI step。
+
+## `js-ffi` 库改进
+
+### 模块组织
+
+建议稳定三层目录/namespace：
+
+- `js-ffi.raw.*`：唯一允许 raw `js/*` 和必要 `unsafe-coerce` 的实现层；
+- `js-ffi.host.*`：小型 external traits 与 checked host wrappers；
+- `js-ffi.*` / `js-ffi.types`：normalized public API、`JsError` 和业务可用数据。
+
+已有公开路径可以通过 re-export 保持兼容，不要求一次性改名。
+
+### 优先补强的应用场景
+
+1. `globalThis`、Node `process`、browser `window/document` 的 target detection；
+2. npm/ES module function import，特别是 default/named export 与 receiver method；
+3. DOM query、event target 和 listener callback；
+4. timer、storage、clipboard 等 effect API 的 Unit/Result 契约；
+5. Promise resolve/reject 与 async callback；
+6. host Array/object 到 `List<T>`、Struct、Enum 的 decoder；
+7. `@calcit/procs` generated-code runtime identity。
+
+每个场景先选真实应用调用路径，不为未使用的完整 DOM/npm surface 建模。
+
+## Runtime contract test 矩阵
+
+### Node
+
+- 生成实际 JS；
+- 使用项目声明的 `@calcit/procs` 版本执行；
+- 调用每个公共 Node binding 的最小成功用例；
+- 对 missing export、错误 primitive、throw、rejection 和 nullish 运行负向 fixture；
+- 验证错误包含 Calcit binding identity，而不只是原生 JS stack。
+
+### Browser
+
+- 在 headless browser 装载真实生成物；
+- 对 DOM property/method、receiver binding、event callback 和 writable field 做 smoke test；
+- 在没有目标 API或返回 nullish 时验证 Option/Result；
+- Node-only binding 在 browser target 于 codegen 前失败，反向亦然。
+
+### Generated runtime identity
+
+- codegen 使用的 proc export 在当前 `@calcit/procs` 中全部存在；
+- compile-time-only form 不泄漏为 runtime proc；
+- Calcit CLI 与 npm runtime 版本不同时给出明确兼容错误或由项目版本策略阻止；
+- contract test 执行 generated JS，而不是只检查文本中是否出现某个 symbol。
+
+### Callback
+
+至少覆盖：
+
+- primitive/Struct callback 参数正常；
+- nullish 参数按声明转换；
+- callback 返回 Unit；
+- callback throw 被保留为明确错误或按 adapter 契约转 Result；
+- async callback rejection；
+- escaping callback 的 `:js-ffi` lexical capability 没有丢失。
+
+## 运行时检查策略
+
+不是所有 external field access 都需要永久重复 `typeof`。建议分三种模式：
+
+| 模式 | 行为 | 使用场景 |
+| --- | --- | --- |
+| boundary | 在建立 typed evidence/decoder 时检查一次 | 默认生产路径 |
+| debug | boundary 外加关键 callback/返回值断言 | 测试、开发、生态升级 |
+| unsafe | 只保留明确 `unsafe-coerce`，由审计和 contract test 承担 | 性能敏感且已证明的 adapter |
+
+模式属于 entry/build policy，不进入普通类型身份。即使选择 unsafe，target 和 capability gate 仍需
+静态检查；关闭 runtime guard 不等于允许未授权 FFI。
+
+## 实施阶段
+
+### Phase 0：真实失败目录
+
+- 从 js-ffi、Editor、Respo workflow 和网站项目收集“静态通过但 runtime 失败”的最小 fixture；
+- 按 target/binding/value/callback/exception/runtime identity 分类；
+- 为已有 public wrapper 标记 raw/host/normalized 层。
+
+### Phase 1：库级 guard 与 contract tests
+
+- 统一 `JsError`、primitive/nullish/function guards 和 object decoder；
+- Node contract test 覆盖 module import、process、exception、Promise；
+- browser contract test 覆盖 DOM、event、receiver 和 storage；
+- effect wrapper 收敛为 Unit 或 Result。
+
+### Phase 2：编译器 evidence 与诊断
+
+- query/analyze 暴露 host contract evidence；
+- unchecked coercion 进入 weak/quality report；
+- target mismatch 在 codegen 前失败；
+- runtime contract error 附带 Calcit definition/path。
+
+### Phase 3：生态采用
+
+- js-ffi 自身达到 Q3；
+- Editor、Respo workflow 和网站各选择至少一个真实 browser consumer 回归；
+- 新 public FFI binding 必须同时提交 schema、contract test 和 normalized API 决策。
+
+## 验收标准
+
+1. 每类已知“类型通过但 runtime 失败”都有最小正向和负向 fixture。
+2. public js-ffi wrapper 不以无理由 Dynamic 隐藏 primitive/nullish/callback 关系。
+3. 从 host object 到 Struct/Enum 的路径经过 decoder 或被明确报告为 unsafe。
+4. Node/browser target mismatch 在运行前失败。
+5. module method 的 receiver lowering 有真实执行测试。
+6. throw/rejection/nullish 分别映射为 Result/Option，而不是偶然的 undefined/Dynamic。
+7. quality 能报告 unchecked host assertion，但不伪造 runtime-test 状态。
+8. 不使用 JS FFI 的程序在类型推断、trait matching 和 codegen 上不受影响。
+
+## 非目标
+
+- 完整导入 TypeScript `.d.ts`；
+- 通用 structural object/union/overload 类型；
+- 运行时深度验证每一次宿主属性读取；
+- 用 FFI 推动 generic trait、associated type 或 effect row；
+- 保证任意第三方 JavaScript 包升级都不会破坏契约。
+
+## 相关资料
+
+- `RFCs/07-08-ffi-features-and-js-object-type-rfc.md`
+- `RFCs/07-31-unsafe-coerce-driven-static-type-boundary-plan.md`
+- `RFCs/08-08-cross-backend-host-ffi-contracts-rfc.md`
+- `RFCs/08-18-calcit-typed-js-ffi-boundary-rfc.md`
+- `RFCs/08-21-type-quality-ci-adoption-rfc.md`
+- `docs/features/js-interop.md`
+- `docs/data/edn.md`
+

--- a/RFCs/08-21-js-ffi-runtime-contract-validation-rfc.md
+++ b/RFCs/08-21-js-ffi-runtime-contract-validation-rfc.md
@@ -218,12 +218,24 @@ quality 输出只声明“发现/未发现静态契约风险”，不能声称 N
 
 | 模式 | 行为 | 使用场景 |
 | --- | --- | --- |
-| boundary | 在建立 typed evidence/decoder 时检查一次 | 默认生产路径 |
+| boundary | 只为一次 decoder 操作检查并立即复制为 Calcit-owned data | 默认生产路径 |
 | debug | boundary 外加关键 callback/返回值断言 | 测试、开发、生态升级 |
 | unsafe | 只保留明确 `unsafe-coerce`，由审计和 contract test 承担 | 性能敏感且已证明的 adapter |
 
 模式属于 entry/build policy，不进入普通类型身份。即使选择 unsafe，target 和 capability gate 仍需
 静态检查；关闭 runtime guard 不等于允许未授权 FFI。
+
+### evidence 的有效范围
+
+host object 默认是可变的，不能把一次检查当成可无限期复用的“已验证外部对象”能力。boundary
+模式的 evidence 仅覆盖当前 decoder 调用：decoder 必须立即读取所需字段并返回 Struct、Enum、
+Option、Result 或其他 Calcit-owned data；调用方不能凭该 evidence 在稍后的代码中直接访问原
+对象。若 adapter 必须保留外部对象或在稍后调用其方法，每一次 field/method access 都要重新
+检查存在性和 primitive/function shape，或改为 debug 模式提供这类断言。external-object trait
+仍只提供静态成员声明与代码生成映射，不证明运行时对象不可变或始终符合该 shape。
+
+unsafe 模式可以有意跳过这些检查，但必须把 `unsafe-coerce` 保留在最小 adapter 中，并由针对
+该 binding 的正向和负向 runtime contract test 提供可追溯证据。
 
 ## 实施阶段
 
@@ -281,4 +293,3 @@ quality 输出只声明“发现/未发现静态契约风险”，不能声称 N
 - `RFCs/08-21-type-quality-ci-adoption-rfc.md`
 - `docs/features/js-interop.md`
 - `docs/data/edn.md`
-

--- a/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
+++ b/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
@@ -1,4 +1,4 @@
-# RFC：setup-cr 版本来源与基础工具链契约
+# RFC：setup-calcit 版本来源与基础工具链契约
 
 状态：Draft
 
@@ -7,16 +7,19 @@
 ## 摘要
 
 普通 Calcit 项目的编译器版本应只有一个项目级事实来源：`deps.cirru` 中的
-`:calcit-version`。`setup-cr` 的默认用法只负责读取这个版本并安装相应工具，不再鼓励在
+`:calcit-version`。新的 `setup-calcit` 默认用法只负责读取这个版本并安装相应工具，不再鼓励在
 workflow 中重复填写 `version`。
 
-`version` input 暂不立即删除，因为 setup-cr 自身测试、没有 `deps.cirru` 的临时任务和紧急
+`version` input 暂不立即删除，因为 setup-calcit 自身测试、没有 `deps.cirru` 的临时任务和紧急
 诊断仍然需要显式版本；但它降级为 fallback。若项目同时提供两个不一致的版本，Action 必须
 明确失败，不能再用隐含优先级覆盖。
 
-在这个单一版本来源基础上，setup-cr 可以补齐缓存、校验、平台路径、结构化输出和工具选择等
+在这个单一版本来源基础上，setup-calcit 可以补齐缓存、校验、平台路径、结构化输出和工具选择等
 基础能力，但仍保持“安装工具”的单一职责。依赖安装、类型门禁和项目测试继续由显式 CI step
 执行。
+
+`calcit-lang/setup-cr` 保留为旧 workflow 的兼容入口。GitHub Actions 不会为 Action 仓库改名
+提供重定向，所以不直接重命名该仓库；新项目迁移到 setup-calcit，旧项目继续使用已发布的 tag。
 
 ## 背景
 
@@ -57,7 +60,7 @@ workflow 中重复填写 `version`。
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: calcit-lang/setup-cr@0.0.9
+- uses: tiye/setup-calcit@v1
 ```
 
 对应项目配置：
@@ -88,7 +91,7 @@ README、Calcit 安装文档、模块模板和 workflow 模板都应优先展示
 增加可选的 `deps-file` input，默认值为 `deps.cirru`。它只用于 monorepo 或非根目录项目：
 
 ```yaml
-- uses: calcit-lang/setup-cr@v1
+- uses: tiye/setup-calcit@v1
   with:
     deps-file: examples/browser/deps.cirru
 ```
@@ -113,7 +116,7 @@ with:
 兼容期只需继续接受 `cr-wasm` 布尔 input；转换后得到唯一的 requested tool set。未知工具、
 重复项或目标版本没有对应 artifact 时，在下载前失败。
 
-setup-cr 不增加 `run-tests`、`run-quality`、`install-modules` 等 input。以下步骤必须继续显式
+setup-calcit 不增加 `run-tests`、`run-quality`、`install-modules` 等 input。以下步骤必须继续显式
 出现在 workflow 中：
 
 ```bash
@@ -167,9 +170,9 @@ Job Summary 只记录版本来源、工具、平台、缓存命中和自检结�
 
 ## 文档迁移
 
-1. setup-cr README quick start 删除显式 `version`；
+1. setup-calcit README quick start 删除显式 `version`，并说明 setup-cr 的 legacy 兼容边界；
 2. Calcit README 将 `:calcit-version` 从“CI hint”提升为项目工具链版本；
-3. workflow 模板统一只引用 setup-cr release，不复制 Calcit 版本；
+3. 新 workflow 模板统一引用 setup-calcit release，不复制 Calcit 版本；
 4. 显式版本用法放入 advanced usage，并说明不应与 `deps.cirru` 冲突；
 5. 错误文案修正历史拼写 `calcit-verison`，并给出实际读取路径。
 
@@ -204,7 +207,7 @@ SHA。现有 `@0.0.x` 标签在迁移期继续可用。
 ### Phase 3：release manifest
 
 - Calcit release 产生 checksums/manifest；
-- setup-cr 校验下载完整性和 capability metadata；
+- setup-calcit 校验下载完整性和 capability metadata；
 - 缓存 key 纳入 manifest/schema version。
 
 ## 验收标准
@@ -213,14 +216,14 @@ SHA。现有 `@0.0.x` 标签在迁移期继续可用。
 2. `deps.cirru` 与 input 冲突时，Action 在下载前失败并展示两个来源。
 3. 安装日志能证明最终版本、来源、工具、平台和缓存状态。
 4. 任一工具下载或自检失败时 Action 必须失败，不能留下部分成功状态。
-5. setup-cr 自身测试覆盖默认或显式缺失 deps、合法 deps、畸形 deps、重复声明、冲突和
+5. setup-calcit 自身测试覆盖默认或显式缺失 deps、合法 deps、畸形 deps、重复声明、冲突和
    artifact 缺失。
 6. Action 不隐式运行 `caps`、formatter、类型门禁或业务测试。
 7. 支持的平台都不依赖硬编码 `/home/runner` 路径。
 
 ## 非目标
 
-- 让 setup-cr 成为新的包管理器；
+- 让 setup-calcit 成为新的包管理器；
 - 自动修改 `deps.cirru`；
 - 替项目选择“最新”版本；
 - 隐式运行项目 CI；

--- a/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
+++ b/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
@@ -72,11 +72,13 @@ README、Calcit 安装文档、模块模板和 workflow 模板都应优先展示
 ### 确定的解析规则
 
 1. 默认读取仓库根目录的 `deps.cirru`；
-2. 找到且只找到一个合法 `:calcit-version` 时，以它为项目版本；
-3. 同时传入相同的 `version` 时允许执行，但 summary 标为 redundant；
-4. 两者不一致时以 `E_SETUP_VERSION_CONFLICT` 失败，并同时打印两个来源和值；
-5. 没有 `deps.cirru` 或其中没有版本时，才使用显式 `version`；
-6. 两者都不存在时失败，并给出创建 `deps.cirru` 的首选修复方式。
+2. 缺少该文件、或文件中没有 `:calcit-version` 时，才允许使用显式 `version`；
+3. 出现多个声明或任一声明不是合法 SemVer 时，以 `E_SETUP_VERSION_INVALID` 失败，绝不回退
+   到 `version` input；
+4. 找到且只找到一个合法 `:calcit-version` 时，以它为项目版本；
+5. 同时传入相同的 `version` 时允许执行，但 summary 标为 redundant；
+6. 两个合法来源不一致时以 `E_SETUP_VERSION_CONFLICT` 失败，并同时打印两个来源和值；
+7. 两者都不存在时失败，并给出创建 `deps.cirru` 的首选修复方式。
 
 这里不再定义“谁的优先级更高”。存在冲突就代表项目状态不自洽，应先修复项目，而不是猜测
 维护者意图。
@@ -179,7 +181,8 @@ SHA。现有 `@0.0.x` 标签在迁移期继续可用。
 - README 默认示例改为从 `deps.cirru` 读取；
 - 明确解析规则；
 - 两个版本不一致时失败；
-- 加入版本解析、缺失、重复、冲突的单元测试。
+- 加入版本解析、缺失、无声明、重复、畸形 SemVer、冲突的单元测试；重复和畸形声明均断言
+  `E_SETUP_VERSION_INVALID`，即使 workflow 同时给出 `version` input 也不能回退。
 
 ### Phase 1：可靠安装
 

--- a/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
+++ b/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
@@ -60,7 +60,7 @@ workflow 中重复填写 `version`。
 
 ```yaml
 - uses: actions/checkout@v4
-- uses: tiye/setup-calcit@v1
+- uses: calcit-lang/setup-calcit@v1
 ```
 
 对应项目配置：
@@ -91,7 +91,7 @@ README、Calcit 安装文档、模块模板和 workflow 模板都应优先展示
 增加可选的 `deps-file` input，默认值为 `deps.cirru`。它只用于 monorepo 或非根目录项目：
 
 ```yaml
-- uses: tiye/setup-calcit@v1
+- uses: calcit-lang/setup-calcit@v1
   with:
     deps-file: examples/browser/deps.cirru
 ```

--- a/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
+++ b/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
@@ -1,0 +1,227 @@
+# RFC：setup-cr 版本来源与基础工具链契约
+
+状态：Draft
+
+日期：2026-08-21
+
+## 摘要
+
+普通 Calcit 项目的编译器版本应只有一个项目级事实来源：`deps.cirru` 中的
+`:calcit-version`。`setup-cr` 的默认用法只负责读取这个版本并安装相应工具，不再鼓励在
+workflow 中重复填写 `version`。
+
+`version` input 暂不立即删除，因为 setup-cr 自身测试、没有 `deps.cirru` 的临时任务和紧急
+诊断仍然需要显式版本；但它降级为 fallback。若项目同时提供两个不一致的版本，Action 必须
+明确失败，不能再用隐含优先级覆盖。
+
+在这个单一版本来源基础上，setup-cr 可以补齐缓存、校验、平台路径、结构化输出和工具选择等
+基础能力，但仍保持“安装工具”的单一职责。依赖安装、类型门禁和项目测试继续由显式 CI step
+执行。
+
+## 背景
+
+当前 setup-cr README 的主示例仍然展示：
+
+```yaml
+- uses: calcit-lang/setup-cr@0.0.8
+  with:
+    version: "0.9.6"
+```
+
+文档又说 `deps.cirru` 中的版本优先，而当前实现实际先读 `deps.cirru`，随后用 `version` input
+覆盖。这产生了三个问题：
+
+1. 项目升级 `deps.cirru` 后可能忘记同步 workflow，CI 安装旧 CLI；
+2. 使用者无法从文档可靠判断冲突时采用哪个版本；
+3. 旧 CLI 可能重写新 Snapshot 的 schema 或 metadata，最终表现为格式差异、类型退化或陌生的
+   CI 失败，而不是清晰的版本冲突。
+
+2026-08 的 0.13.27 生态升级已实际出现这种失败：项目配置已经升级，workflow 中的固定版本仍
+停留在旧版，旧 formatter 随后改变了新 Snapshot。问题不在 formatter 是否“足够兼容”，而在
+项目同时保存了两个互相矛盾的编译器版本。
+
+当前实现还有一些与规模增长不匹配的基础限制：
+
+- 用正则读取版本但没有检测多个或畸形声明；
+- 下载任务没有统一 await，失败聚合和完成时机不够明确；
+- 安装目录固定为 `/home/runner/bin`，把实现绑定到 Ubuntu 路径；
+- 没有公开 resolved version/source/tool paths 等 outputs；
+- 没有复用 tool cache，也没有下载完整性校验；
+- 已不再需要的 `bundler` input 和 `bundle_calcit` 下载路径仍留在 Action 中；
+- `cr-wasm` 等可选工具继续逐个增加布尔 input，扩展性较弱；
+- Action runtime 版本和测试矩阵需要跟随 GitHub Actions runner 演进。
+
+## 决策一：`deps.cirru` 是正常项目的版本事实来源
+
+推荐文档示例改为：
+
+```yaml
+- uses: actions/checkout@v4
+- uses: calcit-lang/setup-cr@0.0.9
+```
+
+对应项目配置：
+
+```cirru.no-check
+{} $ :calcit-version |0.13.27
+```
+
+README、Calcit 安装文档、模块模板和 workflow 模板都应优先展示无 `version` input 的形式。
+显式 input 移到“无项目文件的任务与故障诊断”小节，不再作为 quick start。
+
+### 确定的解析规则
+
+1. 默认读取仓库根目录的 `deps.cirru`；
+2. 找到且只找到一个合法 `:calcit-version` 时，以它为项目版本；
+3. 同时传入相同的 `version` 时允许执行，但 summary 标为 redundant；
+4. 两者不一致时以 `E_SETUP_VERSION_CONFLICT` 失败，并同时打印两个来源和值；
+5. 没有 `deps.cirru` 或其中没有版本时，才使用显式 `version`；
+6. 两者都不存在时失败，并给出创建 `deps.cirru` 的首选修复方式。
+
+这里不再定义“谁的优先级更高”。存在冲突就代表项目状态不自洽，应先修复项目，而不是猜测
+维护者意图。
+
+### 多目录项目
+
+增加可选的 `deps-file` input，默认值为 `deps.cirru`。它只用于 monorepo 或非根目录项目：
+
+```yaml
+- uses: calcit-lang/setup-cr@v1
+  with:
+    deps-file: examples/browser/deps.cirru
+```
+
+路径必须位于 checkout workspace 内，缺失或包含多个版本声明时明确失败。Action 不递归搜索
+“最像项目”的文件，避免在 monorepo 中安装偶然找到的版本。
+
+## 决策二：扩充基础能力，但不接管项目 CI
+
+### 工具选择
+
+`cr` 和 `caps` 保持默认安装。后续用一个可枚举的 `tools` input 取代不断增加布尔项：
+
+```yaml
+with:
+  tools: cr,caps,cr-wasm
+```
+
+`bundle_calcit` 已经不再需要，不进入 `tools`，对应 `bundler` input 和下载分支直接移除。
+兼容期只需继续接受 `cr-wasm` 布尔 input；转换后得到唯一的 requested tool set。未知工具、
+重复项或目标版本没有对应 artifact 时，在下载前失败。
+
+setup-cr 不增加 `run-tests`、`run-quality`、`install-modules` 等 input。以下步骤必须继续显式
+出现在 workflow 中：
+
+```bash
+caps --ci
+cr calcit.cirru --check-only
+cr calcit.cirru analyze quality
+```
+
+这样 Action 升级不会悄悄改变项目测试范围，失败日志也能清楚区分安装、依赖、类型和运行测试。
+
+### 缓存和安装路径
+
+- 使用 GitHub tool cache 按 `tool/version/platform/arch` 查找和保存工具；
+- 临时下载使用 runner 提供的 temp 目录，不写死 `/home/runner`；
+- 最终通过 `core.addPath` 暴露缓存目录；
+- 所有下载 Promise 必须 await，任一失败后不报告安装成功；
+- 相同 job 内重复调用时复用缓存并保持幂等。
+
+平台和架构必须进入 release artifact lookup。MVP 只声明并测试实际发布了二进制的组合；不把
+Ubuntu 上的裸文件名假装成跨平台协议。
+
+### 完整性与版本自检
+
+短期至少在安装后执行轻量版本自检，确认 `cr` 输出的版本与 resolved version 一致。中期由
+Calcit release 发布机器可读 manifest，包含：
+
+- release version；
+- tool name；
+- platform 与 architecture；
+- asset name；
+- SHA-256；
+- 可选的 Snapshot/capability schema version。
+
+Action 先验证 checksum，再加入 PATH。下载到了 HTML 错误页、旧缓存或命名错误的 artifact 时，
+应在 setup 阶段失败。
+
+### Outputs 与 Job Summary
+
+稳定 outputs：
+
+| output | 含义 |
+| --- | --- |
+| `version` | 最终解析出的 Calcit 版本 |
+| `version-source` | `deps-file` 或 `input` |
+| `deps-file` | 实际读取的项目文件路径；无则为空 |
+| `tools` | 成功安装的规范化工具列表 |
+| `cache-hit` | 是否全部来自 tool cache |
+
+Job Summary 只记录版本来源、工具、平台、缓存命中和自检结果，不输出 token、下载 header 或其他
+环境敏感信息。
+
+## 文档迁移
+
+1. setup-cr README quick start 删除显式 `version`；
+2. Calcit README 将 `:calcit-version` 从“CI hint”提升为项目工具链版本；
+3. workflow 模板统一只引用 setup-cr release，不复制 Calcit 版本；
+4. 显式版本用法放入 advanced usage，并说明不应与 `deps.cirru` 冲突；
+5. 错误文案修正历史拼写 `calcit-verison`，并给出实际读取路径。
+
+Action 发布稳定接口后建议提供可移动 major tag，例如 `@v1`；安全要求更高的仓库仍可固定 commit
+SHA。现有 `@0.0.x` 标签在迁移期继续可用。
+
+## 实施阶段
+
+### Phase 0：文档与冲突检测
+
+- README 默认示例改为从 `deps.cirru` 读取；
+- 明确解析规则；
+- 两个版本不一致时失败；
+- 加入版本解析、缺失、重复、冲突的单元测试。
+
+### Phase 1：可靠安装
+
+- await 全部下载；
+- 使用 runner temp 和 tool cache；
+- 增加 resolved outputs、summary 和安装后版本自检；
+- 将 Action runtime 升到 GitHub 当前支持版本。
+
+### Phase 2：工具与平台矩阵
+
+- 引入 `deps-file`、`tools`；
+- 保持 `cr-wasm` input 的兼容转换与 deprecation 提示，移除已废弃的 `bundler`；
+- 对实际支持的 OS/architecture 运行 self-test；
+- 缺失 release artifact 时给出结构化错误。
+
+### Phase 3：release manifest
+
+- Calcit release 产生 checksums/manifest；
+- setup-cr 校验下载完整性和 capability metadata；
+- 缓存 key 纳入 manifest/schema version。
+
+## 验收标准
+
+1. 正常项目的 workflow 不填写 Calcit 版本，只改 `deps.cirru` 即可完成升级。
+2. `deps.cirru` 与 input 冲突时，Action 在下载前失败并展示两个来源。
+3. 安装日志能证明最终版本、来源、工具、平台和缓存状态。
+4. 任一工具下载或自检失败时 Action 必须失败，不能留下部分成功状态。
+5. setup-cr 自身测试覆盖无 deps、合法 deps、畸形 deps、重复声明、冲突和 artifact 缺失。
+6. Action 不隐式运行 `caps`、formatter、类型门禁或业务测试。
+7. 支持的平台都不依赖硬编码 `/home/runner` 路径。
+
+## 非目标
+
+- 让 setup-cr 成为新的包管理器；
+- 自动修改 `deps.cirru`；
+- 替项目选择“最新”版本；
+- 隐式运行项目 CI；
+- 通过兼容 formatter 掩盖 CLI/Snapshot 版本冲突。
+
+## 相关资料
+
+- `README.md`
+- `docs/run/library-quality.md`
+- `RFCs/07-28-git-module-store-rfc.md`
+- `RFCs/08-21-type-quality-ci-adoption-rfc.md`

--- a/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
+++ b/RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md
@@ -72,7 +72,7 @@ README、Calcit 安装文档、模块模板和 workflow 模板都应优先展示
 ### 确定的解析规则
 
 1. 默认读取仓库根目录的 `deps.cirru`；
-2. 缺少该文件、或文件中没有 `:calcit-version` 时，才允许使用显式 `version`；
+2. 所选 `deps-file` 缺失、或文件中没有 `:calcit-version` 时，才允许使用显式 `version`；
 3. 出现多个声明或任一声明不是合法 SemVer 时，以 `E_SETUP_VERSION_INVALID` 失败，绝不回退
    到 `version` input；
 4. 找到且只找到一个合法 `:calcit-version` 时，以它为项目版本；
@@ -93,8 +93,10 @@ README、Calcit 安装文档、模块模板和 workflow 模板都应优先展示
     deps-file: examples/browser/deps.cirru
 ```
 
-路径必须位于 checkout workspace 内，缺失或包含多个版本声明时明确失败。Action 不递归搜索
-“最像项目”的文件，避免在 monorepo 中安装偶然找到的版本。
+路径必须位于 checkout workspace 内。缺失的所选文件等同于没有项目声明：只能使用显式
+`version`，没有该 input 时以 `E_SETUP_VERSION_MISSING` 失败；多个或畸形版本声明均以
+`E_SETUP_VERSION_INVALID` 失败且不能回退。Action 不递归搜索“最像项目”的文件，避免在
+monorepo 中安装偶然找到的版本。
 
 ## 决策二：扩充基础能力，但不接管项目 CI
 
@@ -181,8 +183,9 @@ SHA。现有 `@0.0.x` 标签在迁移期继续可用。
 - README 默认示例改为从 `deps.cirru` 读取；
 - 明确解析规则；
 - 两个版本不一致时失败；
-- 加入版本解析、缺失、无声明、重复、畸形 SemVer、冲突的单元测试；重复和畸形声明均断言
-  `E_SETUP_VERSION_INVALID`，即使 workflow 同时给出 `version` input 也不能回退。
+- 加入版本解析、默认或显式 `deps-file` 缺失、无声明、重复、畸形 SemVer、冲突的单元测试；
+  缺失文件只在给出 input 时回退，重复和畸形声明均断言 `E_SETUP_VERSION_INVALID`，即使
+  workflow 同时给出 `version` input 也不能回退。
 
 ### Phase 1：可靠安装
 
@@ -210,7 +213,8 @@ SHA。现有 `@0.0.x` 标签在迁移期继续可用。
 2. `deps.cirru` 与 input 冲突时，Action 在下载前失败并展示两个来源。
 3. 安装日志能证明最终版本、来源、工具、平台和缓存状态。
 4. 任一工具下载或自检失败时 Action 必须失败，不能留下部分成功状态。
-5. setup-cr 自身测试覆盖无 deps、合法 deps、畸形 deps、重复声明、冲突和 artifact 缺失。
+5. setup-cr 自身测试覆盖默认或显式缺失 deps、合法 deps、畸形 deps、重复声明、冲突和
+   artifact 缺失。
 6. Action 不隐式运行 `caps`、formatter、类型门禁或业务测试。
 7. 支持的平台都不依赖硬编码 `/home/runner` 路径。
 

--- a/RFCs/08-21-static-type-system-evolution-roadmap.md
+++ b/RFCs/08-21-static-type-system-evolution-roadmap.md
@@ -1,0 +1,309 @@
+# RFC：Calcit 静态类型系统长期演进路线
+
+状态：Draft
+
+日期：2026-08-21
+
+## 摘要
+
+Calcit 长期继续借鉴 Rust 与 MoonBit：使用名义数据类型、Enum、Option/Result、trait、穷尽模式
+匹配、局部推断、明确 unsafe/FFI 边界和工具链一体化，逐步提高“typed core 中静态通过即不会发生
+普通类型错误”的可信度。
+
+这里的“借鉴”不是复制语言表面。Calcit 保留持久化数据、GC/运行时值模型、Snapshot、热更新和
+多后端特点；不因为 Rust 成功就引入与当前 value model 不相容的 borrow checker，也不因为 JS
+生态复杂就复制 TypeScript 的结构类型、union 与 overload。
+
+路线优先级是：先堵住精度静默丢失和 FFI unsafe 边界，再完善控制流与局部推断，然后根据真实
+抽象需求扩展 trait。每一步必须通过生态 quality baseline 与真实消费者回归渐进落地。
+
+## 当前基础
+
+Calcit 已有：
+
+- primitive、List/Map/Set/Ref/Fn 等参数化 schema；
+- 名义 Struct、Enum、Trait、Impl 及定义值类型；
+- 显式 generics、TypeVar、`:where` trait constraints；
+- `Option<T>`、`Result<T,E>`、`Unit`、`JsNullish<T>`；
+- applied generic Struct/Enum；
+- bottom-up 推断和调用点泛型绑定；
+- `check-types`、`weak-types`、`quality` 和结构化诊断；
+- JS/native/WASM 等后端前的统一预处理。
+
+这些足以支持一条渐进增强路线，不需要重做类型 AST 或切换到完全不同的语言家族。
+
+## 需要解决的核心矛盾
+
+### `Dynamic` 同时表示意图和失败
+
+当前 `Dynamic` 既可以表示维护者明确选择的开放边界，也可能来自：
+
+- 缺少容器参数；
+- 无法绑定的 TypeVar；
+- 未解析 type slot；
+- 旧 Snapshot 或未知 schema；
+- 推断无法继续时的兼容 fallback。
+
+后续 `weak-types` 虽能找回部分证据，但类型检查阶段已经把“允许任意值”和“我们还不知道”混在
+一起。长期应分离 intentional Dynamic 与内部 Unknown/Unresolved。
+
+### 静态正确与后端正确尚未完全闭环
+
+纯 Calcit、JS FFI、native dylib 和内部 WASM 验证后端承担的保证不同。逻辑 schema、target
+capability、ABI transport 和真实宿主值不能被一个 `matches` 结果混成同一层。
+
+长期模型应是：
+
+```text
+source schema
+  -> inference/type checking
+  -> capability/target validation
+  -> backend contract/ABI validation
+  -> runtime tests for external facts
+```
+
+每层只增加证据，不让 runtime fallback 反过来伪装成静态推断成功。
+
+### 大型框架缺少低摩擦的类型表面
+
+Editor/Respo 类项目中的 Dynamic 集中在 store、component props、dispatch、effect callback 和
+生命周期。这既有历史债务，也说明当前显式 schema 在高阶 UI 代码中成本偏高。解决方案优先是
+改进框架公共类型、局部推断和诊断，而不是直接放宽为结构类型。
+
+## 借鉴范围
+
+### 从 Rust 借鉴
+
+- Enum/Struct 作为主要领域数据模型；
+- Option/Result/Unit/Never 的明确控制流含义；
+- match 穷尽性和不可达分支诊断；
+- trait/impl coherence 与明确的泛型约束；
+- unsafe 是小而可审计的边界；
+- 错误带 expected/actual、来源和可执行修复路径。
+
+暂不借鉴所有权/借用语义。Calcit 的 persistent collection、runtime object、热更新和多后端模型
+与 Rust 资源生命周期不同。若未来需要文件句柄、socket、WASM linear resource 等线性能力，
+应先以独立 resource/effect RFC 证明需求，不把 borrow checker 作为类型系统成熟度指标。
+
+### 从 MoonBit 借鉴
+
+- 局部、可预测的类型推断，减少重复 annotation；
+- 名义 ADT、pattern matching、trait 与泛型的统一开发体验；
+- 编译器、formatter、test、doc、package/CI 作为同一工具链；
+- 对不同后端保持共享类型语义，并在后端边界明确报告限制；
+- 快速反馈和高质量诊断优先于追求最大理论表达力。
+
+不复制其他语言的具体语法或包格式。Calcit 的 Cirru/Snapshot 是自己的事实来源，演进必须保留
+结构编辑和可迁移性。
+
+## 设计不变量
+
+未来类型功能必须满足：
+
+1. 普通 typed core 不因 backend 不同获得不同的类型匹配结果；
+2. FFI metadata、feature/effect 和 ABI transport 不污染普通 nominal type identity；
+3. 无法证明时保留 Unknown evidence，不伪装为成功 specialization；
+4. explicit Dynamic 永远可被 query/quality 解释其 intent；
+5. 新规则先进入 preprocess/analyze，不向 interpreter 增加无关运行时特判；
+6. 诊断包含 definition、path、expected、actual、evidence loss 和修复建议；
+7. 新严格规则通过 baseline/entry policy 渐进启用；
+8. native 与 JS 是公开语义后端，内部 WASM 验证后端不静默返回假结果。
+
+## 路线 A：精度与 sound boundary
+
+### A1. `Unknown/Unresolved` 内部状态
+
+内部增加“不足以完成推断”的 evidence 状态，但不一定立即成为用户可写类型：
+
+- 缺少 generic args；
+- unbound TypeVar；
+- unresolved type slot；
+- 未知 imported schema；
+- 分支无法合并。
+
+它不能像 Dynamic 一样双向匹配所有类型。兼容模式可在最终边界降为 Dynamic，同时产生稳定诊断；
+strict policy 下阻止公开 API、typed decoder 和 FFI 强类型 assertion 使用 unresolved value。
+
+### A2. 显式 Dynamic intent
+
+逐步让 intentional boundary 可由 schema/metadata 表达原因，例如 js-ffi、framework state、macro、
+open data。quality 仍显示这些位置，但与 unresolved 使用不同策略。不要通过注释文本或文件路径
+猜测 intent。
+
+### A3. unsafe inventory
+
+`unsafe-coerce`、raw host operation、native ABI assertion 进入统一 inventory。目标不是禁止 unsafe，
+而是做到 Rust 式“边界很小、调用原因可查、测试责任清楚”。
+
+## 路线 B：控制流与代数数据
+
+### B1. 穷尽性与 Never
+
+- named Enum match 检查所有 variants；
+- duplicate/unreachable pattern 诊断；
+- `Never` 表示必然终止、raise、todo trap 等无返回路径；
+- 分支合并理解 Never，不要求用 Dynamic/nil 填补；
+- Option/Result helper 与 match 保留 payload 精度。
+
+### B2. Narrowing
+
+只对可证明的语言结构做 flow-sensitive narrowing：
+
+- Option/Result/Enum variant match；
+- nil/nullish presence check；
+- predicate 若有明确 compiler-known contract，可收窄对应分支；
+- assertion 只在成功分支增加 evidence。
+
+不引入任意 JavaScript property test 驱动的结构化 narrowing，也不从字符串比较推导复杂 union。
+
+### B3. Data decoding
+
+将严格 Cirru EDN decoder、Map-to-Struct 和未来 JS data decoder 统一建立在 closed data shape 上。
+Dynamic、裸容器和 unresolved slot 不能生成一个看似安全的 decoder。
+
+## 路线 C：局部推断与泛型体验
+
+### C1. 双向检查
+
+在已有 bottom-up inference 上增加 expected-type 向下传播，优先覆盖：
+
+- lambda 作为已知 Fn 参数；
+- Struct/Enum constructor payload；
+- Option/Result method chain；
+- collection literal 的元素/键值；
+- callback return；
+- match branch expected result。
+
+目标是减少重复 annotation，而不是进行不可预测的全程序推断。
+
+### C2. 泛型诊断
+
+泛型失败需要解释：
+
+- 哪个参数绑定了 TypeVar；
+- 哪两个约束冲突；
+- outer shape 是否仍被保留；
+- 是否因 Dynamic/Unknown 丢失 specialization；
+- 可选择补 annotation、泛型或 trait bound 的具体位置。
+
+### C3. Trait coherence
+
+先稳定 impl identity、conflict、selection 和 where-bound 诊断。generic trait、associated type 或
+higher-kinded abstraction 只有同时满足以下条件才进入独立 RFC：
+
+- 至少三个非 FFI 的真实生态用例；
+- 不需要结构化自动满足；
+- 能定义明确 coherence/overlap 规则；
+- native/JS 语义和 query evidence 一致；
+- 不显著恶化常见代码的推断耗时与错误可读性。
+
+## 路线 D：框架与 effect
+
+### D1. 框架类型表面
+
+先在 Respo/Editor 试点：
+
+- 标准化 Store、Reel、Dispatch、Component Props、Effect Callback；
+- 用 generic Struct/Enum/Fn 保留 state/action 关系；
+- framework intentional boundary 只留在入口和生命周期 adapter；
+- 业务 component 内不依赖全局 Dynamic。
+
+如果固定字段 props 的书写成本仍然过高，可以讨论 record/row ergonomics，但必须保留封闭字段、
+名义导出和清晰错误；不直接采用 TypeScript 开放 object type。
+
+### D2. Feature、effect 与 resource 分离
+
+`:features` 表示实现体允许使用的 capability；未来 `:effects` 若存在，表示可传播的 effect；resource
+若需要线性/生命周期约束，则是第三个独立概念。三者不能都塞进 Fn equality 或用一个 set 同时解释。
+
+优先通过 effects graph、query 和 lint 积累用例，再决定是否进入函数类型。
+
+## 兼容与采用
+
+### Strict policy，而非全局硬切换
+
+建议 entry/project policy 逐步提供：
+
+- compatible：允许历史 Dynamic fallback，输出 evidence；
+- ratchet：不得比提交的 quality baseline 增加债务；
+- strict：公开 API、decoder、FFI typed boundary 不允许 unresolved；
+- core：Calcit core/stdlib 使用的更强内部门禁。
+
+名称可以在实现 RFC 中调整，但含义必须清楚。新模块从 strict/zero baseline 开始，历史应用使用
+ratchet，避免每次类型增强引发全生态同步重写。
+
+### 生态验证集
+
+类型系统改动不能只通过 compiler fixtures。至少维护：
+
+- 小型纯库：bisection-key、memof；
+- 高覆盖 FFI：js-ffi、calcit-wss；
+- native dylib：http/wss/fetch 类项目；
+- 框架：recollect、Respo workflow；
+- 大型应用：Editor、网站；
+- native 与 JS 生成/运行；
+- 内部 WASM subset regression。
+
+每次 release 记录 quality baseline delta、诊断变化、后端矩阵和至少一个关键消费者结果。
+
+## 明确暂缓的方向
+
+- 通用 union/intersection/conditional types；
+- TypeScript 式 structural object satisfaction；
+- 任意 overload resolution；
+- 由 JS FFI 单独驱动 generic trait/associated type；
+- 没有资源用例支撑的 borrow checker；
+- 全程序隐式 HM inference；
+- 把 feature/effect/target 混入普通 Fn 匹配；
+- 为每个后端维护不同的核心类型规则。
+
+暂缓不等于永久拒绝；重新提出时必须带真实用例、迁移成本、诊断设计和多后端验证。
+
+## 实施顺序
+
+### Phase 1：保证边界诚实
+
+- 区分内部 Unknown 与 intentional Dynamic；
+- unresolved type slot/generic 不再静默 specialization；
+- unsafe/FFI inventory；
+- quality baseline 在参考模块落地。
+
+### Phase 2：提高 typed core 表达力
+
+- Enum exhaustiveness、Never 和 narrowing；
+- lambda/constructor/callback 的双向检查；
+- 泛型 binding evidence 与冲突诊断。
+
+### Phase 3：框架试点
+
+- Respo/Editor 的 typed state/props/dispatch；
+- 观察是否需要 record ergonomics、generic trait 或 effect contract；
+- 只有数据证明后才提交独立核心扩展 RFC。
+
+### Phase 4：稳定性承诺
+
+- strict policy 成为新模块默认；
+- pure typed core 的 runtime type failure 建立 compiler bug 分类与 regression test；
+- FFI/runtime/ABI 失败有独立 contract 错误和验证矩阵；
+- 类型与诊断机器协议遵循兼容版本策略。
+
+## 成功标准
+
+1. 新模块不使用 Dynamic 也能自然表达常见业务和 callback 数据流。
+2. intentional Dynamic 与 inference failure 在 query/quality 中完全可区分。
+3. pure typed core 出现普通类型 runtime failure 时可以稳定归类为 compiler defect。
+4. Editor/Respo 的 Dynamic 主要收缩到框架入口，而不是遍布业务 definition。
+5. FFI 类型通过后仍由 target/contract tests 提供宿主证据，错误能够指回 Calcit binding。
+6. 新类型特性不会让不使用它的程序改变 trait candidate 或 backend 行为。
+7. 生态升级使用 baseline ratchet，不再依靠一次性大规模改写。
+
+## 与既有 RFC 的关系
+
+- `02-18-language-theory-evolution-plan.md` 继续描述 law、语义分层和类型驱动诊断愿景；本 RFC
+  补充静态类型 sound boundary、推断、控制流和生态采用路线。
+- `07-26-static-semantic-analysis-rfc.md` 是 evidence/diagnostic 基础。
+- `08-05-systematic-nil-reduction-rfc.md` 是 Option/Result/Unit/Never 路线的具体迁移。
+- `08-18-calcit-typed-js-ffi-boundary-rfc.md` 和
+  `08-21-js-ffi-runtime-contract-validation-rfc.md` 负责宿主边界。
+- `08-21-type-quality-ci-adoption-rfc.md` 负责把类型演进安全地推入生态。
+

--- a/RFCs/08-21-type-quality-ci-adoption-rfc.md
+++ b/RFCs/08-21-type-quality-ci-adoption-rfc.md
@@ -1,0 +1,273 @@
+# RFC：Calcit 生态类型质量门禁与 CI 采用方案
+
+状态：Draft
+
+日期：2026-08-21
+
+## 摘要
+
+Calcit 已提供 `analyze check-types`、`analyze weak-types` 和原生 `analyze quality`，并支持按
+definition 保存 baseline。现在缺少的不是另一套统计脚本，而是一份跨模块的采用协议：什么是
+定位报告，什么是发布门禁；新项目与存量项目如何采用；baseline 如何审阅和收紧；静态通过后
+还需要哪些后端运行证据。
+
+本 RFC 规定：
+
+1. 类型质量门禁统一使用 `cr analyze quality`，不得在各仓库自行拼 JSON 或补 JS 比较脚本；
+2. 新模块默认零容忍，存量模块提交按 definition 的 baseline 并只允许逐步收紧；
+3. 类型门禁只是 CI 的静态层，不能替代 native/JS/browser/dylib 的实际运行测试；
+4. 文档、模板、机器输出和 baseline 更新流程形成一条可追溯的生态规范。
+
+## 已有能力
+
+当前仓库已经具备：
+
+- `check-types`：统计 full/partial/none 类型覆盖；
+- `weak-types`：定位 schema/code 中的 Dynamic、nil/Optional 和其他弱类型证据；
+- intent 分类：区分 unresolved debt 与已知 FFI/framework boundary；
+- definition/path、impact、suggestion 等结构化定位信息；
+- `analyze quality`：以非零退出码阻止类型质量回归；
+- `--write-baseline` / `--baseline`：按 definition 保存预算，避免一处清债抵消另一处新增；
+- 单一 JSON envelope，适合 CI 保存和消费。
+
+概念指南见 `docs/type-guidance.md`，完整类库验收矩阵见
+`docs/run/library-quality.md`。本 RFC 不复制这两份 how-to，而是为整个生态规定采用和演进政策。
+
+## 问题
+
+### 工具存在，但采用方式不统一
+
+生态项目目前混合使用以下策略：
+
+- 只运行默认 entry；
+- 只执行 `--check-only`；
+- 分别调用 `check-types` / `weak-types`，但不根据退出码形成门禁；
+- 在 workflow 中用 shell、jq 或 JavaScript 自己比较统计数字；
+- 每次 CI 重新生成 baseline，等同于自动接受新债务；
+- 只生成 JS，不实际执行 Node/browser 测试。
+
+这些 workflow 表面都叫“type check”，实际保证不同，后续升级无法判断失败是新增债务、输出协议
+变化还是自定义脚本失效。
+
+### 类型覆盖率不是正确性证明
+
+类型 full 只说明声明和静态推断足够完整。它不能证明：
+
+- JavaScript import/export 在目标 runtime 中存在；
+- `unsafe-coerce` 的宿主值真的满足声明；
+- browser binding 没有在 Node entry 使用；
+- callback 参数、返回值和 exception 行为符合 FFI 契约；
+- native dylib 的 ABI 与 `cirru_edn` 版本一致；
+- 已生成 JS 与当前 `@calcit/procs` runtime 相容。
+
+因此静态质量与后端契约测试必须分别保留，不能用一项绿色 check 代表全部质量。
+
+## 统一质量层级
+
+每个模块在 README 或维护文档中声明当前采用层级：
+
+| 层级 | 必需证据 | 适用范围 |
+| --- | --- | --- |
+| Q0 Snapshot | `edit format` 无 diff、`--check-only` | 所有项目 |
+| Q1 Type ratchet | `analyze quality` 零容忍或已审阅 baseline | 所有维护中的模块 |
+| Q2 Public API | 公开 API full 优先、examples/docs/test entry | 可复用类库 |
+| Q3 Backend contract | 实际执行声明支持的 native/JS/browser/dylib 路径 | FFI、workflow、应用 |
+| Q4 Consumer | 至少一个真实下游回归 | 核心库、编译器、关键基础模块 |
+
+层级是累积的。Q3 不能跳过 Q1，Q1 也不能声称已覆盖运行时正确性。历史项目可以从 Q0/Q1
+开始，不因一次迁移被迫达到 Q4。
+
+## 规范 CI
+
+### 安装与版本
+
+工具版本来自 `deps.cirru`：
+
+```yaml
+- uses: actions/checkout@v4
+- uses: calcit-lang/setup-cr@0.0.9
+```
+
+普通项目不在 workflow 重复填写 `version`。setup-cr 的详细契约由
+`08-21-setup-cr-version-and-toolchain-contract-rfc.md` 规定。
+
+### Q0 + Q1 基础门禁
+
+新项目：
+
+```bash
+caps --ci
+cr calcit.cirru edit format
+git diff --exit-code -- calcit.cirru
+cr calcit.cirru --check-only
+cr calcit.cirru analyze quality --format json
+```
+
+存量项目只把最后一行改为：
+
+```bash
+cr calcit.cirru analyze quality \
+  --baseline config/calcit-quality.json \
+  --format json
+```
+
+`check-types` 与 `weak-types` 用于本地定位和 PR 解释，不再承担自定义退出逻辑：
+
+```bash
+cr calcit.cirru analyze check-types --summary-only
+cr calcit.cirru analyze weak-types \
+  --only schema-dynamic,code-dynamic \
+  --intent unresolved
+```
+
+CI 可以保存 JSON 报告，但不得解析若干子报告后自行发明总分。需要新的质量维度时，先扩展
+`analyze quality` 的版本化协议，再由所有项目统一升级。
+
+### Q2 公开 API
+
+可复用类库至少增加：
+
+```bash
+cr calcit.cirru analyze check-examples --ns package.api
+cr calcit.cirru docs format-md README.md --check
+cr calcit.cirru docs check-md README.md --failures-only
+cr calcit.cirru --entry test
+```
+
+没有 examples 且命令退出零不代表覆盖完成。公开 definition 必须由 runnable example 或明确的
+测试 entry 覆盖。公开 API 新增 `Dynamic` 时，即使 baseline 仍有余额，也要求 PR 说明它属于哪种
+边界、为什么不能使用泛型/trait/Enum/Option/Result。
+
+### Q3/Q4 后端与消费者
+
+- JS 模块：codegen 后实际运行 Node test；browser API 运行 headless browser smoke/contract test；
+- native dylib：build、复制实际 artifact、由目标 `cr` 进程装载并调用；
+- 多 entry：逐一运行声明支持的 mode/target，不能只测 default；
+- 核心/基础库：记录至少一个真实消费者仓库、commit、entry 和命令。
+
+后端矩阵由项目显式维护，不能交给 setup-cr 自动猜测。
+
+## Baseline 治理
+
+### 首次创建
+
+```bash
+cr calcit.cirru analyze quality \
+  --write-baseline config/calcit-quality.json
+```
+
+生成后必须人工审阅：
+
+- debt 是否确实属于当前项目，而非未加载依赖或错误 entry；
+- intentional FFI/framework 分类是否准确；
+- public API 的 Dynamic 是否可以先收窄；
+- baseline 中每个 definition 是否有负责人或迁移方向。
+
+审阅完成后将文件提交。CI 永远不能先 `--write-baseline` 再 `--baseline`。
+
+### 更新规则
+
+1. 一般 PR 只允许删除或降低 definition 预算；
+2. 新增债务需要独立说明，不与无关功能提交混在一起；
+3. 重命名/移动 definition 时，由工具提供可审阅迁移，不能整体重建以抹去历史；
+4. 编译器新增质量维度时，先输出 migration summary，再更新 baseline schema version；
+5. baseline 文件包含生成它的 quality schema version，不绑定机器绝对路径或时间戳；
+6. intentional boundary 也进入可见报告，只是不与 unresolved debt 使用同一失败策略。
+
+长期目标是让重点模块 baseline 归零，而不是永久维护一个“允许 Dynamic 的白名单”。
+
+## 文档体系
+
+避免同一命令在多个位置出现互相矛盾的解释：
+
+| 文档 | 职责 |
+| --- | --- |
+| `docs/type-guidance.md` | 如何选择具体类型、泛型、trait、Option/Result |
+| `docs/run/library-quality.md` | 可复制的本地与 CI 验收步骤 |
+| 本 RFC | 生态采用、层级、baseline 治理与演进政策 |
+| setup-cr README | 只说明工具安装和版本来源 |
+| 模块 README | 声明本项目达到的质量层级与特有后端矩阵 |
+
+新增质量能力时先更新机器命令和这张职责表，再更新模板；不把临时 shell/JS 脚本复制到多个
+仓库成为事实标准。
+
+## 生态推进顺序
+
+### 第一批：参考项目
+
+- `js-ffi`、`calcit-wss`：保持高类型覆盖，补 Q3 runtime contract；
+- `calcit-http`：为 native callback/options 建立显式 FFI 契约；
+- `bisection-key`：清理容器与泛型 Dynamic，验证存量 baseline 收紧流程；
+- `calcit.std`：作为零容忍或低 baseline 的类库模板。
+
+### 第二批：框架
+
+- `memof`、`recollect`、`respo-calcit-workflow`：先收敛 store、dispatch、callback schema；
+- 把确实属于框架开放边界的 Dynamic 标明 intent；
+- 避免每个应用重复声明同一套框架生命周期类型。
+
+### 第三批：大型应用
+
+- Editor 和网站项目先建立 baseline；
+- 以 namespace/definition 为单位收紧，不做一次性全量重写；
+- 优先处理全局 state、组件 props、effect callback 和跨模块公共 API。
+
+## 机器协议要求
+
+`analyze quality --format json` 应保持：
+
+- stdout 是单一 envelope；
+- stderr 只输出人类摘要和进度；
+- schema version 显式存在；
+- failure reason 区分当前债务、相对 baseline 的新增、baseline 过期和工具配置错误；
+- occurrence 包含 definition、namespace、path、kind、intent、impact、suggestion；
+- 退出码稳定区分 quality failure 与命令/解析失败。
+
+如果 GitHub annotations 或 SARIF 有明确需求，应由 `cr` 原生输出或提供统一转换器。各项目不再
+自行实现一份脆弱的 JS parser。
+
+## 实施阶段
+
+### Phase 0：采用与模板
+
+- 将本 RFC、type guidance、library quality guide 互相链接；
+- 更新模块模板为 setup-cr 无 version + `analyze quality`；
+- 选取四个第一批项目记录 baseline/zero-tolerance 实践。
+
+### Phase 1：协议稳定
+
+- 固定 quality JSON 与 baseline schema version；
+- 补 baseline rename/move 和过期诊断；
+- 提供统一的 GitHub annotation/SARIF 输出时仍保持原生命令为事实来源。
+
+### Phase 2：后端契约接入
+
+- 将 JS FFI unsafe/coercion 和 native ABI 风险纳入质量维度；
+- quality summary 链接对应 Q3 测试，但不伪装成已执行 runtime test；
+- 重点模块逐步从 Q1 推进到 Q3/Q4。
+
+## 验收标准
+
+1. 新 Calcit module 不需要自写 JS 脚本即可阻止类型债务回归。
+2. 存量 module 的 baseline 不会因每次 CI 重建而自动放宽。
+3. CI 日志能明确区分 Snapshot、type quality、backend runtime 和 consumer regression。
+4. 至少四个参考项目采用同一套 Q0/Q1 命令，并记录各自 Q3 矩阵。
+5. 新增 quality 指标通过版本化协议进入生态，不要求所有仓库同时修改自定义 parser。
+6. `full` 类型覆盖不再被文档描述为 FFI/runtime 正确性的充分证明。
+
+## 非目标
+
+- 用单一分数比较不同规模项目；
+- 要求所有历史应用立即零债务；
+- 把 intentional FFI boundary 隐藏出报告；
+- 让 setup-cr 隐式执行项目测试；
+- 以静态门禁替代真实后端运行。
+
+## 相关资料
+
+- `docs/type-guidance.md`
+- `docs/run/library-quality.md`
+- `RFCs/07-26-static-semantic-analysis-rfc.md`
+- `RFCs/08-21-setup-cr-version-and-toolchain-contract-rfc.md`
+- `RFCs/08-21-js-ffi-runtime-contract-validation-rfc.md`
+

--- a/RFCs/README.md
+++ b/RFCs/README.md
@@ -1,6 +1,6 @@
 # RFC 整理索引
 
-更新时间：2026-08-18
+更新时间：2026-08-21
 
 ## 目录原则
 
@@ -37,7 +37,6 @@
 | `07-26-safe-structured-editing-rfc.md`              | Draft         | revision/fingerprint 前置条件、事务编辑、语义 diff 与受影响范围验证。                                                  |
 | `07-26-agent-docs-and-evaluation-rfc.md`            | Draft         | 结构化文档上下文、默认检索范围和 Agent 接口基准。                                                                        |
 | `07-28-git-module-store-rfc.md`                     | Draft         | 保持 `deps.cirru` 与 Git 模块路径，以 tag 为最佳实践并使用 pnpm 式全局目录存储；不引入 registry、lockfile、workspace 或多版本。 |
-| `07-28-project-tooling-contract-rfc.md`             | Draft         | 在既有 `cr` 子命令上补强单项目工具契约，保持 EDN 树形事实来源。                                                        |
 | `07-28-persistent-tree-cursor-rfc.md`               | Draft         | `.calcit/` 本地状态、虚拟 cursor、region/marks/last-query、结构化 clipboard 与 path 迁移。                            |
 | `08-14-architecture-scaffold-rfc.md`                | Implemented   | Cirru EDN architecture graph、existing-definition reconciliation、atomic scaffold apply、work items 与多 Agent 分工边界。 |
 | `08-14-todo-placeholder-rfc.md`                      | Partial       | compiler-known `todo!`、`W_TODO` 与 native/JS/WASM 中止行为已落地；完整 Never/control-flow inference 后续实现。 |
@@ -45,6 +44,10 @@
 | `08-05-systematic-nil-reduction-rfc.md`              | Partial       | 类型驱动减少 nil：先拆分可省略参数与 nullable 值，再迁移至 Option/Result 并逐步收紧 typed code。                  |
 | `08-08-cross-backend-host-ffi-contracts-rfc.md`      | Draft         | 统一 JS/native/WASM/WASI 的逻辑 FFI 契约与诊断，ABI transport 保持 backend-specific；首个完整 shape consumer 为 JS/DOM。 |
 | `08-18-calcit-typed-js-ffi-boundary-rfc.md`           | Draft         | 在现有 Struct/Enum/Fn/trait 上补齐 JS capability gate 与 target validation；FFI metadata 不进入普通 trait 匹配和泛型推断。 |
+| `08-21-setup-cr-version-and-toolchain-contract-rfc.md` | Draft       | 以 `deps.cirru` 为正常项目的唯一 Calcit 版本来源，补齐 setup-cr 的冲突检测、缓存、自检、outputs 与工具选择。 |
+| `08-21-type-quality-ci-adoption-rfc.md`               | Draft       | 统一使用原生 `analyze quality` 与按 definition baseline，定义生态 CI 层级并禁止各项目重复实现 JS 汇总脚本。 |
+| `08-21-js-ffi-runtime-contract-validation-rfc.md`     | Draft       | 在现有 typed JS FFI 声明之上增加 host guard、decoder、runtime contract tests 与 unsafe evidence。 |
+| `08-21-static-type-system-evolution-roadmap.md`       | Draft       | 借鉴 Rust/MoonBit 推进 Unknown/Dynamic 分离、穷尽性、局部推断、trait coherence 与框架类型化。 |
 
 ## 已执行的清理
 

--- a/docs/installation/github-actions.md
+++ b/docs/installation/github-actions.md
@@ -42,10 +42,11 @@ Then install it after checkout. Do not repeat the Calcit version in the workflow
 - uses: calcit-lang/setup-cr@0.0.9
 ```
 
-`setup-cr` reads `deps.cirru` when no explicit version input is supplied. Use an explicit version only
-for a task that intentionally has no project `deps.cirru`; do not provide two version sources for a
-regular project. The Action release controls installer behavior, while `:calcit-version` controls which
-`cr` and `caps` release the project uses.
+`setup-cr` reads the selected `deps.cirru` when no explicit version input is supplied. A missing selected
+file is treated as a task without a project declaration, so it requires an explicit version; a file with
+no `:calcit-version` behaves the same way. Malformed or duplicate declarations fail rather than falling
+back to `version`. Do not provide two version sources for a regular project. The Action release controls
+installer behavior, while `:calcit-version` controls which `cr` and `caps` release the project uses.
 
 Then to load packages defined in `deps.cirru` with `caps`:
 

--- a/docs/installation/github-actions.md
+++ b/docs/installation/github-actions.md
@@ -1,5 +1,6 @@
 ---
 title: "GitHub Actions"
+summary: "Use setup-cr with the project version in deps.cirru, then run caps and the native quality gate."
 scope: "core"
 kind: "reference"
 category: "installation"
@@ -7,18 +8,37 @@ aliases:
   - "github actions"
   - "ci"
   - "workflow"
+  - "setup-cr"
+  - "Calcit CI"
+id: core/installation/github-actions
+related:
+  - core/run/library-quality
+  - core/features/static-analysis
+entry_for:
+  - "setup-cr"
+  - "Calcit GitHub Actions"
 ---
+
 # GitHub Actions
 
-To load Calcit `0.9.18` in a Ubuntu container:
+For a normal Calcit project, declare the compiler version once in `deps.cirru`:
 
-```yaml
-- uses: calcit-lang/setup-cr@0.0.8
-  with:
-    version: "0.9.18"
+```cirru.no-check
+{} $ :calcit-version |0.13.27
 ```
 
-Latest release could be found on https://github.com/calcit-lang/setup-cr/releases/ .
+Then install it after checkout. Do not repeat the Calcit version in the workflow:
+
+```yaml
+- uses: actions/checkout@v4
+
+- uses: calcit-lang/setup-cr@0.0.9
+```
+
+`setup-cr` reads `deps.cirru` when no explicit version input is supplied. Use an explicit version only
+for a task that intentionally has no project `deps.cirru`; do not provide two version sources for a
+regular project. The Action release controls installer behavior, while `:calcit-version` controls which
+`cr` and `caps` release the project uses.
 
 Then to load packages defined in `deps.cirru` with `caps`:
 
@@ -26,10 +46,27 @@ Then to load packages defined in `deps.cirru` with `caps`:
 caps --ci
 ```
 
-The JavaScript dependency lives in `package.json`:
+For a JS project, install its locked runtime dependencies and run the same native quality gate used
+locally:
 
-```js
-"@calcit/procs": "^0.9.18"
+```yaml
+- name: Install dependencies
+  run: caps --ci && yarn install --immutable
+
+- name: Validate Snapshot and type quality
+  run: |
+    cr calcit.cirru edit format
+    git diff --exit-code -- calcit.cirru
+    cr calcit.cirru --check-only
+    cr calcit.cirru analyze quality --baseline config/calcit-quality.json
 ```
 
-Up to date example can be found on https://github.com/calcit-lang/respo-calcit-workflow/blob/main/.github/workflows/upload.yaml#L11 .
+New libraries without existing debt can omit `--baseline` and use the zero-debt gate. `check-types`
+and `weak-types` are reports for diagnosis; `analyze quality` is the CI command that fails on a
+regression. See [Calcit 类库项目验收与质量门禁](../run/library-quality.md) for entries, examples,
+backend tests, and consumer regression requirements.
+
+The JavaScript runtime dependency remains in `package.json`/its lockfile. Keep it compatible with the
+Calcit release declared by the project, and execute generated JS in CI; a successful codegen alone does
+not verify host imports or runtime proc compatibility. For typed host bindings, read
+[JavaScript Interop](../features/js-interop.md).

--- a/docs/installation/github-actions.md
+++ b/docs/installation/github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub Actions"
-summary: "Use setup-cr with the project version in deps.cirru, then run caps and the native quality gate."
+summary: "Use setup-calcit with the project version in deps.cirru, then run caps and the native quality gate."
 scope: "core"
 kind: "reference"
 category: "installation"
@@ -9,6 +9,7 @@ aliases:
   - "ci"
   - "workflow"
   - "setup-cr"
+  - "setup-calcit"
   - "Calcit CI"
 id: core/installation/github-actions
 related:
@@ -16,6 +17,7 @@ related:
   - core/features/static-analysis
 entry_for:
   - "setup-cr"
+  - "setup-calcit"
   - "Calcit GitHub Actions"
 ---
 
@@ -39,14 +41,18 @@ Then install it after checkout. Do not repeat the Calcit version in the workflow
 - name: Enable Yarn
   run: corepack enable && corepack prepare yarn@4.12.0 --activate
 
-- uses: calcit-lang/setup-cr@0.0.9
+- uses: tiye/setup-calcit@v1
 ```
 
-`setup-cr` reads the selected `deps.cirru` when no explicit version input is supplied. A missing selected
+`setup-calcit` reads the selected `deps.cirru` when no explicit version input is supplied. A missing selected
 file is treated as a task without a project declaration, so it requires an explicit version; a file with
 no `:calcit-version` behaves the same way. Malformed or duplicate declarations fail rather than falling
 back to `version`. Do not provide two version sources for a regular project. The Action release controls
 installer behavior, while `:calcit-version` controls which `cr` and `caps` release the project uses.
+
+Existing `calcit-lang/setup-cr` workflows remain supported by their published tags. GitHub Actions does
+not follow action-repository rename redirects, so use `setup-calcit` for new workflows and migrate an
+old workflow only by intentionally replacing its `uses:` reference.
 
 Then to load packages defined in `deps.cirru` with `caps`:
 

--- a/docs/installation/github-actions.md
+++ b/docs/installation/github-actions.md
@@ -32,6 +32,13 @@ Then install it after checkout. Do not repeat the Calcit version in the workflow
 ```yaml
 - uses: actions/checkout@v4
 
+- uses: actions/setup-node@v6
+  with:
+    node-version: 24
+
+- name: Enable Yarn
+  run: corepack enable && corepack prepare yarn@4.12.0 --activate
+
 - uses: calcit-lang/setup-cr@0.0.9
 ```
 
@@ -60,6 +67,18 @@ locally:
     cr calcit.cirru --check-only
     cr calcit.cirru analyze quality --baseline config/calcit-quality.json
 ```
+
+The workflow above covers installation and the static layer. A project that emits JavaScript must add
+its target-specific runtime command; for example, a Node project can compile and execute its smoke or
+contract test as a separate step:
+
+```yaml
+- name: Run generated Node runtime test
+  run: yarn run:node
+```
+
+Browser projects should run an equivalent headless-browser test. Code generation alone is not runtime
+evidence.
 
 New libraries without existing debt can omit `--baseline` and use the zero-debt gate. `check-types`
 and `weak-types` are reports for diagnosis; `analyze quality` is the CI command that fails on a

--- a/docs/installation/github-actions.md
+++ b/docs/installation/github-actions.md
@@ -41,7 +41,7 @@ Then install it after checkout. Do not repeat the Calcit version in the workflow
 - name: Enable Yarn
   run: corepack enable && corepack prepare yarn@4.12.0 --activate
 
-- uses: tiye/setup-calcit@v1
+- uses: calcit-lang/setup-calcit@v1
 ```
 
 `setup-calcit` reads the selected `deps.cirru` when no explicit version input is supplied. A missing selected

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -171,7 +171,7 @@ caps --help
 再用新 `cr` 判断结果；也不要只更新本机而让 CI 继续安装旧版。若团队通过其他受控方式分发二进制，
 使用该方式即可，但要记录实际版本，并确认 `caps --help` 已包含项目需要的新选项。
 
-> ⚠️ CI 中 `cr`/`caps` 的项目版本来自 `deps.cirru` 的 `:calcit-version`。正常 workflow 只使用 `calcit-lang/setup-cr` 安装该版本，不要再在 workflow 重复传 `version`。旧 setup-cr release 可能不支持新 Snapshot/CLI 协议；若升级后出现安装或 Snapshot 错误，先升级 Action release，再确认 `deps.cirru` 是唯一版本来源。详见 [GitHub Actions](../installation/github-actions.md)。
+> ⚠️ CI 中 `cr`/`caps` 的项目版本来自 `deps.cirru` 的 `:calcit-version`。新 workflow 使用 `tiye/setup-calcit@v1` 安装该版本，不要再在 workflow 重复传 `version`。已发布的 `calcit-lang/setup-cr` tag 继续支持旧项目；GitHub Actions 不会为 Action 仓库改名重定向，因此迁移必须显式替换 `uses:`。详见 [GitHub Actions](../installation/github-actions.md)。
 
 ### Step B：先对齐项目版本与 Node 工具链
 
@@ -584,7 +584,7 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
     corepack prepare yarn@4.12.0 --activate
     yarn --version
 
-- uses: calcit-lang/setup-cr@0.0.9
+- uses: tiye/setup-calcit@v1
 
 - name: Install deps
   run: caps --ci && yarn install --immutable
@@ -611,7 +611,7 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
     cr calcit.cirru --entry test
 ```
 
-> ⚠️ CI 中安装的 Calcit 项目版本来自 `deps.cirru`，Action release 只决定安装器协议是否足够新。普通 workflow 不传 `version`；升级时修改 `deps.cirru`，并在需要新安装器能力时更新 `calcit-lang/setup-cr`。不要在 `caps --ci` 之前运行 `cr` 命令，否则会使用默认旧版模块缓存。完整模板见 [GitHub Actions](../installation/github-actions.md)。
+> ⚠️ CI 中安装的 Calcit 项目版本来自 `deps.cirru`，Action release 只决定安装器协议是否足够新。普通 workflow 不传 `version`；升级时修改 `deps.cirru`，并在需要新安装器能力时更新 `tiye/setup-calcit`。不要在 `caps --ci` 之前运行 `cr` 命令，否则会使用默认旧版模块缓存。完整模板见 [GitHub Actions](../installation/github-actions.md)。
 
 说明：若项目依赖 `packageManager: "yarn@4.12.0"`，优先先执行 Corepack 激活，再让 CI 触发 Yarn。不要让 `setup-node` 的 Yarn cache 或其他 Yarn 调用早于 `corepack enable` / `corepack prepare`，否则可能误用 runner 上的全局 Yarn 1。 `caps --ci` 参数保证在 CI 加载模块时使用 HTTPS 协议，避免 CI 环境下的 SSH key 问题。
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -113,17 +113,15 @@ Snapshot 路径；如果同目录存在 `compact.cirru`，还会直接给出上�
 `:require` 规则，例如把：
 
 ```cirru.no-check
-ns app.main
-  :require-macros
-    legacy.macros :refer $ defcomp
+ns app.main $ :require-macros
+  legacy.macros :refer $ defcomp
 ```
 
 改为：
 
 ```cirru.no-check
-ns app.main
-  :require
-    legacy.macros :refer $ defcomp
+ns app.main $ :require
+  legacy.macros :refer $ defcomp
 ```
 
 遇到旧写法时，加载阶段会明确报告 `:require-macros` 迁移提示，而不是只返回笼统的 invalid `ns` form。
@@ -173,7 +171,7 @@ caps --help
 再用新 `cr` 判断结果；也不要只更新本机而让 CI 继续安装旧版。若团队通过其他受控方式分发二进制，
 使用该方式即可，但要记录实际版本，并确认 `caps --help` 已包含项目需要的新选项。
 
-> ⚠️ 注意 CI 中 `calcit-lang/setup-cr` 的版本：旧版本（如 `0.0.8`）安装的 `cr` 可能不识别 `calcit.cirru`。升级后若 CI 报 `"compact.cirru does not exist"`，请升级 `setup-cr` 版本。最新版本请查阅 [setup-cr releases](https://github.com/calcit-lang/setup-cr/releases)。
+> ⚠️ CI 中 `cr`/`caps` 的项目版本来自 `deps.cirru` 的 `:calcit-version`。正常 workflow 只使用 `calcit-lang/setup-cr` 安装该版本，不要再在 workflow 重复传 `version`。旧 setup-cr release 可能不支持新 Snapshot/CLI 协议；若升级后出现安装或 Snapshot 错误，先升级 Action release，再确认 `deps.cirru` 是唯一版本来源。详见 [GitHub Actions](../installation/github-actions.md)。
 
 ### Step B：先对齐项目版本与 Node 工具链
 
@@ -390,8 +388,8 @@ let
   &+ safe-idx 1
 
 match (get-env |APP_MODE)
-  (:some mode) $ println mode
-  (:none) $ println |development
+  (:some mode) (println mode)
+  (:none) (println |development)
 ```
 
 上例使用推荐的原生 `match`；维护旧代码时也可以把同一组分支头替换为 `tag-match`，两者都能处理
@@ -613,7 +611,7 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
     cr calcit.cirru --entry test
 ```
 
-> ⚠️ `calcit-lang/setup-cr` 的版本决定了 CI 中安装的 `cr` 版本。旧版本（如 `0.0.8`）可能不识别 `calcit.cirru`，且不支持新版类型检查。建议保持 `@0.0.9` 或更新。最新版本请查阅 [setup-cr releases](https://github.com/calcit-lang/setup-cr/releases)。不要在 `caps --ci` 之前运行 `cr` 命令，否则会使用默认旧版模块缓存。
+> ⚠️ CI 中安装的 Calcit 项目版本来自 `deps.cirru`，Action release 只决定安装器协议是否足够新。普通 workflow 不传 `version`；升级时修改 `deps.cirru`，并在需要新安装器能力时更新 `calcit-lang/setup-cr`。不要在 `caps --ci` 之前运行 `cr` 命令，否则会使用默认旧版模块缓存。完整模板见 [GitHub Actions](../installation/github-actions.md)。
 
 说明：若项目依赖 `packageManager: "yarn@4.12.0"`，优先先执行 Corepack 激活，再让 CI 触发 Yarn。不要让 `setup-node` 的 Yarn cache 或其他 Yarn 调用早于 `corepack enable` / `corepack prepare`，否则可能误用 runner 上的全局 Yarn 1。 `caps --ci` 参数保证在 CI 加载模块时使用 HTTPS 协议，避免 CI 环境下的 SSH key 问题。
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -171,7 +171,7 @@ caps --help
 再用新 `cr` 判断结果；也不要只更新本机而让 CI 继续安装旧版。若团队通过其他受控方式分发二进制，
 使用该方式即可，但要记录实际版本，并确认 `caps --help` 已包含项目需要的新选项。
 
-> ⚠️ CI 中 `cr`/`caps` 的项目版本来自 `deps.cirru` 的 `:calcit-version`。新 workflow 使用 `tiye/setup-calcit@v1` 安装该版本，不要再在 workflow 重复传 `version`。已发布的 `calcit-lang/setup-cr` tag 继续支持旧项目；GitHub Actions 不会为 Action 仓库改名重定向，因此迁移必须显式替换 `uses:`。详见 [GitHub Actions](../installation/github-actions.md)。
+> ⚠️ CI 中 `cr`/`caps` 的项目版本来自 `deps.cirru` 的 `:calcit-version`。新 workflow 使用 `calcit-lang/setup-calcit@v1` 安装该版本，不要再在 workflow 重复传 `version`。已发布的 `calcit-lang/setup-cr` tag 继续支持旧项目；GitHub Actions 不会为 Action 仓库改名重定向，因此迁移必须显式替换 `uses:`。详见 [GitHub Actions](../installation/github-actions.md)。
 
 ### Step B：先对齐项目版本与 Node 工具链
 
@@ -584,7 +584,7 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
     corepack prepare yarn@4.12.0 --activate
     yarn --version
 
-- uses: tiye/setup-calcit@v1
+- uses: calcit-lang/setup-calcit@v1
 
 - name: Install deps
   run: caps --ci && yarn install --immutable
@@ -611,7 +611,7 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
     cr calcit.cirru --entry test
 ```
 
-> ⚠️ CI 中安装的 Calcit 项目版本来自 `deps.cirru`，Action release 只决定安装器协议是否足够新。普通 workflow 不传 `version`；升级时修改 `deps.cirru`，并在需要新安装器能力时更新 `tiye/setup-calcit`。不要在 `caps --ci` 之前运行 `cr` 命令，否则会使用默认旧版模块缓存。完整模板见 [GitHub Actions](../installation/github-actions.md)。
+> ⚠️ CI 中安装的 Calcit 项目版本来自 `deps.cirru`，Action release 只决定安装器协议是否足够新。普通 workflow 不传 `version`；升级时修改 `deps.cirru`，并在需要新安装器能力时更新 `calcit-lang/setup-calcit`。不要在 `caps --ci` 之前运行 `cr` 命令，否则会使用默认旧版模块缓存。完整模板见 [GitHub Actions](../installation/github-actions.md)。
 
 说明：若项目依赖 `packageManager: "yarn@4.12.0"`，优先先执行 Corepack 激活，再让 CI 触发 Yarn。不要让 `setup-node` 的 Yarn cache 或其他 Yarn 调用早于 `corepack enable` / `corepack prepare`，否则可能误用 runner 上的全局 Yarn 1。 `caps --ci` 参数保证在 CI 加载模块时使用 HTTPS 协议，避免 CI 环境下的 SSH key 问题。
 

--- a/editing-history/20260821-1512-type-system-ecosystem-rfcs.md
+++ b/editing-history/20260821-1512-type-system-ecosystem-rfcs.md
@@ -1,0 +1,25 @@
+# Type system ecosystem RFCs
+
+- Added a setup-cr proposal that makes `deps.cirru` the normal single source
+  of truth for the Calcit version. Explicit action input remains a fallback;
+  conflicting sources fail instead of silently overriding each other.
+- Defined a native type-quality CI adoption model around `analyze quality`,
+  per-definition baselines, cumulative Q0-Q4 evidence, and explicit backend
+  runtime tests. Project-specific JavaScript report aggregators are rejected.
+- Extended the existing typed JS FFI design with runtime contract evidence,
+  reusable guards/decoders, Node/browser negative fixtures, and auditable
+  unsafe host assertions.
+- Added a long-term static type-system roadmap inspired by Rust and MoonBit:
+  distinguish Unknown from intentional Dynamic, improve exhaustiveness,
+  narrowing and bidirectional local inference, and type framework boundaries
+  before considering more complex trait or effect features.
+- Replaced the obsolete fixed-version GitHub Actions quick start with a
+  `deps.cirru`-driven workflow, and added `setup-cr`/quality-gate metadata so
+  `cr docs search` points users to the relevant CI and upgrade guidance.
+- Removed the RFC index entry for a non-existent project tooling RFC and
+  replaced it with the concrete toolchain contract proposal.
+
+Validation: Markdown structure and Calcit fenced examples are checked with
+`cr docs format-md --check` and `cr docs check-md`; `cr docs search` resolves
+the new setup-cr and quality-gate entry; repository diff is checked for
+whitespace errors.


### PR DESCRIPTION
## Summary

- Add separate RFCs for setup-cr version contracts, type-quality CI adoption, JS FFI runtime contracts, and long-term static typing.
- Make deps.cirru the documented source of the Calcit version in GitHub Actions.
- Expose setup-cr and quality-gate guidance through cr docs search.

## Validation

- cr docs format-md --check for every changed Markdown/RFC file.
- cr docs check-md --entry calcit/test.cirru --failures-only for every changed Markdown/RFC file.
- cr docs search setup-cr --summary.
- cr docs search quality gate --summary.
- git diff --check.

Follow-up implementation stays in separate PRs for setup-cr, quality CI adoption, and JS FFI contract tests.