### PR TITLE
feat: enforce macro compile-time capabilities

### DIFF
--- a/docs/MacroSignature.md
+++ b/docs/MacroSignature.md
@@ -36,6 +36,38 @@ and serialize without data loss. They become an explicitly legacy, non-strict
 syntax contracts. An omitted or `Dynamic` legacy macro schema likewise does not
 claim full phase coverage.
 
+## Compile-time capabilities
+
+A strict macro is pure by default. Effects performed while its body is being
+evaluated must be declared separately from runtime/backend `:features`:
+
+```cirru
+:: 'Macro
+  {} (:required $ [])
+    :expansion $ :: 'Expr 'String
+    :capabilities $ #{} :env-read :fs-read
+```
+
+Allowed opt-in capabilities are `:env-read`, `:fs-read`, `:platform-read`,
+`:clock-read`, `:mutable-state`, and `:dynamic-eval`. Any declared capability
+makes the expansion ineligible for the pure-macro cache planned by the macro
+roadmap. Legacy signatures have unknown effects and are likewise ineligible.
+
+`:fs-write`, `:process`, and `:host-ffi` are represented in the capability
+model for diagnostics and auditing, but are rejected during macro expansion
+even when declared. Native methods, JS/raw host access, and registered host
+procedures are all treated as host FFI rather than as unclassified pure calls.
+
+Capability checks remain active through ordinary helper functions. A missing
+declaration reports `E_MACRO_CAPABILITY_MISSING`; a forbidden capability reports
+`E_MACRO_CAPABILITY_DISALLOWED`. Diagnostics include the macro, operation,
+call-site location, and helper chain.
+
+Only effects executed during expansion need capabilities. A pure macro may
+quote or construct syntax containing `get-env`, `read-file`, state mutation, or
+other runtime effects: those operations are checked only if the macro evaluator
+actually calls them while deciding the expansion.
+
 Two motivating cases illustrate the distinction:
 
 - Core `%{}?` receives a struct name as `SyntaxSymbol`, then a rest sequence of
@@ -44,5 +76,6 @@ Two motivating cases illustrate the distinction:
   `SyntaxList`; its expansion is a definition/declaration contract rather than
   a runtime function return value.
 
-This model intentionally does not introduce recursive runtime union types,
-macro expansion caches, or compile-time capability policy.
+This model intentionally does not introduce recursive runtime union types or
+macro expansion caches. It exposes cache eligibility for the later expansion
+optimization without caching anything yet.

