### PR TITLE
fix: make macro coverage and parameter diagnostics trustworthy

### DIFF
--- a/editing-history/20260825-2121-macro-parameter-diagnostics.md
+++ b/editing-history/20260825-2121-macro-parameter-diagnostics.md
@@ -1,0 +1,10 @@
+# Macro parameter diagnostics and coverage
+
+- Added one shared parameter-shape model for required, optional, and rest bindings, including malformed marker sequences. Both preprocessing and `analyze check-types` now use the same comparison and stable diagnostic codes.
+- Preserved ordinary function compatibility: existing function schemas describe fixed arity without separately encoding the `?` marker. Strict optional-shape comparison is enabled for macros, while ordinary functions compare total fixed arity.
+- Macro schema-shape mismatches remain staged during ecosystem migration. `analyze check-types` reports them by default; location-aware preprocessing warnings can be enabled with `CALCIT_WARN_MACRO_SCHEMA_SHAPE=1` and use `W_MACRO_SCHEMA_PARAM_SHAPE`.
+- Corrected whole-`Dynamic` macro coverage from `Full` to `None`; explicitly typed macro schemas with Dynamic argument/result slots remain `Partial`. Explicit `:: Dynamic` now remains distinct from an omitted schema across binary serialization and reports `W_MACRO_SCHEMA_DYNAMIC`, while omission reports `W_SCHEMA_MISSING`.
+- Same-command coverage baseline:
+  - Calcit core: overall `full/partial/none` changed from `420/107/18` to `405/107/33`; macros changed from `18/61/0` to `3/61/15`.
+  - Respo `respo.core`: overall changed from `12/53/1` to `7/53/6`; its five whole-`Dynamic` macros changed from `Full` to `None`.
+- External regression used latest Respo 0.16.86 and Recollect 0.0.34. Respo required rebuilding `.calcit/modules` with `caps --ci` because its local `js-ffi` view was still at 0.1.9 despite `deps.cirru` declaring 0.1.10.

--- a/editing-history/20260825-2138-keep-malformed-macro-params-hard.md
+++ b/editing-history/20260825-2138-keep-malformed-macro-params-hard.md
@@ -1,0 +1,5 @@
+# Keep malformed macro parameters as hard errors
+
+- Review identified that the staged macro-schema partition was too broad and also included `E_DEF_PARAM_SHAPE`.
+- Only schema compatibility mismatches (`E_SCHEMA_REQUIRED_ARGS`, `E_SCHEMA_OPTIONAL_ARGS`, and `E_SCHEMA_REST_ARGS`) are now staged during ecosystem migration.
+- Malformed source parameter sequences and schema-kind mismatches remain hard preprocessing errors.

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -1950,6 +1950,25 @@ mod tests {
     list(vec![leaf("defmacro"), leaf("test-macro"), list(params), leaf("nil")])
   }
 
