### PR TITLE
fix: align Unit truthiness across runtimes

### DIFF
--- a/calcit/test-macro.cirru
+++ b/calcit/test-macro.cirru
@@ -1,7 +1,8 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |test-macro) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |test-macro)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'test-macro.main/main!) (:mode :native) (:reload-fn 'test-macro.main/reload!)
+      :feature-policy $ {}
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
@@ -63,16 +64,15 @@
                     assert-detect fn? $ fn () 1
                   quote $ &let
                     v__1 $ fn () 1
-                    if (fn? v__1) (;nil)
-                      &let () (eprintln)
-                        eprintln
-                          format-to-lisp $ quote
-                            fn () 1
-                          , "|does not satisfy:"
-                            format-to-lisp $ quote fn?
-                            , "| <--------"
-                        eprintln "|  value is:" v__1
-                        raise "|Not satisfied in assertion!"
+                    if (fn? v__1) &unit $ &let () (eprintln)
+                      eprintln
+                        format-to-lisp $ quote
+                          fn () 1
+                        , "|does not satisfy:"
+                          format-to-lisp $ quote fn?
+                          , "| <--------"
+                      eprintln "|  value is:" v__1
+                      raise "|Not satisfied in assertion!"
           :examples $ []
           :schema $ :: 'Dynamic
         |test-expr-in-case $ %{} 'CodeEntry (:doc |)

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -1,7 +1,8 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |app)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :native) (:reload-fn 'app.main/reload!)
+      :feature-policy $ {}
       :modules $ [] |./test-cond.cirru |./test-hygienic.cirru |./test-lens.cirru |./test-list.cirru |./test-macro.cirru |./test-map.cirru |./test-math.cirru |./test-recursion.cirru |./test-set.cirru |./test-string.cirru |./test-edn.cirru |./test-js.cirru |./test-struct.cirru |./test-fn.cirru |./test-anonymous-enum.cirru |./test-algebra.cirru |./test-types.cirru |./test-types-inference.cirru |./test-generics.cirru |./test-enum.cirru |./test-traits.cirru |./test-doc-smoke.cirru |./test-def-meta.cirru |./util.cirru
       :type-slots $ {}
   :files $ {}
@@ -362,7 +363,7 @@
             fn () (log-title "|Testing fn")
               &let
                 empty-f $ fn ()
-                assert= nil $ empty-f
+                assert= &unit $ empty-f
               &let
                 coll-f $ fn (& xs) xs
                 assert= ([] 1 2 3 4 5)
@@ -389,6 +390,9 @@
             fn () (log-title "|Testing if with nil")
               assert= (if false 1) (if nil 1)
               assert= (if false 1 2) (if nil 1 2)
+              assert= (if false 1) (if &unit 1)
+              assert= (if false 1 2) (if &unit 1 2)
+              assert= true $ not &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/editing-history/20260824-0645-unit-truthiness-review.md
+++ b/editing-history/20260824-0645-unit-truthiness-review.md
@@ -1,0 +1,6 @@
+# Align Unit truthiness across runtimes
+
+- Treat `&unit` as false in native conditionals and `not`, matching JavaScript (`void 0`) and WebAssembly (`0`).
+- Make `or` use the shared conditional semantics, then add a Unit regression test.
+- Replace internal no-return `;nil` tails with `&unit`, while retaining `;nil` for legacy absence semantics.
+- Cover `json-stringify &unit` as a type error.

--- a/editing-history/20260824-0705-unit-effect-return-review.md
+++ b/editing-history/20260824-0705-unit-effect-return-review.md
@@ -1,0 +1,5 @@
+# Complete Unit effect-return review
+
+- Document that `not` accepts Unit as a falsey input in its builtin help and core documentation.
+- Ensure `each` and `&doseq` discard callback or body values and return Unit for non-empty traversals.
+- Add definition-attached Unit regressions for both traversal helpers.

--- a/src/builtins/json.rs
+++ b/src/builtins/json.rs
@@ -242,6 +242,13 @@ mod tests {
   }
 
   #[test]
+  fn json_stringify_rejects_unit() {
+    let error = stringify(&[Calcit::Unit]).expect_err("json-stringify should reject Unit");
+    assert_eq!(error.kind, CalcitErrKind::Type);
+    assert!(error.msg.contains(":unit"));
+  }
+
+  #[test]
   fn json_pretty_rejects_wrong_arity() {
     let error = pretty(&[Calcit::Nil, Calcit::Nil]).expect_err("json-pretty should reject wrong arity");
     assert_eq!(error.kind, CalcitErrKind::Arity);

--- a/src/builtins/logics.rs
+++ b/src/builtins/logics.rs
@@ -59,20 +59,22 @@ pub fn binary_greater(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 
 pub fn not(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
-    let hint =
-      String::from("💡 Usage: `not boolean-value`\n  Negates a boolean value\n  Examples: `not true` => false, `not nil` => true");
-    return crate::builtins::err_arity_with_hint("not requires exactly 1 argument (a boolean or nil), but received:", xs, hint);
+    let hint = String::from(
+      "💡 Usage: `not boolean-value`\n  Negates a boolean value\n  Examples: `not true` => false, `not nil` => true, `not &unit` => true",
+    );
+    return crate::builtins::err_arity_with_hint("not requires exactly 1 argument (a boolean, nil, or Unit), but received:", xs, hint);
   }
   match &xs[0] {
-    Calcit::Nil => Ok(Calcit::Bool(true)),
+    Calcit::Nil | Calcit::Unit => Ok(Calcit::Bool(true)),
     Calcit::Bool(b) => Ok(Calcit::Bool(!b)),
     a => {
       let msg = format!(
-        "not requires a boolean or nil as argument, but received: {}",
+        "not requires a boolean, nil, or Unit as argument, but received: {}",
         crate::builtins::meta::type_of(std::slice::from_ref(a))?.lisp_str()
       );
-      let hint =
-        String::from("💡 Hint: Pass a boolean value (true/false) or nil to not\n  Examples: `not true` => false, `not nil` => true");
+      let hint = String::from(
+        "💡 Hint: Pass a boolean value (true/false), nil, or &unit to not\n  Examples: `not true` => false, `not nil` => true, `not &unit` => true",
+      );
       crate::builtins::err_type_with_hint(msg, hint)
     }
   }

--- a/src/builtins/logics.rs
+++ b/src/builtins/logics.rs
@@ -60,7 +60,7 @@ pub fn binary_greater(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 pub fn not(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() != 1 {
     let hint = String::from(
-      "💡 Usage: `not boolean-value`\n  Negates a boolean value\n  Examples: `not true` => false, `not nil` => true, `not &unit` => true",
+      "💡 Usage: `not value`\n  Negates a boolean value; nil and &unit are also falsey\n  Examples: `not true` => false, `not nil` => true, `not &unit` => true",
     );
     return crate::builtins::err_arity_with_hint("not requires exactly 1 argument (a boolean, nil, or Unit), but received:", xs, hint);
   }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -533,7 +533,7 @@ pub fn syntax_if(expr: &CalcitList, scope: &CalcitScope, file_ns: &str, call_sta
 
   let cond_value = runner::evaluate_expr(cond, scope, file_ns, call_stack)?;
   match cond_value {
-    Calcit::Nil | Calcit::Bool(false) => match expr.get(2) {
+    Calcit::Nil | Calcit::Unit | Calcit::Bool(false) => match expr.get(2) {
       Some(false_branch) => runner::evaluate_expr(false_branch, scope, file_ns, call_stack),
       None => Ok(Calcit::Nil),
     },

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -488,7 +488,7 @@
                   name $ &list:first pair
                   xs0 $ &list:last pair
                 quasiquote $ foldl ~xs0 &unit
-                  defn doseq-fn% (_acc ~name) ~@body
+                  defn doseq-fn% (_acc ~name) ~@body &unit
           :examples $ []
             quote $ do
               defatom *seen $ []
@@ -500,6 +500,13 @@
             {} (:return 'Unit)
               :args $ [] 'Dynamic
           :tags $ #{} :effect :internal :macro
+          :tests $ []
+            %{} 'TestEntry (:name |returns-unit-after-body)
+              :code $ quote
+                assert= &unit $ &doseq
+                  x $ [] 1 2
+                  &+ x 1
+              :tags $ #{} :core :unit
         |&enum-def:has-variant? $ %{} 'CodeEntry (:doc "|Test whether an EnumDef declares a variant.")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -4487,7 +4494,7 @@
         |each $ %{} 'CodeEntry (:doc "|Iterate over a collection, apply a function for side effects, and return Unit.")
           :code $ quote
             defn each (xs f)
-              foldl xs &unit $ defn %each (_acc x) (f x)
+              foldl xs &unit $ defn %each (_acc x) (f x) &unit
           :examples $ []
             quote $ assert= &unit
               each ([] 1 2 3)
@@ -4498,6 +4505,12 @@
                 :: 'Fn $ {} (:return 'R)
                   :args $ [] 'T
               :generics $ [] 'T 'R
+          :tests $ []
+            %{} 'TestEntry (:name |returns-unit-after-callbacks)
+              :code $ quote
+                assert= &unit $ each ([] 1 2)
+                  fn (x) x
+              :tags $ #{} :core :unit
         |either $ %{} 'CodeEntry (:doc "|Returns the first non-nil value among its arguments\nBehaves like a nil-coalescing macro: only nil triggers evaluation of subsequent branches, so false is preserved as a value.")
           :code $ quote
             defmacro either (& xs)
@@ -6310,7 +6323,7 @@
             {} (:return 'T)
               :args $ [] 'T
               :generics $ [] 'T
-        |not $ %{} 'CodeEntry (:doc "|internal function for logical not\nSyntax: (not value)\nParams: value (any)\nReturns: boolean\nReturns true if value is falsy (nil or false), false otherwise")
+        |not $ %{} 'CodeEntry (:doc "|internal function for logical not\nSyntax: (not value)\nParams: value (boolean, nil, or Unit)\nReturns: boolean\nReturns true if value is falsy (nil, false, or Unit), false otherwise")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -487,7 +487,7 @@
               let
                   name $ &list:first pair
                   xs0 $ &list:last pair
-                quasiquote $ foldl ~xs0 (;nil)
+                quasiquote $ foldl ~xs0 &unit
                   defn doseq-fn% (_acc ~name) ~@body
           :examples $ []
             quote $ do
@@ -3135,11 +3135,10 @@
                   if
                     not $ string? ~message
                     raise $ str-spaced "|expects 1st argument to be string, got:" ~message
-                  if ~xs (;nil)
-                    &let ()
-                      eprintln "|Failed assertion:" $ format-to-lisp (quote ~xs)
-                      raise $ ~
-                        &str:concat (&str:concat message "| ") (format-to-lisp xs)
+                  if ~xs &unit $ &let ()
+                    eprintln "|Failed assertion:" $ format-to-lisp (quote ~xs)
+                    raise $ ~
+                      &str:concat (&str:concat message "| ") (format-to-lisp xs)
           :examples $ []
             quote $ assert "|x should be positive" (> 1 0)
             quote $ assert "|list should not be empty"
@@ -3154,15 +3153,14 @@
               &let
                 v $ gensym |v
                 quasiquote $ &let (~v ~code)
-                  if (~f ~v) (;nil)
-                    &let () (eprintln)
-                      eprintln
-                        format-to-lisp $ quote ~code
-                        , "|does not satisfy:"
-                          format-to-lisp $ quote ~f
-                          , "| <--------"
-                      eprintln "|  value is:" ~v
-                      raise "|Not satisfied in assertion!"
+                  if (~f ~v) &unit $ &let () (eprintln)
+                    eprintln
+                      format-to-lisp $ quote ~code
+                      , "|does not satisfy:"
+                        format-to-lisp $ quote ~f
+                        , "| <--------"
+                    eprintln "|  value is:" ~v
+                    raise "|Not satisfied in assertion!"
           :examples $ []
             quote $ assert-detect number? (+ 1 2)
             quote $ assert-detect list? ([] 1 2 3)
@@ -4489,10 +4487,9 @@
         |each $ %{} 'CodeEntry (:doc "|Iterate over a collection, apply a function for side effects, and return Unit.")
           :code $ quote
             defn each (xs f)
-              foldl xs (;nil)
-                defn %each (_acc x) (f x)
+              foldl xs &unit $ defn %each (_acc x) (f x)
           :examples $ []
-            quote $ assert= nil
+            quote $ assert= &unit
               each ([] 1 2 3)
                 fn (x) (&+ x 1)
           :schema $ :: 'Fn
@@ -4903,7 +4900,7 @@
                 not $ list? args
                 raise $ str-spaced "|fn expects args in list, got:" args
               if (&list:empty? body)
-                quasiquote $ defn f% ~args (;nil)
+                quasiquote $ defn f% ~args &unit
                 quasiquote $ defn f% ~args ~@body
           :examples $ []
             quote $ map ([] 1 2 3)
@@ -6606,31 +6603,32 @@
               :args $ [] (:: 'Optional 'T)
               :generics $ [] 'T
               :return $ :: 'Option 'T
-        |or $ %{} 'CodeEntry (:doc "|Logical disjunction macro. Skips evaluating later forms once a truthy (non-nil, non-false) value is found, preserving the first truthy result.")
+        |or $ %{} 'CodeEntry (:doc "|Logical disjunction macro. Skips later forms once a truthy (non-nil, non-false, non-Unit) value is found, preserving the first truthy result.")
           :code $ quote
             defmacro or (item & xs)
               if (&list:empty? xs) item $ if (list? item)
                 &let
                   v1# $ gensym |v1
                   quasiquote $ &let (~v1# ~item)
-                    if
-                      if (nil? ~v1#) true $ &= false ~v1#
+                    if ~v1# (~ v1#)
                       or
                         ~ $ &list:first xs
                         ~@ $ &list:rest xs
-                      ~ v1#
-                quasiquote $ if
-                  if (nil? ~item) true $ &= false ~item
+                quasiquote $ if ~item (~ item)
                   or
                     ~ $ &list:first xs
                     ~@ $ &list:rest xs
-                  ~ item
           :examples $ []
             quote $ assert= |done (or nil |done false)
             quote $ assert= false (or false nil)
             quote $ assert= 2 (or nil 2 3)
           :schema $ :: 'Dynamic
           :tags $ #{} :macro
+          :tests $ []
+            %{} 'TestEntry (:name |skips-unit-and-returns-next-truthy-value)
+              :code $ quote
+                assert= |next $ or &unit |next
+              :tags $ #{} :core :unit
         |pairs-map $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn pairs-map (xs)

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -1782,7 +1782,7 @@ fn hinted_async(xs: &CalcitList) -> bool {
   }
 
   fn is_truthy(form: &Calcit) -> bool {
-    !matches!(form, Calcit::Nil | Calcit::Bool(false))
+    !matches!(form, Calcit::Nil | Calcit::Unit | Calcit::Bool(false))
   }
 
   fn schema_marks_async(form: &Calcit) -> bool {


### PR DESCRIPTION
## Summary
- treat `&unit` as false in native conditional evaluation and `not`, matching JavaScript and WebAssembly
- make the `or` macro follow shared conditional truthiness and migrate internal no-return tails to `&unit`
- add Unit regressions for core behavior and `json-stringify`

Addresses the follow-up review feedback on #402.

## Validation
- `cargo test`
- `yarn compile`
- `yarn try-core-tests`
- `yarn try-rs`
- `yarn try-js`
- `yarn check-agent-interface`
- `cargo clippy --all-targets -- -D warnings`