### PR TITLE
refactor: type assertion macros

### DIFF
--- a/editing-history/20260826-0007-assertion-macro-contracts.md
+++ b/editing-history/20260826-0007-assertion-macro-contracts.md
@@ -1,0 +1,8 @@
+# Assertion macro contracts
+
+- Migrated the three `calcit.core` assertion macros and five `calcit.test` helpers to strict, pure phase-aware contracts.
+- Kept input values as `Expr<Dynamic>` because equality and truthiness intentionally accept heterogeneous runtime values.
+- Declared precise expansion results: `Expr<Unit>` for assertion helpers and `Expr<Bool>` for `throws?`.
+- Added the missing successful `&unit` branch to `assert=` so its implementation matches its long-standing Unit contract.
+- Added snapshot coverage and exercised definition-attached tests plus public examples.
+- On `calcit/test.cirru`, strict/pure macro candidates increased from 895 to 1,666 while total expansions stayed at 2,432.

--- a/editing-history/20260826-0023-assertion-macro-review.md
+++ b/editing-history/20260826-0023-assertion-macro-review.md
@@ -1,0 +1,4 @@
+# Assertion macro review
+
+- Strengthened the real Snapshot inventory test to assert the exact required input count for each `calcit.test` assertion helper.
+- Kept the original history timestamp because the commit was created at `2026-08-26 00:13:33 +0800`; the review bot compared against the previous UTC date.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -3160,8 +3160,10 @@
             quote $ assert "|list should not be empty"
               not $ empty? ([] 1)
           :schema $ :: 'Macro
