### PR TITLE
perf: stabilize JS struct field indices

### DIFF
--- a/editing-history/20260824-2155-stable-js-struct-layout.md
+++ b/editing-history/20260824-2155-stable-js-struct-layout.md
@@ -1,0 +1,9 @@
+# Stable JavaScript Struct layout
+
+- Align JavaScript Struct, Enum, and implementation metadata ordering with native lexical tag-name ordering.
+- Make typed JS Struct reads and updates consume their precomputed field indices while retaining field-tag consistency checks.
+- Canonicalize Cirru EDN Struct field/value pairs during parsing so serialized data adopts the same layout.
+- Cover reversed tag-registration order and invalid indexed access in the JavaScript runtime regression suite.
+- Add `yarn bench-struct-index` to compare the previous tag-lookup codegen path with indexed access plus its schema-drift check.
+
+Focused JS benchmark on Apple arm64 / Node 24.4.1, 5,000,000 reads over a 32-field Struct (three runs): tag lookup median 574.51 ms; indexed access with field-tag validation median 37.56 ms (~15.3x faster). Native indexed Struct access is unchanged by this JS-only runtime/codegen optimization.

--- a/editing-history/20260824-2155-stable-js-struct-layout.md
+++ b/editing-history/20260824-2155-stable-js-struct-layout.md
@@ -5,5 +5,7 @@
 - Canonicalize Cirru EDN Struct field/value pairs during parsing so serialized data adopts the same layout.
 - Cover reversed tag-registration order and invalid indexed access in the JavaScript runtime regression suite.
 - Add `yarn bench-struct-index` to compare the previous tag-lookup codegen path with indexed access plus its schema-drift check.
+- Normalize paired metadata in exported JS Struct, StructDef, and Impl constructors for compatibility with older runtime values.
+- Align native `&struct:nth` index/tag validation and empty JS `with-at` arity errors with the indexed update primitives.
 
 Focused JS benchmark on Apple arm64 / Node 24.4.1, 5,000,000 reads over a 32-field Struct (three runs): tag lookup median 574.51 ms; indexed access with field-tag validation median 37.56 ms (~15.3x faster). Native indexed Struct access is unchanged by this JS-only runtime/codegen optimization.

--- a/editing-history/20260824-2224-struct-index-review-followups.md
+++ b/editing-history/20260824-2224-struct-index-review-followups.md
@@ -1,0 +1,7 @@
+# Struct index review follow-ups
+
+- Reused native struct index validation for reads, including exact numeric indices and optional field-tag checks.
+- Canonicalized paired struct metadata at exported JavaScript constructor boundaries so legacy or external callers cannot create unsorted field/value layouts.
+- Aligned JavaScript `withAt` arity validation with the native runtime.
+- Added reverse-registration EDN, legacy metadata, stale-tag, fractional-index, and empty-update regressions.
+- Re-ran the full Rust, Calcit, JavaScript, IR, WASM, and agent-interface validation suites.

--- a/editing-history/20260824-2233-indexed-struct-js-regressions.md
+++ b/editing-history/20260824-2233-indexed-struct-js-regressions.md
@@ -1,0 +1,5 @@
+# Indexed Struct JavaScript regressions
+
+- Covered fractional indices in JavaScript indexed Struct reads.
+- Covered stale field tags in JavaScript indexed `assocAt` and `withAt` updates.
+- Kept the regression matrix aligned with native indexed Struct validation.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test-snippets": "cargo test -q snippets::tests",
     "check-js-runtime": "node scripts/check-js-runtime-identity.mjs",
     "bench-recur-smoke": "cargo run --bin calcit -- calcit/test.cirru js && node --input-type=module -e \"import { test_loop } from './js-out/test-recursion.main.mjs'; const n=3000; const t0=process.hrtime.bigint(); for(let i=0;i<n;i++) test_loop(); const dt=Number(process.hrtime.bigint()-t0)/1e6; console.log('test_loop_ms='+dt.toFixed(3));\"",
+    "bench-struct-index": "yarn compile && node scripts/bench-struct-index.mjs",
     "check-smooth": "yarn fmt-rs && yarn lint-rs && yarn test-rs && yarn check-all",
     "check-all": "yarn compile && yarn check-js-runtime && yarn check-agent-interface && yarn try-core-tests && yarn try-rs && yarn try-js && yarn try-ir && yarn try-wasm",
     "check-agent-interface": "cargo build --bin calcit && node scripts/check-agent-interface.mjs",

--- a/scripts/bench-struct-index.mjs
+++ b/scripts/bench-struct-index.mjs
@@ -1,0 +1,23 @@
+import { performance } from "node:perf_hooks";
+import { CalcitStructDef, CalcitStructValue, newTag } from "../lib/calcit.procs.mjs";
+
+const fieldCount = 32;
+const iterations = 5_000_000;
+const fields = Array.from({ length: fieldCount }, (_, idx) => newTag(`field-${idx.toString().padStart(2, "0")}`));
+const values = Array.from({ length: fieldCount }, (_, idx) => idx + 1);
+const definition = new CalcitStructDef(newTag("StructIndexBenchmark"), fields, new Array(fieldCount).fill(null));
+const value = new CalcitStructValue(definition.name, fields, values, definition);
+const targetIndex = 27;
+const targetField = fields[targetIndex];
+
+const run = (label, read) => {
+  let checksum = 0;
+  for (let idx = 0; idx < 100_000; idx++) checksum += read();
+  const started = performance.now();
+  for (let idx = 0; idx < iterations; idx++) checksum += read();
+  const elapsed = performance.now() - started;
+  console.log(`${label}: ${elapsed.toFixed(2)}ms checksum=${checksum}`);
+};
+
+run("tag-lookup", () => value.getRequired(targetField));
+run("indexed-with-check", () => value.nthAt(targetIndex, targetField));

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -63,6 +63,30 @@ try {
     "struct field lookup must reject a missing field instead of returning nil"
   );
 
