### PR TITLE
feat(caps): verify Calcit JS runtime chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ caps tree
 caps why calcit-lang/memof
 caps status
 caps verify
+caps verify --toolchain # after yarn install, for JS projects
 ```
 
 ### Development

--- a/docs/installation/github-actions.md
+++ b/docs/installation/github-actions.md
@@ -70,6 +70,9 @@ locally:
 - name: Install dependencies
   run: caps --ci && yarn install --immutable
 
+- name: Verify Calcit runtime toolchain
+  run: caps verify --toolchain
+
 - name: Validate Snapshot and type quality
   run: |
     calcit calcit.cirru edit format

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -158,7 +158,7 @@ caps status
 
 Use `caps verify` for the stronger immutable-store and native-receipt checks. For JavaScript projects,
 run `caps verify --toolchain` after `yarn install` to require that `:calcit-version`, `caps`, the
-`package.json` `@calcit/procs` version anchor, and the installed runtime package agree. Shared
+`package.json` `@calcit/procs` declaration, and the installed runtime package agree exactly. Shared
 store revisions should not be edited directly; reinstall a damaged revision instead. `caps` overwrites
 `~/.config/calcit/module-caches/AGENTS.md` on every invocation with the workflow for changing a dependency:
 use its Git repository, commit the change, publish a new tag, then update `deps.cirru` and reinstall.

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -156,7 +156,9 @@ Check that every project link points to the revision selected from `deps.cirru` 
 caps status
 ```
 
-Use `caps verify` for the stronger immutable-store and native-receipt checks. Shared
+Use `caps verify` for the stronger immutable-store and native-receipt checks. For JavaScript projects,
+run `caps verify --toolchain` after `yarn install` to require that `:calcit-version`, `caps`, the
+`package.json` `@calcit/procs` version anchor, and the installed runtime package agree. Shared
 store revisions should not be edited directly; reinstall a damaged revision instead. `caps` overwrites
 `~/.config/calcit/module-caches/AGENTS.md` on every invocation with the workflow for changing a dependency:
 use its Git repository, commit the change, publish a new tag, then update `deps.cirru` and reinstall.

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -216,13 +216,13 @@ caps upgrade --all
 
 说明：`caps upgrade --all` 会检查 `:dependencies` 与根项目的 `:dev-dependencies`，更新
 对应分组中的依赖版本与 `:calcit-version`；如果确实发生升级，还会顺带执行一次
-`yarn up @calcit/procs@^<calcit-version>`，把 JS 运行时包的版本锚点同步到当前 Calcit 发布链路。
+`yarn up @calcit/procs@<calcit-version>`，把 JS 运行时包精确同步到当前 Calcit 发布链路。
 
 如果依赖清单本来已经是最新、但 `package.json` 中的 `@calcit/procs` 仍旧，`caps upgrade --all`
-可能没有产生更新动作。此时应显式执行 `yarn up @calcit/procs@^<calcit-version>`，审阅
+可能没有产生更新动作。此时应显式执行 `yarn up @calcit/procs@<calcit-version>`，审阅
 `package.json` / `yarn.lock`，然后在 `yarn install` 后运行 `caps verify --toolchain`。这个命令会
-要求 `deps.cirru :calcit-version`、运行中的 `caps`、`package.json` 的 `@calcit/procs` 版本锚点
-（精确版本或同版本的 `^` 范围）以及 Yarn 解析出的实际包版本完全一致；适合直接作为 CI 门禁。
+要求 `deps.cirru :calcit-version`、运行中的 `caps`、`package.json` 的 `@calcit/procs` 声明
+以及 Yarn 解析出的实际包版本全部精确一致；适合直接作为 CI 门禁。
 
 如果你只想批量把旧版本提升到最新标签，也可以继续用：
 
@@ -239,7 +239,6 @@ caps
 caps tree
 caps status
 caps verify
-caps verify --toolchain
 ```
 
 说明：这一步才会按当前 `deps.cirru` 下载/同步模块内容。根项目的两个依赖分组都会安装，
@@ -254,6 +253,7 @@ corepack enable
 corepack prepare yarn@4.12.0 --activate  # 示例；优先采用 packageManager 固定的版本
 yarn --version
 yarn install --immutable
+caps verify --toolchain
 ```
 
 说明：团队若习惯 Yarn Berry，建议固定 `packageManager` 并使用 `--immutable` 做一致性校验。

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -216,12 +216,13 @@ caps upgrade --all
 
 说明：`caps upgrade --all` 会检查 `:dependencies` 与根项目的 `:dev-dependencies`，更新
 对应分组中的依赖版本与 `:calcit-version`；如果确实发生升级，还会顺带执行一次
