### PR TITLE
chore: release 0.13.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.42"
+version = "0.13.43"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "calcit"
 autobins = false
-version = "0.13.42"
+version = "0.13.43"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202608241525-release-01343.md
+++ b/editing-history/202608241525-release-01343.md
@@ -1,0 +1,5 @@
+# Release 0.13.43
+
+- Align Unit truthiness across native, JavaScript, and WASM runtimes.
+- Reconcile existing `StructDef` and `EnumDef` definitions with matching scaffold architecture markers.
+- Include the range backend consistency and performance improvements merged after 0.13.42.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.42",
+  "version": "0.13.43",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
## Release 0.13.43

- align Unit truthiness across native, JavaScript, and WASM runtimes (#405)
- reconcile StructDef and EnumDef scaffold architecture markers (#407)
- include range backend consistency and performance improvements (#398)

## Validation

- cargo check --locked --workspace
- cargo test --locked --workspace
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo fmt --check
- 226 calcit-core definition tests
- native runtime suite
- JavaScript runtime suite
- WASM runtime suite