### PR TITLE
refactor: type pattern matching macros

### DIFF
--- a/editing-history/20260826-0120-pattern-macro-contracts.md
+++ b/editing-history/20260826-0120-pattern-macro-contracts.md
@@ -1,0 +1,8 @@
+# Pattern-matching macro contracts
+
+- Migrated `tag-match`, `list-match`, `struct-match`, `case`, and their internal expansion helpers to strict, compile-time-pure macro contracts.
+- Kept branch bodies as `SyntaxList`; retained `list-match`'s heterogeneous public argument sequence as an intentional `Syntax` rest boundary while typing its internal helper exactly.
+- Corrected the pre-existing `tag-match` example expectation from `got:hello` to `hello:got`, matching `str x |:got`.
+- Added exact Snapshot assertions for required, optional, rest, capability, and expansion contracts across both `calcit.core` and `calcit.internal`.
+- Increased strict macro coverage in `calcit/test.cirru` from 1805 to 1949 of 2432 expansions.
+- Verified all repository gates plus Respo `be8141e`, Recollect `6c235d0`, and js-ffi `25869b6`; js-ffi dependencies were reinstalled from its 0.13.44 lockfile before Node/browser contract tests.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -298,7 +298,10 @@
                     quasiquote $ &case ~item ~default ~@others
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic) 'SyntaxList
           :tags $ #{} :internal :macro
         |&cirru-nth $ %{} 'CodeEntry (:doc "|internal function for Cirru nth operation\nSyntax: (&cirru-nth cirru-list index)\nParams: cirru-list (cirru quote list), index (number)\nReturns: cirru node\nGets nth element from Cirru list node, errors if index is out of bounds")
           :code $ quote &runtime-implementation
@@ -856,8 +859,9 @@
           :examples $ []
           :schema $ :: 'Macro
             {}
-              :args $ [] (:: 'List 'T) 'Dynamic 'Dynamic 'Dynamic
-              :generics $ [] 'T
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic) 'SyntaxList 'SyntaxList 'SyntaxList
           :tags $ #{} :internal :macro
         |&list:append $ %{} 'CodeEntry (:doc |)
           :code $ quote (&runtime-implementation)
@@ -2365,7 +2369,10 @@
                           &struct-match-internal ~value $ ~@ (&list:rest body)
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Struct)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :internal :macro
         |&struct:assoc $ %{} 'CodeEntry (:doc "|Associate a declared field on a struct value.")
           :code $ quote &runtime-implementation
@@ -3485,7 +3492,10 @@
                     , ~@patterns
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |case-default $ %{} 'CodeEntry (:doc "|Case macro variant with an explicit default branch\nEvaluates the target once, compares it against pattern/result pairs, and falls back to the provided default when no pattern matches.")
           :code $ quote
@@ -6052,7 +6062,10 @@
                 () nil
                 (head tail) head
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
           :tags $ #{} :macro
         |list? $ %{} 'CodeEntry (:doc "|checks if value is a list\nSyntax: (list? x)\nParams: x (any)\nReturns: true if x is a list, false otherwise\nType predicate for list data structure")
           :code $ quote &runtime-implementation
@@ -7589,7 +7602,10 @@
                     &struct-match-internal ~value ~@body
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Struct)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |struct-with $ %{} 'CodeEntry (:doc "|Construct a new struct value by replacing declared fields.")
           :code $ quote
@@ -7673,12 +7689,15 @@
               tag-match (:: :ok 1)
                 (:ok v) (&+ v 10)
                 (:err e) (eprintln e)
-            quote $ assert= |got:hello
+            quote $ assert= |hello:got
               tag-match (:: :some |hello)
                 (:some x) (str x |:got)
                 (:none) |nothing
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |tag? $ %{} 'CodeEntry (:doc "|Check if a value is a tag (keyword)")
           :code $ quote &runtime-implementation
