### PR TITLE
refactor: type control-flow macros

### DIFF
--- a/editing-history/20260826-0038-control-flow-macro-contracts.md
+++ b/editing-history/20260826-0038-control-flow-macro-contracts.md
@@ -1,0 +1,9 @@
+# Control-flow macro contracts
+
+- Migrated `or`, `either`, `when`, `when-not`, `if-not`, `if-let`, and `when-let` to strict, pure phase-aware contracts.
+- Preserved expression-level Dynamic boundaries where branch value types intentionally vary, while declaring `when-let` as `Expr<Option<Dynamic>>`.
+- Corrected the `or false nil` example to expect the final falsey value (`nil`) and clarified that behavior in its documentation.
+- Fixed strict macro body parameter typing: `SyntaxList` is represented as a list, `SyntaxSymbol` as a symbol, and rest bindings as lists of their declared syntax element type.
+- Added regression coverage for strict macro body parameter representations and the real core Snapshot inventory.
+- Increased strict macro coverage in `calcit/test.cirru` from 1666 to 1805 of 2432 expansions.
+- Verified the release compiler against Respo `be8141e` (27 tests and check-only JS) and Recollect `6c235d0` (9 native tests plus JS/Node tests).

--- a/editing-history/20260826-0100-review-exact-control-flow-contracts.md
+++ b/editing-history/20260826-0100-review-exact-control-flow-contracts.md
@@ -1,0 +1,5 @@
+# Exact control-flow contract regression checks
+
+- Strengthened the core Snapshot inventory to assert each migrated control-flow macro's exact required, optional, and rest syntax contracts.
+- Asserted exact expansion types, including `when-let` as `Expr<Option<Dynamic>>` and the remaining macros as `Expr<Dynamic>`.
+- Documented the strict macro body type helpers added by the original change.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -4564,7 +4564,11 @@
             quote $ assert= false (either false true)
             quote $ assert= |backup (either nil nil |backup)
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -5403,7 +5407,11 @@
                 v $ %none
                 , v |missing
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :optional $ [] (:: 'Expr 'Dynamic)
+              :required $ [] 'SyntaxList (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |if-not $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -5425,7 +5433,11 @@
                     quasiquote $ if ~condition ~false-branch ~true-branch
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |impl-origin $ %{} 'CodeEntry (:doc "|Return the trait origin of an impl as Option<Trait>; inherent method bags produce none.")
           :code $ quote
@@ -6651,7 +6663,7 @@
               :args $ [] (:: 'Optional 'T)
               :generics $ [] 'T
               :return $ :: 'Option 'T
-        |or $ %{} 'CodeEntry (:doc "|Logical disjunction macro. Skips later forms once a truthy (non-nil, non-false, non-Unit) value is found, preserving the first truthy result.")
+        |or $ %{} 'CodeEntry (:doc "|Logical disjunction macro. Skips later forms once a truthy (non-nil, non-false, non-Unit) value is found and returns it; when every form is falsey, returns the final form.")
           :code $ quote
             defmacro or (item & xs)
               if (&list:empty? xs) item $ if (list? item)
@@ -6668,10 +6680,14 @@
                     ~@ $ &list:rest xs
           :examples $ []
             quote $ assert= |done (or nil |done false)
-            quote $ assert= false (or false nil)
+            quote $ assert= nil (or false nil)
             quote $ assert= 2 (or nil 2 3)
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
           :tests $ []
             %{} 'TestEntry (:name |skips-unit-and-returns-next-truthy-value)
@@ -8113,7 +8129,11 @@
             quote $ assert= nil
               when false $ inc 1
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |when-let $ %{} 'CodeEntry (:doc "|Consume Option<T>, evaluate the body only for some, and return Option<R>.")
           :code $ quote
@@ -8135,8 +8155,10 @@
           :examples $ []
           :schema $ :: 'Macro
             {}
-              :args $ [] 'Dynamic
-              :return $ :: 'Option 'Dynamic
+              :capabilities $ #{}
+              :expansion $ :: 'Expr (:: 'Option 'Dynamic)
+              :required $ [] 'SyntaxList
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |when-not $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -8150,7 +8172,11 @@
                   &let () ~@body
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |with-cpu-time $ %{} 'CodeEntry (:doc |)
           :code $ quote

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6174,6 +6174,29 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
   Ok(Calcit::List(Arc::from(CalcitList::Vector(xs))))
 }
 
