### PR TITLE
feat: add typed Option Result binding macros

### DIFF
--- a/RFCs/08-23-option-result-binding-macros-rfc.md
+++ b/RFCs/08-23-option-result-binding-macros-rfc.md
@@ -1,0 +1,72 @@
+# Option / Result 顺序绑定宏 RFC
+
+状态：Experimental
+日期：2026-08-23
+
+## 目标
+
+在不增加 parser syntax、提前返回控制流或隐式 unwrap 的前提下，简化连续的
+`Option` / `Result` 计算。实验能力完全由 core macro 提供，并展开为已有的
+`.and-then` 方法调用。
+
+本 RFC 不继续推进 labelled arguments。label 会同时进入参数声明、函数类型、
+调用绑定、偏函数与各 codegen 后端，现阶段复杂度高于收益。
+
+## API
+
+```cirru.no-check
+option:let
+    user $ get users user-id
+    profile $ get user :profile
+  %some $ render profile
+
+result:let
+    content $ read-file path
+    data $ parse-data content
+  save-data data
+```
+
+两个宏沿用现有 `let` 的 binding pair 结构。每个右侧表达式必须返回对应容器，
+body 也必须显式返回对应容器；宏不会自动添加 `%some` / `%ok`。
+
+`result:let` 展开为：
+
+```cirru.no-check
+(read-file path) .and-then $ fn (content)
+  (parse-data content) .and-then $ fn (data)
+    save-data data
+```
+
+`option:let` 同样展开为嵌套的 `.and-then`。因此每个表达式只求值一次，
+`:none` / `:err` 由现有方法原样短路传播，错误类型不同仍需显式 `.map-err`。
+
+## 方法优先的公开边界
+
+普通函数能力优先通过 Option / Result 的 method bag 暴露。用户代码应写
+`.map`、`.and-then`、`.or-else`、`.map-err` 和 `.unwrap-or`，命名空间函数
+`option:*` / `result:*` 保留为 core lowering 与动态边界。
+
+`option:let` / `result:let` 自身是控制代码展开的宏，不能通过运行时 method
+dispatch 调用，因此保留命名空间形式；它们生成的组合代码仍使用 `.and-then`。
+后续若增加 `fold`、lazy fallback、`flatten` 等普通函数，必须同步注册到对应
+method bag，并以接收者方法作为文档主用法。
+
+## 诊断与边界
+
+- bindings 必须是由二元 pair 组成的 list；左侧必须是 symbol；
+- body 至少包含一个表达式；
+- 不提供 Rust `?` 式外围函数 early return；macro 只控制自己包裹的 continuation；
+- 不在 Option 与 Result 之间隐式转换；
+- 不接受 nil / JsNullish 作为容器替代；
+- macro schema 本身保持 Dynamic AST 边界，展开结果继续接受普通方法 schema 检查。
+
+## 验收
+
+1. 多个 `:some` / `:ok` 绑定按顺序进入 body；
+2. `:none` / `:err` 在后续表达式执行前短路；
+3. body 返回裸值、容器混用和 Result 错误类型不一致时产生类型诊断；
+4. macro expansion 只包含现有 `fn`、`do` 和 `.and-then` 调用；
+5. Native 与 JS 构建和现有 core 测试全部通过。
+
+实验阶段先在真实 Calcit 项目替换少量嵌套 `.and-then`。只有在类型诊断、错误位置
+和生成代码都稳定后再移除 `:experimental`，不为缩短字符数增加新 parser syntax。

--- a/calcit/type-fail/.gitattributes
+++ b/calcit/type-fail/.gitattributes
@@ -1,2 +1,2 @@
 
-*.cirru -diff linguist-generated
+*.cirru diff -linguist-generated

--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -21,7 +21,7 @@
 
 - 前 4 个会触发 `schema mismatch while preprocessing definition`（定义时校验）。
 - `schema-call-arg-type-mismatch.cirru` 会触发基于 schema 的函数参数类型告警，并在 `--check-only` 下被当作错误处理。
