### PR TITLE
feat: simplify typed Option query defaults

### DIFF
--- a/RFCs/08-23-typed-option-query-ergonomics-rfc.md
+++ b/RFCs/08-23-typed-option-query-ergonomics-rfc.md
@@ -1,0 +1,110 @@
+# 类型安全的 Option 查询终点 RFC
+
+状态：Implemented（待发布与生态迁移）
+日期：2026-08-23
+
+## 背景与生态证据
+
+`08-05-systematic-nil-reduction-rfc.md` 把公开缺失值统一为 `Option<T>`，边界已经比旧的
+`nil` 契约安全。但迁移后的业务代码出现了新的机械噪音：一次普通查询往往立即接
+`option:unwrap-or`，把“查找”和“缺失时采用业务默认值”拆成两层调用。
+
+对 `/Users/chenyong/repo` 下本地 Calcit Snapshot 的初步盘点发现：
+
+- 约 102 个 Calcit 项目包含 unwrap 相关调用；
+- `unwrap-or` 约 1500 次，直接 `unwrap` 约 300 次；
+- 单行可识别的 `option:unwrap-or (get ...)` 约 985 次；
+- `get-env`、`first`、`last`、`nth` 后立即提供默认值也是重复模式；
+- 典型业务仓库包括 Respo 组件、Lilac、Termina 服务和 Cumulo 应用。
+
+这些调用可分为四类：
+
+1. 查询后立即采用默认值；
+2. 根据 some/none 分支并绑定 payload；
+3. 由前置条件证明必然存在的内部不变量；
+4. Result 的可恢复错误处理。
+
+第一类数量最大，适合由 core API 直接简化。第二类已经由 `if-let`、`when-let` 和
+`match` 覆盖。第三类仍需显式 `.unwrap`，但应保持少量且靠近证明。第四类不能被
+Option 默认值 API 吞掉错误信息。
+
+## 设计原则
+
+- 不引入 `Option<T> -> T` 隐式转换；
+- 不让查询函数的原始返回类型随上下文变化；
+- 默认值必须经过现有 `.unwrap-or` 泛型检查；payload 可推断时，类型不兼容继续产生诊断，Dynamic 边界不伪造额外证据；
+- 需要区分“存在”和“缺失”时，继续返回并处理完整 `Option`；
+- 已知 Struct 字段继续使用 `(:field value)`，不允许借查询 helper 绕过字段检查；
+- 名称明确表达这是“以默认值结束查询”，而不是一般的错误恢复。
+
+## API
+
+新增以下 core 宏：
+
+| API | 展开语义 | 适用边界 |
+| --- | --- | --- |
+| `get-or base key fallback` | `option:unwrap-or (get base key) fallback` | Map / List / String / Enum 查询 |
+| `get-in-or base path fallback` | `option:unwrap-or (get-in base path) fallback` | 开放动态路径 |
+| `get-env-or name fallback` | `option:unwrap-or (get-env name) fallback` | 环境变量 |
+| `first-or xs fallback` | `option:unwrap-or (first xs) fallback` | 空集合默认值 |
+| `last-or xs fallback` | `option:unwrap-or (last xs) fallback` | 空集合默认值 |
+| `nth-or xs idx fallback` | `option:unwrap-or (nth xs idx) fallback` | 越界默认值 |
+
+使用宏而不是给原查询函数增加多重返回类型：`get x k` 始终保持 `Option<T>`，不会因为
+第三个参数或期望类型而改变契约。宏展开后仍由已有 Option helper 完成泛型绑定和参数检查；
+若来源本来就是 `Option<Dynamic>`，结果也不会假装获得具体 payload 类型。
+
+```cirru.no-check
+let
+    port $ get-or config :port 6000
+    mode $ get-env-or |mode |release
+    title $ get-in-or data ([] :page :title) |Untitled
+  println port mode title
+```
+
+fallback 沿用普通函数参数的 eager 求值语义。惰性 fallback 暂不开放：验证中发现
+`option:fold` 尚未强制两个回调共享返回类型，已记录为 issue #388。修复并验证该类型缺口后，
+可以单独评估 `*-or-else`，不能在当前 API 中悄悄改变副作用顺序。
+
+## 分支与不变量
+
+查询值需要分支时不使用 `*-or`：
+
+```cirru.no-check
+if-let
+  user $ get users user-id
+  render-user user
+  render-missing user-id
+```
+
+`if-let` 消费 `Option<T>` 并只在 some 分支绑定 `T`；`when-let` 用于返回
+`Option<R>` 的单分支组合；完整数据流优先使用穷尽 `match`。
+
+`.unwrap` 只保留在已有控制流、断言或数据结构不变量确实证明 some 的位置。迁移工具不得把
+`.unwrap` 机械替换为任意空值，也不得用 `unsafe-coerce` 擦除 Option。
+
+## 迁移与验收
+
+首轮生态迁移优先处理机械可验证的形式：
+
+```cirru.no-check
+option:unwrap-or (get config :port) 6000
+; =>
+get-or config :port 6000
+```
+
+迁移后必须运行当前项目的 `--check-only`、测试和对应 JS/native 构建。验收至少包括：
+
+1. 六个宏的存在与缺失路径测试；
+2. fallback 类型不兼容的负向诊断；
+3. Native 与 JS 的真实项目回归；
+4. 文档示例检查；
+5. 发布后在代表性生态仓库中证明辅助调用数量下降。
+
+## 非目标
+
+- 不改变 `get`、`get-in`、`first`、`last`、`nth`、`get-env` 的 Option 返回契约；
+- 不为 Result 提供会丢弃错误信息的查询别名；
+- 不删除 `option:unwrap-or` 的内部 lowering 实现；
+- 不保证业务 fallback 是惰性表达式；
+- 不自动修改 Dynamic 或旧 Optional/JsNullish 边界。