@@ -8519,7 +8538,10 @@
                       if (&= pattern '_) branch $ raise (str-spaced "|unknown supported pattern:" pair)
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Tag)
         |normalize-trait-type $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn normalize-trait-type (t0)

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4124,6 +4124,89 @@ mod tests {
       }
     }
 
+    for def_name in [
+      "tag-match",
+      "list-match",
+      "&list-match-internal",
+      "struct-match",
+      "&struct-match-internal",
+      "case",
+      "&case",
+    ] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert!(signature.optional_inputs.is_empty(), "{def_name} should not have optional inputs");
+      assert!(matches!(
+        signature.expansion,
+        crate::calcit::MacroExpansionType::Expr(ref inner)
+          if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+      ));
+      match def_name {
+        "tag-match" | "struct-match" | "&struct-match-internal" | "case" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Expr(inner)]
+              if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+        }
+        "list-match" => {
+          assert!(signature.required_inputs.is_empty());
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+        }
+        "&list-match-internal" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [
+              crate::calcit::MacroSyntaxType::Expr(inner),
+              crate::calcit::MacroSyntaxType::SyntaxList,
+              crate::calcit::MacroSyntaxType::SyntaxList,
+              crate::calcit::MacroSyntaxType::SyntaxList
+            ] if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(signature.rest_input.is_none());
+        }
+        "&case" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [
+              crate::calcit::MacroSyntaxType::Expr(item),
+              crate::calcit::MacroSyntaxType::Expr(default),
+              crate::calcit::MacroSyntaxType::SyntaxList
+            ] if matches!(item.as_ref(), CalcitTypeAnnotation::Dynamic)
+              && matches!(default.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+        }
+        _ => unreachable!(),
+      }
+    }
+
+    let internal_file = snapshot.files.get("calcit.internal").expect("calcit.internal file should exist");
+    let CalcitTypeAnnotation::Macro(tag_internal) = internal_file.defs["&tag-match-internal"].schema.as_ref() else {
+      panic!("&tag-match-internal should load as MacroSignature");
+    };
+    assert!(tag_internal.is_strict());
+    assert!(tag_internal.capabilities.is_empty());
+    assert!(tag_internal.optional_inputs.is_empty());
+    assert!(matches!(
+      tag_internal.required_inputs.as_slice(),
+      [
+        crate::calcit::MacroSyntaxType::Expr(value),
+        crate::calcit::MacroSyntaxType::Expr(tag)
+      ] if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+        && matches!(tag.as_ref(), CalcitTypeAnnotation::Tag)
+    ));
+    assert!(matches!(tag_internal.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+    assert!(matches!(
+      tag_internal.expansion,
+      crate::calcit::MacroExpansionType::Expr(ref inner)
+        if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+    ));
+
     let test_file = snapshot.files.get("calcit.test").expect("calcit.test file should exist");
     for def_name in ["is", "is-not=", "is-throws", "is=", "throws?"] {
       let CalcitTypeAnnotation::Macro(signature) = test_file.defs[def_name].schema.as_ref() else {


### PR DESCRIPTION
## Summary

- migrate `tag-match`, `list-match`, `struct-match`, `case`, and their internal helpers to strict, compile-time-pure macro contracts
- describe branch arms as syntax lists and type fixed internal helper inputs exactly
- preserve `list-match`'s heterogeneous public arguments as an intentional raw-syntax rest boundary
- correct the pre-existing `tag-match` example expectation and add exact Snapshot regression assertions

## Coverage

Strict macro coverage in `calcit/test.cirru` increases from 1805 to 1949 of 2432 expansions (+144), with no legacy-signature bypasses for the migrated macros.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`
- definition examples: `tag-match`, `list-match`
- Respo `be8141e`: 27 tests and check-only JS compilation
- Recollect `6c235d0`: 9 native tests, JS compilation, and Node tests
- js-ffi `25869b6`: default/node/browser checks plus Node and browser contract tests after reinstalling the 0.13.44 lockfile

Progresses #437
