### PR TITLE
feat: inventory unsafe coercions

### DIFF
--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -135,6 +135,17 @@ method calls and JavaScript lowering. Keep that assertion at the adapter
 boundary. Application namespaces should call ordinary schema-typed wrappers,
 not pass npm `JsObject` values around.
 
+Audit these exceptional assertions without executing the program:
+
+```bash
+calcit analyze weak-types --only unsafe-coerce
+```
+
+The report gives each assertion's `code@...` Snapshot path and declared target
+schema. Treat the result as a runtime-contract checklist: keep the assertion in
+one adapter, test accepted host values and rejected shapes, then return a
+normal Calcit `Option`, `Result`, struct, or enum to application code.
+
 For example, the host name can differ from the Calcit name while the field type
 stays visible to the type checker:
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -79,6 +79,9 @@ calcit analyze weak-types --ns app.main --only code-nil --intent unresolved,decl
 # Inspect explicitly permitted JS FFI dynamic boundaries
 calcit analyze weak-types --ns app.main --intent intentional-js-ffi
 
+# Inventory every explicit unchecked JS FFI assertion with its target schema
+calcit analyze weak-types --ns app.main --only unsafe-coerce
+
 # Machine-readable definition rows and Snapshot paths
 calcit analyze check-types --ns app.main --format json
 calcit analyze weak-types --ns app.main --intent unresolved --format json
@@ -103,6 +106,8 @@ calcit query type-at app.main/calculate-total --path code@3.2 --format json
 An explicit function schema feature such as `:features $ #{} :js-ffi` classifies dynamic schema/code occurrences as `intentional-js-ffi`. A selected entry binding of `:type-slots` to `:dynamic` stays visible as `intentional-type-slot-dynamic`. Neither hides the location, but both separate an explicit boundary choice from unresolved type debt. The FFI feature does not classify `nil`, because an FFI capability does not imply that every nullable branch is intentional.
 
 For `code-nil`, the report includes both raw `nil` and the explicit `;nil` Unit marker. Every nil form inside a function declared to return `Unit` is classified as `declared-unit`; `;nil` is also always classified as explicit Unit, including inside generated macro branches. For legacy `Optional<T>`, only structurally proven return positions inherit `declared-optional`; embedded nil values remain unresolved. `declared-unit` is excluded from migration debt, while `declared-optional` remains visible so application APIs move to `Option` or `Result`. The core release gate runs `analyze weak-types --only code-nil --intent unresolved,declared-optional` and requires no findings.
+
+`unsafe-coerce` is reported separately as `unsafe-coerce` with the explicit `explicit-unsafe` intent, its exact `code@...` path, and the asserted target schema. It is an inventory, not ordinary unresolved Dynamic debt, so the existing quality baseline stays stable while each boundary is audited. JSON adds `W_JS_FFI_UNCHECKED_COERCE` whenever the selected scope contains one or more assertions. Keep each assertion in a narrow adapter and cover both accepted and rejected host values with runtime-contract tests.
 
 For one definition, `calcit query context '<ns/def>' --format json` embeds the same distinction in its diagnostics and returns the definition revision together with Snapshot paths.
 
@@ -134,7 +139,7 @@ warning remains a completion-gate failure until the body is implemented.
 `raise "|TODO..."` does not emit `W_TODO`, because ordinary exception behavior
 and implementation-completion status are separate concerns.
 
-`analyze.weak-types` uses protocol `schema_version: 3`: v2 added nil intent classes, and v3 adds the closed `unresolved-type-slot` kind plus `W_UNRESOLVED_TYPE_SLOT`. Consumers should reject older versions when they require these fields rather than accepting an older envelope and silently missing the new debt.
+`analyze.weak-types` uses protocol `schema_version: 4`: v2 added nil intent classes, v3 added the closed `unresolved-type-slot` kind plus `W_UNRESOLVED_TYPE_SLOT`, and v4 adds the closed `unsafe-coerce` kind, `explicit-unsafe` intent, target-schema detail, and `W_JS_FFI_UNCHECKED_COERCE`. Consumers should reject older versions when they require these fields rather than accepting an older envelope and silently missing the new debt.
 
 Use `--summary-only` when only aggregate counts are needed. Human output stops after the aggregate section; JSON keeps `data.summary` and the scope revision while returning an empty `data.definitions` array. `defstruct`, `defenum`, `deftrait`, and `defimpl` have explicit definition-kind schemas: `StructDef`, `EnumDef`, `Trait`, and `Impl`. Legacy snapshots that used `Dynamic` at these roots are normalized on load and written back with the marker. Their fields, enum payloads, and methods are still analyzed normally, but the declaration root itself neither creates a `schema-dynamic` finding nor increases Dynamic usage counts.
 

