### PR TITLE
fix: bound native recur scope growth

### DIFF
--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -153,6 +153,24 @@ mod tests {
     assert_eq!(trailing_option_arg_count(&types, 3), 2);
     assert_eq!(trailing_option_arg_count(&types, 4), 0, "partial metadata must keep exact arity");
   }
+
+  #[test]
+  fn restores_call_frame_without_dropping_captured_bindings() {
+    let mut scope = CalcitScope::default();
+    scope.insert_mut(1, Calcit::Number(42.0));
+    let checkpoint = scope.frame_checkpoint();
+
+    for value in 0..100_000 {
+      scope.restore_frame(checkpoint);
+      scope.insert_mut(2, Calcit::Number(value as f64));
+      scope.insert_mut(3, Calcit::Number((value + 1) as f64));
+    }
+
+    assert_eq!(scope.0.len(), checkpoint + 2);
+    assert_eq!(scope.get(1), Some(&Calcit::Number(42.0)));
+    assert_eq!(scope.get(2), Some(&Calcit::Number(99_999.0)));
+    assert_eq!(scope.get(3), Some(&Calcit::Number(100_000.0)));
+  }
 }
 
 /// Macro variant of Calcit data
@@ -182,6 +200,16 @@ impl Display for ScopePair {
 pub struct CalcitScope(Vec<ScopePair>);
 
 impl CalcitScope {
+  /// Capture the current end of a lexical frame before adding call-local bindings.
+  pub(crate) fn frame_checkpoint(&self) -> usize {
+    self.0.len()
+  }
+
+  /// Drop bindings added after a frame checkpoint while preserving captured scope.
+  pub(crate) fn restore_frame(&mut self, checkpoint: usize) {
+    self.0.truncate(checkpoint);
+  }
+
   /// load value of a symbol from the scope (reverse scan for shadowing)
   pub fn get(&self, key: u16) -> Option<&Calcit> {
     for pair in self.0.iter().rev() {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -308,9 +308,11 @@ pub fn call_expr(
       // println!("macro... {} {}", x, CrListWrap(current_values.to_owned()));
 
       let mut body_scope = CalcitScope::default();
+      let frame_checkpoint = body_scope.frame_checkpoint();
 
       Ok(loop {
         // need to handle recursion
+        body_scope.restore_frame(frame_checkpoint);
         bind_marked_args(&mut body_scope, &info.args, &current_values, call_stack)?;
         let code = evaluate_lines(info.body.as_ref().as_slice(), &body_scope, &info.def_ns, &next_stack)?;
         match code {
@@ -580,6 +582,7 @@ pub fn run_fn(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) ->
   let completed_values = complete_trailing_option_args(values, info);
   let values = completed_values.as_deref().unwrap_or(values);
   let mut body_scope = (*info.scope).to_owned();
+  let frame_checkpoint = body_scope.frame_checkpoint();
   match &*info.args {
     CalcitFnArgs::Args(args) => {
       if args.len() != values.len() {
@@ -597,6 +600,7 @@ pub fn run_fn(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) ->
   if let Calcit::Recur(xs) = v {
     let mut current_values = xs.to_vec();
     loop {
+      body_scope.restore_frame(frame_checkpoint);
       match &*info.args {
         CalcitFnArgs::Args(args) => {
           if args.len() != current_values.len() {
@@ -622,6 +626,7 @@ pub fn run_fn(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) ->
 pub fn run_fn_owned(values: Vec<Calcit>, info: &CalcitFn, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   let values = complete_trailing_option_args(&values, info).unwrap_or(values);
   let mut body_scope = (*info.scope).to_owned();
+  let frame_checkpoint = body_scope.frame_checkpoint();
   match &*info.args {
     CalcitFnArgs::Args(args) => {
       if args.len() != values.len() {
@@ -639,6 +644,7 @@ pub fn run_fn_owned(values: Vec<Calcit>, info: &CalcitFn, call_stack: &CallStack
   if let Calcit::Recur(xs) = v {
     let mut current_values = xs.to_vec();
     loop {
+      body_scope.restore_frame(frame_checkpoint);
       match &*info.args {
         CalcitFnArgs::Args(args) => {
           if args.len() != current_values.len() {
@@ -906,7 +912,20 @@ pub fn evaluate_spreaded_args_from(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitFnUsageMeta, CalcitStructDef, CalcitStructValue, CalcitTypeAnnotation};
+  use crate::calcit::{CalcitFnUsageMeta, CalcitStructDef, CalcitStructValue, CalcitSymbolInfo, CalcitTypeAnnotation};
+
+  fn local_value(name: &str, idx: u16) -> Calcit {
+    Calcit::Local(CalcitLocal {
+      idx,
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.runner"),
+        at_def: Arc::from("tail-loop"),
+      }),
+      location: None,
+      type_info: crate::calcit::DYNAMIC_TYPE.clone(),
+    })
+  }
 
   fn user_option_type() -> Arc<CalcitTypeAnnotation> {
     let option_def = crate::calcit::CalcitEnumDef::from_struct(CalcitStructValue {
@@ -946,5 +965,53 @@ mod tests {
     let option = user_option_type();
     let info = fn_info(vec![Arc::new(CalcitTypeAnnotation::Number), option.clone(), option]);
     assert!(complete_trailing_option_args(&[Calcit::Number(1.0)], &info).is_none());
+  }
+
+  #[test]
+  fn long_recur_preserves_captured_scope() {
+    let x = CalcitLocal::track_sym(&Arc::from("tail-loop-x"));
+    let acc = CalcitLocal::track_sym(&Arc::from("tail-loop-acc"));
+    let captured = CalcitLocal::track_sym(&Arc::from("tail-loop-captured"));
+    let x_value = || local_value("tail-loop-x", x);
+    let acc_value = || local_value("tail-loop-acc", acc);
+    let captured_value = || local_value("tail-loop-captured", captured);
+
+    let condition = Calcit::from(vec![Calcit::Proc(CalcitProc::NativeLessThan), x_value(), Calcit::Number(1.0)]);
+    let completed = Calcit::from(vec![Calcit::Proc(CalcitProc::NativeAdd), acc_value(), captured_value()]);
+    let next_x = Calcit::from(vec![Calcit::Proc(CalcitProc::NativeMinus), x_value(), Calcit::Number(1.0)]);
+    let next_acc = Calcit::from(vec![Calcit::Proc(CalcitProc::NativeAdd), acc_value(), Calcit::Number(1.0)]);
+    let recur = Calcit::from(vec![Calcit::Proc(CalcitProc::Recur), next_x, next_acc]);
+    let body = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::If, Arc::from("tests.runner")),
+      condition,
+      completed,
+      recur,
+    ]);
+
+    let mut closure_scope = CalcitScope::default();
+    closure_scope.insert_mut(captured, Calcit::Number(42.0));
+    let info = CalcitFn {
+      name: Arc::from("tail-loop"),
+      def_ns: Arc::from("tests.runner"),
+      def_ref: None,
+      usage: CalcitFnUsageMeta::default(),
+      scope: Arc::new(closure_scope),
+      args: Arc::new(CalcitFnArgs::Args(vec![x, acc])),
+      body: vec![body],
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      return_type: Arc::new(CalcitTypeAnnotation::Number),
+      arg_types: vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::Number)],
+      rest_type: None,
+    };
+
+    let result = run_fn_owned(
+      vec![Calcit::Number(100_000.0), Calcit::Number(0.0)],
+      &info,
+      &CallStackList::default(),
+    )
+    .expect("long recur should complete");
+
+    assert_eq!(result, Calcit::Number(100_042.0));
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1453,10 +1453,12 @@ fn preprocess_list_call(
       let next_stack = call_stack.extend_owned(&info.def_ns, &info.name, StackKind::Macro, code, args.to_vec());
 
       let mut body_scope = CalcitScope::default();
+      let frame_checkpoint = body_scope.frame_checkpoint();
 
       loop {
         // need to handle recursion
         // println!("evaluating line: {:?}", body);
+        body_scope.restore_frame(frame_checkpoint);
         runner::bind_marked_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
         let code = runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack)?;
         match code {


### PR DESCRIPTION
## Summary

- keep captured lexical bindings separate from call-local argument bindings
- restore the call frame before each native `recur` iteration instead of appending another set of arguments
- apply the same bounded-frame behavior to runtime and preprocess macro recursion
- add a 100,000-iteration evaluator regression test that also verifies captured bindings survive

Closes #410
Part of #409

## Memory benchmark

The benchmark runs a two-argument tail-recursive loop for 200,000 iterations with the release CLI and records maximum RSS.

| build | zero iterations | 200k iterations | growth |
| --- | ---: | ---: | ---: |
| `main` (`92e3d35b`) | 27,394,048 B | 71,860,224 B | +44,466,176 B |
| this branch | 26,935,296 B | 25,378,816 B | within baseline variance |

User CPU time for the 200k case stayed effectively unchanged (about 1.50s before, 1.48s after).

## Compatibility

No static type assumptions or dispatch changes are introduced. Captured scope is preserved, current arguments still shadow captures, marked/rest arguments still use the existing binder, and only bindings belonging to the previous recur iteration are discarded.

Validated against current remote downstream heads:

- `calcit-lang/recollect@a694d4c` (0.0.33): native tests 9/9; JS test codegen and Node runtime passed; Dynamic usage unchanged at 204/405 (50.4%). Its default production codegen remains blocked by four existing dependency type warnings; the same failure reproduces with the repository's installed Calcit 0.13.40.
- `Respo/respo.calcit@ead78c3` (0.16.85): definition tests 25/25; production Vite build passed; real-browser render and Todo interaction passed with zero console errors; Dynamic usage unchanged at 284/1034 (27.5%).

## Validation

- `cargo fmt --all -- --check`
- `cargo test -q` (451 + 241 + 24 + 4 tests)
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release --bin calcit`
- `target/release/calcit calcit/test.cirru`
- `target/release/calcit calcit/test.cirru js && node js-out/main.mjs`

The progressive WASM script remains at its existing 0/10 baseline: nine fixtures require an `io.log_str` import that the runner does not provide, and one fixture hits an unrelated `global.set` validation error. This change does not touch WASM or code generation.
