### PR TITLE
perf: index typed enum match branches

### DIFF
--- a/RFCs/04-15-match-syntax-rfc.md
+++ b/RFCs/04-15-match-syntax-rfc.md
@@ -127,20 +127,26 @@ missing = all_variants - covered_tags
 
 ## 6. JS 代码生成
 
-生成立即执行函数表达式（IIFE）：
+动态或无法安全重排的 match 保留立即执行函数中的 if-else 链。静态已知 enum 且分支没有重复 tag、wildcard 位于末尾时，预处理器会生成内部 declaration-order branch table；JS codegen 对该形式生成 `switch (tag.idx)`，native evaluator 通过 enum definition 的 variant index 直接选择 slot。这个内部表示不增加用户语法，匿名 enum 和动态边界仍使用兼容路径。
+
+概念上的 JS 输出如下：
 
 ```javascript
 (() => {
   let match_v = <value>;
   let match_t = _$n_tuple_$o_nth(match_v, 0);
-  if (match_t === _kn_ok && _$n_tuple_$o_count(match_v) === 1) {
-    return kwd_$o_success;  // (:ok) :success
-  } else if (match_t === _kn_err && _$n_tuple_$o_count(match_v) === 2) {
-    let msg = _$n_tuple_$o_nth(match_v, 1);
-    return msg;  // (:err msg) msg
-  } else {
-    throw new Error("match: no matching branch for tag");
+  switch (match_t.idx) {
+    case _kn_ok.idx:
+      if (_$n_tuple_$o_count(match_v) === 1) return kwd_$o_success;
+      break;
+    case _kn_err.idx:
+      if (_$n_tuple_$o_count(match_v) === 2) {
+        let msg = _$n_tuple_$o_nth(match_v, 1);
+        return msg;
+      }
+      break;
   }
+  throw new Error("match: no matching branch for tag");
 })()
 ```
 

--- a/RFCs/04-15-type-directed-optimization-catalog.md
+++ b/RFCs/04-15-type-directed-optimization-catalog.md
@@ -71,18 +71,21 @@
 
 ---
 
-### P3: `tag-match` 分支整数化 ⬜ 推迟（侵入性大，CalcitTuple 12+ 构造点需改动）
+### P3: 已知 enum 的 `match` 分支索引化 ✅ #422
 
-**问题**: `tag-match` 运行时用 tag 字符串逐一比较（线性扫描分支）。JS codegen 也是 if-else 链。
+**问题**: 原生 `match` 虽然保留了 enum 类型和分支结构，native 运行时仍逐项比较 tag，JS codegen 也输出 if-else 链。旧目录将其写成 `tag-match` 优化，但该宏展开后已经丢失结构；真正可安全优化的是原生 `match`。
 
-**位置**: `src/builtins/syntax.rs` L933-1050（runner），`src/codegen/emit_js.rs` L897-978（JS codegen）。
+**实际方案**:
 
-**方案**:
+- 预处理器仅在 enum 类型已知、tag 不重复、wildcard 位于末尾时，生成内部 declaration-order branch table；
+- native 复用 `CalcitEnumDef` 已有的 tag→variant HashMap，一次查找后直接选择 branch slot；
+- JS 对同一内部表示生成 `switch (tag.idx)`；
+- WASM 继续消费其已有整数 tag，并兼容 branch table 表示；
+- 动态/匿名 enum、重复 tag、early wildcard 保留原始线性表示和语义。
 
-- **Rust 端**: enum 类型已知时预处理阶段把 tag 比较替换为 `variant_index` 的整数比较
-- **JS 端**: emit `switch (tag.idx)` 替代 if-else 链
+没有给 `CalcitEnumValue` 新增字段，也没有增加用户语法，因此避免修改所有 enum 构造和序列化边界。
 
-**收益**: 5+ 分支时 O(n) → O(1)。
+**收益**: native 从 O(branches) 降为平均 O(1) branch selection；JS 由引擎整数 switch 分派。
 
 **影响**: 中 — 状态机、消息路由场景（Cumulo updater dispatcher）明显加速。
 
@@ -162,9 +165,9 @@
 | 4    | P2   | `0e705f1` | NativeRecordWithAt 批量索引化           | Record 批量更新加速（fibo 不涉及） |
 | 5    | P7   | `fa325c6` | if 常量折叠                             | 宏展开场景受益                     |
 | -    | 额外 | `7c04880` | runtime def resolution 去重复 RwLock 读 | 微优化                             |
+| 6    | P3   | #422      | typed `match` branch table + JS switch  | enum dispatcher / state machine    |
 
 ### 待定
 
-- **P3**: tag-match 整数化 — 推迟，CalcitTuple 12+ 构造点需改动，侵入性大
 - **P4**: Method dispatch 静态绑定 — 推迟，实现复杂度高
 - **P6**: get-in/assoc-in 静态路径展开 — 未开始，视实际瓶颈决定