--- a/RFCs/08-23-typed-option-query-ergonomics-rfc.md
+++ b/RFCs/08-23-typed-option-query-ergonomics-rfc.md
@@ -9,7 +9,7 @@
 `nil` 契约安全。但迁移后的业务代码出现了新的机械噪音：一次普通查询往往立即接
 `option:unwrap-or`，把“查找”和“缺失时采用业务默认值”拆成两层调用。
 
-对 `/Users/chenyong/repo` 下本地 Calcit Snapshot 的初步盘点发现：
+对 2026-08-23 同步到各仓库默认分支后的本地 Calcit Snapshot 样本盘点发现：
 
 - 约 102 个 Calcit 项目包含 unwrap 相关调用；
 - `unwrap-or` 约 1500 次，直接 `unwrap` 约 300 次；

--- a/RFCs/README.md
+++ b/RFCs/README.md
@@ -1,6 +1,6 @@
 # RFC 整理索引
 
-更新时间：2026-08-21
+更新时间：2026-08-23
 
 ## 目录原则
 
@@ -48,6 +48,7 @@
 | `08-21-type-quality-ci-adoption-rfc.md`               | Draft       | 统一使用原生 `analyze quality` 与按 definition baseline，定义生态 CI 层级并禁止各项目重复实现 JS 汇总脚本。 |
 | `08-21-js-ffi-runtime-contract-validation-rfc.md`     | Draft       | 在现有 typed JS FFI 声明之上增加 host guard、decoder、runtime contract tests 与 unsafe evidence。 |
 | `08-21-static-type-system-evolution-roadmap.md`       | Draft       | 借鉴 Rust/MoonBit 推进 Unknown/Dynamic 分离、穷尽性、局部推断、trait coherence 与框架类型化。 |
+| `08-23-typed-option-query-ergonomics-rfc.md`           | Implemented | 保持 Option 边界，新增 `get-or` 等类型安全查询终点，减少业务代码中的机械 unwrap。 |
 
 ## 已执行的清理
 

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -94,7 +94,10 @@ let
 let
     find-user $ fn (users id)
       find users $ fn (u)
-        = (option:unwrap $ get u :id) id
+        if-let
+          user-id $ get u :id
+          = user-id id
+          , false
   println $ find-user
     [] ({} (:id |001) (:name |Alice))
     , |001
@@ -236,8 +239,11 @@ let
     toggle-todo! $ fn (id)
       swap! todos $ fn (items)
         map items $ fn (todo)
-          if (= (option:unwrap $ get todo :id) id)
-            assoc todo :done $ not (option:unwrap $ get todo :done)
+          if-let
+            todo-id $ get todo :id
+            if (= todo-id id)
+              assoc todo :done $ not (get-or todo :done false)
+              , todo
             , todo
   add-todo! |buy-milk
   add-todo! |write-docs

--- a/docs/features/hashmap.md
+++ b/docs/features/hashmap.md
@@ -189,10 +189,14 @@ let
 ```cirru
 let
     m $ {} (:a :one) (:b :two)
-    val $ get m :missing
-  val .unwrap-or :default
+    val $ get-or m :missing :default
+  , val
   ; => :default
 ```
+
+`get-or` 是 `(get m key) .unwrap-or fallback` 的类型安全查询终点；payload 类型可推断时，
+fallback 必须兼容该类型。需要区分 key 存在与缺失时仍使用 `get`，再以 `if-let` 或
+`match` 处理完整 `Option`。
 
 ### Counting occurrences
 
@@ -202,10 +206,7 @@ let
     init $ {}
     freq $ foldl words init $ fn (acc w)
       let
-          cur $ get acc w
-          n $ tag-match cur
-            (:some value) , value
-            (:none) 0
+          n $ get-or acc w 0
         assoc acc w (inc n)
   println freq
   ; ({} (:a 3) (:b 2) (:c 1))

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -270,6 +270,13 @@ Core lookup APIs that no longer need to preserve bootstrapping compatibility use
 - Public collection methods follow the same contract: Map/Set `.destruct` return their named destruct enums. Struct does not expose `.nth`, because field position is not stable across backends; field-name `get` returns the field's declared type directly.
 - `when-let` consumes `Option<T>` and returns `Option<R>`; `update-in` passes `Option<T>` to its updater so a missing leaf is never represented by nil.
 
