### PR TITLE
fix: tolerate same-package namespace cycles

### DIFF
--- a/history/2026082223-same-package-namespaces.md
+++ b/history/2026082223-same-package-namespaces.md
@@ -1,0 +1,5 @@
+# Same-package namespace loading
+
+- Treat namespaces from the target package as already authoritative when a transitive dependency cycle lists them again.
+- Keep rejecting conflicting namespaces that cross package boundaries.
+- Add regression coverage for duplicate same-package namespaces with different snapshot content.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ fn load_module_recursive(
 /// graph or a mismatched dependency resolution.
 pub fn merge_module_files(target: &mut snapshot::Snapshot, module: &snapshot::Snapshot, module_path: &str) -> Result<(), String> {
   for (namespace, file) in &module.files {
-    if namespace == &format!("{}.$meta", target.package) {
+    if namespace == &target.package || namespace.starts_with(&format!("{}.", target.package)) {
       continue;
     }
     if let Some(existing) = target.files.get(namespace) {
@@ -452,13 +452,14 @@ mod module_resolution_tests {
   }
 
   #[test]
-  fn merge_module_files_reuses_meta_for_same_package_modules() {
+  fn merge_module_files_reuses_namespaces_for_same_package_modules() {
     let root = temp_root("same-package-meta");
     write_module(&root, "one", &[], "one");
     write_module(&root, "two", &[], "two");
     let module_folder = project_module_folder(&root);
     let mut target = load_module("one/", &root, &module_folder).unwrap();
     let original_meta = target.files.get("one.$meta").unwrap().clone();
+    let original_file = target.files.get("one").unwrap().clone();
     let mut dependency = load_module("two/", &root, &module_folder).unwrap();
     dependency.package = target.package.clone();
     dependency.files.remove("two.$meta");
@@ -466,8 +467,12 @@ mod module_resolution_tests {
       "one.$meta".to_owned(),
       super::snapshot::gen_meta_ns("one.$meta", "dependency/calcit.cirru"),
     );
+    dependency
+      .files
+      .insert("one".to_owned(), super::snapshot::gen_meta_ns("one", "dependency/calcit.cirru"));
     merge_module_files(&mut target, &dependency, "two/").unwrap();
     assert_eq!(target.files.get("one.$meta").unwrap(), &original_meta);
+    assert_eq!(target.files.get("one").unwrap(), &original_file);
     fs::remove_dir_all(root).unwrap();
   }
 


### PR DESCRIPTION
修复循环依赖中同一 package namespace 被重复合并的问题；保留跨 package 冲突检查，并加入回归测试。