--- a/editing-history/202608252249-macro-compile-time-capabilities.md
+++ b/editing-history/202608252249-macro-compile-time-capabilities.md
@@ -1,0 +1,27 @@
+# Macro compile-time capabilities
+
+Issue #435 adds an enforceable effect boundary around strict macro execution.
+The capability policy is centralized in `runner::macro_capability` and remains
+active through ordinary helper calls by using a scoped evaluator context.
+
+Strict `MacroSignature` values now serialize a dedicated `:capabilities`
+hashset. Pure expansion needs no declaration. Environment, filesystem,
+platform, clock, mutable-state, and dynamic-eval reads/actions may be declared;
+filesystem writes, process control, and host FFI are classified but always
+rejected. Legacy macro signatures stay compatible, but their effects remain
+unknown and they are not eligible for future pure-expansion caching.
+
+The evaluator checks builtin procedures, state/dynamic-eval syntax, native
+methods, registered procedures, and raw host code. Missing declarations use
+`E_MACRO_CAPABILITY_MISSING`; forbidden operations use
+`E_MACRO_CAPABILITY_DISALLOWED`. Both preserve the macro call location and
+helper chain. Quoted code that performs an effect later at runtime remains a
+pure expansion. Macro diagnostics also reuse the raw call-head location instead
+of the locationless resolved import, preserving no-argument call sites.
+
+Validation covered formatting, clippy, all Rust and CLI tests, native/JS/IR/WASM
+integration, agent-interface checks, and the macro-signature documentation.
+Latest Respo passed 27 tests and 126 documentation blocks. Latest Recollect
+passed 9 native tests plus JS and WASM regressions. Its production build still
+reports the existing Respo DOM FFI and `:unit`/`:nil` warning baseline; neither
+external repository was modified.

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -323,6 +323,7 @@ fn check_proc_arity(name: CalcitProc, args: &[Calcit]) -> Result<(), CalcitErr> 
 /// make sure that stack information attached in errors from procs
 pub fn handle_proc(name: CalcitProc, args: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   check_proc_arity(name, args)?;
+  crate::runner::macro_capability::check_proc(name, call_stack)?;
 
   if using_stack() {
     handle_proc_internal(name, args, call_stack).map_err(|e| {

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -50,7 +50,7 @@ pub use symbol::{CalcitImport, CalcitSymbolInfo, ImportInfo};
 pub use syntax_name::{CalcitSyntax, SyntaxTypeSignature};
 pub use thunk::{CalcitThunk, CalcitThunkInfo};
 pub use type_annotation::{
-  CalcitFnTypeAnnotation, CalcitGenericBound, CalcitTypeAnnotation, DYNAMIC_TYPE, MacroExpansionType, MacroSignature,
+  CalcitFnTypeAnnotation, CalcitGenericBound, CalcitTypeAnnotation, DYNAMIC_TYPE, MacroCapability, MacroExpansionType, MacroSignature,
   MacroSignatureCompatibility, MacroSyntaxType, SchemaKind, brief_type_of_value, clear_type_slots, configure_entry_type_slots,
   pop_type_slot_override, push_type_slot_override, register_program_lookups, register_type_slot, resolve_type_slot,
   value_matches_type_annotation, with_type_annotation_warning_context,

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -360,6 +360,66 @@ pub enum MacroSignatureCompatibility {
   Legacy(Arc<CalcitFnTypeAnnotation>),
 }
 
+/// Effects that may be performed while a macro is expanding. These are
+/// deliberately separate from ordinary function `:features`: capabilities
+/// are an executable compile-time policy, not documentation or a runtime
+/// backend marker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MacroCapability {
+  EnvRead,
+  FsRead,
+  PlatformRead,
+  ClockRead,
+  MutableState,
+  DynamicEval,
+  FsWrite,
+  Process,
+  HostFfi,
+}
+
+impl MacroCapability {
+  pub fn as_str(self) -> &'static str {
+    match self {
+      Self::EnvRead => "env-read",
+      Self::FsRead => "fs-read",
+      Self::PlatformRead => "platform-read",
+      Self::ClockRead => "clock-read",
+      Self::MutableState => "mutable-state",
+      Self::DynamicEval => "dynamic-eval",
+      Self::FsWrite => "fs-write",
+      Self::Process => "process",
+      Self::HostFfi => "host-ffi",
+    }
+  }
+
+  pub fn parse(name: &str) -> Option<Self> {
+    match name.trim_start_matches(':') {
+      "env-read" => Some(Self::EnvRead),
+      "fs-read" => Some(Self::FsRead),
+      "platform-read" => Some(Self::PlatformRead),
+      "clock-read" => Some(Self::ClockRead),
+      "mutable-state" => Some(Self::MutableState),
+      "dynamic-eval" => Some(Self::DynamicEval),
+      "fs-write" => Some(Self::FsWrite),
+      "process" => Some(Self::Process),
+      "host-ffi" => Some(Self::HostFfi),
+      _ => None,
+    }
+  }
+
+  /// Dangerous host mutations are intentionally unavailable to macro
+  /// expansion. Keeping them in the model gives diagnostics and tooling a
+  /// complete, auditable classification without turning declarations into an
+  /// escape hatch.
+  pub fn is_allowed(self) -> bool {
+    !matches!(self, Self::FsWrite | Self::Process | Self::HostFfi)
+  }
+
+  pub fn is_cache_safe(self) -> bool {
+    false
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MacroSignature {
   pub generics: Arc<Vec<Arc<str>>>,
@@ -368,6 +428,7 @@ pub struct MacroSignature {
   pub optional_inputs: Arc<Vec<MacroSyntaxType>>,
   pub rest_input: Option<MacroSyntaxType>,
   pub expansion: MacroExpansionType,
+  pub capabilities: Arc<HashSet<MacroCapability>>,
   pub features: Arc<HashSet<EdnTag>>,
   pub compatibility: MacroSignatureCompatibility,
 }
@@ -392,6 +453,13 @@ impl Ord for MacroSignature {
       .then_with(|| self.optional_inputs.cmp(&other.optional_inputs))
       .then_with(|| self.rest_input.cmp(&other.rest_input))
       .then_with(|| self.expansion.cmp(&other.expansion))
+      .then_with(|| {
+        let mut a = self.capabilities.iter().copied().collect::<Vec<_>>();
+        let mut b = other.capabilities.iter().copied().collect::<Vec<_>>();
+        a.sort_unstable();
+        b.sort_unstable();
+        a.cmp(&b)
+      })
       .then_with(|| self_features.cmp(&other_features))
       .then_with(|| self.compatibility.cmp(&other.compatibility))
   }
@@ -405,6 +473,9 @@ impl Hash for MacroSignature {
     self.optional_inputs.hash(state);
     self.rest_input.hash(state);
     self.expansion.hash(state);
+    let mut capabilities = self.capabilities.iter().copied().collect::<Vec<_>>();
+    capabilities.sort_unstable();
+    capabilities.hash(state);
     let mut features = self.features.iter().map(EdnTag::ref_str).collect::<Vec<_>>();
     features.sort_unstable();
     features.hash(state);
@@ -421,6 +492,7 @@ impl MacroSignature {
       optional_inputs: Arc::new(vec![]),
       rest_input: None,
       expansion: MacroExpansionType::Dynamic,
+      capabilities: Arc::new(HashSet::new()),
       features: Arc::new(HashSet::new()),
       compatibility: MacroSignatureCompatibility::Legacy(Arc::new(CalcitFnTypeAnnotation {
         generics: Arc::new(vec![]),
@@ -446,6 +518,7 @@ impl MacroSignature {
       optional_inputs: Arc::new(vec![]),
       rest_input: None,
       expansion: MacroExpansionType::Dynamic,
+      capabilities: Arc::new(HashSet::new()),
       features: annotation.features.clone(),
       compatibility: MacroSignatureCompatibility::Legacy(annotation),
     }
@@ -453,6 +526,12 @@ impl MacroSignature {
 
   pub fn is_strict(&self) -> bool {
     matches!(self.compatibility, MacroSignatureCompatibility::Strict)
+  }
+
+  /// Later expansion caching may only trust strict macros whose compile-time
+  /// execution has no declared effects. Legacy signatures remain unknown.
+  pub fn is_cache_eligible(&self) -> bool {
+    self.is_strict() && self.capabilities.iter().all(|capability| capability.is_cache_safe())
   }
 
   fn parse_contract(form: &Edn, generics: &[Arc<str>]) -> Option<MacroSyntaxType> {
@@ -534,6 +613,15 @@ impl MacroSignature {
     }
     if let Some(expansion) = Self::expansion_to_edn(&self.expansion) {
       map.insert_key("expansion", expansion);
+    }
+    if !self.capabilities.is_empty() {
+      let mut set = EdnSetView::default();
+      let mut capabilities = self.capabilities.iter().copied().collect::<Vec<_>>();
+      capabilities.sort_unstable();
+      for capability in capabilities {
+        set.insert(Edn::Tag(EdnTag::new(capability.as_str())));
+      }
+      map.insert_key("capabilities", Edn::Set(set));
     }
     if !self.generics.is_empty() {
       map.insert_key(
@@ -1542,7 +1630,9 @@ impl CalcitTypeAnnotation {
       return None;
     }
 
-    let strict = ["required", "optional", "expansion"].iter().any(|key| map.tag_get(key).is_some());
+    let strict = ["required", "optional", "expansion", "capabilities"]
+      .iter()
+      .any(|key| map.tag_get(key).is_some());
     if !strict {
       let legacy = Self::parse_fn_schema_from_edn(schema)?;
       return Some(MacroSignature::from_legacy_fn(legacy));
@@ -1597,6 +1687,19 @@ impl CalcitTypeAnnotation {
         _ => None,
       })
       .unwrap_or_default();
+    let capabilities = match map.tag_get("capabilities") {
+      None => Arc::new(HashSet::new()),
+      Some(Edn::Set(xs)) => Arc::new(
+        xs.0
+          .iter()
+          .map(|item| match item {
+            Edn::Tag(tag) => MacroCapability::parse(tag.ref_str()),
+            _ => None,
+          })
+          .collect::<Option<HashSet<_>>>()?,
+      ),
+      Some(_) => return None,
+    };
     Some(MacroSignature {
       generics: Arc::new(generics),
       where_bounds: Arc::new(where_bounds),
@@ -1604,6 +1707,7 @@ impl CalcitTypeAnnotation {
       optional_inputs: Arc::new(optional_inputs),
       rest_input,
       expansion,
+      capabilities,
       features,
       compatibility: MacroSignatureCompatibility::Strict,
     })
@@ -1638,7 +1742,10 @@ impl CalcitTypeAnnotation {
     if !has_schema_fields {
       return None;
     }
-    if ["required", "optional", "expansion"].iter().any(|key| map.tag_get(key).is_some()) {
+    if ["required", "optional", "expansion", "capabilities"]
+      .iter()
+      .any(|key| map.tag_get(key).is_some())
+    {
       return None;
     }
 
@@ -4034,6 +4141,10 @@ mod tests {
     map.insert_key("optional", Edn::List(EdnListView(vec![Edn::Symbol(Arc::from("SyntaxList"))])));
     map.insert_key("rest", Edn::Symbol(Arc::from("Syntax")));
     map.insert_key("expansion", Edn::enum_value("Expr", vec![Edn::Symbol(Arc::from("T"))]));
+    map.insert_key(
+      "capabilities",
+      Edn::Set(EdnSetView(HashSet::from([Edn::tag("env-read"), Edn::tag("fs-read")]))),
+    );
     let schema = Edn::enum_value("Macro", vec![Edn::Map(map)]);
 
     let signature = CalcitTypeAnnotation::parse_macro_signature_from_edn(&schema).expect("strict macro signature");
@@ -4049,6 +4160,9 @@ mod tests {
     assert!(matches!(signature.optional_inputs.as_slice(), [MacroSyntaxType::SyntaxList]));
     assert!(matches!(signature.rest_input, Some(MacroSyntaxType::Syntax)));
     assert!(matches!(signature.expansion, MacroExpansionType::Expr(_)));
+    assert!(signature.capabilities.contains(&MacroCapability::EnvRead));
+    assert!(signature.capabilities.contains(&MacroCapability::FsRead));
+    assert!(!signature.is_cache_eligible());
 
     let reloaded = CalcitTypeAnnotation::parse_macro_signature_from_edn(&signature.to_wrapped_schema_edn()).expect("round trip");
     assert_eq!(reloaded, signature);
@@ -4062,6 +4176,7 @@ mod tests {
     let schema = Edn::enum_value("Macro", vec![Edn::Map(map)]);
     let signature = CalcitTypeAnnotation::parse_macro_signature_from_edn(&schema).expect("legacy macro schema");
     assert!(!signature.is_strict());
+    assert!(!signature.is_cache_eligible());
     assert!(matches!(signature.compatibility, MacroSignatureCompatibility::Legacy(_)));
     assert!(matches!(signature.expansion, MacroExpansionType::Dynamic));
   }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,3 +1,4 @@
+pub mod macro_capability;
 pub mod preprocess;
 pub mod track;
 
@@ -231,7 +232,15 @@ pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_sta
       }
     },
     Recur(_) => unreachable!("recur not expected to be from symbol"),
-    RawCode(_, code) => unreachable!("raw code `{}` cannot be called", code),
+    RawCode(_, code) => {
+      macro_capability::check_host_ffi(code, call_stack)?;
+      Err(CalcitErr::use_msg_stack_location(
+        CalcitErrKind::Unexpected,
+        format!("raw host code `{code}` cannot be evaluated by the native runtime"),
+        call_stack,
+        expr.get_location(),
+      ))
+    }
     Set(_) => Err(CalcitErr::use_msg_stack_location(
       CalcitErrKind::Unexpected,
       "unexpected set for expr",
@@ -272,6 +281,7 @@ pub fn call_expr(
       builtins::handle_proc(*p, &values, call_stack)
     }
     Calcit::Syntax(s, def_ns) => {
+      macro_capability::check_syntax(s, call_stack)?;
       let rest_nodes = xs.skip(1).expect("expected syntax rest nodes");
       if using_stack() {
         let next_stack = call_stack.extend_owned(
@@ -295,6 +305,7 @@ pub fn call_expr(
       }
     }
     Calcit::Method(name, kind) => {
+      macro_capability::check_method(name, kind, call_stack)?;
       if matches!(kind, MethodKind::Invoke(_)) {
         let values = if spreading {
           evaluate_spreaded_args_from(xs, 1, scope, file_ns, call_stack)?
@@ -396,7 +407,17 @@ pub fn call_expr(
         // need to handle recursion
         body_scope.restore_frame(frame_checkpoint);
         bind_marked_args(&mut body_scope, &info.args, &current_values, call_stack)?;
-        let code = evaluate_lines(info.body.as_ref().as_slice(), &body_scope, &info.def_ns, &next_stack)?;
+        let evaluate_body = || evaluate_lines(info.body.as_ref().as_slice(), &body_scope, &info.def_ns, &next_stack);
+        let code = if info.signature.is_strict() {
+          macro_capability::with_macro_context(
+            Arc::from(format!("{}/{}", info.def_ns, info.name)),
+            info.signature.capabilities.clone(),
+            xs.first().and_then(Calcit::get_location),
+            evaluate_body,
+          )?
+        } else {
+          evaluate_body()?
+        };
         match code {
           Calcit::Recur(ys) => {
             current_values = ys;
@@ -442,6 +463,7 @@ pub fn call_expr(
       }
     }
     Calcit::Registered(alias) => {
+      macro_capability::check_registered(alias, call_stack)?;
       let values = if spreading {
         evaluate_spreaded_args_from(xs, 1, scope, file_ns, call_stack)?
       } else {
@@ -994,7 +1016,82 @@ pub fn evaluate_spreaded_args_from(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitFnUsageMeta, CalcitStructDef, CalcitStructValue, CalcitSymbolInfo, CalcitTypeAnnotation};
+  use crate::calcit::{
+    CalcitFnUsageMeta, CalcitMacro, CalcitStructDef, CalcitStructValue, CalcitSymbolInfo, CalcitTypeAnnotation, MacroCapability,
+    MacroExpansionType, MacroSignature, MacroSignatureCompatibility,
+  };
+  use std::collections::HashSet;
+
+  fn strict_test_macro(name: &str, body: Vec<Calcit>, capabilities: HashSet<MacroCapability>) -> Calcit {
+    Calcit::Macro {
+      id: Arc::from(format!("tests.runner/{name}")),
+      info: Arc::new(CalcitMacro {
+        name: Arc::from(name),
+        def_ns: Arc::from("tests.runner"),
+        args: Arc::new(vec![]),
+        body: Arc::new(body),
+        signature: Arc::new(MacroSignature {
+          generics: Arc::new(vec![]),
+          where_bounds: Arc::new(vec![]),
+          required_inputs: Arc::new(vec![]),
+          optional_inputs: Arc::new(vec![]),
+          rest_input: None,
+          expansion: MacroExpansionType::Expr(Arc::new(CalcitTypeAnnotation::String)),
+          capabilities: Arc::new(capabilities),
+          features: Arc::new(HashSet::new()),
+          compatibility: MacroSignatureCompatibility::Strict,
+        }),
+      }),
+    }
+  }
+
+  fn call_zero_arg_macro(value: &Calcit) -> Result<Calcit, CalcitErr> {
+    let call = CalcitList::from(std::slice::from_ref(value));
+    call_expr(
+      value,
+      &call.view(),
+      &CalcitScope::default(),
+      "tests.runner",
+      &CallStackList::default(),
+      false,
+    )
+  }
+
+  #[test]
+  fn strict_macro_runtime_path_enforces_declared_env_reads() {
+    let body = vec![Calcit::from(vec![
+      Calcit::Proc(CalcitProc::GetEnv),
+      Calcit::new_str("CALCIT_TEST_CAPABILITY_MISSING_ENV"),
+      Calcit::new_str("fallback"),
+    ])];
+    let pure = strict_test_macro("read-env", body.clone(), HashSet::new());
+    let error = call_zero_arg_macro(&pure).expect_err("undeclared compile-time env read must fail");
+    assert_eq!(error.code(), Some("E_MACRO_CAPABILITY_MISSING"));
+
+    let declared = strict_test_macro("read-env", body, HashSet::from([MacroCapability::EnvRead]));
+    assert_eq!(
+      call_zero_arg_macro(&declared).expect("declared env read"),
+      Calcit::new_str("fallback")
+    );
+  }
+
+  #[test]
+  fn strict_macro_may_emit_runtime_env_read_without_capability() {
+    let runtime_call = Calcit::from(vec![
+      Calcit::Proc(CalcitProc::GetEnv),
+      Calcit::new_str("CALCIT_TEST_CAPABILITY_MISSING_ENV"),
+      Calcit::new_str("runtime-fallback"),
+    ]);
+    let body = vec![Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::Quote, Arc::from("tests.runner")),
+      runtime_call,
+    ])];
+    let emitting_macro = strict_test_macro("emit-env", body, HashSet::new());
+    assert_eq!(
+      call_zero_arg_macro(&emitting_macro).expect("emitting runtime effect stays pure"),
+      Calcit::new_str("runtime-fallback")
+    );
+  }
 
   fn local_value(name: &str, idx: u16) -> Calcit {
     Calcit::Local(CalcitLocal {

--- a/src/runner/macro_capability.rs
+++ b/src/runner/macro_capability.rs
@@ -1,0 +1,232 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use crate::calcit::{CalcitErr, CalcitErrKind, CalcitProc, CalcitSyntax, MacroCapability, MethodKind, NodeLocation};
+use crate::call_stack::{CallStackList, StackKind};
+
+#[derive(Debug, Clone)]
+struct MacroExecutionContext {
+  macro_name: Arc<str>,
+  declared: Arc<HashSet<MacroCapability>>,
+  call_location: Option<NodeLocation>,
+}
+
+thread_local! {
+  static MACRO_EXECUTION_STACK: RefCell<Vec<MacroExecutionContext>> = const { RefCell::new(vec![]) };
+}
+
+struct ContextGuard;
+
+impl Drop for ContextGuard {
+  fn drop(&mut self) {
+    MACRO_EXECUTION_STACK.with(|stack| {
+      stack.borrow_mut().pop();
+    });
+  }
+}
+
+/// Execute a strict macro body under its declared compile-time capability
+/// policy. A thread-local stack makes calls through arbitrary helper functions
+/// auditable without adding policy parameters to every evaluator function.
+pub fn with_macro_context<T>(
+  macro_name: Arc<str>,
+  declared: Arc<HashSet<MacroCapability>>,
+  call_location: Option<NodeLocation>,
+  f: impl FnOnce() -> Result<T, CalcitErr>,
+) -> Result<T, CalcitErr> {
+  MACRO_EXECUTION_STACK.with(|stack| {
+    stack.borrow_mut().push(MacroExecutionContext {
+      macro_name,
+      declared,
+      call_location,
+    });
+  });
+  let _guard = ContextGuard;
+  f()
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CapabilityPolicy {
+  Requires(MacroCapability),
+  Forbidden(MacroCapability),
+}
+
+impl CapabilityPolicy {
+  fn capability(self) -> MacroCapability {
+    match self {
+      Self::Requires(capability) | Self::Forbidden(capability) => capability,
+    }
+  }
+}
+
+fn proc_policy(proc: CalcitProc) -> Option<CapabilityPolicy> {
+  use CalcitProc::*;
+  let required = match proc {
+    GetEnv => MacroCapability::EnvRead,
+    ReadFile | ReadDir => MacroCapability::FsRead,
+    NativeGetOs | NativeGetCalcitBackend | NativeGetCalcitRunningMode => MacroCapability::PlatformRead,
+    UnixTimeMs | CpuTime => MacroCapability::ClockRead,
+    GenerateId | NativeResetGenSymIndex | RegisterCalcitBuiltinImpls | Atom | AtomDeref | AddWatch | RemoveWatch => {
+      MacroCapability::MutableState
+    }
+    WriteFile => return Some(CapabilityPolicy::Forbidden(MacroCapability::FsWrite)),
+    Quit => return Some(CapabilityPolicy::Forbidden(MacroCapability::Process)),
+    _ => return None,
+  };
+  Some(CapabilityPolicy::Requires(required))
+}
+
+fn syntax_policy(syntax: &CalcitSyntax) -> Option<CapabilityPolicy> {
+  match syntax {
+    CalcitSyntax::Eval => Some(CapabilityPolicy::Requires(MacroCapability::DynamicEval)),
+    CalcitSyntax::Defatom | CalcitSyntax::Reset => Some(CapabilityPolicy::Requires(MacroCapability::MutableState)),
+    _ => None,
+  }
+}
+
+fn helper_chain(call_stack: &CallStackList) -> String {
+  let chain = call_stack
+    .0
+    .iter()
+    .filter(|frame| matches!(frame.kind, StackKind::Fn | StackKind::Macro | StackKind::Syntax | StackKind::Method))
+    .map(|frame| format!("{}/{}", frame.ns, frame.def))
+    .collect::<Vec<_>>();
+  if chain.is_empty() {
+    "(direct call)".to_owned()
+  } else {
+    chain.join(" -> ")
+  }
+}
+
+fn check_policy(policy: CapabilityPolicy, operation: &str, call_stack: &CallStackList) -> Result<(), CalcitErr> {
+  let context = MACRO_EXECUTION_STACK.with(|stack| stack.borrow().last().cloned());
+  let Some(context) = context else {
+    return Ok(());
+  };
+  let capability = policy.capability();
+  let (code, reason) = match policy {
+    CapabilityPolicy::Forbidden(_) => (
+      "E_MACRO_CAPABILITY_DISALLOWED",
+      format!("compile-time capability :{} is disallowed by policy", capability.as_str()),
+    ),
+    CapabilityPolicy::Requires(_) if !context.declared.contains(&capability) => (
+      "E_MACRO_CAPABILITY_MISSING",
+      format!("compile-time capability :{} was not declared", capability.as_str()),
+    ),
+    CapabilityPolicy::Requires(_) => return Ok(()),
+  };
+  let message = format!(
+    "macro `{}` cannot execute `{operation}`: {reason}\n  helper-chain: {}",
+    context.macro_name,
+    helper_chain(call_stack)
+  );
+  let mut error = CalcitErr::use_msg_stack_location_with_code(CalcitErrKind::Effect, message, code, call_stack, context.call_location);
+  error.hint = Some(if capability.is_allowed() {
+    format!(
+      "Declare `:capabilities $ #{{}} :{}` on the strict Macro signature, or move the effect into generated runtime code.",
+      capability.as_str()
+    )
+  } else {
+    format!(
+      "Compile-time :{} cannot be enabled. Move the operation into generated runtime code or remove the host effect.",
+      capability.as_str()
+    )
+  });
+  Err(error)
+}
+
+pub fn check_proc(proc: CalcitProc, call_stack: &CallStackList) -> Result<(), CalcitErr> {
+  match proc_policy(proc) {
+    Some(policy) => check_policy(policy, proc.as_ref(), call_stack),
+    None => Ok(()),
+  }
+}
+
+pub fn check_syntax(syntax: &CalcitSyntax, call_stack: &CallStackList) -> Result<(), CalcitErr> {
+  match syntax_policy(syntax) {
+    Some(policy) => check_policy(policy, syntax.as_ref(), call_stack),
+    None => Ok(()),
+  }
+}
+
+pub fn check_registered(alias: &str, call_stack: &CallStackList) -> Result<(), CalcitErr> {
+  check_policy(CapabilityPolicy::Forbidden(MacroCapability::HostFfi), alias, call_stack)
+}
+
+pub fn check_host_ffi(operation: &str, call_stack: &CallStackList) -> Result<(), CalcitErr> {
+  check_policy(CapabilityPolicy::Forbidden(MacroCapability::HostFfi), operation, call_stack)
+}
+
+pub fn check_method(name: &str, kind: &MethodKind, call_stack: &CallStackList) -> Result<(), CalcitErr> {
+  if matches!(kind, MethodKind::Invoke(_) | MethodKind::TagAccess) {
+    Ok(())
+  } else {
+    check_policy(
+      CapabilityPolicy::Forbidden(MacroCapability::HostFfi),
+      &format!(".{name}"),
+      call_stack,
+    )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::calcit::{Calcit, CalcitScope};
+
+  #[test]
+  fn pure_context_rejects_env_read() {
+    let error = with_macro_context(Arc::from("app/read-env"), Arc::new(HashSet::new()), None, || {
+      check_proc(CalcitProc::GetEnv, &CallStackList::default())
+    })
+    .expect_err("env read must need a declaration");
+    assert_eq!(error.code(), Some("E_MACRO_CAPABILITY_MISSING"));
+    assert!(error.msg.contains(":env-read"));
+  }
+
+  #[test]
+  fn declared_env_read_is_allowed() {
+    let declared = Arc::new(HashSet::from([MacroCapability::EnvRead]));
+    with_macro_context(Arc::from("app/read-env"), declared, None, || {
+      check_proc(CalcitProc::GetEnv, &CallStackList::default())
+    })
+    .expect("declared env read should pass");
+  }
+
+  #[test]
+  fn dangerous_capability_stays_forbidden_when_declared() {
+    let declared = Arc::new(HashSet::from([MacroCapability::FsWrite]));
+    let error = with_macro_context(Arc::from("app/write"), declared, None, || {
+      check_proc(CalcitProc::WriteFile, &CallStackList::default())
+    })
+    .expect_err("file writes are not an opt-in escape hatch");
+    assert_eq!(error.code(), Some("E_MACRO_CAPABILITY_DISALLOWED"));
+  }
+
+  #[test]
+  fn generated_runtime_effect_syntax_remains_pure() {
+    let emitted_runtime_call = Calcit::from(vec![Calcit::Proc(CalcitProc::GetEnv), Calcit::new_str("MODE")]);
+    let quoted = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::Quote, Arc::from("tests.capability")),
+      emitted_runtime_call,
+    ]);
+    with_macro_context(Arc::from("tests.capability/emit-env"), Arc::new(HashSet::new()), None, || {
+      crate::runner::evaluate_expr(&quoted, &CalcitScope::default(), "tests.capability", &CallStackList::default())
+    })
+    .expect("quoting a runtime effect must not perform that effect during expansion");
+  }
+
+  #[test]
+  fn diagnostic_keeps_transitive_helper_chain() {
+    let stack = CallStackList::default()
+      .extend("tests.capability", "outer-macro", StackKind::Macro, &Calcit::Nil, &[])
+      .extend("tests.capability", "read-mode-helper", StackKind::Fn, &Calcit::Nil, &[]);
+    let error = with_macro_context(Arc::from("tests.capability/outer-macro"), Arc::new(HashSet::new()), None, || {
+      check_proc(CalcitProc::GetEnv, &stack)
+    })
+    .expect_err("transitive helper effects must be checked");
+    assert!(error.msg.contains("read-mode-helper"));
+    assert!(error.msg.contains("outer-macro"));
+  }
+}

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1706,7 +1706,6 @@ fn preprocess_list_call(
   match head_value {
     Some(Calcit::Macro { info, .. }) => {
       let mut current_values: Vec<Calcit> = args.to_vec();
-      let call_location = head_form.get_location().or_else(|| args.first().and_then(Calcit::get_location));
       let mut macro_type_bindings = validate_macro_call_inputs(
         info.name.as_ref(),
         info.signature.as_ref(),
@@ -1727,40 +1726,53 @@ fn preprocess_list_call(
       let mut body_scope = CalcitScope::default();
       let frame_checkpoint = body_scope.frame_checkpoint();
 
-      loop {
-        // need to handle recursion
-        // println!("evaluating line: {:?}", body);
-        body_scope.restore_frame(frame_checkpoint);
-        runner::bind_marked_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
-        let code = runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack)?;
-        match code {
-          Calcit::Recur(ys) => {
-            current_values = ys;
-            let recur_args = CalcitList::from(current_values.as_slice());
-            macro_type_bindings = validate_macro_call_inputs(
-              info.name.as_ref(),
-              info.signature.as_ref(),
-              &recur_args,
-              scope_types,
-              &next_stack,
-              call_location.clone(),
-            )?;
-          }
-          _ => {
-            // println!("gen code: {} {}", code, &code.lisp_str());
-            let processed = preprocess_expr(&code, scope_defs, scope_types, file_ns, check_warnings, &next_stack)?;
-            validate_macro_expansion_result(
-              info.name.as_ref(),
-              info.signature.as_ref(),
-              (&code, &processed),
-              scope_types,
-              macro_type_bindings,
-              &next_stack,
-              call_location,
-            )?;
-            return Ok(processed);
+      let execute_macro = || -> Result<Calcit, CalcitErr> {
+        loop {
+          // need to handle recursion
+          body_scope.restore_frame(frame_checkpoint);
+          runner::bind_marked_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
+          let code = runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack)?;
+          match code {
+            Calcit::Recur(ys) => {
+              current_values = ys;
+              let recur_args = CalcitList::from(current_values.as_slice());
+              macro_type_bindings = validate_macro_call_inputs(
+                info.name.as_ref(),
+                info.signature.as_ref(),
+                &recur_args,
+                scope_types,
+                &next_stack,
+                call_location.clone(),
+              )?;
+            }
+            _ => {
+              let processed = preprocess_expr(&code, scope_defs, scope_types, file_ns, check_warnings, &next_stack)?;
+              validate_macro_expansion_result(
+                info.name.as_ref(),
+                info.signature.as_ref(),
+                (&code, &processed),
+                scope_types,
+                macro_type_bindings,
+                &next_stack,
+                call_location.clone(),
+              )?;
+              return Ok(processed);
+            }
           }
         }
+      };
+
+      if info.signature.is_strict() {
+        runner::macro_capability::with_macro_context(
+          Arc::from(format!("{}/{}", info.def_ns, info.name)),
+          info.signature.capabilities.clone(),
+          call_location.clone(),
+          execute_macro,
+        )
+      } else {
+        // Legacy Macro schemas remain compatible, but their effects are
+        // deliberately unknown and therefore cannot be considered pure.
+        execute_macro()
       }
     }
 
@@ -7289,6 +7301,7 @@ mod tests {
       optional_inputs: Arc::new(optional_inputs),
       rest_input,
       expansion,
+      capabilities: Arc::new(HashSet::new()),
       features: Arc::new(HashSet::new()),
       compatibility: crate::calcit::MacroSignatureCompatibility::Strict,
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -50,6 +50,8 @@ fn canonical_schema_field_name(text: &str) -> Option<&'static str> {
     "rest" => Some("rest"),
     "generics" => Some("generics"),
     "where" => Some("where"),
+    "features" => Some("features"),
+    "capabilities" => Some("capabilities"),
     _ => None,
   }
 }
@@ -1242,6 +1244,7 @@ pub const VALID_SCHEMA_FIELDS: &[&str] = &[
   ":required",
   ":optional",
   ":expansion",
+  ":capabilities",
   ":rest",
   ":generics",
   ":where",
@@ -1596,6 +1599,7 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
   let mut required_node: Option<&Cirru> = None;
   let mut optional_node: Option<&Cirru> = None;
   let mut expansion_node: Option<&Cirru> = None;
+  let mut capabilities_node: Option<&Cirru> = None;
   let mut where_node: Option<&Cirru> = None;
   let mut features_node: Option<&Cirru> = None;
 
@@ -1610,6 +1614,7 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
         ":required" => required_node = Some(val),
         ":optional" => optional_node = Some(val),
         ":expansion" => expansion_node = Some(val),
+        ":capabilities" => capabilities_node = Some(val),
         ":rest" => rest_node = Some(val),
         ":where" => where_node = Some(val),
         ":features" => features_node = Some(val),
@@ -1676,6 +1681,25 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
     }
     if let Some(var) = used.iter().find(|name| looks_like_undeclared_type_var(name)) {
       return Err(format!("Type variable `'{var}` is used but no `:generics` field is declared."));
+    }
+  }
+
+  if let Some(capabilities_val) = capabilities_node {
+    let Cirru::List(items) = capabilities_val else {
+      return Err("`:capabilities` must be a hashset like `(#{} :env-read :fs-read)`".to_owned());
+    };
+    if !matches!(items.first(), Some(Cirru::Leaf(first)) if first.as_ref() == "#{}") {
+      return Err("`:capabilities` must be a hashset like `(#{} :env-read :fs-read)`".to_owned());
+    }
+    for item in items.iter().skip(1) {
+      let Cirru::Leaf(name) = item else {
+        return Err("`:capabilities` hashset items must be simple leaf tags".to_owned());
+      };
+      if crate::calcit::MacroCapability::parse(name).is_none() {
+        return Err(format!(
+          "Unknown macro capability `{name}`. Expected one of: :env-read, :fs-read, :platform-read, :clock-read, :mutable-state, :dynamic-eval, :fs-write, :process, :host-ffi"
+        ));
+      }
     }
   }
 
@@ -3879,7 +3903,7 @@ mod tests {
   #[test]
   fn phase_aware_macro_schema_writes_and_loads_as_macro_signature() {
     let schema = cirru_parser::parse(
-      ":: 'Macro\n  {} (:generics $ [] 'T)\n    :required $ [] 'SyntaxSymbol (:: 'Expr 'T)\n    :optional $ [] 'SyntaxList\n    :rest 'Syntax\n    :expansion $ :: 'Expr 'T",
+      ":: 'Macro\n  {} (:generics $ [] 'T)\n    :required $ [] 'SyntaxSymbol (:: 'Expr 'T)\n    :optional $ [] 'SyntaxList\n    :rest 'Syntax\n    :expansion $ :: 'Expr 'T\n    :capabilities $ #{} :env-read :fs-read",
     )
     .expect("strict macro schema should parse")
     .into_iter()
@@ -3893,10 +3917,25 @@ mod tests {
     assert_eq!(signature.required_inputs.len(), 2);
     assert_eq!(signature.optional_inputs.len(), 1);
     assert!(signature.rest_input.is_some());
+    assert!(signature.capabilities.contains(&crate::calcit::MacroCapability::EnvRead));
+    assert!(signature.capabilities.contains(&crate::calcit::MacroCapability::FsRead));
 
     let saved = schema_annotation_to_edn(annotation.as_ref());
     let loaded = parse_loaded_schema_annotation(&saved, "test macro schema").expect("saved strict signature should reload");
     assert_eq!(loaded, annotation);
+  }
+
+  #[test]
+  fn macro_schema_rejects_unknown_compile_time_capabilities() {
+    let schema = cirru_parser::parse(
+      ":: 'Macro\n  {} (:required $ [])\n    :expansion $ :: 'Expr 'String\n    :capabilities $ #{} :network-everything",
+    )
+    .expect("schema syntax")
+    .into_iter()
+    .next()
+    .expect("schema node");
+    let error = parse_schema_annotation_for_write(&schema).expect_err("unknown capabilities must not silently become pure");
+    assert!(error.contains("Unknown macro capability"), "unexpected error: {error}");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add canonical `:capabilities` metadata to strict `MacroSignature` values
- enforce pure-by-default expansion across builtin procs, syntax, helpers, methods, registered procs, and raw host code
- distinguish declared read/state/eval capabilities from forbidden write/process/host-FFI operations
- preserve legacy macros as effect-unknown and expose strict pure-macro cache eligibility
- keep generated runtime effects pure while reporting direct/transitive compile-time effects with stable diagnostics and call sites

## Validation

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (505 library, 244 CLI, 24 caps, 4 cr-wasm)
- `yarn compile`
- `yarn check-all` (native, JS, IR, WASM, benchmarks)
- `yarn check-agent-interface` (17/17)
- MacroSignature docs: 2/2 blocks
- latest Respo main: 27/27 tests, 126/126 docs blocks
- latest Recollect main: 9/9 native tests, JS and WASM regressions passed

## External baseline note

Recollect's production JS build reaches codegen but remains blocked by 11 existing warnings from current Respo main (DOM FFI typing and `:unit`/`:nil` return mismatches). The warnings do not involve macro capability execution; both external worktrees remain clean.

Closes #435
