### PR TITLE
fix: expand option and result let with method-first dispatch

### DIFF
--- a/RFCs/08-23-option-result-binding-macros-rfc.md
+++ b/RFCs/08-23-option-result-binding-macros-rfc.md
@@ -32,8 +32,8 @@ body 也必须显式返回对应容器；宏不会自动添加 `%some` / `%ok`�
 `result:let` 展开为：
 
 ```cirru.no-check
-(read-file path) .and-then $ fn (content)
-  (parse-data content) .and-then $ fn (data)
+.and-then (read-file path) $ fn (content)
+  .and-then (parse-data content) $ fn (data)
     save-data data
 ```
 

--- a/editing-history/20260823-2250-fix-option-let-method-order.md
+++ b/editing-history/20260823-2250-fix-option-let-method-order.md
@@ -1,0 +1,5 @@
+# Fix Option and Result binding macro method order
+
+- Corrected `option:let` and `result:let` expansion to call `.and-then` in Calcit's method-first form.
+- Added regression tests where a binding is an evaluated expression rather than a literal container.
+- Corrected the RFC expansion example and linked the regression to Issue #394.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -6470,7 +6470,7 @@
                       raise $ str-spaced "|option:let expects a symbol for binding, got:" x
                     &let
                       value $ &list:nth pair 1
-                      quasiquote $ ~value .and-then
+                      quasiquote $ .and-then ~value
                         fn (~x)
                           option:let
                             ~ $ &list:rest pairs
@@ -6494,6 +6494,12 @@
                       unreachable $ raise |option-let-should-short-circuit
                     %some $ + x y unreachable
               :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |expression-binding)
+              :code $ quote
+                assert= (%some 3)
+                  option:let
+                      x $ if true (%some 2) (%none)
+                    %some $ inc x
         |option:map $ %{} 'CodeEntry (:doc "|Mappable map implementation for Option")
           :code $ quote
             defn option:map (opt f)
@@ -7010,7 +7016,7 @@
                       raise $ str-spaced "|result:let expects a symbol for binding, got:" x
                     &let
                       value $ &list:nth pair 1
-                      quasiquote $ ~value .and-then
+                      quasiquote $ .and-then ~value
                         fn (~x)
                           result:let
                             ~ $ &list:rest pairs
@@ -7034,6 +7040,12 @@
                       unreachable $ raise |result-let-should-short-circuit
                     %ok $ + x y unreachable
               :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |expression-binding)
+              :code $ quote
+                assert= (%ok 3)
+                  result:let
+                      x $ if true (%ok 2) (%err |unreachable)
+                    %ok $ inc x
         |result:map $ %{} 'CodeEntry (:doc "|Mappable map implementation for Result")
           :code $ quote
             defn result:map (res f)


### PR DESCRIPTION
Fixes #394.

Corrects both binding macros to expand through `.and-then` in Calcit method-first form. Adds expression-binding regressions for Option and Result, and corrects the RFC expansion example.

Validated with core macro tests, cargo test, cargo clippy -- -D warnings, and fresh-CLI regressions in bisection-key and Respo.