### PR TITLE
fix: address recent review follow-ups

### DIFF
--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -113,7 +113,8 @@ config/calcit-quality.json -diff linguist-generated
 ```
 
 这与常见的 `yarn.lock -diff linguist-generated` 约定相同：文件继续参与 CI 和版本控制，只在
-GitHub PR 中默认不展开。任何 baseline 更新仍须人工展开并按 definition 审阅，不能因折叠而自动接受新债务。
+GitHub PR 中默认不展开。注意 `-diff` 也会让本地 Git 默认不显示文本 diff；若需要本地审阅，
+可省略 `-diff`。任何 baseline 更新仍须人工展开并按 definition 审阅，不能因折叠而自动接受新债务。
 
 ## 3. API examples 与文档
 

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -49,8 +49,9 @@ baseline 是已提交的机器生成工件。为避免它的 JSON diff 默认占
 config/calcit-quality.json -diff linguist-generated
 ```
 
-这不会忽略或删除 baseline；GitHub 只会默认折叠其 diff。更新 baseline 的 PR 仍应展开文件并按
-definition 审阅预算变化。
+这不会忽略或删除 baseline；GitHub 只会默认折叠其 diff。`-diff` 同时会让本地 Git 默认不生成
+该文件的文本 diff；如果本地审阅优先，可省略 `-diff`，只保留 `linguist-generated`。更新
+baseline 的 PR 仍应展开文件并按 definition 审阅预算变化。
 
 ## Option / Result 组合
 

--- a/editing-history/20260820-1704-repository-maintenance-review.md
+++ b/editing-history/20260820-1704-repository-maintenance-review.md
@@ -16,5 +16,6 @@
   consolidated even within the normal current-development window.
 
 Validation: `yarn compile`, `cargo clippy --all-targets -- -D warnings`,
-`cargo test -q`, `yarn check-agent-interface`, and `cr docs check-md` over
-every Markdown file with `--entry calcit/test.cirru`.
+`cargo test -q`, `yarn check-agent-interface`,
+`cr docs check-md README.md --entry calcit/test.cirru`, and
+`./scripts/check-docs-md.sh calcit/test.cirru` for the Markdown under `docs/`.

--- a/editing-history/202608212200-review-followups.md
+++ b/editing-history/202608212200-review-followups.md
@@ -1,0 +1,11 @@
+# Review follow-ups from recent PRs
+
+- Preserved unresolved type-slot occurrences while applying intentional
+  Dynamic and JS FFI intents through nested annotations.
+- Corrected the maintenance record's Markdown validation commands and restored
+  ascending order for the 0.12.58 and 0.12.59 archive entries.
+- Documented the local `git diff` trade-off of the `.gitattributes` `-diff`
+  attribute for generated quality baselines.
+
+Validation: `cargo fmt --check`, targeted type-coverage tests, and the required
+repository checks after the follow-up changes.

