### PR TITLE
refactor: type collection macros

### DIFF
--- a/editing-history/20260826-0133-collection-macro-contracts.md
+++ b/editing-history/20260826-0133-collection-macro-contracts.md
@@ -1,0 +1,9 @@
+# Collection macro contracts
+
+- Migrated `{}`, `%{}`, and `{,}` to strict, compile-time-pure macro contracts.
+- Declared map literal expansions as `Expr<Map<Dynamic, Dynamic>>` and struct literal expansion as `Expr<Struct>`.
+- Kept pair-oriented inputs as `SyntaxList` and the flat comma-filtering `{,}` body as an intentional raw `Syntax` rest boundary.
+- Corrected the pre-existing `%{}` example to use field pairs `(:x 1)` and `(:y 2)` rather than list-constructor calls that introduced extra fields.
+- Added exact Snapshot assertions for each macro's input and expansion contracts.
+- Increased strict macro coverage in `calcit/test.cirru` from 1949 to 2133 of 2432 expansions.
+- Verified all repository gates plus Respo `be8141e`, Recollect `6c235d0`, and js-ffi `25869b6` with the current compiler.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -84,11 +84,13 @@
           :examples $ []
             quote $ let
                 Point $ defstruct Point (:x 'Number) (:y 'Number)
-                rec $ %{} Point ([] :x 1) ([] :y 2)
+                rec $ %{} Point (:x 1) (:y 2)
               assert= 1 $ :x rec
           :schema $ :: 'Macro
-            {} (:return 'Struct)
-              :args $ [] 'Dynamic
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Struct
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |%{}? $ %{} 'CodeEntry (:doc "|Partial struct constructor. It allows declared Optional fields to be omitted and fills them with nil.")
           :code $ quote
@@ -8299,7 +8301,10 @@
                   section-by ([] ~@xs) 2
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Map
+              :required $ []
           :tags $ #{} :macro
         |{} $ %{} 'CodeEntry (:doc "|macro for creating hashmaps\nSyntax: ({} (:key value) ...)\nParams: pairs (key-value pairs)\nReturns: hashmap\nCreates a hashmap from key-value pairs")
           :code $ quote
@@ -8317,7 +8322,10 @@
             quote $ {} (:a 1) (:b 2)
             quote $ {} (:name |Alice) (:age 30)
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Map
+              :required $ []
           :tags $ #{} :macro
         |~ $ %{} 'CodeEntry (:doc "|internal syntax for interpolating value in macro\nSyntax: (~ expr) inside quasiquote\nParams: expr (expression to evaluate)\nReturns: evaluated expression\nUnquotes expression inside quasiquote")
           :code $ quote &runtime-implementation

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4207,6 +4207,53 @@ mod tests {
         if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
     ));
 
+    for def_name in ["{}", "%{}", "{,}"] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert!(signature.optional_inputs.is_empty(), "{def_name} should not have optional inputs");
+      match def_name {
+        "{}" => {
+          assert!(signature.required_inputs.is_empty());
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+        }
+        "%{}" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Expr(inner)]
+              if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+        }
+        "{,}" => {
+          assert!(signature.required_inputs.is_empty());
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+        }
+        _ => unreachable!(),
+      }
+      if def_name == "%{}" {
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref inner)
+            if inner.as_ref()
+              == &CalcitTypeAnnotation::Custom(Arc::new(Calcit::tag("struct")))
+        ));
+      } else {
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref inner)
+            if matches!(
+              inner.as_ref(),
+              CalcitTypeAnnotation::Map(key, value)
+                if matches!(key.as_ref(), CalcitTypeAnnotation::Dynamic)
+                  && matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+            )
+        ));
+      }
+    }
+
     let test_file = snapshot.files.get("calcit.test").expect("calcit.test file should exist");
     for def_name in ["is", "is-not=", "is-throws", "is=", "throws?"] {
       let CalcitTypeAnnotation::Macro(signature) = test_file.defs[def_name].schema.as_ref() else {


### PR DESCRIPTION
## Summary

- migrate `{}`, `%{}`, and `{,}` to strict, compile-time-pure macro contracts
- type map literal expansions as maps and struct literal expansion as a struct
- preserve pair inputs as syntax lists and `{,}`'s flat comma-filtering input as an intentional raw-syntax boundary
- correct the invalid pre-existing `%{}` example and add exact Snapshot contract assertions

## Coverage

Strict macro coverage in `calcit/test.cirru` increases from 1949 to 2133 of 2432 expansions (+184), with no legacy-signature bypasses for these macros.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`
- definition examples: `{}`, `%{}`
- Respo `be8141e`: 27 tests and check-only JS compilation
- Recollect `6c235d0`: 9 native tests, JS compilation, and Node tests
- js-ffi `25869b6`: check plus Node/browser contract tests

Progresses #437