+  fn macro_schema_with_optional(required: usize, optional: usize, has_rest: bool) -> CalcitTypeAnnotation {
+    let mut arg_types = vec![calcit::calcit::DYNAMIC_TYPE.clone(); required];
+    arg_types.extend((0..optional).map(|_| {
+      Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from("Option"),
+        Arc::new(vec![calcit::calcit::DYNAMIC_TYPE.clone()]),
+      ))
+    }));
+    CalcitTypeAnnotation::Fn(Arc::new(calcit::calcit::CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types,
+      return_type: calcit::calcit::DYNAMIC_TYPE.clone(),
+      fn_kind: SchemaKind::Macro,
+      rest_type: has_rest.then(|| calcit::calcit::DYNAMIC_TYPE.clone()),
+      features: Arc::new(HashSet::new()),
+    }))
+  }
+
   fn code_entry(code: Cirru, schema: CalcitTypeAnnotation) -> snapshot::CodeEntry {
     snapshot::CodeEntry {
       doc: String::new(),
@@ -2017,6 +2036,26 @@ mod tests {
 
     assert_eq!(row.kind, type_coverage::DefKind::Other);
     assert_eq!(row.level, type_coverage::CoverageLevel::None);
+  }
+
+  #[test]
+  fn type_coverage_does_not_mark_whole_dynamic_macros_as_full() {
+    let entry = code_entry(defmacro_code(&["form"]), CalcitTypeAnnotation::Dynamic);
+    let row = type_coverage::analyze_code_entry("app.main", "expand-form", &entry);
+
+    assert_eq!(row.kind, type_coverage::DefKind::Macro);
+    assert_eq!(row.level, type_coverage::CoverageLevel::None);
+    assert!(row.schema_issues.iter().any(|issue| issue.starts_with("[W_MACRO_SCHEMA_DYNAMIC]")));
+
+    let mut missing = code_entry(defmacro_code(&["form"]), CalcitTypeAnnotation::Dynamic);
+    missing.schema = calcit::calcit::DYNAMIC_TYPE.clone();
+    let row = type_coverage::analyze_code_entry("app.main", "missing-schema", &missing);
+    assert!(row.schema_issues.iter().any(|issue| issue.starts_with("[W_SCHEMA_MISSING]")));
+
+    let partially_typed = code_entry(defmacro_code(&["form"]), fn_schema_annotation(SchemaKind::Macro, 1, false));
+    let row = type_coverage::analyze_code_entry("app.main", "expand-form", &partially_typed);
+    assert_eq!(row.level, type_coverage::CoverageLevel::Partial);
+    assert!(row.schema_issues.iter().any(|issue| issue.contains("W_SCHEMA_DYNAMIC")));
   }
 
   #[test]
@@ -2235,11 +2274,39 @@ mod tests {
   }
 
   #[test]
-  fn validate_macro_arity_is_ignored() {
+  fn validate_macro_required_arity_mismatch_is_reported() {
     let schema = fn_schema_annotation(SchemaKind::Macro, 1, false);
     let code = defmacro_code(&["a", "b"]);
     let issues = type_coverage::validate_def_vs_schema("myns", "my-macro", &code, &schema);
-    assert!(issues.is_empty(), "macro arity differences should not be reported: {issues:?}");
+    assert!(
+      issues.iter().any(|issue| issue.starts_with("[E_SCHEMA_REQUIRED_ARGS]")),
+      "{issues:?}"
+    );
+  }
+
+  #[test]
+  fn validate_macro_optional_and_rest_shapes() {
+    let code = list(vec![
+      leaf("defmacro"),
+      leaf("test-macro"),
+      list(vec![leaf("a"), leaf("?"), leaf("b"), leaf("&"), leaf("xs")]),
+      leaf("nil"),
+    ]);
+    let schema = macro_schema_with_optional(1, 1, true);
+    let issues = type_coverage::validate_def_vs_schema("myns", "my-macro", &code, &schema);
+    assert!(issues.is_empty(), "well-formed optional/rest macro should pass: {issues:?}");
+
+    let mismatch = macro_schema_with_optional(2, 0, false);
+    let issues = type_coverage::validate_def_vs_schema("myns", "my-macro", &code, &mismatch);
+    assert!(
+      issues.iter().any(|issue| issue.starts_with("[E_SCHEMA_REQUIRED_ARGS]")),
+      "{issues:?}"
+    );
+    assert!(
+      issues.iter().any(|issue| issue.starts_with("[E_SCHEMA_OPTIONAL_ARGS]")),
+      "{issues:?}"
+    );
+    assert!(issues.iter().any(|issue| issue.starts_with("[E_SCHEMA_REST_ARGS]")), "{issues:?}");
   }
 
   #[test]

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -40,6 +40,7 @@ pub use calcit_trait::{CalcitTrait, CalcitTraitMemberKind};
 pub use enum_value::CalcitEnumValue;
 pub(crate) use fns::trailing_option_arg_count;
 pub use fns::{CalcitArgLabel, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitMacro, CalcitScope};
+pub use fns::{ParamShape, ParamShapeToken, compare_param_shapes};
 pub use list::{CalcitCallKind, CalcitList, CalcitListView, CalcitNumberBinaryOp};
 pub use local::CalcitLocal;
 pub use proc_name::{CalcitProc, ProcArity, ProcTypeSignature};

--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -13,6 +13,126 @@ pub(crate) fn trailing_option_arg_count(arg_types: &[Arc<CalcitTypeAnnotation>],
   arg_types.iter().rev().take_while(|arg| arg.is_option_type()).count()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParamShapeToken {
+  Binding,
+  OptionalMark,
+  RestMark,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamShape {
+  pub required: usize,
+  pub optional: usize,
+  pub has_rest: bool,
+  pub errors: Vec<&'static str>,
+}
+
+impl ParamShape {
+  pub fn from_tokens(tokens: impl IntoIterator<Item = ParamShapeToken>) -> Self {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Phase {
+      Required,
+      Optional,
+      RestBinding,
+      AfterRest,
+    }
+
+    let mut shape = Self {
+      required: 0,
+      optional: 0,
+      has_rest: false,
+      errors: vec![],
+    };
+    let mut phase = Phase::Required;
+    let mut saw_optional_mark = false;
+
+    for token in tokens {
+      match token {
+        ParamShapeToken::Binding => match phase {
+          Phase::Required => shape.required += 1,
+          Phase::Optional => shape.optional += 1,
+          Phase::RestBinding => {
+            shape.has_rest = true;
+            phase = Phase::AfterRest;
+          }
+          Phase::AfterRest => shape.errors.push("binding appears after the rest parameter"),
+        },
+        ParamShapeToken::OptionalMark => match phase {
+          Phase::Required => {
+            saw_optional_mark = true;
+            phase = Phase::Optional;
+          }
+          Phase::Optional => shape.errors.push("optional marker appears more than once"),
+          Phase::RestBinding | Phase::AfterRest => shape.errors.push("optional marker appears after the rest marker"),
+        },
+        ParamShapeToken::RestMark => match phase {
+          Phase::Required | Phase::Optional => phase = Phase::RestBinding,
+          Phase::RestBinding | Phase::AfterRest => shape.errors.push("rest marker appears more than once"),
+        },
+      }
+    }
+
+    if saw_optional_mark && shape.optional == 0 {
+      shape.errors.push("optional marker is missing an optional binding");
+    }
+    if phase == Phase::RestBinding {
+      shape.errors.push("rest marker is missing its binding");
+    }
+    shape
+  }
+
+  pub fn from_schema(arg_types: &[Arc<CalcitTypeAnnotation>], has_rest: bool) -> Self {
+    let optional = trailing_option_arg_count(arg_types, arg_types.len());
+    Self {
+      required: arg_types.len() - optional,
+      optional,
+      has_rest,
+      errors: vec![],
+    }
+  }
+
+  /// Preserve the established callable arity model for ordinary functions,
+  /// whose schemas describe every fixed slot but do not encode the `?`
+  /// marker separately. Macro diagnostics use the full shape instead.
+  pub fn as_fixed_arity(&self) -> Self {
+    Self {
+      required: self.required + self.optional,
+      optional: 0,
+      has_rest: self.has_rest,
+      errors: self.errors.clone(),
+    }
+  }
+}
+
+pub fn compare_param_shapes(owner: &str, code: &ParamShape, schema: &ParamShape) -> Vec<String> {
+  let mut issues = code
+    .errors
+    .iter()
+    .map(|detail| format!("[E_DEF_PARAM_SHAPE] {owner}: malformed parameter list: {detail}"))
+    .collect::<Vec<_>>();
+  if code.required != schema.required {
+    issues.push(format!(
+      "[E_SCHEMA_REQUIRED_ARGS] {owner}: schema has {} required arg(s) but code has {}",
+      schema.required, code.required
+    ));
+  }
+  if code.optional != schema.optional {
+    issues.push(format!(
+      "[E_SCHEMA_OPTIONAL_ARGS] {owner}: schema has {} optional arg(s) but code has {}",
+      schema.optional, code.optional
+    ));
+  }
+  if code.has_rest != schema.has_rest {
+    issues.push(if code.has_rest {
+      format!("[E_SCHEMA_REST_ARGS] {owner}: code has & rest param but schema has no :rest")
+    } else {
+      format!("[E_SCHEMA_REST_ARGS] {owner}: schema has :rest but code has no & param")
+    });
+  }
+  issues
+}
+
 /// structure of a function arguments
 #[derive(Debug, Clone)]
 pub enum CalcitArgLabel {
@@ -170,6 +290,45 @@ mod tests {
     assert_eq!(scope.get(1), Some(&Calcit::Number(42.0)));
     assert_eq!(scope.get(2), Some(&Calcit::Number(99_999.0)));
     assert_eq!(scope.get(3), Some(&Calcit::Number(100_000.0)));
+  }
+
+  #[test]
+  fn parameter_shapes_track_required_optional_and_rest_bindings() {
+    let shape = ParamShape::from_tokens([
+      ParamShapeToken::Binding,
+      ParamShapeToken::OptionalMark,
+      ParamShapeToken::Binding,
+      ParamShapeToken::RestMark,
+      ParamShapeToken::Binding,
+    ]);
+    assert_eq!(shape.required, 1);
+    assert_eq!(shape.optional, 1);
+    assert!(shape.has_rest);
+    assert!(shape.errors.is_empty());
+  }
+
+  #[test]
+  fn parameter_shapes_report_malformed_marker_sequences() {
+    let cases = [
+      (vec![ParamShapeToken::OptionalMark], "optional marker is missing"),
+      (vec![ParamShapeToken::RestMark], "rest marker is missing"),
+      (
+        vec![ParamShapeToken::RestMark, ParamShapeToken::Binding, ParamShapeToken::Binding],
+        "binding appears after",
+      ),
+      (
+        vec![ParamShapeToken::OptionalMark, ParamShapeToken::OptionalMark],
+        "optional marker appears more than once",
+      ),
+      (
+        vec![ParamShapeToken::OptionalMark, ParamShapeToken::RestMark, ParamShapeToken::Binding],
+        "optional marker is missing",
+      ),
+    ];
+    for (tokens, expected) in cases {
+      let shape = ParamShape::from_tokens(tokens);
+      assert!(shape.errors.iter().any(|error| error.contains(expected)), "{shape:?}");
+    }
   }
 }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6026,9 +6026,7 @@ pub fn preprocess_defn(
       }
       warn_on_legacy_optional_public_schema(ctx.file_ns, def_name.as_ref(), &def_schema, ctx.check_warnings);
       let schema_issues = validate_def_schema_during_preprocess(head, ctx.file_ns, def_name.as_ref(), ys, &def_schema);
-      let (staged_macro_issues, hard_schema_issues): (Vec<_>, Vec<_>) = schema_issues
-        .into_iter()
-        .partition(|issue| matches!(head, CalcitSyntax::Defmacro) && !issue.starts_with("[E_SCHEMA_KIND]"));
+      let (staged_macro_issues, hard_schema_issues) = partition_def_schema_issues(head, schema_issues);
       let definition_location = NodeLocation::new(
         info.at_ns.to_owned(),
         info.at_def.to_owned(),
@@ -6847,6 +6845,18 @@ fn emit_staged_macro_schema_warnings(
       check_warnings,
     );
   }
+}
+
+fn is_staged_macro_schema_compatibility_issue(issue: &str) -> bool {
+  ["[E_SCHEMA_REQUIRED_ARGS]", "[E_SCHEMA_OPTIONAL_ARGS]", "[E_SCHEMA_REST_ARGS]"]
+    .iter()
+    .any(|code| issue.starts_with(code))
+}
+
+fn partition_def_schema_issues(head: &CalcitSyntax, issues: Vec<String>) -> (Vec<String>, Vec<String>) {
+  issues
+    .into_iter()
+    .partition(|issue| matches!(head, CalcitSyntax::Defmacro) && is_staged_macro_schema_compatibility_issue(issue))
 }
 
 fn contains_legacy_optional(annotation: &CalcitTypeAnnotation) -> bool {
@@ -11994,5 +12004,21 @@ mod tests {
     assert_eq!(warnings[0].code(), Some("W_MACRO_SCHEMA_PARAM_SHAPE"));
     assert_eq!(warnings[0].location(), &location);
     assert!(warnings[0].message().contains("E_SCHEMA_REST_ARGS"));
+  }
+
+  #[test]
+  fn only_macro_schema_compatibility_mismatches_are_staged() {
+    let issues = vec![
+      "[E_SCHEMA_REQUIRED_ARGS] app/demo: mismatch".to_owned(),
+      "[E_SCHEMA_OPTIONAL_ARGS] app/demo: mismatch".to_owned(),
+      "[E_SCHEMA_REST_ARGS] app/demo: mismatch".to_owned(),
+      "[E_DEF_PARAM_SHAPE] app/demo: malformed parameter list".to_owned(),
+      "[E_SCHEMA_KIND] app/demo: wrong definition kind".to_owned(),
+    ];
+    let (staged, hard) = partition_def_schema_issues(&CalcitSyntax::Defmacro, issues);
+    assert_eq!(staged.len(), 3);
+    assert_eq!(hard.len(), 2);
+    assert!(hard.iter().any(|issue| issue.starts_with("[E_DEF_PARAM_SHAPE]")));
+    assert!(hard.iter().any(|issue| issue.starts_with("[E_SCHEMA_KIND]")));
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8,7 +8,8 @@ use crate::{
     self, Calcit, CalcitArgLabel, CalcitCallKind, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnTypeAnnotation, CalcitImpl,
     CalcitImport, CalcitList, CalcitLocal, CalcitNumberBinaryOp, CalcitProc, CalcitScope, CalcitStructDef, CalcitSymbolInfo,
     CalcitSyntax, CalcitTrait, CalcitTraitMemberKind, CalcitTypeAnnotation, GENERATED_DEF, ImportInfo, LocatedWarning, NodeLocation,
-    RawCodeType, SchemaKind, brief_type_of_value, pop_type_slot_override, push_type_slot_override, register_type_slot,
+    ParamShape, ParamShapeToken, RawCodeType, SchemaKind, brief_type_of_value, compare_param_shapes, pop_type_slot_override,
+    push_type_slot_override, register_type_slot,
   },
   call_stack::{CallStackList, StackKind},
   codegen, program, runner,
@@ -6025,18 +6026,29 @@ pub fn preprocess_defn(
       }
       warn_on_legacy_optional_public_schema(ctx.file_ns, def_name.as_ref(), &def_schema, ctx.check_warnings);
       let schema_issues = validate_def_schema_during_preprocess(head, ctx.file_ns, def_name.as_ref(), ys, &def_schema);
-      if !schema_issues.is_empty() {
-        let details = schema_issues.join("\n  - ");
+      let (staged_macro_issues, hard_schema_issues): (Vec<_>, Vec<_>) = schema_issues
+        .into_iter()
+        .partition(|issue| matches!(head, CalcitSyntax::Defmacro) && !issue.starts_with("[E_SCHEMA_KIND]"));
+      let definition_location = NodeLocation::new(
+        info.at_ns.to_owned(),
+        info.at_def.to_owned(),
+        location.to_owned().unwrap_or_default(),
+      );
+      // Existing projects contain macro schemas that predate parameter-shape
+      // validation. Keep the location-aware preprocessing diagnostic opt-in
+      // during migration; `analyze check-types` reports the same issues by
+      // default without blocking project execution.
+      if std::env::var_os("CALCIT_WARN_MACRO_SCHEMA_SHAPE").is_some() {
+        emit_staged_macro_schema_warnings(staged_macro_issues, ctx.file_ns, &definition_location, ctx.check_warnings);
+      }
+      if !hard_schema_issues.is_empty() {
+        let details = hard_schema_issues.join("\n  - ");
         return Err(CalcitErr::use_msg_stack_location_with_code(
           CalcitErrKind::Type,
           format!("schema mismatch while preprocessing definition:\n  - {details}"),
           "E_SCHEMA_DEF_MISMATCH",
           ctx.call_stack,
-          Some(NodeLocation::new(
-            info.at_ns.to_owned(),
-            info.at_def.to_owned(),
-            location.to_owned().unwrap_or_default(),
-          )),
+          Some(definition_location),
         ));
       }
 
@@ -6812,28 +6824,29 @@ pub fn preprocess_assert_traits(
   Ok(assert_expr)
 }
 
-fn analyze_def_schema_param_arity(args: &CalcitList) -> (usize, bool) {
-  let mut required_count = 0;
-  let mut has_rest = false;
-  let mut skip_rest_binding = false;
+fn analyze_def_schema_param_shape(args: &CalcitList) -> ParamShape {
+  ParamShape::from_tokens(args.iter().map(|item| match item {
+    Calcit::Syntax(CalcitSyntax::ArgOptional, _) => ParamShapeToken::OptionalMark,
+    Calcit::Syntax(CalcitSyntax::ArgSpread, _) => ParamShapeToken::RestMark,
+    _ => ParamShapeToken::Binding,
+  }))
+}
 
-  for item in args {
-    if matches!(item, Calcit::Syntax(CalcitSyntax::ArgSpread, _)) {
-      has_rest = true;
-      skip_rest_binding = true;
-      continue;
-    }
-    if matches!(item, Calcit::Syntax(CalcitSyntax::ArgOptional, _)) {
-      continue;
-    }
-    if skip_rest_binding {
-      skip_rest_binding = false;
-      continue;
-    }
-    required_count += 1;
+fn emit_staged_macro_schema_warnings(
+  issues: Vec<String>,
+  file_ns: &str,
+  definition_location: &NodeLocation,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  for issue in issues {
+    gen_check_warning_code_at(
+      format!("[Warn] staged macro schema mismatch: {issue}"),
+      "W_MACRO_SCHEMA_PARAM_SHAPE",
+      file_ns,
+      Some(definition_location.clone()),
+      check_warnings,
+    );
   }
-
-  (required_count, has_rest)
 }
 
 fn contains_legacy_optional(annotation: &CalcitTypeAnnotation) -> bool {
@@ -6906,34 +6919,25 @@ fn validate_def_schema_during_preprocess(
 
   match (fn_annot.fn_kind, code_kind) {
     (SchemaKind::Fn, "defmacro") => {
-      issues.push(format!("{ns}/{def_name}: schema :kind is :fn but code uses defmacro"));
+      issues.push(format!(
+        "[E_SCHEMA_KIND] {ns}/{def_name}: schema :kind is :fn but code uses defmacro"
+      ));
     }
     (SchemaKind::Macro, "defn" | "defwasm-export" | "defwasm-import") => {
-      issues.push(format!("{ns}/{def_name}: schema :kind is :macro but code uses {code_kind}"));
+      issues.push(format!(
+        "[E_SCHEMA_KIND] {ns}/{def_name}: schema :kind is :macro but code uses {code_kind}"
+      ));
     }
     _ => {}
   }
 
-  if code_kind == "defmacro" {
-    return issues;
+  let mut code_shape = analyze_def_schema_param_shape(args);
+  let mut schema_shape = ParamShape::from_schema(&fn_annot.arg_types, fn_annot.rest_type.is_some());
+  if code_kind != "defmacro" {
+    code_shape = code_shape.as_fixed_arity();
+    schema_shape = schema_shape.as_fixed_arity();
   }
-
-  let (required_count, has_rest) = analyze_def_schema_param_arity(args);
-  let schema_required = fn_annot.arg_types.len();
-  let schema_has_rest = fn_annot.rest_type.is_some();
-
-  if required_count != schema_required {
-    issues.push(format!(
-      "{ns}/{def_name}: schema has {schema_required} required arg(s) but code has {required_count}"
-    ));
-  }
-  if has_rest != schema_has_rest {
-    if has_rest {
-      issues.push(format!("{ns}/{def_name}: code has & rest param but schema has no :rest"));
-    } else {
-      issues.push(format!("{ns}/{def_name}: schema has :rest but code has no & param"));
-    }
-  }
+  issues.extend(compare_param_shapes(&format!("{ns}/{def_name}"), &code_shape, &schema_shape));
 
   issues
 }
@@ -11893,7 +11897,7 @@ mod tests {
   }
 
   #[test]
-  fn validate_def_schema_ignores_macro_arity_details() {
+  fn validate_def_schema_reports_macro_required_and_rest_mismatches() {
     let args = CalcitList::from(&[
       Calcit::Local(CalcitLocal {
         idx: CalcitLocal::track_sym(&Arc::from("args")),
@@ -11928,7 +11932,7 @@ mod tests {
     }));
 
     let issues = validate_def_schema_during_preprocess(&CalcitSyntax::Defmacro, "calcit.core", "fn", &args, &schema);
-    assert!(issues.is_empty(), "macro arity differences should be ignored: {issues:?}");
+    assert!(issues.iter().any(|issue| issue.starts_with("[E_SCHEMA_REST_ARGS]")), "{issues:?}");
   }
 
   #[test]
@@ -11967,8 +11971,28 @@ mod tests {
       }),
     ] as &[Calcit]);
 
-    let (required_count, has_rest) = analyze_def_schema_param_arity(&args);
-    assert_eq!(required_count, 3, "optional marker should not count as its own arg");
-    assert!(!has_rest);
+    let shape = analyze_def_schema_param_shape(&args);
+    assert_eq!(shape.required, 2);
+    assert_eq!(shape.optional, 1);
+    assert!(!shape.has_rest);
+    assert!(shape.errors.is_empty());
+  }
+
+  #[test]
+  fn staged_macro_schema_warning_keeps_code_and_definition_location() {
+    let location = NodeLocation::new(Arc::from("app.macros"), Arc::from("demo"), Arc::new(vec![1, 2]));
+    let warnings = RefCell::new(vec![]);
+    emit_staged_macro_schema_warnings(
+      vec!["[E_SCHEMA_REST_ARGS] app.macros/demo: code has & rest param but schema has no :rest".to_owned()],
+      "app.macros",
+      &location,
+      &warnings,
+    );
+
+    let warnings = warnings.borrow();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].code(), Some("W_MACRO_SCHEMA_PARAM_SHAPE"));
+    assert_eq!(warnings[0].location(), &location);
+    assert!(warnings[0].message().contains("E_SCHEMA_REST_ARGS"));
   }
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -431,7 +431,8 @@ mod schema_serde {
     S: serde::Serializer,
   {
     let edn: Option<Edn> = match schema.as_ref() {
-      CalcitTypeAnnotation::Dynamic => None,
+      CalcitTypeAnnotation::Dynamic if schema_annotation_is_missing(schema) => None,
+      CalcitTypeAnnotation::Dynamic => Some(schema_annotation_to_edn(schema.as_ref())),
       // Keep the binary snapshot representation of function schemas stable:
       // build.rs and older runtimes expect the direct map form here. Value
       // annotations use their ordinary type-expression representation.
@@ -451,6 +452,13 @@ mod schema_serde {
       Some(v) => parse_loaded_schema_annotation(&v, "CodeEntry.schema").map_err(serde::de::Error::custom)?,
     })
   }
+}
+
+/// Missing schemas use the shared Dynamic singleton. An explicitly declared
+/// `:: Dynamic` is parsed into its own Arc so analysis and binary snapshots can
+/// preserve the difference between omitted and intentionally untyped schemas.
+pub fn schema_annotation_is_missing(schema: &Arc<CalcitTypeAnnotation>) -> bool {
+  matches!(schema.as_ref(), CalcitTypeAnnotation::Dynamic) && Arc::ptr_eq(schema, &DYNAMIC_TYPE)
 }
 
 mod tags_serde {
@@ -3543,6 +3551,20 @@ mod tests {
     let code = Cirru::List(vec![Cirru::leaf("defstruct")]);
     let explicit = Arc::new(CalcitTypeAnnotation::Custom(Arc::new(Calcit::tag("struct"))));
     assert_eq!(normalize_schema_for_code(&code, &explicit), explicit);
+  }
+
+  #[test]
+  fn binary_schema_round_trip_distinguishes_missing_and_explicit_dynamic() {
+    let mut explicit = CodeEntry::from_code(Cirru::leaf("nil"));
+    explicit.schema = Arc::new(CalcitTypeAnnotation::Dynamic);
+    let bytes = rmp_serde::to_vec(&explicit).expect("explicit Dynamic entry should encode");
+    let decoded: CodeEntry = rmp_serde::from_slice(&bytes).expect("explicit Dynamic entry should decode");
+    assert!(!schema_annotation_is_missing(&decoded.schema));
+
+    let missing = CodeEntry::from_code(Cirru::leaf("nil"));
+    let bytes = rmp_serde::to_vec(&missing).expect("missing schema entry should encode");
+    let decoded: CodeEntry = rmp_serde::from_slice(&bytes).expect("missing schema entry should decode");
+    assert!(schema_annotation_is_missing(&decoded.schema));
   }
 
   #[test]

--- a/src/type_coverage.rs
+++ b/src/type_coverage.rs
@@ -3,9 +3,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
+use std::sync::Arc;
 
 use calcit::calcit::{
-  CalcitProc, CalcitSyntax, CalcitTypeAnnotation, ProcTypeSignature, SchemaKind, SyntaxTypeSignature, resolve_type_slot,
+  CalcitProc, CalcitSyntax, CalcitTypeAnnotation, ParamShape, ParamShapeToken, ProcTypeSignature, SchemaKind, SyntaxTypeSignature,
+  compare_param_shapes, resolve_type_slot,
 };
 use calcit::cli_args::{CheckTypesCommand, WeakTypesCommand};
 use calcit::snapshot;
@@ -625,13 +627,25 @@ fn weak_type_impact(occurrence: &WeakTypeOccurrence) -> &'static str {
   "The dynamic slot erases type relations at this boundary, reducing call checking, generic binding, and compile-time method specialization."
 }
 
-fn entry_schema_issues(ns: &str, def_name: &str, code: &Cirru, annotation: &CalcitTypeAnnotation) -> Vec<String> {
+fn entry_schema_issues(ns: &str, def_name: &str, code: &Cirru, schema: &Arc<CalcitTypeAnnotation>) -> Vec<String> {
+  let annotation = schema.as_ref();
   let mut issues = validate_def_vs_schema(ns, def_name, code, annotation);
   let has_js_ffi_feature = matches!(
     annotation,
     CalcitTypeAnnotation::Fn(fn_annot) if fn_annot.features.iter().any(|feature| feature.ref_str() == "js-ffi")
   );
   if matches!(annotation, CalcitTypeAnnotation::Dynamic) {
+    if matches!(code, Cirru::List(items) if matches!(items.first(), Some(Cirru::Leaf(head)) if head.as_ref() == "defmacro")) {
+      let (warning, detail) = if snapshot::schema_annotation_is_missing(schema) {
+        ("W_SCHEMA_MISSING", "has no declared macro schema")
+      } else {
+        (
+          "W_MACRO_SCHEMA_DYNAMIC",
+          "declares an intentionally untyped whole-Dynamic macro schema",
+        )
+      };
+      issues.push(format!("[{warning}] {ns}/{def_name} {detail}"));
+    }
     return issues;
   }
 
@@ -1734,69 +1748,45 @@ pub fn validate_def_vs_schema(ns: &str, def_name: &str, code: &Cirru, schema: &C
   // Kind mismatch
   match (fn_annot.fn_kind, code_kind) {
     (SchemaKind::Fn, "defmacro") => {
-      issues.push(format!("{ns}/{def_name}: schema :kind is :fn but code uses defmacro"));
+      issues.push(format!(
+        "[E_SCHEMA_KIND] {ns}/{def_name}: schema :kind is :fn but code uses defmacro"
+      ));
     }
     (SchemaKind::Macro, "defn") => {
-      issues.push(format!("{ns}/{def_name}: schema :kind is :macro but code uses defn"));
+      issues.push(format!(
+        "[E_SCHEMA_KIND] {ns}/{def_name}: schema :kind is :macro but code uses defn"
+      ));
     }
     _ => {}
   }
 
-  if code_kind == "defmacro" {
-    return issues;
+  let mut code_shape = analyze_param_shape(xs.get(2));
+  let mut schema_shape = ParamShape::from_schema(&fn_annot.arg_types, fn_annot.rest_type.is_some());
+  if code_kind != "defmacro" {
+    code_shape = code_shape.as_fixed_arity();
+    schema_shape = schema_shape.as_fixed_arity();
   }
-
-  // Arity check
-  let (required_count, has_rest) = analyze_param_arity(xs.get(2));
-  let schema_required = fn_annot.arg_types.len();
-  let schema_has_rest = fn_annot.rest_type.is_some();
-
-  if required_count != schema_required {
-    issues.push(format!(
-      "{ns}/{def_name}: schema has {schema_required} required arg(s) but code has {required_count}"
-    ));
-  }
-  if has_rest != schema_has_rest {
-    if has_rest {
-      issues.push(format!("{ns}/{def_name}: code has & rest param but schema has no :rest"));
-    } else {
-      issues.push(format!("{ns}/{def_name}: schema has :rest but code has no & param"));
-    }
-  }
+  issues.extend(compare_param_shapes(&format!("{ns}/{def_name}"), &code_shape, &schema_shape));
 
   issues
 }
 
 /// Count required params and detect rest param from a defn/defmacro args form.
 pub fn analyze_param_arity(args: Option<&Cirru>) -> (usize, bool) {
+  let shape = analyze_param_shape(args);
+  (shape.required, shape.has_rest)
+}
+
+fn analyze_param_shape(args: Option<&Cirru>) -> ParamShape {
   let Some(Cirru::List(xs)) = args else {
-    return (0, false);
+    return ParamShape::from_tokens([]);
   };
-  let mut required = 0usize;
-  let mut has_rest = false;
-  let mut after_amp = false;
-  for item in xs.iter() {
-    match item {
-      Cirru::Leaf(s) => {
-        let s = s.as_ref();
-        if s == "&" {
-          after_amp = true;
-        } else if s == "[]" || s == "," || s == "?" {
-          // skip structural markers
-        } else if after_amp {
-          has_rest = true;
-        } else if !s.starts_with(':') && !s.starts_with('|') && !s.chars().all(|c| c.is_ascii_digit()) {
-          required += 1;
-        }
-      }
-      Cirru::List(_) => {
-        if !after_amp {
-          required += 1;
-        }
-      }
-    }
-  }
-  (required, has_rest)
+  ParamShape::from_tokens(xs.iter().filter_map(|item| match item {
+    Cirru::Leaf(s) if matches!(s.as_ref(), "[]" | ",") => None,
+    Cirru::Leaf(s) if s.as_ref() == "?" => Some(ParamShapeToken::OptionalMark),
+    Cirru::Leaf(s) if s.as_ref() == "&" => Some(ParamShapeToken::RestMark),
+    _ => Some(ParamShapeToken::Binding),
+  }))
 }
 
 pub fn analyze_code_entry(ns: &str, def_name: &str, entry: &snapshot::CodeEntry) -> TypeCoverageRow {
@@ -2007,7 +1997,13 @@ pub fn analyze_code_entry(ns: &str, def_name: &str, entry: &snapshot::CodeEntry)
         let body = &xs[3..];
         let params = extract_param_symbols(args);
         let param_annotations = extract_assert_type_annotations(body);
-        (DefKind::Macro, params, param_annotations, Vec::new(), None, CoverageLevel::Full)
+        let typed_count = count_typed_params(&params, &param_annotations);
+        let level = if typed_count > 0 {
+          CoverageLevel::Partial
+        } else {
+          CoverageLevel::None
+        };
+        (DefKind::Macro, params, param_annotations, Vec::new(), None, level)
       }
       Some(Cirru::Leaf(head)) if &**head == "def" => {
         let inferred = xs.get(2).and_then(infer_data_type);


### PR DESCRIPTION
Closes #433.

## What changed

- add a shared parameter-shape model for required, optional, rest, and malformed marker sequences
- use the same shape comparison from preprocessing and `analyze check-types`
- validate macro required/optional/rest compatibility with stable diagnostic codes
- classify whole-`Dynamic` macros as `None` and typed schemas with Dynamic slots as `Partial`
- preserve explicit `:: Dynamic` versus an omitted schema across binary snapshots
- report explicit whole-Dynamic macros as `W_MACRO_SCHEMA_DYNAMIC` and missing macro schemas as `W_SCHEMA_MISSING`
- replace the test that locked in ignored macro arity with positive and negative cases

Ordinary functions retain their existing fixed-arity compatibility because their schemas do not encode the source `?` marker separately.

Macro shape enforcement is staged for the existing ecosystem: `analyze check-types` reports mismatches by default. Location-aware preprocessing warnings can be enabled with `CALCIT_WARN_MACRO_SCHEMA_SHAPE=1`; they use `W_MACRO_SCHEMA_PARAM_SHAPE` and retain the definition AST location.

## Coverage baseline

Using the same namespace-scoped command before and after:

| Project | Before full/partial/none | After full/partial/none |
| --- | --- | --- |
| Calcit `calcit.core` overall | 420 / 107 / 18 | 405 / 107 / 33 |
| Calcit `calcit.core` macros | 18 / 61 / 0 | 3 / 61 / 15 |
| Respo `respo.core` overall | 12 / 53 / 1 | 7 / 53 / 6 |
| Respo `respo.core` macros | 5 / 0 / 0 | 0 / 0 / 5 |

The five changed Respo macros are `defcomp`, `defeffect`, `defplugin`, `error-boundary`, and `show`. They remain deliberately dynamic, but are no longer reported as fully typed.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test` (491 + 244 + 24 + 4 tests)
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (17/17)
- latest Respo 0.16.86: 27/27 tests
- latest Recollect 0.0.34: 9/9 unit tests

The Respo regression first exposed a stale local module view (`js-ffi` 0.1.9 while `deps.cirru` declared 0.1.10); rebuilding it with the current `caps --ci` produced the clean 27/27 result.
