### PR TITLE
fix(types): enforce shared fold callback return

### DIFF
--- a/editing-history/20260824-0040-option-fold-shared-return.md
+++ b/editing-history/20260824-0040-option-fold-shared-return.md
@@ -7,6 +7,9 @@
   their final expression. This supplies the none-branch binding for `U` while
   keeping unhinted callbacks with parameters dynamic, avoiding retroactive
   tightening of existing higher-order call sites.
+- The inferred thunk annotation must preserve `SchemaKind::Macro` for
+  `defmacro` forms, matching the explicit-hint path; a dedicated regression
+  test prevents zero-argument macros from being exposed as ordinary functions.
 - Regression coverage includes the shared-binding matcher and literal thunk
   inference. The CLI reproduction now fails during preprocessing when a
   `String` none branch is combined with a numeric Option payload and `identity`.

--- a/editing-history/20260824-0040-option-fold-shared-return.md
+++ b/editing-history/20260824-0040-option-fold-shared-return.md
@@ -10,6 +10,14 @@
 - The inferred thunk annotation must preserve `SchemaKind::Macro` for
   `defmacro` forms, matching the explicit-hint path; a dedicated regression
   test prevents zero-argument macros from being exposed as ordinary functions.
+- Callback signature matching stages generic bindings and commits them only on
+  success, so a rejected nested callback cannot constrain a later argument.
+  `option:fold` additionally recovers a concrete return type for unhinted
+  callback bodies during its own argument check, including parameterized
+  callbacks, without globally tightening unrelated higher-order calls.
+- Preprocessing regressions cover direct folds, parameterized callbacks, and a
+  user macro expanding to `option:fold`; empty unhinted functions remain
+  dynamic rather than treating their parameter list as a return value.
 - Regression coverage includes the shared-binding matcher and literal thunk
   inference. The CLI reproduction now fails during preprocessing when a
   `String` none branch is combined with a numeric Option payload and `identity`.

--- a/editing-history/20260824-0040-option-fold-shared-return.md
+++ b/editing-history/20260824-0040-option-fold-shared-return.md
@@ -1,0 +1,12 @@
+# option:fold shared callback return type
+
+- Higher-order callback matching must reuse the enclosing generic binding map.
+  A fresh map per callback makes repeated variables such as `option:fold`'s
+  return `U` independent and silently accepts incompatible branch results.
+- Unhinted zero-argument thunks may safely retain a concrete return type from
+  their final expression. This supplies the none-branch binding for `U` while
+  keeping unhinted callbacks with parameters dynamic, avoiding retroactive
+  tightening of existing higher-order call sites.
+- Regression coverage includes the shared-binding matcher and literal thunk
+  inference. The CLI reproduction now fails during preprocessing when a
+  `String` none branch is combined with a numeric Option payload and `identity`.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -201,6 +201,31 @@ fn option_migration_source_calls_fail_during_preprocessing() {
 }
 
 #[test]
