### PR TITLE
fix: preserve canonical schema kinds across rewrites

### DIFF
--- a/editing-history/20260823-1645-definition-schema-roundtrip.md
+++ b/editing-history/20260823-1645-definition-schema-roundtrip.md
@@ -1,0 +1,6 @@
+# Definition schema round-trip 修复
+
+- 发现连续两次 `calcit edit/tree` 会把 `StructDef` / `EnumDef` schema 误读为匿名 `Enum`。
+- 根因是 Snapshot 的零 payload 类型包装 `:: 'Type` 仅对 `Dynamic` 特判，其他 canonical symbol 落入普通 enum 解析。
+- 统一通过 canonical type symbol parser 读取非 callable 的零 payload schema，并覆盖两次 load/save 的回归测试。
+- 真实复现与影响记录在 calcit-lang/calcit#390。

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -488,8 +488,19 @@ fn parse_loaded_schema_annotation(value: &Edn, owner: &str) -> Result<Arc<Calcit
     }
   }
 
-  if matches!(value, Edn::Enum(view) if view.variant.as_ref() == "Dynamic" && view.extra.is_empty()) {
-    return Ok(DYNAMIC_TYPE.clone());
+  // Snapshot writers wrap standalone type symbols as zero-payload EDN enums
+  // (`:: 'String`, `:: 'StructDef`, ...). Decode those wrappers back through
+  // the canonical symbol parser. Otherwise a second unrelated Snapshot write
+  // would interpret definition-kind markers as anonymous Enum values and
+  // silently serialize `StructDef`/`EnumDef` as `Enum`.
+  if let Edn::Enum(view) = value
+    && view.extra.is_empty()
+    && let Some(canonical) = CalcitTypeAnnotation::canonical_type_symbol_name(&view.variant)
+    && !matches!(canonical, "Fn" | "Macro" | "Optional" | "JsNullish" | "Variadic")
+  {
+    return Ok(CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from(
+      canonical,
+    ))));
   }
 
   // Primitive type tag stored as a plain EDN tag (e.g. :string, :number).
@@ -3940,6 +3951,44 @@ mod tests {
         edn,
         Edn::enum_value(CalcitTypeAnnotation::canonical_type_symbol_name(kind).expect("known kind"), vec![]),
         "schema kind `:{kind}` must round-trip as a canonical symbol, not degrade to dynamic"
+      );
+    }
+  }
+
+  #[test]
+  fn test_zero_payload_canonical_schema_wrappers_survive_repeated_round_trips() {
+    for symbol in [
+      "Dynamic",
+      "Unit",
+      "Bool",
+      "Number",
+      "String",
+      "Symbol",
+      "Tag",
+      "List",
+      "Map",
+      "Set",
+      "Enum",
+      "Ref",
+      "Buffer",
+      "CirruQuote",
+      "JsObject",
+      "Struct",
+      "StructDef",
+      "EnumDef",
+      "Trait",
+      "Impl",
+    ] {
+      let serialized = Edn::enum_value(symbol, vec![]);
+      let first = parse_loaded_schema_annotation(&serialized, "test/schema").unwrap_or_else(|error| panic!("{symbol}: {error}"));
+      let first_saved = schema_annotation_to_edn(first.as_ref());
+      assert_eq!(first_saved, serialized, "{symbol} should survive the first save");
+
+      let second = parse_loaded_schema_annotation(&first_saved, "test/schema").unwrap_or_else(|error| panic!("{symbol}: {error}"));
+      assert_eq!(
+        schema_annotation_to_edn(second.as_ref()),
+        serialized,
+        "{symbol} should not degrade on the second save"
       );
     }
   }


### PR DESCRIPTION
Closes #390.

## Summary
- decode zero-payload canonical schema wrappers through the canonical type parser
- preserve `StructDef`, `EnumDef`, and other standalone schema kinds across repeated Snapshot edits
- add a two-cycle load/save regression test

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`
- reproduced and verified against the affected edn-formatter Snapshot