### PR TITLE
perf: instrument macro expansion costs

### DIFF
--- a/docs/MacroSignature.md
+++ b/docs/MacroSignature.md
@@ -14,6 +14,7 @@ The canonical snapshot/source form is:
     :optional $ [] 'SyntaxList
     :rest 'Syntax
     :expansion $ :: 'Expr 'T
+    :capabilities $ #{}
 ```
 
 Input contracts are `Syntax`, `SyntaxSymbol`, `SyntaxList`, and `Expr<T>`.

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -11,11 +11,14 @@ aliases:
   - "reload-fn"
   - "reload fn"
   - "watch-dir"
+  - "macro metrics"
+  - "macro expansion metrics"
 entry_for:
   - "calcit -w"
   - "calcit js -w"
   - "calcit --help"
   - "calcit --reload-fn"
+  - "calcit --macro-metrics"
 ---
 
 # CLI Options
@@ -103,6 +106,41 @@ calcit analyze dynamic-methods --deps
 ```
 
 The default scope contains project namespaces only. `--deps` includes reachable dependency namespaces, and `--max` returns a non-zero status when the finding count exceeds the reviewed limit.
+
+### Macro Expansion Metrics (--macro-metrics)
+
+Use opt-in macro metrics to profile compile, check, and hot-reload work without
+changing normal CLI output:
+
+```bash
+cargo build --release --bin calcit
+target/release/calcit --macro-metrics --check-only calcit/test.cirru
+target/release/calcit --macro-metrics --check-only /path/to/respo/calcit.cirru js
+```
+
+The CLI writes one `macro-expansion-metrics: {...}` JSON record to stderr when
+it exits. Timing fields use nanoseconds. Per-macro and total evaluator and
+post-preprocess times are exclusive: when a nested macro starts, its parent's
+timer pauses, so totals do not double-count recursive expansion work.
+
+The report also records general-evaluator fallbacks, cache hits and misses,
+miss reasons, bypass reasons, and actual invalidation reasons. Before the pure
+expansion cache lands, eligible strict/pure macros report a
+`cache-not-implemented` miss; legacy and effectful signatures report explicit
+bypasses rather than false invalidations.
+
+Reproducible release-mode baseline from 2026-08-25 (three warm runs, median):
+
+| Project | Revision | Expansions | Evaluator | Post-preprocess | General fallback |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Calcit test snapshot | `32883223` | 2,432 | 20.21 ms | 52.61 ms | 2,432 |
+| Respo JS check | `be8141e` | 1,414 | 14.24 ms | 35.50 ms | 1,414 |
+
+Calcit's highest post-preprocess costs in the median run were `assert=`
+(21.66 ms), `let` (10.16 ms), `def` (5.39 ms), and `fn` (4.20 ms). Respo's
+were `let` (11.53 ms), `def` (4.71 ms), `fn` (2.92 ms), and `cond` (1.87 ms).
+These results prioritize common structural macros and post-expansion processing
+for the typed Macro IR phase; they do not claim application runtime gains.
 
 ### Hot Reloading Configuration
 

--- a/editing-history/20260825-2311-macro-capability-review-followup.md
+++ b/editing-history/20260825-2311-macro-capability-review-followup.md
@@ -1,0 +1,10 @@
+# Macro capability review follow-up
+
+- Keep the canonical strict Macro signature example complete by serializing an
+  explicit empty `:capabilities` set.
+- Treat mutable BufList construction and mutation as `:mutable-state` during
+  macro expansion.
+- Validate capability leaves as colon-prefixed tags before general Cirru EDN
+  parsing, preserving a stable schema-specific error instead of accepting a
+  write that cannot round-trip.
+- Verified with the macro capability and macro schema unit-test groups.