--- a/editing-history/ARCHIVE.md
+++ b/editing-history/ARCHIVE.md
@@ -26,13 +26,13 @@ Git history.
 | 0.12.55 | Semantic snapshot entry descriptions and canonical symbol storage for entry functions. |
 | 0.12.56 | Routine version bump after snapshot/entry work. |
 | 0.12.57 | CLI mutation, atomic staging, test deduplication (PR #284) plus Windows staged-file synchronization fixes. |
+| 0.12.58 | Receiver-first method inference and nominal trait identity fixes. |
+| 0.12.59 | Top-level nominal value schema fix. |
 | 0.13.0 | Concentrated breaking-change baseline for the Option/Result/Unit/JsNullish public contracts. |
 | 0.13.1 | Fixed recursive expansion of self-referential nominal struct type annotations. |
 | 0.13.2 | Struct/enum data model cleanup (PR #301), direct required Struct field access, symbol-based nominal formatting. |
 | 0.13.3 | Struct/Enum terminology migration, deprecated API analysis, cross-backend canonical EDN formatting. |
 | 0.13.4 | Typed host FFI (external-object traits) merged and released. |
-| 0.12.58 | Receiver-first method inference and nominal trait identity fixes. |
-| 0.12.59 | Top-level nominal value schema fix. |
 | 0.13.5 | Typed `js-get` / `js-set` field access plus named-type preservation. |
 | 0.13.6 | Opt-in raw-JS-FFI warning and readable low-cost JS emission. |
 | 0.13.7 | Definition-attached core tests and safer, less noisy `cr` edits. |

--- a/src/type_coverage.rs
+++ b/src/type_coverage.rs
@@ -440,7 +440,9 @@ fn scan_schema_dynamic_annotation(
         let start = occurrences.len();
         scan_schema_dynamic_annotation(&resolved, path, detail, occurrences);
         for occurrence in &mut occurrences[start..] {
-          occurrence.intent = WeakTypeIntent::IntentionalTypeSlotDynamic;
+          if occurrence.intent == WeakTypeIntent::Unresolved && occurrence.kind != WeakTypeKind::UnresolvedTypeSlot {
+            occurrence.intent = WeakTypeIntent::IntentionalTypeSlotDynamic;
+          }
         }
       }
       None => push_weak_type_occurrence(
@@ -470,7 +472,9 @@ fn scan_schema_dynamic_annotation(
       scan_schema_dynamic_annotation(inner, &format!("{path}.item"), &nested_detail, occurrences);
       if matches!(annotation, CalcitTypeAnnotation::JsNullish(_)) {
         for occurrence in &mut occurrences[occurrence_start..] {
-          occurrence.intent = WeakTypeIntent::IntentionalJsFfi;
+          if occurrence.kind == WeakTypeKind::SchemaDynamic && occurrence.intent == WeakTypeIntent::Unresolved {
+            occurrence.intent = WeakTypeIntent::IntentionalJsFfi;
+          }
         }
       }
     }
@@ -2463,4 +2467,66 @@ pub fn format_weak_types(options: &WeakTypesCommand, snapshot: &snapshot::Snapsh
   let mut out = String::new();
   run_weak_types_report(options, snapshot, &mut out)?;
   Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use calcit::calcit::{CalcitTypeAnnotation, clear_type_slots, push_type_slot_override};
+
+  use super::{WeakTypeIntent, WeakTypeKind, scan_schema_dynamic_annotation};
+
+  fn scan(annotation: CalcitTypeAnnotation) -> Vec<super::WeakTypeOccurrence> {
+    let mut occurrences = vec![];
+    scan_schema_dynamic_annotation(&annotation, "schema", "root", &mut occurrences);
+    occurrences
+  }
+
+  #[test]
+  fn nested_unresolved_slots_keep_unresolved_intent() {
+    clear_type_slots();
+    push_type_slot_override(
+      Arc::from("outer"),
+      Arc::new(CalcitTypeAnnotation::JsNullish(Arc::new(CalcitTypeAnnotation::TypeSlot(
+        Arc::from("inner"),
+      )))),
+    );
+
+    let occurrences = scan(CalcitTypeAnnotation::TypeSlot(Arc::from("outer")));
+
+    assert_eq!(occurrences.len(), 1);
+    assert_eq!(occurrences[0].kind, WeakTypeKind::UnresolvedTypeSlot);
+    assert_eq!(occurrences[0].intent, WeakTypeIntent::Unresolved);
+    clear_type_slots();
+  }
+
+  #[test]
+  fn nested_js_nullish_dynamic_keeps_ffi_intent() {
+    clear_type_slots();
+    push_type_slot_override(
+      Arc::from("outer"),
+      Arc::new(CalcitTypeAnnotation::JsNullish(Arc::new(CalcitTypeAnnotation::Dynamic))),
+    );
+
+    let occurrences = scan(CalcitTypeAnnotation::TypeSlot(Arc::from("outer")));
+
+    assert_eq!(occurrences.len(), 1);
+    assert_eq!(occurrences[0].kind, WeakTypeKind::SchemaDynamic);
+    assert_eq!(occurrences[0].intent, WeakTypeIntent::IntentionalJsFfi);
+    clear_type_slots();
+  }
+
+  #[test]
+  fn resolved_dynamic_slots_receive_slot_intent() {
+    clear_type_slots();
+    push_type_slot_override(Arc::from("slot"), Arc::new(CalcitTypeAnnotation::Dynamic));
+
+    let occurrences = scan(CalcitTypeAnnotation::TypeSlot(Arc::from("slot")));
+
+    assert_eq!(occurrences.len(), 1);
+    assert_eq!(occurrences[0].kind, WeakTypeKind::SchemaDynamic);
+    assert_eq!(occurrences[0].intent, WeakTypeIntent::IntentionalTypeSlotDynamic);
+    clear_type_slots();
+  }
 }


### PR DESCRIPTION
Follow-up for unresolved review threads from recent merged PRs.

Changes:
- Preserve unresolved type-slot and nested JS FFI intents in weak-type analysis, with regression tests.
- Correct the maintenance review validation commands and release archive order.
- Document the local `git diff` trade-off of `.gitattributes` `-diff`.

Validation:
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test
- yarn compile
- yarn check-all
- yarn check-agent-interface
- README/docs Markdown checks