### PR TITLE
fix: accept callable schema wrappers

### DIFF
--- a/editing-history/20260823-1711-callable-schema-wrapper.md
+++ b/editing-history/20260823-1711-callable-schema-wrapper.md
@@ -1,0 +1,5 @@
+# Callable schema wrapper 兼容修复
+
+- 跟进 PR #391 的异步审查，允许零 payload 的 `:: 'Fn` / `:: 'Macro` 进入 canonical symbol parser。
+- `Fn` 稳定往返为动态函数 schema；无签名信息的 `Macro` 也解析为动态函数并 canonicalize 为 `Fn`。
+- 仅继续拒绝必须携带内部类型的 `Optional`、`JsNullish`、`Variadic` 零 payload 包装。

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -496,7 +496,7 @@ fn parse_loaded_schema_annotation(value: &Edn, owner: &str) -> Result<Arc<Calcit
   if let Edn::Enum(view) = value
     && view.extra.is_empty()
     && let Some(canonical) = CalcitTypeAnnotation::canonical_type_symbol_name(&view.variant)
-    && !matches!(canonical, "Fn" | "Macro" | "Optional" | "JsNullish" | "Variadic")
+    && !matches!(canonical, "Optional" | "JsNullish" | "Variadic")
   {
     return Ok(CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from(
       canonical,
@@ -3968,6 +3968,7 @@ mod tests {
       "List",
       "Map",
       "Set",
+      "Fn",
       "Enum",
       "Ref",
       "Buffer",
@@ -3991,6 +3992,20 @@ mod tests {
         "{symbol} should not degrade on the second save"
       );
     }
+  }
+
+  #[test]
+  fn test_zero_payload_macro_schema_wrapper_canonicalizes_to_dyn_fn() {
+    let parsed = parse_loaded_schema_annotation(&Edn::enum_value("Macro", vec![]), "test/schema").unwrap();
+    assert!(matches!(parsed.as_ref(), CalcitTypeAnnotation::DynFn));
+
+    let canonical = Edn::enum_value("Fn", vec![]);
+    let first_saved = schema_annotation_to_edn(parsed.as_ref());
+    assert_eq!(first_saved, canonical);
+
+    let second = parse_loaded_schema_annotation(&first_saved, "test/schema").unwrap();
+    assert!(matches!(second.as_ref(), CalcitTypeAnnotation::DynFn));
+    assert_eq!(schema_annotation_to_edn(second.as_ref()), canonical);
   }
 
   #[test]


### PR DESCRIPTION
Follow-up to the asynchronous review on #391: https://github.com/calcit-lang/calcit/pull/391#discussion_r3838113360

## Changes
- allow zero-payload `Fn` and `Macro` wrappers through the canonical symbol parser
- keep rejecting only wrappers that require an inner payload (`Optional`, `JsNullish`, `Variadic`)
- verify `Fn` survives repeated round trips
- verify an unsigned `Macro` wrapper canonicalizes to the shared dynamic-function representation and remains stable as `Fn`

## Validation
- `cargo fmt`
- targeted zero-payload wrapper tests
- `cargo clippy -- -D warnings`
- `yarn check-all`