### PR TITLE
refactor: type core structural macros

### DIFF
--- a/docs/MacroSignature.md
+++ b/docs/MacroSignature.md
@@ -37,6 +37,37 @@ and serialize without data loss. They become an explicitly legacy, non-strict
 syntax contracts. An omitted or `Dynamic` legacy macro schema likewise does not
 claim full phase coverage.
 
+## Migrating structural macros
+
+Do not replace a whole-`Dynamic` schema with invented runtime parameter types.
+First describe the raw syntax the macro actually inspects and the semantic kind
+of the emitted form. For example, a binding macro with one list-shaped syntax
+argument and arbitrary body forms can use:
+
+```cirru
+:: 'Macro
+  {} (:required $ [] 'SyntaxList)
+    :rest 'Syntax
+    :expansion $ :: 'Expr 'Dynamic
+    :capabilities $ #{}
+```
+
+`Expr<Dynamic>` here is an explicit semantic boundary: the expansion is known
+to be an expression, but its value type depends on user code. It is stricter
+than a legacy whole-`Dynamic` macro without pretending that every body form has
+one static value type. Use `SyntaxSymbol` for declaration names, `SyntaxList`
+for argument/binding/pair lists, `Expr<T>` only when call-site semantic typing
+is meaningful, and `Definition<T>` or `Declarations` only when the emitted AST
+is genuinely a definition.
+
+After migration, inspect the stored contract rather than relying on coverage
+percentages alone:
+
+```bash
+calcit query schema calcit.core/let
+calcit query context calcit.core/let --format json
+```
+
 ## Compile-time capabilities
 
 A strict macro is pure by default. Effects performed while its body is being

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -123,11 +123,12 @@ it exits. Timing fields use nanoseconds. Per-macro and total evaluator and
 post-preprocess times are exclusive: when a nested macro starts, its parent's
 timer pauses, so totals do not double-count recursive expansion work.
 
-The report also records general-evaluator fallbacks, cache hits and misses,
-miss reasons, bypass reasons, and actual invalidation reasons. Before the pure
-expansion cache lands, eligible strict/pure macros report a
-`cache-not-implemented` miss; legacy and effectful signatures report explicit
-bypasses rather than false invalidations.
+The report records general-evaluator fallbacks, cache misses, miss reasons, and
+bypass reasons. Before the pure expansion cache lands, eligible strict/pure
+macros report a `cache-not-implemented` miss; legacy and effectful signatures
+report explicit bypasses rather than false invalidations. The `cacheHits` and
+`cacheInvalidations` fields are reserved for the cache implementation and stay
+at zero or empty until that implementation activates them.
 
 Reproducible release-mode baseline from 2026-08-25 (three warm runs, median):
 

--- a/editing-history/20260825-2337-macro-query-and-capability-scope.md
+++ b/editing-history/20260825-2337-macro-query-and-capability-scope.md
@@ -1,0 +1,11 @@
+# Macro query and capability scope follow-up
+
+- Preserve strict Macro contracts in `query schema`, `query context`, and JSON
+  output instead of degrading them through ordinary type serialization.
+- Serialize an explicit empty `:capabilities` set for every strict/pure Macro;
+  legacy signatures retain their compatibility representation.
+- Limit a strict macro's capability context to evaluation of its own body.
+  Post-preprocessing an emitted expansion may invoke a separate nested macro,
+  whose effects must not be charged to the outer emitter.
+- Added query regression coverage and validated the boundary with the migrated
+  core `fn` macro emitting bodies that contain platform-sensitive legacy macros.

--- a/editing-history/20260825-2338-core-structural-macro-contracts.md
+++ b/editing-history/20260825-2338-core-structural-macro-contracts.md
@@ -1,0 +1,10 @@
+# Core structural macro contracts
+
+- Migrated `let`, `fn`, `and`, `cond`, and `do` from whole-Dynamic legacy
+  schemas to strict, compile-time-pure phase contracts.
+- Kept expansion values as `Expr<Dynamic>` where the result depends on user
+  code, while enforcing list-shaped binding/argument/condition syntax.
+- Canonicalized strict Macro storage with explicit empty capability sets and
+  added snapshot assertions so the migrated set cannot silently regress.
+- The Calcit test snapshot now exposes 895 strict/pure expansion candidates in
+  the measured run (up from 4), while preserving all 2,432 expansions.