-`yarn up @calcit/procs`，把 JS 运行时包同步到当前 Calcit 版本链路。
+`yarn up @calcit/procs@^<calcit-version>`，把 JS 运行时包的版本锚点同步到当前 Calcit 发布链路。
 
 如果依赖清单本来已经是最新、但 `package.json` 中的 `@calcit/procs` 仍旧，`caps upgrade --all`
-可能没有产生更新动作。此时应显式执行 `yarn up @calcit/procs`，审阅 `package.json` / `yarn.lock`，
-并确认安装后的包版本与当前 Calcit 发布链路相符；不要只根据 caps 的 “Already up to date” 判断
-JS runtime 已同步。
+可能没有产生更新动作。此时应显式执行 `yarn up @calcit/procs@^<calcit-version>`，审阅
+`package.json` / `yarn.lock`，然后在 `yarn install` 后运行 `caps verify --toolchain`。这个命令会
+要求 `deps.cirru :calcit-version`、运行中的 `caps`、`package.json` 的 `@calcit/procs` 版本锚点
+（精确版本或同版本的 `^` 范围）以及 Yarn 解析出的实际包版本完全一致；适合直接作为 CI 门禁。
 
 如果你只想批量把旧版本提升到最新标签，也可以继续用：
 
@@ -238,6 +239,7 @@ caps
 caps tree
 caps status
 caps verify