+When a query immediately ends in a business default, use the typed query
+macros `get-or`, `get-in-or`, `get-env-or`, `first-or`, `last-or`, and
+`nth-or`. They preserve the original Option-returning APIs and expand through
+`.unwrap-or`, so an incompatible fallback is rejected whenever the payload type
+is known; an existing Dynamic boundary remains Dynamic. Keep the original Option
+and use `if-let` or exhaustive `match` when absence is a distinct branch.
+
 Raw JavaScript property reads and native calls are different: they return `JsNullish<JsObject>`. Narrow them with `js-present?`/`js-nullish?`; `nil?`, `some?`, and generic `optionally` do not erase this host boundary. Use `js-nullish->option` only as an explicit conversion after accepting or validating the opaque payload contract.
 
 When a generic payload cannot be inferred, Calcit keeps the nominal wrapper and uses `Dynamic` only for the unknown payload—for example, `find` over a dynamically typed list is still `Option<Dynamic>`, not plain `Dynamic`. This makes migration mistakes visible. Using nullable predicates (`some?`/`nil?`), positional enum access, or raw comparison on that Option reports `W_NOMINAL_ENUM_LEGACY_USE`; switch to Option methods or `tag-match`.
@@ -282,7 +289,7 @@ do
   assert= (%none) $ optionally nil
   assert= (%some 2) $ find ([] 1 2 3) (fn (x) (> x 1))
   assert= (%ok 1.5) $ parse-float |1.5
-  assert= |fallback $ (get-env |__MISSING_ENV__) .unwrap-or |fallback
+  assert= |fallback $ get-env-or |__MISSING_ENV__ |fallback
   assert= 0 $
     %none
     , .unwrap-or 0

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -293,6 +293,10 @@ Dynamic 应限制在 JS FFI、宏和框架开放数据边界。普通多态使�
 
 优先使用接收者方法组合可选值，例如 `opt .map f`、`opt .and-then f`、`opt .or-else f`；`Result` 同样使用 `.and-then`、`.map-err`、`.or-else`。`.unwrap` 只用于已经证明为 `some`/`ok` 的分支，`.unwrap-or` 只在默认值终点使用，避免把 `Option` 过早还原成 `nil`。
 
+查询后立即结束为业务默认值时，优先使用 `get-or`、`get-in-or`、`get-env-or`、
+`first-or`、`last-or`、`nth-or`。这些宏展开到类型化的 `.unwrap-or`，不会改变原查询 API
+的 `Option<T>` 契约。需要区分缺失分支时使用 `if-let` 或穷尽 `match`。
+
 `get-in` 返回 `Option<T>`，适合开放 Map/List 路径；不要用它绕过 Struct 字段检查，Struct 应使用 `(:field value)`。`update-in` 的 updater 接收 `Option<T>`，必须显式处理缺失值。
 
 ### Complex Types

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -352,8 +352,10 @@ let
 - `struct-match` - struct pattern matching
 - `list-match` - list destructuring match
 - `field-match` - map field matching
-- `if-let` - unwrap an `Option<T>` with explicit some/none branches
+- `if-let` - bind an `Option<T>` payload with explicit some/none branches
 - `when-let` - run a body for `%some` and return `Option<R>`