+  const lateField = runtimeA.newTag("zz-layout-field");
+  const earlyField = runtimeA.newTag("aa-layout-field");
+  assert.ok(lateField.idx < earlyField.idx, "fixture must register fields in reverse lexical order");
+  assert.ok(
+    runtimeA.compareTagNames(runtimeA.newTag("\ue000"), runtimeA.newTag("𐀀")) < 0,
+    "field ordering must match Rust Unicode scalar ordering rather than UTF-16 code-unit ordering"
+  );
+  const layoutDef = runtimeA.defstruct(
+    runtimeA.newTag("LayoutProbe"),
+    new runtimeA.CalcitSliceList([lateField, todoType]),
+    new runtimeA.CalcitSliceList([earlyField, todoType])
+  );
+  assert.deepEqual(
+    layoutDef.fields.map((field) => field.value),
+    ["aa-layout-field", "zz-layout-field"],
+    "Struct field layout must be lexical rather than tag-registration order"
+  );
+  const layoutValue = new runtimeA.CalcitStructValue(layoutDef.name, layoutDef.fields, ["early", "late"], layoutDef);
+  assert.equal(layoutValue.nthAt(0, earlyField), "early", "indexed Struct reads should use the stable layout");
+  assert.equal(layoutValue.assocAt(1, lateField, "updated").values[1], "updated");
+  assert.deepEqual(layoutValue.withAt(0, earlyField, "a", 1, lateField, "z").values, ["a", "z"]);
+  assert.throws(() => layoutValue.nthAt(0, lateField), /expects field :aa-layout-field/);
+  assert.throws(() => layoutValue.assocAt(-1, earlyField, "bad"), /non-negative integer index/);
+
   runtimeA.load_console_formatter_$x_();
   const formatter = globalThis.devtoolsFormatters.at(-1);
   const embeddedObjects = (node, found = []) => {

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -94,6 +94,9 @@ try {
   assert.deepEqual(layoutValue.withAt(0, earlyField, "a", 1, lateField, "z").values, ["a", "z"]);
   assert.throws(() => layoutValue.nthAt(0, lateField), /expects field :aa-layout-field/);
   assert.throws(() => layoutValue.assocAt(-1, earlyField, "bad"), /non-negative integer index/);
+  assert.throws(() => layoutValue.nthAt(0.5, earlyField), /non-negative integer index/);
+  assert.throws(() => layoutValue.assocAt(0, lateField, "bad"), /expects field :aa-layout-field/);
+  assert.throws(() => layoutValue.withAt(0, lateField, "bad"), /expects field :aa-layout-field/);
   assert.throws(() => layoutValue.withAt(), /index\/tag\/value triples/);
   const parsedReverseLayout = runtimeA.parse_cirru_edn(
     "%{} 'LayoutProbe\n  :zz-layout-field |late\n  :aa-layout-field |early",

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -80,12 +80,27 @@ try {
     ["aa-layout-field", "zz-layout-field"],
     "Struct field layout must be lexical rather than tag-registration order"
   );
+  const legacyLayoutValue = new runtimeA.CalcitStructValue(
+    layoutDef.name,
+    [lateField, earlyField],
+    ["late", "early"],
+    { name: layoutDef.name, fields: [lateField, earlyField], fieldTypes: [todoType, todoType], impls: [] }
+  );
+  assert.deepEqual(legacyLayoutValue.fields, [earlyField, lateField], "legacy Struct metadata should be canonicalized");
+  assert.deepEqual(legacyLayoutValue.values, ["early", "late"], "canonicalization must preserve field/value alignment");
   const layoutValue = new runtimeA.CalcitStructValue(layoutDef.name, layoutDef.fields, ["early", "late"], layoutDef);
   assert.equal(layoutValue.nthAt(0, earlyField), "early", "indexed Struct reads should use the stable layout");
   assert.equal(layoutValue.assocAt(1, lateField, "updated").values[1], "updated");
   assert.deepEqual(layoutValue.withAt(0, earlyField, "a", 1, lateField, "z").values, ["a", "z"]);
   assert.throws(() => layoutValue.nthAt(0, lateField), /expects field :aa-layout-field/);
   assert.throws(() => layoutValue.assocAt(-1, earlyField, "bad"), /non-negative integer index/);
+  assert.throws(() => layoutValue.withAt(), /index\/tag\/value triples/);
+  const parsedReverseLayout = runtimeA.parse_cirru_edn(
+    "%{} 'LayoutProbe\n  :zz-layout-field |late\n  :aa-layout-field |early",
+    null
+  );
+  assert.deepEqual(parsedReverseLayout.fields, [earlyField, lateField], "EDN Struct fields should be canonicalized");
+  assert.deepEqual(parsedReverseLayout.values, ["early", "late"], "EDN Struct values must follow canonicalized fields");
 
   runtimeA.load_console_formatter_$x_();
   const formatter = globalThis.devtoolsFormatters.at(-1);

--- a/src/builtins/structs.rs
+++ b/src/builtins/structs.rs
@@ -635,14 +635,34 @@ pub fn call_loose_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 /// This is the optimized path emitted by the preprocessor when the field index is known at compile time.
 pub fn struct_nth(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   // Accept 2 or 3 args: (struct, idx) or (struct, idx, :field-tag)
-  // The 3rd arg (field tag) is only used by JS codegen; Rust runtime ignores it.
+  // The optional field tag guards generated code against stale schema indices.
   if xs.len() < 2 || xs.len() > 3 {
     return CalcitErr::err_nodes(CalcitErrKind::Arity, "&struct:nth expected 2-3 arguments, but received:", xs);
   }
   match (&xs[0], &xs[1]) {
     (Calcit::Struct(CalcitStructValue { values, struct_ref }), Calcit::Number(n)) => {
-      let idx = *n as usize;
+      let idx = checked_struct_index(*n, "&struct:nth")?;
       if idx < values.len() {
+        if let Some(field) = xs.get(2) {
+          let Calcit::Tag(field_tag) = field else {
+            return CalcitErr::err_str(
+              CalcitErrKind::Type,
+              format!("&struct:nth expected an optional field tag, but received: {}", field.lisp_str()),
+            );
+          };
+          let Some(expected_tag) = struct_ref.fields.get(idx) else {
+            return CalcitErr::err_str(
+              CalcitErrKind::Arity,
+              format!("&struct:nth struct `{}` is missing field metadata at index {idx}", struct_ref.name),
+            );
+          };
+          if expected_tag != field_tag {
+            return CalcitErr::err_str(
+              CalcitErrKind::Type,
+              format!("&struct:nth index {idx} expects field `:{expected_tag}`, but received `:{field_tag}`"),
+            );
+          }
+        }
         Ok(values[idx].to_owned())
       } else {
         CalcitErr::err_str(
@@ -1562,6 +1582,22 @@ mod tests {
     let with_error = struct_with_at(&[struct_value, Calcit::Number(1.0), Calcit::tag("x"), Calcit::Number(3.0)])
       .expect_err("stale with tag must fail");
     assert!(with_error.msg.contains("expects field `:y`"));
+  }
+
+  #[test]
+  fn indexed_struct_reads_validate_indices_and_field_tags() {
+    let struct_value = indexed_struct_fixture();
+    let stale = struct_nth(&[struct_value.clone(), Calcit::Number(0.0), Calcit::tag("y")]).expect_err("stale read tag must fail");
+    assert!(stale.msg.contains("expects field `:x`"));
+
+    let invalid =
+      struct_nth(&[struct_value.clone(), Calcit::Number(0.5), Calcit::tag("x")]).expect_err("fractional read index must fail");
+    assert!(invalid.msg.contains("non-negative integer index"));
+
+    assert_eq!(
+      struct_nth(&[struct_value, Calcit::Number(1.0), Calcit::tag("y")]).expect("matching index/tag read"),
+      Calcit::Number(2.0)
+    );
   }
 
   #[test]

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -629,14 +629,14 @@ fn gen_call_code(
     // deftype-slot is preprocessing-only; it has no JS runtime effect.
     Calcit::Proc(CalcitProc::DeftypeSlot) => Ok(format!("{return_code}null")),
     Calcit::Proc(CalcitProc::WithTypeSlot) => Err("internal compiler error: with-type-slot escaped preprocessing".to_owned()),
-    // &struct:nth: with 3 args (struct, idx, :field-tag), use struct.getRequired(tag) for JS
-    // because JS CalcitStructValue fields are sorted by tag.idx (registration order), not alphabetically.
-    // With 2 args (struct, idx), fall back to struct.values[idx] (only valid when index matches).
+    // &struct:nth: typed calls carry the expected field tag so stale schema
+    // metadata fails loudly while the JS runtime reads by precomputed index.
     Calcit::Proc(CalcitProc::NativeStructNth) => {
       if body.len() == 3 {
         let record_code = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
+        let idx_code = to_js_code(&body[1], ns, local_defs, file_imports, tags, None)?;
         let tag_code = to_js_code(&body[2], ns, local_defs, file_imports, tags, None)?;
-        Ok(format!("{return_code}{record_code}.getRequired({tag_code})"))
+        Ok(format!("{return_code}{record_code}.nthAt({idx_code}, {tag_code})"))
       } else if body.len() == 2 {
         let record_code = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
         let idx_code = to_js_code(&body[1], ns, local_defs, file_imports, tags, None)?;
@@ -645,39 +645,34 @@ fn gen_call_code(
         Err(format!("&struct:nth expected 2-3 arguments, got: {body}"))
       }
     }
-    // &struct:assoc-at: optimized assoc with pre-resolved index.
-    // JS uses struct.assoc(tag, value) since JS field ordering differs from Rust.
+    // &struct:assoc-at: direct indexed update with a stale-metadata tag check.
     Calcit::Proc(CalcitProc::NativeStructAssocAt) => {
       if body.len() == 4 {
         let record_code = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
+        let idx_code = to_js_code(&body[1], ns, local_defs, file_imports, tags, None)?;
         let tag_code = to_js_code(&body[2], ns, local_defs, file_imports, tags, None)?;
         let value_code = to_js_code(&body[3], ns, local_defs, file_imports, tags, None)?;
-        Ok(format!("{return_code}{record_code}.assoc({tag_code}, {value_code})"))
+        Ok(format!("{return_code}{record_code}.assocAt({idx_code}, {tag_code}, {value_code})"))
       } else {
         Err(format!("&struct:assoc-at expected 4 arguments, got: {body}"))
       }
     }
-    // &struct:with-at: optimized with pre-resolved indices.
-    // JS ignores indices and calls the same _$n_record_$o_with(proto, tag, val, ...) function.
+    // &struct:with-at: direct indexed batch update with tag checks.
     Calcit::Proc(CalcitProc::NativeStructWithAt) => {
       if body.len() >= 3 && (body.len() - 1).is_multiple_of(3) {
-        let proc_prefix = get_proc_prefix(ns);
         let record_code = to_js_code(&body[0], ns, local_defs, file_imports, tags, None)?;
         let triple_count = (body.len() - 1) / 3;
-        let mut all_args = vec![record_code];
+        let mut all_args = vec![];
         for i in 0..triple_count {
           let base = 1 + i * 3;
-          // Skip index (body[base]), emit tag and value for JS
+          let idx_code = to_js_code(&body[base], ns, local_defs, file_imports, tags, None)?;
           let tag_code = to_js_code(&body[base + 1], ns, local_defs, file_imports, tags, None)?;
           let value_code = to_js_code(&body[base + 2], ns, local_defs, file_imports, tags, None)?;
+          all_args.push(idx_code);
           all_args.push(tag_code);
           all_args.push(value_code);
         }
-        Ok(format!(
-          "{return_code}{proc_prefix}{}({})",
-          escape_var("&struct:with"),
-          all_args.join(", ")
-        ))
+        Ok(format!("{return_code}{record_code}.withAt({})", all_args.join(", ")))
       } else {
         Err(format!(
           "&struct:with-at expected (struct, idx, tag, val, ...) triples, got: {body}"
@@ -2466,5 +2461,48 @@ mod tests {
     let code = to_js_code(&form, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("map literal should compile");
 
     assert_eq!(code, "$clt._$n__$M_(_t_.value, 1)");
+  }
+
+  #[test]
+  fn typed_struct_codegen_keeps_precomputed_indices() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let nth = Calcit::from(vec![
+      Calcit::Proc(CalcitProc::NativeStructNth),
+      symbol("person"),
+      Calcit::Number(0.0),
+      Calcit::Tag(EdnTag::from("name")),
+    ]);
+    let assoc = Calcit::from(vec![
+      Calcit::Proc(CalcitProc::NativeStructAssocAt),
+      symbol("person"),
+      Calcit::Number(0.0),
+      Calcit::Tag(EdnTag::from("name")),
+      Calcit::Str(Arc::from("Ada")),
+    ]);
+    let with = Calcit::from(vec![
+      Calcit::Proc(CalcitProc::NativeStructWithAt),
+      symbol("person"),
+      Calcit::Number(0.0),
+      Calcit::Tag(EdnTag::from("name")),
+      Calcit::Str(Arc::from("Ada")),
+      Calcit::Number(1.0),
+      Calcit::Tag(EdnTag::from("score")),
+      Calcit::Number(9.0),
+    ]);
+
+    assert_eq!(
+      to_js_code(&nth, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("indexed read should compile"),
+      "person.nthAt(0, _t_.name)"
+    );
+    assert_eq!(
+      to_js_code(&assoc, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("indexed assoc should compile"),
+      "person.assocAt(0, _t_.name, \"Ada\")"
+    );
+    assert_eq!(
+      to_js_code(&with, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("indexed batch update should compile"),
+      "person.withAt(0, _t_.name, \"Ada\", 1, _t_.score, 9)"
+    );
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1636,7 +1636,7 @@ fn preprocess_list_call(
             && let Some(idx) = struct_def.index_of(tag.ref_str())
           {
             // Emit (&struct:nth processed_arg idx :field-tag)
-            // The 3rd arg (field tag) is used by JS codegen where field order differs from Rust
+            // The field tag lets every backend reject stale index metadata after schema drift.
             let items: Vec<Calcit> = vec![
               Calcit::Proc(CalcitProc::NativeStructNth),
               processed_arg,

--- a/ts-src/calcit-data.mts
+++ b/ts-src/calcit-data.mts
@@ -143,6 +143,32 @@ export function compareTagNames(x: CalcitTag, y: CalcitTag): number {
   return 0;
 }
 
+export function tagNamesAreCanonical(fields: CalcitTag[]): boolean {
+  for (let idx = 1; idx < fields.length; idx++) {
+    if (compareTagNames(fields[idx - 1], fields[idx]) >= 0) return false;
+  }
+  return true;
+}
+
+export function canonicalizeTagPairs<T>(fields: CalcitTag[], values: T[], context: string): [CalcitTag[], T[]] {
+  if (fields.length !== values.length) {
+    throw new Error(`${context}: fields and values length mismatch`);
+  }
+  if (tagNamesAreCanonical(fields)) return [fields, values];
+
+  const pairs = fields.map((field, idx) => [field, values[idx]] as [CalcitTag, T]);
+  pairs.sort((a, b) => compareTagNames(a[0], b[0]));
+  for (let idx = 1; idx < pairs.length; idx++) {
+    if (pairs[idx - 1][0].value === pairs[idx][0].value) {
+      throw new Error(`${context}: duplicated field :${pairs[idx][0].value}`);
+    }
+  }
+  return [
+    pairs.map(([field]) => field),
+    pairs.map(([, value]) => value),
+  ];
+}
+
 /** returns -1 when not found */
 export function findInFields(xs: Array<CalcitTag>, y: CalcitTag): number {
   let low = 0;

--- a/ts-src/calcit-data.mts
+++ b/ts-src/calcit-data.mts
@@ -126,6 +126,23 @@ export let getStringName = (x: CalcitValue): string => {
   throw new Error("Cannot get string as name");
 };
 
+/** Compare tag names by Unicode scalar value, matching Rust `str` ordering. */
+export function compareTagNames(x: CalcitTag, y: CalcitTag): number {
+  let xIdx = 0;
+  let yIdx = 0;
+  while (xIdx < x.value.length && yIdx < y.value.length) {
+    const xCode = x.value.codePointAt(xIdx)!;
+    const yCode = y.value.codePointAt(yIdx)!;
+    if (xCode < yCode) return -1;
+    if (xCode > yCode) return 1;
+    xIdx += xCode > 0xffff ? 2 : 1;
+    yIdx += yCode > 0xffff ? 2 : 1;
+  }
+  if (xIdx < x.value.length) return 1;
+  if (yIdx < y.value.length) return -1;
+  return 0;
+}
+
 /** returns -1 when not found */
 export function findInFields(xs: Array<CalcitTag>, y: CalcitTag): number {
   let low = 0;
@@ -134,9 +151,10 @@ export function findInFields(xs: Array<CalcitTag>, y: CalcitTag): number {
   while (low <= high) {
     const mid = Math.floor((low + high) / 2);
     const midVal = xs[mid];
-    if (midVal.idx < y.idx) {
+    const ordering = compareTagNames(midVal, y);
+    if (ordering < 0) {
       low = mid + 1;
-    } else if (midVal.idx > y.idx) {
+    } else if (ordering > 0) {
       high = mid - 1;
     } else {
       return mid;

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -17,6 +17,7 @@ import {
   refsRegistry,
   toString,
   getStringName,
+  compareTagNames,
   _$n__$e_,
   hashFunction,
 } from "./calcit-data.mjs";
@@ -252,7 +253,7 @@ export let defstruct = (name: CalcitValue, ...entries: CalcitValue[]): CalcitStr
     fields.push({ tag: fieldTag, type: fieldType });
   }
 
-  fields.sort((a, b) => a.tag.idx - b.tag.idx);
+  fields.sort((a, b) => compareTagNames(a.tag, b.tag));
   for (let i = 1; i < fields.length; i++) {
     if (fields[i - 1].tag.value === fields[i].tag.value) {
       throw new Error(`defstruct duplicated field: ${fields[i].tag.toString()}`);
@@ -279,7 +280,7 @@ export let defenum = (name: CalcitValue, ...variants: CalcitValue[]): CalcitEnum
     entries.push({ tag, payload });
   }
 
-  entries.sort((a, b) => a.tag.idx - b.tag.idx);
+  entries.sort((a, b) => compareTagNames(a.tag, b.tag));
   for (let i = 1; i < entries.length; i++) {
     if (entries[i - 1].tag.value === entries[i].tag.value) {
       throw new Error(`defenum duplicated variant: ${entries[i].tag.toString()}`);
@@ -324,7 +325,7 @@ export let _$n_impl_$o__$o_new = (name: CalcitValue, ...pairs: CalcitValue[]): C
     }
     entries.push({ tag: fieldTag, value });
   }
-  entries.sort((a, b) => a.tag.idx - b.tag.idx);
+  entries.sort((a, b) => compareTagNames(a.tag, b.tag));
   for (let i = 1; i < entries.length; i++) {
     if (entries[i - 1].tag.value === entries[i].tag.value) {
       throw new Error(`&impl::new duplicated field: ${entries[i].tag.toString()}`);
@@ -391,11 +392,22 @@ export function _$n_struct_$o_field_tag(x: CalcitValue, idx: CalcitValue): Calci
   return x.fields[i];
 }
 
-export function _$n_struct_$o_nth(x: CalcitValue, idx: CalcitValue): CalcitValue {
+export function _$n_struct_$o_nth(x: CalcitValue, idx: CalcitValue, field?: CalcitValue): CalcitValue {
   if (!(x instanceof CalcitStructValue)) throw new Error(`&struct:nth expected a struct value, got ${x}`);
+  if (field !== undefined) return x.nthAt(idx, field);
   const i = idx as number;
   if (i < 0 || i >= x.values.length) throw new Error(`&struct:nth index ${i} out of range for struct with ${x.values.length} fields`);
   return x.values[i];
+}
+
+export function _$n_struct_$o_assoc_at(x: CalcitValue, idx: CalcitValue, field: CalcitValue, value: CalcitValue): CalcitValue {
+  if (!(x instanceof CalcitStructValue)) throw new Error(`&struct:assoc-at expected a struct value, got ${x}`);
+  return x.assocAt(idx, field, value);
+}
+
+export function _$n_struct_$o_with_at(x: CalcitValue, ...triples: CalcitValue[]): CalcitValue {
+  if (!(x instanceof CalcitStructValue)) throw new Error(`&struct:with-at expected a struct value, got ${x}`);
+  return x.withAt(...triples);
 }
 
 
@@ -1845,8 +1857,8 @@ const decode_typed_edn_node = (graph: DataShapeGraph, nodeId: number, input: any
         const idx = actualNames.indexOf(name);
         decodedFields.set(name, decode_typed_edn_node(graph, fieldNode, input.values[idx], `${path}.${name}`, depth + 1));
       });
-      // Native declarations use lexical field order while the JS runtime keeps
-      // its interned-tag order. Re-align values to the nominal JS declaration.
+      // Re-align by name so values produced by older runtimes or external data
+      // still adopt the current nominal declaration's canonical field layout.
       if (decodedFields.size !== node.nominal.fields.length) {
         return typed_edn_error(path, `struct :${node.nominal.name.value} decoder fields do not match its nominal declaration`);
       }

--- a/ts-src/js-cirru.mts
+++ b/ts-src/js-cirru.mts
@@ -6,7 +6,7 @@ import { CalcitList, CalcitSliceList } from "./js-list.mjs";
 import { CalcitStructValue } from "./js-struct-value.mjs";
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 import { CalcitSet } from "./js-set.mjs";
-import { CalcitTag, CalcitSymbol, CalcitRecur, newTag } from "./calcit-data.mjs";
+import { CalcitTag, CalcitSymbol, CalcitRecur, newTag, compareTagNames } from "./calcit-data.mjs";
 import { CalcitEnumValue } from "./js-enum-value.mjs";
 import { CalcitEnumDef } from "./js-enum-def.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
@@ -352,9 +352,7 @@ const extract_cirru_edn_inner = (x: CirruEdnFormat, options: CalcitValue, preser
           throw new Error(`Expected field pairs for struct, got: ${pair}`);
         }
       });
-      entries.sort((a, b) => {
-        return a[0].cmp(b[0]);
-      });
+      entries.sort((a, b) => compareTagNames(a[0], b[0]));
       let fields: Array<CalcitTag> = [];
       let values: Array<CalcitValue> = [];
 

--- a/ts-src/js-impl.mts
+++ b/ts-src/js-impl.mts
@@ -1,6 +1,6 @@
 import { Hash } from "@calcit/ternary-tree";
 import { CalcitValue } from "./js-primes.mjs";
-import { CalcitTag, castTag, findInFields, toString } from "./calcit-data.mjs";
+import { CalcitTag, canonicalizeTagPairs, castTag, findInFields, toString } from "./calcit-data.mjs";
 import type { CalcitTrait } from "./js-trait.mjs";
 
 const CALCIT_IMPL_BRAND = Symbol.for("@calcit/procs/CalcitImpl");
@@ -44,10 +44,11 @@ export class CalcitImpl {
     // optimized dependencies. A global, non-enumerable brand keeps impl values
     // recognizable across those otherwise distinct module instances.
     Object.defineProperty(this, CALCIT_IMPL_BRAND, { value: true });
+    const [canonicalFields, canonicalValues] = canonicalizeTagPairs(fields, values, "CalcitImpl");
     this.name = name;
     this.origin = origin;
-    this.fields = fields;
-    this.values = values;
+    this.fields = canonicalFields;
+    this.values = canonicalValues;
     this.cachedHash = null;
   }
 

--- a/ts-src/js-struct-def.mts
+++ b/ts-src/js-struct-def.mts
@@ -1,4 +1,4 @@
-import { CalcitTag, toString } from "./calcit-data.mjs";
+import { CalcitTag, canonicalizeTagPairs, toString } from "./calcit-data.mjs";
 import { CalcitValue } from "./js-primes.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
 
@@ -10,12 +10,10 @@ export class CalcitStructDef {
   cachedHash: number;
 
   constructor(name: CalcitTag, fields: CalcitTag[], fieldTypes: CalcitValue[], impls: CalcitImpl[] = []) {
-    if (fields.length !== fieldTypes.length) {
-      throw new Error("CalcitStructDef: fields and fieldTypes length mismatch");
-    }
+    const [canonicalFields, canonicalTypes] = canonicalizeTagPairs(fields, fieldTypes, "CalcitStructDef");
     this.name = name;
-    this.fields = fields;
-    this.fieldTypes = fieldTypes;
+    this.fields = canonicalFields;
+    this.fieldTypes = canonicalTypes;
     this.impls = impls;
     this.cachedHash = null;
   }

--- a/ts-src/js-struct-value.mts
+++ b/ts-src/js-struct-value.mts
@@ -1,7 +1,17 @@
 import { initTernaryTreeMap, Hash, insert } from "@calcit/ternary-tree";
 import { CalcitValue } from "./js-primes.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
-import { newTag, castTag, toString, CalcitTag, getStringName, findInFields, compareTagNames } from "./calcit-data.mjs";
+import {
+  newTag,
+  castTag,
+  toString,
+  CalcitTag,
+  getStringName,
+  findInFields,
+  compareTagNames,
+  canonicalizeTagPairs,
+  tagNamesAreCanonical,
+} from "./calcit-data.mjs";
 
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 
@@ -15,18 +25,18 @@ export class CalcitStructValue {
   cachedHash: Hash;
   constructor(name: CalcitTag, fields: Array<CalcitTag>, values?: Array<CalcitValue>, structRef?: CalcitStructDef) {
     this.name = name;
-    let fieldNames = fields.map(castTag);
-    this.fields = fields;
-    if (values != null) {
-      if (values.length !== fields.length) {
-        throw new Error("fields/values length not match");
-      }
-      this.values = values;
-    } else {
-      this.values = new Array(fieldNames.length);
-    }
+    const fieldNames = fields.map(castTag);
+    const sourceValues = values ?? new Array(fieldNames.length);
+    const [canonicalFields, canonicalValues] = canonicalizeTagPairs(fieldNames, sourceValues, "CalcitStructValue");
+    this.fields = canonicalFields;
+    this.values = canonicalValues;
     this.cachedHash = null;
-    this.structRef = structRef || new CalcitStructDef(name, fields, new Array(fields.length).fill(null));
+    this.structRef =
+      structRef == null
+        ? new CalcitStructDef(name, canonicalFields, new Array(canonicalFields.length).fill(null))
+        : tagNamesAreCanonical(structRef.fields)
+          ? structRef
+          : new CalcitStructDef(structRef.name, structRef.fields, structRef.fieldTypes, structRef.impls);
   }
   get(k: CalcitValue) {
     let field = castTag(k);
@@ -76,7 +86,7 @@ export class CalcitStructValue {
     return new CalcitStructValue(this.name, this.fields, values, this.structRef);
   }
   withAt(...triples: CalcitValue[]): CalcitStructValue {
-    if (triples.length % 3 !== 0) {
+    if (triples.length === 0 || triples.length % 3 !== 0) {
       throw new Error("&struct:with-at expected index/tag/value triples");
     }
     const values = this.values.slice();

--- a/ts-src/js-struct-value.mts
+++ b/ts-src/js-struct-value.mts
@@ -1,7 +1,7 @@
 import { initTernaryTreeMap, Hash, insert } from "@calcit/ternary-tree";
 import { CalcitValue } from "./js-primes.mjs";
 import { CalcitImpl } from "./js-impl.mjs";
-import { newTag, castTag, toString, CalcitTag, getStringName, findInFields } from "./calcit-data.mjs";
+import { newTag, castTag, toString, CalcitTag, getStringName, findInFields, compareTagNames } from "./calcit-data.mjs";
 
 import { CalcitMap, CalcitSliceMap } from "./js-map.mjs";
 
@@ -63,6 +63,40 @@ export class CalcitStructValue {
     }
     return new CalcitStructValue(this.name, this.fields, values, this.structRef);
   }
+  nthAt(index: CalcitValue, field: CalcitValue): CalcitValue {
+    const idx = checkedStructIndex(index, "&struct:nth");
+    this.assertFieldAt(idx, field, "&struct:nth");
+    return this.values[idx];
+  }
+  assocAt(index: CalcitValue, field: CalcitValue, value: CalcitValue): CalcitStructValue {
+    const idx = checkedStructIndex(index, "&struct:assoc-at");
+    this.assertFieldAt(idx, field, "&struct:assoc-at");
+    const values = this.values.slice();
+    values[idx] = value;
+    return new CalcitStructValue(this.name, this.fields, values, this.structRef);
+  }
+  withAt(...triples: CalcitValue[]): CalcitStructValue {
+    if (triples.length % 3 !== 0) {
+      throw new Error("&struct:with-at expected index/tag/value triples");
+    }
+    const values = this.values.slice();
+    for (let base = 0; base < triples.length; base += 3) {
+      const idx = checkedStructIndex(triples[base], "&struct:with-at");
+      this.assertFieldAt(idx, triples[base + 1], "&struct:with-at");
+      values[idx] = triples[base + 2];
+    }
+    return new CalcitStructValue(this.name, this.fields, values, this.structRef);
+  }
+  private assertFieldAt(idx: number, field: CalcitValue, operation: string): void {
+    if (idx >= this.fields.length) {
+      throw new Error(`${operation} index ${idx} out of range for struct '${this.name.value}' with ${this.fields.length} fields`);
+    }
+    const fieldTag = castTag(field);
+    const expectedTag = this.fields[idx];
+    if (expectedTag.value !== fieldTag.value) {
+      throw new Error(`${operation} index ${idx} expects field :${expectedTag.value}, but received :${fieldTag.value}`);
+    }
+  }
   /** return -1 for missing */
   findIndex(k: CalcitValue) {
     let field = castTag(k);
@@ -97,35 +131,21 @@ export class CalcitStructValue {
 }
 
 export let new_struct_value = (name: CalcitValue, ...fields: Array<CalcitValue>): CalcitValue => {
-  let fieldNames = fields.map(castTag).sort((x, y) => {
-    if (x.idx < y.idx) {
-      return -1;
-    } else if (x.idx > y.idx) {
-      return 1;
-    } else {
-      throw new Error(`Unexpected duplication in struct fields: ${x.toString()}`);
-    }
-  });
+  let fieldNames = fields.map(castTag).sort(compareTagNames);
+  assertUniqueFields(fieldNames, "Unexpected duplication in struct fields");
   return new CalcitStructValue(castTag(name), fieldNames);
 };
 
 export let new_impl_struct_value = (impl: CalcitImpl, name: CalcitValue, ...fields: Array<CalcitValue>): CalcitValue => {
-  let fieldNames = fields.map(castTag).sort((x, y) => {
-    if (x.idx < y.idx) {
-      return -1;
-    } else if (x.idx > y.idx) {
-      return 1;
-    } else {
-      throw new Error(`Unexpected duplication in struct fields: ${x.toString()}`);
-    }
-  });
+  let fieldNames = fields.map(castTag).sort(compareTagNames);
+  assertUniqueFields(fieldNames, "Unexpected duplication in struct fields");
   let nameTag = castTag(name);
   let structRef = new CalcitStructDef(nameTag, fieldNames, new Array(fieldNames.length).fill(null), [impl]);
   return new CalcitStructValue(nameTag, fieldNames, undefined, structRef);
 };
 
 /** Loose record: `?{} :field1 val1 :field2 val2` – record without a declared struct.
- *  Fields are sorted by tag index. The record name is "?" (sentinel). */
+ *  Fields use the same lexical layout as named structs. The record name is "_". */
 export let _$q__$M_ = (...xs: Array<CalcitValue>): CalcitValue => {
   if (xs.length % 2 !== 0) {
     throw new Error("?{} expected pairs of :field value");
@@ -134,10 +154,10 @@ export let _$q__$M_ = (...xs: Array<CalcitValue>): CalcitValue => {
   for (let i = 0; i < xs.length; i += 2) {
     pairs.push([castTag(xs[i]), xs[i + 1]]);
   }
-  pairs.sort((a, b) => a[0].idx - b[0].idx);
+  pairs.sort((a, b) => compareTagNames(a[0], b[0]));
   // Check for duplicate fields after sorting
   for (let i = 1; i < pairs.length; i++) {
-    if (pairs[i][0].idx === pairs[i - 1][0].idx) {
+    if (pairs[i][0].value === pairs[i - 1][0].value) {
       throw new Error(`?{} received duplicate field: :${getStringName(pairs[i][0])}`);
     }
   }
@@ -146,6 +166,21 @@ export let _$q__$M_ = (...xs: Array<CalcitValue>): CalcitValue => {
   let looseTag = newTag("_");
   return new CalcitStructValue(looseTag, fieldNames, values);
 };
+
+function checkedStructIndex(value: CalcitValue, operation: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${operation} expected a non-negative integer index, but received: ${value}`);
+  }
+  return value;
+}
+
+function assertUniqueFields(fields: CalcitTag[], message: string): void {
+  for (let idx = 1; idx < fields.length; idx++) {
+    if (fields[idx - 1].value === fields[idx].value) {
+      throw new Error(`${message}: ${fields[idx].toString()}`);
+    }
+  }
+}
 
 export let fieldsEqual = (xs: Array<CalcitTag>, ys: Array<CalcitTag>): boolean => {
   if (xs === ys) {


### PR DESCRIPTION
## Summary

- Canonicalize JavaScript Struct, Enum, and Impl field metadata by Unicode scalar name order, matching the native Rust layout.
- Emit typed `&struct:nth`, `&struct:assoc-at`, and `&struct:with-at` calls as indexed JavaScript operations with stale field-tag checks.
- Canonicalize Cirru EDN Struct parsing and cover reverse tag-registration order, invalid indices, stale tags, and generated code.
- Canonicalize metadata at exported JavaScript constructors for compatibility with values created by older runtimes or external callers.
- Add a focused `yarn bench-struct-index` benchmark.

Closes #418.

Advances #409.

## Benchmark

Apple arm64 / Node 24.4.1, 5,000,000 reads over a 32-field Struct, median of three runs:

- Previous generated path (`getRequired` tag lookup): 574.51 ms
- Indexed path with tag validation: 37.56 ms
- Approximately 15.3x faster, with an identical checksum

Native indexed Struct access is unchanged by this JavaScript optimization.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn check-all`
- `yarn bench-struct-index` (three runs)
- Latest `Respo/respo.calcit` main (`ead78c3`): native 25/25; JavaScript compile and indexed module import against the local runtime
- Latest `calcit-lang/recollect` main (`a694d4c`): native 9/9 and JavaScript tests against the local runtime

Recollect diff/patch remains intentionally dynamic; no downstream source changes were required.