+caps verify --toolchain
 ```
 
 说明：这一步才会按当前 `deps.cirru` 下载/同步模块内容。根项目的两个依赖分组都会安装，
@@ -604,6 +606,9 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
 
 - name: Install deps
   run: caps --ci && yarn install --immutable
+
+- name: Verify Calcit runtime toolchain
+  run: caps verify --toolchain
 
 - name: Validate Calcit snapshot and types
   run: |

--- a/editing-history/20260823-2328-caps-toolchain-guard.md
+++ b/editing-history/20260823-2328-caps-toolchain-guard.md
@@ -1,6 +1,6 @@
 # `caps verify --toolchain` runtime version guard
 
 - `deps.cirru :calcit-version` is the project-selected Calcit release. A regular `caps verify` validates module-store integrity; `caps verify --toolchain` additionally makes this version a CI gate.
-- For JavaScript projects the guard requires the running `caps` release, `package.json`'s `@calcit/procs` anchor (either the exact version or `^` with the same anchor), and the version Yarn resolves through `yarn node` to match exactly. This supports both Yarn PnP and node-modules installations.
-- `caps upgrade --all` now requests `@calcit/procs@^<current-calcit-version>` explicitly, so its manifest update remains tied to the Calcit release rather than whichever npm version happens to be latest.
+- For JavaScript projects the guard requires the running `caps` release, `package.json`'s exact `@calcit/procs` version, and the version Yarn resolves through `yarn node` to match exactly. This supports both Yarn PnP and node-modules installations.
+- `caps upgrade --all` now requests `@calcit/procs@<current-calcit-version>` explicitly, so its manifest and lockfile remain tied to the Calcit release rather than whichever npm version happens to be latest.
 - Place `caps verify --toolchain` after `caps --ci && yarn install --immutable` in JS CI. Native-only projects without `package.json` remain supported and verify the Calcit/deps pair only.

--- a/editing-history/20260823-2328-caps-toolchain-guard.md
+++ b/editing-history/20260823-2328-caps-toolchain-guard.md
@@ -1,0 +1,6 @@
+# `caps verify --toolchain` runtime version guard
+
+- `deps.cirru :calcit-version` is the project-selected Calcit release. A regular `caps verify` validates module-store integrity; `caps verify --toolchain` additionally makes this version a CI gate.
+- For JavaScript projects the guard requires the running `caps` release, `package.json`'s `@calcit/procs` anchor (either the exact version or `^` with the same anchor), and the version Yarn resolves through `yarn node` to match exactly. This supports both Yarn PnP and node-modules installations.
+- `caps upgrade --all` now requests `@calcit/procs@^<current-calcit-version>` explicitly, so its manifest update remains tied to the Calcit release rather than whichever npm version happens to be latest.
+- Place `caps verify --toolchain` after `caps --ci && yarn install --immutable` in JS CI. Native-only projects without `package.json` remain supported and verify the Calcit/deps pair only.

--- a/editing-history/20260823-2340-caps-toolchain-review-followup.md
+++ b/editing-history/20260823-2340-caps-toolchain-review-followup.md
@@ -1,0 +1,6 @@
+# Follow up: exact JS runtime toolchain guard
+
+- The CI guard now treats a `package.json` without `@calcit/procs` as an error. The no-`package.json` case remains the explicit native-project escape hatch.
+- Both `caps upgrade --all` and `caps verify --toolchain` use exact `@calcit/procs` versions. A SemVer caret could otherwise resolve a newer patch and make the upgrade command violate its own gate.
+- `caps upgrade --all <path/to/deps.cirru>` now runs Yarn in the directory containing that dependency file, rather than the caller's working directory.
+- Toolchain helper tests cover absent, exact, range, and installed-version cases, plus deriving the project root from a non-default `deps.cirru` path.

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -257,7 +257,10 @@ pub fn main() -> Result<(), String> {
           return Err(format!("{issues} module(s) are not in the expected state"));
         }
       }
-      Some(SubCommand::Verify(_)) => {
+      Some(SubCommand::Verify(opts)) => {
+        if opts.toolchain {
+          verify_toolchain(&deps, &cli_args)?;
+        }
         let graph = resolve_for_cli(&deps, &cli_args, false)?;
         print_warnings(&graph);
         let issues = verify_project_view(&graph, &graph_options(&cli_args, false)?)?;
@@ -345,6 +348,99 @@ fn graph_options(options: &TopLevelCaps, build_native: bool) -> Result<GraphOpti
   })
 }
 
+fn verify_toolchain(deps: &PackageDeps, options: &TopLevelCaps) -> Result<(), String> {
+  let expected = deps.calcit_version.as_deref().ok_or_else(|| {
+    format!(
+      "{} has no :calcit-version; add the Calcit release used by this project",
+      options.input
+    )
+  })?;
+  Version::parse(expected).map_err(|error| format!("invalid :calcit-version '{expected}': {error}"))?;
+  if expected != CALCIT_VERSION {
+    return Err(format!(
+      "Calcit toolchain mismatch: {} declares {expected}, but running caps is {CALCIT_VERSION}; install Calcit {expected} or upgrade deps.cirru",
+      options.input
+    ));
+  }
+
+  let project_root = graph_options(options, false)?.project_root;
+  let package_json = project_root.join("package.json");
+  if !package_json.exists() {
+    println!("toolchain: Calcit {expected} verified (no package.json; skipped @calcit/procs)");
+    return Ok(());
+  }
+
+  let package = read_procs_manifest_spec(&package_json)?;
+  let Some(spec) = package else {
+    println!("toolchain: Calcit {expected} verified (package.json has no @calcit/procs)");
+    return Ok(());
+  };
+  let accepted_specs = [expected.to_owned(), format!("^{expected}")];
+  if !accepted_specs.iter().any(|candidate| candidate == &spec) {
+    return Err(format!(
+      "Calcit toolchain mismatch: {} declares @calcit/procs@{spec}, expected {} (or ^{}); run `caps upgrade --all` or `yarn up @calcit/procs@^{expected}`",
+      package_json.display(),
+      expected,
+      expected
+    ));
+  }
+
+  let output = Command::new("yarn")
+    .args(["node", "-p", "require('@calcit/procs/package.json').version"])
+    .current_dir(&project_root)
+    .output()
+    .map_err(|error| format!("failed to run `yarn node` to inspect @calcit/procs: {error}; run `yarn install` first"))?;
+  if !output.status.success() {
+    return Err(format!(
+      "failed to resolve installed @calcit/procs with `yarn node`; run `yarn install` first: {}",
+      String::from_utf8_lossy(&output.stderr).trim()
+    ));
+  }
+  let installed = String::from_utf8(output.stdout)
+    .map_err(|error| format!("@calcit/procs version output was not UTF-8: {error}"))?
+    .trim()
+    .to_owned();
+  if installed != expected {
+    return Err(format!(
+      "Calcit toolchain mismatch: installed @calcit/procs is {installed}, expected {expected}; run `yarn up @calcit/procs@^{expected}` and commit the lockfile"
+    ));
+  }
+  println!("toolchain: Calcit and @calcit/procs are both {expected}");
+  Ok(())
+}
+
+fn read_procs_manifest_spec(package_json: &Path) -> Result<Option<String>, String> {
+  let content = fs::read_to_string(package_json).map_err(|error| format!("failed to read {}: {error}", package_json.display()))?;
+  let package: serde_json::Value =
+    serde_json::from_str(&content).map_err(|error| format!("invalid {}: {error}", package_json.display()))?;
+  let mut specs = Vec::new();
+  for section in ["dependencies", "devDependencies"] {
+    let Some(entries) = package.get(section) else {
+      continue;
+    };
+    let Some(entries) = entries.as_object() else {
+      return Err(format!("invalid {}.{section}: expected an object", package_json.display()));
+    };
+    let Some(value) = entries.get("@calcit/procs") else {
+      continue;
+    };
+    let Some(spec) = value.as_str() else {
+      return Err(format!(
+        "invalid {}.{section}.@calcit/procs: expected a version string",
+        package_json.display()
+      ));
+    };
+    specs.push(spec.to_owned());
+  }
+  if specs.len() > 1 && specs[0] != specs[1] {
+    return Err(format!(
+      "{} declares conflicting @calcit/procs versions in dependencies and devDependencies",
+      package_json.display()
+    ));
+  }
+  Ok(specs.into_iter().next())
+}
+
 fn resolve_for_cli(deps: &PackageDeps, options: &TopLevelCaps, build_native: bool) -> Result<ResolvedGraph, String> {
   resolve_graph(deps, &graph_options(options, build_native)?)
 }
@@ -424,9 +520,13 @@ enum SubCommand {
 struct StatusCaps {}
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
-/// verify store contents, project links, and native receipts
+/// verify store contents, project links, native receipts, and optionally the JS runtime toolchain
 #[argh(subcommand, name = "verify")]
-struct VerifyCaps {}
+struct VerifyCaps {
+  /// require :calcit-version, caps, the @calcit/procs manifest range, and its installed version to agree
+  #[argh(switch)]
+  toolchain: bool,
+}
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 /// rebuild the project module links from resolved immutable store entries
@@ -901,16 +1001,17 @@ fn sync_calcit_procs_package() -> Result<(), String> {
   }
 
   println!("syncing npm package {}...", "@calcit/procs".green());
+  let package_spec = format!("@calcit/procs@^{CALCIT_VERSION}");
   let status = Command::new("yarn")
-    .args(["up", "@calcit/procs"])
+    .args(["up", &package_spec])
     .status()
-    .map_err(|e| format!("failed to run `yarn up @calcit/procs`: {e}"))?;
+    .map_err(|e| format!("failed to run `yarn up {package_spec}`: {e}"))?;
 
   if status.success() {
     Ok(())
   } else {
     Err(format!(
-      "`yarn up @calcit/procs` exited with status {}",
+      "`yarn up {package_spec}` exited with status {}",
       status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
     ))
   }
@@ -1014,6 +1115,28 @@ mod tests {
     let parsed = cirru_edn::parse("{} (:version ||)").unwrap();
     let deps: PackageDeps = parsed.try_into().unwrap();
     assert!(deps.version.is_none());
+  }
+
+  #[test]
+  fn reads_procs_spec_from_runtime_or_development_dependencies() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-toolchain-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    let package_json = root.join("package.json");
+
+    std::fs::write(&package_json, r#"{"dependencies":{"@calcit/procs":"^0.13.38"}}"#).unwrap();
+    assert_eq!(super::read_procs_manifest_spec(&package_json), Ok(Some("^0.13.38".to_owned())));
+
+    std::fs::write(&package_json, r#"{"devDependencies":{"@calcit/procs":"0.13.38"}}"#).unwrap();
+    assert_eq!(super::read_procs_manifest_spec(&package_json), Ok(Some("0.13.38".to_owned())));
+
+    std::fs::write(
+      &package_json,
+      r#"{"dependencies":{"@calcit/procs":"^0.13.37"},"devDependencies":{"@calcit/procs":"^0.13.38"}}"#,
+    )
+    .unwrap();
+    assert!(super::read_procs_manifest_spec(&package_json).unwrap_err().contains("conflicting"));
+    std::fs::remove_dir_all(root).unwrap();
   }
 
   #[test]

--- a/src/bin/calcit_deps.rs
+++ b/src/bin/calcit_deps.rs
@@ -329,16 +329,7 @@ fn download_deps(deps: PackageDeps, options: TopLevelCaps) -> Result<(), String>
 }
 
 fn graph_options(options: &TopLevelCaps, build_native: bool) -> Result<GraphOptions, String> {
-  let input = PathBuf::from(&options.input);
-  let absolute_input = if input.is_absolute() {
-    input
-  } else {
-    std::env::current_dir().map_err(|e| e.to_string())?.join(input)
-  };
-  let project_root = absolute_input
-    .parent()
-    .ok_or_else(|| format!("cannot determine project directory from {}", absolute_input.display()))?
-    .to_path_buf();
+  let project_root = project_root_from_input(&options.input)?;
   Ok(GraphOptions {
     project_root,
     modules_dir: modules_dir(options)?,
@@ -346,6 +337,19 @@ fn graph_options(options: &TopLevelCaps, build_native: bool) -> Result<GraphOpti
     strict: options.strict,
     build_native,
   })
+}
+
+fn project_root_from_input(input: &str) -> Result<PathBuf, String> {
+  let input = PathBuf::from(input);
+  let absolute_input = if input.is_absolute() {
+    input
+  } else {
+    std::env::current_dir().map_err(|error| error.to_string())?.join(input)
+  };
+  absolute_input
+    .parent()
+    .ok_or_else(|| format!("cannot determine project directory from {}", absolute_input.display()))
+    .map(Path::to_path_buf)
 }
 
 fn verify_toolchain(deps: &PackageDeps, options: &TopLevelCaps) -> Result<(), String> {
@@ -370,20 +374,7 @@ fn verify_toolchain(deps: &PackageDeps, options: &TopLevelCaps) -> Result<(), St
     return Ok(());
   }
 
-  let package = read_procs_manifest_spec(&package_json)?;
-  let Some(spec) = package else {
-    println!("toolchain: Calcit {expected} verified (package.json has no @calcit/procs)");
-    return Ok(());
-  };
-  let accepted_specs = [expected.to_owned(), format!("^{expected}")];
-  if !accepted_specs.iter().any(|candidate| candidate == &spec) {
-    return Err(format!(
-      "Calcit toolchain mismatch: {} declares @calcit/procs@{spec}, expected {} (or ^{}); run `caps upgrade --all` or `yarn up @calcit/procs@^{expected}`",
-      package_json.display(),
-      expected,
-      expected
-    ));
-  }
+  verify_procs_manifest_spec(&package_json, expected)?;
 
   let output = Command::new("yarn")
     .args(["node", "-p", "require('@calcit/procs/package.json').version"])
@@ -400,13 +391,35 @@ fn verify_toolchain(deps: &PackageDeps, options: &TopLevelCaps) -> Result<(), St
     .map_err(|error| format!("@calcit/procs version output was not UTF-8: {error}"))?
     .trim()
     .to_owned();
-  if installed != expected {
-    return Err(format!(
-      "Calcit toolchain mismatch: installed @calcit/procs is {installed}, expected {expected}; run `yarn up @calcit/procs@^{expected}` and commit the lockfile"
-    ));
-  }
+  verify_installed_procs_version(&installed, expected)?;
   println!("toolchain: Calcit and @calcit/procs are both {expected}");
   Ok(())
+}
+
+fn verify_procs_manifest_spec(package_json: &Path, expected: &str) -> Result<(), String> {
+  let spec = read_procs_manifest_spec(package_json)?.ok_or_else(|| {
+    format!(
+      "Calcit toolchain mismatch: {} has no @calcit/procs dependency; add `@calcit/procs@{expected}`",
+      package_json.display()
+    )
+  })?;
+  if spec != expected {
+    return Err(format!(
+      "Calcit toolchain mismatch: {} declares @calcit/procs@{spec}, expected {expected}; run `caps upgrade --all` or `yarn up @calcit/procs@{expected}`",
+      package_json.display()
+    ));
+  }
+  Ok(())
+}
+
+fn verify_installed_procs_version(installed: &str, expected: &str) -> Result<(), String> {
+  if installed == expected {
+    Ok(())
+  } else {
+    Err(format!(
+      "Calcit toolchain mismatch: installed @calcit/procs is {installed}, expected {expected}; run `yarn up @calcit/procs@{expected}` and commit the lockfile"
+    ))
+  }
 }
 
 fn read_procs_manifest_spec(package_json: &Path) -> Result<Option<String>, String> {
@@ -523,7 +536,7 @@ struct StatusCaps {}
 /// verify store contents, project links, native receipts, and optionally the JS runtime toolchain
 #[argh(subcommand, name = "verify")]
 struct VerifyCaps {
-  /// require :calcit-version, caps, the @calcit/procs manifest range, and its installed version to agree
+  /// require :calcit-version, caps, the exact @calcit/procs manifest version, and its installed version to agree
   #[argh(switch)]
   toolchain: bool,
 }
@@ -984,7 +997,7 @@ fn upgrade_packages(deps: PackageDeps, deps_file: &str, opts: &UpgradeCaps) -> R
   if !outdated_packages.is_empty() || calcit_version_needs_update {
     update_deps_file(&outdated_packages, calcit_version_needs_update, deps_file)?;
     if opts.all {
-      sync_calcit_procs_package()?;
+      sync_calcit_procs_package(&project_root_from_input(deps_file)?)?;
     }
     println!("deps.cirru updated successfully!");
     Ok(true)
@@ -994,16 +1007,22 @@ fn upgrade_packages(deps: PackageDeps, deps_file: &str, opts: &UpgradeCaps) -> R
   }
 }
 
-fn sync_calcit_procs_package() -> Result<(), String> {
-  if !Path::new("package.json").exists() {
-    println!("skipping {} sync: no package.json found", "@calcit/procs".yellow());
+fn sync_calcit_procs_package(project_root: &Path) -> Result<(), String> {
+  let package_json = project_root.join("package.json");
+  if !package_json.exists() {
+    println!(
+      "skipping {} sync: no package.json found in {}",
+      "@calcit/procs".yellow(),
+      project_root.display()
+    );
     return Ok(());
   }
 
   println!("syncing npm package {}...", "@calcit/procs".green());
-  let package_spec = format!("@calcit/procs@^{CALCIT_VERSION}");
+  let package_spec = format!("@calcit/procs@{CALCIT_VERSION}");
   let status = Command::new("yarn")
     .args(["up", &package_spec])
+    .current_dir(project_root)
     .status()
     .map_err(|e| format!("failed to run `yarn up {package_spec}`: {e}"))?;
 
@@ -1079,7 +1098,7 @@ fn print_column(pkg: ColoredString, expected: ColoredString, latest: ColoredStri
 mod tests {
   use super::{
     PackageDeps, VersionBumpCaps, VersionCaps, VersionGetCaps, VersionSubcommand, handle_version_command, module_folder,
-    normalize_package_name,
+    normalize_package_name, project_root_from_input, verify_installed_procs_version, verify_procs_manifest_spec,
   };
   use cirru_edn::Edn;
   use std::collections::HashMap;
@@ -1136,6 +1155,43 @@ mod tests {
     )
     .unwrap();
     assert!(super::read_procs_manifest_spec(&package_json).unwrap_err().contains("conflicting"));
+    std::fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn toolchain_manifest_and_installed_versions_require_exact_matches() {
+    let root = std::env::temp_dir().join(format!("calcit-caps-toolchain-enforcement-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("nested")).unwrap();
+    let package_json = root.join("package.json");
+
+    std::fs::write(&package_json, "{}").unwrap();
+    assert!(
+      verify_procs_manifest_spec(&package_json, "0.13.38")
+        .unwrap_err()
+        .contains("has no @calcit/procs")
+    );
+
+    std::fs::write(&package_json, r#"{"dependencies":{"@calcit/procs":"0.13.38"}}"#).unwrap();
+    assert!(verify_procs_manifest_spec(&package_json, "0.13.38").is_ok());
+    assert!(verify_installed_procs_version("0.13.38", "0.13.38").is_ok());
+
+    std::fs::write(&package_json, r#"{"dependencies":{"@calcit/procs":"^0.13.38"}}"#).unwrap();
+    assert!(
+      verify_procs_manifest_spec(&package_json, "0.13.38")
+        .unwrap_err()
+        .contains("expected 0.13.38")
+    );
+    assert!(
+      verify_installed_procs_version("0.13.39", "0.13.38")
+        .unwrap_err()
+        .contains("installed @calcit/procs is 0.13.39")
+    );
+
+    assert_eq!(
+      project_root_from_input(root.join("nested/deps.cirru").to_str().unwrap()),
+      Ok(root.join("nested"))
+    );
     std::fs::remove_dir_all(root).unwrap();
   }
 


### PR DESCRIPTION
Adds `caps verify --toolchain` as a CI gate for the Calcit JS runtime chain. It checks deps.cirru, the running caps version, package.json's @calcit/procs anchor, and Yarn's resolved package version. caps upgrade --all now updates @calcit/procs with the current Calcit version anchor.\n\nValidation: cargo test, cargo clippy --bin caps -- -D warnings, yarn check-agent-interface, yarn check-all.