+- `get-or`, `get-in-or`, `get-env-or` - finish a lookup with a type-checked fallback
+- `first-or`, `last-or`, `nth-or` - finish positional lookup with a type-checked fallback
 
 Nested updates are nominal as well: `update-in` passes `Option<T>` to its
 updater, and `dissoc-in` treats an empty path as a no-op. Public lookup and

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -368,7 +368,7 @@ Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field`
 #### Option 返回 API 对照
 
 以下 API 不再用 `nil` 或 `-1` 表示缺失。把结果直接传给算术、字符串或集合函数时，诊断会显示完整的
-`Option<T>` 推断类型，并建议用 `option:unwrap-or` 或 `tag-match` 显式处理：
+`Option<T>` 推断类型，并建议用类型化 `*-or` 查询终点、`.unwrap-or`、`if-let` 或 `match` 显式处理：
 
 | API | 当前返回类型 | 迁移注意点 |
 | --- | --- | --- |
@@ -384,7 +384,7 @@ let
     xs $ [] 1 2 3
     predicate $ fn (x) = x 2
     idx $ find-index xs predicate
-    safe-idx $ option:unwrap-or idx 0
+    safe-idx $ idx .unwrap-or 0
   &+ safe-idx 1
 
 match (get-env |APP_MODE)
@@ -396,6 +396,21 @@ match (get-env |APP_MODE)
 `Option` 的 `:some` / `:none`，但 `match` 额外提供穷举检查。
 
 只有业务语义确实有合理默认值时才用 `unwrap-or`；需要区分“缺失”和“存在”时保留两个分支。
+
+查询结果立即采用默认值时可直接机械迁移，不改变原查询 API 的 Option 契约：
+
+```cirru.no-check
+option:unwrap-or (get config :port) 6000
+; =>
+get-or config :port 6000
+
+option:unwrap-or (get-env |mode) |release
+; =>
+get-env-or |mode |release
+```
+
+同类 API 包括 `get-in-or`、`first-or`、`last-or`、`nth-or`。fallback 必须与 payload
+类型兼容；需要区分缺失分支时不要使用这些终点，改用 `if-let` 或穷尽 `match`。
 
 #### `.trim` / `.blank?` 接收者迁移
 

--- a/editing-history/20260823-1541-typed-option-query-ergonomics.md
+++ b/editing-history/20260823-1541-typed-option-query-ergonomics.md
@@ -1,0 +1,7 @@
+# 类型安全的 Option 查询终点
+
+- 盘点本地 Calcit 生态中的 `unwrap` / `unwrap-or` 使用，确认最大重复模式是查询后立即提供默认值。
+- 新增 `get-or`、`get-in-or`、`get-env-or`、`first-or`、`last-or`、`nth-or` 六个 core 宏；宏展开到内部 `option:unwrap-or`，保留 Option 泛型检查和跨后端语义。
+- 保持原查询 API 始终返回 `Option<T>`，分支处理继续使用 `if-let` / `match`，不引入隐式解包或 Dynamic fallback。
+- 增加正常、缺失和 fallback 类型不兼容测试，并更新诊断、升级文档、常见模式与 RFC 索引。
+- 验证中发现 `option:fold` 未强制两个回调共享返回类型，记录为 GitHub issue #388；因此本版不承诺惰性 fallback。

--- a/editing-history/20260823-1615-option-query-review-fixes.md
+++ b/editing-history/20260823-1615-option-query-review-fixes.md
@@ -1,0 +1,6 @@
+# Option 查询终点 review 修正
+
+- RFC 的生态统计改为记录样本同步日期与默认分支状态，不包含本机绝对路径。
+- `RuntimeMapMeta`、`RuntimeMapResponse` 的 schema kind 与 `defstruct` 对齐为 `Struct`。
+- Option 迁移诊断只在能识别直接查询来源时推荐对应的 `get-or` 等 helper；普通 Option 值继续给出分支或方法建议。
+- 增加诊断单元测试，覆盖直接查询与无可证明查询来源两条路径。

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -216,10 +216,33 @@ fn option_returning_api_type_mismatches_include_unwrap_and_match_help() {
         .find(|warning| warning.code() == Some("W_PROC_ARG_TYPE_MISMATCH") && warning.message().contains(inferred))
         .unwrap_or_else(|| panic!("missing mismatch for {inferred}; warnings: {warnings:?}"));
       assert!(warning.message().contains("inferred type"), "warning: {warning:?}");
-      assert!(warning.message().contains("option:unwrap-or"), "warning: {warning:?}");
+      assert!(
+        warning.message().contains("typed `*-or` query helper when available"),
+        "warning: {warning:?}"
+      );
+      assert!(warning.message().contains(".unwrap-or"), "warning: {warning:?}");
       assert!(warning.message().contains("native `match`"), "warning: {warning:?}");
       assert!(warning.message().contains("tag-match"), "warning: {warning:?}");
     }
+  });
+}
+
+#[test]
+fn typed_query_fallback_rejects_a_different_payload_type() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries("get-or ({} (:a 1)) :a |wrong");
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("get-or mismatch should preprocess far enough to report its expanded typed helper call");
+
+    let warnings = warnings.borrow();
+    let warning = warnings
+      .iter()
+      .find(|warning| warning.code() == Some("W_FN_ARG_TYPE_MISMATCH"))
+      .unwrap_or_else(|| panic!("missing typed fallback mismatch; warnings: {warnings:?}"));
+    assert!(warning.message().contains("`calcit.core/option:unwrap-or` arg 2 expects type `'T`"));
+    assert!(warning.message().contains("got `:string`"));
   });
 }
 

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2,6 +2,7 @@
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |calcit)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'calcit.core/println!) (:mode :native) (:reload-fn 'calcit.core/println!)
+      :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
   :files $ {}
@@ -2735,7 +2736,7 @@
                 :generics $ [] 'T
                 :args $ [] 'T 'T
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Compare $ %{} 'CodeEntry (:doc "|Core trait for three-way comparison. Number and String implement it and return -1, 0, or 1.")
           :code $ quote
@@ -2745,7 +2746,7 @@
                 :generics $ [] 'T
                 :return 'Number
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Contains $ %{} 'CodeEntry (:doc "|Core trait: Contains")
           :code $ quote
@@ -2755,7 +2756,7 @@
                 :generics $ [] 'T 'K
                 :return 'Bool
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Countable $ %{} 'CodeEntry (:doc "|Core trait: Countable")
           :code $ quote
@@ -2764,7 +2765,16 @@
                 :generics $ [] 'T
                 :args $ [] 'T
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
+          :tags $ #{} :trait
+        |Debug $ %{} 'CodeEntry (:doc "|Core trait: Debug. All built-in Calcit values implement this diagnostic representation.")
+          :code $ quote
+            deftrait Debug $ .debug
+              :: :fn $ {} (:return :string)
+                :generics $ [] 'T
+                :args $ [] 'T
+          :examples $ []
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Deserialize $ %{} 'CodeEntry (:doc "|Core trait: Deserialize")
           :code $ quote
