### PR TITLE
docs: link quality and FFI errors to guides

### DIFF
--- a/editing-history/20260821-1648-type-quality-and-ffi-doc-hints.md
+++ b/editing-history/20260821-1648-type-quality-and-ffi-doc-hints.md
@@ -1,0 +1,12 @@
+# Type quality and JS FFI documentation hints
+
+- Added a direct `cr docs read library-quality.md --full` hint when the native
+  `analyze quality` gate fails, so baseline regressions lead to the accepted
+  CI workflow rather than project-local report scripts.
+- Added a direct `cr docs read js-interop.md --full` hint to strict JS FFI
+  capability, target, and read-only external-field diagnostics.
+- Added regression assertions that the strict FFI errors retain their stable
+  diagnostic code and expose the documentation command.
+
+Validation: targeted Rust tests for the affected diagnostics, full Rust tests,
+Markdown documentation checks, and `git diff --check`.

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -94,7 +94,7 @@ fn run_quality(options: &QualityCommand, snapshot: &snapshot::Snapshot) -> Resul
     Ok(())
   } else {
     Err(format!(
-      "Static quality gate failed with {} regression(s).",
+      "Static quality gate failed with {} regression(s). Run `cr docs read library-quality.md --full` for the baseline and CI workflow.",
       outcome.violations.len()
     ))
   }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2558,7 +2558,7 @@ fn require_js_ffi_feature(
   }
 
   let message = format!(
-    "[Warn] {operation} used in {file_ns}/{def_name} without `:js-ffi` feature in schema — isolate host operations in a binding function with `:features $ #{{}} :js-ffi`"
+    "[Warn] {operation} used in {file_ns}/{def_name} without `:js-ffi` feature in schema — isolate host operations in a binding function with `:features $ #{{}} :js-ffi`; read `cr docs read js-interop.md --full` for the adapter and capability policy"
   );
   if matches!(policy, crate::snapshot::FeaturePolicy::Error) {
     return Err(CalcitErr::use_msg_stack_location_with_code(
@@ -2616,7 +2616,7 @@ fn validate_js_ffi_target(
     return Ok(());
   }
   let message = format!(
-    "[Error] {operation} requires `{}` target, but the selected entry targets `{}` in {file_ns}/{def_name}",
+    "[Error] {operation} requires `{}` target, but the selected entry targets `{}` in {file_ns}/{def_name}; read `cr docs read js-interop.md --full` for target-specific bindings",
     expected.as_str(),
     active.as_str()
   );
@@ -3727,7 +3727,7 @@ fn check_typed_js_field_operation(
     && !external_trait_field_is_writable(field_trait, field_name)
   {
     let message = format!(
-      "[Warn] `js-set` cannot write read-only external-object field `:{field_name}` in {file_ns}/{def_name}; add `:writable $ #{{}} :{field_name}` to that trait's `:ffi` metadata or expose a mutating method instead"
+      "[Warn] `js-set` cannot write read-only external-object field `:{field_name}` in {file_ns}/{def_name}; add `:writable $ #{{}} :{field_name}` to that trait's `:ffi` metadata or expose a mutating method instead; read `cr docs read js-interop.md --full` for external-object contracts"
     );
     let location = key.get_location().or_else(|| head.get_location());
     if matches!(policy, crate::snapshot::FeaturePolicy::Error) {
@@ -7730,6 +7730,7 @@ mod tests {
     .expect_err("rewritten typed js-get must require the js-ffi feature");
 
     assert_eq!(error.code(), Some("E_JS_FFI_FEATURE_REQUIRED"));
+    assert!(error.to_string().contains("cr docs read js-interop.md --full"));
   }
 
   #[test]
@@ -7854,6 +7855,7 @@ mod tests {
     .expect_err("error policy must reject a read-only external field");
 
     assert_eq!(error.code(), Some("E_JS_FFI_FIELD_READONLY"));
+    assert!(error.to_string().contains("cr docs read js-interop.md --full"));
   }
 
   #[test]
@@ -7873,6 +7875,7 @@ mod tests {
     .expect_err("strict policy must reject an unmarked host operation");
 
     assert_eq!(error.code(), Some("E_JS_FFI_FEATURE_REQUIRED"));
+    assert!(error.to_string().contains("cr docs read js-interop.md --full"));
     assert!(warnings.borrow().is_empty());
   }
 


### PR DESCRIPTION
## Summary

- Point analyze quality failures to the native library-quality baseline and CI guide.
- Point strict JS FFI capability, target, and read-only external-field diagnostics to the JavaScript interop guide.
- Add regression assertions that strict FFI diagnostics retain the documentation command.

## Validation

- cargo fmt --all
- cargo test -q
- cargo clippy --all-targets -- -D warnings
- yarn compile
- cr docs check-md for the linked quality and JS interop documentation
- real failing analyze quality invocation contains the library-quality documentation hint
- git diff --check