### PR TITLE
feat: add dynamic method analysis policy

### DIFF
--- a/calcit/test-dynamic-method-scope.cirru
+++ b/calcit/test-dynamic-method-scope.cirru
@@ -1,0 +1,34 @@
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |test-effects-graph)
+  :entries $ {}
+    :default $ {} (:description |) (:init-fn 'test-effects-graph.main/main!) (:mode :native) (:reload-fn 'test-effects-graph.main/reload!)
+      :feature-policy $ {}
+      :modules $ [] |./test-method-errors.cirru
+      :type-slots $ {}
+  :files $ {}
+    |test-effects-graph.main $ %{} 'FileEntry
+      :defs $ {}
+        |io-helper $ %{} 'CodeEntry (:doc "|reads a file path")
+          :code $ quote
+            defn io-helper (path) (read-file path)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |main! $ %{} 'CodeEntry (:doc "|entry with io and state effects")
+          :code $ quote
+            defn main! () $ trigger-type-error
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |reload! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn reload! () $ :: 'Unit
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |state-helper $ %{} 'CodeEntry (:doc "|defines and mutates an atom")
+          :code $ quote
+            defn state-helper () (defatom *counter 0) (reset! *counter 1) (swap! *counter inc)
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns test-effects-graph.main $ :require
+            test-method-errors.main :refer $ trigger-type-error

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -63,6 +63,12 @@ calcit analyze weak-types --ns app.main
 # Deprecated API calls, including the source definition and exact code path
 calcit analyze deprecated --ns app.main
 
+# Reachable unresolved method dispatch, without unrelated warning categories
+calcit analyze dynamic-methods
+
+# Enforce a reviewed dynamic-dispatch budget in CI
+calcit analyze dynamic-methods --max 4 --summary-only --format json
+
 # Enforce zero type/weak-type/deprecated debt with a non-zero failure exit
 calcit analyze quality
 
@@ -86,6 +92,7 @@ calcit analyze weak-types --ns app.main --only unsafe-coerce
 calcit analyze check-types --ns app.main --format json
 calcit analyze weak-types --ns app.main --intent unresolved --format json
 calcit analyze deprecated --ns app.main --format json
+calcit analyze dynamic-methods --format json
 
 # Keep aggregate counts but omit definition rows (especially useful for agents)
 calcit analyze check-types --ns app.main --summary-only --format json
@@ -113,7 +120,9 @@ For one definition, `calcit query context '<ns/def>' --format json` embeds the s
 
 For one expression, `calcit query type-at '<ns/def>' --path code@... --format json` preprocesses only static program metadata and returns inferred type, expected type, typed bindings, confidence, method candidates, and diagnostics. It does not run the application entry. Paths use the same stable Snapshot coordinates returned by structural query commands.
 