@@ -2773,7 +2783,7 @@
                 :generics $ [] 'T
                 :args $ [] :string
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Eq $ %{} 'CodeEntry (:doc "|Core trait: Eq")
           :code $ quote
@@ -2782,7 +2792,7 @@
                 :generics $ [] 'T
                 :args $ [] 'T 'T
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Len $ %{} 'CodeEntry (:doc "|Core trait: Len")
           :code $ quote
@@ -2791,7 +2801,7 @@
                 :generics $ [] 'T
                 :args $ [] 'T
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |ListDestruct $ %{} 'CodeEntry (:doc "|Nominal result of destruct-list: none, or a head element with the remaining list.")
           :code $ quote
@@ -2799,7 +2809,7 @@
               :some 'T $ :: 'List 'T
               :none
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
           :tags $ #{} :data
         |MapDestruct $ %{} 'CodeEntry (:doc "|Nominal result of destruct-map: none, or a key, value, and remaining map.")
           :code $ quote
@@ -2807,7 +2817,7 @@
               :some 'K 'V $ :: 'Map 'K 'V
               :none
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
           :tags $ #{} :data
         |Mappable $ %{} 'CodeEntry (:doc "|Core trait: Mappable")
           :code $ quote
@@ -2816,7 +2826,7 @@
                 :generics $ [] 'T
                 :args $ [] 'T :fn
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Multiply $ %{} 'CodeEntry (:doc "|Core trait: Multiply")
           :code $ quote
@@ -2825,7 +2835,7 @@
                 :generics $ [] 'T
                 :args $ [] 'T 'T
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |Option $ %{} 'CodeEntry (:doc "|Rust-style Option enum")
           :code $ quote
