### PR TITLE
fix: reconcile scaffold data-kind schemas

### DIFF
--- a/editing-history/20260824-1540-scaffold-data-kind-schema.md
+++ b/editing-history/20260824-1540-scaffold-data-kind-schema.md
@@ -1,0 +1,6 @@
+# Reconcile concrete data-definition schemas in scaffold plans
+
+- Accept an existing concrete `StructDef` or `EnumDef` schema when a scaffold plan declares the corresponding broad definition-kind marker.
+- Decode zero-payload canonical schema wrappers consistently at both snapshot-load and write-validation boundaries, avoiding their accidental interpretation as anonymous enum values.
+- Keep the compatibility rule directional and limited to data-definition schemas so unrelated function and value schemas remain strict.
+- Cover both struct and enum definition markers with a regression test.

--- a/src/bin/cli_handlers/scaffold.rs
+++ b/src/bin/cli_handlers/scaffold.rs
@@ -579,7 +579,7 @@ fn validate_existing_compatibility(
     ));
   }
   let mut diff = BTreeSet::new();
-  if entry.schema.as_ref() != spec.schema_annotation.as_ref() {
+  if !scaffold_schema_compatible(entry.schema.as_ref(), spec.schema_annotation.as_ref()) {
     let existing_dynamic = matches!(entry.schema.as_ref(), CalcitTypeAnnotation::Dynamic);
     let planned_dynamic = matches!(spec.schema_annotation.as_ref(), CalcitTypeAnnotation::Dynamic);
     if existing_dynamic || planned_dynamic {
@@ -615,6 +615,13 @@ fn validate_existing_compatibility(
     diff.insert("code".to_owned());
   }
   Ok(diff)
+}
+
+fn scaffold_schema_compatible(existing: &CalcitTypeAnnotation, planned: &CalcitTypeAnnotation) -> bool {
+  existing == planned
+    || (matches!(existing, CalcitTypeAnnotation::StructDef(_) | CalcitTypeAnnotation::EnumDef(_))
+      && matches!(planned, CalcitTypeAnnotation::Custom(_))
+      && existing.matches_annotation(planned))
 }
 
 fn report_to_edn(report: &ScaffoldPlanReport, dry_run: bool, apply_result: &ScaffoldApplyResult) -> Edn {
@@ -876,7 +883,12 @@ fn edn_symbol(value: &Edn, context: &str) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-  use super::{apply_scaffold, parse_architecture_plan, plan_id, reconcile_plan};
+  use std::sync::Arc;
+
+  use calcit::calcit::{Calcit, CalcitEnumDef, CalcitStructDef, CalcitStructValue, CalcitTypeAnnotation};
+  use cirru_edn::EdnTag;
+
+  use super::{apply_scaffold, parse_architecture_plan, plan_id, reconcile_plan, scaffold_schema_compatible};
   use crate::cli_handlers::edit::load_snapshot;
   use crate::cli_handlers::test_support::TestProject;
 
@@ -922,6 +934,27 @@ mod tests {
       :code $ quote (def scaffold-answer 42)
 "#;
 
+  const DATA_DEFINITION_KIND_PLAN: &str = r#"
+{}
+  :schema-version 1
+  :feature 'data-kinds
+  :roots $ #{} 'app.main/Box0 'app.main/Choice0
+  :definitions $ {}
+    'app.main/Box0 $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Nominal box."
+      :schema $ :: 'StructDef
+      :code $ quote (defstruct Box0 (:value 'String))
+    'app.main/Choice0 $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Nominal choice."
+      :schema $ :: 'EnumDef
+      :code $ quote (defenum Choice0 (:none))
+  :edges $ #{}
+"#;
+
   #[test]
   fn parses_flat_symbol_graph_and_has_stable_plan_id() {
     let plan = parse_architecture_plan(PLAN).expect("plan should parse");
@@ -949,6 +982,47 @@ mod tests {
     let invalid = PLAN.replace("[] 'value", "[] |value");
     let error = parse_architecture_plan(&invalid).expect_err("string params should be rejected");
     assert!(error.contains("Symbol"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn accepts_concrete_data_definition_schemas_for_kind_markers() {
+    let plan = parse_architecture_plan(DATA_DEFINITION_KIND_PLAN).expect("data definition plan should parse");
+    let planned_struct_schema = plan
+      .definitions
+      .get("app.main/Box0")
+      .expect("struct plan should exist")
+      .schema_annotation
+      .as_ref();
+    let planned_enum_schema = plan
+      .definitions
+      .get("app.main/Choice0")
+      .expect("enum plan should exist")
+      .schema_annotation
+      .as_ref();
+    let struct_schema = CalcitTypeAnnotation::StructDef(Arc::new(CalcitStructDef::from_fields(
+      EdnTag::new("Box0"),
+      vec![EdnTag::new("value")],
+    )));
+    let enum_schema = CalcitTypeAnnotation::EnumDef(Arc::new(
+      CalcitEnumDef::from_struct(CalcitStructValue {
+        struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("Choice0"), vec![EdnTag::new("none")])),
+        values: Arc::new(vec![Calcit::Nil]),
+      })
+      .expect("enum definition should be valid"),
+    ));
+
+    assert!(matches!(planned_struct_schema, CalcitTypeAnnotation::Custom(_)));
+    assert!(matches!(planned_enum_schema, CalcitTypeAnnotation::Custom(_)));
+    assert!(scaffold_schema_compatible(&struct_schema, planned_struct_schema));
+    assert!(scaffold_schema_compatible(&enum_schema, planned_enum_schema));
+    assert!(!scaffold_schema_compatible(
+      &struct_schema,
+      &CalcitTypeAnnotation::from_tag_name("Struct")
+    ));
+    assert!(!scaffold_schema_compatible(
+      &CalcitTypeAnnotation::Number,
+      &CalcitTypeAnnotation::Dynamic
+    ));
   }
 
   #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -493,14 +493,8 @@ fn parse_loaded_schema_annotation(value: &Edn, owner: &str) -> Result<Arc<Calcit
   // the canonical symbol parser. Otherwise a second unrelated Snapshot write
   // would interpret definition-kind markers as anonymous Enum values and
   // silently serialize `StructDef`/`EnumDef` as `Enum`.
-  if let Edn::Enum(view) = value
-    && view.extra.is_empty()
-    && let Some(canonical) = CalcitTypeAnnotation::canonical_type_symbol_name(&view.variant)
-    && !matches!(canonical, "Optional" | "JsNullish" | "Variadic")
-  {
-    return Ok(CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from(
-      canonical,
-    ))));
+  if let Some(annotation) = parse_zero_payload_schema_wrapper(value) {
+    return Ok(annotation);
   }
 
   // Primitive type tag stored as a plain EDN tag (e.g. :string, :number).
@@ -547,6 +541,20 @@ fn parse_loaded_schema_annotation(value: &Edn, owner: &str) -> Result<Arc<Calcit
     ));
   }
   Ok(annotation)
+}
+
+fn parse_zero_payload_schema_wrapper(value: &Edn) -> Option<Arc<CalcitTypeAnnotation>> {
+  let Edn::Enum(view) = value else { return None };
+  if !view.extra.is_empty() {
+    return None;
+  }
+  let canonical = CalcitTypeAnnotation::canonical_type_symbol_name(&view.variant)?;
+  if matches!(canonical, "Optional" | "JsNullish" | "Variadic") {
+    return None;
+  }
+  Some(CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from(
+    canonical,
+  ))))
 }
 
 fn tags_vec_to_set(tags: Vec<String>) -> HashSet<EdnTag> {
@@ -1677,6 +1685,9 @@ pub fn parse_schema_annotation_for_write(schema: &Cirru) -> Result<Arc<CalcitTyp
     parse_schema_data(schema)?;
   }
   let schema_edn = schema_cirru_to_edn(schema.clone());
+  if let Some(annotation) = parse_zero_payload_schema_wrapper(&schema_edn) {
+    return Ok(annotation);
+  }
   Ok(
     CalcitTypeAnnotation::parse_fn_schema_from_edn(&schema_edn)
       .map(|signature| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature))))


### PR DESCRIPTION
Closes #400.

- decode zero-payload canonical schema wrappers consistently during scaffold plan parsing
- accept concrete StructDef/EnumDef annotations against the corresponding broad plan markers
- keep compatibility directional and limited to data-definition schemas
- cover StructDef and EnumDef plan parsing with regression tests

Validation:
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check
- reproduced the issue CLI flow with an existing defstruct; scaffold dry-run now reports reuse-complete