--- a/editing-history/202608212232-unsafe-coerce-inventory.md
+++ b/editing-history/202608212232-unsafe-coerce-inventory.md
@@ -1,0 +1,25 @@
+# Unsafe-coerce inventory
+
+## Summary
+
+- Extended `calcit analyze weak-types` with the closed `unsafe-coerce` kind and
+  the `explicit-unsafe` intent.
+- Every executable assertion now reports its exact `code@...` Snapshot path and
+  declared target schema, without classifying it as unresolved Dynamic debt.
+- Bumped the JSON protocol to v4 and added `W_JS_FFI_UNCHECKED_COERCE` so
+  tooling can turn the inventory into a runtime-contract test checklist.
+- Kept the existing eight-metric `analyze quality` baseline stable; the new
+  inventory is deliberately visible but not budgeted until a versioned baseline
+  migration is introduced.
+
+## Validation
+
+- `cargo fmt`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-agent-interface` (13/13 scenarios)
+- `yarn check-all`
+- New debug CLI against `../respo-calcit-workflow/calcit.cirru` with
+  `analyze weak-types --only unsafe-coerce --format json --summary-only`
+  (4 inventory hits, JSON protocol v4)

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -243,7 +243,7 @@ const scenarios = [
       "json",
     ],
     check(result) {
-      if (result.schema_version !== 3 || result.command !== "analyze.weak-types" || result.data.summary.hits === 0) {
+      if (result.schema_version !== 4 || result.command !== "analyze.weak-types" || result.data.summary.hits === 0) {
         throw new Error("weak type result is incomplete");
       }
       const occurrences = result.data.definitions.flatMap((definition) => definition.occurrences);

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -2145,6 +2145,7 @@ mod tests {
     let err = type_coverage::parse_weak_type_kinds("schema-dynamic,unknown").expect_err("unknown filters should fail");
     assert!(err.contains("unknown"), "err: {err}");
     assert!(type_coverage::parse_weak_type_kinds("unresolved-type-slot").is_ok());
+    assert!(type_coverage::parse_weak_type_kinds("unsafe-coerce").is_ok());
   }
 
   #[test]
@@ -2214,6 +2215,48 @@ mod tests {
     let err = type_coverage::parse_weak_type_intents("unresolved,guessed").expect_err("unknown intents should fail");
     assert!(err.contains("guessed"), "err: {err}");
     assert!(type_coverage::parse_weak_type_intents("declared-unit,declared-optional").is_ok());
+    assert!(type_coverage::parse_weak_type_intents("explicit-unsafe").is_ok());
+  }
+
+  #[test]
+  fn analyze_weak_types_inventories_unsafe_coerce_with_target_and_path() {
+    let entry = snapshot::CodeEntry {
+      doc: "".to_owned(),
+      examples: vec![],
+      tests: vec![],
+      tags: HashSet::new(),
+      code: list(vec![
+        leaf("defn"),
+        leaf("load-id"),
+        list(vec![]),
+        list(vec![leaf("unsafe-coerce"), leaf("js/nanoid"), leaf("'String")]),
+      ]),
+      schema: CalcitTypeAnnotation::Fn(Arc::new(calcit::calcit::CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: vec![],
+        return_type: Arc::new(CalcitTypeAnnotation::String),
+        fn_kind: SchemaKind::Fn,
+        rest_type: None,
+        features: Arc::new(HashSet::from([cirru_edn::EdnTag::new("js-ffi")])),
+      }))
+      .into(),
+      ffi: None,
+    };
+
+    let row = type_coverage::analyze_weak_types_entry(
+      "app.npm",
+      "load-id",
+      &entry,
+      &BTreeSet::from([type_coverage::WeakTypeKind::UnsafeCoerce]),
+    )
+    .expect("unsafe coercion should be inventoried");
+    assert_eq!(row.occurrences.len(), 1);
+    let occurrence = &row.occurrences[0];
+    assert_eq!(occurrence.kind, type_coverage::WeakTypeKind::UnsafeCoerce);
+    assert_eq!(occurrence.intent, type_coverage::WeakTypeIntent::ExplicitUnsafe);
+    assert_eq!(occurrence.path, "code@3");
+    assert_eq!(occurrence.detail, "unsafe-coerce:target='String");
   }
 
   #[test]
@@ -2246,11 +2289,12 @@ mod tests {
     let row = type_coverage::analyze_weak_types_entry("app.main", "ffi-wrapper", &entry, &type_coverage::WeakTypeKind::all())
       .expect("should find weak types");
 
-    for occurrence in row
-      .occurrences
-      .iter()
-      .filter(|occurrence| occurrence.kind != type_coverage::WeakTypeKind::CodeNil)
-    {
+    for occurrence in row.occurrences.iter().filter(|occurrence| {
+      !matches!(
+        occurrence.kind,
+        type_coverage::WeakTypeKind::CodeNil | type_coverage::WeakTypeKind::UnsafeCoerce
+      )
+    }) {
       assert_eq!(
         occurrence.intent,
         type_coverage::WeakTypeIntent::IntentionalJsFfi,
@@ -2327,7 +2371,7 @@ mod tests {
     };
     let weak_json = type_coverage::format_weak_types_json(&weak_options, &snapshot).expect("weak type JSON should format");
     let weak_value: serde_json::Value = serde_json::from_str(&weak_json).expect("weak type JSON should parse");
-    assert_eq!(weak_value["schema_version"], 3);
+    assert_eq!(weak_value["schema_version"], 4);
     assert_eq!(weak_value["command"], "analyze.weak-types");
     assert_eq!(weak_value["data"]["filters"]["intent"], "unresolved");
     assert_eq!(weak_value["data"]["definitions"][0]["occurrences"][0]["path"], "schema.args.0");

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -270,10 +270,10 @@ pub struct WeakTypesCommand {
   /// namespace prefix scope filter
   #[argh(option)]
   pub ns_prefix: Option<String>,
-  /// match kinds to include, comma-separated: schema-dynamic,unresolved-type-slot,code-dynamic,code-nil
+  /// match kinds to include, comma-separated: schema-dynamic,unresolved-type-slot,code-dynamic,code-nil,unsafe-coerce
   #[argh(option)]
   pub only: Option<String>,
-  /// intent classes to include, comma-separated: unresolved,intentional-js-ffi,intentional-type-slot-dynamic,declared-unit,declared-optional
+  /// intent classes to include, comma-separated: unresolved,intentional-js-ffi,intentional-type-slot-dynamic,explicit-unsafe,declared-unit,declared-optional
   #[argh(option)]
   pub intent: Option<String>,
   /// output format: human (default) or json

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -164,11 +164,18 @@ fn collect_quality_snapshot(options: &QualityCommand, snapshot: &snapshot::Snaps
         WeakTypeKind::UnresolvedTypeSlot => {}
         WeakTypeKind::CodeDynamic => metrics.code_dynamic += 1,
         WeakTypeKind::CodeNil => metrics.code_nil += 1,
+        // Unsafe assertions are intentionally inventoried separately from the
+        // stable eight-metric quality baseline. A future baseline migration can
+        // promote this count into an enforced budget without reclassifying it.
+        WeakTypeKind::UnsafeCoerce => {}
       }
       match occurrence.intent {
         WeakTypeIntent::Unresolved => metrics.unresolved += 1,
         WeakTypeIntent::DeclaredOptional => metrics.declared_optional += 1,
-        WeakTypeIntent::IntentionalJsFfi | WeakTypeIntent::IntentionalTypeSlotDynamic | WeakTypeIntent::DeclaredUnit => {}
+        WeakTypeIntent::IntentionalJsFfi
+        | WeakTypeIntent::IntentionalTypeSlotDynamic
+        | WeakTypeIntent::ExplicitUnsafe
+        | WeakTypeIntent::DeclaredUnit => {}
       }
     }
   }

--- a/src/type_coverage.rs
+++ b/src/type_coverage.rs
@@ -124,6 +124,7 @@ pub enum WeakTypeKind {
   UnresolvedTypeSlot,
   CodeDynamic,
   CodeNil,
+  UnsafeCoerce,
 }
 
 impl WeakTypeKind {
@@ -133,11 +134,18 @@ impl WeakTypeKind {
       Self::UnresolvedTypeSlot => "unresolved-type-slot",
       Self::CodeDynamic => "code-dynamic",
       Self::CodeNil => "code-nil",
+      Self::UnsafeCoerce => "unsafe-coerce",
     }
   }
 
   pub fn all() -> BTreeSet<Self> {
-    BTreeSet::from([Self::SchemaDynamic, Self::UnresolvedTypeSlot, Self::CodeDynamic, Self::CodeNil])
+    BTreeSet::from([
+      Self::SchemaDynamic,
+      Self::UnresolvedTypeSlot,
+      Self::CodeDynamic,
+      Self::CodeNil,
+      Self::UnsafeCoerce,
+    ])
   }
 }
 
@@ -146,6 +154,7 @@ pub enum WeakTypeIntent {
   Unresolved,
   IntentionalJsFfi,
   IntentionalTypeSlotDynamic,
+  ExplicitUnsafe,
   DeclaredUnit,
   DeclaredOptional,
 }
@@ -156,6 +165,7 @@ impl WeakTypeIntent {
       Self::Unresolved => "unresolved",
       Self::IntentionalJsFfi => "intentional-js-ffi",
       Self::IntentionalTypeSlotDynamic => "intentional-type-slot-dynamic",
+      Self::ExplicitUnsafe => "explicit-unsafe",
       Self::DeclaredUnit => "declared-unit",
       Self::DeclaredOptional => "declared-optional",
     }
@@ -166,6 +176,7 @@ impl WeakTypeIntent {
       Self::Unresolved,
       Self::IntentionalJsFfi,
       Self::IntentionalTypeSlotDynamic,
+      Self::ExplicitUnsafe,
       Self::DeclaredUnit,
       Self::DeclaredOptional,
     ])
@@ -305,9 +316,10 @@ pub fn parse_weak_type_kinds(raw: &str) -> Result<BTreeSet<WeakTypeKind>, String
       "unresolved-type-slot" => WeakTypeKind::UnresolvedTypeSlot,
       "code-dynamic" => WeakTypeKind::CodeDynamic,
       "code-nil" => WeakTypeKind::CodeNil,
+      "unsafe-coerce" => WeakTypeKind::UnsafeCoerce,
       other => {
         return Err(format!(
-          "Unknown weak-type filter `{other}`. Expected comma-separated values from: schema-dynamic, unresolved-type-slot, code-dynamic, code-nil"
+          "Unknown weak-type filter `{other}`. Expected comma-separated values from: schema-dynamic, unresolved-type-slot, code-dynamic, code-nil, unsafe-coerce"
         ));
       }
     };
@@ -316,7 +328,7 @@ pub fn parse_weak_type_kinds(raw: &str) -> Result<BTreeSet<WeakTypeKind>, String
 
   if selected.is_empty() {
     return Err(
-      "Weak-type filter cannot be empty. Use comma-separated values from: schema-dynamic, unresolved-type-slot, code-dynamic, code-nil"
+      "Weak-type filter cannot be empty. Use comma-separated values from: schema-dynamic, unresolved-type-slot, code-dynamic, code-nil, unsafe-coerce"
         .to_owned(),
     );
   }
@@ -332,11 +344,12 @@ pub fn parse_weak_type_intents(raw: &str) -> Result<BTreeSet<WeakTypeIntent>, St
       "unresolved" => WeakTypeIntent::Unresolved,
       "intentional-js-ffi" => WeakTypeIntent::IntentionalJsFfi,
       "intentional-type-slot-dynamic" => WeakTypeIntent::IntentionalTypeSlotDynamic,
+      "explicit-unsafe" => WeakTypeIntent::ExplicitUnsafe,
       "declared-unit" => WeakTypeIntent::DeclaredUnit,
       "declared-optional" => WeakTypeIntent::DeclaredOptional,
       other => {
         return Err(format!(
-          "Unknown weak-type intent `{other}`. Expected comma-separated values from: unresolved, intentional-js-ffi, intentional-type-slot-dynamic, declared-unit, declared-optional"
+          "Unknown weak-type intent `{other}`. Expected comma-separated values from: unresolved, intentional-js-ffi, intentional-type-slot-dynamic, explicit-unsafe, declared-unit, declared-optional"
         ));
       }
     };
@@ -345,7 +358,7 @@ pub fn parse_weak_type_intents(raw: &str) -> Result<BTreeSet<WeakTypeIntent>, St
 
   if selected.is_empty() {
     return Err(
-      "Weak-type intent filter cannot be empty. Use comma-separated values from: unresolved, intentional-js-ffi, intentional-type-slot-dynamic, declared-unit, declared-optional"
+      "Weak-type intent filter cannot be empty. Use comma-separated values from: unresolved, intentional-js-ffi, intentional-type-slot-dynamic, explicit-unsafe, declared-unit, declared-optional"
         .to_owned(),
     );
   }
@@ -507,6 +520,9 @@ fn scan_schema_dynamic_annotation(
 }
 
 fn weak_type_suggestion(occurrence: &WeakTypeOccurrence) -> &'static str {
+  if occurrence.kind == WeakTypeKind::UnsafeCoerce {
+    return "Keep this assertion in a small `:js-ffi` adapter, validate or normalize the host value into Option, Result, a struct, or an enum before it reaches application code, and add positive and negative runtime-contract tests.";
+  }
   if occurrence.intent == WeakTypeIntent::IntentionalJsFfi {
     return "Keep the dynamic value isolated at the declared JS FFI boundary and validate or convert it before typed code consumes it.";
   }
@@ -555,6 +571,9 @@ fn weak_type_suggestion(occurrence: &WeakTypeOccurrence) -> &'static str {
 }
 
 fn weak_type_impact(occurrence: &WeakTypeOccurrence) -> &'static str {
+  if occurrence.kind == WeakTypeKind::UnsafeCoerce {
+    return "This explicit assertion bypasses static compatibility at the host boundary; an incompatible JavaScript value can enter typed code and fail only at runtime.";
+  }
   if occurrence.intent == WeakTypeIntent::IntentionalJsFfi {
     return "The value stays dynamic at an explicit boundary; typed callers must validate or convert it before relying on methods or generic relations.";
   }
@@ -776,6 +795,22 @@ fn scan_cirru_weak_types(
           // when it appears inside a macro-generated branch.
           occurrence.intent = WeakTypeIntent::DeclaredUnit;
         }
+      }
+      if root == "code"
+        && selected.contains(&WeakTypeKind::UnsafeCoerce)
+        && matches!(head.as_deref(), Some("unsafe-coerce"))
+        && !matches!(parent.and_then(|it| it.head.as_deref()), Some("quote" | "quasiquote"))
+      {
+        let target = items
+          .get(2)
+          .map(render_cirru_inline)
+          .unwrap_or_else(|| "<missing-target>".to_owned());
+        occurrences.push(WeakTypeOccurrence {
+          kind: WeakTypeKind::UnsafeCoerce,
+          intent: WeakTypeIntent::ExplicitUnsafe,
+          detail: format!("unsafe-coerce:target={target}"),
+          path: format_cirru_path(root, path),
+        });
       }
       for (idx, item) in items.iter().enumerate() {
         path.push(idx);
@@ -1040,18 +1075,20 @@ pub fn run_weak_types_report(options: &WeakTypesCommand, snapshot: &snapshot::Sn
   }
   let _ = writeln!(
     out,
-    "- hits: schema-dynamic={} unresolved-type-slot={} code-dynamic={} code-nil={}",
+    "- hits: schema-dynamic={} unresolved-type-slot={} code-dynamic={} code-nil={} unsafe-coerce={}",
     kind_count.get("schema-dynamic").copied().unwrap_or(0),
     kind_count.get("unresolved-type-slot").copied().unwrap_or(0),
     kind_count.get("code-dynamic").copied().unwrap_or(0),
-    kind_count.get("code-nil").copied().unwrap_or(0)
+    kind_count.get("code-nil").copied().unwrap_or(0),
+    kind_count.get("unsafe-coerce").copied().unwrap_or(0)
   );
   let _ = writeln!(
     out,
-    "- intents: unresolved={} intentional-js-ffi={} intentional-type-slot-dynamic={} declared-unit={} declared-optional={}",
+    "- intents: unresolved={} intentional-js-ffi={} intentional-type-slot-dynamic={} explicit-unsafe={} declared-unit={} declared-optional={}",
     intent_count.get("unresolved").copied().unwrap_or(0),
     intent_count.get("intentional-js-ffi").copied().unwrap_or(0),
     intent_count.get("intentional-type-slot-dynamic").copied().unwrap_or(0),
+    intent_count.get("explicit-unsafe").copied().unwrap_or(0),
     intent_count.get("declared-unit").copied().unwrap_or(0),
     intent_count.get("declared-optional").copied().unwrap_or(0)
   );
@@ -1106,11 +1143,32 @@ pub fn run_weak_types_report(options: &WeakTypesCommand, snapshot: &snapshot::Sn
       "- next: filter `--only code-nil --intent unresolved,declared-optional`; declare Unit and remove redundant nil/`;nil` for no-value returns, then prefer Option/Result for application absence or failure."
     );
   }
+  let unsafe_coercions = rows
+    .iter()
+    .flat_map(|row| row.occurrences.iter())
+    .filter(|occurrence| occurrence.kind == WeakTypeKind::UnsafeCoerce)
+    .count();
+  if unsafe_coercions > 0 {
+    let _ = writeln!(
+      out,
+      "- agent-note: {unsafe_coercions} explicit unsafe coercion(s) cross a JS FFI boundary and need a documented runtime contract."
+    );
+    let _ = writeln!(
+      out,
+      "- next: rerun with `--only unsafe-coerce`; keep each assertion in a minimal adapter and add positive and negative boundary-contract tests."
+    );
+  }
   if options.summary_only {
     return Ok(());
   }
   let _ = writeln!(out, "- detail:");
-  for kind in ["schema-dynamic", "unresolved-type-slot", "code-dynamic", "code-nil"] {
+  for kind in [
+    "schema-dynamic",
+    "unresolved-type-slot",
+    "code-dynamic",
+    "code-nil",
+    "unsafe-coerce",
+  ] {
     let _ = writeln!(out, "  - {kind}");
     if let Some(items) = detail_count.get(kind) {
       for (detail, count) in items {
@@ -2347,13 +2405,20 @@ pub fn format_weak_types_json(options: &WeakTypesCommand, snapshot: &snapshot::S
       *intents.entry(occurrence.intent.as_str()).or_insert(0) += 1;
     }
   }
-  for kind in ["schema-dynamic", "unresolved-type-slot", "code-dynamic", "code-nil"] {
+  for kind in [
+    "schema-dynamic",
+    "unresolved-type-slot",
+    "code-dynamic",
+    "code-nil",
+    "unsafe-coerce",
+  ] {
     kinds.entry(kind).or_insert(0);
   }
   for intent in [
     "unresolved",
     "intentional-js-ffi",
     "intentional-type-slot-dynamic",
+    "explicit-unsafe",
     "declared-unit",
     "declared-optional",
   ] {
@@ -2402,6 +2467,11 @@ pub fn format_weak_types_json(options: &WeakTypesCommand, snapshot: &snapshot::S
         && matches!(occurrence.intent, WeakTypeIntent::Unresolved | WeakTypeIntent::DeclaredOptional)
     })
     .count();
+  let unsafe_coercions = rows
+    .iter()
+    .flat_map(|row| row.occurrences.iter())
+    .filter(|occurrence| occurrence.kind == WeakTypeKind::UnsafeCoerce)
+    .count();
   let mut diagnostics = vec![];
   if unresolved_dynamic > 0 {
     diagnostics.push(serde_json::json!({
@@ -2430,8 +2500,17 @@ pub fn format_weak_types_json(options: &WeakTypesCommand, snapshot: &snapshot::S
       "suggestion": "Declare Unit and remove redundant nil/`;nil` for no-value returns. Prefer Option for application absence and Result when failure details matter; keep Optional only at compatibility or FFI boundaries.",
     }));
   }
+  if unsafe_coercions > 0 {
+    diagnostics.push(serde_json::json!({
+      "code": "W_JS_FFI_UNCHECKED_COERCE",
+      "phase": "analysis",
+      "severity": "warning",
+      "message": format!("{unsafe_coercions} explicit unsafe coercion(s) bypass static compatibility at a JS FFI boundary."),
+      "suggestion": "Keep each assertion in a minimal adapter, validate or normalize host values before application code consumes them, and add positive and negative runtime-contract tests.",
+    }));
+  }
   let envelope = serde_json::json!({
-    "schema_version": 3,
+    "schema_version": 4,
     "command": "analyze.weak-types",
     "revision": analysis_revision(snapshot, &ids)?,
     "data": {


### PR DESCRIPTION
## Summary
- add unsafe-coerce / explicit-unsafe inventory rows to analyze weak-types
- report exact Snapshot paths, declared target schemas, and JSON v4 diagnostic W_JS_FFI_UNCHECKED_COERCE
- keep the existing eight-metric quality baseline stable while documenting the audit workflow

## Validation
- cargo fmt
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-agent-interface
- yarn check-all
- new CLI scan against respo-calcit-workflow