-- `trait-method-generic-receiver-mismatch.cirru` 会验证泛型方法根据 receiver 的 `Option<String>` 绑定其 fallback 类型，并拒绝 `Number` fallback。
+- `trait-method-generic-receiver-mismatch.cirru` 会验证泛型方法根据 receiver 的 `Option<String>` 绑定其 fallback 类型，并拒绝 `Number` fallback；同时验证 `.and-then` callback 不能返回裸 payload。
 - `generic-where-bound-mismatch.cirru` 会触发 `W_GENERIC_WHERE_BOUND_MISMATCH`，验证泛型 `:where` 约束在调用点能被发现，并在 `--check-only` 下被当作错误处理。
 - `type-slot-record-call-arg-type-mismatch.cirru` 会验证 `bind-type` 绑定 struct 实例后，`*slot` 参与调用点类型检查。
 - `type-slot-bind-unknown.cirru` 会验证未声明 slot 的 `bind-type` 会直接失败。

--- a/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
+++ b/calcit/type-fail/trait-method-generic-receiver-mismatch.cirru
@@ -1,12 +1,22 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |type-fail-trait-method-generic-receiver) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-trait-method-generic-receiver)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'type-fail-trait-method-generic-receiver.main/main!) (:mode :native) (:reload-fn 'type-fail-trait-method-generic-receiver.main/reload!)
+      :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
   :files $ {}
     |type-fail-trait-method-generic-receiver.main $ %{} 'FileEntry
       :defs $ {}