--- a/editing-history/20260825-2356-delayed-macro-metrics-review.md
+++ b/editing-history/20260825-2356-delayed-macro-metrics-review.md
@@ -1,0 +1,5 @@
+# Delayed macro metrics review
+
+- Clarified that `cacheHits` and `cacheInvalidations` are reserved report fields until the expansion cache is implemented.
+- Made the metrics report unit test operate on local state, avoiding interference with global opt-in metrics state when Rust tests run in parallel.
+- Kept production collection behavior unchanged by extracting small state-local recording and serialization helpers.

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -336,6 +336,7 @@ fn query_schema_cirru(annotation: &CalcitTypeAnnotation, wrapped: bool) -> Resul
     CalcitTypeAnnotation::Dynamic => return Ok(None),
     CalcitTypeAnnotation::Fn(fn_annot) if wrapped => fn_annot.to_wrapped_schema_edn(),
     CalcitTypeAnnotation::Fn(fn_annot) => fn_annot.to_schema_edn(),
+    CalcitTypeAnnotation::Macro(signature) => signature.to_wrapped_schema_edn(),
     other => other.to_type_edn(),
   };
   snapshot::schema_edn_to_cirru(&schema_edn).map(|cirru| {
@@ -903,6 +904,32 @@ mod type_query_tests {
     let value: serde_json::Value = serde_json::from_str(&output).expect("schema output should be valid JSON");
     assert_eq!(value["data"]["canonical_schema"], "'Ref");
     assert_eq!(value["data"]["tree"], "'Ref");
+  }
+
+  #[test]
+  fn strict_macro_schema_queries_preserve_phase_contracts() {
+    let schema = cirru_parser::parse(
+      ":: 'Macro\n  {} (:required $ [] 'SyntaxList)\n    :rest 'Syntax\n    :expansion $ :: 'Expr 'Dynamic\n    :capabilities $ #{}",
+    )
+    .expect("strict macro schema syntax")
+    .into_iter()
+    .next()
+    .expect("schema node");
+    let annotation = snapshot::parse_schema_annotation_for_write(&schema).expect("strict macro schema");
+
+    let displayed = format_query_schema(annotation.as_ref(), true);
+    assert!(displayed.contains(":: 'Macro"), "unexpected schema: {displayed}");
+    assert!(displayed.contains(":required"), "unexpected schema: {displayed}");
+    assert!(displayed.contains(":capabilities $ #{}"), "unexpected schema: {displayed}");
+    assert_eq!(
+      context_schema(annotation.as_ref()).expect("context schema"),
+      Some(displayed.trim().to_owned())
+    );
+
+    let output = format_schema_query_json("app.main/with-bindings", "project", annotation.as_ref(), "revision-1".to_owned())
+      .expect("macro schema JSON");
+    let value: serde_json::Value = serde_json::from_str(&output).expect("schema output should be valid JSON");
+    assert_eq!(value["data"]["tree"][1], "'Macro");
   }
 
   #[test]
@@ -1976,7 +2003,7 @@ fn namespace_source(snapshot: &snapshot::Snapshot, namespace: &str) -> String {
 fn context_schema(annotation: &CalcitTypeAnnotation) -> Result<Option<String>, String> {
   match annotation {
     CalcitTypeAnnotation::Dynamic => Ok(None),
-    CalcitTypeAnnotation::Fn(_) => Ok(Some(format_query_schema(annotation, true).trim().to_owned())),
+    CalcitTypeAnnotation::Fn(_) | CalcitTypeAnnotation::Macro(_) => Ok(Some(format_query_schema(annotation, true).trim().to_owned())),
     _ => Ok(Some(format_type_query_annotation(annotation)?)),
   }
 }
@@ -1984,6 +2011,11 @@ fn context_schema(annotation: &CalcitTypeAnnotation) -> Result<Option<String>, S
 fn context_features(annotation: &CalcitTypeAnnotation) -> Vec<String> {
   let mut features = match annotation {
     CalcitTypeAnnotation::Fn(fn_annot) => fn_annot
+      .features
+      .iter()
+      .map(|feature| feature.ref_str().to_owned())
+      .collect::<Vec<_>>(),
+    CalcitTypeAnnotation::Macro(signature) => signature
       .features
       .iter()
       .map(|feature| feature.ref_str().to_owned())

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -614,15 +614,13 @@ impl MacroSignature {
     if let Some(expansion) = Self::expansion_to_edn(&self.expansion) {
       map.insert_key("expansion", expansion);
     }
-    if !self.capabilities.is_empty() {
-      let mut set = EdnSetView::default();
-      let mut capabilities = self.capabilities.iter().copied().collect::<Vec<_>>();
-      capabilities.sort_unstable();
-      for capability in capabilities {
-        set.insert(Edn::Tag(EdnTag::new(capability.as_str())));
-      }
-      map.insert_key("capabilities", Edn::Set(set));
+    let mut set = EdnSetView::default();
+    let mut capabilities = self.capabilities.iter().copied().collect::<Vec<_>>();
+    capabilities.sort_unstable();
+    for capability in capabilities {
+      set.insert(Edn::Tag(EdnTag::new(capability.as_str())));
     }
+    map.insert_key("capabilities", Edn::Set(set));
     if !self.generics.is_empty() {
       map.insert_key(
         "generics",

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -31,7 +31,8 @@
               quasiquote $ ->%
                 ~@ $ reverse xs
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :macro
         |%err $ %{} 'CodeEntry (:doc "|Create Err variant of Result")
           :code $ quote
@@ -104,9 +105,10 @@
                 p $ %{}? Point (:x 1)
               assert= nil $ :y p
           :schema $ :: 'Macro
-            {} (:required $ [] 'SyntaxSymbol)
-              :rest 'SyntaxList
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
               :expansion $ :: 'Expr 'Struct
+              :required $ [] 'SyntaxSymbol
           :tags $ #{} :macro
         |& $ %{} 'CodeEntry (:doc "|internal syntax for spreading in function definition and call\nSyntax: (& rest-args) in params or (f & args) in calls\nParams: varies based on context\nReturns: varies based on context\nMarks rest parameters or argument spreading")
           :code $ quote &runtime-implementation
@@ -2667,7 +2669,8 @@
               quasiquote $ ->
                 ~@ $ reverse xs
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :macro
         |<= $ %{} 'CodeEntry (:doc "|Less than or equal comparison, supports multiple arguments")
           :code $ quote
@@ -3049,7 +3052,12 @@
           :examples $ []
             quote $ assert= false (and true false true)
             quote $ assert= |done (and true |done)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |any? $ %{} 'CodeEntry (:doc "|checks if any element in collection satisfies the predicate function, returns true on first match, short-circuits evaluation")
           :code $ quote
@@ -3588,7 +3596,11 @@
                 true :fallback
             quote $ assert= :fallback
               cond (false :branch) (true :fallback)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
           :tags $ #{} :macro
         |conj $ %{} 'CodeEntry (:doc "|Appends values to the end of a list, returning a new list\nSupports adding multiple values by chaining additional arguments.")
           :code $ quote
@@ -4474,7 +4486,12 @@
               do (inc 1) (+ 1 2)
             quote $ assert= |world
               do (str |hello) (str |world)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |drop $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -4538,7 +4555,8 @@
             quote $ assert= 42 (either nil 42 nil)
             quote $ assert= false (either false true)
             quote $ assert= |backup (either nil nil |backup)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :macro
         |empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -4922,7 +4940,10 @@
             quote $ filter ([] 1 2 3 4 5)
               fn (n) (> n 2)
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList
           :tags $ #{} :macro
         |fn? $ %{} 'CodeEntry (:doc "|Check if a value is a function")
           :code $ quote &runtime-implementation
@@ -5395,7 +5416,8 @@
                       quote nil
                     quasiquote $ if ~condition ~false-branch ~true-branch
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :macro
         |impl-origin $ %{} 'CodeEntry (:doc "|Return the trait origin of an impl as Option<Trait>; inherent method bags produce none.")
           :code $ quote
@@ -5847,7 +5869,10 @@
                 a 10
               * a a
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList
           :tags $ #{} :macro
         |let-destruct $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -6006,7 +6031,8 @@
               list-match ([] 1 2 3)
                 () nil
                 (head tail) head
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :macro
         |list? $ %{} 'CodeEntry (:doc "|checks if value is a list\nSyntax: (list? x)\nParams: x (any)\nReturns: true if x is a list, false otherwise\nType predicate for list data structure")
           :code $ quote &runtime-implementation
@@ -6636,7 +6662,8 @@
             quote $ assert= |done (or nil |done false)
             quote $ assert= false (or false nil)
             quote $ assert= 2 (or nil 2 3)
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :macro
           :tests $ []
             %{} 'TestEntry (:name |skips-unit-and-returns-next-truthy-value)
@@ -6849,7 +6876,8 @@
           :code $ quote
             defmacro record-match (& _args) (raise "|`record-match` was removed; use `struct-match`")
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :deprecated :macro
         |record-struct $ %{} 'CodeEntry (:doc "|Deprecated legacy function. Replace `record-struct` with `struct-definition`, which returns Option<StructDef>.")
           :code $ quote
@@ -6864,7 +6892,8 @@
           :code $ quote
             defmacro record-with (& _args) (raise "|`record-with` was removed; use `struct-with`")
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :deprecated :macro
         |record? $ %{} 'CodeEntry (:doc "|Deprecated legacy predicate. Replace `record?` with `struct?` for values or `struct-def?` for definitions.")
           :code $ quote
@@ -7703,7 +7732,8 @@
               if (&list:empty? xs) (raise "|thread-as expects at least 1 expression")
               quasiquote $ ->% ~@xs
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :alias :macro
         |thread-first $ %{} 'CodeEntry (:doc "|a alias for `->`")
           :code $ quote
@@ -7711,7 +7741,8 @@
               if (&list:empty? xs) (raise "|thread-first expects at least 1 expression")
               quasiquote $ -> ~@xs
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :alias :macro
         |thread-last $ %{} 'CodeEntry (:doc "|a alias for `->>`")
           :code $ quote
@@ -7719,7 +7750,8 @@
               if (&list:empty? xs) (raise "|thread-last expects at least 1 expression")
               quasiquote $ ->> ~@xs
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :alias :macro
         |thread-step? $ %{} 'CodeEntry (:doc "|Check whether a value is a valid thread-macro step form")
           :code $ quote
@@ -8213,7 +8245,8 @@
                 quasiquote $ pairs-map
                   section-by ([] ~@xs) 2
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Macro
+            {} $ :args ([])
           :tags $ #{} :macro
         |{} $ %{} 'CodeEntry (:doc "|macro for creating hashmaps\nSyntax: ({} (:key value) ...)\nParams: pairs (key-value pairs)\nReturns: hashmap\nCreates a hashmap from key-value pairs")
           :code $ quote

--- a/src/runner/macro_metrics.rs
+++ b/src/runner/macro_metrics.rs
@@ -91,18 +91,20 @@ fn update(name: &str, f: impl FnOnce(&mut MacroExpansionMetric)) {
 /// count as misses (`cache-not-implemented`), while effectful and legacy calls
 /// are bypassed with a stable reason.
 pub fn record_expansion(name: &str, signature: &MacroSignature) {
-  update(name, |metric| {
-    metric.expansions += 1;
-    metric.general_evaluator_fallbacks += 1;
-    if !signature.is_strict() {
-      add_reason(&mut metric.cache_bypasses, "legacy-signature", 1);
-    } else if !signature.capabilities.is_empty() {
-      add_reason(&mut metric.cache_bypasses, "declared-capabilities", 1);
-    } else {
-      metric.cache_misses += 1;
-      add_reason(&mut metric.cache_miss_reasons, "cache-not-implemented", 1);
-    }
-  });
+  update(name, |metric| record_expansion_metric(metric, signature));
+}
+
+fn record_expansion_metric(metric: &mut MacroExpansionMetric, signature: &MacroSignature) {
+  metric.expansions += 1;
+  metric.general_evaluator_fallbacks += 1;
+  if !signature.is_strict() {
+    add_reason(&mut metric.cache_bypasses, "legacy-signature", 1);
+  } else if !signature.capabilities.is_empty() {
+    add_reason(&mut metric.cache_bypasses, "declared-capabilities", 1);
+  } else {
+    metric.cache_misses += 1;
+    add_reason(&mut metric.cache_miss_reasons, "cache-not-implemented", 1);
+  }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -187,6 +189,10 @@ pub fn reset(enabled: bool) {
 
 pub fn report_json() -> Result<String, String> {
   let metrics = METRICS.lock().expect("read macro expansion metrics").clone();
+  report_json_for(metrics)
+}
+
+fn report_json_for(metrics: BTreeMap<String, MacroExpansionMetric>) -> Result<String, String> {
   serde_json::to_string(&MacroMetricsReport {
     schema_version: 1,
     unit: "nanoseconds",
@@ -242,20 +248,17 @@ mod tests {
 
   #[test]
   fn report_separates_counts_timings_and_cache_reasons() {
-    reset(true);
-    record_expansion("tests/pure", &pure_signature());
+    let mut metrics = BTreeMap::new();
+    let pure = metrics.entry("tests/pure".to_owned()).or_default();
+    record_expansion_metric(pure, &pure_signature());
+    pure.evaluator_nanos = 1;
+    pure.post_preprocess_nanos = 2;
     let legacy = MacroSignature::legacy_dynamic();
-    record_expansion("tests/legacy", &legacy);
+    record_expansion_metric(metrics.entry("tests/legacy".to_owned()).or_default(), &legacy);
     let mut effectful = pure_signature();
     effectful.capabilities = Arc::new(HashSet::from([MacroCapability::EnvRead]));
-    record_expansion("tests/effectful", &effectful);
-    {
-      let _timer = PhaseTimer::start("tests/pure", MacroMetricPhase::Evaluator);
-    }
-    {
-      let _timer = PhaseTimer::start("tests/pure", MacroMetricPhase::PostPreprocess);
-    }
-    let report: serde_json::Value = serde_json::from_str(&report_json().expect("metrics JSON")).expect("valid JSON");
+    record_expansion_metric(metrics.entry("tests/effectful".to_owned()).or_default(), &effectful);
+    let report: serde_json::Value = serde_json::from_str(&report_json_for(metrics).expect("metrics JSON")).expect("valid JSON");
     assert_eq!(report["totals"]["expansions"], 3);
     assert_eq!(report["totals"]["generalEvaluatorFallbacks"], 3);
     assert_eq!(report["totals"]["cacheMisses"], 1);
@@ -263,7 +266,7 @@ mod tests {
     assert_eq!(report["totals"]["cacheBypasses"]["legacy-signature"], 1);
     assert_eq!(report["totals"]["cacheBypasses"]["declared-capabilities"], 1);
     assert_eq!(report["totals"]["cacheInvalidations"], serde_json::json!({}));
-    assert!(report["macros"]["tests/pure"]["evaluatorNanos"].as_u64().is_some());
-    reset(false);
+    assert_eq!(report["macros"]["tests/pure"]["evaluatorNanos"], 1);
+    assert_eq!(report["macros"]["tests/pure"]["postPreprocessNanos"], 2);
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1735,7 +1735,19 @@ fn preprocess_list_call(
           runner::bind_marked_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
           let evaluator_timer =
             runner::macro_metrics::PhaseTimer::start(&macro_name, runner::macro_metrics::MacroMetricPhase::Evaluator);
-          let code = runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack)?;
+          let evaluate_body = || runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack);
+          let code = if info.signature.is_strict() {
+            runner::macro_capability::with_macro_context(
+              Arc::from(macro_name.as_str()),
+              info.signature.capabilities.clone(),
+              call_location.clone(),
+              evaluate_body,
+            )?
+          } else {
+            // Legacy Macro schemas remain compatible, but their effects are
+            // deliberately unknown and therefore cannot be considered pure.
+            evaluate_body()?
+          };
           drop(evaluator_timer);
           match code {
             Calcit::Recur(ys) => {
@@ -1768,19 +1780,7 @@ fn preprocess_list_call(
           }
         }
       };
-
-      if info.signature.is_strict() {
-        runner::macro_capability::with_macro_context(
-          Arc::from(macro_name.as_str()),
-          info.signature.capabilities.clone(),
-          call_location.clone(),
-          execute_macro,
-        )
-      } else {
-        // Legacy Macro schemas remain compatible, but their effects are
-        // deliberately unknown and therefore cannot be considered pure.
-        execute_macro()
-      }
+      execute_macro()
     }
 
     Some(Calcit::Fn { info, .. }) => {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -3988,6 +3988,39 @@ mod tests {
         );
       }
     }
+
+    for def_name in ["let", "fn", "and", "cond", "do"] {
+      let entry = core_file.defs.get(def_name).unwrap_or_else(|| panic!("missing def: {def_name}"));
+      let CalcitTypeAnnotation::Macro(signature) = entry.schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert!(
+        matches!(signature.expansion, crate::calcit::MacroExpansionType::Expr(ref inner) if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)),
+        "{def_name} should explicitly retain a dynamic expression result"
+      );
+    }
+
+    for def_name in ["let", "fn"] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        unreachable!()
+      };
+      assert!(matches!(
+        signature.required_inputs.as_slice(),
+        [crate::calcit::MacroSyntaxType::SyntaxList]
+      ));
+      assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+    }
+
+    let CalcitTypeAnnotation::Macro(cond_signature) = core_file.defs["cond"].schema.as_ref() else {
+      unreachable!()
+    };
+    assert!(cond_signature.required_inputs.is_empty());
+    assert!(matches!(
+      cond_signature.rest_input,
+      Some(crate::calcit::MacroSyntaxType::SyntaxList)
+    ));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- preserve strict macro phase contracts in `query schema` and `query context`
- scope compile-time capability enforcement to evaluation of a strict macro body, rather than effects contained in the emitted runtime expression
- migrate the high-frequency structural macros `let`, `fn`, `and`, `cond`, and `do` to strict phase-aware contracts
- clarify the migration strategy and add snapshot/query regression coverage
- address delayed review feedback from #441 by documenting reserved cache fields and isolating the metrics report test from global state

## Impact

On the Calcit test snapshot, strict/pure cache candidates increase from 4 to 895 expansions while total expansion count remains 2,432. `Expr<Dynamic>` is retained as an explicit semantic boundary where the macro guarantees an expression but cannot yet promise its runtime value type.

The Snapshot formatter also canonicalizes existing bare legacy `Dynamic` macro schemas as explicit legacy `Macro { :args [] }` contracts; this does not make those macros strict.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- full `cargo test`: 508 library, 246 CLI, 24 caps, and 4 WASM tests
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (17/17)
- Macro signature docs examples (3/3)
- Respo `be8141e`: 27/27 native tests and JS check-only
- Recollect `6c235d0`: 9/9 native tests, JS codegen/runtime, and WASM
- targeted delayed-review metrics and strict macro capability tests

Closes #442
Progresses #437