+fn option_fold_callbacks_share_return_type_during_preprocessing() {
+  run_with_large_stack(|| {
+    let snippets = [
+      "option:fold (%some 1) (fn () |wrong) identity",
+      "option:fold (%some 1) (fn () |wrong) (fn (x) 1)",
+      "defmacro fold-or (base fallback)\n  quasiquote $ option:fold\n    , ~base\n    fn () ~fallback\n    , identity\n\ndefn main! () $ fold-or (%some 1) |wrong",
+    ];
+
+    for snippet in snippets {
+      let entries = load_snippet_entries(snippet);
+      let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+      runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+        .expect("option:fold mismatch should surface as a preprocessing warning");
+      let warnings = warnings.borrow();
+      assert!(
+        warnings
+          .iter()
+          .any(|warning| { warning.code() == Some("W_FN_ARG_TYPE_MISMATCH") && warning.message().contains("calcit.core/option:fold") }),
+        "option:fold callback mismatch should be reported for {snippet:?}, got: {warnings:?}"
+      );
+    }
+  });
+}
+
+#[test]
 fn option_returning_api_type_mismatches_include_unwrap_and_match_help() {
   run_with_large_stack(|| {
     let entries = load_snippet_entries("do\n  &+ (find-index ([] 1 2) $ fn (x) = x 2) 1\n  starts-with? (get-env |HOME) |/");

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -3926,6 +3926,20 @@ mod tests {
   }
 
   #[test]
+  fn failed_callback_signature_does_not_leak_partial_generic_bindings() {
+    let generic = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let expected = CalcitTypeAnnotation::from_function_parts(vec![generic.clone(), generic], Arc::new(CalcitTypeAnnotation::Unit));
+    let actual = CalcitTypeAnnotation::from_function_parts(
+      vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)],
+      Arc::new(CalcitTypeAnnotation::Unit),
+    );
+    let mut bindings = TypeBindings::new();
+
+    assert!(!actual.matches_with_bindings(&expected, &mut bindings));
+    assert!(bindings.is_empty(), "a failed callback match must not constrain later arguments");
+  }
+
+  #[test]
   fn collect_arg_type_hints_keeps_non_variadic() {
     let body_items = vec![Calcit::List(Arc::new(CalcitList::from(&[
       Calcit::Syntax(CalcitSyntax::AssertType, Arc::from("tests")),
@@ -5200,6 +5214,8 @@ impl CalcitFnTypeAnnotation {
     // Don't require generics count to match: actual concrete functions don't declare
     // generics even when expected fn type uses TypeVars. Bindings resolve TypeVars below.
 
+    let mut staged_bindings = bindings.clone();
+
     for (idx, expected) in other.arg_types.iter().enumerate() {
       let actual = self.arg_types.get(idx).or(self.rest_type.as_ref());
       let Some(actual) = actual else {
@@ -5208,7 +5224,7 @@ impl CalcitFnTypeAnnotation {
       // Callback parameters are contravariant: every value promised by the expected contract
       // must be accepted by the actual callable. This matters for a function accepting
       // `optional<T>` being used where a callback receives `T`.
-      if !expected.matches_with_bindings(actual, bindings) {
+      if !expected.matches_with_bindings(actual, &mut staged_bindings) {
         return false;
       }
     }
@@ -5219,12 +5235,19 @@ impl CalcitFnTypeAnnotation {
       let Some(actual_rest) = &self.rest_type else {
         return false;
       };
-      if !expected_rest.matches_with_bindings(actual_rest, bindings) {
+      if !expected_rest.matches_with_bindings(actual_rest, &mut staged_bindings) {
         return false;
       }
     }
 
-    self.return_type.matches_with_bindings(other.return_type.as_ref(), bindings)
+    if !self
+      .return_type
+      .matches_with_bindings(other.return_type.as_ref(), &mut staged_bindings)
+    {
+      return false;
+    }
+    *bindings = staged_bindings;
+    true
   }
 }
 

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2690,7 +2690,7 @@ impl CalcitTypeAnnotation {
       (Self::Fn(_), Self::DynFn) | (Self::DynFn, Self::Fn(_)) => true,
       // Tags are callable in Calcit (as map key accessors), so they satisfy :fn requirements
       (Self::Tag, Self::DynFn) | (Self::Tag, Self::Fn(_)) => true,
-      (Self::Fn(a), Self::Fn(b)) => a.matches_signature(b.as_ref()),
+      (Self::Fn(a), Self::Fn(b)) => a.matches_signature_with_bindings(b.as_ref(), bindings),
       (Self::Variadic(a), Self::Variadic(b)) => a.matches_with_bindings(b, bindings),
       (Self::Custom(a), Self::Custom(b)) => a.as_ref() == b.as_ref(),
       (Self::StructValue(a), Self::StructValue(b)) => a.name == b.name,
@@ -3905,6 +3905,24 @@ mod tests {
     assert!(type_var.matches_with_bindings(&type_var, &mut bindings));
     assert!(type_var.matches_with_bindings(&type_var, &mut bindings));
     assert!(bindings.is_empty(), "an identical type variable needs no self-binding");
+  }
+
+  #[test]
+  fn sibling_callbacks_share_generic_return_bindings() {
+    let generic_t = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let generic_u = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("U")));
+    let expected_none = CalcitTypeAnnotation::from_function_parts(vec![], generic_u.clone());
+    let expected_some = CalcitTypeAnnotation::from_function_parts(vec![generic_t], generic_u);
+    let actual_none = CalcitTypeAnnotation::from_function_parts(vec![], Arc::new(CalcitTypeAnnotation::String));
+    let actual_some =
+      CalcitTypeAnnotation::from_function_parts(vec![Arc::new(CalcitTypeAnnotation::Number)], Arc::new(CalcitTypeAnnotation::Number));
+    let mut bindings = TypeBindings::new();
+
+    assert!(actual_none.matches_with_bindings(&expected_none, &mut bindings));
+    assert!(
+      !actual_some.matches_with_bindings(&expected_some, &mut bindings),
+      "a sibling callback must return the U bound by the first callback"
+    );
   }
 
   #[test]
@@ -5165,6 +5183,14 @@ impl CalcitFnTypeAnnotation {
   }
 
   pub fn matches_signature(&self, other: &CalcitFnTypeAnnotation) -> bool {
+    let mut bindings = TypeBindings::new();
+    self.matches_signature_with_bindings(other, &mut bindings)
+  }
+
+  /// Match a callable signature while preserving bindings from its enclosing
+  /// generic call. This lets sibling callbacks share a return type variable,
+  /// such as the two branches accepted by `option:fold`.
+  pub(crate) fn matches_signature_with_bindings(&self, other: &CalcitFnTypeAnnotation, bindings: &mut TypeBindings) -> bool {
     // `self` is the actual callable and `other` is the expected callback shape. An actual
     // callable cannot require more fixed arguments than the expected contract guarantees.
     if self.arg_types.len() > other.arg_types.len() {
@@ -5174,8 +5200,6 @@ impl CalcitFnTypeAnnotation {
     // Don't require generics count to match: actual concrete functions don't declare
     // generics even when expected fn type uses TypeVars. Bindings resolve TypeVars below.
 
-    let mut bindings = TypeBindings::new();
-
     for (idx, expected) in other.arg_types.iter().enumerate() {
       let actual = self.arg_types.get(idx).or(self.rest_type.as_ref());
       let Some(actual) = actual else {
@@ -5184,7 +5208,7 @@ impl CalcitFnTypeAnnotation {
       // Callback parameters are contravariant: every value promised by the expected contract
       // must be accepted by the actual callable. This matters for a function accepting
       // `optional<T>` being used where a callback receives `T`.
-      if !expected.matches_with_bindings(actual, &mut bindings) {
+      if !expected.matches_with_bindings(actual, bindings) {
         return false;
       }
     }
@@ -5195,12 +5219,12 @@ impl CalcitFnTypeAnnotation {
       let Some(actual_rest) = &self.rest_type else {
         return false;
       };
-      if !expected_rest.matches_with_bindings(actual_rest, &mut bindings) {
+      if !expected_rest.matches_with_bindings(actual_rest, bindings) {
         return false;
       }
     }
 
-    self.return_type.matches_with_bindings(other.return_type.as_ref(), &mut bindings)
+    self.return_type.matches_with_bindings(other.return_type.as_ref(), bindings)
   }
 }
 

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -16,7 +16,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::type_inference::infer_struct_field_type;
+use super::type_inference::{infer_struct_field_type, infer_unhinted_callback_signature};
 use crate::calcit::{
   self, Calcit, CalcitFn, CalcitGenericBound, CalcitList, CalcitLocal, CalcitProc, CalcitSyntax, CalcitTypeAnnotation, LocatedWarning,
   NodeLocation,
@@ -206,6 +206,10 @@ where
   }
 
   let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
+  let is_option_fold = matches!(
+    ctx.head_form,
+    Calcit::Import(import) if import.ns.as_ref() == calcit::CORE_NS && import.def.as_ref() == "option:fold"
+  );
 
   for (idx, (arg, expected_type)) in ctx.args.iter().zip(ctx.expected_types.iter()).enumerate() {
     if matches!(expected_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
@@ -224,10 +228,19 @@ where
       return; // Done after variadic
     }
 
-    if let Some(actual_type) = resolve_type_value(arg, ctx.scope_types)
-      && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
-    {
-      ctx.emit_warning(idx + 1, expected_type.as_ref(), actual_type.as_ref(), &make_warning);
+    if let Some(actual_type) = resolve_type_value(arg, ctx.scope_types) {
+      let actual_type = if is_option_fold
+        && matches!(actual_type.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn)
+        && matches!(expected_type.as_ref(), CalcitTypeAnnotation::Fn(_))
+        && let Calcit::List(callback) = arg
+      {
+        infer_unhinted_callback_signature(callback, ctx.scope_types).unwrap_or(actual_type)
+      } else {
+        actual_type
+      };
+      if !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings) {
+        ctx.emit_warning(idx + 1, expected_type.as_ref(), actual_type.as_ref(), &make_warning);
+      }
     }
   }
 

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -762,33 +762,20 @@ fn infer_preprocessed_function_type(xs: &CalcitList) -> Arc<CalcitTypeAnnotation
     .skip(3)
     .find_map(CalcitTypeAnnotation::extract_fn_annotation_from_hint_form);
   let Some(hinted) = hinted else {
-    let (arg_types, rest_type) = infer_preprocessed_function_parameters(xs.get(2));
     // Keep ordinary unhinted callbacks dynamic: inferring their return type can
     // retroactively tighten existing higher-order calls. A zero-argument thunk
     // is safe to retain, and provides the U anchor for eliminators such as
     // `option:fold`.
-    if !arg_types.is_empty() || rest_type.is_some() {
-      return Arc::new(CalcitTypeAnnotation::DynFn);
-    }
-    let inferred_return = xs
-      .get(xs.len().saturating_sub(1))
-      .and_then(|body| infer_type_from_expr(body, &ScopeTypes::new()))
-      .filter(|annotation| !matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn));
-    let Some(return_type) = inferred_return else {
+    let Some(inferred) = infer_unhinted_callback_signature(xs, &ScopeTypes::new()) else {
       return Arc::new(CalcitTypeAnnotation::DynFn);
     };
-    return Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
-      generics: Arc::new(vec![]),
-      where_bounds: Arc::new(vec![]),
-      arg_types,
-      return_type,
-      fn_kind: match xs.first() {
-        Some(Calcit::Syntax(CalcitSyntax::Defmacro, _)) => SchemaKind::Macro,
-        _ => SchemaKind::Fn,
-      },
-      rest_type,
-      features: Arc::new(std::collections::HashSet::new()),
-    })));
+    let CalcitTypeAnnotation::Fn(signature) = inferred.as_ref() else {
+      return Arc::new(CalcitTypeAnnotation::DynFn);
+    };
+    if !signature.arg_types.is_empty() || signature.rest_type.is_some() {
+      return Arc::new(CalcitTypeAnnotation::DynFn);
+    }
+    return inferred;
   };
   let CalcitTypeAnnotation::Fn(fn_annotation) = hinted.as_ref() else {
     return hinted;
@@ -814,6 +801,38 @@ fn infer_preprocessed_function_type(xs: &CalcitList) -> Arc<CalcitTypeAnnotation
     rest_type: fn_annotation.rest_type.clone().or(inferred_rest_type),
     features: fn_annotation.features.clone(),
   })))
+}
+
+/// Recover a concrete signature from an already preprocessed anonymous
+/// callback when its body has a statically known final expression. Callers
+/// choose whether using the recovered signature is appropriate for their
+/// contract; ordinary unhinted functions remain dynamic by default.
+pub(crate) fn infer_unhinted_callback_signature(xs: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
+  let fn_kind = match xs.first()? {
+    Calcit::Syntax(CalcitSyntax::Defmacro, _) => SchemaKind::Macro,
+    Calcit::Syntax(CalcitSyntax::Defn | CalcitSyntax::DefWasmExport | CalcitSyntax::DefWasmImport, _) => SchemaKind::Fn,
+    _ => return None,
+  };
+  if xs.len() <= 3
+    || xs
+      .iter()
+      .skip(3)
+      .any(|form| CalcitTypeAnnotation::extract_fn_annotation_from_hint_form(form).is_some())
+  {
+    return None;
+  }
+  let (arg_types, rest_type) = infer_preprocessed_function_parameters(xs.get(2));
+  let return_type = infer_type_from_expr(xs.get(xs.len() - 1)?, scope_types)
+    .filter(|annotation| !matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn))?;
+  Some(Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+    generics: Arc::new(vec![]),
+    where_bounds: Arc::new(vec![]),
+    arg_types,
+    return_type,
+    fn_kind,
+    rest_type,
+    features: Arc::new(std::collections::HashSet::new()),
+  }))))
 }
 
 fn infer_preprocessed_function_parameters(
@@ -1763,6 +1782,22 @@ mod tests {
       panic!("an unhinted zero-argument macro should retain a macro signature: {inferred:?}");
     };
     assert_eq!(signature.fn_kind, SchemaKind::Macro);
+  }
+
+  #[test]
+  fn unhinted_empty_function_remains_dynamic() {
+    let empty_callback = CalcitList::from(
+      &[
+        Calcit::Syntax(CalcitSyntax::Defn, Arc::from("tests.callback")),
+        symbol("callback"),
+        Calcit::from(Vec::<Calcit>::new()),
+      ][..],
+    );
+
+    assert!(matches!(
+      infer_preprocessed_function_type(&empty_callback).as_ref(),
+      CalcitTypeAnnotation::DynFn
+    ));
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -762,7 +762,30 @@ fn infer_preprocessed_function_type(xs: &CalcitList) -> Arc<CalcitTypeAnnotation
     .skip(3)
     .find_map(CalcitTypeAnnotation::extract_fn_annotation_from_hint_form);
   let Some(hinted) = hinted else {
-    return Arc::new(CalcitTypeAnnotation::DynFn);
+    let (arg_types, rest_type) = infer_preprocessed_function_parameters(xs.get(2));
+    // Keep ordinary unhinted callbacks dynamic: inferring their return type can
+    // retroactively tighten existing higher-order calls. A zero-argument thunk
+    // is safe to retain, and provides the U anchor for eliminators such as
+    // `option:fold`.
+    if !arg_types.is_empty() || rest_type.is_some() {
+      return Arc::new(CalcitTypeAnnotation::DynFn);
+    }
+    let inferred_return = xs
+      .get(xs.len().saturating_sub(1))
+      .and_then(|body| infer_type_from_expr(body, &ScopeTypes::new()))
+      .filter(|annotation| !matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn));
+    let Some(return_type) = inferred_return else {
+      return Arc::new(CalcitTypeAnnotation::DynFn);
+    };
+    return Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types,
+      return_type,
+      fn_kind: SchemaKind::Fn,
+      rest_type,
+      features: Arc::new(std::collections::HashSet::new()),
+    })));
   };
   let CalcitTypeAnnotation::Fn(fn_annotation) = hinted.as_ref() else {
     return hinted;
@@ -1701,6 +1724,24 @@ mod tests {
       value.as_deref(),
       Some(CalcitTypeAnnotation::JsNullish(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::JsObject)
     ));
+  }
+
+  #[test]
+  fn unhinted_callback_retains_a_concrete_literal_return_type() {
+    let callback = CalcitList::from(
+      &[
+        Calcit::Syntax(CalcitSyntax::Defn, Arc::from("tests.callback")),
+        symbol("callback"),
+        Calcit::from(Vec::<Calcit>::new()),
+        Calcit::Str(Arc::from("fallback")),
+      ][..],
+    );
+
+    let inferred = infer_preprocessed_function_type(&callback);
+    let CalcitTypeAnnotation::Fn(signature) = inferred.as_ref() else {
+      panic!("an unhinted callback with a literal body should retain a function signature: {inferred:?}");
+    };
+    assert!(matches!(signature.return_type.as_ref(), CalcitTypeAnnotation::String));
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -782,7 +782,10 @@ fn infer_preprocessed_function_type(xs: &CalcitList) -> Arc<CalcitTypeAnnotation
       where_bounds: Arc::new(vec![]),
       arg_types,
       return_type,
-      fn_kind: SchemaKind::Fn,
+      fn_kind: match xs.first() {
+        Some(Calcit::Syntax(CalcitSyntax::Defmacro, _)) => SchemaKind::Macro,
+        _ => SchemaKind::Fn,
+      },
       rest_type,
       features: Arc::new(std::collections::HashSet::new()),
     })));