--- a/editing-history/20260825-0020-indexed-enum-match.md
+++ b/editing-history/20260825-0020-indexed-enum-match.md
@@ -1,0 +1,34 @@
+# Indexed enum match dispatch
+
+## Context
+
+Issue #422 continues the performance roadmap after scoped dynamic-method diagnostics. Native `match` retained typed enum structure but still scanned branch tags, while JS emitted an if/else chain.
+
+## Changes
+
+- Exposed the existing enum tag-to-variant declaration index.
+- Rewrote statically known, semantics-safe `match` forms into an internal declaration-ordered branch table.
+- Declined the rewrite for duplicate tags, unknown tags, or a wildcard before the final branch so source-order behavior stays unchanged.
+- Selected native branches directly through the enum variant index.
+- Emitted JS integer-tag `switch` dispatch for indexed matches.
+- Kept WASM compatible with the internal table representation.
+- Added focused table/codegen tests and native/JS comparison benchmarks.
+- Updated the optimization catalog and native-match RFC.
+
+## Compatibility notes
+
+- No user-facing syntax was added.
+- `CalcitEnumValue` layout and all enum construction/serialization boundaries remain unchanged.
+- Dynamic and anonymous enum matches retain the original linear representation.
+- Runtime type, payload arity, wildcard, and no-match behavior remain explicit.
+
+## Validation plan
+
+- `cargo fmt`
+- `cargo clippy --all-targets -- -D warnings`
+- `yarn compile`
+- `cargo test`
+- `yarn check-all`
+- `yarn check-agent-interface`
+- `yarn bench-enum-match`
+- current Respo and Recollect main regression

--- a/editing-history/20260825-0100-indexed-enum-match-validation.md
+++ b/editing-history/20260825-0100-indexed-enum-match-validation.md
@@ -1,0 +1,7 @@
+# Indexed enum match validation fixes
+
+- Fixed the release benchmark example to import internal Calcit value types from the public `calcit::calcit` module.
+- Reduced the indexed JS match helper argument count and derived the wildcard slot from the internal table layout, keeping Clippy clean without changing generated semantics.
+- Applied `cargo fmt` to the touched Rust code.
+- Verified `cargo clippy -- -D warnings`, `cargo test`, `yarn compile`, `yarn check-all`, and `yarn check-agent-interface`.
+- Measured the 16-variant last-branch benchmark at 291.55 ms for linear native tag scanning versus 108.35 ms for indexed lookup; the JS comparison measured 37.62 ms versus 31.06 ms.

--- a/editing-history/20260825-0120-indexed-enum-match-review.md
+++ b/editing-history/20260825-0120-indexed-enum-match-review.md
@@ -1,0 +1,7 @@
+# Indexed enum match review fixes
+
+- Kept indexed JS match control flow inside an IIFE with real branch returns, so non-tail and assignment contexts cannot leak into wildcard or no-match handling after a successful case.
+- Included the matched value expression in `js-await` detection while continuing to exclude nested function scopes.
+- Added native runtime coverage for indexed branch selection and arity-mismatch wildcard fallback.
+- Added JS codegen coverage for non-return labels and awaited matched values.
+- Re-ran formatting, Clippy, Rust tests, TypeScript compilation, Agent interface checks, and the native/JS/WASM integration suite.

--- a/examples/bench_enum_match.rs
+++ b/examples/bench_enum_match.rs
@@ -1,0 +1,41 @@
+use std::hint::black_box;
+use std::sync::Arc;
+use std::time::Instant;
+
+use calcit::{Calcit, CalcitEnumDef, CalcitList, CalcitStructDef, CalcitStructValue};
+use cirru_edn::EdnTag;
+
+const ITERATIONS: usize = 5_000_000;
+const VARIANT_COUNT: usize = 16;
+
+fn main() {
+  let fields: Vec<EdnTag> = (0..VARIANT_COUNT).map(|idx| EdnTag::new(format!("variant-{idx:02}"))).collect();
+  let values = vec![Calcit::from(CalcitList::Vector(vec![])); fields.len()];
+  let enum_def = CalcitEnumDef::from_struct(CalcitStructValue {
+    struct_ref: Arc::new(CalcitStructDef::from_fields(EdnTag::new("DispatchState"), fields)),
+    values: Arc::new(values),
+  })
+  .expect("valid benchmark enum");
+  let target = enum_def.variants().last().expect("last variant").tag.clone();
+
+  run("linear-tag-scan", || {
+    enum_def
+      .variants()
+      .iter()
+      .position(|variant| variant.tag == target)
+      .expect("target variant")
+  });
+  run("indexed-branch-slot", || enum_def.variant_index(&target).expect("target variant"));
+}
+
+fn run(label: &str, mut dispatch: impl FnMut() -> usize) {
+  let mut checksum = 0usize;
+  for _ in 0..100_000 {
+    checksum = checksum.wrapping_add(black_box(dispatch()));
+  }
+  let started = Instant::now();
+  for _ in 0..ITERATIONS {
+    checksum = checksum.wrapping_add(black_box(dispatch()));
+  }
+  println!("{label}: {:.2}ms checksum={checksum}", started.elapsed().as_secs_f64() * 1000.0);
+}

--- a/examples/bench_enum_match.rs
+++ b/examples/bench_enum_match.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 use std::sync::Arc;
 use std::time::Instant;
 
-use calcit::{Calcit, CalcitEnumDef, CalcitList, CalcitStructDef, CalcitStructValue};
+use calcit::calcit::{Calcit, CalcitEnumDef, CalcitList, CalcitStructDef, CalcitStructValue};
 use cirru_edn::EdnTag;
 
 const ITERATIONS: usize = 5_000_000;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test-snippets": "cargo test -q snippets::tests",
     "check-js-runtime": "node scripts/check-js-runtime-identity.mjs",
     "bench-recur-smoke": "cargo run --bin calcit -- calcit/test.cirru js && node --input-type=module -e \"import { test_loop } from './js-out/test-recursion.main.mjs'; const n=3000; const t0=process.hrtime.bigint(); for(let i=0;i<n;i++) test_loop(); const dt=Number(process.hrtime.bigint()-t0)/1e6; console.log('test_loop_ms='+dt.toFixed(3));\"",
