### PR TITLE
feat: publish release asset manifest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,8 +63,10 @@ jobs:
       - run: cargo build --release
 
       - name: Generate release asset manifest
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: >
-          node scripts/release-manifest.mjs "${{ github.event.release.tag_name }}"
+          node scripts/release-manifest.mjs "$RELEASE_TAG"
           target/release/calcit target/release/caps target/release/cr-wasm
           > target/release/calcit-release-manifest.json
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,6 +62,12 @@ jobs:
 
       - run: cargo build --release
 
+      - name: Generate release asset manifest
+        run: >
+          node scripts/release-manifest.mjs "${{ github.event.release.tag_name }}"
+          target/release/calcit target/release/caps target/release/cr-wasm
+          > target/release/calcit-release-manifest.json
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
@@ -69,6 +75,7 @@ jobs:
             target/release/calcit
             target/release/cr-wasm
             target/release/caps
+            target/release/calcit-release-manifest.json
 
       - uses: katyo/publish-crates@v1
         with:

--- a/editing-history/202608212330-release-asset-manifest.md
+++ b/editing-history/202608212330-release-asset-manifest.md
@@ -1,0 +1,9 @@
+# Versioned release asset manifest
+
+- The release workflow now publishes `calcit-release-manifest.json` alongside
+  `calcit`, `caps`, and `cr-wasm`.
+- Manifest schema v1 records release version, filename, byte size, and SHA-256
+  for each asset. Setup tooling can verify a downloaded binary before adding it
+  to `PATH`, without trusting a successful HTTP response alone.
+- The generator uses Node standard-library APIs and has a focused fixture test
+  so the release file remains deterministic and machine-readable.

--- a/editing-history/202608212345-release-manifest-review.md
+++ b/editing-history/202608212345-release-manifest-review.md
@@ -1,0 +1,6 @@
+# Release manifest review follow-up
+
+The release-manifest helper now emits a single-line usage error instead of a
+stack trace. The publishing workflow passes the release tag through an
+environment variable, preventing release metadata from being interpolated into
+shell source.

--- a/scripts/release-manifest.mjs
+++ b/scripts/release-manifest.mjs
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+const [, , version, ...assetPaths] = process.argv;
+
+if (!version || assetPaths.length === 0) {
+  throw new Error("Usage: node scripts/release-manifest.mjs <version> <asset>...");
+}
+
+const assets = await Promise.all(
+  assetPaths.map(async (assetPath) => {
+    const [content, metadata] = await Promise.all([readFile(assetPath), stat(assetPath)]);
+    return {
+      name: path.basename(assetPath),
+      sha256: createHash("sha256").update(content).digest("hex"),
+      size: metadata.size,
+    };
+  }),
+);
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      schemaVersion: 1,
+      version,
+      assets,
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/scripts/release-manifest.mjs
+++ b/scripts/release-manifest.mjs
@@ -5,28 +5,29 @@ import path from "node:path";
 const [, , version, ...assetPaths] = process.argv;
 
 if (!version || assetPaths.length === 0) {
-  throw new Error("Usage: node scripts/release-manifest.mjs <version> <asset>...");
+  process.stderr.write("Usage: node scripts/release-manifest.mjs <version> <asset>...\n");
+  process.exitCode = 1;
+} else {
+  const assets = await Promise.all(
+    assetPaths.map(async (assetPath) => {
+      const [content, metadata] = await Promise.all([readFile(assetPath), stat(assetPath)]);
+      return {
+        name: path.basename(assetPath),
+        sha256: createHash("sha256").update(content).digest("hex"),
+        size: metadata.size,
+      };
+    }),
+  );
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        version,
+        assets,
+      },
+      null,
+      2,
+    )}\n`,
+  );
 }
-
-const assets = await Promise.all(
-  assetPaths.map(async (assetPath) => {
-    const [content, metadata] = await Promise.all([readFile(assetPath), stat(assetPath)]);
-    return {
-      name: path.basename(assetPath),
-      sha256: createHash("sha256").update(content).digest("hex"),
-      size: metadata.size,
-    };
-  }),
-);
-
-process.stdout.write(
-  `${JSON.stringify(
-    {
-      schemaVersion: 1,
-      version,
-      assets,
-    },
-    null,
-    2,
-  )}\n`,
-);

--- a/scripts/release-manifest.test.mjs
+++ b/scripts/release-manifest.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("release manifest records asset name, size, and SHA-256", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "calcit-release-manifest-"));
+  const asset = path.join(directory, "calcit");
+  await writeFile(asset, "calcit release asset");
+
+  const result = spawnSync(process.execPath, ["scripts/release-manifest.mjs", "0.13.28", asset], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+
+  const manifest = JSON.parse(result.stdout);
+  assert.deepEqual(manifest, {
+    schemaVersion: 1,
+    version: "0.13.28",
+    assets: [
+      {
+        name: "calcit",
+        sha256: createHash("sha256").update("calcit release asset").digest("hex"),
+        size: 20,
+      },
+    ],
+  });
+});

--- a/scripts/release-manifest.test.mjs
+++ b/scripts/release-manifest.test.mjs
@@ -30,3 +30,13 @@ test("release manifest records asset name, size, and SHA-256", async () => {
     ],
   });
 });
+
+test("release manifest reports a concise usage error", () => {
+  const result = spawnSync(process.execPath, ["scripts/release-manifest.mjs"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.equal(result.stderr, "Usage: node scripts/release-manifest.mjs <version> <asset>...\n");
+});


### PR DESCRIPTION
## Summary\n- publish a schema-versioned release manifest with asset names, sizes, and SHA-256 values\n- attach the manifest to every GitHub release for setup-calcit verification\n\n## Verification\n- node --test scripts/release-manifest.test.mjs\n- generated a manifest from target/debug/calcit