### PR TITLE
perf: specialize typed native number operations

### DIFF
--- a/editing-history/20260824-2119-validate-number-call-metadata.md
+++ b/editing-history/20260824-2119-validate-number-call-metadata.md
@@ -1,0 +1,8 @@
+# Validate specialized number-call metadata
+
+- Guard the native NumberBinary fast path with the stored proc identity, so a
+  manually constructed executable call with stale or mismatched metadata uses
+  ordinary dispatch rather than a different arithmetic operation.
+- Classify the small supported native-proc set before resolving argument types,
+  keeping all other calls off the specialization analysis path.
+- Rename the function-hint regression to describe its compile-time-only role.

--- a/editing-history/202608242013-typed-native-number-ops.md
+++ b/editing-history/202608242013-typed-native-number-ops.md
@@ -1,0 +1,34 @@
+# Typed native number operations
+
+## Context
+
+Typed functions carried an injected one-argument `hint-fn` form in their native runtime body. Tail recursion therefore re-evaluated compile-time metadata on every iteration. Native calls also discarded proven `Number` argument types before evaluation and rebuilt a temporary argument vector for the normal proc dispatcher.
+
+## Changes
+
+- Capture surrounding-function `hint-fn` metadata in `CalcitFn`, then remove that one-argument form from the executable body. Targeted two-argument hints retain their runtime behavior.
+- Add internal executable-call metadata that does not affect Calcit List equality, ordering, hashing, display, or language-level mutation behavior.
+- Mark exact two-argument `&+`, `&-`, `&*`, `&/`, `&<`, and `&>` calls only when both processed arguments resolve to `Number`.
+- Evaluate specialized arguments exactly once from left to right into a fixed two-value array, execute the numeric operation directly, and preserve the existing dynamic proc error path if static evidence becomes stale.
+- Leave Dynamic, unresolved, wrong-arity, spread, JS, and WASM calls on their existing paths.
+
+## Performance
+
+The release benchmark runs the same two-argument tail-recursive loop for 1,000,000 iterations.
+
+- Typed pre-change internal median: 1,664.953 ms.
+- Typed post-change internal median: 457.819 ms, a 72.5% reduction after removing runtime metadata evaluation and adding the specialized calls.
+- On the post-change binary, the specialized typed loop median was 457.819 ms versus 483.450 ms for the otherwise identical Dynamic loop, a 5.3% typed fast-path improvement.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test -q` (463 + 241 + 24 + 4 tests)
+- `yarn compile`
+- `yarn check-agent-interface` (13/13)
+- `yarn check-all`, including native, JS, IR, and WASM checks
+- Latest Recollect `a694d4c`: native tests 9/9; test-entry JS generation and Node runtime passed. Its default entry retains the same four pre-existing dependency type warnings.
+- Latest Respo `ead78c3`: tests 25/25, JS generation, Vite production build, and a browser Todo interaction passed with zero console errors.
+
+The downstream Dynamic boundaries remain observable rather than being forced static: Recollect reports 204/405 (50.4%) Dynamic type positions, and Respo reports 284/1034 (27.5%).

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -65,6 +65,7 @@ pub fn defn(expr: &CalcitListView<'_>, scope: &CalcitScope, file_ns: &str) -> Re
       {
         *last = Arc::new(CalcitTypeAnnotation::Variadic(inner.clone()));
       }
+      let runtime_body = body_items.iter().filter(|form| !is_function_metadata_hint(form)).cloned().collect();
       let is_macro_gen = s.as_ref().contains('%');
       Ok(Calcit::Fn {
         id: gen_core_id(),
@@ -81,7 +82,7 @@ pub fn defn(expr: &CalcitListView<'_>, scope: &CalcitScope, file_ns: &str) -> Re
           usage: CalcitFnUsageMeta::default(),
           scope: Arc::new(scope.to_owned()),
           args: Arc::new(parsed_args),
-          body: body_items,
+          body: runtime_body,
           generics,
           where_bounds,
           return_type,
@@ -99,6 +100,16 @@ pub fn defn(expr: &CalcitListView<'_>, scope: &CalcitScope, file_ns: &str) -> Re
       "defn expected a symbol and a list of arguments, but received insufficient arguments",
     ),
   }
+}
+
+/// A one-argument `hint-fn` form describes the surrounding function. Its
+/// information is copied into `CalcitFn` above and is not executable body code.
+/// Two-argument forms still target an expression and must retain runtime behavior.
+fn is_function_metadata_hint(form: &Calcit) -> bool {
+  matches!(
+    form,
+    Calcit::List(xs) if xs.len() == 2 && matches!(xs.first(), Some(Calcit::Syntax(CalcitSyntax::HintFn, _)))
+  )
 }
 
 pub fn defmacro(expr: &CalcitListView<'_>, _scope: &CalcitScope, def_ns: &str) -> Result<Calcit, CalcitErr> {
@@ -259,6 +270,20 @@ mod tests {
   }
 
   #[test]
+  fn only_surrounding_function_hints_are_runtime_metadata() {
+    let ns = "tests.fn";
+    let metadata_hint = Calcit::from(vec![Calcit::Syntax(CalcitSyntax::HintFn, Arc::from(ns)), Calcit::from(vec![])]);
+    let targeted_hint = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::HintFn, Arc::from(ns)),
+      Calcit::Number(1.0),
+      Calcit::Tag(EdnTag::from("number")),
+    ]);
+
+    assert!(is_function_metadata_hint(&metadata_hint));
+    assert!(!is_function_metadata_hint(&targeted_hint));
+  }
+
+  #[test]
   fn defn_captures_return_type_hint() {
     let ns = "tests.fn";
     let scope = CalcitScope::default();
@@ -277,7 +302,7 @@ mod tests {
     );
     let body_expr = make_symbol("x", ns, "main");
 
-    let expr = CalcitList::Vector(vec![fn_name, args_list, hint_form, body_expr]);
+    let expr = CalcitList::Vector(vec![fn_name, args_list, hint_form, body_expr.clone()]);
 
     let resolved = defn(&expr.view(), &scope, ns).expect("defn should succeed");
     match resolved {
@@ -285,6 +310,7 @@ mod tests {
         assert!(matches!(info.return_type.as_ref(), CalcitTypeAnnotation::Number));
         assert_eq!(info.arg_types.len(), 1, "single parameter function should track one arg type slot");
         assert!(info.arg_types.iter().all(|slot| matches!(**slot, CalcitTypeAnnotation::Dynamic)));
+        assert_eq!(info.body, vec![body_expr], "function metadata hint must not execute as body code");
       }
       other => panic!("expected function, got {other}"),
     }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -270,7 +270,7 @@ mod tests {
   }
 
   #[test]
-  fn only_surrounding_function_hints_are_runtime_metadata() {
+  fn only_surrounding_function_hints_are_compile_time_metadata() {
     let ns = "tests.fn";
     let metadata_hint = Calcit::from(vec![Calcit::Syntax(CalcitSyntax::HintFn, Arc::from(ns)), Calcit::from(vec![])]);
     let targeted_hint = Calcit::from(vec![

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -40,7 +40,7 @@ pub use calcit_trait::{CalcitTrait, CalcitTraitMemberKind};
 pub use enum_value::CalcitEnumValue;
 pub(crate) use fns::trailing_option_arg_count;
 pub use fns::{CalcitArgLabel, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitMacro, CalcitScope};
-pub use list::{CalcitList, CalcitListView};
+pub use list::{CalcitCallKind, CalcitList, CalcitListView, CalcitNumberBinaryOp};
 pub use local::CalcitLocal;
 pub use proc_name::{CalcitProc, ProcArity, ProcTypeSignature};
 pub use struct_value::CalcitStructValue;

--- a/src/calcit/list.rs
+++ b/src/calcit/list.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::cmp::Ordering;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::{fmt::Debug, ops::Index, sync::Arc};
@@ -7,10 +8,30 @@ use im_ternary_tree::TernaryTreeList;
 
 use crate::Calcit;
 
-#[derive(Debug, Clone, Ord, PartialOrd)]
+/// Internal execution metadata attached to contiguous call nodes. It never
+/// changes the language-level list value represented by the stored items.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CalcitCallKind {
+  #[default]
+  Normal,
+  NumberBinary(CalcitNumberBinaryOp),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CalcitNumberBinaryOp {
+  Add,
+  Subtract,
+  Multiply,
+  Divide,
+  LessThan,
+  GreaterThan,
+}
+
+#[derive(Debug, Clone)]
 /// abstraction over im_ternary_tree::TernaryTreeList
 pub enum CalcitList {
   Vector(Vec<Calcit>),
+  Call(Vec<Calcit>, CalcitCallKind),
   List(TernaryTreeList<Calcit>),
 }
 
@@ -28,6 +49,7 @@ impl PartialEq for CalcitList {
   fn eq(&self, other: &Self) -> bool {
     match (self, other) {
       (CalcitList::Vector(xs), CalcitList::Vector(ys)) => xs == ys,
+      (CalcitList::Call(xs, _), CalcitList::Call(ys, _)) => xs == ys,
       (CalcitList::List(xs), CalcitList::List(ys)) => xs == ys,
       (a, b) => {
         let a_size = a.len();
@@ -47,6 +69,18 @@ impl PartialEq for CalcitList {
 }
 
 impl Eq for CalcitList {}
+
+impl Ord for CalcitList {
+  fn cmp(&self, other: &Self) -> Ordering {
+    self.iter().cmp(other.iter())
+  }
+}
+
+impl PartialOrd for CalcitList {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
 
 impl Hash for CalcitList {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -144,6 +178,7 @@ impl Index<usize> for CalcitList {
   fn index(&self, idx: usize) -> &Calcit {
     match self {
       CalcitList::Vector(xs) => &xs[idx],
+      CalcitList::Call(xs, _) => &xs[idx],
       CalcitList::List(xs) => &xs[idx],
     }
   }
@@ -306,6 +341,7 @@ impl CalcitList {
   pub fn len(&self) -> usize {
     match self {
       CalcitList::Vector(xs) => xs.len(),
+      CalcitList::Call(xs, _) => xs.len(),
       CalcitList::List(xs) => xs.len(),
     }
   }
@@ -313,6 +349,7 @@ impl CalcitList {
   pub fn is_empty(&self) -> bool {
     match self {
       CalcitList::Vector(xs) => xs.is_empty(),
+      CalcitList::Call(xs, _) => xs.is_empty(),
       CalcitList::List(xs) => xs.is_empty(),
     }
   }
@@ -320,6 +357,7 @@ impl CalcitList {
   pub fn get(&self, idx: usize) -> Option<&Calcit> {
     match self {
       CalcitList::Vector(xs) => xs.get(idx),
+      CalcitList::Call(xs, _) => xs.get(idx),
       CalcitList::List(xs) => xs.get(idx),
     }
   }
@@ -327,6 +365,7 @@ impl CalcitList {
   pub fn first(&self) -> Option<&Calcit> {
     match self {
       CalcitList::Vector(xs) => xs.first(),
+      CalcitList::Call(xs, _) => xs.first(),
       CalcitList::List(xs) => xs.first(),
     }
   }
@@ -343,9 +382,21 @@ impl CalcitList {
     self.view().skip(start)
   }
 
+  pub fn executable(items: Vec<Calcit>, kind: CalcitCallKind) -> Self {
+    CalcitList::Call(items, kind)
+  }
+
+  pub fn call_kind(&self) -> CalcitCallKind {
+    match self {
+      CalcitList::Call(_, kind) => *kind,
+      CalcitList::Vector(_) | CalcitList::List(_) => CalcitCallKind::Normal,
+    }
+  }
+
   pub fn into_list(self) -> Self {
     match self {
       CalcitList::Vector(xs) => CalcitList::List(TernaryTreeList::from(xs)),
+      CalcitList::Call(xs, _) => CalcitList::List(TernaryTreeList::from(xs)),
       CalcitList::List(_) => self.to_owned(),
     }
   }
@@ -353,6 +404,7 @@ impl CalcitList {
   pub fn to_vec(&self) -> Vec<Calcit> {
     match self {
       CalcitList::Vector(xs) => xs.to_owned(),
+      CalcitList::Call(xs, _) => xs.to_owned(),
       CalcitList::List(xs) => xs.to_vec(),
     }
   }
@@ -364,6 +416,7 @@ impl CalcitList {
         ys = ys.push(x);
         CalcitList::List(ys)
       }
+      CalcitList::Call(xs, _) => CalcitList::List(TernaryTreeList::from(xs).push(x)),
       CalcitList::List(xs) => CalcitList::List(xs.push(x)),
     }
   }
@@ -371,6 +424,7 @@ impl CalcitList {
   pub fn push_left(&self, x: Calcit) -> Self {
     match self {
       CalcitList::Vector(xs) => CalcitList::List(TernaryTreeList::from(xs).prepend(x)),
+      CalcitList::Call(xs, _) => CalcitList::List(TernaryTreeList::from(xs).prepend(x)),
       CalcitList::List(xs) => CalcitList::List(xs.push_left(x)),
     }
   }
@@ -384,6 +438,7 @@ impl CalcitList {
         }
         CalcitList::List(ys)
       }
+      CalcitList::Call(xs, _) => CalcitList::List(TernaryTreeList::from(xs.iter().skip(1).cloned().collect::<Vec<_>>())),
       CalcitList::List(xs) => CalcitList::List(xs.drop_left()),
     }
   }
@@ -397,6 +452,9 @@ impl CalcitList {
         }
         Ok(CalcitList::List(ys))
       }
+      CalcitList::Call(xs, _) => Ok(CalcitList::List(TernaryTreeList::from(
+        xs.iter().skip(n).cloned().collect::<Vec<_>>(),
+      ))),
       CalcitList::List(xs) => Ok(CalcitList::List(xs.skip(n)?)),
     }
   }
@@ -410,6 +468,9 @@ impl CalcitList {
         }
         Ok(CalcitList::List(ys))
       }
+      CalcitList::Call(xs, _) => Ok(CalcitList::List(TernaryTreeList::from(
+        xs.iter().take(xs.len() - 1).cloned().collect::<Vec<_>>(),
+      ))),
       CalcitList::List(xs) => Ok(CalcitList::List(xs.butlast()?)),
     }
   }
@@ -417,6 +478,10 @@ impl CalcitList {
   pub fn slice(&self, start: usize, end: usize) -> Result<Self, String> {
     match self {
       CalcitList::Vector(xs) => {
+        let ys = TernaryTreeList::from(xs);
+        Ok(CalcitList::List(ys.slice(start, end)?))
+      }
+      CalcitList::Call(xs, _) => {
         let ys = TernaryTreeList::from(xs);
         Ok(CalcitList::List(ys.slice(start, end)?))
       }
@@ -433,6 +498,7 @@ impl CalcitList {
         }
         CalcitList::List(ys)
       }
+      CalcitList::Call(xs, _) => CalcitList::List(TernaryTreeList::from(xs).reverse()),
       CalcitList::List(xs) => CalcitList::List(xs.reverse()),
     }
   }
@@ -440,6 +506,11 @@ impl CalcitList {
   pub fn assoc(&self, idx: usize, x: Calcit) -> Result<Self, String> {
     match self {
       CalcitList::Vector(xs) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.assoc(idx, x)?;
+        Ok(CalcitList::List(ys))
+      }
+      CalcitList::Call(xs, _) => {
         let mut ys = TernaryTreeList::from(xs);
         ys = ys.assoc(idx, x)?;
         Ok(CalcitList::List(ys))
@@ -455,6 +526,11 @@ impl CalcitList {
         ys = ys.dissoc(idx)?;
         Ok(CalcitList::List(ys))
       }
+      CalcitList::Call(xs, _) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.dissoc(idx)?;
+        Ok(CalcitList::List(ys))
+      }
       CalcitList::List(xs) => Ok(CalcitList::List(xs.dissoc(idx)?)),
     }
   }
@@ -466,6 +542,11 @@ impl CalcitList {
         ys = ys.assoc_before(idx, x)?;
         Ok(CalcitList::List(ys))
       }
+      CalcitList::Call(xs, _) => {
+        let mut ys = TernaryTreeList::from(xs);
+        ys = ys.assoc_before(idx, x)?;
+        Ok(CalcitList::List(ys))
+      }
       CalcitList::List(xs) => Ok(CalcitList::List(xs.assoc_before(idx, x)?)),
     }
   }
@@ -473,6 +554,7 @@ impl CalcitList {
   pub fn assoc_after(&self, idx: usize, x: Calcit) -> Result<Self, String> {
     let base_list = match self {
       CalcitList::Vector(xs) => TernaryTreeList::from(xs),
+      CalcitList::Call(xs, _) => TernaryTreeList::from(xs),
       CalcitList::List(xs) => xs.clone(),
     };
     Ok(CalcitList::List(base_list.assoc_after(idx, x)?))
@@ -481,6 +563,7 @@ impl CalcitList {
   pub fn index_of(&self, x: &Calcit) -> Option<usize> {
     match self {
       CalcitList::Vector(xs) => xs.iter().position(|y| y == x),
+      CalcitList::Call(xs, _) => xs.iter().position(|y| y == x),
       CalcitList::List(xs) => xs.index_of(x),
     }
   }
@@ -488,6 +571,11 @@ impl CalcitList {
   pub fn traverse(&self, f: &mut dyn FnMut(&Calcit)) {
     match self {
       CalcitList::Vector(xs) => {
+        for x in xs {
+          f(x);
+        }
+      }
+      CalcitList::Call(xs, _) => {
         for x in xs {
           f(x);
         }
@@ -502,6 +590,12 @@ impl CalcitList {
     // self.0.traverse_result(f)
     match self {
       CalcitList::Vector(xs) => {
+        for x in xs {
+          f(x)?;
+        }
+        Ok(())
+      }
+      CalcitList::Call(xs, _) => {
         for x in xs {
           f(x)?;
         }
@@ -529,11 +623,12 @@ mod tests {
   }
 
   #[test]
-  fn borrowed_views_read_vector_and_persistent_lists() {
+  fn borrowed_views_read_all_list_storage_kinds() {
     let vector = CalcitList::Vector(values());
+    let call = CalcitList::executable(values(), CalcitCallKind::NumberBinary(CalcitNumberBinaryOp::Add));
     let persistent = CalcitList::List(TernaryTreeList::from(values()));
 
-    for source in [&vector, &persistent] {
+    for source in [&vector, &call, &persistent] {
       let tail = source.view_from(1).expect("valid argument tail");
       assert_eq!(tail.len(), 3);
       assert_eq!(tail.first(), Some(&Calcit::Number(2.0)));
@@ -552,5 +647,20 @@ mod tests {
 
     assert!(view.get(3).is_none());
     assert!(view.skip(4).is_err());
+  }
+
+  #[test]
+  fn executable_metadata_does_not_change_list_value_semantics() {
+    let normal = CalcitList::executable(values(), CalcitCallKind::Normal);
+    let specialized = CalcitList::executable(values(), CalcitCallKind::NumberBinary(CalcitNumberBinaryOp::Add));
+    let vector = CalcitList::Vector(values());
+    let persistent = CalcitList::List(TernaryTreeList::from(values()));
+
+    assert_eq!(normal, specialized);
+    assert_eq!(specialized, vector);
+    assert_eq!(specialized, persistent);
+    assert_eq!(normal.cmp(&specialized), Ordering::Equal);
+    assert_eq!(specialized.call_kind(), CalcitCallKind::NumberBinary(CalcitNumberBinaryOp::Add));
+    assert_eq!(specialized.push_right(Calcit::Number(5.0)).call_kind(), CalcitCallKind::Normal);
   }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -198,6 +198,7 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_sta
       Some(x) => {
         if let CalcitCallKind::NumberBinary(operation) = xs.call_kind()
           && xs.len() == 3
+          && matches!(xs.first(), Some(Calcit::Proc(proc)) if *proc == number_binary_proc(operation))
         {
           return evaluate_number_binary_call(operation, xs, scope, file_ns, call_stack);
         }
@@ -1074,6 +1075,20 @@ mod tests {
       .expect_err("stale static evidence must use the normal type error");
 
     assert!(format!("{err}").contains("&+ requires 2 numbers"));
+  }
+
+  #[test]
+  fn mismatched_number_binary_metadata_uses_normal_dispatch() {
+    let expr = Calcit::from(CalcitList::executable(
+      vec![Calcit::Proc(CalcitProc::NativeMultiply), Calcit::Number(2.0), Calcit::Number(3.0)],
+      CalcitCallKind::NumberBinary(CalcitNumberBinaryOp::Add),
+    ));
+
+    assert_eq!(
+      evaluate_expr(&expr, &CalcitScope::default(), "tests.runner", &CallStackList::default())
+        .expect("mismatched call metadata must use the stored procedure"),
+      Calcit::Number(6.0)
+    );
   }
 
   #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -7,8 +7,9 @@ use std::vec;
 
 use crate::builtins;
 use crate::calcit::{
-  CORE_NS, Calcit, CalcitArgLabel, CalcitEnumValue, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitImport, CalcitList,
-  CalcitListView, CalcitLocal, CalcitProc, CalcitScope, CalcitSyntax, MethodKind, NodeLocation, trailing_option_arg_count,
+  CORE_NS, Calcit, CalcitArgLabel, CalcitCallKind, CalcitEnumValue, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitImport,
+  CalcitList, CalcitListView, CalcitLocal, CalcitNumberBinaryOp, CalcitProc, CalcitScope, CalcitSyntax, MethodKind, NodeLocation,
+  trailing_option_arg_count,
 };
 use crate::call_stack::{CallStackList, StackKind, using_stack};
 use crate::data::cirru;
@@ -106,6 +107,52 @@ fn build_fn_arity_mismatch_error(info: &CalcitFn, values: &[Calcit], call_stack:
   CalcitErr::use_msg_stack(CalcitErrKind::Unexpected, msg, call_stack)
 }
 
+fn number_binary_proc(operation: CalcitNumberBinaryOp) -> CalcitProc {
+  match operation {
+    CalcitNumberBinaryOp::Add => CalcitProc::NativeAdd,
+    CalcitNumberBinaryOp::Subtract => CalcitProc::NativeMinus,
+    CalcitNumberBinaryOp::Multiply => CalcitProc::NativeMultiply,
+    CalcitNumberBinaryOp::Divide => CalcitProc::NativeDivide,
+    CalcitNumberBinaryOp::LessThan => CalcitProc::NativeLessThan,
+    CalcitNumberBinaryOp::GreaterThan => CalcitProc::NativeGreaterThan,
+  }
+}
+
+fn evaluate_number_binary_call(
+  operation: CalcitNumberBinaryOp,
+  xs: &CalcitList,
+  scope: &CalcitScope,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Calcit, CalcitErr> {
+  debug_assert_eq!(xs.len(), 3, "specialized binary calls must contain a head and two arguments");
+
+  let evaluate_arg = |arg: &Calcit| {
+    if arg.is_expr_evaluated() {
+      Ok(arg.to_owned())
+    } else {
+      evaluate_expr(arg, scope, file_ns, call_stack)
+    }
+  };
+  // Preserve normal call semantics: each argument is evaluated exactly once,
+  // from left to right, before the operator sees either value.
+  let values = [evaluate_arg(&xs[1])?, evaluate_arg(&xs[2])?];
+
+  match (&values[0], &values[1]) {
+    (Calcit::Number(a), Calcit::Number(b)) => match operation {
+      CalcitNumberBinaryOp::Add => Ok(Calcit::Number(a + b)),
+      CalcitNumberBinaryOp::Subtract => Ok(Calcit::Number(a - b)),
+      CalcitNumberBinaryOp::Multiply => Ok(Calcit::Number(a * b)),
+      CalcitNumberBinaryOp::Divide => Ok(Calcit::Number(a / b)),
+      CalcitNumberBinaryOp::LessThan => Ok(Calcit::Bool(a < b)),
+      CalcitNumberBinaryOp::GreaterThan => Ok(Calcit::Bool(a > b)),
+    },
+    // Static evidence may become stale after hot reload or host interop. Keep
+    // the established dynamic error and stack behavior without re-evaluating.
+    _ => builtins::handle_proc(number_binary_proc(operation), &values, call_stack),
+  }
+}
+
 pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   // println!("eval code: {}", expr.lisp_str());
   use Calcit::*;
@@ -149,6 +196,11 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_sta
         expr.get_location(),
       )),
       Some(x) => {
+        if let CalcitCallKind::NumberBinary(operation) = xs.call_kind()
+          && xs.len() == 3
+        {
+          return evaluate_number_binary_call(operation, xs, scope, file_ns, call_stack);
+        }
         // println!("eval expr: {}", expr.lisp_str());
         // println!("eval expr x: {}", x);
 
@@ -978,6 +1030,72 @@ mod tests {
     let option = user_option_type();
     let info = fn_info(vec![Arc::new(CalcitTypeAnnotation::Number), option.clone(), option]);
     assert!(complete_trailing_option_args(&[Calcit::Number(1.0)], &info).is_none());
+  }
+
+  #[test]
+  fn evaluates_specialized_number_binary_calls() {
+    let cases = [
+      (CalcitNumberBinaryOp::Add, 8.0, 2.0, Calcit::Number(10.0)),
+      (CalcitNumberBinaryOp::Subtract, 8.0, 2.0, Calcit::Number(6.0)),
+      (CalcitNumberBinaryOp::Multiply, 8.0, 2.0, Calcit::Number(16.0)),
+      (CalcitNumberBinaryOp::Divide, 8.0, 2.0, Calcit::Number(4.0)),
+      (CalcitNumberBinaryOp::LessThan, 2.0, 8.0, Calcit::Bool(true)),
+      (CalcitNumberBinaryOp::GreaterThan, 8.0, 2.0, Calcit::Bool(true)),
+    ];
+
+    for (operation, left, right, expected) in cases {
+      let expr = Calcit::from(CalcitList::executable(
+        vec![
+          Calcit::Proc(number_binary_proc(operation)),
+          Calcit::Number(left),
+          Calcit::Number(right),
+        ],
+        CalcitCallKind::NumberBinary(operation),
+      ));
+      assert_eq!(
+        evaluate_expr(&expr, &CalcitScope::default(), "tests.runner", &CallStackList::default()).expect("specialized call"),
+        expected
+      );
+    }
+  }
+
+  #[test]
+  fn specialized_number_call_preserves_dynamic_error_fallback() {
+    let operation = CalcitNumberBinaryOp::Add;
+    let expr = Calcit::from(CalcitList::executable(
+      vec![
+        Calcit::Proc(CalcitProc::NativeAdd),
+        Calcit::Str(Arc::from("oops")),
+        Calcit::Number(1.0),
+      ],
+      CalcitCallKind::NumberBinary(operation),
+    ));
+    let err = evaluate_expr(&expr, &CalcitScope::default(), "tests.runner", &CallStackList::default())
+      .expect_err("stale static evidence must use the normal type error");
+
+    assert!(format!("{err}").contains("&+ requires 2 numbers"));
+  }
+
+  #[test]
+  fn specialized_number_call_evaluates_arguments_left_to_right() {
+    let failing_left = Calcit::from(vec![
+      Calcit::Proc(CalcitProc::NativeAdd),
+      Calcit::Str(Arc::from("left")),
+      Calcit::Number(1.0),
+    ]);
+    let failing_right = Calcit::from(vec![
+      Calcit::Proc(CalcitProc::NativeMinus),
+      Calcit::Str(Arc::from("right")),
+      Calcit::Number(1.0),
+    ]);
+    let expr = Calcit::from(CalcitList::executable(
+      vec![Calcit::Proc(CalcitProc::NativeAdd), failing_left, failing_right],
+      CalcitCallKind::NumberBinary(CalcitNumberBinaryOp::Add),
+    ));
+    let err = evaluate_expr(&expr, &CalcitScope::default(), "tests.runner", &CallStackList::default())
+      .expect_err("left argument should fail first");
+
+    assert!(format!("{err}").contains("&+ requires 2 numbers"));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -902,14 +902,6 @@ fn into_executable_call(expr: Calcit) -> Calcit {
 }
 
 fn classify_number_binary_call(head: &Calcit, args: &[Calcit], scope_types: &ScopeTypes) -> CalcitCallKind {
-  if args.len() != 2
-    || !args
-      .iter()
-      .all(|arg| matches!(resolve_type_value(arg, scope_types).as_deref(), Some(CalcitTypeAnnotation::Number)))
-  {
-    return CalcitCallKind::Normal;
-  }
-
   let Calcit::Proc(proc) = head else {
     return CalcitCallKind::Normal;
   };
@@ -922,6 +914,13 @@ fn classify_number_binary_call(head: &Calcit, args: &[Calcit], scope_types: &Sco
     CalcitProc::NativeGreaterThan => CalcitNumberBinaryOp::GreaterThan,
     _ => return CalcitCallKind::Normal,
   };
+  if args.len() != 2
+    || !args
+      .iter()
+      .all(|arg| matches!(resolve_type_value(arg, scope_types).as_deref(), Some(CalcitTypeAnnotation::Number)))
+  {
+    return CalcitCallKind::Normal;
+  }
   CalcitCallKind::NumberBinary(operation)
 }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5,10 +5,10 @@ mod type_rewriting;
 use crate::{
   builtins::{self, is_js_syntax_procs, is_proc_name, is_registered_proc},
   calcit::{
-    self, Calcit, CalcitArgLabel, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnTypeAnnotation, CalcitImpl, CalcitImport,
-    CalcitList, CalcitLocal, CalcitProc, CalcitScope, CalcitStructDef, CalcitSymbolInfo, CalcitSyntax, CalcitTrait,
-    CalcitTraitMemberKind, CalcitTypeAnnotation, GENERATED_DEF, ImportInfo, LocatedWarning, NodeLocation, RawCodeType, SchemaKind,
-    brief_type_of_value, pop_type_slot_override, push_type_slot_override, register_type_slot,
+    self, Calcit, CalcitArgLabel, CalcitCallKind, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnTypeAnnotation, CalcitImpl,
+    CalcitImport, CalcitList, CalcitLocal, CalcitNumberBinaryOp, CalcitProc, CalcitScope, CalcitStructDef, CalcitSymbolInfo,
+    CalcitSyntax, CalcitTrait, CalcitTraitMemberKind, CalcitTypeAnnotation, GENERATED_DEF, ImportInfo, LocatedWarning, NodeLocation,
+    RawCodeType, SchemaKind, brief_type_of_value, pop_type_slot_override, push_type_slot_override, register_type_slot,
   },
   call_stack::{CallStackList, StackKind},
   codegen, program, runner,
@@ -894,9 +894,35 @@ pub fn compile_source_def_for_snapshot(
 /// traversal over persistent list updates. Quoted/list values stay untouched.
 fn into_executable_call(expr: Calcit) -> Calcit {
   match expr {
-    Calcit::List(items) if matches!(items.as_ref(), CalcitList::List(_)) => Calcit::from(items.to_vec()),
+    Calcit::List(items) if matches!(items.as_ref(), CalcitList::List(_)) => {
+      Calcit::from(CalcitList::executable(items.to_vec(), CalcitCallKind::Normal))
+    }
     _ => expr,
   }
+}
+
+fn classify_number_binary_call(head: &Calcit, args: &[Calcit], scope_types: &ScopeTypes) -> CalcitCallKind {
+  if args.len() != 2
+    || !args
+      .iter()
+      .all(|arg| matches!(resolve_type_value(arg, scope_types).as_deref(), Some(CalcitTypeAnnotation::Number)))
+  {
+    return CalcitCallKind::Normal;
+  }
+
+  let Calcit::Proc(proc) = head else {
+    return CalcitCallKind::Normal;
+  };
+  let operation = match proc {
+    CalcitProc::NativeAdd => CalcitNumberBinaryOp::Add,
+    CalcitProc::NativeMinus => CalcitNumberBinaryOp::Subtract,
+    CalcitProc::NativeMultiply => CalcitNumberBinaryOp::Multiply,
+    CalcitProc::NativeDivide => CalcitNumberBinaryOp::Divide,
+    CalcitProc::NativeLessThan => CalcitNumberBinaryOp::LessThan,
+    CalcitProc::NativeGreaterThan => CalcitNumberBinaryOp::GreaterThan,
+    _ => return CalcitCallKind::Normal,
+  };
+  CalcitCallKind::NumberBinary(operation)
 }
 
 pub fn preprocess_expr(
@@ -2153,7 +2179,9 @@ fn preprocess_list_call(
           ys = ys.prepend(Calcit::Syntax(CalcitSyntax::CallSpread, file_ns.into()));
           Ok(Calcit::from(CalcitList::List(ys)))
         } else {
-          Ok(Calcit::from(CalcitList::List(ys)))
+          let items = ys.to_vec();
+          let kind = classify_number_binary_call(&items[0], &items[1..], scope_types);
+          Ok(Calcit::from(CalcitList::executable(items, kind)))
         }
       }
       h => {
@@ -6655,10 +6683,10 @@ mod tests {
     let Calcit::List(outer) = resolved else {
       panic!("expected outer call")
     };
-    assert!(matches!(outer.as_ref(), CalcitList::Vector(_)));
+    assert!(matches!(outer.as_ref(), CalcitList::Call(_, CalcitCallKind::Normal)));
     assert!(matches!(
       outer.get(2),
-      Some(Calcit::List(inner)) if matches!(inner.as_ref(), CalcitList::Vector(_))
+      Some(Calcit::List(inner)) if matches!(inner.as_ref(), CalcitList::Call(_, CalcitCallKind::Normal))
     ));
   }
 
@@ -6684,11 +6712,87 @@ mod tests {
     let Calcit::List(outer) = resolved else {
       panic!("expected quote call")
     };
-    assert!(matches!(outer.as_ref(), CalcitList::Vector(_)));
+    assert!(matches!(outer.as_ref(), CalcitList::Call(_, CalcitCallKind::Normal)));
     assert!(matches!(
       outer.get(1),
       Some(Calcit::List(inner)) if matches!(inner.as_ref(), CalcitList::List(_))
     ));
+  }
+
+  #[test]
+  fn classifies_exact_number_binary_native_calls() {
+    let typed_local = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("typed-number")),
+      sym: Arc::from("typed-number"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.executable"),
+        at_def: Arc::from("main"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::Number),
+    });
+    let args = [typed_local, Calcit::Number(1.0)];
+
+    for (proc, operation) in [
+      (CalcitProc::NativeAdd, CalcitNumberBinaryOp::Add),
+      (CalcitProc::NativeMinus, CalcitNumberBinaryOp::Subtract),
+      (CalcitProc::NativeMultiply, CalcitNumberBinaryOp::Multiply),
+      (CalcitProc::NativeDivide, CalcitNumberBinaryOp::Divide),
+      (CalcitProc::NativeLessThan, CalcitNumberBinaryOp::LessThan),
+      (CalcitProc::NativeGreaterThan, CalcitNumberBinaryOp::GreaterThan),
+    ] {
+      assert_eq!(
+        classify_number_binary_call(&Calcit::Proc(proc), &args, &ScopeTypes::new()),
+        CalcitCallKind::NumberBinary(operation)
+      );
+    }
+  }
+
+  #[test]
+  fn preprocessed_number_binary_call_carries_static_operation() {
+    let expr = Cirru::List(vec![Cirru::leaf("&+"), Cirru::leaf("1"), Cirru::leaf("2")]);
+    let code = code_to_calcit(&expr, "tests.executable", "main", vec![]).expect("parse native number call");
+    let warnings = RefCell::new(vec![]);
+
+    let resolved = preprocess_expr(
+      &code,
+      &HashSet::new(),
+      &mut ScopeTypes::new(),
+      "tests.executable",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess native number call");
+
+    let Calcit::List(call) = resolved else {
+      panic!("expected executable call")
+    };
+    assert_eq!(call.call_kind(), CalcitCallKind::NumberBinary(CalcitNumberBinaryOp::Add));
+  }
+
+  #[test]
+  fn leaves_dynamic_and_non_binary_native_calls_unspecialized() {
+    let dynamic_local = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("dynamic-number")),
+      sym: Arc::from("dynamic-number"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.executable"),
+        at_def: Arc::from("main"),
+      }),
+      location: None,
+      type_info: crate::calcit::DYNAMIC_TYPE.clone(),
+    });
+    let dynamic_args = [dynamic_local, Calcit::Number(1.0)];
+    let unary_args = [Calcit::Number(1.0)];
+
+    assert_eq!(
+      classify_number_binary_call(&Calcit::Proc(CalcitProc::NativeAdd), &dynamic_args, &ScopeTypes::new()),
+      CalcitCallKind::Normal
+    );
+    assert_eq!(
+      classify_number_binary_call(&Calcit::Proc(CalcitProc::NativeAdd), &unary_args, &ScopeTypes::new()),
+      CalcitCallKind::Normal
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- keep surrounding-function `hint-fn` metadata in `CalcitFn` without executing that metadata on every native function iteration
- attach internal call-kind metadata to contiguous executable calls and specialize exact two-argument `&+`, `&-`, `&*`, `&/`, `&<`, and `&>` calls when both arguments are statically `Number`
- evaluate the specialized arguments once, left to right, with fixed storage while preserving the existing dynamic error fallback and all Dynamic/spread/JS/WASM paths
- preserve List value semantics: execution metadata does not affect equality, ordering, hashing, display, or language-level mutations

## Performance

Release benchmark, identical two-argument tail-recursive loop, 1,000,000 iterations, five-run medians:

- typed before: 1,664.953 ms
- typed after: 457.819 ms (72.5% lower, including removal of runtime metadata evaluation)
- Dynamic after: 483.450 ms, so the typed native-op path is 5.3% faster than the otherwise identical Dynamic path on the same binary

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q` (463 + 241 + 24 + 4)
- `yarn compile`
- `yarn check-agent-interface` (13/13)
- `yarn check-all` (native, JS, IR, and WASM)
- Recollect main `a694d4c`: native 9/9, test-entry JS generation and Node runtime passed; default entry retains its same four pre-existing dependency warnings
- Respo main `ead78c3`: tests 25/25, JS generation, Vite production build, and browser Todo interaction passed with zero console errors

Dynamic framework boundaries remain intact: Recollect still reports 204/405 (50.4%) Dynamic type positions and Respo 284/1034 (27.5%).

Closes #416
Part of #409
