### PR TITLE
fix: skip transitive project modules

### DIFF
--- a/editing-history/202608241335-skip-transitive-self-modules.md
+++ b/editing-history/202608241335-skip-transitive-self-modules.md
@@ -1,0 +1,10 @@
+# Skip transitive copies of the project package
+
+- A project's direct dependency can reintroduce that same package through a
+  transitive dependency. Current namespace collision checks then rejected the
+  project source during normal compile and static-analysis commands.
+- Added a project-level merge path that drops only namespaces belonging to the
+  root package before applying the existing strict module merge. Direct module
+  conflict checks remain unchanged.
+- Added a regression test and verified the real respo-markdown project against
+  the current Respo dependency graph.

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -2754,7 +2754,7 @@ fn load_snapshot_with_entry(input_path: &str, entry: Option<&str>) -> Result<sna
   for module_path in &modules_to_load {
     match load_module_silent(module_path, base_dir, &module_folder) {
       Ok(module_snapshot) => {
-        calcit::merge_module_files(&mut snapshot, &module_snapshot, module_path)?;
+        calcit::merge_project_module_files(&mut snapshot, &module_snapshot, module_path)?;
       }
       Err(e) => {
         eprintln!("Warning: Failed to load module '{module_path}': {e}");

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -254,7 +254,7 @@ fn run_cli() -> Result<(), String> {
 
     for module_path in &command.dep {
       let module_data = calcit::load_module(module_path, base_dir, &module_folder)?;
-      calcit::merge_module_files(&mut snapshot, &module_data, module_path)?;
+      calcit::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
     }
   } else if let Some(CalcitCommand::Eval(ref command)) = cli_args.subcommand {
     eval_once = true;
@@ -273,7 +273,7 @@ fn run_cli() -> Result<(), String> {
 
     for module_path in &command.dep {
       let module_data = calcit::load_module(module_path, base_dir, &module_folder)?;
-      calcit::merge_module_files(&mut snapshot, &module_data, module_path)?;
+      calcit::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
     }
   } else {
     if !input_path.exists() {
@@ -300,7 +300,7 @@ fn run_cli() -> Result<(), String> {
     let module_paths = snapshot.active_entry()?.modules.clone();
     for module_path in &module_paths {
       let module_data = calcit::load_module(module_path, base_dir, &module_folder)?;
-      calcit::merge_module_files(&mut snapshot, &module_data, module_path)?;
+      calcit::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
     }
   }
   let selected_entry = snapshot.active_entry()?.clone();

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), String> {
   let module_paths = snapshot.active_entry()?.modules.clone();
   for module_path in &module_paths {
     let module_data = calcit::load_module(module_path, base_dir, &module_folder)?;
-    calcit::merge_module_files(&mut snapshot, &module_data, module_path)?;
+    calcit::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
   }
 
   let selected_entry = snapshot.active_entry()?;

--- a/src/call_graph_diff.rs
+++ b/src/call_graph_diff.rs
@@ -127,7 +127,7 @@ fn attach_modules_and_core(
   let module_paths = snapshot.active_entry()?.modules.to_vec();
   for module_path in &module_paths {
     let module_data = crate::load_module(module_path, base_dir, module_folder)?;
-    crate::merge_module_files(snapshot, &module_data, module_path)?;
+    crate::merge_project_module_files(snapshot, &module_data, module_path)?;
   }
 
   for (ns, file) in &core_snapshot.files {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,9 +357,32 @@ pub fn merge_module_files(target: &mut snapshot::Snapshot, module: &snapshot::Sn
   Ok(())
 }
 
+/// Merge a direct dependency into a project snapshot.
+///
+/// A library's development graph can revisit that library through a transitive
+/// dependency (for example, a documentation UI that renders Markdown). The
+/// project source is authoritative for its own package namespaces, so discard
+/// those transitive copies before applying the normal, strict module merge.
+pub fn merge_project_module_files(
+  target: &mut snapshot::Snapshot,
+  module: &snapshot::Snapshot,
+  module_path: &str,
+) -> Result<(), String> {
+  if target.package.is_empty() {
+    return merge_module_files(target, module, module_path);
+  }
+
+  let namespace_prefix = format!("{}.", target.package);
+  let mut filtered_module = module.clone();
+  filtered_module
+    .files
+    .retain(|namespace, _| namespace != &target.package && !namespace.starts_with(&namespace_prefix));
+  merge_module_files(target, &filtered_module, module_path)
+}
+
 #[cfg(test)]
 mod module_resolution_tests {
-  use super::{load_module, merge_module_files, project_module_folder, resolve_module_snapshot_candidates};
+  use super::{load_module, merge_module_files, merge_project_module_files, project_module_folder, resolve_module_snapshot_candidates};
   use std::fs;
   use std::path::{Path, PathBuf};
 
@@ -499,6 +522,29 @@ mod module_resolution_tests {
       .insert("one".to_owned(), super::snapshot::gen_meta_ns("one", "dependency/calcit.cirru"));
     let error = merge_module_files(&mut target, &dependency, "two/").unwrap_err();
     assert!(error.contains("namespace `one` conflicts with existing content"));
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn project_merge_keeps_project_namespaces_over_transitive_copies() {
+    let root = temp_root("project-self-dependency");
+    write_module(&root, "one", &[], "one");
+    write_module(&root, "two", &[], "two");
+    let module_folder = project_module_folder(&root);
+    let mut target = load_module("one/", &root, &module_folder).unwrap();
+    let original = target.files.get("one").unwrap().clone();
+    let mut dependency = load_module("two/", &root, &module_folder).unwrap();
+    dependency
+      .files
+      .insert("one".to_owned(), super::snapshot::gen_meta_ns("one", "dependency/calcit.cirru"));
+    dependency.files.insert(
+      "two.extra".to_owned(),
+      super::snapshot::gen_meta_ns("two.extra", "dependency/calcit.cirru"),
+    );
+
+    merge_project_module_files(&mut target, &dependency, "two/").unwrap();
+    assert_eq!(target.files.get("one").unwrap(), &original);
+    assert!(target.files.contains_key("two.extra"));
     fs::remove_dir_all(root).unwrap();
   }
 


### PR DESCRIPTION
## Summary
- preserve root project namespaces when a dependency reintroduces the same package transitively
- keep strict conflicts for unrelated module namespaces
- add a regression test

## Validation
- cargo test
- cargo clippy --all-targets -- -D warnings
- yarn compile
- yarn check-agent-interface
- real respo-markdown check, smoke test, JS generation, and Vite build

Closes #403.