### PR TITLE
feat: add phase-aware macro signatures

### DIFF
--- a/docs/MacroSignature.md
+++ b/docs/MacroSignature.md
@@ -1,0 +1,48 @@
+# Phase-aware macro signatures
+
+Calcit macros run in two phases: their parameters are unevaluated syntax, while
+their expansion is later preprocessed as an expression or declaration. A macro
+signature therefore uses a dedicated `MacroSignature`; it is not a function
+signature with a different `:kind`.
+
+The canonical snapshot/source form is:
+
+```cirru
+:: 'Macro
+  {} (:generics $ [] 'T)
+    :required $ [] 'SyntaxSymbol (:: 'Expr 'T)
+    :optional $ [] 'SyntaxList
+    :rest 'Syntax
+    :expansion $ :: 'Expr 'T
+```
+
+Input contracts are `Syntax`, `SyntaxSymbol`, `SyntaxList`, and `Expr<T>`.
+`SyntaxSymbol` and `SyntaxList` inspect the raw AST shape. `Expr<T>` accepts an
+expression syntax node and, where its type is inferable at the call site, binds
+or checks its semantic type. Optional slots are declared separately from
+required slots, and `:rest` describes each additional input node; the macro body
+receives that rest binding as a syntax list.
+
+Expansion contracts are `Expr<T>`, `Definition<T>`, and `Declarations`.
+Expression contracts are checked after expansion and preprocessing. Definition
+contracts additionally require definition syntax, while `Declarations` accepts
+one declaration or a `do` form containing declarations. Diagnostics identify
+whether the violation belongs to input syntax or the expansion result and keep
+the macro call stack and source location.
+
+Existing `(:: 'Macro ({} (:args ...) (:return ...)))` schemas remain readable
+and serialize without data loss. They become an explicitly legacy, non-strict
+`MacroSignature`: their runtime-looking types are compatibility metadata, not
+syntax contracts. An omitted or `Dynamic` legacy macro schema likewise does not
+claim full phase coverage.
+
+Two motivating cases illustrate the distinction:
+
+- Core `%{}?` receives a struct name as `SyntaxSymbol`, then a rest sequence of
+  `SyntaxList` field entries, and expands to `Expr<Struct>`.
+- Respo `defstyle` receives a style name as `SyntaxSymbol` and rule data as
+  `SyntaxList`; its expansion is a definition/declaration contract rather than
+  a runtime function return value.
+
+This model intentionally does not introduce recursive runtime union types,
+macro expansion caches, or compile-time capability policy.

