### PR TITLE
fix: avoid same-package metadata collisions

### DIFF
--- a/2026082200-same-package-module-meta.md
+++ b/2026082200-same-package-module-meta.md
@@ -1,0 +1,4 @@
+# 2026-08-22 00:00
+
+- 同 package 的应用和依赖模块现在复用应用 Snapshot 的 `<package>.$meta`，避免 self-module 迁移时把重复 meta 误判为命名空间冲突。
+- 保留其它同名命名空间的冲突检查，并增加同 package meta 回归测试。

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,9 @@ fn load_module_recursive(
 /// graph or a mismatched dependency resolution.
 pub fn merge_module_files(target: &mut snapshot::Snapshot, module: &snapshot::Snapshot, module_path: &str) -> Result<(), String> {
   for (namespace, file) in &module.files {
+    if namespace == &format!("{}.$meta", target.package) {
+      continue;
+    }
     if let Some(existing) = target.files.get(namespace) {
       if existing == file {
         continue;
@@ -445,6 +448,26 @@ mod module_resolution_tests {
     let other = load_module("two/", &root, &module_folder).unwrap();
     let error = merge_module_files(&mut target, &other, "two/").unwrap_err();
     assert!(error.contains("namespace `shared` conflicts with existing content"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn merge_module_files_reuses_meta_for_same_package_modules() {
+    let root = temp_root("same-package-meta");
+    write_module(&root, "one", &[], "one");
+    write_module(&root, "two", &[], "two");
+    let module_folder = project_module_folder(&root);
+    let mut target = load_module("one/", &root, &module_folder).unwrap();
+    let original_meta = target.files.get("one.$meta").unwrap().clone();
+    let mut dependency = load_module("two/", &root, &module_folder).unwrap();
+    dependency.package = target.package.clone();
+    dependency.files.remove("two.$meta");
+    dependency.files.insert(
+      "one.$meta".to_owned(),
+      super::snapshot::gen_meta_ns("one.$meta", "dependency/calcit.cirru"),
+    );
+    merge_module_files(&mut target, &dependency, "two/").unwrap();
+    assert_eq!(target.files.get("one.$meta").unwrap(), &original_meta);
     fs::remove_dir_all(root).unwrap();
   }
 


### PR DESCRIPTION
## Summary
- reuse the target package metadata namespace when merging modules
- add regression coverage for same-package module metadata

This prevents newer Calcit versions from rejecting projects whose package metadata is repeated by a same-package module graph.

## Validation
- `cargo fmt --all`
- `cargo test module_resolution_tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --bin calcit`

Closes #383