+    "bench-enum-match": "cargo run --release --example bench_enum_match && yarn compile && node scripts/bench-enum-match.mjs",
     "bench-struct-index": "yarn compile && node scripts/bench-struct-index.mjs",
     "check-smooth": "yarn fmt-rs && yarn lint-rs && yarn test-rs && yarn check-all",
     "check-all": "yarn compile && yarn check-js-runtime && yarn check-agent-interface && yarn try-core-tests && yarn try-rs && yarn try-js && yarn try-ir && yarn try-wasm",

--- a/scripts/bench-enum-match.mjs
+++ b/scripts/bench-enum-match.mjs
@@ -1,0 +1,24 @@
+import { performance } from "node:perf_hooks";
+import { newTag } from "../lib/calcit.procs.mjs";
+
+const variantCount = 16;
+const iterations = 5_000_000;
+const tags = Array.from({ length: variantCount }, (_, idx) => newTag(`enum-match-${idx.toString().padStart(2, "0")}`));
+const target = tags.at(-1);
+
+const ifBody = tags.map((tag, idx) => `${idx === 0 ? "if" : "else if"} (tag === tags[${idx}]) return ${idx};`).join("\n");
+const switchBody = tags.map((tag, idx) => `case ${tag.idx}: return ${idx};`).join("\n");
+const linearDispatch = new Function("tag", "tags", `${ifBody}\nreturn -1;`);
+const switchDispatch = new Function("tag", `switch (tag.idx) {${switchBody}} return -1;`);
+
+run("if-else-tag-chain", () => linearDispatch(target, tags));
+run("integer-tag-switch", () => switchDispatch(target));
+
+function run(label, dispatch) {
+  let checksum = 0;
+  for (let idx = 0; idx < 100_000; idx += 1) checksum += dispatch();
+  const started = performance.now();
+  for (let idx = 0; idx < iterations; idx += 1) checksum += dispatch();
+  const elapsed = performance.now() - started;
+  console.log(`${label}: ${elapsed.toFixed(2)}ms checksum=${checksum}`);
+}

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -1265,6 +1265,33 @@ pub fn syntax_match(
     }
   };
 
+  // A statically known enum match is preprocessed into
+  // [value, enum-definition, declaration-ordered branch table]. The final
+  // table slot is an optional trailing wildcard branch.
+  if expr.len() == 3
+    && let Calcit::EnumDef(enum_def) = &expr[1]
+    && let Calcit::List(table) = &expr[2]
+  {
+    let wildcard_idx = enum_def.variants().len();
+    if table.len() != wildcard_idx + 1 {
+      return CalcitErr::err_str(CalcitErrKind::Unexpected, "indexed match table has invalid length");
+    }
+    if let Some(variant_idx) = enum_def.variant_index(&tag)
+      && let Some(result) = evaluate_indexed_match_branch(&table[variant_idx], extra, scope, file_ns, call_stack)?
+    {
+      return Ok(result);
+    }
+    if let Some(result) = evaluate_indexed_match_branch(&table[wildcard_idx], extra, scope, file_ns, call_stack)? {
+      return Ok(result);
+    }
+    return Err(CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Unexpected,
+      format!("match found no matching branch for tag :{}", tag.ref_str()),
+      call_stack,
+      expr[0].get_location(),
+    ));
+  }
+
   // Iterate over branches
   for branch_idx in 1..expr.len() {
     let branch = match &expr[branch_idx] {
@@ -1348,4 +1375,62 @@ pub fn syntax_match(
     call_stack,
     expr[0].get_location(),
   ))
+}
+
+fn evaluate_indexed_match_branch(
+  branch: &Calcit,
+  extra: &[Calcit],
+  scope: &CalcitScope,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Option<Calcit>, CalcitErr> {
+  if matches!(branch, Calcit::Nil) {
+    return Ok(None);
+  }
+  let Calcit::List(pair) = branch else {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Unexpected,
+      "indexed match slot expected a branch pair",
+    ));
+  };
+  if pair.len() != 2 {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Unexpected,
+      "indexed match slot expected a 2-element branch pair",
+    ));
+  }
+  let pattern = &pair[0];
+  let body = &pair[1];
+  if matches!(
+    pattern,
+    Calcit::Symbol { sym, .. } | Calcit::Local(CalcitLocal { sym, .. }) if sym.as_ref() == "_"
+  ) {
+    return evaluate_expr(body, scope, file_ns, call_stack).map(Some);
+  }
+  let Calcit::List(pattern_items) = pattern else {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Unexpected,
+      "indexed match slot expected a tag pattern",
+    ));
+  };
+  let binding_count = pattern_items.len().saturating_sub(1);
+  if binding_count != extra.len() {
+    return Ok(None);
+  }
+  let mut body_scope = scope.to_owned();
+  for (binding, value) in pattern_items.iter().skip(1).zip(extra) {
+    match binding {
+      Calcit::Local(CalcitLocal { idx, .. }) => body_scope.insert_mut(*idx, value.to_owned()),
+      Calcit::Symbol { sym, .. } => body_scope.insert_mut(CalcitLocal::track_sym(sym), value.to_owned()),
+      other => {
+        return Err(CalcitErr::use_msg_stack_location(
+          CalcitErrKind::Syntax,
+          format!("match pattern expected a binding name, got: {other}"),
+          call_stack,
+          other.get_location(),
+        ));
+      }
+    }
+  }
+  evaluate_expr(body, &body_scope, file_ns, call_stack).map(Some)
 }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -229,7 +229,7 @@ fn collect_param_symbols(args: &CalcitList) -> Result<Vec<Arc<str>>, String> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitStructDef, CalcitStructValue, CalcitTrait};