+fn macro_contract_body_type(contract: &MacroSyntaxType) -> Arc<CalcitTypeAnnotation> {
+  match contract {
+    MacroSyntaxType::SyntaxSymbol => Arc::new(CalcitTypeAnnotation::Symbol),
+    MacroSyntaxType::SyntaxList => Arc::new(CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(
+      MacroSyntaxType::Syntax,
+    ))))),
+    MacroSyntaxType::Syntax | MacroSyntaxType::Expr(_) => Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(contract.clone()))),
+  }
+}
+
+fn strict_macro_body_parameter_types(signature: &MacroSignature) -> Vec<Arc<CalcitTypeAnnotation>> {
+  let required_types = signature.required_inputs.iter().map(macro_contract_body_type);
+  let optional_types = signature
+    .optional_inputs
+    .iter()
+    .map(|contract| Arc::new(CalcitTypeAnnotation::Optional(macro_contract_body_type(contract))));
+  let rest_type = signature
+    .rest_input
+    .iter()
+    .map(|contract| Arc::new(CalcitTypeAnnotation::List(macro_contract_body_type(contract))));
+  required_types.chain(optional_types).chain(rest_type).collect()
+}
+
 pub fn preprocess_defn(
   head: &CalcitSyntax,
   head_ns: &str,
@@ -6321,22 +6344,7 @@ pub fn preprocess_defn(
       if let CalcitTypeAnnotation::Macro(signature) = def_schema.as_ref()
         && signature.is_strict()
       {
-        let required_types = signature
-          .required_inputs
-          .iter()
-          .map(|contract| Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(contract.clone()))));
-        let optional_types = signature.optional_inputs.iter().map(|contract| {
-          Arc::new(CalcitTypeAnnotation::Optional(Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(
-            contract.clone(),
-          )))))
-        });
-        let parameter_types = required_types.chain(optional_types).chain(
-          signature
-            .rest_input
-            .iter()
-            .map(|_| Arc::new(CalcitTypeAnnotation::Syntax(Arc::new(MacroSyntaxType::SyntaxList)))),
-        );
-        for (param_sym, type_info) in param_symbols.iter().zip(parameter_types) {
+        for (param_sym, type_info) in param_symbols.iter().zip(strict_macro_body_parameter_types(signature)) {
           body_types.insert(param_sym.clone(), type_info);
         }
       }