@@ -2839,7 +2849,7 @@
           :code $ quote
             defimpl OptionMappableImpl Mappable $ .map option:map
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Impl
           :tags $ #{} :trait-impl
         |OptionMethods $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -2859,7 +2869,7 @@
           :code $ quote
             defimpl ResultMappableImpl Mappable $ .map result:map
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Impl
           :tags $ #{} :trait-impl
         |ResultMethods $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -2871,7 +2881,7 @@
           :code $ quote
             defstruct RuntimeMapMeta $ :kind 'Tag
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
         |RuntimeMapResponse $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct RuntimeMapResponse (:code 'Number)
@@ -2879,7 +2889,7 @@
               :body 'Dynamic
               :meta $ :: 'Option RuntimeMapMeta
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
           :tags $ #{} :data :internal
         |Serialize $ %{} 'CodeEntry (:doc "|Core trait: Serialize")
           :code $ quote
@@ -2888,7 +2898,7 @@
                 :generics $ [] 'T
                 :args $ [] 'T
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |SetDestruct $ %{} 'CodeEntry (:doc "|Nominal result of destruct-set: none, or an element with the remaining set.")
           :code $ quote
@@ -2896,17 +2906,8 @@
               :some 'T $ :: 'Set 'T
               :none
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
           :tags $ #{} :data
-        |Debug $ %{} 'CodeEntry (:doc "|Core trait: Debug. All built-in Calcit values implement this diagnostic representation.")
-          :code $ quote
-            deftrait Debug $ .debug
-              :: :fn $ {} (:return :string)
-                :generics $ [] 'T
-                :args $ [] 'T
-          :examples $ []
-          :schema $ :: 'Dynamic
-          :tags $ #{} :trait
         |Show $ %{} 'CodeEntry (:doc "|Core trait: Show. User-facing presentation is opt-in; implement it explicitly with defimpl.")
           :code $ quote
             deftrait Show $ .show
@@ -2914,13 +2915,13 @@
                 :generics $ [] 'T
                 :args $ [] 'T
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Trait
           :tags $ #{} :trait
         |StringDestruct $ %{} 'CodeEntry (:doc "|Nominal result of destruct-str: none, or the first character with the remaining string.")
           :code $ quote
             defenum StringDestruct (:some 'String 'String) (:none)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Enum
           :tags $ #{} :data
         |[,] $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -4851,6 +4852,25 @@
               :code $ quote
                 assert= (%some |a) (first |abc)
               :tags $ #{} :core :unit
+        |first-or $ %{} 'CodeEntry (:doc "|Return the first item, or a type-compatible fallback for an empty collection.")
+          :code $ quote
+            defmacro first-or (xs fallback)
+              quasiquote $ option:unwrap-or
+                first $ ~ xs
+                ~ fallback
+          :examples $ []
+            quote $ assert= 0
+              first-or ([]) 0
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic 'Dynamic)
+          :tags $ #{} :macro
+          :tests $ []
+            %{} 'TestEntry (:name |returns-first-item-or-fallback)
+              :code $ quote
+                do
+                  assert= 1 $ first-or ([] 1 2) 0
+                  assert= 0 $ first-or ([]) 0
+              :tags $ #{} :core :unit
         |flipped $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro flipped (f & args)
@@ -5141,6 +5161,22 @@
               :features $ #{} :env :io
               :return $ :: 'Option 'String
           :tags $ #{} :env :io
+        |get-env-or $ %{} 'CodeEntry (:doc "|Read an environment variable, or return a String fallback when it is absent.")
+          :code $ quote
+            defmacro get-env-or (name fallback)
+              quasiquote $ option:unwrap-or
+                get-env $ ~ name
+                ~ fallback
+          :examples $ []
+            quote $ assert= |fallback (get-env-or |__CALCIT_TEST_MISSING_ENV_83B125E9__ |fallback)
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic 'Dynamic)
+          :tags $ #{} :macro
+          :tests $ []
+            %{} 'TestEntry (:name |returns-fallback-for-missing-env)
+              :code $ quote
+                assert= |fallback $ get-env-or |__CALCIT_TEST_MISSING_ENV_83B125E9__ |fallback
+              :tags $ #{} :core :unit
         |get-in $ %{} 'CodeEntry (:doc "|Get a nested value as Option<Dynamic>; none represents a missing path or nil encountered during traversal.")
           :code $ quote
             defn get-in (base path)
@@ -5178,6 +5214,62 @@
                   get-in
                     &{} :a $ &{} :b 2
                     [] :a :b
+              :tags $ #{} :core :unit
+        |get-in-or $ %{} 'CodeEntry (:doc "|Lookup a nested path and return its payload, or return a type-compatible fallback when the path is missing.")
+          :code $ quote
+            defmacro get-in-or (base path fallback)
+              quasiquote $ option:unwrap-or
+                get-in (~ base) (~ path)
+                ~ fallback
+          :examples $ []
+            quote $ assert= |missing
+              get-in-or
+                {} $ :a
+                  {} $ :b |found
+                [] :a :missing
+                , |missing
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic 'Dynamic 'Dynamic)
+          :tags $ #{} :macro
+          :tests $ []
+            %{} 'TestEntry (:name |returns-nested-value-or-fallback)
+              :code $ quote
+                do
+                  assert= 1 $ get-in-or
+                    {} $ :a
+                      {} $ :b 1
+                    [] :a :b
+                    , 2
+                  assert= 2 $ get-in-or
+                    {} $ :a
+                      {} $ :b 1
+                    [] :a :missing
+                    , 2
+              :tags $ #{} :core :unit
+        |get-or $ %{} 'CodeEntry (:doc "|Lookup a key or index and return its payload, or return a type-compatible fallback when the lookup is none.")
+          :code $ quote
+            defmacro get-or (base k fallback)
+              quasiquote $ option:unwrap-or
+                get (~ base) (~ k)
+                ~ fallback
+          :examples $ []
+            quote $ assert= 0
+              get-or
+                {} $ :a 1
+                , :missing 0
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic 'Dynamic 'Dynamic)
+          :tags $ #{} :macro
+          :tests $ []
+            %{} 'TestEntry (:name |returns-value-or-fallback)
+              :code $ quote
+                do
+                  assert= 1 $ get-or
+                    {} $ :a 1
+                    , :a 2
+                  assert= 2 $ get-or
+                    {} $ :a 1
+                    , :missing 2
               :tags $ #{} :core :unit
         |group-by $ %{} 'CodeEntry (:doc "|Group elements by the result of applying function f to each element")
           :code $ quote
@@ -5245,7 +5337,7 @@
             quote $ if (empty? xs) 0 (count xs)
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal :syntax
-        |if-let $ %{} 'CodeEntry (:doc "|Conditionally binds the result of an expression to a symbol and executes the matching branch when the value is non-nil.")
+        |if-let $ %{} 'CodeEntry (:doc "|Consume Option<T>, bind its payload in the some branch, and evaluate the explicit none branch without calling unwrap.")
           :code $ quote
             defmacro if-let (pair then ? else)
               if
@@ -5697,6 +5789,25 @@
             %{} 'TestEntry (:name |returns-last-string-character)
               :code $ quote
                 assert= (%some |c) (last |abc)
+              :tags $ #{} :core :unit
+        |last-or $ %{} 'CodeEntry (:doc "|Return the last item, or a type-compatible fallback for an empty collection.")
+          :code $ quote
+            defmacro last-or (xs fallback)
+              quasiquote $ option:unwrap-or
+                last $ ~ xs
+                ~ fallback
+          :examples $ []
+            quote $ assert= 3
+              last-or ([] 1 2 3) 0
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic 'Dynamic)
+          :tags $ #{} :macro
+          :tests $ []
+            %{} 'TestEntry (:name |returns-last-item-or-fallback)
+              :code $ quote
+                do
+                  assert= 2 $ last-or ([] 1 2) 0
+                  assert= 0 $ last-or ([]) 0
               :tags $ #{} :core :unit
         |let $ %{} 'CodeEntry (:doc "|macro for local bindings\nSyntax: (let ([name value] ...) body...)\nParams: pairs (list of binding pairs), body (expressions)\nReturns: result of body with bindings in scope\nCreates multiple local bindings sequentially")
           :code $ quote