+  use crate::calcit::{CalcitEnumDef, CalcitStructDef, CalcitStructValue, CalcitTrait};
   use crate::call_stack::CallStackList;
   use cirru_edn::EdnTag;
 
@@ -418,6 +418,47 @@ mod tests {
     ]);
     let result = assert_traits(&expr.view(), &scope, "tests.assert", &CallStackList::default()).expect("assert-traits should pass");
     assert!(matches!(result, Calcit::Struct(_)));
+  }
+
+  #[test]
+  fn indexed_match_selects_variant_and_falls_back_on_arity_mismatch() {
+    let enum_def = Arc::new(
+      CalcitEnumDef::from_struct(CalcitStructValue {
+        struct_ref: Arc::new(CalcitStructDef::from_fields(
+          EdnTag::from("MaybeNumber"),
+          vec![EdnTag::from("none"), EdnTag::from("some")],
+        )),
+        values: Arc::new(vec![Calcit::Nil, Calcit::from(vec![Calcit::Tag(EdnTag::from("number"))])]),
+      })
+      .expect("valid enum definition"),
+    );
+    let binding = make_local("value", "tests.match", "indexed");
+    let some_branch = Calcit::from(vec![
+      Calcit::from(vec![Calcit::Tag(EdnTag::from("some")), binding.to_owned()]),
+      binding,
+    ]);
+    let wildcard = Calcit::from(vec![make_symbol("_", "tests.match", "indexed"), Calcit::Number(-1.0)]);
+    let table = Calcit::from(vec![Calcit::Nil, some_branch, wildcard]);
+    let make_expr = |extra| {
+      CalcitList::Vector(vec![
+        Calcit::Enum(CalcitEnumValue {
+          tag: Arc::new(Calcit::Tag(EdnTag::from("some"))),
+          extra,
+          sum_type: Some(enum_def.clone()),
+        }),
+        Calcit::EnumDef(enum_def.as_ref().to_owned()),
+        table.to_owned(),
+      ])
+    };
+    let scope = CalcitScope::default();
+    let stack = CallStackList::default();
+
+    let selected = syntax_match(&make_expr(vec![Calcit::Number(7.0)]).view(), &scope, "tests.match", &stack)
+      .expect("matching arity should select indexed branch");
+    assert_eq!(selected, Calcit::Number(7.0));
+
+    let fallback = syntax_match(&make_expr(vec![]).view(), &scope, "tests.match", &stack).expect("arity mismatch should use wildcard");
+    assert_eq!(fallback, Calcit::Number(-1.0));
   }
 
   #[test]

--- a/src/calcit/sum_type.rs
+++ b/src/calcit/sum_type.rs
@@ -118,6 +118,14 @@ impl CalcitEnumDef {
     self.variant_index.get(name).map(|idx| &self.variants[*idx])
   }
 