@@ -7388,6 +7396,32 @@ mod tests {
     .expect_err("wrong expansion result type");
     assert_eq!(err.code.as_deref(), Some("E_MACRO_EXPANSION_EXPR_TYPE"));
     assert!(err.msg.contains("expansion-result violation"));
+  }
+
+  #[test]
+  fn strict_macro_rest_body_binding_is_a_list_of_declared_syntax() {
+    let rest_contract = MacroSyntaxType::Expr(Arc::new(CalcitTypeAnnotation::Dynamic));
+    let signature = strict_macro_signature(vec![], vec![], Some(rest_contract.clone()), MacroExpansionType::Dynamic);
+    let parameter_types = strict_macro_body_parameter_types(&signature);
+    assert!(matches!(
+      parameter_types.as_slice(),
+      [item]
+        if matches!(
+          item.as_ref(),
+          CalcitTypeAnnotation::List(inner)
+            if matches!(inner.as_ref(), CalcitTypeAnnotation::Syntax(contract) if contract.as_ref() == &rest_contract)
+        )
+    ));
+
+    let list_signature = strict_macro_signature(
+      vec![MacroSyntaxType::SyntaxList, MacroSyntaxType::SyntaxSymbol],
+      vec![],
+      None,
+      MacroExpansionType::Dynamic,
+    );
+    let parameter_types = strict_macro_body_parameter_types(&list_signature);
+    assert!(matches!(parameter_types[0].as_ref(), CalcitTypeAnnotation::List(_)));
+    assert!(matches!(parameter_types[1].as_ref(), CalcitTypeAnnotation::Symbol));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6174,6 +6174,7 @@ fn preprocess_match(head: &CalcitSyntax, head_ns: &str, args: &CalcitList, ctx: 
   Ok(Calcit::List(Arc::from(CalcitList::Vector(xs))))
 }
 
+/// Maps a source-facing macro contract to the runtime type visible inside the macro body.
 fn macro_contract_body_type(contract: &MacroSyntaxType) -> Arc<CalcitTypeAnnotation> {
   match contract {
     MacroSyntaxType::SyntaxSymbol => Arc::new(CalcitTypeAnnotation::Symbol),
@@ -6184,6 +6185,7 @@ fn macro_contract_body_type(contract: &MacroSyntaxType) -> Arc<CalcitTypeAnnotat
   }
 }
 
+/// Builds body parameter types in required, optional, and rest binding order.
 fn strict_macro_body_parameter_types(signature: &MacroSignature) -> Vec<Arc<CalcitTypeAnnotation>> {
   let required_types = signature.required_inputs.iter().map(macro_contract_body_type);
   let optional_types = signature

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4055,7 +4055,73 @@ mod tests {
       assert_eq!(signature.required_inputs.len(), required, "{def_name} required inputs");
       assert_eq!(signature.optional_inputs.len(), optional, "{def_name} optional inputs");
       assert_eq!(signature.rest_input.is_some(), has_rest, "{def_name} rest input");
-      assert!(matches!(signature.expansion, crate::calcit::MacroExpansionType::Expr(_)));
+      match def_name {
+        "or" | "when" | "when-not" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Expr(inner)]
+              if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(matches!(
+            signature.rest_input,
+            Some(crate::calcit::MacroSyntaxType::Expr(ref inner))
+              if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+        }
+        "either" | "if-not" => {
+          assert!(signature.required_inputs.is_empty());
+          assert!(matches!(
+            signature.rest_input,
+            Some(crate::calcit::MacroSyntaxType::Expr(ref inner))
+              if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+        }
+        "if-let" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [
+              crate::calcit::MacroSyntaxType::SyntaxList,
+              crate::calcit::MacroSyntaxType::Expr(inner)
+            ] if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(matches!(
+            signature.optional_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Expr(inner)]
+              if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(signature.rest_input.is_none());
+        }
+        "when-let" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::SyntaxList]
+          ));
+          assert!(matches!(
+            signature.rest_input,
+            Some(crate::calcit::MacroSyntaxType::Expr(ref inner))
+              if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+        }
+        _ => unreachable!(),
+      }
+      if def_name == "when-let" {
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref inner)
+            if matches!(
+              inner.as_ref(),
+              CalcitTypeAnnotation::TypeRef(name, args)
+                if name.as_ref() == "Option"
+                  && matches!(args.as_slice(), [item] if matches!(item.as_ref(), CalcitTypeAnnotation::Dynamic))
+            )
+        ));
+      } else {
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref inner)
+            if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+        ));
+      }
     }
 
     let test_file = snapshot.files.get("calcit.test").expect("calcit.test file should exist");

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4038,6 +4038,26 @@ mod tests {
       ));
     }
 
+    for (def_name, required, optional, has_rest) in [
+      ("or", 1, 0, true),
+      ("either", 0, 0, true),
+      ("when", 1, 0, true),
+      ("when-not", 1, 0, true),
+      ("if-not", 0, 0, true),
+      ("if-let", 2, 1, false),
+      ("when-let", 1, 0, true),
+    ] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert_eq!(signature.required_inputs.len(), required, "{def_name} required inputs");
+      assert_eq!(signature.optional_inputs.len(), optional, "{def_name} optional inputs");
+      assert_eq!(signature.rest_input.is_some(), has_rest, "{def_name} rest input");
+      assert!(matches!(signature.expansion, crate::calcit::MacroExpansionType::Expr(_)));
+    }
+
     let test_file = snapshot.files.get("calcit.test").expect("calcit.test file should exist");
     for def_name in ["is", "is-not=", "is-throws", "is=", "throws?"] {
       let CalcitTypeAnnotation::Macro(signature) = test_file.defs[def_name].schema.as_ref() else {


### PR DESCRIPTION
## Summary

- migrate `or`, `either`, `when`, `when-not`, `if-not`, `if-let`, and `when-let` to strict, compile-time-pure macro contracts
- represent strict macro body binders according to their declared contracts, including list-typed rest inputs
- correct the `or false nil` example and document its final-falsey-value behavior
- extend snapshot and preprocessing regression coverage

## Coverage

Strict macro coverage in `calcit/test.cirru` increases from 1666 to 1805 of 2432 expansions.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`
- Respo `be8141e`: 27 tests and check-only JS compilation
- Recollect `6c235d0`: 9 native tests, JS compilation, and Node tests

Closes #445
Progresses #437
