### PR TITLE
perf: keep ordinary calls in contiguous storage

### DIFF
--- a/editing-history/202608241731-contiguous-executable-calls.md
+++ b/editing-history/202608241731-contiguous-executable-calls.md
@@ -1,0 +1,34 @@
+# Contiguous executable calls
+
+## Summary
+
+- Keep immutable ordinary proc, function, and method call nodes in
+  `CalcitList::Vector` after preprocessing instead of rebuilding them as
+  persistent `TernaryTreeList` values.
+- Preserve persistent storage for syntax calls because their runtime handlers
+  still rely on cheap structural `skip` operations.
+- Leave quoted and runtime List values untouched; the optimization is confined
+  to the result of preprocessing executable non-syntax calls.
+- Cover nested ordinary calls and the syntax/quote boundary with representation
+  regression tests.
+
+## Performance notes
+
+- A broader prototype that also converted syntax calls regressed a 200,000
+  iteration tail loop by about 6%, since `CalcitList::skip` rebuilt a persistent
+  tail from the Vector on every `if` evaluation. A borrowed syntax-argument view
+  is required before that representation can change safely.
+- On five release runs of the same 1,000,000-iteration loop, the retained
+  ordinary-call-only change reduced median internal runtime from 7,810.963 ms
+  to 6,998.677 ms (~10.4%) and median user CPU from 7.23 s to 6.95 s (~3.9%).
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo test -q`
+- `cargo clippy --all-targets -- -D warnings`
+- `yarn compile`
+- `yarn check-agent-interface`
+- `yarn check-all`
+- Current `calcit-lang/recollect` and `Respo/respo.calcit` main heads, including
+  native/JS tests, Respo production build, and real-browser interaction.

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -890,6 +890,18 @@ pub fn compile_source_def_for_snapshot(
   Ok(())
 }
 
+/// Ordinary runtime call nodes are immutable after preprocessing and favor
+/// contiguous traversal over persistent list updates. Syntax calls still use
+/// cheap persistent `skip` operations, and quoted/list values stay untouched.
+fn into_executable_call(expr: Calcit) -> Calcit {
+  match expr {
+    Calcit::List(items) if matches!(items.as_ref(), CalcitList::List(_)) && !matches!(items.first(), Some(Calcit::Syntax(..))) => {
+      Calcit::from(items.to_vec())
+    }
+    _ => expr,
+  }
+}
+
 pub fn preprocess_expr(
   expr: &Calcit,
   scope_defs: &HashSet<Arc<str>>,
@@ -1132,7 +1144,7 @@ pub fn preprocess_expr(
       } else {
         // TODO whether function bothers this...
         // println!("start calling: {}", expr);
-        preprocess_list_call(xs, scope_defs, scope_types, file_ns, check_warnings, call_stack)
+        preprocess_list_call(xs, scope_defs, scope_types, file_ns, check_warnings, call_stack).map(into_executable_call)
       }
     }
     Calcit::Number(..)
@@ -6621,6 +6633,65 @@ mod tests {
 
   fn lock_preprocess_test_state() -> std::sync::MutexGuard<'static, ()> {
     PREPROCESS_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+  }
+
+  #[test]
+  fn preprocessed_calls_use_contiguous_nodes() {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("+"),
+      Cirru::leaf("1"),
+      Cirru::List(vec![Cirru::leaf("*"), Cirru::leaf("2"), Cirru::leaf("3")]),
+    ]);
+    let code = code_to_calcit(&expr, "tests.executable", "main", vec![]).expect("parse call");
+    let warnings = RefCell::new(vec![]);
+
+    let resolved = preprocess_expr(
+      &code,
+      &HashSet::new(),
+      &mut ScopeTypes::new(),
+      "tests.executable",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess call");
+
+    let Calcit::List(outer) = resolved else {
+      panic!("expected outer call")
+    };
+    assert!(matches!(outer.as_ref(), CalcitList::Vector(_)));
+    assert!(matches!(
+      outer.get(2),
+      Some(Calcit::List(inner)) if matches!(inner.as_ref(), CalcitList::Vector(_))
+    ));
+  }
+
+  #[test]
+  fn executable_conversion_keeps_syntax_and_quoted_lists_persistent() {
+    let quoted = Calcit::List(Arc::new(CalcitList::List(TernaryTreeList::from(vec![
+      Calcit::Number(1.0),
+      Calcit::Number(2.0),
+    ]))));
+    let code = Calcit::from(vec![Calcit::Syntax(CalcitSyntax::Quote, Arc::from("tests.executable")), quoted]);
+    let warnings = RefCell::new(vec![]);
+
+    let resolved = preprocess_expr(
+      &code,
+      &HashSet::new(),
+      &mut ScopeTypes::new(),
+      "tests.executable",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess quote");
+
+    let Calcit::List(outer) = resolved else {
+      panic!("expected quote call")
+    };
+    assert!(matches!(outer.as_ref(), CalcitList::List(_)));
+    assert!(matches!(
+      outer.get(1),
+      Some(Calcit::List(inner)) if matches!(inner.as_ref(), CalcitList::List(_))
+    ));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- keep preprocessed ordinary proc, function, and method calls in contiguous `CalcitList::Vector` storage
- normalize nested calls through the existing preprocessing boundary
- preserve persistent storage for syntax calls and quoted/list values
- add regression tests for both the optimized path and the syntax/quote boundary

Closes #412
Part of #409

## Why syntax calls remain persistent

An initial prototype converted every preprocessed call. It regressed a 200,000-iteration tail loop by about 6% because `if` and other syntax handlers currently call `CalcitList::skip`; doing that from a Vector rebuilds a persistent argument tail on every evaluation. This PR keeps syntax calls on their current representation. A borrowed syntax-argument view is tracked as the next evaluator slice in #409.

## Benchmark

Five release runs of the same two-argument 1,000,000-iteration tail loop on `main` (`4fd9bb27`) and this branch:

| build | median internal runtime | median user CPU | result |
| --- | ---: | ---: | ---: |
| `main` | 7,810.963 ms | 7.23 s | `500000500000` |
| this branch | 6,998.677 ms | 6.95 s | `500000500000` |

That is about 10.4% lower internal runtime and 3.9% lower user CPU on this evaluator-heavy case.

## Compatibility

This changes only the internal storage selected after preprocessing. It does not add static type requirements, change call dispatch, recursively rewrite quoted data, or alter language List equality/hashing. Intentional Dynamic boundaries remain intact.

Validated against current remote downstream heads:

- `calcit-lang/recollect@a694d4c` (0.0.33): native definition tests 9/9; JS test codegen and Node runtime passed; Dynamic usage unchanged at 204/405 (50.4%). Default production codegen remains blocked by the same four existing dependency type warnings already reproducible on the repository toolchain.
- `Respo/respo.calcit@ead78c3` (0.16.85): definition tests 25/25; JS codegen and production Vite build passed; real-browser render and Todo interaction passed with zero console errors; Dynamic usage unchanged at 284/1034 (27.5%).

## Validation

- `cargo fmt --all -- --check`
- `cargo test -q` (453 + 241 + 24 + 4 tests)
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-agent-interface` (13/13)
- `yarn check-all`, including native, JS runtime/identity, IR, and full WASM checks

Implementation and the rejected broader prototype are recorded in `editing-history/202608241731-contiguous-executable-calls.md`.