-These analysis commands run as static Snapshot readers: they load configured modules and core metadata but do not preprocess or execute the application entry. With `--format json`, stdout is one versioned JSON envelope containing a stable scope revision, filters, summary, and definition-level rows; startup/command messages stay on stderr.
+`check-types`, `weak-types`, `deprecated`, and `quality` run as static Snapshot readers: they load configured modules and core metadata but do not preprocess or execute the application entry. `dynamic-methods` preprocesses the selected entry's reachable definitions without executing them, because receiver inference and method specialization are preprocessing results. With `--format json`, stdout is one versioned JSON envelope containing a stable scope revision, filters, summary, and finding or definition rows; startup/command messages stay on stderr.
+
+`analyze dynamic-methods` reports only `P_DYNAMIC_METHOD_DISPATCH` and `P_DYNAMIC_POSTFIX_METHOD`; ordinary type warnings and JS FFI diagnostics do not contaminate its count. Project namespaces are the default scope, while `--deps` includes reachable modules. `--summary-only` omits individual findings. `--max <count>` turns the report into a focused CI policy and emits `E_DYNAMIC_METHOD_POLICY` with a non-zero status when the count grows beyond the reviewed budget. A receiver made concrete by normal inference, a trait constraint, or an explicit reviewed `unsafe-coerce` boundary is not unresolved dispatch.
 
 `analyze quality` combines the release-facing metrics from `check-types`, `weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic,code-nil,unsafe-coerce --intent unresolved,declared-optional,explicit-unsafe`, and `deprecated`. `unsafeCoerce` is an independent budget for explicit host assertions; it is not folded into unresolved Dynamic debt. With no baseline it is a zero-debt gate. `--baseline <file>` compares against a committed baseline and exits non-zero on regression; `--write-baseline <file>` atomically writes a reviewed native baseline. Native v2 baselines keep budgets per definition, so improving one definition cannot hide new debt in another. Native v1 and the older flat eight-metric shape remain readable and preserve their original eight-metric enforcement; v1 is reported as `native-baseline-v1` and does not claim an `unsafeCoerce` delta. Regenerate a reviewed baseline to adopt that budget. Scope flags (`--ns`, `--ns-prefix`, `--deps`) are recorded in native baselines and must match when they are enforced.
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -93,6 +93,17 @@ Warn when dynamic method dispatch cannot be specialized at preprocess time, and 
 calcit --warn-dyn-method
 ```
 
+For a focused, machine-readable inventory that excludes unrelated type and FFI warnings, use the dedicated analysis command:
+
+```bash
+calcit analyze dynamic-methods
+calcit analyze dynamic-methods --summary-only --format json
+calcit analyze dynamic-methods --max 0
+calcit analyze dynamic-methods --deps
+```
+
+The default scope contains project namespaces only. `--deps` includes reachable dependency namespaces, and `--max` returns a non-zero status when the finding count exceeds the reviewed limit.
+
 ### Hot Reloading Configuration
 
 **--init-fn**: Override the main entry function:

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -150,7 +150,7 @@ yarn install
 yarn install --immutable
 calcit calcit.cirru edit format
 calcit calcit.cirru --check-only
-calcit calcit.cirru --warn-dyn-method --check-only
+calcit calcit.cirru analyze dynamic-methods --max 0
 calcit calcit.cirru analyze deprecated --summary-only --format json
 calcit calcit.cirru analyze weak-types --intent unresolved,declared-optional --summary-only --format json
 calcit calcit.cirru
@@ -620,10 +620,10 @@ WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在�
     while IFS= read -r entry; do
       if [ "$entry" = "default" ]; then
         calcit calcit.cirru --check-only
-        calcit calcit.cirru --warn-dyn-method --check-only
+        calcit calcit.cirru analyze dynamic-methods --max 0
       else
         calcit calcit.cirru --entry "$entry" --check-only
-        calcit calcit.cirru --entry "$entry" --warn-dyn-method --check-only
+        calcit calcit.cirru --entry "$entry" analyze dynamic-methods --max 0
       fi
     done < <(calcit calcit.cirru config show | awk '/^Snapshot Entries:/{in_entries=1; next} in_entries && /^  [^ ]/{print $1}')
     calcit calcit.cirru analyze quality --baseline config/calcit-quality.json
@@ -663,7 +663,7 @@ definition-attached unit tests 时，应删除对应示例行并替换成项目�
 4. `yarn install --immutable`
 5. `calcit calcit.cirru edit format` 后 `git diff --exit-code -- calcit.cirru`
 6. default 与每个 named entry 的 `--check-only`
-7. 每个 entry 的 `--warn-dyn-method --check-only`（普通检查全绿后启用）
+7. 每个 entry 的 `analyze dynamic-methods --max <reviewed-limit>`；清零后使用 `--max 0`
 8. 所有声明支持的 entry 行为测试（默认 once；watch 另行验收）
 9. `analyze quality` 的 JSON baseline 或零目标（`check-types`、dynamic/nil `weak-types`、`deprecated` 仍作为定位报告）
 10. `calcit test --require-match`、公开 namespace 的 `check-examples` 与 `docs check-md`
@@ -678,7 +678,7 @@ definition-attached unit tests 时，应删除对应示例行并替换成项目�
 | 依赖图 | `caps tree/status/verify` | 递归版本、链接、store/native 收据 | 状态异常会阻断；普通图告警用 `--strict` 收紧 |
 | Snapshot 规范化 | `calcit edit format` + `git diff` | 旧 configs/schema 拼写和规范化建议 | format 告警不阻断，diff 需人工审阅 |
 | entry 预处理 | `calcit --entry ... --check-only` | 配置、缺失定义、参数/返回值、数据与 trait 类型错误 | 错误或 warning 均阻断 |
-| 动态分派 | `calcit --warn-dyn-method --check-only` | 动态 receiver、无法专门化的方法与未类型化 FFI 访问 | warning 会随 check-only 阻断 |
+| 动态分派 | `calcit analyze dynamic-methods --max <reviewed-limit>` | 动态 receiver 与无法专门化的方法；默认排除依赖和无关 FFI warning | 超过上限时阻断；`--deps` 可审计依赖 |
 | 静态债务 | `analyze check-types/weak-types/deprecated --format json` | 覆盖率、dynamic、nil/Optional、废弃调用 | 报告本身不按命中数阻断，CI 比较 summary |
 | 示例与测试 | `check-examples`、`docs check-md`、`calcit test --require-match` | API 示例、文档片段、definition-attached tests | 失败或未匹配测试时阻断 |
 | 行为与后端 | entry、Node/Vite、项目测试 | native/JS/FFI 的真实行为差异 | 由进程退出码阻断 |

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -470,15 +470,17 @@ calcit calcit.cirru analyze deprecated --summary-only
 `:features $ #{} :js-ffi`，并在进入 typed code 前 validate/convert。无返回值使用 `Unit`；业务缺失
 使用 `Option`，需要错误信息时使用 `Result`，不要让旧 `Optional<T>` 或裸 `nil` 无限保留。
 