@@ -6263,6 +6374,25 @@
             {}
               :args $ [] 'Dynamic 'Number
               :return $ :: 'Option 'Dynamic
+        |nth-or $ %{} 'CodeEntry (:doc "|Return an indexed item, or a type-compatible fallback when the index is invalid or out of bounds.")
+          :code $ quote
+            defmacro nth-or (xs idx fallback)
+              quasiquote $ option:unwrap-or
+                nth (~ xs) (~ idx)
+                ~ fallback
+          :examples $ []
+            quote $ assert= 0
+              nth-or ([] 1 2 3) 9 0
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic 'Dynamic 'Dynamic)
+          :tags $ #{} :macro
+          :tests $ []
+            %{} 'TestEntry (:name |returns-indexed-item-or-fallback)
+              :code $ quote
+                do
+                  assert= 2 $ nth-or ([] 1 2) 1 0
+                  assert= 0 $ nth-or ([] 1 2) 9 0
+              :tags $ #{} :core :unit
         |number? $ %{} 'CodeEntry (:doc "|Predicate that checks whether a value is a numeric scalar")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -8089,6 +8219,11 @@
             def &core-countable-struct-impl $ &impl::new :&core-countable-struct-impl (:: :count &struct:count)
           :examples $ []
           :schema $ :: 'Dynamic
+        |&core-debug-impl $ %{} 'CodeEntry (:doc "|Core trait impl for Debug")
+          :code $ quote
+            def &core-debug-impl $ &impl::new :&core-debug-impl (:: :debug &str)
+          :examples $ []
+          :schema $ :: 'Dynamic
         |&core-eq-impl $ %{} 'CodeEntry (:doc "|Core trait impl for Eq")
           :code $ quote
             def &core-eq-impl $ &impl::new :&core-eq-impl (:: :eq? &=)
@@ -8132,11 +8267,6 @@
         |&core-multiply-number-impl $ %{} 'CodeEntry (:doc "|Core trait impl for Multiply on number")
           :code $ quote
             def &core-multiply-number-impl $ &impl::new :&core-multiply-number-impl (:: :multiply &*)
-          :examples $ []
-          :schema $ :: 'Dynamic
-        |&core-debug-impl $ %{} 'CodeEntry (:doc "|Core trait impl for Debug")
-          :code $ quote
-            def &core-debug-impl $ &impl::new :&core-debug-impl (:: :debug &str)
           :examples $ []
           :schema $ :: 'Dynamic
         |&field-match-internal $ %{} 'CodeEntry (:doc |)

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2881,7 +2881,7 @@
           :code $ quote
             defstruct RuntimeMapMeta $ :kind 'Tag
           :examples $ []
-          :schema $ :: 'Enum
+          :schema $ :: 'Struct
         |RuntimeMapResponse $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct RuntimeMapResponse (:code 'Number)
@@ -2889,7 +2889,7 @@
               :body 'Dynamic
               :meta $ :: 'Option RuntimeMapMeta
           :examples $ []
-          :schema $ :: 'Enum
+          :schema $ :: 'Struct
           :tags $ #{} :data :internal
         |Serialize $ %{} 'CodeEntry (:doc "|Core trait: Serialize")
           :code $ quote

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -4058,7 +4058,9 @@ fn warn_on_nominal_enum_legacy_absence_use(
     | "symbol?" | "fn?" | "bool?" | "buffer?" | "cirru-quote?" | "ref?" | "macro?" | "syntax?" => {
       "pattern-match the nominal enum before applying a payload type predicate"
     }
-    _ if enum_name == "Option" => "use `tag-match`, `option:unwrap-or`, or an Option method to access the payload",
+    _ if enum_name == "Option" => {
+      "use `if-let`/`match` for branches, a typed `*-or` query helper for a lookup default, or an Option method to access the payload"
+    }
     _ => "use `tag-match` instead of positional access on the nominal enum",
   };
   let message = format!(

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3916,6 +3916,21 @@ fn nominal_enum_expression_name(value: &Calcit, scope_types: &ScopeTypes) -> Opt
   }
 }
 
+fn option_query_default_helper(value: &Calcit) -> Option<&'static str> {
+  let Calcit::List(items) = value else {
+    return None;
+  };
+  match items.first().and_then(canonical_absence_operation_name) {
+    Some("get") => Some("get-or"),
+    Some("get-in") => Some("get-in-or"),
+    Some("get-env") => Some("get-env-or"),
+    Some("first") => Some("first-or"),
+    Some("last") => Some("last-or"),
+    Some("nth") => Some("nth-or"),
+    _ => None,
+  }
+}
+
 /// Return the nominal element type used by a membership operation, when the
 /// collection has enough static information to prove it. `includes?` checks
 /// map values while `contains?` checks map keys.