+  /// Return the stable declaration-order slot for a variant tag.
+  ///
+  /// Preprocessed enum matches use this index to select an already validated
+  /// branch directly instead of scanning every branch tag at runtime.
+  pub fn variant_index(&self, tag: &EdnTag) -> Option<usize> {
+    self.variant_index.get(tag.ref_str()).copied()
+  }
+
   fn collect_variants(struct_value: &CalcitStructValue) -> Result<(Vec<EnumVariant>, HashMap<String, usize>), String> {
     let mut variants: Vec<EnumVariant> = Vec::with_capacity(struct_value.fields().len());
     let mut index: HashMap<String, usize> = HashMap::with_capacity(struct_value.fields().len());

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -1245,8 +1245,8 @@ fn gen_match_code(
     return Err("match expected value and branches".to_owned());
   }
 
-  if let (Some(Calcit::EnumDef(enum_def)), Some(Calcit::List(table))) = (body.get(1), body.get(2)) {
-    return gen_indexed_match_code(&body[0], enum_def, table, local_defs, ns, file_imports, tags, base_return_label);
+  if let (Some(Calcit::EnumDef(_)), Some(Calcit::List(table))) = (body.get(1), body.get(2)) {
+    return gen_indexed_match_code(&body[0], table, local_defs, ns, file_imports, tags, base_return_label);
   }
 
   let has_await = detect_await(body);
@@ -1355,7 +1355,6 @@ fn gen_match_code(
 
 fn gen_indexed_match_code(
   value: &Calcit,
-  enum_def: &calcit::CalcitEnumDef,
   table: &CalcitList,
   local_defs: &HashSet<Arc<str>>,
   ns: &str,
@@ -1363,10 +1362,9 @@ fn gen_indexed_match_code(
   tags: &RefCell<HashSet<EdnTag>>,
   base_return_label: Option<&str>,
 ) -> Result<String, String> {
-  let wildcard_idx = enum_def.variants().len();
-  if table.len() != wildcard_idx + 1 {
+  let Some(wildcard_idx) = table.len().checked_sub(1) else {
     return Err("indexed match table has invalid length".to_owned());
-  }
+  };
 
   let has_await = detect_await(table);
   let return_label = base_return_label.unwrap_or("return ");
@@ -1421,11 +1419,7 @@ fn gen_indexed_match_code(
 
   match &table[wildcard_idx] {
     Calcit::Nil => {
-      write!(
-        chunk,
-        "throw new Error(\"match: no matching branch for tag \" + {tag_var});"
-      )
-      .expect("write");
+      write!(chunk, "throw new Error(\"match: no matching branch for tag \" + {tag_var});").expect("write");
     }
     Calcit::List(pair) if pair.len() == 2 => {
       let body_code = to_js_code(&pair[1], ns, local_defs, file_imports, tags, Some(return_label))?;
@@ -2261,42 +2255,15 @@ mod tests {
 
   #[test]
   fn indexed_enum_match_codegen_uses_numeric_switch_dispatch() {
-    let enum_def = calcit::CalcitEnumDef::from_struct(calcit::CalcitStructValue {
-      struct_ref: Arc::new(calcit::CalcitStructDef::from_fields(
-        EdnTag::from("State"),
-        vec![EdnTag::from("idle"), EdnTag::from("running"), EdnTag::from("done")],
-      )),
-      values: Arc::new(vec![Calcit::from(vec![]), Calcit::from(vec![]), Calcit::from(vec![])]),
-    })
-    .expect("valid enum");
-    let branch = |tag: &str, value: f64| {
-      Calcit::from(vec![
-        Calcit::from(vec![Calcit::Tag(EdnTag::from(tag))]),
-        Calcit::Number(value),
-      ])
-    };
+    let branch = |tag: &str, value: f64| Calcit::from(vec![Calcit::from(vec![Calcit::Tag(EdnTag::from(tag))]), Calcit::Number(value)]);
     let wildcard = Calcit::from(vec![symbol("_"), Calcit::Number(-1.0)]);
-    let table = CalcitList::Vector(vec![
-      branch("idle", 0.0),
-      branch("running", 1.0),
-      branch("done", 2.0),
-      wildcard,
-    ]);
+    let table = CalcitList::Vector(vec![branch("idle", 0.0), branch("running", 1.0), branch("done", 2.0), wildcard]);
     let local_defs = HashSet::from([Arc::from("state")]);
     let file_imports = RefCell::new(ImportsDict::new());
     let tags = RefCell::new(HashSet::new());
 
-    let code = gen_indexed_match_code(
-      &symbol("state"),
-      &enum_def,
-      &table,
-      &local_defs,
-      "tests.emit-js",
-      &file_imports,
-      &tags,
-      None,
-    )
-    .expect("indexed match codegen");
+    let code = gen_indexed_match_code(&symbol("state"), &table, &local_defs, "tests.emit-js", &file_imports, &tags, None)
+      .expect("indexed match codegen");
 
     assert!(code.contains("switch ("), "{code}");
     assert!(code.contains("case _t_.idle.idx:"), "{code}");

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -1060,29 +1060,28 @@ fn gen_symbol_code(s: &str, def_ns: &str, at_def: &str, xs: &Calcit, passed_defs
 }
 
 fn detect_await(xs: &CalcitList) -> bool {
-  for x in xs {
-    match x {
-      Calcit::List(al) => {
-        if matches!(
-          al.get(0),
-          Some(Calcit::Syntax(
-            CalcitSyntax::Defn | CalcitSyntax::DefWasmExport | CalcitSyntax::DefWasmImport,
-            _
-          ))
-        ) {
-          // a nested function has its own scope deciding if it's async
-          continue;
-        } else if detect_await(al) {
-          return true;
-        }
+  xs.iter().any(detect_await_node)
+}
+
+fn detect_await_node(x: &Calcit) -> bool {
+  match x {
+    Calcit::List(al) => {
+      if matches!(
+        al.first(),
+        Some(Calcit::Syntax(
+          CalcitSyntax::Defn | CalcitSyntax::DefWasmExport | CalcitSyntax::DefWasmImport,
+          _
+        ))
+      ) {
+        // a nested function has its own scope deciding if it's async
+        false
+      } else {
+        detect_await(al)
       }
-      Calcit::Symbol { sym, .. } if &**sym == "js-await" => {
-        return true;
-      }
-      _ => {}
     }
+    Calcit::Symbol { sym, .. } if &**sym == "js-await" => true,
+    _ => false,
   }
-  false
 }
 
 fn gen_let_code(
@@ -1366,8 +1365,8 @@ fn gen_indexed_match_code(
     return Err("indexed match table has invalid length".to_owned());
   };
 
-  let has_await = detect_await(table);
-  let return_label = base_return_label.unwrap_or("return ");
+  let has_await = detect_await_node(value) || detect_await(table);
+  let return_label = "return ";
   let proc_prefix = get_proc_prefix(ns);
   let value_code = to_js_code(value, ns, local_defs, file_imports, tags, None)?;
   let val_var = js_gensym("match_v");
@@ -1428,10 +1427,10 @@ fn gen_indexed_match_code(
     other => return Err(format!("indexed match wildcard slot expected a branch pair, got: {other}")),
   }
 
-  if base_return_label.is_some() {
-    Ok(chunk)
-  } else {
-    Ok(make_fn_wrapper(&chunk, has_await))
+  let wrapped = make_fn_wrapper(&chunk, has_await);
+  match base_return_label {
+    Some(label) => Ok(format!("{label}{wrapped}")),
+    None => Ok(wrapped),
   }
 }
 
@@ -2270,6 +2269,45 @@ mod tests {
     assert!(code.contains("case _t_.running.idx:"), "{code}");
     assert!(code.contains("case _t_.done.idx:"), "{code}");
     assert!(!code.contains(" else if "), "{code}");
+  }
+
+  #[test]
+  fn indexed_enum_match_codegen_wraps_non_return_contexts() {
+    let branch = Calcit::from(vec![Calcit::from(vec![Calcit::Tag(EdnTag::from("idle"))]), Calcit::Number(0.0)]);
+    let table = CalcitList::Vector(vec![branch, Calcit::Nil]);
+    let local_defs = HashSet::from([Arc::from("state")]);
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+
+    let code = gen_indexed_match_code(
+      &symbol("state"),
+      &table,
+      &local_defs,
+      "tests.emit-js",
+      &file_imports,
+      &tags,
+      Some("result = "),
+    )
+    .expect("indexed match codegen");
+
+    assert!(code.starts_with("result = (function _fn_()"), "{code}");
+    assert!(code.contains("return 0"), "{code}");
+  }
+
+  #[test]
+  fn indexed_enum_match_codegen_detects_await_in_matched_value() {
+    let branch = Calcit::from(vec![Calcit::from(vec![Calcit::Tag(EdnTag::from("idle"))]), Calcit::Number(0.0)]);
+    let table = CalcitList::Vector(vec![branch, Calcit::Nil]);
+    let value = Calcit::from(vec![symbol("js-await"), symbol("state-promise")]);
+    let local_defs = HashSet::from([Arc::from("state-promise")]);
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+
+    let code = gen_indexed_match_code(&value, &table, &local_defs, "tests.emit-js", &file_imports, &tags, None)
+      .expect("async indexed match codegen");
+
+    assert!(code.starts_with("await (async function _async_fn_()"), "{code}");
+    assert!(code.contains("await state_promise"), "{code}");
   }
 
   #[test]

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -1245,6 +1245,10 @@ fn gen_match_code(
     return Err("match expected value and branches".to_owned());
   }
 
+  if let (Some(Calcit::EnumDef(enum_def)), Some(Calcit::List(table))) = (body.get(1), body.get(2)) {
+    return gen_indexed_match_code(&body[0], enum_def, table, local_defs, ns, file_imports, tags, base_return_label);
+  }
+
   let has_await = detect_await(body);
   let return_label = base_return_label.unwrap_or("return ");
   let proc_prefix = get_proc_prefix(ns);
@@ -1340,6 +1344,94 @@ fn gen_match_code(
       " else {{ throw new Error(\"match: no matching branch for tag \" + {tag_var}); }}"
     )
     .expect("write");
+  }
+
+  if base_return_label.is_some() {
+    Ok(chunk)
+  } else {
+    Ok(make_fn_wrapper(&chunk, has_await))
+  }
+}
+
+fn gen_indexed_match_code(
+  value: &Calcit,
+  enum_def: &calcit::CalcitEnumDef,
+  table: &CalcitList,
+  local_defs: &HashSet<Arc<str>>,
+  ns: &str,
+  file_imports: &RefCell<ImportsDict>,
+  tags: &RefCell<HashSet<EdnTag>>,
+  base_return_label: Option<&str>,
+) -> Result<String, String> {
+  let wildcard_idx = enum_def.variants().len();
+  if table.len() != wildcard_idx + 1 {
+    return Err("indexed match table has invalid length".to_owned());
+  }
+
+  let has_await = detect_await(table);
+  let return_label = base_return_label.unwrap_or("return ");
+  let proc_prefix = get_proc_prefix(ns);
+  let value_code = to_js_code(value, ns, local_defs, file_imports, tags, None)?;
+  let val_var = js_gensym("match_v");
+  let tag_var = js_gensym("match_t");
+  let mut chunk = String::new();
+  writeln!(chunk, "let {val_var} = {value_code};").expect("write");
+  writeln!(chunk, "let {tag_var} = {proc_prefix}_$n_enum_$o_nth({val_var}, 0);").expect("write");
+  writeln!(chunk, "switch ({tag_var}.idx) {{").expect("write");
+
+  for branch in table.iter().take(wildcard_idx) {
+    let Calcit::List(pair) = branch else {
+      if matches!(branch, Calcit::Nil) {
+        continue;
+      }
+      return Err(format!("indexed match slot expected a branch pair, got: {branch}"));
+    };
+    if pair.len() != 2 {
+      return Err(format!("indexed match branch expected a pair, got: {branch}"));
+    }
+    let Calcit::List(pattern) = &pair[0] else {
+      return Err(format!("indexed match pattern expected a list, got: {}", pair[0]));
+    };
+    let Some(Calcit::Tag(tag)) = pattern.first() else {
+      return Err(format!("indexed match pattern expected a tag, got: {}", pair[0]));
+    };
+    tags.borrow_mut().insert(tag.to_owned());
+    let tag_code = tags::tag_access(tag.ref_str());
+    let arity = pattern.len();
+    writeln!(chunk, "case {tag_code}.idx:").expect("write");
+    writeln!(chunk, "if ({proc_prefix}_$n_enum_$o_count({val_var}) === {arity}) {{").expect("write");
+
+    let mut scoped_defs = local_defs.to_owned();
+    for (idx, binding) in pattern.iter().skip(1).enumerate() {
+      let bind_name = match binding {
+        Calcit::Local(CalcitLocal { sym, .. }) | Calcit::Symbol { sym, .. } => {
+          scoped_defs.insert(sym.to_owned());
+          escape_var(sym)
+        }
+        other => return Err(format!("match binding expected symbol, got: {other}")),
+      };
+      writeln!(chunk, "let {bind_name} = {proc_prefix}_$n_enum_$o_nth({val_var}, {});", idx + 1).expect("write");
+    }
+    let body_code = to_js_code(&pair[1], ns, &scoped_defs, file_imports, tags, Some(return_label))?;
+    writeln!(chunk, "{body_code}").expect("write");
+    writeln!(chunk, "}}").expect("write");
+    writeln!(chunk, "break;").expect("write");
+  }
+  writeln!(chunk, "}}").expect("write");
+
+  match &table[wildcard_idx] {
+    Calcit::Nil => {
+      write!(
+        chunk,
+        "throw new Error(\"match: no matching branch for tag \" + {tag_var});"
+      )
+      .expect("write");
+    }
+    Calcit::List(pair) if pair.len() == 2 => {
+      let body_code = to_js_code(&pair[1], ns, local_defs, file_imports, tags, Some(return_label))?;
+      write!(chunk, "{body_code}").expect("write");
+    }
+    other => return Err(format!("indexed match wildcard slot expected a branch pair, got: {other}")),
   }
 
   if base_return_label.is_some() {
@@ -2165,6 +2257,52 @@ mod tests {
       }),
       location: None,
     }
+  }
+
+  #[test]
+  fn indexed_enum_match_codegen_uses_numeric_switch_dispatch() {
+    let enum_def = calcit::CalcitEnumDef::from_struct(calcit::CalcitStructValue {
+      struct_ref: Arc::new(calcit::CalcitStructDef::from_fields(
+        EdnTag::from("State"),
+        vec![EdnTag::from("idle"), EdnTag::from("running"), EdnTag::from("done")],
+      )),
+      values: Arc::new(vec![Calcit::from(vec![]), Calcit::from(vec![]), Calcit::from(vec![])]),
+    })
+    .expect("valid enum");
+    let branch = |tag: &str, value: f64| {
+      Calcit::from(vec![
+        Calcit::from(vec![Calcit::Tag(EdnTag::from(tag))]),
+        Calcit::Number(value),
+      ])
+    };
+    let wildcard = Calcit::from(vec![symbol("_"), Calcit::Number(-1.0)]);
+    let table = CalcitList::Vector(vec![
+      branch("idle", 0.0),
+      branch("running", 1.0),
+      branch("done", 2.0),
+      wildcard,
+    ]);
+    let local_defs = HashSet::from([Arc::from("state")]);
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+
+    let code = gen_indexed_match_code(
+      &symbol("state"),
+      &enum_def,
+      &table,
+      &local_defs,
+      "tests.emit-js",
+      &file_imports,
+      &tags,
+      None,
+    )
+    .expect("indexed match codegen");
+
+    assert!(code.contains("switch ("), "{code}");
+    assert!(code.contains("case _t_.idle.idx:"), "{code}");
+    assert!(code.contains("case _t_.running.idx:"), "{code}");
+    assert!(code.contains("case _t_.done.idx:"), "{code}");
+    assert!(!code.contains(" else if "), "{code}");
   }
 
   #[test]

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -2931,7 +2931,14 @@ fn emit_match(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
   ctx.emit(Instruction::LocalSet(tag_local));
 
   // Collect branches: separate tag branches and wildcard
-  let branches = &args[1..];
+  let branches: Vec<&Calcit> = if args.len() == 3
+    && matches!(&args[1], Calcit::EnumDef(_))
+    && let Calcit::List(table) = &args[2]
+  {
+    table.iter().filter(|branch| !matches!(branch, Calcit::Nil)).collect()
+  } else {
+    args[1..].iter().collect()
+  };
   let mut tag_branches: Vec<(&Calcit, &Calcit)> = Vec::new(); // (pattern, body)
   let mut wildcard_body: Option<&Calcit> = None;
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5413,7 +5413,9 @@ fn build_indexed_match_table(enum_def: &calcit::CalcitEnumDef, branches: &[Calci
     }
 
     let Calcit::List(pattern_items) = pattern else { return None };
-    let Some(Calcit::Tag(tag)) = pattern_items.first() else { return None };
+    let Some(Calcit::Tag(tag)) = pattern_items.first() else {
+      return None;
+    };
     let variant_idx = enum_def.variant_index(tag)?;
     if !matches!(slots[variant_idx], Calcit::Nil) {
       return None;

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5384,6 +5384,46 @@ fn resolve_enum_type_for_match(
   }
 }
 
+fn is_match_wildcard(pattern: &Calcit) -> bool {
+  matches!(
+    pattern,
+    Calcit::Symbol { sym, .. } | Calcit::Local(CalcitLocal { sym, .. }) if sym.as_ref() == "_"
+  )
+}
+
+/// Arrange validated match branches by enum declaration slot. The final slot
+/// stores an optional trailing wildcard branch. Decline forms whose source
+/// order carries semantics that an indexed table cannot preserve.
+fn build_indexed_match_table(enum_def: &calcit::CalcitEnumDef, branches: &[Calcit]) -> Option<Calcit> {
+  let mut slots = vec![Calcit::Nil; enum_def.variants().len() + 1];
+  let wildcard_slot = enum_def.variants().len();
+
+  for (branch_idx, branch) in branches.iter().enumerate() {
+    let Calcit::List(pair) = branch else { return None };
+    if pair.len() != 2 {
+      return None;
+    }
+    let pattern = &pair[0];
+    if is_match_wildcard(pattern) {
+      if branch_idx + 1 != branches.len() || !matches!(slots[wildcard_slot], Calcit::Nil) {
+        return None;
+      }
+      slots[wildcard_slot] = branch.to_owned();
+      continue;
+    }
+
+    let Calcit::List(pattern_items) = pattern else { return None };
+    let Some(Calcit::Tag(tag)) = pattern_items.first() else { return None };
+    let variant_idx = enum_def.variant_index(tag)?;
+    if !matches!(slots[variant_idx], Calcit::Nil) {
+      return None;
+    }
+    slots[variant_idx] = branch.to_owned();
+  }
+
+  Some(Calcit::from(CalcitList::Vector(slots)))
+}
+
 /// Preprocess `match` syntax and perform exhaustiveness checking.
 /// Input form (pair-based): `(match <value> (<pattern1> <body1>) (<pattern2> <body2>) ...)`
 ///
@@ -5627,6 +5667,17 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
         ctx.check_warnings,
       );
     }
+  }
+
+  if let Some(enum_def) = enum_def
+    && let Some(table) = build_indexed_match_table(enum_def, &xs[2..])
+  {
+    return Ok(Calcit::from(CalcitList::Vector(vec![
+      xs[0].to_owned(),
+      xs[1].to_owned(),
+      Calcit::EnumDef(enum_def.to_owned()),
+      table,
+    ])));
   }
 
   Ok(Calcit::List(Arc::from(CalcitList::Vector(xs))))
@@ -6657,6 +6708,58 @@ mod tests {
 
   fn lock_preprocess_test_state() -> std::sync::MutexGuard<'static, ()> {
     PREPROCESS_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+  }
+
+  fn match_branch(tag: &str, body: &str) -> Calcit {
+    Calcit::from(vec![
+      Calcit::from(vec![Calcit::Tag(cirru_edn::EdnTag::from(tag))]),
+      Calcit::Tag(cirru_edn::EdnTag::from(body)),
+    ])
+  }
+
+  fn wildcard_match_branch(body: &str) -> Calcit {
+    Calcit::from(vec![
+      Calcit::Symbol {
+        sym: Arc::from("_"),
+        info: Arc::new(CalcitSymbolInfo {
+          at_ns: Arc::from("tests.match"),
+          at_def: Arc::from("dispatch"),
+        }),
+        location: None,
+      },
+      Calcit::Tag(cirru_edn::EdnTag::from(body)),
+    ])
+  }
+
+  fn indexed_match_enum() -> CalcitEnumDef {
+    let fields = vec![
+      cirru_edn::EdnTag::from("idle"),
+      cirru_edn::EdnTag::from("running"),
+      cirru_edn::EdnTag::from("done"),
+    ];
+    CalcitEnumDef::from_struct(CalcitStructValue {
+      struct_ref: Arc::new(CalcitStructDef::from_fields(cirru_edn::EdnTag::from("State"), fields)),
+      values: Arc::new(vec![Calcit::from(vec![]), Calcit::from(vec![]), Calcit::from(vec![])]),
+    })
+    .expect("valid enum")
+  }
+
+  #[test]
+  fn indexed_match_table_uses_variant_order_and_declines_ambiguous_forms() {
+    let enum_def = indexed_match_enum();
+    let done = match_branch("done", "finished");
+    let idle = match_branch("idle", "waiting");
+    let wildcard = wildcard_match_branch("unknown");
+    let table = build_indexed_match_table(&enum_def, &[done.clone(), idle.clone(), wildcard.clone()]).expect("indexed table");
+    let Calcit::List(slots) = table else { panic!("expected table") };
+
+    assert_eq!(slots[0], idle);
+    assert!(matches!(slots[1], Calcit::Nil));
+    assert_eq!(slots[2], done);
+    assert_eq!(slots[3], wildcard);
+    assert!(build_indexed_match_table(&enum_def, &[match_branch("idle", "first"), match_branch("idle", "second")]).is_none());
+    assert!(build_indexed_match_table(&enum_def, &[wildcard_match_branch("early"), match_branch("done", "late")]).is_none());
+    assert!(build_indexed_match_table(&enum_def, &[match_branch("missing", "unknown")]).is_none());
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- preprocess statically known, semantics-safe enum `match` forms into an internal declaration-ordered branch table
- select native branches through the enum definition's existing O(1) variant index
- emit JS integer-tag `switch` dispatch while keeping WASM compatible with the indexed representation
- retain the original representation for dynamic/anonymous enums, duplicate tags, unknown tags, and early wildcards
- add focused table/codegen tests plus repeatable native and JS comparison benchmarks
- update the optimization catalog and native-match RFC

## Compatibility

No user-facing syntax or `CalcitEnumValue` layout changes. Runtime payload arity, wildcard, no-match, dynamic, and anonymous-enum behavior remain explicit.

## Validation

- `git diff --check`
- `package.json` JSON parse
- full local and downstream validation will be recorded after the first Actions compile feedback

Closes #422
Part of #409