--- a/editing-history/20260825-2312-macro-expansion-metrics.md
+++ b/editing-history/20260825-2312-macro-expansion-metrics.md
@@ -1,0 +1,11 @@
+# Macro expansion metrics baseline
+
+- Added opt-in `--macro-metrics` JSON-on-stderr instrumentation for expansion
+  counts, exclusive evaluator/post-preprocess time, general evaluator fallback,
+  and cache outcome reasons.
+- Nested macro phases pause parent timers so aggregate costs are not inflated by
+  recursive inclusive timing.
+- Release-mode baselines on the Calcit test snapshot and latest Respo identify
+  post-expansion processing and common structural macros as the next targets.
+- This is the instrumentation checkpoint for issue #436; it deliberately does
+  not add the typed Macro IR or pure expansion cache yet.

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -78,27 +78,28 @@ pub fn print_command_echo(cli_args: &ToplevelCalcit) {
 
 fn render_command_echo(cli_args: &ToplevelCalcit) -> Option<String> {
   let subcommand = cli_args.subcommand.as_ref()?;
+  let base_command = command_prefix(cli_args.macro_metrics);
   let snapshot_command = if cli_args.input == calcit::DEFAULT_SNAPSHOT_FILE {
-    "calcit".to_owned()
+    base_command.clone()
   } else {
-    format!("calcit {}", format_atom(&cli_args.input))
+    format!("{base_command} {}", format_atom(&cli_args.input))
   };
   let mut tokens = vec![match subcommand {
     CalcitCommand::Query(cmd) => format!("{snapshot_command} query {}", query_name(&cmd.subcommand)),
     CalcitCommand::Docs(cmd) => match &cmd.subcommand {
       DocsSubcommand::RemoteLibs(opts) => match opts.subcommand.as_ref() {
-        Some(subcommand) => format!("calcit docs remote-libs {}", libs_name(subcommand)),
-        None => "calcit docs remote-libs".to_string(),
+        Some(subcommand) => format!("{base_command} docs remote-libs {}", libs_name(subcommand)),
+        None => format!("{base_command} docs remote-libs"),
       },
-      other => format!("calcit docs {}", docs_name(other)),
+      other => format!("{base_command} docs {}", docs_name(other)),
     },
-    CalcitCommand::Libs(cmd) => format!("calcit libs {}", libs_name(cmd.subcommand.as_ref()?)),
+    CalcitCommand::Libs(cmd) => format!("{base_command} libs {}", libs_name(cmd.subcommand.as_ref()?)),
     CalcitCommand::Edit(cmd) => format!("{snapshot_command} edit {}", edit_name(&cmd.subcommand)),
     CalcitCommand::Tree(cmd) => format!("{snapshot_command} tree {}", tree_name(&cmd.subcommand)),
     CalcitCommand::Cursor(cmd) => format!("{snapshot_command} cursor {}", cursor_name(&cmd.subcommand)),
     CalcitCommand::Config(cmd) => format!("{snapshot_command} config {}", config_name(&cmd.subcommand)),
     CalcitCommand::Analyze(cmd) => format!("{snapshot_command} analyze {}", analyze_name(&cmd.subcommand)),
-    CalcitCommand::Cirru(cmd) => format!("calcit cirru {}", cirru_name(&cmd.subcommand)),
+    CalcitCommand::Cirru(cmd) => format!("{base_command} cirru {}", cirru_name(&cmd.subcommand)),
     CalcitCommand::Test(_) => format!("{snapshot_command} test"),
     _ => return None,
   }];
@@ -141,6 +142,14 @@ fn render_command_echo(cli_args: &ToplevelCalcit) -> Option<String> {
   }
 
   Some(tokens.join(" "))
+}
+
+fn command_prefix(macro_metrics: bool) -> String {
+  if macro_metrics {
+    "calcit --macro-metrics".to_owned()
+  } else {
+    "calcit".to_owned()
+  }
 }
 
 fn render_command_explanation(cli_args: &ToplevelCalcit) -> Option<String> {
@@ -1417,7 +1426,13 @@ fn push_config(tokens: &mut Vec<String>, cmd: &ConfigCommand) {
 
 #[cfg(test)]
 mod tests {
-  use super::{DEFAULT_ECHO_TOKEN_PREFIX, push_switch, push_value};
+  use super::{DEFAULT_ECHO_TOKEN_PREFIX, command_prefix, push_switch, push_value};
+
+  #[test]
+  fn global_macro_metrics_switch_precedes_snapshot_and_subcommand() {
+    assert_eq!(command_prefix(true), "calcit --macro-metrics");
+    assert_eq!(command_prefix(false), "calcit");
+  }
 
   #[test]
   fn default_command_echo_tokens_are_marked_without_hiding_real_parentheses() {

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -277,6 +277,7 @@ fn run_cli() -> Result<(), String> {
   // Query/analyze commands may run preprocessing before the normal program-loading path.
   runner::preprocess::set_warn_dyn_method(cli_args.warn_dyn_method);
   runner::preprocess::set_verbose_preprocess(cli_args.verbose);
+  let _macro_metrics_report = runner::macro_metrics::ReportOnDrop::new(cli_args.macro_metrics);
 
   if cli_handlers::should_echo_command(&cli_args) {
     cli_handlers::suppress_command_guidance();

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -52,6 +52,9 @@ pub struct ToplevelCalcit {
   /// print progress details and timing while loading and compiling
   #[argh(switch)]
   pub verbose: bool,
+  /// emit machine-readable macro expansion metrics to stderr on exit
+  #[argh(switch)]
+  pub macro_metrics: bool,
   /// maximum seconds for one JS/IR compilation (0 disables the limit)
   #[argh(option, default = "60")]
   pub timeout: u64,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,4 +1,5 @@
 pub mod macro_capability;
+pub mod macro_metrics;
 pub mod preprocess;
 pub mod track;
 
@@ -383,6 +384,8 @@ pub fn call_expr(
       );
 
       let mut current_values: Vec<Calcit> = xs.iter().skip(1).cloned().collect();
+      let macro_name = format!("{}/{}", info.def_ns, info.name);
+      macro_metrics::record_expansion(&macro_name, info.signature.as_ref());
 
       let next_stack = if using_stack() {
         call_stack.extend_owned(
@@ -407,7 +410,10 @@ pub fn call_expr(
         // need to handle recursion
         body_scope.restore_frame(frame_checkpoint);
         bind_marked_args(&mut body_scope, &info.args, &current_values, call_stack)?;
-        let evaluate_body = || evaluate_lines(info.body.as_ref().as_slice(), &body_scope, &info.def_ns, &next_stack);
+        let evaluate_body = || {
+          let _timer = macro_metrics::PhaseTimer::start(&macro_name, macro_metrics::MacroMetricPhase::Evaluator);
+          evaluate_lines(info.body.as_ref().as_slice(), &body_scope, &info.def_ns, &next_stack)
+        };
         let code = if info.signature.is_strict() {
           macro_capability::with_macro_context(
             Arc::from(format!("{}/{}", info.def_ns, info.name)),

--- a/src/runner/macro_capability.rs
+++ b/src/runner/macro_capability.rs
@@ -67,9 +67,16 @@ fn proc_policy(proc: CalcitProc) -> Option<CapabilityPolicy> {
     ReadFile | ReadDir => MacroCapability::FsRead,
     NativeGetOs | NativeGetCalcitBackend | NativeGetCalcitRunningMode => MacroCapability::PlatformRead,
     UnixTimeMs | CpuTime => MacroCapability::ClockRead,
-    GenerateId | NativeResetGenSymIndex | RegisterCalcitBuiltinImpls | Atom | AtomDeref | AddWatch | RemoveWatch => {
-      MacroCapability::MutableState
-    }
+    GenerateId
+    | NativeResetGenSymIndex
+    | RegisterCalcitBuiltinImpls
+    | NativeBufListNew
+    | NativeBufListPush
+    | NativeBufListConcat
+    | Atom
+    | AtomDeref
+    | AddWatch
+    | RemoveWatch => MacroCapability::MutableState,
     WriteFile => return Some(CapabilityPolicy::Forbidden(MacroCapability::FsWrite)),
     Quit => return Some(CapabilityPolicy::Forbidden(MacroCapability::Process)),
     _ => return None,
@@ -192,6 +199,22 @@ mod tests {
       check_proc(CalcitProc::GetEnv, &CallStackList::default())
     })
     .expect("declared env read should pass");
+  }
+
+  #[test]
+  fn buf_list_procedures_require_mutable_state() {
+    for proc in [
+      CalcitProc::NativeBufListNew,
+      CalcitProc::NativeBufListPush,
+      CalcitProc::NativeBufListConcat,
+    ] {
+      let error = with_macro_context(Arc::from("app/mutate-buffer"), Arc::new(HashSet::new()), None, || {
+        check_proc(proc, &CallStackList::default())
+      })
+      .expect_err("mutable BufList procedures must need a declaration");
+      assert_eq!(error.code(), Some("E_MACRO_CAPABILITY_MISSING"));
+      assert!(error.msg.contains(":mutable-state"));
+    }
   }
 
   #[test]

--- a/src/runner/macro_metrics.rs
+++ b/src/runner/macro_metrics.rs
@@ -1,0 +1,269 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+use crate::calcit::MacroSignature;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static METRICS: LazyLock<Mutex<BTreeMap<String, MacroExpansionMetric>>> = LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+thread_local! {
+  static ACTIVE_PHASES: RefCell<Vec<ActivePhase>> = const { RefCell::new(vec![]) };
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MacroExpansionMetric {
+  pub expansions: u64,
+  pub evaluator_nanos: u64,
+  pub post_preprocess_nanos: u64,
+  pub general_evaluator_fallbacks: u64,
+  pub cache_hits: u64,
+  pub cache_misses: u64,
+  pub cache_miss_reasons: BTreeMap<String, u64>,
+  pub cache_bypasses: BTreeMap<String, u64>,
+  pub cache_invalidations: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MacroMetricTotals {
+  expansions: u64,
+  evaluator_nanos: u64,
+  post_preprocess_nanos: u64,
+  general_evaluator_fallbacks: u64,
+  cache_hits: u64,
+  cache_misses: u64,
+  cache_miss_reasons: BTreeMap<String, u64>,
+  cache_bypasses: BTreeMap<String, u64>,
+  cache_invalidations: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MacroMetricsReport {
+  schema_version: u8,
+  unit: &'static str,
+  totals: MacroMetricTotals,
+  macros: BTreeMap<String, MacroExpansionMetric>,
+}
+
+fn add_reason(target: &mut BTreeMap<String, u64>, reason: &str, count: u64) {
+  *target.entry(reason.to_owned()).or_default() += count;
+}
+
+fn totals(metrics: &BTreeMap<String, MacroExpansionMetric>) -> MacroMetricTotals {
+  let mut totals = MacroMetricTotals::default();
+  for metric in metrics.values() {
+    totals.expansions += metric.expansions;
+    totals.evaluator_nanos += metric.evaluator_nanos;
+    totals.post_preprocess_nanos += metric.post_preprocess_nanos;
+    totals.general_evaluator_fallbacks += metric.general_evaluator_fallbacks;
+    totals.cache_hits += metric.cache_hits;
+    totals.cache_misses += metric.cache_misses;
+    for (reason, count) in &metric.cache_miss_reasons {
+      add_reason(&mut totals.cache_miss_reasons, reason, *count);
+    }
+    for (reason, count) in &metric.cache_bypasses {
+      add_reason(&mut totals.cache_bypasses, reason, *count);
+    }
+    for (reason, count) in &metric.cache_invalidations {
+      add_reason(&mut totals.cache_invalidations, reason, *count);
+    }
+  }
+  totals
+}
+
+fn update(name: &str, f: impl FnOnce(&mut MacroExpansionMetric)) {
+  if !ENABLED.load(Ordering::Relaxed) {
+    return;
+  }
+  let mut metrics = METRICS.lock().expect("lock macro expansion metrics");
+  f(metrics.entry(name.to_owned()).or_default());
+}
+
+/// Record one macro call before evaluator execution. The cache counters are
+/// intentionally explicit even before a cache exists: strict pure candidates
+/// count as misses (`cache-not-implemented`), while effectful and legacy calls
+/// are bypassed with a stable reason.
+pub fn record_expansion(name: &str, signature: &MacroSignature) {
+  update(name, |metric| {
+    metric.expansions += 1;
+    metric.general_evaluator_fallbacks += 1;
+    if !signature.is_strict() {
+      add_reason(&mut metric.cache_bypasses, "legacy-signature", 1);
+    } else if !signature.capabilities.is_empty() {
+      add_reason(&mut metric.cache_bypasses, "declared-capabilities", 1);
+    } else {
+      metric.cache_misses += 1;
+      add_reason(&mut metric.cache_miss_reasons, "cache-not-implemented", 1);
+    }
+  });
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacroMetricPhase {
+  Evaluator,
+  PostPreprocess,
+}
+
+struct ActivePhase {
+  name: String,
+  phase: MacroMetricPhase,
+  resumed_at: Instant,
+}
+
+pub struct PhaseTimer {
+  name: String,
+  phase: MacroMetricPhase,
+}
+
+impl PhaseTimer {
+  pub fn start(name: &str, phase: MacroMetricPhase) -> Option<Self> {
+    if !ENABLED.load(Ordering::Relaxed) {
+      return None;
+    }
+    let now = Instant::now();
+    let paused_parent = ACTIVE_PHASES.with(|phases| {
+      let mut phases = phases.borrow_mut();
+      let paused = phases
+        .last()
+        .map(|parent| (parent.name.clone(), parent.phase, now.duration_since(parent.resumed_at)));
+      phases.push(ActivePhase {
+        name: name.to_owned(),
+        phase,
+        resumed_at: now,
+      });
+      paused
+    });
+    if let Some((parent_name, parent_phase, elapsed)) = paused_parent {
+      record_phase(&parent_name, parent_phase, elapsed);
+    }
+    Some(Self {
+      name: name.to_owned(),
+      phase,
+    })
+  }
+}
+
+fn duration_nanos(duration: Duration) -> u64 {
+  duration.as_nanos().min(u128::from(u64::MAX)) as u64
+}
+
+fn record_phase(name: &str, phase: MacroMetricPhase, elapsed: Duration) {
+  let elapsed = duration_nanos(elapsed);
+  update(name, |metric| match phase {
+    MacroMetricPhase::Evaluator => metric.evaluator_nanos += elapsed,
+    MacroMetricPhase::PostPreprocess => metric.post_preprocess_nanos += elapsed,
+  });
+}
+
+impl Drop for PhaseTimer {
+  fn drop(&mut self) {
+    let now = Instant::now();
+    let elapsed = ACTIVE_PHASES.with(|phases| {
+      let mut phases = phases.borrow_mut();
+      let active = phases.pop().expect("macro metric phase stack must be balanced");
+      debug_assert_eq!(active.name, self.name);
+      debug_assert_eq!(active.phase, self.phase);
+      if let Some(parent) = phases.last_mut() {
+        parent.resumed_at = now;
+      }
+      now.duration_since(active.resumed_at)
+    });
+    record_phase(&self.name, self.phase, elapsed);
+  }
+}
+
+pub fn reset(enabled: bool) {
+  ENABLED.store(enabled, Ordering::SeqCst);
+  METRICS.lock().expect("reset macro expansion metrics").clear();
+  ACTIVE_PHASES.with(|phases| phases.borrow_mut().clear());
+}
+
+pub fn report_json() -> Result<String, String> {
+  let metrics = METRICS.lock().expect("read macro expansion metrics").clone();
+  serde_json::to_string(&MacroMetricsReport {
+    schema_version: 1,
+    unit: "nanoseconds",
+    totals: totals(&metrics),
+    macros: metrics,
+  })
+  .map_err(|error| format!("failed to serialize macro expansion metrics: {error}"))
+}
+
+pub struct ReportOnDrop {
+  enabled: bool,
+}
+
+impl ReportOnDrop {
+  pub fn new(enabled: bool) -> Self {
+    reset(enabled);
+    Self { enabled }
+  }
+}
+
+impl Drop for ReportOnDrop {
+  fn drop(&mut self) {
+    if self.enabled {
+      match report_json() {
+        Ok(report) => eprintln!("macro-expansion-metrics: {report}"),
+        Err(error) => eprintln!("[Warn] {error}"),
+      }
+      ENABLED.store(false, Ordering::SeqCst);
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::calcit::{MacroCapability, MacroExpansionType, MacroSignatureCompatibility};
+  use std::collections::HashSet;
+  use std::sync::Arc;
+
+  fn pure_signature() -> MacroSignature {
+    MacroSignature {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      required_inputs: Arc::new(vec![]),
+      optional_inputs: Arc::new(vec![]),
+      rest_input: None,
+      expansion: MacroExpansionType::Dynamic,
+      capabilities: Arc::new(HashSet::new()),
+      features: Arc::new(HashSet::new()),
+      compatibility: MacroSignatureCompatibility::Strict,
+    }
+  }
+
+  #[test]
+  fn report_separates_counts_timings_and_cache_reasons() {
+    reset(true);
+    record_expansion("tests/pure", &pure_signature());
+    let legacy = MacroSignature::legacy_dynamic();
+    record_expansion("tests/legacy", &legacy);
+    let mut effectful = pure_signature();
+    effectful.capabilities = Arc::new(HashSet::from([MacroCapability::EnvRead]));
+    record_expansion("tests/effectful", &effectful);
+    {
+      let _timer = PhaseTimer::start("tests/pure", MacroMetricPhase::Evaluator);
+    }
+    {
+      let _timer = PhaseTimer::start("tests/pure", MacroMetricPhase::PostPreprocess);
+    }
+    let report: serde_json::Value = serde_json::from_str(&report_json().expect("metrics JSON")).expect("valid JSON");
+    assert_eq!(report["totals"]["expansions"], 3);
+    assert_eq!(report["totals"]["generalEvaluatorFallbacks"], 3);
+    assert_eq!(report["totals"]["cacheMisses"], 1);
+    assert_eq!(report["totals"]["cacheMissReasons"]["cache-not-implemented"], 1);
+    assert_eq!(report["totals"]["cacheBypasses"]["legacy-signature"], 1);
+    assert_eq!(report["totals"]["cacheBypasses"]["declared-capabilities"], 1);
+    assert_eq!(report["totals"]["cacheInvalidations"], serde_json::json!({}));
+    assert!(report["macros"]["tests/pure"]["evaluatorNanos"].as_u64().is_some());
+    reset(false);
+  }
+}

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1705,6 +1705,8 @@ fn preprocess_list_call(
 
   match head_value {
     Some(Calcit::Macro { info, .. }) => {
+      let macro_name = format!("{}/{}", info.def_ns, info.name);
+      runner::macro_metrics::record_expansion(&macro_name, info.signature.as_ref());
       let mut current_values: Vec<Calcit> = args.to_vec();
       let mut macro_type_bindings = validate_macro_call_inputs(
         info.name.as_ref(),
@@ -1731,7 +1733,10 @@ fn preprocess_list_call(
           // need to handle recursion
           body_scope.restore_frame(frame_checkpoint);
           runner::bind_marked_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
+          let evaluator_timer =
+            runner::macro_metrics::PhaseTimer::start(&macro_name, runner::macro_metrics::MacroMetricPhase::Evaluator);
           let code = runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack)?;
+          drop(evaluator_timer);
           match code {
             Calcit::Recur(ys) => {
               current_values = ys;
@@ -1746,6 +1751,8 @@ fn preprocess_list_call(
               )?;
             }
             _ => {
+              let _post_preprocess_timer =
+                runner::macro_metrics::PhaseTimer::start(&macro_name, runner::macro_metrics::MacroMetricPhase::PostPreprocess);
               let processed = preprocess_expr(&code, scope_defs, scope_types, file_ns, check_warnings, &next_stack)?;
               validate_macro_expansion_result(
                 info.name.as_ref(),
@@ -1764,7 +1771,7 @@ fn preprocess_list_call(
 
       if info.signature.is_strict() {
         runner::macro_capability::with_macro_context(
-          Arc::from(format!("{}/{}", info.def_ns, info.name)),
+          Arc::from(macro_name.as_str()),
           info.signature.capabilities.clone(),
           call_location.clone(),
           execute_macro,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1555,9 +1555,6 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
     ));
   }
 
-  // EDN-level validity
-  parse_schema_data(schema)?;
-
   // Reject deprecated :nil type annotation
   check_no_nil_type(schema)?;
 
@@ -1695,6 +1692,9 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
       let Cirru::Leaf(name) = item else {
         return Err("`:capabilities` hashset items must be simple leaf tags".to_owned());
       };
+      if !name.starts_with(':') {
+        return Err(format!("Macro capability `{name}` must be a colon-prefixed tag"));
+      }
       if crate::calcit::MacroCapability::parse(name).is_none() {
         return Err(format!(
           "Unknown macro capability `{name}`. Expected one of: :env-read, :fs-read, :platform-read, :clock-read, :mutable-state, :dynamic-eval, :fs-write, :process, :host-ffi"
@@ -1725,6 +1725,10 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
       }
     }
   }
+
+  // Run the general EDN parser after field-specific checks so malformed
+  // capability metadata receives the stable schema diagnostic above.
+  parse_schema_data(schema)?;
 
   Ok(())
 }
@@ -3936,6 +3940,18 @@ mod tests {
     .expect("schema node");
     let error = parse_schema_annotation_for_write(&schema).expect_err("unknown capabilities must not silently become pure");
     assert!(error.contains("Unknown macro capability"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn macro_schema_rejects_non_tag_compile_time_capabilities() {
+    let schema =
+      cirru_parser::parse(":: 'Macro\n  {} (:required $ [])\n    :expansion $ :: 'Expr 'String\n    :capabilities $ #{} env-read")
+        .expect("schema syntax")
+        .into_iter()
+        .next()
+        .expect("schema node");
+    let error = parse_schema_annotation_for_write(&schema).expect_err("capability symbols must not pass as tags");
+    assert!(error.contains("colon-prefixed tag"), "unexpected error: {error}");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add opt-in `--macro-metrics` JSON diagnostics for expansion counts, exclusive evaluator/post-preprocess time, evaluator fallbacks, and cache outcome reasons
- pause parent phase timers during nested macro expansion so aggregate costs do not double-count recursive work
- document reproducible three-run release baselines for the Calcit test snapshot and latest Respo
- address delayed review feedback from #440: canonical empty capabilities, mutable BufList classification, and strict capability-tag validation

## Baseline

Three warm release runs, median:

- Calcit test snapshot: 2,432 expansions, 20.21 ms evaluator, 52.61 ms post-preprocess
- Respo JS check: 1,414 expansions, 14.24 ms evaluator, 35.50 ms post-preprocess

The profile prioritizes common structural macros and post-expansion processing for the next typed Macro IR phase. This PR intentionally does not add the IR or cache yet.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (508 lib, 245 CLI, 24 caps, 4 wasm)
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (17/17)
- `calcit docs check-md --entry calcit/test.cirru docs/run/cli-options.md`
- latest Respo main: 27/27 definition-attached tests; JS check and release-mode metrics passed

Progresses #436.