@@ -4046,22 +4061,25 @@ fn warn_on_nominal_enum_legacy_absence_use(
 
   let guidance = match operation {
     "nil?" | "some?" if enum_name == "Option" => {
-      "use `option:none?`/`option:some?` (or the corresponding methods) instead of nullable-value predicates"
+      "use `option:none?`/`option:some?` (or the corresponding methods) instead of nullable-value predicates".to_owned()
     }
-    "nil?" | "some?" => "use `tag-match` to inspect the nominal enum variant",
+    "nil?" | "some?" => "use `tag-match` to inspect the nominal enum variant".to_owned(),
     "=" | "&=" if enum_name == "Option" => {
-      "compare Option values only with other Options, or unwrap/pattern-match before comparing a payload"
+      "compare Option values only with other Options, or unwrap/pattern-match before comparing a payload".to_owned()
     }
-    "=" | "&=" => "compare values of the same nominal enum, or pattern-match before comparing a payload",
-    "&compare" if enum_name == "Option" => "unwrap or pattern-match the Option before comparing its payload",
+    "=" | "&=" => "compare values of the same nominal enum, or pattern-match before comparing a payload".to_owned(),
+    "&compare" if enum_name == "Option" => "unwrap or pattern-match the Option before comparing its payload".to_owned(),
     "list?" | "map?" | "set?" | "struct?" | "enum?" | "struct-def?" | "enum-def?" | "tag?" | "number?" | "string?" | "keyword?"
     | "symbol?" | "fn?" | "bool?" | "buffer?" | "cirru-quote?" | "ref?" | "macro?" | "syntax?" => {
-      "pattern-match the nominal enum before applying a payload type predicate"
+      "pattern-match the nominal enum before applying a payload type predicate".to_owned()
     }
-    _ if enum_name == "Option" => {
-      "use `if-let`/`match` for branches, a typed `*-or` query helper for a lookup default, or an Option method to access the payload"
-    }
-    _ => "use `tag-match` instead of positional access on the nominal enum",
+    _ if enum_name == "Option" => match option_query_default_helper(value) {
+      Some(helper) => {
+        format!("use `if-let`/`match` for branches, typed `{helper}` for this query default, or an Option method to access the payload")
+      }
+      None => "use `if-let`/`match` for branches or an Option method to access the payload".to_owned(),
+    },
+    _ => "use `tag-match` instead of positional access on the nominal enum".to_owned(),
   };
   let message = format!(
     "[Warn] `{operation}` consumes nominal enum `{enum_name}` value `{value}` in {file_ns}/{def_name}; this often indicates a nullable-returning API migrated to a nominal type; {guidance}"
@@ -6704,6 +6722,26 @@ mod tests {
       &method_warnings,
     );
     assert_eq!(method_warnings.borrow().len(), 1, "structural Option methods should warn");
+    assert!(
+      !method_warnings.borrow()[0].message().contains("*-or"),
+      "a local Option value has no provable matching query-default helper"
+    );
+
+    let direct_get = Calcit::from(vec![core_head("get"), Calcit::Nil, Calcit::Number(0.0)]);
+    let direct_get_warnings = RefCell::new(vec![]);
+    warn_on_nominal_enum_legacy_absence_use(
+      &core_head("count"),
+      &CalcitList::from(std::slice::from_ref(&direct_get)),
+      &ScopeTypes::new(),
+      "tests.option-migration",
+      "demo",
+      &direct_get_warnings,
+    );
+    assert_eq!(direct_get_warnings.borrow().len(), 1, "direct get payload misuse should warn");
+    assert!(
+      direct_get_warnings.borrow()[0].message().contains("`get-or`"),
+      "a direct get query should suggest its matching typed fallback helper"
+    );
 
     let equality_head = core_head("=");
     let mixed_equality_args = CalcitList::from(&[option_value.to_owned(), Calcit::Number(1.0)] as &[Calcit]);

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -60,7 +60,7 @@ fn append_option_migration_hint(
 ) -> String {
   if actual_type.is_option_type() && !expected_type.is_option_type() {
     message.push_str(&format!(
-      "; inferred type `{}` is an Option rather than its payload; use `option:unwrap-or` for a safe default or native `match` (legacy `tag-match`) to handle both variants before passing it here",
+      "; inferred type `{}` is an Option rather than its payload; use a matching typed `*-or` query helper when available or `.unwrap-or` for a safe default, or native `match` (legacy `tag-match`) to handle both variants before passing it here",
       actual_type.to_brief_string()
     ));
   }


### PR DESCRIPTION
## Summary
- add typed `get-or`, `get-in-or`, `get-env-or`, `first-or`, `last-or`, and `nth-or` query endpoints
- preserve Option-returning contracts and fallback type checks while reducing mechanical unwrap calls
- document ecosystem evidence, migration guidance, and branch-binding patterns
- improve Option diagnostics and add positive/negative tests

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn compile`
- `yarn try-wasm`
- `yarn check-agent-interface`
- `yarn check-all`
- changed Markdown checked with `calcit docs check-md`
- latest Respo/alerts: `--check-only` and JS codegen after `get-env-or` migration
- latest worktools/serve-json: `--check-only` after Dynamic Map `get-or` migration

Related: #388 tracks a separate callback-return inference gap discovered while evaluating lazy fallback semantics; this PR does not claim to solve it.