+        |invalid-result-callback $ %{} 'CodeEntry (:doc "|Method callback deliberately returns a bare payload instead of Result.")
+          :code $ quote
+            defn invalid-result-callback (result)
+              result .and-then $ fn (value) value
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Result 'Number 'String)
+              :return $ :: 'Result 'Number 'String
         |main! $ %{} 'CodeEntry (:doc "|Entry for generic Option receiver method argument mismatch")
           :code $ quote
             defn main! (option) (option .unwrap-or 0)

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -376,6 +376,19 @@ parsed .and-then
   fn (value) $ validate value
 ```
 
+连续的同类容器步骤可以实验性使用 core macro；它们只展开为接收者 `.and-then`
+调用，不增加 parser syntax，也不自动 wrap 最终 body：
+
+```cirru.no-check
+result:let
+    content $ read-file path
+    data $ parse-data content
+  save-data data
+```
+
+`option:let` 使用相同的 binding pair 结构。每个右侧和最终 body 都必须保持同一种
+Option/Result 容器；错误类型需要转换时显式使用 `.map-err`。
+
 需要尝试备用来源时使用 `.or-else`；它只在 `none`/`err` 分支调用 fallback。`.unwrap` 只适合已经由 `tag-match`、`.some?` 或明确不变量证明为 `some` 的位置；默认值用 `.unwrap-or`，继续转换用 `.map` / `.and-then`。接收者已静态推断为 `Option`/`Result` 时，避免使用 `option:*` / `result:*` 的函数形式，以便接收者类型和类型流保持可见；未类型化 legacy 数据或 core 边界才保留直接 helper。
 
 `get-in` 返回 `Option<T>`，适合 Map/List/字符串等可能缺失的路径；路径进入 Struct 时应改用类型化的 `(:field value)` 访问，字段需要可缺失时在 Struct 中声明 `Option<T>`。`update-in` 的 updater 接收 `Option<T>`，缺失分支应显式处理，不要无条件 unwrap：

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -255,6 +255,14 @@ them to their internal direct implementations. Direct names such as
 `option:unwrap-or` and `result:unwrap-or` are core implementation details, not
 the public call style.
 
+For longer sequential pipelines, the experimental `option:let` and
+`result:let` macros reuse the ordinary `let` binding shape and lower entirely
+to nested `.and-then` calls. Their final body must return the same container;
+they do not introduce parser syntax or implicit wrapping. Macros remain
+namespace-qualified because expansion is compile-time behavior, while any new
+ordinary Option/Result operation should be registered in the corresponding
+method bag and documented in receiver-first form.
+
 `optionally` exists only for legacy core/internal `Optional<T>` compatibility. Public function schemas reject `Optional<T>`; new APIs return `Option<T>`, `Result<T,E>`, or `Unit` directly.
 
 Core lookup APIs that no longer need to preserve bootstrapping compatibility use nominal results directly:

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -67,6 +67,19 @@ loaded .and-then $ fn (value) (validate value)
 
 备用来源使用 `.or-else`。`.unwrap-or` 只用于确实需要默认值的终点，`.map` 用于同步转换，`.and-then` 用于下一个仍可能失败的操作。保留 `Option` 本身能让类型系统持续检查缺失路径；不要为了集合判断而把它解成 `nil`。
 
+多个连续步骤可以实验性使用 `option:let` / `result:let`。它们是普通 core macro，
+只展开为嵌套的 `.and-then`，不增加语言 syntax，也不会自动 wrap 或 unwrap body：
+
+```cirru.no-check
+result:let
+    content $ read-file path
+    data $ parse-data content
+  save-data data
+```
+
+body 必须继续返回 `Result`；Option 版本遵循相同规则。普通组合函数仍以接收者方法
+作为公开形式，`option:*` / `result:*` 直接函数调用主要保留给 core lowering。
+
 ## get-in / update-in
 
 `get-in` 是可能失败的开放数据访问，返回 `Option<T>`。不要用它绕过 Struct 字段检查；Struct 路径应使用 `(:field value)`，字段可缺失就把字段声明为 `Option<T>`。

--- a/editing-history/20260823-2101-option-result-binding-macros.md
+++ b/editing-history/20260823-2101-option-result-binding-macros.md
@@ -1,0 +1,9 @@
+# Option / Result 顺序绑定宏
+
+- 放弃 labelled arguments 方向，避免参数声明、函数类型、偏函数和 codegen 同时增加语法与绑定规则。
+- 在 core 中实验性增加 `option:let` / `result:let`，复用普通 `let` binding pair，并完全展开为接收者 `.and-then` 调用。
+- 宏不自动添加 `%some` / `%ok`，不提供外围函数 early return，也不在 Option、Result、nil 与 JsNullish 之间隐式转换。
+- 方法调用预处理现在会先用 receiver 绑定泛型，再把专门化后的 Fn 参数契约注入匿名 callback；callback 的返回类型因此能检查容器外层和 Result 错误类型。
+- 泛型函数返回检查不再因包含 type variable 而整体跳过，而是允许绑定 payload，同时继续验证 `Option` / `Result` 等外层结构。
+- 普通 Option/Result 能力保持 method-first：公开代码优先 `.map`、`.and-then`、`.or-else`、`.map-err`、`.unwrap-or`；命名空间函数主要服务 core lowering。
+- type-fail Snapshot 恢复普通文本 diff，不再通过目录级 `.gitattributes` 隐藏 Calcit 源码。

--- a/editing-history/20260823-2110-review-followup-393.md
+++ b/editing-history/20260823-2110-review-followup-393.md
@@ -1,0 +1,4 @@
+# PR #393 review follow-up
+
+- `expected_method_argument_types` 现在要求 receiver 与方法签名的 receiver 类型成功匹配后才注入 callback 契约。
+- receiver 绑定失败时直接回退，不使用空的或部分泛型 bindings 生成错误的 `EXPECTED_FN_TYPE`。

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -359,6 +359,30 @@ fn type_fail_trait_method_generic_receiver_fixture_reports_warning_code() {
       "warning message was: {}",
       matched[0].message()
     );
+
+    let callback_warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+    runner::preprocess::ensure_ns_def_compiled(
+      "type-fail-trait-method-generic-receiver.main",
+      "invalid-result-callback",
+      &callback_warnings,
+      &CallStackList::default(),
+    )
+    .expect("method callback fixture should preprocess with warnings, not hard errors");
+    let callback_warnings = callback_warnings.borrow();
+    let return_warnings: Vec<&LocatedWarning> = callback_warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_FN_RETURN_TYPE_MISMATCH"))
+      .collect();
+    assert_eq!(
+      return_warnings.len(),
+      1,
+      "expected one callback return warning, got: {callback_warnings:?}"
+    );
+    assert!(
+      return_warnings[0].message().contains("Result") && return_warnings[0].message().contains("number"),
+      "warning message was: {}",
+      return_warnings[0].message()
+    );
   });
 }
 

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -6449,6 +6449,51 @@
                   :args $ [] 'T
               :generics $ [] 'T 'U
           :tags $ #{} :internal
+        |option:let $ %{} 'CodeEntry (:doc "|Sequentially bind Option payloads through the .and-then method; stops at the first none and requires the body to return Option.")
+          :code $ quote
+            defmacro option:let (pairs & body)
+              if
+                not $ and (list? pairs) (every? pairs list?)
+                raise $ str-spaced "|option:let expects pairs in list, got:" pairs
+              if (&list:empty? body) (raise "|option:let expects at least 1 body expression")
+              if (&list:empty? pairs)
+                quasiquote $ do (~@ body)
+                &let
+                  pair $ &list:nth pairs 0
+                  if
+                    not $ &= 2 (&list:count pair)
+                    raise $ str-spaced "|option:let expects binding pair, got:" pair
+                  &let
+                    x $ &list:nth pair 0
+                    if
+                      not $ symbol? x
+                      raise $ str-spaced "|option:let expects a symbol for binding, got:" x
+                    &let
+                      value $ &list:nth pair 1
+                      quasiquote $ ~value .and-then
+                        fn (~x)
+                          option:let
+                            ~ $ &list:rest pairs
+                            ~@ body
+          :examples $ []
+            quote $ assert= (%some 5)
+              option:let
+                  x $ %some 2
+                  y $ %some 3
+                %some $ + x y
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic)
+          :tags $ #{} :experimental :macro
+          :tests $ []
+            %{} 'TestEntry (:name |short-circuits-none)
+              :code $ quote
+                assert= (%none)
+                  option:let
+                      x $ %some 2
+                      y $ %none
+                      unreachable $ raise |option-let-should-short-circuit
+                    %some $ + x y unreachable
+              :tags $ #{} :core :unit
         |option:map $ %{} 'CodeEntry (:doc "|Mappable map implementation for Option")
           :code $ quote
             defn option:map (opt f)
@@ -6944,6 +6989,51 @@
               :args $ [] (:: 'Result 'T 'E)
               :generics $ [] 'T 'E
           :tags $ #{} :internal
+        |result:let $ %{} 'CodeEntry (:doc "|Sequentially bind Result payloads through the .and-then method; preserves the first error and requires the body to return Result.")
+          :code $ quote
+            defmacro result:let (pairs & body)
+              if
+                not $ and (list? pairs) (every? pairs list?)
+                raise $ str-spaced "|result:let expects pairs in list, got:" pairs
+              if (&list:empty? body) (raise "|result:let expects at least 1 body expression")
+              if (&list:empty? pairs)
+                quasiquote $ do (~@ body)
+                &let
+                  pair $ &list:nth pairs 0
+                  if
+                    not $ &= 2 (&list:count pair)
+                    raise $ str-spaced "|result:let expects binding pair, got:" pair
+                  &let
+                    x $ &list:nth pair 0
+                    if
+                      not $ symbol? x
+                      raise $ str-spaced "|result:let expects a symbol for binding, got:" x
+                    &let
+                      value $ &list:nth pair 1
+                      quasiquote $ ~value .and-then
+                        fn (~x)
+                          result:let
+                            ~ $ &list:rest pairs
+                            ~@ body
+          :examples $ []
+            quote $ assert= (%ok 5)
+              result:let
+                  x $ %ok 2
+                  y $ %ok 3
+                %ok $ + x y
+          :schema $ :: 'Macro
+            {} $ :args ([] 'Dynamic)
+          :tags $ #{} :experimental :macro
+          :tests $ []
+            %{} 'TestEntry (:name |preserves-first-error)
+              :code $ quote
+                assert= (%err |stopped)
+                  result:let
+                      x $ %ok 2
+                      y $ %err |stopped
+                      unreachable $ raise |result-let-should-short-circuit
+                    %ok $ + x y unreachable
+              :tags $ #{} :core :unit
         |result:map $ %{} 'CodeEntry (:doc "|Mappable map implementation for Result")
           :code $ quote
             defn result:map (res f)

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3583,7 +3583,9 @@ fn expected_method_argument_types(type_value: &CalcitTypeAnnotation, method_name
   let fn_annotation = signature.as_function()?;
   let expected_receiver = fn_annotation.arg_types.first()?;
   let mut bindings = HashMap::new();
-  type_value.matches_with_bindings(expected_receiver.as_ref(), &mut bindings);
+  if !type_value.matches_with_bindings(expected_receiver.as_ref(), &mut bindings) {
+    return None;
+  }
   Some(
     fn_annotation
       .arg_types

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1376,9 +1376,22 @@ fn preprocess_list_call(
               calcit::MethodKind::Invoke(type_info.clone())
             };
             let typed_method = Calcit::Method(method_name.clone(), method_kind);
+            let expected_method_args = expected_method_argument_types(type_info.as_ref(), method_name.as_ref());
             let mut processed_args = CalcitList::new_inner_from(&[head_form]);
-            for arg in args.iter().skip(1) {
-              processed_args = processed_args.push(preprocess_expr(arg, scope_defs, scope_types, file_ns, check_warnings, call_stack)?);
+            for (arg_idx, arg) in args.iter().skip(1).enumerate() {
+              let expected_fn = expected_method_args
+                .as_ref()
+                .and_then(|types| types.get(arg_idx))
+                .and_then(|expected| expected.resolve_to_fn());
+              let previous_fn = EXPECTED_FN_TYPE.with(|cell| {
+                let mut slot = cell.borrow_mut();
+                let previous = slot.take();
+                *slot = expected_fn;
+                previous
+              });
+              let processed = preprocess_expr(arg, scope_defs, scope_types, file_ns, check_warnings, call_stack);
+              EXPECTED_FN_TYPE.with(|cell| *cell.borrow_mut() = previous_fn);
+              processed_args = processed_args.push(processed?);
             }
             let processed_args = CalcitList::from(processed_args);
             if is_display_contract {
@@ -3541,6 +3554,44 @@ fn check_struct_method_args(
       }
     }
   }
+}
+
+/// Resolve method argument types after binding the receiver's generic payloads.
+/// This is used before preprocessing inline callbacks, so their parameter and
+/// return contracts are available while the callback body is checked.
+fn expected_method_argument_types(type_value: &CalcitTypeAnnotation, method_name: &str) -> Option<Vec<Arc<CalcitTypeAnnotation>>> {
+  let signature = if let Some(traits) = trait_list_from_type(type_value) {
+    find_trait_method_type(&traits, method_name).map(|(_, method_type)| method_type.clone())?
+  } else {
+    let impl_values = get_impls_from_type(type_value)?;
+    let method_entry = find_method_entry_for_type(type_value, &impl_values, method_name)?;
+    match method_entry {
+      Calcit::Import(import) => program::lookup_def_schema(&import.ns, &import.def),
+      Calcit::Fn { info, .. } if info.def_ref.is_some() => program::lookup_def_schema(&info.def_ns, &info.name),
+      Calcit::Fn { info, .. } => Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+        generics: info.generics.clone(),
+        where_bounds: info.where_bounds.clone(),
+        arg_types: info.arg_types.clone(),
+        return_type: info.return_type.clone(),
+        fn_kind: SchemaKind::Fn,
+        rest_type: info.rest_type.clone(),
+        features: Arc::new(HashSet::new()),
+      }))),
+      _ => return None,
+    }
+  };
+  let fn_annotation = signature.as_function()?;
+  let expected_receiver = fn_annotation.arg_types.first()?;
+  let mut bindings = HashMap::new();
+  type_value.matches_with_bindings(expected_receiver.as_ref(), &mut bindings);
+  Some(
+    fn_annotation
+      .arg_types
+      .iter()
+      .skip(1)
+      .map(|arg| arg.substitute_type_vars(&bindings))
+      .collect(),
+  )
 }
 
 fn warn_on_dynamic_trait_call(
@@ -5742,7 +5793,15 @@ pub fn preprocess_defn(
 
       // Check function return type if declared
       // Extract return type hint from processed body (after preprocessing)
-      let return_type_hint = detect_return_type_hint_from_processed_body(&processed_body);
+      let detected_return_type = detect_return_type_hint_from_processed_body(&processed_body);
+      let return_type_hint = if matches!(detected_return_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
+        effective_fn_schema
+          .as_ref()
+          .map(|schema| schema.return_type.clone())
+          .unwrap_or(detected_return_type)
+      } else {
+        detected_return_type
+      };
       check_function_return_type(
         &processed_body,
         &return_type_hint,

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -558,10 +558,6 @@ pub(crate) fn check_function_return_type(
     return;
   }
 
-  if declared_return_type.contains_type_var() {
-    return;
-  }
-
   if fn_body.is_empty() {
     return;
   }
@@ -576,7 +572,11 @@ pub(crate) fn check_function_return_type(
     return;
   }
 
-  if !actual_type.as_ref().matches_annotation(declared_return_type.as_ref()) {
+  let mut bindings = HashMap::new();
+  if !actual_type
+    .as_ref()
+    .matches_with_bindings(declared_return_type.as_ref(), &mut bindings)
+  {
     let expected_str = declared_return_type.as_ref().to_brief_string();
     let actual_str = actual_type.as_ref().to_brief_string();
     gen_check_warning_code(
@@ -616,6 +616,62 @@ mod tests {
     let message = append_js_ffi_type_hint("type mismatch".to_owned(), "js-nullish<:js-object>");
     assert!(message.contains("stay opaque after JsNullish checks"));
     assert!(message.contains("unsafe-coerce"));
+  }
+
+  #[test]
+  fn generic_return_contract_still_checks_outer_shape() {
+    let body = vec![Calcit::Number(1.0)];
+    let expected = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("calcit.core/Result"),
+      Arc::new(vec![
+        Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))),
+        Arc::new(CalcitTypeAnnotation::String),
+      ]),
+    ));
+    let warnings = RefCell::new(vec![]);
+
+    check_function_return_type(&body, &expected, &ScopeTypes::new(), "tests.return", "callback", &warnings);
+
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1, "a generic payload must not erase the Result wrapper contract");
+    assert_eq!(warnings[0].code(), Some("W_FN_RETURN_TYPE_MISMATCH"));
+  }
+
+  #[test]
+  fn generic_return_contract_accepts_matching_wrapper() {
+    let generic = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let expected = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("calcit.core/Option"),
+      Arc::new(vec![generic]),
+    ));
+    let actual = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("calcit.core/Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    let local = CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("value")),
+      sym: Arc::from("value"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.return"),
+        at_def: Arc::from("callback"),
+      }),
+      location: None,
+      type_info: actual,
+    };
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(Arc::from("value"), local.type_info.clone());
+    let warnings = RefCell::new(vec![]);
+
+    check_function_return_type(
+      &[Calcit::Local(local)],
+      &expected,
+      &scope_types,
+      "tests.return",
+      "callback",
+      &warnings,
+    );
+
+    assert!(warnings.borrow().is_empty(), "matching generic wrappers should remain valid");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add experimental option:let and result:let core macros that lower to receiver .and-then calls
- keep ordinary Option and Result APIs method-first and avoid new parser syntax or implicit wrapping
- specialize method callback contracts from receiver generics and validate generic outer return shapes
- add positive, short-circuit, and type-fail coverage plus RFC and agent documentation
- restore text diffs for type-fail Calcit snapshots

## Validation

- cargo fmt
- cargo clippy -- -D warnings
- cargo test
- yarn compile
- yarn check-agent-interface
- yarn check-all
- Markdown checks for CalcitAgent, type guidance, polymorphism, and the RFC
- eval checks for valid chains, short circuiting, bare-body rejection, Option/Result mismatch, and Result error-type mismatch