--- a/editing-history/202608252220-phase-aware-macro-signatures.md
+++ b/editing-history/202608252220-phase-aware-macro-signatures.md
@@ -1,0 +1,35 @@
+# Phase-aware macro signatures
+
+Implemented roadmap issue #434 after the parameter-shape diagnostics from
+#433/#438 landed.
+
+- Added a dedicated `MacroSignature` model instead of representing macros as
+  runtime `CalcitFnTypeAnnotation` values.
+- Split raw inputs into `Syntax`, `SyntaxSymbol`, `SyntaxList`, and `Expr<T>`;
+  split expansion results into `Expr<T>`, `Definition<T>`, and `Declarations`.
+- Added required, optional, rest, generic, where-bound, and feature metadata.
+- Preserved old `Macro {:args ... :return ...}` snapshots as explicit legacy,
+  non-strict signatures; the ordinary Fn parser rejects strict macro fields.
+- Attached signatures to materialized `CalcitMacro` values, typed macro-body
+  locals at syntax phase, and added separate call-input and expansion-result
+  diagnostics with source locations and macro stacks.
+- Updated snapshot, detailed snapshot, weak-type, and coverage paths so the new
+  model survives all formats and contributes accurate coverage.
+- Migrated core `%{}?` to `SyntaxSymbol + & SyntaxList -> Expr<Struct>` and
+  documented Respo `defstyle` as the declaration-output case study.
+
+Validation performed:
+
+- `cargo fmt`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-all`
+- `yarn check-agent-interface`
+- `calcit docs check-md --entry src/cirru/calcit-core.cirru docs/MacroSignature.md`
+- latest Respo main: 27/27 tests and 126/126 documentation blocks
+- latest Recollect main: 9/9 Calcit tests plus JS tests
+
+External regressions used globally installed Calcit 0.13.44 and refreshed
+`@calcit/procs` 0.13.44; stale local 0.13.27 packages were replaced before the
+final run.

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -12,7 +12,7 @@ use crate::builtins::meta::{NS_SYMBOL_DICT, type_of};
 
 use crate::calcit::{
   self, CalcitArgLabel, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitList, CalcitListView,
-  CalcitLocal, CalcitMacro, CalcitSymbolInfo, CalcitSyntax, CalcitTypeAnnotation, LocatedWarning,
+  CalcitLocal, CalcitMacro, CalcitSymbolInfo, CalcitSyntax, CalcitTypeAnnotation, LocatedWarning, MacroSignature,
 };
 use crate::calcit::{Calcit, CalcitEnumValue, CalcitErr, CalcitScope, gen_core_id};
 use crate::call_stack::CallStackList;
@@ -114,15 +114,23 @@ fn is_function_metadata_hint(form: &Calcit) -> bool {
 
 pub fn defmacro(expr: &CalcitListView<'_>, _scope: &CalcitScope, def_ns: &str) -> Result<Calcit, CalcitErr> {
   match (expr.first(), expr.get(1)) {
-    (Some(Calcit::Symbol { sym: s, .. }), Some(Calcit::List(xs))) => Ok(Calcit::Macro {
-      id: gen_core_id(),
-      info: Arc::new(CalcitMacro {
-        name: s.to_owned(),
-        def_ns: Arc::from(def_ns),
-        args: Arc::new(get_raw_args(xs)?),
-        body: Arc::new(expr.skip(2)?.to_vec()),
-      }),
-    }),
+    (Some(Calcit::Symbol { sym: s, .. }), Some(Calcit::List(xs))) => {
+      let signature = match crate::program::lookup_def_schema(def_ns, s).as_ref() {
+        CalcitTypeAnnotation::Macro(signature) => signature.clone(),
+        CalcitTypeAnnotation::Fn(annotation) => Arc::new(MacroSignature::from_legacy_fn(annotation.as_ref().clone())),
+        _ => Arc::new(MacroSignature::legacy_dynamic()),
+      };
+      Ok(Calcit::Macro {
+        id: gen_core_id(),
+        info: Arc::new(CalcitMacro {
+          name: s.to_owned(),
+          def_ns: Arc::from(def_ns),
+          args: Arc::new(get_raw_args(xs)?),
+          body: Arc::new(expr.skip(2)?.to_vec()),
+          signature,
+        }),
+      })
+    }
     (Some(a), Some(b)) => CalcitErr::err_str(
       CalcitErrKind::Type,
       format!("defmacro expected a symbol and a list of arguments, but received: {a} {b}"),

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -50,9 +50,10 @@ pub use symbol::{CalcitImport, CalcitSymbolInfo, ImportInfo};
 pub use syntax_name::{CalcitSyntax, SyntaxTypeSignature};
 pub use thunk::{CalcitThunk, CalcitThunkInfo};
 pub use type_annotation::{
-  CalcitFnTypeAnnotation, CalcitGenericBound, CalcitTypeAnnotation, DYNAMIC_TYPE, SchemaKind, brief_type_of_value, clear_type_slots,
-  configure_entry_type_slots, pop_type_slot_override, push_type_slot_override, register_program_lookups, register_type_slot,
-  resolve_type_slot, value_matches_type_annotation, with_type_annotation_warning_context,
+  CalcitFnTypeAnnotation, CalcitGenericBound, CalcitTypeAnnotation, DYNAMIC_TYPE, MacroExpansionType, MacroSignature,
+  MacroSignatureCompatibility, MacroSyntaxType, SchemaKind, brief_type_of_value, clear_type_slots, configure_entry_type_slots,
+  pop_type_slot_override, push_type_slot_override, register_program_lookups, register_type_slot, resolve_type_slot,
+  value_matches_type_annotation, with_type_annotation_warning_context,
 };
 
 use compare::{

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -511,6 +511,9 @@ impl GraphBuilder {
       CalcitTypeAnnotation::TypeVar(name) => Err(unsupported_type(&format!("generic variable '{name} is not bound"))),
       CalcitTypeAnnotation::AnonymousEnum => Err(unsupported_type("anonymous enum has no declared enum schema")),
       CalcitTypeAnnotation::DynFn | CalcitTypeAnnotation::Fn(_) => Err(unsupported_type("function values are not closed data")),
+      CalcitTypeAnnotation::Macro(_) | CalcitTypeAnnotation::Syntax(_) => {
+        Err(unsupported_type("compile-time macro syntax contracts are not application data"))
+      }
       CalcitTypeAnnotation::Trait(_) | CalcitTypeAnnotation::TraitSet(_) => {
         Err(unsupported_type("trait constraints are not data shapes"))
       }

--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -340,6 +340,7 @@ pub struct CalcitMacro {
   pub def_ns: Arc<str>,
   pub args: Arc<Vec<CalcitArgLabel>>,
   pub body: Arc<Vec<Calcit>>,
+  pub signature: Arc<crate::calcit::MacroSignature>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -281,6 +281,11 @@ pub enum CalcitTypeAnnotation {
   /// function type without a known signature
   DynFn,
   Fn(Arc<CalcitFnTypeAnnotation>),
+  /// Compile-time macro contract. Unlike `Fn`, its inputs describe raw syntax
+  /// and its output describes the semantic value produced after expansion.
+  Macro(Arc<MacroSignature>),
+  /// A macro-body local whose value is an unevaluated syntax node.
+  Syntax(Arc<MacroSyntaxType>),
   /// Hashset type
   Set(Arc<CalcitTypeAnnotation>),
   Ref(Arc<CalcitTypeAnnotation>),
@@ -328,6 +333,236 @@ pub enum CalcitTypeAnnotation {
   /// A type slot reference declared via `deftype-slot` and bound via `bind-type`.
   /// At type-checking time, this is resolved by looking up the global TYPE_SLOTS registry.
   TypeSlot(Arc<str>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MacroSyntaxType {
+  Syntax,
+  SyntaxSymbol,
+  SyntaxList,
+  Expr(Arc<CalcitTypeAnnotation>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MacroExpansionType {
+  Dynamic,
+  Expr(Arc<CalcitTypeAnnotation>),
+  Definition(Arc<CalcitTypeAnnotation>),
+  Declarations,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MacroSignatureCompatibility {
+  Strict,
+  /// Existing `Macro {:args ... :return ...}` schemas mixed runtime and syntax
+  /// phases. Keep their data for lossless snapshots, but do not enforce it as
+  /// a strict syntax/expansion contract.
+  Legacy(Arc<CalcitFnTypeAnnotation>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MacroSignature {
+  pub generics: Arc<Vec<Arc<str>>>,
+  pub where_bounds: Arc<Vec<CalcitGenericBound>>,
+  pub required_inputs: Arc<Vec<MacroSyntaxType>>,
+  pub optional_inputs: Arc<Vec<MacroSyntaxType>>,
+  pub rest_input: Option<MacroSyntaxType>,
+  pub expansion: MacroExpansionType,
+  pub features: Arc<HashSet<EdnTag>>,
+  pub compatibility: MacroSignatureCompatibility,
+}
+
+impl PartialOrd for MacroSignature {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+impl Ord for MacroSignature {
+  fn cmp(&self, other: &Self) -> Ordering {
+    let mut self_features = self.features.iter().map(EdnTag::ref_str).collect::<Vec<_>>();
+    let mut other_features = other.features.iter().map(EdnTag::ref_str).collect::<Vec<_>>();
+    self_features.sort_unstable();
+    other_features.sort_unstable();
+    self
+      .generics
+      .cmp(&other.generics)
+      .then_with(|| self.where_bounds.cmp(&other.where_bounds))
+      .then_with(|| self.required_inputs.cmp(&other.required_inputs))
+      .then_with(|| self.optional_inputs.cmp(&other.optional_inputs))
+      .then_with(|| self.rest_input.cmp(&other.rest_input))
+      .then_with(|| self.expansion.cmp(&other.expansion))
+      .then_with(|| self_features.cmp(&other_features))
+      .then_with(|| self.compatibility.cmp(&other.compatibility))
+  }
+}
+
+impl Hash for MacroSignature {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.generics.hash(state);
+    self.where_bounds.hash(state);
+    self.required_inputs.hash(state);
+    self.optional_inputs.hash(state);
+    self.rest_input.hash(state);
+    self.expansion.hash(state);
+    let mut features = self.features.iter().map(EdnTag::ref_str).collect::<Vec<_>>();
+    features.sort_unstable();
+    features.hash(state);
+    self.compatibility.hash(state);
+  }
+}
+
+impl MacroSignature {
+  pub fn legacy_dynamic() -> Self {
+    Self {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      required_inputs: Arc::new(vec![]),
+      optional_inputs: Arc::new(vec![]),
+      rest_input: None,
+      expansion: MacroExpansionType::Dynamic,
+      features: Arc::new(HashSet::new()),
+      compatibility: MacroSignatureCompatibility::Legacy(Arc::new(CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: vec![],
+        return_type: crate::calcit::DYNAMIC_TYPE.clone(),
+        fn_kind: SchemaKind::Macro,
+        rest_type: None,
+        features: Arc::new(HashSet::new()),
+      })),
+    }
+  }
+
+  pub fn from_legacy_fn(annotation: CalcitFnTypeAnnotation) -> Self {
+    let annotation = Arc::new(CalcitFnTypeAnnotation {
+      fn_kind: SchemaKind::Macro,
+      ..annotation
+    });
+    Self {
+      generics: annotation.generics.clone(),
+      where_bounds: annotation.where_bounds.clone(),
+      required_inputs: Arc::new(vec![]),
+      optional_inputs: Arc::new(vec![]),
+      rest_input: None,
+      expansion: MacroExpansionType::Dynamic,
+      features: annotation.features.clone(),
+      compatibility: MacroSignatureCompatibility::Legacy(annotation),
+    }
+  }
+
+  pub fn is_strict(&self) -> bool {
+    matches!(self.compatibility, MacroSignatureCompatibility::Strict)
+  }
+
+  fn parse_contract(form: &Edn, generics: &[Arc<str>]) -> Option<MacroSyntaxType> {
+    match form {
+      Edn::Symbol(name) | Edn::Quote(cirru_parser::Cirru::Leaf(name)) => match name.as_ref() {
+        "Syntax" => Some(MacroSyntaxType::Syntax),
+        "SyntaxSymbol" => Some(MacroSyntaxType::SyntaxSymbol),
+        "SyntaxList" => Some(MacroSyntaxType::SyntaxList),
+        _ => None,
+      },
+      Edn::Enum(view) if view.variant.as_ref() == "Expr" && view.extra.len() == 1 => {
+        let semantic = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(
+          &CalcitTypeAnnotation::edn_type_to_calcit(&view.extra[0]),
+          generics,
+        );
+        Some(MacroSyntaxType::Expr(semantic))
+      }
+      _ => None,
+    }
+  }
+
+  fn parse_expansion(form: Option<&Edn>, generics: &[Arc<str>]) -> Option<MacroExpansionType> {
+    let form = form?;
+    match form {
+      Edn::Symbol(name) | Edn::Quote(cirru_parser::Cirru::Leaf(name)) if name.as_ref() == "Declarations" => {
+        Some(MacroExpansionType::Declarations)
+      }
+      Edn::Enum(view) if view.variant.as_ref() == "Declarations" && view.extra.is_empty() => Some(MacroExpansionType::Declarations),
+      Edn::Enum(view) if matches!(view.variant.as_ref(), "Expr" | "Definition") && view.extra.len() == 1 => {
+        let semantic = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(
+          &CalcitTypeAnnotation::edn_type_to_calcit(&view.extra[0]),
+          generics,
+        );
+        if view.variant.as_ref() == "Expr" {
+          Some(MacroExpansionType::Expr(semantic))
+        } else {
+          Some(MacroExpansionType::Definition(semantic))
+        }
+      }
+      _ => None,
+    }
+  }
+
+  fn contract_to_edn(contract: &MacroSyntaxType) -> Edn {
+    match contract {
+      MacroSyntaxType::Syntax => Edn::Symbol(Arc::from("Syntax")),
+      MacroSyntaxType::SyntaxSymbol => Edn::Symbol(Arc::from("SyntaxSymbol")),
+      MacroSyntaxType::SyntaxList => Edn::Symbol(Arc::from("SyntaxList")),
+      MacroSyntaxType::Expr(semantic) => Edn::enum_value("Expr", vec![semantic.to_type_edn()]),
+    }
+  }
+
+  fn expansion_to_edn(expansion: &MacroExpansionType) -> Option<Edn> {
+    match expansion {
+      MacroExpansionType::Dynamic => None,
+      MacroExpansionType::Expr(semantic) => Some(Edn::enum_value("Expr", vec![semantic.to_type_edn()])),
+      MacroExpansionType::Definition(semantic) => Some(Edn::enum_value("Definition", vec![semantic.to_type_edn()])),
+      MacroExpansionType::Declarations => Some(Edn::enum_value("Declarations", vec![])),
+    }
+  }
+
+  pub fn to_wrapped_schema_edn(&self) -> Edn {
+    if let MacroSignatureCompatibility::Legacy(annotation) = &self.compatibility {
+      return annotation.to_wrapped_schema_edn();
+    }
+    let mut map = EdnMapView::default();
+    map.insert_key(
+      "required",
+      Edn::List(EdnListView(self.required_inputs.iter().map(Self::contract_to_edn).collect())),
+    );
+    if !self.optional_inputs.is_empty() {
+      map.insert_key(
+        "optional",
+        Edn::List(EdnListView(self.optional_inputs.iter().map(Self::contract_to_edn).collect())),
+      );
+    }
+    if let Some(rest) = &self.rest_input {
+      map.insert_key("rest", Self::contract_to_edn(rest));
+    }
+    if let Some(expansion) = Self::expansion_to_edn(&self.expansion) {
+      map.insert_key("expansion", expansion);
+    }
+    if !self.generics.is_empty() {
+      map.insert_key(
+        "generics",
+        Edn::List(EdnListView(self.generics.iter().map(|name| Edn::Symbol(name.clone())).collect())),
+      );
+    }
+    if let Some(where_bounds) = (CalcitFnTypeAnnotation {
+      generics: self.generics.clone(),
+      where_bounds: self.where_bounds.clone(),
+      arg_types: vec![],
+      return_type: crate::calcit::DYNAMIC_TYPE.clone(),
+      fn_kind: SchemaKind::Macro,
+      rest_type: None,
+      features: self.features.clone(),
+    })
+    .where_bounds_to_edn()
+    {
+      map.insert_key("where", where_bounds);
+    }
+    if !self.features.is_empty() {
+      let mut set = EdnSetView::default();
+      for feature in self.features.iter() {
+        set.insert(Edn::Tag(feature.clone()));
+      }
+      map.insert_key("features", Edn::Set(set));
+    }
+    Edn::enum_value("Macro", vec![Edn::Map(map)])
+  }
 }
 
 impl CalcitTypeAnnotation {
@@ -378,6 +613,24 @@ impl CalcitTypeAnnotation {
         value.validate_applied_type_args()
       }
       Self::Fn(signature) => signature.validate_applied_type_args(),
+      Self::Macro(signature) => {
+        for contract in signature.required_inputs.iter().chain(signature.optional_inputs.iter()) {
+          if let MacroSyntaxType::Expr(semantic) = contract {
+            semantic.validate_applied_type_args()?;
+          }
+        }
+        if let Some(MacroSyntaxType::Expr(semantic)) = &signature.rest_input {
+          semantic.validate_applied_type_args()?;
+        }
+        match &signature.expansion {
+          MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => semantic.validate_applied_type_args(),
+          MacroExpansionType::Dynamic | MacroExpansionType::Declarations => Ok(()),
+        }
+      }
+      Self::Syntax(contract) => match contract.as_ref() {
+        MacroSyntaxType::Expr(semantic) => semantic.validate_applied_type_args(),
+        MacroSyntaxType::Syntax | MacroSyntaxType::SyntaxSymbol | MacroSyntaxType::SyntaxList => Ok(()),
+      },
       Self::Struct(base, args) => {
         for arg in args.iter() {
           arg.validate_applied_type_args()?;
@@ -1272,6 +1525,90 @@ impl CalcitTypeAnnotation {
     Self::parse_type_annotation_form_inner(&Self::edn_type_to_calcit(form), &[], true)
   }
 
+  /// Parse a phase-aware macro signature. New signatures use
+  /// `:required/:optional/:rest/:expansion`; existing `:args/:return` macro
+  /// schemas are retained as explicitly legacy, non-strict signatures.
+  pub fn parse_macro_signature_from_edn(schema: &Edn) -> Option<MacroSignature> {
+    let (map, wrapped_macro) = match schema {
+      Edn::Map(map) => (map, false),
+      Edn::Enum(view) if matches!(view.variant.as_ref(), "macro" | "Macro") => match view.extra.first() {
+        Some(Edn::Map(map)) => (map, true),
+        _ => return None,
+      },
+      _ => return None,
+    };
+    let tagged_macro = matches!(map.tag_get("kind"), Some(Edn::Tag(tag)) if tag.ref_str() == "macro");
+    if !wrapped_macro && !tagged_macro {
+      return None;
+    }
+
+    let strict = ["required", "optional", "expansion"].iter().any(|key| map.tag_get(key).is_some());
+    if !strict {
+      let legacy = Self::parse_fn_schema_from_edn(schema)?;
+      return Some(MacroSignature::from_legacy_fn(legacy));
+    }
+
+    let generics: Vec<Arc<str>> = match map.tag_get("generics") {
+      None => vec![],
+      Some(Edn::List(xs)) => xs
+        .0
+        .iter()
+        .map(|item| match item {
+          Edn::Symbol(name) if !name.starts_with('\'') => Some(name.clone()),
+          _ => None,
+        })
+        .collect::<Option<Vec<_>>>()?,
+      Some(_) => return None,
+    };
+    let parse_contracts = |field: Option<&Edn>| -> Option<Vec<MacroSyntaxType>> {
+      match field {
+        None => Some(vec![]),
+        Some(Edn::List(xs)) => xs
+          .0
+          .iter()
+          .map(|item| MacroSignature::parse_contract(item, generics.as_slice()))
+          .collect(),
+        Some(_) => None,
+      }
+    };
+    let required_inputs = parse_contracts(map.tag_get("required"))?;
+    let optional_inputs = parse_contracts(map.tag_get("optional"))?;
+    let rest_input = match map.tag_get("rest") {
+      Some(item) => Some(MacroSignature::parse_contract(item, generics.as_slice())?),
+      None => None,
+    };
+    let expansion = MacroSignature::parse_expansion(map.tag_get("expansion"), generics.as_slice())?;
+    let where_bounds = map
+      .tag_get("where")
+      .and_then(|value| Self::parse_where_bounds_from_edn(value, generics.as_slice()))
+      .unwrap_or_default();
+    let features = map
+      .tag_get("features")
+      .and_then(|value| match value {
+        Edn::Set(xs) => Some(Arc::new(
+          xs.0
+            .iter()
+            .filter_map(|item| match item {
+              Edn::Tag(tag) => Some(tag.clone()),
+              _ => None,
+            })
+            .collect(),
+        )),
+        _ => None,
+      })
+      .unwrap_or_default();
+    Some(MacroSignature {
+      generics: Arc::new(generics),
+      where_bounds: Arc::new(where_bounds),
+      required_inputs: Arc::new(required_inputs),
+      optional_inputs: Arc::new(optional_inputs),
+      rest_input,
+      expansion,
+      features,
+      compatibility: MacroSignatureCompatibility::Strict,
+    })
+  }
+
   /// Parse a schema [`Edn`] map value (as stored in [`crate::snapshot::CodeEntry::schema`])
   /// directly into a [`CalcitFnTypeAnnotation`], without going through a Cirru/Calcit roundtrip.
   ///
@@ -1299,6 +1636,9 @@ impl CalcitTypeAnnotation {
       .iter()
       .any(|key| map.tag_get(key).is_some());
     if !has_schema_fields {
+      return None;
+    }
+    if ["required", "optional", "expansion"].iter().any(|key| map.tag_get(key).is_some()) {
       return None;
     }
 
@@ -2528,6 +2868,8 @@ impl CalcitTypeAnnotation {
   pub(crate) fn matches_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
     match (self, expected) {
       (_, Self::Dynamic) | (Self::Dynamic, _) => true,
+      (Self::Macro(actual), Self::Macro(expected)) => actual == expected,
+      (Self::Syntax(actual), Self::Syntax(expected)) => actual == expected,
       // Compatibility for annotations constructed by older embedders before
       // `:any` was normalized during parsing. Alias semantics are symmetric.
       (_, Self::Custom(expected)) if Self::custom_keyword_matches(expected, "any") => true,
@@ -3187,6 +3529,13 @@ impl CalcitTypeAnnotation {
 
     match self {
       Self::Fn(signature) => signature.describe(),
+      Self::Macro(_) => "macro-signature".to_owned(),
+      Self::Syntax(contract) => match contract.as_ref() {
+        MacroSyntaxType::Syntax => "syntax".to_owned(),
+        MacroSyntaxType::SyntaxSymbol => "syntax-symbol".to_owned(),
+        MacroSyntaxType::SyntaxList => "syntax-list".to_owned(),
+        MacroSyntaxType::Expr(semantic) => format!("syntax-expr<{}>", semantic.describe()),
+      },
       Self::Variadic(inner) => format!("variadic {}", inner.describe()),
       Self::Custom(_) => "custom".to_string(),
       Self::Optional(inner) => format!("optional<{}>", inner.describe()),
@@ -3259,6 +3608,8 @@ impl CalcitTypeAnnotation {
       Self::TypeSlot(_) => 31,
       Self::StructDef(_) => 32,
       Self::EnumDef(_) => 33,
+      Self::Macro(_) => 34,
+      Self::Syntax(_) => 35,
     }
   }
 }
@@ -3668,6 +4019,52 @@ mod tests {
   use super::*;
   use crate::calcit::CalcitSymbolInfo;
   use std::collections::BTreeSet;
+
+  #[test]
+  fn phase_aware_macro_signature_round_trips_without_fn_conflation() {
+    let mut map = EdnMapView::default();
+    map.insert_key("generics", Edn::List(EdnListView(vec![Edn::Symbol(Arc::from("T"))])));
+    map.insert_key(
+      "required",
+      Edn::List(EdnListView(vec![
+        Edn::Symbol(Arc::from("SyntaxSymbol")),
+        Edn::enum_value("Expr", vec![Edn::Symbol(Arc::from("T"))]),
+      ])),
+    );
+    map.insert_key("optional", Edn::List(EdnListView(vec![Edn::Symbol(Arc::from("SyntaxList"))])));
+    map.insert_key("rest", Edn::Symbol(Arc::from("Syntax")));
+    map.insert_key("expansion", Edn::enum_value("Expr", vec![Edn::Symbol(Arc::from("T"))]));
+    let schema = Edn::enum_value("Macro", vec![Edn::Map(map)]);
+
+    let signature = CalcitTypeAnnotation::parse_macro_signature_from_edn(&schema).expect("strict macro signature");
+    assert!(
+      CalcitTypeAnnotation::parse_fn_schema_from_edn(&schema).is_none(),
+      "strict macro contracts must not be accepted as runtime function annotations"
+    );
+    assert!(signature.is_strict());
+    assert!(matches!(
+      signature.required_inputs.as_slice(),
+      [MacroSyntaxType::SyntaxSymbol, MacroSyntaxType::Expr(_)]
+    ));
+    assert!(matches!(signature.optional_inputs.as_slice(), [MacroSyntaxType::SyntaxList]));
+    assert!(matches!(signature.rest_input, Some(MacroSyntaxType::Syntax)));
+    assert!(matches!(signature.expansion, MacroExpansionType::Expr(_)));
+
+    let reloaded = CalcitTypeAnnotation::parse_macro_signature_from_edn(&signature.to_wrapped_schema_edn()).expect("round trip");
+    assert_eq!(reloaded, signature);
+  }
+
+  #[test]
+  fn legacy_macro_schema_is_explicitly_non_strict() {
+    let mut map = EdnMapView::default();
+    map.insert_key("args", Edn::List(EdnListView(vec![Edn::Symbol(Arc::from("Struct"))])));
+    map.insert_key("return", Edn::Symbol(Arc::from("Struct")));
+    let schema = Edn::enum_value("Macro", vec![Edn::Map(map)]);
+    let signature = CalcitTypeAnnotation::parse_macro_signature_from_edn(&schema).expect("legacy macro schema");
+    assert!(!signature.is_strict());
+    assert!(matches!(signature.compatibility, MacroSignatureCompatibility::Legacy(_)));
+    assert!(matches!(signature.expansion, MacroExpansionType::Dynamic));
+  }
 
   fn core_impl_trait_names(definition: &str) -> BTreeSet<String> {
     fn visit(node: &cirru_parser::Cirru, names: &mut BTreeSet<String>) {
@@ -4922,6 +5319,14 @@ impl Hash for CalcitTypeAnnotation {
         signature.arg_types.hash(state);
         signature.return_type.hash(state);
       }
+      Self::Macro(signature) => {
+        "macro-signature".hash(state);
+        signature.hash(state);
+      }
+      Self::Syntax(contract) => {
+        "syntax".hash(state);
+        contract.hash(state);
+      }
       Self::Set(inner) => {
         "set".hash(state);
         inner.hash(state);
@@ -5034,6 +5439,8 @@ impl Ord for CalcitTypeAnnotation {
         .cmp(&b.generics)
         .then_with(|| a.arg_types.cmp(&b.arg_types))
         .then_with(|| a.return_type.cmp(&b.return_type)),
+      (Self::Macro(a), Self::Macro(b)) => a.cmp(b),
+      (Self::Syntax(a), Self::Syntax(b)) => a.cmp(b),
       (Self::Set(a), Self::Set(b)) => a.cmp(b),
       (Self::Ref(a), Self::Ref(b)) => a.cmp(b),
       (Self::Variadic(a), Self::Variadic(b)) => a.cmp(b),
@@ -5385,6 +5792,8 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
     CalcitTypeAnnotation::CirruQuote => matches!(value, Calcit::CirruQuote(_)),
     CalcitTypeAnnotation::AnonymousEnum => matches!(value, Calcit::Enum(_)),
     CalcitTypeAnnotation::DynFn | CalcitTypeAnnotation::Fn(_) => matches!(value, Calcit::Fn { .. } | Calcit::Proc(_)),
+    CalcitTypeAnnotation::Macro(_) => matches!(value, Calcit::Macro { .. }),
+    CalcitTypeAnnotation::Syntax(_) => false,
     CalcitTypeAnnotation::Struct(expected_struct, _) => match value {
       Calcit::Struct(r) => r.struct_ref.name == expected_struct.name,
       _ => false,

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -104,8 +104,9 @@
                 p $ %{}? Point (:x 1)
               assert= nil $ :y p
           :schema $ :: 'Macro
-            {} (:return 'Struct)
-              :args $ [] 'Struct
+            {} (:required $ [] 'SyntaxSymbol)
+              :rest 'SyntaxList
+              :expansion $ :: 'Expr 'Struct
           :tags $ #{} :macro
         |& $ %{} 'CodeEntry (:doc "|internal syntax for spreading in function definition and call\nSyntax: (& rest-args) in params or (f & args) in calls\nParams: varies based on context\nReturns: varies based on context\nMarks rest parameters or argument spreading")
           :code $ quote &runtime-implementation

--- a/src/detailed_snapshot.rs
+++ b/src/detailed_snapshot.rs
@@ -145,6 +145,7 @@ mod schema_serde {
     let edn: Option<Edn> = match schema.as_ref() {
       CalcitTypeAnnotation::Dynamic => None,
       CalcitTypeAnnotation::Fn(fn_annot) => Some(fn_annot.to_schema_edn()),
+      CalcitTypeAnnotation::Macro(signature) => Some(signature.to_wrapped_schema_edn()),
       _ => None,
     };
     edn.serialize(s)
@@ -157,8 +158,9 @@ mod schema_serde {
     let opt = Option::<Edn>::deserialize(d)?;
     Ok(match opt {
       None | Some(Edn::Nil) => DYNAMIC_TYPE.clone(),
-      Some(v) => CalcitTypeAnnotation::parse_fn_schema_from_edn(&v)
-        .map(|s| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(s))))
+      Some(v) => CalcitTypeAnnotation::parse_macro_signature_from_edn(&v)
+        .map(|s| Arc::new(CalcitTypeAnnotation::Macro(Arc::new(s))))
+        .or_else(|| CalcitTypeAnnotation::parse_fn_schema_from_edn(&v).map(|s| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(s)))))
         .unwrap_or_else(|| DYNAMIC_TYPE.clone()),
     })
   }
@@ -307,8 +309,9 @@ impl TryFrom<Edn> for DetailedCodeEntry {
         validate_test_names(tests.iter().map(|test| test.name.as_str()), "DetailedCodeEntry.tests")?;
         let schema_parsed: Arc<CalcitTypeAnnotation> = match schema {
           None | Some(Edn::Nil) => DYNAMIC_TYPE.clone(),
-          Some(v) => CalcitTypeAnnotation::parse_fn_schema_from_edn(&v)
-            .map(|s| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(s))))
+          Some(v) => CalcitTypeAnnotation::parse_macro_signature_from_edn(&v)
+            .map(|s| Arc::new(CalcitTypeAnnotation::Macro(Arc::new(s))))
+            .or_else(|| CalcitTypeAnnotation::parse_fn_schema_from_edn(&v).map(|s| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(s)))))
             .unwrap_or_else(|| DYNAMIC_TYPE.clone()),
         };
         Ok(DetailedCodeEntry {

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -7,9 +7,9 @@ use crate::{
   calcit::{
     self, Calcit, CalcitArgLabel, CalcitCallKind, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnTypeAnnotation, CalcitImpl,
     CalcitImport, CalcitList, CalcitLocal, CalcitNumberBinaryOp, CalcitProc, CalcitScope, CalcitStructDef, CalcitSymbolInfo,
-    CalcitSyntax, CalcitTrait, CalcitTraitMemberKind, CalcitTypeAnnotation, GENERATED_DEF, ImportInfo, LocatedWarning, NodeLocation,
-    ParamShape, ParamShapeToken, RawCodeType, SchemaKind, brief_type_of_value, compare_param_shapes, pop_type_slot_override,
-    push_type_slot_override, register_type_slot,
+    CalcitSyntax, CalcitTrait, CalcitTraitMemberKind, CalcitTypeAnnotation, GENERATED_DEF, ImportInfo, LocatedWarning,
+    MacroExpansionType, MacroSignature, MacroSyntaxType, NodeLocation, ParamShape, ParamShapeToken, RawCodeType, SchemaKind,
+    brief_type_of_value, compare_param_shapes, pop_type_slot_override, push_type_slot_override, register_type_slot,
   },
   call_stack::{CallStackList, StackKind},
   codegen, program, runner,
@@ -1706,6 +1706,15 @@ fn preprocess_list_call(
   match head_value {
     Some(Calcit::Macro { info, .. }) => {
       let mut current_values: Vec<Calcit> = args.to_vec();
+      let call_location = head_form.get_location().or_else(|| args.first().and_then(Calcit::get_location));
+      let mut macro_type_bindings = validate_macro_call_inputs(
+        info.name.as_ref(),
+        info.signature.as_ref(),
+        &args,
+        scope_types,
+        call_stack,
+        call_location.clone(),
+      )?;
 
       warn_on_trait_impl_method_tag_syntax(info.as_ref(), &args, file_ns, def_name.as_ref(), check_warnings);
 
@@ -1727,10 +1736,29 @@ fn preprocess_list_call(
         match code {
           Calcit::Recur(ys) => {
             current_values = ys;
+            let recur_args = CalcitList::from(current_values.as_slice());
+            macro_type_bindings = validate_macro_call_inputs(
+              info.name.as_ref(),
+              info.signature.as_ref(),
+              &recur_args,
+              scope_types,
+              &next_stack,
+              call_location.clone(),
+            )?;
           }
           _ => {
             // println!("gen code: {} {}", code, &code.lisp_str());
-            return preprocess_expr(&code, scope_defs, scope_types, file_ns, check_warnings, &next_stack);
+            let processed = preprocess_expr(&code, scope_defs, scope_types, file_ns, check_warnings, &next_stack)?;
+            validate_macro_expansion_result(
+              info.name.as_ref(),
+              info.signature.as_ref(),
+              (&code, &processed),
+              scope_types,
+              macro_type_bindings,
+              &next_stack,
+              call_location,
+            )?;
+            return Ok(processed);
           }
         }
       }
@@ -5051,6 +5079,204 @@ fn check_callable_type(
     }
   }
 }
+
+fn macro_syntax_contract_label(contract: &MacroSyntaxType) -> String {
+  match contract {
+    MacroSyntaxType::Syntax => "Syntax".to_owned(),
+    MacroSyntaxType::SyntaxSymbol => "SyntaxSymbol".to_owned(),
+    MacroSyntaxType::SyntaxList => "SyntaxList".to_owned(),
+    MacroSyntaxType::Expr(semantic) => format!("Expr<{}>", semantic.to_brief_string()),
+  }
+}
+
+fn macro_input_contract(signature: &MacroSignature, idx: usize) -> Option<&MacroSyntaxType> {
+  if idx < signature.required_inputs.len() {
+    signature.required_inputs.get(idx)
+  } else if idx < signature.required_inputs.len() + signature.optional_inputs.len() {
+    signature.optional_inputs.get(idx - signature.required_inputs.len())
+  } else {
+    signature.rest_input.as_ref()
+  }
+}
+
+fn validate_macro_call_inputs(
+  macro_name: &str,
+  signature: &MacroSignature,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  call_stack: &CallStackList,
+  call_location: Option<NodeLocation>,
+) -> Result<HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>, CalcitErr> {
+  let mut bindings = HashMap::new();
+  if !signature.is_strict() {
+    return Ok(bindings);
+  }
+  let min = signature.required_inputs.len();
+  let max = signature.required_inputs.len() + signature.optional_inputs.len();
+  if args.len() < min || (signature.rest_input.is_none() && args.len() > max) {
+    let expected = if signature.rest_input.is_some() {
+      format!("at least {min}")
+    } else if min == max {
+      min.to_string()
+    } else {
+      format!("{min}..={max}")
+    };
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Arity,
+      format!(
+        "macro input-syntax violation in `{macro_name}`: expected {expected} argument(s), got {}",
+        args.len()
+      ),
+      "E_MACRO_INPUT_ARITY",
+      call_stack,
+      call_location,
+    ));
+  }
+  for (idx, arg) in args.iter().enumerate() {
+    let Some(contract) = macro_input_contract(signature, idx) else {
+      continue;
+    };
+    let shape_matches = match contract {
+      MacroSyntaxType::Syntax | MacroSyntaxType::Expr(_) => true,
+      MacroSyntaxType::SyntaxSymbol => matches!(arg, Calcit::Symbol { .. }),
+      MacroSyntaxType::SyntaxList => matches!(arg, Calcit::List(_)),
+    };
+    if !shape_matches {
+      return Err(CalcitErr::use_msg_stack_location_with_code(
+        CalcitErrKind::Type,
+        format!(
+          "macro input-syntax violation in `{macro_name}` at argument {}: expected {}, got {}",
+          idx + 1,
+          macro_syntax_contract_label(contract),
+          brief_type_of_value(arg)
+        ),
+        "E_MACRO_INPUT_SYNTAX",
+        call_stack,
+        arg.get_location().or_else(|| call_location.clone()),
+      ));
+    }
+    if let MacroSyntaxType::Expr(expected) = contract
+      && let Some(actual) = infer_type_from_expr(arg, scope_types)
+      && !matches!(actual.as_ref(), CalcitTypeAnnotation::Dynamic)
+      && !actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings)
+    {
+      return Err(CalcitErr::use_msg_stack_location_with_code(
+        CalcitErrKind::Type,
+        format!(
+          "macro input-syntax violation in `{macro_name}` at argument {}: expression expects semantic type `{}`, got `{}`",
+          idx + 1,
+          expected.to_brief_string(),
+          actual.to_brief_string()
+        ),
+        "E_MACRO_INPUT_EXPR_TYPE",
+        call_stack,
+        arg.get_location().or_else(|| call_location.clone()),
+      ));
+    }
+  }
+  Ok(bindings)
+}
+
+fn is_definition_syntax(code: &Calcit) -> bool {
+  let Calcit::List(xs) = code else { return false };
+  match xs.first() {
+    Some(Calcit::Syntax(head, _)) => matches!(
+      head,
+      CalcitSyntax::Defn | CalcitSyntax::Defmacro | CalcitSyntax::DefWasmExport | CalcitSyntax::DefWasmImport
+    ),
+    Some(Calcit::Symbol { sym, .. }) => matches!(
+      sym.as_ref(),
+      "defn" | "defmacro" | "defstruct" | "defenum" | "deftrait" | "defimpl" | "defwasm-export" | "defwasm-import"
+    ),
+    _ => false,
+  }
+}
+
+fn validate_macro_expansion_result(
+  macro_name: &str,
+  signature: &MacroSignature,
+  expansion: (&Calcit, &Calcit),
+  scope_types: &ScopeTypes,
+  mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>,
+  call_stack: &CallStackList,
+  call_location: Option<NodeLocation>,
+) -> Result<(), CalcitErr> {
+  let (raw_expansion, processed) = expansion;
+  if !signature.is_strict() {
+    return Ok(());
+  }
+  match &signature.expansion {
+    MacroExpansionType::Dynamic => Ok(()),
+    MacroExpansionType::Declarations => {
+      let valid = is_definition_syntax(raw_expansion)
+        || matches!(raw_expansion, Calcit::List(xs) if xs.first().is_some_and(|head| matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "do")) && xs.iter().skip(1).all(is_definition_syntax));
+      if valid {
+        Ok(())
+      } else {
+        Err(CalcitErr::use_msg_stack_location_with_code(
+          CalcitErrKind::Type,
+          format!("macro expansion-result violation in `{macro_name}`: expected Declarations, got `{raw_expansion}`"),
+          "E_MACRO_EXPANSION_DECLARATIONS",
+          call_stack,
+          raw_expansion.get_location().or(call_location),
+        ))
+      }
+    }
+    MacroExpansionType::Definition(expected) => {
+      if !is_definition_syntax(raw_expansion) {
+        return Err(CalcitErr::use_msg_stack_location_with_code(
+          CalcitErrKind::Type,
+          format!(
+            "macro expansion-result violation in `{macro_name}`: expected Definition<{}>",
+            expected.to_brief_string()
+          ),
+          "E_MACRO_EXPANSION_DEFINITION",
+          call_stack,
+          raw_expansion.get_location().or(call_location),
+        ));
+      }
+      if let Some(actual) = resolve_type_value(processed, scope_types)
+        && !matches!(actual.as_ref(), CalcitTypeAnnotation::Dynamic)
+        && !actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings)
+      {
+        return Err(CalcitErr::use_msg_stack_location_with_code(
+          CalcitErrKind::Type,
+          format!(
+            "macro expansion-result violation in `{macro_name}`: expected definition type `{}`, got `{}`",
+            expected.to_brief_string(),
+            actual.to_brief_string()
+          ),
+          "E_MACRO_EXPANSION_DEFINITION_TYPE",
+          call_stack,
+          raw_expansion.get_location().or(call_location),
+        ));
+      }
+      Ok(())
+    }
+    MacroExpansionType::Expr(expected) => {
+      let Some(actual) = resolve_type_value(processed, scope_types) else {
+        return Ok(());
+      };
+      if matches!(actual.as_ref(), CalcitTypeAnnotation::Dynamic)
+        || actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings)
+      {
+        Ok(())
+      } else {
+        Err(CalcitErr::use_msg_stack_location_with_code(
+          CalcitErrKind::Type,
+          format!(
+            "macro expansion-result violation in `{macro_name}`: expected Expr<{}>, got `{}`",
+            expected.to_brief_string(),
+            actual.to_brief_string()
+          ),
+          "E_MACRO_EXPANSION_EXPR_TYPE",
+          call_stack,
+          raw_expansion.get_location().or(call_location),
+        ))
+      }
+    }
+  }
+}
 /// Get the impl records from a type value
 /// - If type_value is already a Struct, use it directly
 /// - If type_value is a Tag, map to corresponding core impl list
@@ -6026,7 +6252,14 @@ pub fn preprocess_defn(
       }
       warn_on_legacy_optional_public_schema(ctx.file_ns, def_name.as_ref(), &def_schema, ctx.check_warnings);
       let schema_issues = validate_def_schema_during_preprocess(head, ctx.file_ns, def_name.as_ref(), ys, &def_schema);
-      let (staged_macro_issues, hard_schema_issues) = partition_def_schema_issues(head, schema_issues);
+      let (staged_macro_issues, hard_schema_issues) = if matches!(
+        def_schema.as_ref(),
+        CalcitTypeAnnotation::Macro(signature) if signature.is_strict()
+      ) {
+        (vec![], schema_issues)
+      } else {
+        partition_def_schema_issues(head, schema_issues)
+      };
       let definition_location = NodeLocation::new(
         info.at_ns.to_owned(),
         info.at_def.to_owned(),
@@ -6066,6 +6299,28 @@ pub fn preprocess_defn(
         CalcitTypeAnnotation::Dynamic => EXPECTED_FN_TYPE.with(|cell| cell.borrow().clone()),
         _ => None,
       });
+      if let CalcitTypeAnnotation::Macro(signature) = def_schema.as_ref()
+        && signature.is_strict()
+      {
+        let required_types = signature
+          .required_inputs
+          .iter()
+          .map(|contract| Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(contract.clone()))));
+        let optional_types = signature.optional_inputs.iter().map(|contract| {
+          Arc::new(CalcitTypeAnnotation::Optional(Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(
+            contract.clone(),
+          )))))
+        });
+        let parameter_types = required_types.chain(optional_types).chain(
+          signature
+            .rest_input
+            .iter()
+            .map(|_| Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(MacroSyntaxType::SyntaxList)))),
+        );
+        for (param_sym, type_info) in param_symbols.iter().zip(parameter_types) {
+          body_types.insert(param_sym.clone(), type_info);
+        }
+      }
       if let Some(fn_annot) = &effective_fn_schema {
         let body_type_bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = fn_annot
           .where_bounds
@@ -6123,7 +6378,10 @@ pub fn preprocess_defn(
       let prev_features = CURRENT_FN_FEATURES.with(|cell| {
         let mut guard = cell.borrow_mut();
         let old = guard.take();
-        *guard = effective_fn_schema.as_ref().map(|fn_annot| fn_annot.features.clone());
+        *guard = match def_schema.as_ref() {
+          CalcitTypeAnnotation::Macro(signature) => Some(signature.features.clone()),
+          _ => effective_fn_schema.as_ref().map(|fn_annot| fn_annot.features.clone()),
+        };
         old
       });
 
@@ -6873,6 +7131,30 @@ fn contains_legacy_optional(annotation: &CalcitTypeAnnotation) -> bool {
         || info.rest_type.as_ref().is_some_and(|item| contains_legacy_optional(item))
         || contains_legacy_optional(info.return_type.as_ref())
     }
+    CalcitTypeAnnotation::Macro(signature) => match &signature.compatibility {
+      crate::calcit::MacroSignatureCompatibility::Legacy(info) => {
+        info.arg_types.iter().any(|item| contains_legacy_optional(item))
+          || info.rest_type.as_ref().is_some_and(|item| contains_legacy_optional(item))
+          || contains_legacy_optional(info.return_type.as_ref())
+      }
+      crate::calcit::MacroSignatureCompatibility::Strict => {
+        let contract_contains = |contract: &MacroSyntaxType| match contract {
+          MacroSyntaxType::Expr(semantic) => contains_legacy_optional(semantic),
+          MacroSyntaxType::Syntax | MacroSyntaxType::SyntaxSymbol | MacroSyntaxType::SyntaxList => false,
+        };
+        signature.required_inputs.iter().any(contract_contains)
+          || signature.optional_inputs.iter().any(contract_contains)
+          || signature.rest_input.as_ref().is_some_and(contract_contains)
+          || match &signature.expansion {
+            MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => contains_legacy_optional(semantic),
+            MacroExpansionType::Dynamic | MacroExpansionType::Declarations => false,
+          }
+      }
+    },
+    CalcitTypeAnnotation::Syntax(contract) => match contract.as_ref() {
+      MacroSyntaxType::Expr(semantic) => contains_legacy_optional(semantic),
+      MacroSyntaxType::Syntax | MacroSyntaxType::SyntaxSymbol | MacroSyntaxType::SyntaxList => false,
+    },
     CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => {
       args.iter().any(|item| contains_legacy_optional(item))
     }
@@ -6913,6 +7195,35 @@ fn validate_def_schema_during_preprocess(
   args: &CalcitList,
   schema: &CalcitTypeAnnotation,
 ) -> Vec<String> {
+  if let CalcitTypeAnnotation::Macro(signature) = schema {
+    if !matches!(head, CalcitSyntax::Defmacro) {
+      let code_kind = match head {
+        CalcitSyntax::Defn => "defn",
+        CalcitSyntax::DefWasmExport => "defwasm-export",
+        CalcitSyntax::DefWasmImport => "defwasm-import",
+        _ => "non-macro definition",
+      };
+      return vec![format!(
+        "[E_SCHEMA_KIND] {ns}/{def_name}: schema :kind is :macro but code uses {code_kind}"
+      )];
+    }
+    if signature.is_strict() {
+      let code_shape = analyze_def_schema_param_shape(args);
+      let schema_shape = ParamShape {
+        required: signature.required_inputs.len(),
+        optional: signature.optional_inputs.len(),
+        has_rest: signature.rest_input.is_some(),
+        errors: vec![],
+      };
+      return compare_param_shapes(&format!("{ns}/{def_name}"), &code_shape, &schema_shape);
+    }
+    if let crate::calcit::MacroSignatureCompatibility::Legacy(fn_annot) = &signature.compatibility {
+      let code_shape = analyze_def_schema_param_shape(args);
+      let schema_shape = ParamShape::from_schema(&fn_annot.arg_types, fn_annot.rest_type.is_some());
+      return compare_param_shapes(&format!("{ns}/{def_name}"), &code_shape, &schema_shape);
+    }
+    return vec![];
+  }
   let CalcitTypeAnnotation::Fn(fn_annot) = schema else {
     return vec![];
   };
@@ -6964,6 +7275,139 @@ mod tests {
   use std::sync::{LazyLock, Mutex};
 
   static PREPROCESS_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+  fn strict_macro_signature(
+    required_inputs: Vec<MacroSyntaxType>,
+    optional_inputs: Vec<MacroSyntaxType>,
+    rest_input: Option<MacroSyntaxType>,
+    expansion: MacroExpansionType,
+  ) -> MacroSignature {
+    MacroSignature {
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      required_inputs: Arc::new(required_inputs),
+      optional_inputs: Arc::new(optional_inputs),
+      rest_input,
+      expansion,
+      features: Arc::new(HashSet::new()),
+      compatibility: crate::calcit::MacroSignatureCompatibility::Strict,
+    }
+  }
+
+  fn test_symbol(name: &str) -> Calcit {
+    Calcit::Symbol {
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.macro-signature"),
+        at_def: Arc::from("demo"),
+      }),
+      location: Some(Arc::from(vec![1, 2, 3])),
+    }
+  }
+
+  #[test]
+  fn phase_aware_macro_inputs_distinguish_symbols_lists_quotes_and_expr_generics() {
+    let signature = strict_macro_signature(
+      vec![
+        MacroSyntaxType::SyntaxSymbol,
+        MacroSyntaxType::Expr(Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))),
+      ],
+      vec![MacroSyntaxType::SyntaxList],
+      Some(MacroSyntaxType::Syntax),
+      MacroExpansionType::Expr(Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))),
+    );
+    let syntax_list = Calcit::from(vec![test_symbol("f"), Calcit::Number(1.0)]);
+    let quoted_literal = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::Quote, Arc::from("tests.macro-signature")),
+      test_symbol("literal"),
+    ]);
+    let args = CalcitList::from(vec![test_symbol("name"), Calcit::Number(1.0), syntax_list, quoted_literal].as_slice());
+    let bindings = validate_macro_call_inputs(
+      "typed-macro",
+      &signature,
+      &args,
+      &ScopeTypes::new(),
+      &CallStackList::default(),
+      None,
+    )
+    .expect("valid syntax contracts");
+    assert!(matches!(bindings.get("T").map(Arc::as_ref), Some(CalcitTypeAnnotation::Number)));
+
+    let invalid = CalcitList::from(vec![Calcit::from(vec![test_symbol("quoted")]), Calcit::Number(1.0)].as_slice());
+    let err = validate_macro_call_inputs(
+      "typed-macro",
+      &signature,
+      &invalid,
+      &ScopeTypes::new(),
+      &CallStackList::default(),
+      None,
+    )
+    .expect_err("a list is not symbol syntax");
+    assert_eq!(err.code.as_deref(), Some("E_MACRO_INPUT_SYNTAX"));
+    assert!(err.msg.contains("input-syntax violation"));
+
+    validate_macro_expansion_result(
+      "typed-macro",
+      &signature,
+      (&Calcit::Number(2.0), &Calcit::Number(2.0)),
+      &ScopeTypes::new(),
+      bindings.clone(),
+      &CallStackList::default(),
+      None,
+    )
+    .expect("generic expansion type follows Expr<T> input");
+    let err = validate_macro_expansion_result(
+      "typed-macro",
+      &signature,
+      (&Calcit::Str(Arc::from("wrong")), &Calcit::Str(Arc::from("wrong"))),
+      &ScopeTypes::new(),
+      bindings,
+      &CallStackList::default(),
+      None,
+    )
+    .expect_err("wrong expansion result type");
+    assert_eq!(err.code.as_deref(), Some("E_MACRO_EXPANSION_EXPR_TYPE"));
+    assert!(err.msg.contains("expansion-result violation"));
+  }
+
+  #[test]
+  fn phase_aware_macro_definition_and_declarations_outputs_are_distinct() {
+    let definition = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::Defn, Arc::from("tests.macro-signature")),
+      test_symbol("generated"),
+      Calcit::from(vec![]),
+      Calcit::Number(1.0),
+    ]);
+    let definition_signature = strict_macro_signature(
+      vec![],
+      vec![],
+      None,
+      MacroExpansionType::Definition(Arc::new(CalcitTypeAnnotation::Dynamic)),
+    );
+    validate_macro_expansion_result(
+      "define-one",
+      &definition_signature,
+      (&definition, &definition),
+      &ScopeTypes::new(),
+      HashMap::new(),
+      &CallStackList::default(),
+      None,
+    )
+    .expect("definition output");
+
+    let declarations_signature = strict_macro_signature(vec![], vec![], None, MacroExpansionType::Declarations);
+    let err = validate_macro_expansion_result(
+      "define-many",
+      &declarations_signature,
+      (&Calcit::Number(1.0), &Calcit::Number(1.0)),
+      &ScopeTypes::new(),
+      HashMap::new(),
+      &CallStackList::default(),
+      None,
+    )
+    .expect_err("expression is not declarations");
+    assert_eq!(err.code.as_deref(), Some("E_MACRO_EXPANSION_DECLARATIONS"));
+  }
 
   fn lock_preprocess_test_state() -> std::sync::MutexGuard<'static, ()> {
     PREPROCESS_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
@@ -10388,6 +10832,7 @@ mod tests {
       def_ns: Arc::from(calcit::CORE_NS),
       args: Arc::new(vec![]),
       body: Arc::new(vec![]),
+      signature: Arc::new(crate::calcit::MacroSignature::legacy_dynamic()),
     };
 
     let warnings = RefCell::new(vec![]);

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -7,9 +7,7 @@ use std::collections::hash_set::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::calcit::{
-  Calcit, CalcitFnTypeAnnotation, CalcitTypeAnnotation, DYNAMIC_TYPE, SchemaKind, with_type_annotation_warning_context,
-};
+use crate::calcit::{Calcit, CalcitTypeAnnotation, DYNAMIC_TYPE, MacroSignature, with_type_annotation_warning_context};
 use crate::data::edn::{format_deserialize_error, format_edn_display};
 
 const SNAPSHOT_ABOUT_MESSAGE: &str = "Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.";
@@ -46,6 +44,9 @@ fn canonical_schema_field_name(text: &str) -> Option<&'static str> {
     "kind" => Some("kind"),
     "args" => Some("args"),
     "return" => Some("return"),
+    "required" => Some("required"),
+    "optional" => Some("optional"),
+    "expansion" => Some("expansion"),
     "rest" => Some("rest"),
     "generics" => Some("generics"),
     "where" => Some("where"),
@@ -527,6 +528,9 @@ fn parse_loaded_schema_annotation(value: &Edn, owner: &str) -> Result<Arc<Calcit
     parse_schema_data(&schema_cirru)
       .map_err(|e| format!("failed to validate {owner}: {e}; schema={}", format_edn_preview(&normalized)))?;
 
+    if let Some(signature) = CalcitTypeAnnotation::parse_macro_signature_from_edn(&normalized) {
+      return Ok(Arc::new(CalcitTypeAnnotation::Macro(Arc::new(signature))));
+    }
     return CalcitTypeAnnotation::parse_fn_schema_from_edn(&normalized)
       .map(|s| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(s))))
       .ok_or_else(|| {
@@ -606,6 +610,7 @@ pub fn schema_annotation_to_edn(schema: &CalcitTypeAnnotation) -> Edn {
   let expression = match schema {
     CalcitTypeAnnotation::Dynamic => Edn::Symbol(Arc::from("Dynamic")),
     CalcitTypeAnnotation::Fn(fn_annot) => fn_annot.to_wrapped_schema_edn(),
+    CalcitTypeAnnotation::Macro(signature) => signature.to_wrapped_schema_edn(),
     // Runtime-resolved nominal types are intentionally persisted as their
     // broad schema kinds. Their concrete definitions belong to source code,
     // and serializing only a local name would lose namespace identity.
@@ -1230,7 +1235,18 @@ fn validate_serialized_snapshot_content(content: &str) -> Result<(), String> {
 }
 
 /// Valid top-level field names accepted in a schema map.
-pub const VALID_SCHEMA_FIELDS: &[&str] = &[":kind", ":args", ":return", ":rest", ":generics", ":where", ":features"];
+pub const VALID_SCHEMA_FIELDS: &[&str] = &[
+  ":kind",
+  ":args",
+  ":return",
+  ":required",
+  ":optional",
+  ":expansion",
+  ":rest",
+  ":generics",
+  ":where",
+  ":features",
+];
 
 /// Recursively check a Cirru schema tree for deprecated `:nil` type annotations.
 fn check_no_nil_type(node: &Cirru) -> Result<(), String> {
@@ -1577,6 +1593,9 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
   let mut args_node: Option<&Cirru> = None;
   let mut return_node: Option<&Cirru> = None;
   let mut rest_node: Option<&Cirru> = None;
+  let mut required_node: Option<&Cirru> = None;
+  let mut optional_node: Option<&Cirru> = None;
+  let mut expansion_node: Option<&Cirru> = None;
   let mut where_node: Option<&Cirru> = None;
   let mut features_node: Option<&Cirru> = None;
 
@@ -1588,6 +1607,9 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
         ":generics" => generics_node = Some(val),
         ":args" => args_node = Some(val),
         ":return" => return_node = Some(val),
+        ":required" => required_node = Some(val),
+        ":optional" => optional_node = Some(val),
+        ":expansion" => expansion_node = Some(val),
         ":rest" => rest_node = Some(val),
         ":where" => where_node = Some(val),
         ":features" => features_node = Some(val),
@@ -1608,6 +1630,9 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
       collect_type_vars(node, &mut used);
     }
     if let Some(node) = rest_node {
+      collect_type_vars(node, &mut used);
+    }
+    for node in [required_node, optional_node, expansion_node].into_iter().flatten() {
       collect_type_vars(node, &mut used);
     }
     if let Some(node) = where_node {
@@ -1641,6 +1666,9 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
       collect_type_vars(node, &mut used);
     }
     if let Some(node) = rest_node {
+      collect_type_vars(node, &mut used);
+    }
+    for node in [required_node, optional_node, expansion_node].into_iter().flatten() {
       collect_type_vars(node, &mut used);
     }
     if let Some(node) = where_node {
@@ -1697,8 +1725,12 @@ pub fn parse_schema_annotation_for_write(schema: &Cirru) -> Result<Arc<CalcitTyp
     return Ok(annotation);
   }
   Ok(
-    CalcitTypeAnnotation::parse_fn_schema_from_edn(&schema_edn)
-      .map(|signature| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature))))
+    CalcitTypeAnnotation::parse_macro_signature_from_edn(&schema_edn)
+      .map(|signature| Arc::new(CalcitTypeAnnotation::Macro(Arc::new(signature))))
+      .or_else(|| {
+        CalcitTypeAnnotation::parse_fn_schema_from_edn(&schema_edn)
+          .map(|signature| Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature))))
+      })
       .unwrap_or_else(|| CalcitTypeAnnotation::parse_type_annotation_from_edn(&schema_edn)),
   )
 }
@@ -1749,23 +1781,16 @@ fn normalize_schema_for_code(code: &Cirru, schema: &Arc<CalcitTypeAnnotation>) -
     }
   }
 
-  let CalcitTypeAnnotation::Fn(fn_annot) = schema.as_ref() else {
-    return schema.clone();
-  };
-
-  if !code_declares_macro(code) || matches!(fn_annot.fn_kind, SchemaKind::Macro) {
+  if !code_declares_macro(code) || matches!(schema.as_ref(), CalcitTypeAnnotation::Macro(_)) {
     return schema.clone();
   }
-
-  Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
-    generics: fn_annot.generics.clone(),
-    where_bounds: fn_annot.where_bounds.clone(),
-    arg_types: fn_annot.arg_types.clone(),
-    return_type: fn_annot.return_type.clone(),
-    fn_kind: SchemaKind::Macro,
-    rest_type: fn_annot.rest_type.clone(),
-    features: fn_annot.features.clone(),
-  })))
+  match schema.as_ref() {
+    CalcitTypeAnnotation::Fn(fn_annot) => Arc::new(CalcitTypeAnnotation::Macro(Arc::new(MacroSignature::from_legacy_fn(
+      fn_annot.as_ref().clone(),
+    )))),
+    CalcitTypeAnnotation::Dynamic => Arc::new(CalcitTypeAnnotation::Macro(Arc::new(MacroSignature::legacy_dynamic()))),
+    _ => schema.clone(),
+  }
 }
 
 /// structure of runtime snapshot files such as `calcit.cirru` (legacy: `compact.cirru`)
@@ -3575,7 +3600,7 @@ mod tests {
     // 2. Format it to Cirru string (via cirru_edn::format)
     // 3. Parse it back (via cirru_edn::parse)
     // 4. TryFrom<Edn> for CodeEntry
-    // 5. Check entry.schema is Fn with fn_kind: Macro
+    // 5. Check entry.schema is the dedicated legacy-compatible MacroSignature
 
     let schema_text = "{} (:kind :macro) (:return :bool) (:args ([] :number :number))";
     let schema_cirru = cirru_parser::parse(schema_text)
@@ -3618,17 +3643,17 @@ mod tests {
     let reloaded: CodeEntry = parsed_edn.try_into().expect("TryFrom<Edn> should succeed");
 
     // Check the schema was preserved
-    match reloaded.schema.as_ref() {
-      CalcitTypeAnnotation::Fn(fn_annot) => {
-        assert_eq!(
-          fn_annot.fn_kind,
-          SchemaKind::Macro,
-          "fn_kind must survive round-trip; cirru_text: {cirru_text:?}"
-        );
-        assert_eq!(fn_annot.arg_types.len(), 2, "arg_types must survive round-trip");
-      }
-      other => panic!("schema must be Fn after round-trip, got {other:?}; cirru_text: {cirru_text:?}"),
-    }
+    let CalcitTypeAnnotation::Macro(signature) = reloaded.schema.as_ref() else {
+      panic!(
+        "schema must be Macro after round-trip, got {:?}; cirru_text: {cirru_text:?}",
+        reloaded.schema
+      )
+    };
+    let crate::calcit::MacroSignatureCompatibility::Legacy(fn_annot) = &signature.compatibility else {
+      panic!("legacy schema should keep compatibility payload")
+    };
+    assert_eq!(fn_annot.fn_kind, SchemaKind::Macro);
+    assert_eq!(fn_annot.arg_types.len(), 2, "arg_types must survive round-trip");
   }
 
   #[test]
@@ -3795,10 +3820,13 @@ mod tests {
     );
 
     let entry: CodeEntry = entry.try_into().expect("code entry should parse");
-    let CalcitTypeAnnotation::Fn(fn_annot) = entry.schema.as_ref() else {
-      panic!("schema should be fn-like");
+    let CalcitTypeAnnotation::Macro(signature) = entry.schema.as_ref() else {
+      panic!("defmacro schema should normalize to MacroSignature");
     };
-    assert_eq!(fn_annot.fn_kind, SchemaKind::Macro);
+    assert!(matches!(
+      signature.compatibility,
+      crate::calcit::MacroSignatureCompatibility::Legacy(_)
+    ));
   }
 
   #[test]
@@ -3849,6 +3877,29 @@ mod tests {
   }
 
   #[test]
+  fn phase_aware_macro_schema_writes_and_loads_as_macro_signature() {
+    let schema = cirru_parser::parse(
+      ":: 'Macro\n  {} (:generics $ [] 'T)\n    :required $ [] 'SyntaxSymbol (:: 'Expr 'T)\n    :optional $ [] 'SyntaxList\n    :rest 'Syntax\n    :expansion $ :: 'Expr 'T",
+    )
+    .expect("strict macro schema should parse")
+    .into_iter()
+    .next()
+    .expect("schema node");
+    let annotation = parse_schema_annotation_for_write(&schema).expect("strict macro schema should validate");
+    let CalcitTypeAnnotation::Macro(signature) = annotation.as_ref() else {
+      panic!("strict macro schema must not become Fn: {annotation:?}")
+    };
+    assert!(signature.is_strict());
+    assert_eq!(signature.required_inputs.len(), 2);
+    assert_eq!(signature.optional_inputs.len(), 1);
+    assert!(signature.rest_input.is_some());
+
+    let saved = schema_annotation_to_edn(annotation.as_ref());
+    let loaded = parse_loaded_schema_annotation(&saved, "test macro schema").expect("saved strict signature should reload");
+    assert_eq!(loaded, annotation);
+  }
+
+  #[test]
   fn test_load_snapshot_preserves_selected_real_world_schemas() {
     let core_file_content = fs::read_to_string("src/cirru/calcit-core.cirru").expect("Failed to read calcit-core.cirru");
     let edn_data = cirru_edn::parse(&core_file_content).expect("Failed to parse cirru content as EDN");
@@ -3870,11 +3921,17 @@ mod tests {
       "optionally",
     ] {
       let entry = core_file.defs.get(def_name).unwrap_or_else(|| panic!("missing def: {def_name}"));
-      assert!(
-        matches!(entry.schema.as_ref(), CalcitTypeAnnotation::Fn(_)),
-        "schema for {def_name} should stay fn-like after load, got {:?}",
-        entry.schema
-      );
+      if matches!(def_name, "%{}" | "deftrait" | "[,]" | "noted") {
+        assert!(
+          matches!(entry.schema.as_ref(), CalcitTypeAnnotation::Macro(_)),
+          "{def_name} should load as MacroSignature"
+        );
+      } else {
+        assert!(
+          matches!(entry.schema.as_ref(), CalcitTypeAnnotation::Fn(_)),
+          "schema for {def_name} should stay fn-like"
+        );
+      }
     }
   }
 

--- a/src/type_coverage.rs
+++ b/src/type_coverage.rs
@@ -6,8 +6,8 @@ use std::fmt::Write;
 use std::sync::Arc;
 
 use calcit::calcit::{
-  CalcitProc, CalcitSyntax, CalcitTypeAnnotation, ParamShape, ParamShapeToken, ProcTypeSignature, SchemaKind, SyntaxTypeSignature,
-  compare_param_shapes, resolve_type_slot,
+  CalcitProc, CalcitSyntax, CalcitTypeAnnotation, MacroExpansionType, MacroSignatureCompatibility, MacroSyntaxType, ParamShape,
+  ParamShapeToken, ProcTypeSignature, SchemaKind, SyntaxTypeSignature, compare_param_shapes, resolve_type_slot,
 };
 use calcit::cli_args::{CheckTypesCommand, WeakTypesCommand};
 use calcit::snapshot;
@@ -88,6 +88,12 @@ fn unwrap_singleton_group(mut node: &Cirru) -> &Cirru {
 fn entry_polymorphism(entry: &snapshot::CodeEntry) -> (Vec<String>, Vec<String>) {
   if let CalcitTypeAnnotation::Fn(fn_annot) = entry.schema.as_ref() {
     return fn_polymorphism(fn_annot);
+  }
+  if let CalcitTypeAnnotation::Macro(signature) = entry.schema.as_ref() {
+    return (
+      signature.generics.iter().map(|name| format!("'{name}")).collect(),
+      signature.where_bounds.iter().map(|bound| bound.to_brief_string()).collect(),
+    );
   }
 
   let Cirru::List(items) = &entry.code else {
@@ -269,6 +275,31 @@ fn count_annotation_positions(annotation: &CalcitTypeAnnotation) -> (usize, usiz
       add(&fn_annot.return_type);
       if let Some(rest) = &fn_annot.rest_type {
         add(rest);
+      }
+    }
+    CalcitTypeAnnotation::Macro(signature) => {
+      if let MacroSignatureCompatibility::Legacy(fn_annot) = &signature.compatibility {
+        for arg in &fn_annot.arg_types {
+          add(arg);
+        }
+        add(&fn_annot.return_type);
+        if let Some(rest) = &fn_annot.rest_type {
+          add(rest);
+        }
+      } else {
+        for contract in signature.required_inputs.iter().chain(signature.optional_inputs.iter()) {
+          if let MacroSyntaxType::Expr(semantic) = contract {
+            add(semantic);
+          }
+        }
+        if let Some(MacroSyntaxType::Expr(semantic)) = &signature.rest_input {
+          add(semantic);
+        }
+        match &signature.expansion {
+          MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => add(semantic),
+          MacroExpansionType::Dynamic => dynamic += 1,
+          MacroExpansionType::Declarations => {}
+        }
       }
     }
     CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => {
@@ -524,6 +555,32 @@ fn scan_schema_dynamic_annotation(
         scan_schema_dynamic_annotation(rest, &format!("{path}.rest"), &rest_detail, occurrences);
       }
     }
+    CalcitTypeAnnotation::Macro(signature) => {
+      if let MacroSignatureCompatibility::Legacy(fn_annot) = &signature.compatibility {
+        for (idx, arg) in fn_annot.arg_types.iter().enumerate() {
+          scan_schema_dynamic_annotation(arg, &format!("{path}.legacy-args.{idx}"), detail, occurrences);
+        }
+        scan_schema_dynamic_annotation(&fn_annot.return_type, &format!("{path}.legacy-return"), detail, occurrences);
+      } else {
+        for (idx, contract) in signature.required_inputs.iter().chain(signature.optional_inputs.iter()).enumerate() {
+          if let MacroSyntaxType::Expr(semantic) = contract {
+            scan_schema_dynamic_annotation(semantic, &format!("{path}.inputs.{idx}.expr"), detail, occurrences);
+          }
+        }
+        if let Some(MacroSyntaxType::Expr(semantic)) = &signature.rest_input {
+          scan_schema_dynamic_annotation(semantic, &format!("{path}.rest.expr"), detail, occurrences);
+        }
+        match &signature.expansion {
+          MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => {
+            scan_schema_dynamic_annotation(semantic, &format!("{path}.expansion"), detail, occurrences);
+          }
+          MacroExpansionType::Dynamic => {
+            scan_schema_dynamic_annotation(&CalcitTypeAnnotation::Dynamic, &format!("{path}.expansion"), detail, occurrences)
+          }
+          MacroExpansionType::Declarations => {}
+        }
+      }
+    }
     CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => {
       for (idx, arg) in args.iter().enumerate() {
         let type_arg_detail = extend_schema_dynamic_detail(detail, "type-arg");
@@ -630,10 +687,11 @@ fn weak_type_impact(occurrence: &WeakTypeOccurrence) -> &'static str {
 fn entry_schema_issues(ns: &str, def_name: &str, code: &Cirru, schema: &Arc<CalcitTypeAnnotation>) -> Vec<String> {
   let annotation = schema.as_ref();
   let mut issues = validate_def_vs_schema(ns, def_name, code, annotation);
-  let has_js_ffi_feature = matches!(
-    annotation,
-    CalcitTypeAnnotation::Fn(fn_annot) if fn_annot.features.iter().any(|feature| feature.ref_str() == "js-ffi")
-  );
+  let has_js_ffi_feature = match annotation {
+    CalcitTypeAnnotation::Fn(fn_annot) => fn_annot.features.iter().any(|feature| feature.ref_str() == "js-ffi"),
+    CalcitTypeAnnotation::Macro(signature) => signature.features.iter().any(|feature| feature.ref_str() == "js-ffi"),
+    _ => false,
+  };
   if matches!(annotation, CalcitTypeAnnotation::Dynamic) {
     if matches!(code, Cirru::List(items) if matches!(items.first(), Some(Cirru::Leaf(head)) if head.as_ref() == "defmacro")) {
       let (warning, detail) = if snapshot::schema_annotation_is_missing(schema) {
@@ -719,6 +777,10 @@ fn classify_code_nil(parent: Option<&WeakCodeParent>) -> &'static str {
 fn nil_return_intent(annotation: &CalcitTypeAnnotation) -> WeakTypeIntent {
   let return_type = match annotation {
     CalcitTypeAnnotation::Fn(fn_annotation) => fn_annotation.return_type.as_ref(),
+    CalcitTypeAnnotation::Macro(signature) => match &signature.expansion {
+      MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => semantic.as_ref(),
+      MacroExpansionType::Dynamic | MacroExpansionType::Declarations => annotation,
+    },
     other => other,
   };
   match return_type {
@@ -1011,10 +1073,11 @@ pub fn analyze_weak_types_entry(
 
   occurrences.retain(|occurrence| selected.contains(&occurrence.kind));
 
-  let has_js_ffi_feature = matches!(
-    entry.schema.as_ref(),
-    CalcitTypeAnnotation::Fn(fn_annot) if fn_annot.features.iter().any(|feature| feature.ref_str() == "js-ffi")
-  );
+  let has_js_ffi_feature = match entry.schema.as_ref() {
+    CalcitTypeAnnotation::Fn(fn_annot) => fn_annot.features.iter().any(|feature| feature.ref_str() == "js-ffi"),
+    CalcitTypeAnnotation::Macro(signature) => signature.features.iter().any(|feature| feature.ref_str() == "js-ffi"),
+    _ => false,
+  };
   if has_js_ffi_feature {
     for occurrence in &mut occurrences {
       if matches!(occurrence.kind, WeakTypeKind::SchemaDynamic | WeakTypeKind::CodeDynamic) {
@@ -1728,6 +1791,36 @@ pub fn validate_def_vs_schema(ns: &str, def_name: &str, code: &Cirru, schema: &C
     return vec![];
   }
 
+  if let CalcitTypeAnnotation::Macro(signature) = schema {
+    let Cirru::List(xs) = code else { return vec![] };
+    if !matches!(xs.first(), Some(Cirru::Leaf(head)) if head.as_ref() == "defmacro") {
+      let code_kind = xs
+        .first()
+        .and_then(|head| match head {
+          Cirru::Leaf(head) => Some(head.as_ref()),
+          _ => None,
+        })
+        .unwrap_or("non-macro definition");
+      return vec![format!(
+        "[E_SCHEMA_KIND] {ns}/{def_name}: schema :kind is :macro but code uses {code_kind}"
+      )];
+    }
+    let code_shape = analyze_param_shape(xs.get(2));
+    let schema_shape = if signature.is_strict() {
+      ParamShape {
+        required: signature.required_inputs.len(),
+        optional: signature.optional_inputs.len(),
+        has_rest: signature.rest_input.is_some(),
+        errors: vec![],
+      }
+    } else if let MacroSignatureCompatibility::Legacy(fn_annot) = &signature.compatibility {
+      ParamShape::from_schema(&fn_annot.arg_types, fn_annot.rest_type.is_some())
+    } else {
+      return vec![];
+    };
+    return compare_param_shapes(&format!("{ns}/{def_name}"), &code_shape, &schema_shape);
+  }
+
   let CalcitTypeAnnotation::Fn(fn_annot) = schema else {
     // Non-Fn schema (Dynamic, etc.) has no structural constraints
     return vec![];
@@ -1803,6 +1896,74 @@ pub fn analyze_code_entry(ns: &str, def_name: &str, entry: &snapshot::CodeEntry)
     {
       return analyze_builtin_syntax(def_name, &sig);
     }
+  }
+
+  if let CalcitTypeAnnotation::Macro(signature) = entry.schema.as_ref() {
+    if let MacroSignatureCompatibility::Legacy(fn_annot) = &signature.compatibility
+      && let Ok(schema) = snapshot::schema_edn_to_cirru(&fn_annot.to_schema_edn())
+      && let Some((params, param_annotations, return_type_hints, level)) = extract_fn_schema_hints(&schema)
+    {
+      return TypeCoverageRow {
+        ns: ns.to_owned(),
+        def: def_name.to_owned(),
+        kind: DefKind::Macro,
+        level: downgrade_coverage_for_dynamic_annotation(level, entry.schema.as_ref()),
+        params,
+        param_annotations,
+        return_type_hints,
+        generics: signature.generics.iter().map(|name| format!("'{name}")).collect(),
+        where_bounds: signature.where_bounds.iter().map(|bound| bound.to_brief_string()).collect(),
+        data_type: None,
+        schema_issues: entry_schema_issues(ns, def_name, &entry.code, &entry.schema),
+      };
+    }
+
+    let contract_label = |contract: &MacroSyntaxType| match contract {
+      MacroSyntaxType::Syntax => "Syntax".to_owned(),
+      MacroSyntaxType::SyntaxSymbol => "SyntaxSymbol".to_owned(),
+      MacroSyntaxType::SyntaxList => "SyntaxList".to_owned(),
+      MacroSyntaxType::Expr(semantic) => format!("Expr<{}>", semantic.to_brief_string()),
+    };
+    let mut params = vec![];
+    let mut param_annotations = BTreeMap::new();
+    for (idx, contract) in signature.required_inputs.iter().enumerate() {
+      let name = format!("arg-{}", idx + 1);
+      params.push(name.clone());
+      param_annotations.insert(name, vec![contract_label(contract)]);
+    }
+    for (idx, contract) in signature.optional_inputs.iter().enumerate() {
+      let name = format!("optional-{}", idx + 1);
+      params.push(name.clone());
+      param_annotations.insert(name, vec![contract_label(contract)]);
+    }
+    if let Some(contract) = &signature.rest_input {
+      params.push("rest".to_owned());
+      param_annotations.insert("rest".to_owned(), vec![contract_label(contract)]);
+    }
+    let expansion = match &signature.expansion {
+      MacroExpansionType::Dynamic => "Dynamic".to_owned(),
+      MacroExpansionType::Expr(semantic) => format!("Expr<{}>", semantic.to_brief_string()),
+      MacroExpansionType::Definition(semantic) => format!("Definition<{}>", semantic.to_brief_string()),
+      MacroExpansionType::Declarations => "Declarations".to_owned(),
+    };
+    let level = if signature.is_strict() && !matches!(signature.expansion, MacroExpansionType::Dynamic) {
+      CoverageLevel::Full
+    } else {
+      CoverageLevel::Partial
+    };
+    return TypeCoverageRow {
+      ns: ns.to_owned(),
+      def: def_name.to_owned(),
+      kind: DefKind::Macro,
+      level: downgrade_coverage_for_dynamic_annotation(level, entry.schema.as_ref()),
+      params,
+      param_annotations,
+      return_type_hints: vec![expansion],
+      generics: signature.generics.iter().map(|name| format!("'{name}")).collect(),
+      where_bounds: signature.where_bounds.iter().map(|bound| bound.to_brief_string()).collect(),
+      data_type: None,
+      schema_issues: entry_schema_issues(ns, def_name, &entry.code, &entry.schema),
+    };
   }
 
   // Function schemas are the canonical source for top-level callable coverage.


### PR DESCRIPTION
## Summary

- introduce a dedicated `MacroSignature` for raw syntax inputs and semantic expansion outputs
- preserve legacy `Macro {:args ... :return ...}` snapshots as explicit non-strict compatibility signatures
- validate macro inputs before expansion and semantic/declaration results after preprocessing
- carry syntax-phase types into macro bodies and update snapshots, coverage, weak-type analysis
- migrate `%{}?` and document `%{}?` / Respo `defstyle` case studies

## Validation

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`
- MacroSignature docs: 1/1 block
- latest Respo: 27/27 tests, 126/126 docs blocks
- latest Recollect: 9/9 Calcit tests and JS tests with `@calcit/procs` 0.13.44

Closes #434
