### PR TITLE
refactor: type definition value macros

### DIFF
--- a/editing-history/20260826-0152-definition-macro-contracts.md
+++ b/editing-history/20260826-0152-definition-macro-contracts.md
@@ -1,0 +1,25 @@
+# Definition-value macro contracts
+
+## Changes
+
+- Migrated `def` to a pure phase-aware macro contract with a symbol declaration name and an explicit dynamic expression boundary.
+- Migrated `deftrait`, `defstruct`, `defimpl`, and `defenum` to strict syntax-input contracts with precise `Trait`, `StructDef`, `Impl`, and `EnumDef` expression outputs.
+- Kept symbol/tag compatibility for data-definition names by using unrestricted syntax for those positions; method and field forms use list syntax where the macro requires pair/list forms.
+- Added Snapshot assertions for required, optional, rest, capability, and expansion fields so serialization regressions cannot silently weaken these contracts.
+
+## Semantic finding
+
+Although these macros generate top-level definition values, the core `def` macro is consumed before the outer expansion-result check. Their observable expansion contract is therefore `Expr<T>`, not `Definition<T>`. Using `Definition<T>` fails against the real core corpus because the checked form is already `&trait::new`, `&struct-def:new`, `&impl::new`, or `&enum-def:new`.
+
+## Validation
+
+- Core strict macro expansions: `2133/2432` -> `2341/2432`; legacy bypasses: `299` -> `91`.
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `yarn compile`
+- `cargo test`
+- `yarn check-all`
+- `yarn check-agent-interface`
+- Respo `be8141e`: 27 definition-attached tests and JS check-only passed.
+- Recollect `6c235d0`: 9 unit tests, JS generation, and Node runtime passed.
+- js-ffi `25869b6`: default/node/browser checks plus Node and browser-node contracts passed.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -3911,7 +3911,10 @@
             defmacro def (_name x) x
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxSymbol (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |defatom $ %{} 'CodeEntry (:doc "|internal syntax for defining referenced state\nSyntax: (defatom name initial-value)\nParams: name (symbol), initial-value (any)\nReturns: atom definition\nDefines a mutable reference with initial value")
           :code $ quote &runtime-implementation
@@ -4009,7 +4012,10 @@
           :examples $ []
             quote $ defenum Result ([] 'T 'E) (:ok 'T) (:err 'E)
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'EnumDef
+              :required $ [] 'Syntax
           :tags $ #{} :macro
         |defimpl $ %{} 'CodeEntry (:doc "|macro for defining trait implementation values\nSyntax: (defimpl ImplName Trait (.method value) ...)\nParams: ImplName (symbol), Trait (symbol), method pairs\nReturns: impl value\nNotes: new code passes raw symbols; tag arguments remain only as legacy compatibility for originless method bags. This macro does not attach an impl to a target type/value; use `impl-traits` separately.\nExpands to &impl::new")
           :code $ quote
@@ -4091,7 +4097,10 @@
                                 quasiquote $ [] ~key ~v0
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Impl
+              :required $ [] 'Syntax 'Syntax
           :tags $ #{} :macro
         |defmacro $ %{} 'CodeEntry (:doc "|internal syntax for defining macros\nSyntax: (defmacro name [args] body)\nParams: name (symbol), args (list of symbols), body (expression)\nReturns: macro definition\nDefines a macro that transforms code at compile time")
           :code $ quote &runtime-implementation
@@ -4236,7 +4245,10 @@
           :examples $ []
             quote $ defstruct Person (:name 'String) (:age 'Number)
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'StructDef
+              :required $ [] 'Syntax
           :tags $ #{} :macro
         |deftrait $ %{} 'CodeEntry (:doc "|macro for defining traits\nSyntax: (deftrait Name (.method (:: :fn $ {} (:args [...]) (:return t))) ...)\nParams: Name (symbol/tag), methods (list of (tag type))\nNotes: use :fn (tag) for DynFn when signature is intentionally omitted\nReturns: trait definition value\nExpands to &trait::new")
           :code $ quote
@@ -4270,7 +4282,10 @@
                     [] ~@normalized
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Trait
+              :required $ [] 'Syntax
           :tags $ #{} :macro
         |deftype-slot $ %{} 'CodeEntry (:doc "|Declare a named compile-time type slot supplied by a library. Syntax: (deftype-slot :slot-name). Applications should bind the slot for each entry with calcit config set-type-slot; an unbound slot falls back to :dynamic.")
           :code $ quote &runtime-implementation

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4002,6 +4002,60 @@ mod tests {
       );
     }
 
+    let CalcitTypeAnnotation::Macro(def_signature) = core_file.defs["def"].schema.as_ref() else {
+      panic!("def should load as MacroSignature");
+    };
+    assert!(def_signature.is_strict());
+    assert!(def_signature.capabilities.is_empty());
+    assert!(matches!(
+      def_signature.required_inputs.as_slice(),
+      [
+        crate::calcit::MacroSyntaxType::SyntaxSymbol,
+        crate::calcit::MacroSyntaxType::Expr(value)
+      ] if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+    ));
+    assert!(def_signature.optional_inputs.is_empty());
+    assert!(def_signature.rest_input.is_none());
+    assert!(matches!(
+      def_signature.expansion,
+      crate::calcit::MacroExpansionType::Expr(ref value)
+        if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+    ));
+
+    for (def_name, expected_output, rest_is_list) in [
+      ("deftrait", "trait", true),
+      ("defstruct", "struct-def", true),
+      ("defimpl", "impl", false),
+      ("defenum", "enum-def", true),
+    ] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert!(signature.optional_inputs.is_empty(), "{def_name} should not have optional inputs");
+      match def_name {
+        "defimpl" => assert!(matches!(
+          signature.required_inputs.as_slice(),
+          [crate::calcit::MacroSyntaxType::Syntax, crate::calcit::MacroSyntaxType::Syntax]
+        )),
+        _ => assert!(matches!(
+          signature.required_inputs.as_slice(),
+          [crate::calcit::MacroSyntaxType::Syntax]
+        )),
+      }
+      if rest_is_list {
+        assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+      } else {
+        assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+      }
+      assert!(matches!(
+        signature.expansion,
+        crate::calcit::MacroExpansionType::Expr(ref output)
+          if matches!(output.as_ref(), CalcitTypeAnnotation::Custom(value) if value.as_ref() == &Calcit::tag(expected_output))
+      ));
+    }
+
     for def_name in ["let", "fn"] {
       let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
         unreachable!()


### PR DESCRIPTION
## Summary

- give `def` a strict symbol/expression contract with an explicit dynamic value boundary
- type `deftrait`, `defstruct`, `defimpl`, and `defenum` by their accepted syntax and precise generated value types
- lock the complete phase contracts in Snapshot tests

## Phase-model finding

These macros produce top-level definition values, but `def` is consumed before expansion-result validation. The observable results are therefore `Expr<Trait>`, `Expr<StructDef>`, `Expr<Impl>`, and `Expr<EnumDef>`, rather than declaration syntax represented by `Definition<T>`.

## Coverage

- strict reachable expansions: 2133/2432 -> 2341/2432
- legacy-signature bypasses: 299 -> 91

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- Respo `be8141e`: 27 tests and JS check-only
- Recollect `6c235d0`: 9 tests, JS generation, Node runtime
- js-ffi `25869b6`: default/node/browser checks and both runtime contracts

Progresses #437