-再对每个 entry 开启动态方法告警：
+再对每个 entry 运行独立的动态方法报告；已有项目可以先记录非零上限，再逐步降低：
 
 ```bash
-calcit calcit.cirru --warn-dyn-method --check-only
-calcit calcit.cirru --entry test --warn-dyn-method --check-only
+calcit calcit.cirru analyze dynamic-methods --summary-only --format json
+calcit calcit.cirru analyze dynamic-methods --max 0
+calcit calcit.cirru --entry test analyze dynamic-methods --max 0
 ```
 
-这个开关会暴露无法静态专门化的方法调用和未类型化的动态接收者。它不是第一步：先修复普通
-`--check-only`，再打开额外告警，否则旧项目的初始噪音可能掩盖真正的配置和 API 错误。
+该报告只统计无法静态专门化的方法调用，不混入普通类型或 JS FFI warning；默认不统计依赖，
+维护模块时可加 `--deps` 查看完整可达范围。旧的 `--warn-dyn-method --check-only` 仍适合交互排查，
+但会和其他预处理 warning 一起阻断，不适合作为单一性能指标的 CI policy。
 
 ### 3.6 存量项目的类型收紧策略
 

--- a/editing-history/20260824-2256-dynamic-method-analysis.md
+++ b/editing-history/20260824-2256-dynamic-method-analysis.md
@@ -1,0 +1,9 @@
+# Dynamic method analysis
+
+- Added `analyze dynamic-methods` to inventory unresolved method dispatch without mixing in unrelated preprocessing warnings.
+- Added stable codes for prefix and postfix dynamic dispatch findings.
+- Added project-only default scope, opt-in dependency scope, deterministic de-duplication, JSON and summary output.
+- Added `--max` as an incremental CI performance policy for existing typed projects.
+- Verified the initial project-only inventory against current Respo and Recollect main branches.
+- Respo reports 8 project findings and passes a reviewed `--max 8`; Recollect reports 0 project findings and 4 reachable dependency findings.
+- Respo native tests pass 25/25 and Recollect native tests pass 9/9 with the installed branch build.