@@ -1742,6 +1745,24 @@ mod tests {
       panic!("an unhinted callback with a literal body should retain a function signature: {inferred:?}");
     };
     assert!(matches!(signature.return_type.as_ref(), CalcitTypeAnnotation::String));
+  }
+
+  #[test]
+  fn unhinted_zero_arg_macro_retains_macro_kind() {
+    let macro_form = CalcitList::from(
+      &[
+        Calcit::Syntax(CalcitSyntax::Defmacro, Arc::from("tests.callback")),
+        symbol("callback"),
+        Calcit::from(Vec::<Calcit>::new()),
+        Calcit::Str(Arc::from("fallback")),
+      ][..],
+    );
+
+    let inferred = infer_preprocessed_function_type(&macro_form);
+    let CalcitTypeAnnotation::Fn(signature) = inferred.as_ref() else {
+      panic!("an unhinted zero-argument macro should retain a macro signature: {inferred:?}");
+    };
+    assert_eq!(signature.fn_kind, SchemaKind::Macro);
   }
 
   #[test]


### PR DESCRIPTION
Fixes #388.

Reuses generic bindings while matching nested callback signatures, so option:fold shares its result type across both branches. Unhinted zero-argument thunks retain a concrete final-expression type to bind the none-branch result without tightening existing parameterized callbacks.

Verified with cargo clippy, cargo test, yarn compile, yarn check-agent-interface, yarn check-all, and the issue CLI reproduction.