-            {} (:return 'Unit)
-              :args $ [] 'Dynamic 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
           :tags $ #{} :control :log :macro
         |assert-detect $ %{} 'CodeEntry (:doc "|Assert that a value satisfies a predicate, raise with details when false, and return Unit on success.")
           :code $ quote
@@ -3182,8 +3184,10 @@
             quote $ assert-detect list? ([] 1 2 3)
             quote $ assert-detect even? (* 2 5)
           :schema $ :: 'Macro
-            {} (:return 'Unit)
-              :args $ [] 'Dynamic 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
           :tags $ #{} :control :log :macro
         |assert-type $ %{} 'CodeEntry (:doc "|internal syntax for type assertion at preprocessing stage\nSyntax: (assert-type expr type-expr)\nParams: expr (any), type-expr (type annotation)\nReturns: evaluated result of expr\nAsserts that expr matches the given type annotation during static analysis")
           :code $ quote &runtime-implementation
@@ -3205,12 +3209,16 @@
                           eprintln |Right: ~vb
                           eprintln "|      " $ format-to-lisp (quote ~b)
                           raise "|not equal in assertion!"
+                        , &unit
           :examples $ []
             quote $ assert= 4 (+ 2 2)
             quote $ assert= |hello (str |hel |lo)
             quote $ assert= ([] 1 2 3) (range 1 4)
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
           :tags $ #{} :control :log :macro
         |assoc $ %{} 'CodeEntry (:doc "|Associate a key or index in maps, lists, enums, and structs.")
           :code $ quote
@@ -8543,8 +8551,10 @@
               quasiquote $ assert |Expected-truthy-expression: ~expr
           :examples $ []
           :schema $ :: 'Macro
-            {} (:return 'Unit)
-              :args $ [] 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :control :macro :test
           :tests $ []
             %{} 'TestEntry (:name |accepts-truthy)
@@ -8560,8 +8570,10 @@
               quasiquote $ assert |Expected-values-to-differ: (not= ~left ~right)
           :examples $ []
           :schema $ :: 'Macro
-            {} (:return 'Unit)
-              :args $ [] 'Dynamic 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
           :tags $ #{} :control :macro :test
           :tests $ []
             %{} 'TestEntry (:name |accepts-different-values)
@@ -8580,8 +8592,10 @@
                   fn (error) true
           :examples $ []
           :schema $ :: 'Macro
-            {} (:return 'Unit)
-              :args $ [] 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :control :macro :test
           :tests $ []
             %{} 'TestEntry (:name |accepts-raised-errors)
@@ -8594,8 +8608,10 @@
               quasiquote $ assert= ~expected ~actual
           :examples $ []
           :schema $ :: 'Macro
-            {} (:return 'Unit)
-              :args $ [] 'Dynamic 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
           :tags $ #{} :control :macro :test
           :tests $ []
             %{} 'TestEntry (:name |compares-values)
@@ -8614,8 +8630,10 @@
                 fn (error) true
           :examples $ []
           :schema $ :: 'Macro
-            {} (:return 'Bool)
-              :args $ [] 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Bool
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :control :macro :test
           :tests $ []
             %{} 'TestEntry (:name |detects-raised-errors)

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4021,6 +4021,46 @@ mod tests {
       cond_signature.rest_input,
       Some(crate::calcit::MacroSyntaxType::SyntaxList)
     ));
+
+    for def_name in ["assert", "assert-detect", "assert="] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert_eq!(signature.required_inputs.len(), 2);
+      assert!(signature.required_inputs.iter().all(
+        |input| matches!(input, crate::calcit::MacroSyntaxType::Expr(inner) if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic))
+      ));
+      assert!(matches!(
+        signature.expansion,
+        crate::calcit::MacroExpansionType::Expr(ref inner) if matches!(inner.as_ref(), CalcitTypeAnnotation::Unit)
+      ));
+    }
+
+    let test_file = snapshot.files.get("calcit.test").expect("calcit.test file should exist");
+    for def_name in ["is", "is-not=", "is-throws", "is=", "throws?"] {
+      let CalcitTypeAnnotation::Macro(signature) = test_file.defs[def_name].schema.as_ref() else {
+        panic!("calcit.test/{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "calcit.test/{def_name} should use a phase-aware contract");
+      assert!(
+        signature.capabilities.is_empty(),
+        "calcit.test/{def_name} should be compile-time pure"
+      );
+      assert!(signature.required_inputs.iter().all(
+        |input| matches!(input, crate::calcit::MacroSyntaxType::Expr(inner) if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic))
+      ));
+      let expected = if def_name == "throws?" {
+        &CalcitTypeAnnotation::Bool
+      } else {
+        &CalcitTypeAnnotation::Unit
+      };
+      assert!(matches!(
+        signature.expansion,
+        crate::calcit::MacroExpansionType::Expr(ref inner) if inner.as_ref() == expected
+      ));
+    }
   }
 
   #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4043,11 +4043,17 @@ mod tests {
       let CalcitTypeAnnotation::Macro(signature) = test_file.defs[def_name].schema.as_ref() else {
         panic!("calcit.test/{def_name} should load as MacroSignature");
       };
+      let expected_input_count = match def_name {
+        "is" | "is-throws" | "throws?" => 1,
+        "is-not=" | "is=" => 2,
+        _ => unreachable!(),
+      };
       assert!(signature.is_strict(), "calcit.test/{def_name} should use a phase-aware contract");
       assert!(
         signature.capabilities.is_empty(),
         "calcit.test/{def_name} should be compile-time pure"
       );
+      assert_eq!(signature.required_inputs.len(), expected_input_count);
       assert!(signature.required_inputs.iter().all(
         |input| matches!(input, crate::calcit::MacroSyntaxType::Expr(inner) if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic))
       ));


### PR DESCRIPTION
## Summary

- migrate `calcit.core/assert`, `assert-detect`, and `assert=` to strict pure macro contracts
- migrate `calcit.test/is`, `is-not=`, `is-throws`, `is=`, and `throws?` to strict pure macro contracts
- retain `Expr<Dynamic>` inputs because truthiness and equality intentionally accept heterogeneous runtime values
- declare precise expansion types: `Expr<Unit>` for assertions and `Expr<Bool>` for `throws?`
- add the missing successful `&unit` branch to `assert=` so implementation and contract agree
- extend the real core Snapshot regression inventory

## Macro metrics

On `calcit/test.cirru`, total expansion count remains 2,432 while strict/pure candidates increase from 895 to 1,666. The migrated reachable calls are:

- `assert`: 42
- `assert-detect`: 23
- `assert=`: 706

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- full `cargo test`: 508 library, 246 CLI, 24 caps, and 4 WASM tests
- `yarn compile`
- `yarn check-all` including 226 core unit tests, native/JS/IR/WASM, and benchmarks
- `yarn check-agent-interface` (17/17)
- all attached tests for the five `calcit.test` macros
- all examples for the three `calcit.core` assertion macros
- Respo `be8141e`: 27/27 tests and JS check-only
- Recollect `6c235d0`: 9/9 tests and JS runtime

Progresses #437