--- a/editing-history/20260824-2329-dynamic-method-review-followups.md
+++ b/editing-history/20260824-2329-dynamic-method-review-followups.md
@@ -1,0 +1,7 @@
+# Dynamic method analysis review follow-ups
+
+- Documented the accepted `text` output alias and advertised `dynamic-methods` in parent CLI help.
+- Preserved every imprecisely located generated warning while still de-duplicating warnings with exact Snapshot coordinates.
+- Added a module-backed CLI fixture proving project-only and reachable dependency scopes end to end.
+- Strengthened the policy smoke test to require individual finding rows.
+- Updated the upgrade CI template, checklist, and troubleshooting matrix to use the focused dynamic-method policy.

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -314,11 +314,47 @@ const scenarios = [
       if (result.data.summary.findings !== 2 || result.data.summary.passed !== false) {
         throw new Error("dynamic-methods policy did not fail above its limit");
       }
+      if (result.data.findings.length !== 2) {
+        throw new Error("dynamic-methods policy omitted fixture finding rows");
+      }
       if (result.data.findings.some((finding) => !finding.code?.startsWith("P_DYNAMIC_"))) {
         throw new Error("dynamic-methods report included unrelated warnings");
       }
       if (result.diagnostics[0]?.code !== "E_DYNAMIC_METHOD_POLICY") {
         throw new Error("dynamic-methods policy failure lost its structured diagnostic");
+      }
+    },
+  },
+  {
+    name: "dynamic method project scope",
+    args: [
+      "calcit/test-dynamic-method-scope.cirru",
+      "analyze",
+      "dynamic-methods",
+      "--summary-only",
+      "--format",
+      "json",
+    ],
+    check(result) {
+      if (result.data.summary.findings !== 0 || result.data.filters.include_dependencies !== false) {
+        throw new Error("dynamic-methods default scope leaked dependency findings");
+      }
+    },
+  },
+  {
+    name: "dynamic method dependency scope",
+    args: [
+      "calcit/test-dynamic-method-scope.cirru",
+      "analyze",
+      "dynamic-methods",
+      "--deps",
+      "--summary-only",
+      "--format",
+      "json",
+    ],
+    check(result) {
+      if (result.data.summary.findings !== 2 || result.data.filters.include_dependencies !== true) {
+        throw new Error("dynamic-methods --deps lost reachable module findings");
       }
     },
   },

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -277,6 +277,52 @@ const scenarios = [
     },
   },
   {
+    name: "dynamic method summary",
+    args: [
+      "calcit/test-method-errors.cirru",
+      "analyze",
+      "dynamic-methods",
+      "--summary-only",
+      "--format",
+      "json",
+    ],
+    check(result) {
+      if (result.schema_version !== 1 || result.command !== "analyze.dynamic-methods") {
+        throw new Error("unexpected analyze.dynamic-methods envelope");
+      }
+      if (result.data.summary.findings !== 2 || result.data.findings.length !== 0) {
+        throw new Error("dynamic-methods summary did not preserve aggregate-only output");
+      }
+      if (result.data.summary.passed !== true || !result.revision.startsWith("md5:")) {
+        throw new Error("dynamic-methods summary lost policy or revision metadata");
+      }
+    },
+  },
+  {
+    name: "dynamic method policy failure",
+    args: [
+      "calcit/test-method-errors.cirru",
+      "analyze",
+      "dynamic-methods",
+      "--max",
+      "1",
+      "--format",
+      "json",
+    ],
+    expectedStatus: 1,
+    check(result) {
+      if (result.data.summary.findings !== 2 || result.data.summary.passed !== false) {
+        throw new Error("dynamic-methods policy did not fail above its limit");
+      }
+      if (result.data.findings.some((finding) => !finding.code?.startsWith("P_DYNAMIC_"))) {
+        throw new Error("dynamic-methods report included unrelated warnings");
+      }
+      if (result.diagnostics[0]?.code !== "E_DYNAMIC_METHOD_POLICY") {
+        throw new Error("dynamic-methods policy failure lost its structured diagnostic");
+      }
+    },
+  },
+  {
     name: "static quality gate failure",
     args: [
       "calcit/test.cirru",

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -564,6 +564,19 @@ fn render_analyze_explanation(cmd: &AnalyzeCommand) -> Option<String> {
       }
       desc
     }
+    AnalyzeSubcommand::DynamicMethods(opts) => {
+      let mut desc = "locates unresolved dynamic method dispatch in reachable definitions".to_string();
+      if opts.deps {
+        desc.push_str(", including dependencies");
+      }
+      if opts.summary_only {
+        desc.push_str(", returning aggregate counts only");
+      }
+      if let Some(limit) = opts.max {
+        desc.push_str(&format!(", enforcing a maximum of {limit}"));
+      }
+      desc
+    }
     AnalyzeSubcommand::Deprecated(opts) => {
       let mut desc = "locates calls to APIs marked deprecated".to_string();
       if let Some(ns) = &opts.ns {
@@ -858,6 +871,13 @@ fn push_analyze(tokens: &mut Vec<String>, cmd: &AnalyzeCommand) {
       value "format" => &opts.format; default "human",
       switch "deps" => opts.deps,
       switch "summary-only" => opts.summary_only
+    ),
+    AnalyzeSubcommand::DynamicMethods(opts) => echo_items!(
+      tokens,
+      value "format" => &opts.format; default "human",
+      switch "deps" => opts.deps,
+      switch "summary-only" => opts.summary_only,
+      opt_owned "max" => opts.max.map(|value| value.to_string()); default "none"
     ),
     AnalyzeSubcommand::Deprecated(opts) => echo_items!(
       tokens,
@@ -1256,6 +1276,7 @@ fn analyze_name(subcommand: &AnalyzeSubcommand) -> &'static str {
     AnalyzeSubcommand::CheckExamples(_) => "check-examples",
     AnalyzeSubcommand::CheckTypes(_) => "check-types",
     AnalyzeSubcommand::WeakTypes(_) => "weak-types",
+    AnalyzeSubcommand::DynamicMethods(_) => "dynamic-methods",
     AnalyzeSubcommand::Deprecated(_) => "deprecated",
     AnalyzeSubcommand::Quality(_) => "quality",
     AnalyzeSubcommand::EffectsGraph(_) => "effects-graph",

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 #[allow(unused_imports)]
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -34,8 +34,8 @@ mod cr_cirru_suite_tests;
 use calcit::calcit::{CalcitFnTypeAnnotation, CalcitTypeAnnotation, LocatedWarning, SchemaKind};
 use calcit::call_stack::CallStackList;
 use calcit::cli_args::{
-  AnalyzeSubcommand, CalcitCommand, CallGraphCommand, CheckTypesCommand, CountCallsCommand, DeprecatedCommand, EffectsGraphCommand,
-  QualityCommand, TestCommand, ToplevelCalcit, WeakTypesCommand,
+  AnalyzeSubcommand, CalcitCommand, CallGraphCommand, CheckTypesCommand, CountCallsCommand, DeprecatedCommand, DynamicMethodsCommand,
+  EffectsGraphCommand, QualityCommand, TestCommand, ToplevelCalcit, WeakTypesCommand,
 };
 use calcit::snapshot::ChangesDict;
 use calcit::util::string::strip_shebang;
@@ -96,6 +96,133 @@ fn run_quality(options: &QualityCommand, snapshot: &snapshot::Snapshot) -> Resul
     Err(format!(
       "Static quality gate failed with {} regression(s). Run `calcit docs read library-quality.md --full` for the baseline and CI workflow.",
       outcome.violations.len()
+    ))
+  }
+}
+
+fn collect_dynamic_method_findings(
+  warnings: Vec<LocatedWarning>,
+  include_dependencies: bool,
+  project_namespaces: &HashSet<String>,
+) -> Vec<LocatedWarning> {
+  let mut unique = BTreeMap::new();
+  for warning in warnings {
+    if !matches!(warning.code(), Some("P_DYNAMIC_METHOD_DISPATCH" | "P_DYNAMIC_POSTFIX_METHOD")) {
+      continue;
+    }
+    let location = warning.location();
+    if !include_dependencies && !project_namespaces.contains(location.ns.as_ref()) {
+      continue;
+    }
+    let key = (
+      location.ns.to_string(),
+      location.def.to_string(),
+      location.coord.to_vec(),
+      warning.code().unwrap_or_default().to_owned(),
+      warning.message().to_owned(),
+    );
+    unique.entry(key).or_insert(warning);
+  }
+  unique.into_values().collect()
+}
+
+fn run_dynamic_methods(
+  options: &DynamicMethodsCommand,
+  entries: &ProgramEntries,
+  snapshot: &snapshot::Snapshot,
+  project_namespaces: &HashSet<String>,
+) -> Result<(), String> {
+  if !matches!(options.format.as_str(), "human" | "text" | "json") {
+    return Err(format!(
+      "Unknown dynamic-methods output format `{}`. Expected `human` or `json`.",
+      options.format
+    ));
+  }
+
+  let previous_warn_setting = runner::preprocess::is_warn_dyn_method_enabled();
+  runner::preprocess::set_warn_dyn_method(true);
+  let collected = (|| {
+    let warnings = RefCell::new(Vec::new());
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .map_err(|failure| failure.msg)?;
+    runner::preprocess::ensure_ns_def_compiled(&entries.reload_ns, &entries.reload_def, &warnings, &CallStackList::default())
+      .map_err(|failure| failure.msg)?;
+    Ok::<Vec<LocatedWarning>, String>(warnings.into_inner())
+  })();
+  runner::preprocess::set_warn_dyn_method(previous_warn_setting);
+
+  let findings = collect_dynamic_method_findings(collected?, options.deps, project_namespaces);
+  let finding_count = findings.len();
+  let passed = options.max.is_none_or(|limit| finding_count <= limit);
+  let revision_ids = snapshot
+    .files
+    .iter()
+    .filter(|(namespace, _)| options.deps || project_namespaces.contains(namespace.as_str()))
+    .flat_map(|(namespace, file)| file.defs.keys().map(|definition| (namespace.clone(), definition.clone())))
+    .collect::<Vec<_>>();
+  let revision = type_coverage::analysis_revision(snapshot, &revision_ids)?;
+
+  match options.format.as_str() {
+    "human" | "text" => {
+      println!("Dynamic method dispatch analysis");
+      println!("- scope: {}", if options.deps { "project+dependencies" } else { "project" });
+      println!("- revision: {revision}");
+      println!("- findings: {finding_count}");
+      if let Some(limit) = options.max {
+        println!("- policy: {} (limit {limit})", if passed { "PASS" } else { "FAIL" });
+      }
+      if !options.summary_only {
+        for warning in &findings {
+          println!("- {warning}");
+        }
+      }
+    }
+    "json" => {
+      let rows = if options.summary_only {
+        Vec::new()
+      } else {
+        findings.iter().map(LocatedWarning::as_json).collect::<Vec<_>>()
+      };
+      println!(
+        "{}",
+        serde_json::json!({
+          "schema_version": 1,
+          "command": "analyze.dynamic-methods",
+          "revision": revision,
+          "data": {
+            "filters": {
+              "include_dependencies": options.deps,
+              "summary_only": options.summary_only,
+              "max": options.max,
+            },
+            "summary": {
+              "findings": finding_count,
+              "passed": passed,
+            },
+            "findings": rows,
+          },
+          "diagnostics": if passed {
+            Vec::<serde_json::Value>::new()
+          } else {
+            vec![serde_json::json!({
+              "code": "E_DYNAMIC_METHOD_POLICY",
+              "phase": "analysis",
+              "severity": "error",
+              "message": format!("Dynamic method dispatch findings {finding_count} exceed limit {}.", options.max.unwrap_or_default()),
+            })]
+          },
+        })
+      );
+    }
+    _ => unreachable!("dynamic-methods output format was validated before analysis"),
+  }
+
+  if passed {
+    Ok(())
+  } else {
+    Err(format!(
+      "Dynamic method dispatch policy failed: {finding_count} finding(s) exceed --max {}.",
+      options.max.unwrap_or_default()
     ))
   }
 }
@@ -405,6 +532,7 @@ fn run_cli() -> Result<(), String> {
       ),
       AnalyzeSubcommand::CheckTypes(check_types_options) => run_check_types(check_types_options, &snapshot),
       AnalyzeSubcommand::WeakTypes(weak_type_options) => run_weak_types(weak_type_options, &snapshot),
+      AnalyzeSubcommand::DynamicMethods(options) => run_dynamic_methods(options, &entries, &snapshot, &project_namespaces),
       AnalyzeSubcommand::Deprecated(deprecated_options) => run_deprecated(deprecated_options, &snapshot),
       AnalyzeSubcommand::Quality(quality_options) => run_quality(quality_options, &snapshot),
       AnalyzeSubcommand::EffectsGraph(effects_graph_options) => run_effects_graph(&entries, effects_graph_options),
@@ -1668,6 +1796,35 @@ mod tests {
 
     assert_eq!(project.files["calcit.core"].ns.doc, "source core");
     assert!(project.files.contains_key("calcit.internal"));
+  }
+
+  #[test]
+  fn dynamic_method_findings_are_scoped_deduplicated_and_code_filtered() {
+    fn warning(namespace: &str, code: &str, coord: Vec<u16>) -> LocatedWarning {
+      LocatedWarning::new_with_detail(
+        format!("warning {code}"),
+        calcit::calcit::NodeLocation::new(Arc::from(namespace), Arc::from("run"), Arc::from(coord)),
+        Some(code.to_owned()),
+        None,
+      )
+    }
+
+    let project_namespaces = HashSet::from(["app.main".to_owned()]);
+    let warnings = vec![
+      warning("app.main", "P_DYNAMIC_METHOD_DISPATCH", vec![1]),
+      warning("app.main", "P_DYNAMIC_METHOD_DISPATCH", vec![1]),
+      warning("app.main", "W_JS_FFI_UNTYPED_ACCESS", vec![2]),
+      warning("dep.lib", "P_DYNAMIC_POSTFIX_METHOD", vec![3]),
+    ];
+
+    let project_only = collect_dynamic_method_findings(warnings.clone(), false, &project_namespaces);
+    assert_eq!(project_only.len(), 1);
+    assert_eq!(project_only[0].location().ns.as_ref(), "app.main");
+
+    let with_dependencies = collect_dynamic_method_findings(warnings, true, &project_namespaces);
+    assert_eq!(with_dependencies.len(), 2);
+    assert_eq!(with_dependencies[0].location().ns.as_ref(), "app.main");
+    assert_eq!(with_dependencies[1].location().ns.as_ref(), "dep.lib");
   }
 
   #[test]

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -106,7 +106,7 @@ fn collect_dynamic_method_findings(
   project_namespaces: &HashSet<String>,
 ) -> Vec<LocatedWarning> {
   let mut unique = BTreeMap::new();
-  for warning in warnings {
+  for (occurrence_index, warning) in warnings.into_iter().enumerate() {
     if !matches!(warning.code(), Some("P_DYNAMIC_METHOD_DISPATCH" | "P_DYNAMIC_POSTFIX_METHOD")) {
       continue;
     }
@@ -114,12 +114,18 @@ fn collect_dynamic_method_findings(
     if !include_dependencies && !project_namespaces.contains(location.ns.as_ref()) {
       continue;
     }
+    // A precise Snapshot coordinate identifies one call and can be de-duplicated
+    // when init/reload reach the same definition. Generated macro forms may only
+    // carry `coord=[]`; retain each of those occurrences to avoid undercounting
+    // repeated identical calls at an imprecise fallback location.
+    let occurrence_key = if location.coord.is_empty() { occurrence_index + 1 } else { 0 };
     let key = (
       location.ns.to_string(),
       location.def.to_string(),
       location.coord.to_vec(),
       warning.code().unwrap_or_default().to_owned(),
       warning.message().to_owned(),
+      occurrence_key,
     );
     unique.entry(key).or_insert(warning);
   }
@@ -134,7 +140,7 @@ fn run_dynamic_methods(
 ) -> Result<(), String> {
   if !matches!(options.format.as_str(), "human" | "text" | "json") {
     return Err(format!(
-      "Unknown dynamic-methods output format `{}`. Expected `human` or `json`.",
+      "Unknown dynamic-methods output format `{}`. Expected `human`, `text`, or `json`.",
       options.format
     ));
   }
@@ -1813,18 +1819,24 @@ mod tests {
     let warnings = vec![
       warning("app.main", "P_DYNAMIC_METHOD_DISPATCH", vec![1]),
       warning("app.main", "P_DYNAMIC_METHOD_DISPATCH", vec![1]),
+      warning("app.main", "P_DYNAMIC_METHOD_DISPATCH", vec![]),
+      warning("app.main", "P_DYNAMIC_METHOD_DISPATCH", vec![]),
       warning("app.main", "W_JS_FFI_UNTYPED_ACCESS", vec![2]),
       warning("dep.lib", "P_DYNAMIC_POSTFIX_METHOD", vec![3]),
     ];
 
     let project_only = collect_dynamic_method_findings(warnings.clone(), false, &project_namespaces);
-    assert_eq!(project_only.len(), 1);
+    assert_eq!(
+      project_only.len(),
+      3,
+      "precise duplicates collapse but fallback occurrences remain distinct"
+    );
     assert_eq!(project_only[0].location().ns.as_ref(), "app.main");
 
     let with_dependencies = collect_dynamic_method_findings(warnings, true, &project_namespaces);
-    assert_eq!(with_dependencies.len(), 2);
+    assert_eq!(with_dependencies.len(), 4);
     assert_eq!(with_dependencies[0].location().ns.as_ref(), "app.main");
-    assert_eq!(with_dependencies[1].location().ns.as_ref(), "dep.lib");
+    assert_eq!(with_dependencies[3].location().ns.as_ref(), "dep.lib");
   }
 
   #[test]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -206,6 +206,8 @@ pub enum AnalyzeSubcommand {
   CheckTypes(CheckTypesCommand),
   /// locate weakly-typed hotspots such as :dynamic schema usage and nil literals
   WeakTypes(WeakTypesCommand),
+  /// locate unresolved dynamic method dispatch in reachable definitions
+  DynamicMethods(DynamicMethodsCommand),
   /// locate calls to definitions marked with the :deprecated tag
   Deprecated(DeprecatedCommand),
   /// enforce type coverage, weak-type, and deprecated API quality budgets
@@ -285,6 +287,24 @@ pub struct WeakTypesCommand {
   /// emit aggregate counts without per-definition details
   #[argh(switch, long = "summary-only")]
   pub summary_only: bool,
+}
+
+/// locate unresolved dynamic method dispatch in reachable definitions
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand, name = "dynamic-methods")]
+pub struct DynamicMethodsCommand {
+  /// output format: human (default) or json
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
+  /// include dependency namespaces
+  #[argh(switch)]
+  pub deps: bool,
+  /// emit aggregate counts without individual findings
+  #[argh(switch, long = "summary-only")]
+  pub summary_only: bool,
+  /// fail when the finding count exceeds this limit
+  #[argh(option)]
+  pub max: Option<usize>,
 }
 
 /// locate calls to definitions marked with the :deprecated tag

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -183,7 +183,7 @@ pub struct ExecCommand {
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 #[argh(subcommand, name = "analyze")]
-/// analyze code structure and helpers (call-graph, call-graph-diff, count-calls, program-diff, check-examples, check-types, weak-types, deprecated, quality, js-escape)
+/// analyze code structure and helpers (call-graph, call-graph-diff, count-calls, program-diff, check-examples, check-types, weak-types, dynamic-methods, deprecated, quality, js-escape)
 pub struct AnalyzeCommand {
   #[argh(subcommand)]
   pub subcommand: AnalyzeSubcommand,

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3675,9 +3675,9 @@ fn warn_on_dynamic_trait_call(
   );
 
   if let Some(loc) = head.get_location().or_else(|| receiver.get_location()) {
-    gen_check_warning_with_location(message, loc, check_warnings);
+    gen_check_warning_with_location_code(message, "P_DYNAMIC_METHOD_DISPATCH", loc, check_warnings);
   } else {
-    gen_check_warning(message, file_ns, check_warnings);
+    gen_check_warning_code(message, "P_DYNAMIC_METHOD_DISPATCH", file_ns, check_warnings);
   }
 }
 
@@ -11149,6 +11149,7 @@ mod tests {
 
     let warnings_vec = warnings.borrow();
     assert!(!warnings_vec.is_empty(), "should warn on dynamic trait call");
+    assert_eq!(warnings_vec[0].code(), Some("P_DYNAMIC_METHOD_DISPATCH"));
     let warning_msg = warnings_vec[0].to_string();
     assert!(
       warning_msg.contains("dynamic trait call") && warning_msg.contains(".greet"),


### PR DESCRIPTION
## Summary

- Add `calcit analyze dynamic-methods` as a focused inventory of unresolved method dispatch in reachable definitions.
- Assign stable `P_DYNAMIC_METHOD_DISPATCH` and `P_DYNAMIC_POSTFIX_METHOD` diagnostic codes while excluding unrelated type and JS FFI warnings.
- Default to project namespaces, with `--deps` for reachable module findings.
- Add deterministic de-duplication, human/JSON output, `--summary-only`, and a `--max` CI policy.
- Document migration from the mixed `--warn-dyn-method --check-only` workflow.

Closes #420.

Advances #409.

## Real-project results

- Latest Respo main: 8 project findings; `--max 8` passes.
- Latest Recollect main: 0 project findings; `--max 0` passes.
- Recollect with `--deps`: 4 reachable dependency findings; `--max 4` passes.
- Respo native tests: 25/25.
- Recollect native tests: 9/9.

No runtime dispatch behavior or downstream source was changed.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (15/15)
- Installed the branch with `cargo install --path . --force` before upstream regression testing
