### PR TITLE
refactor: type transform macros

### DIFF
--- a/editing-history/20260826-0203-transform-macro-contracts.md
+++ b/editing-history/20260826-0203-transform-macro-contracts.md
@@ -1,0 +1,28 @@
+# Transform macro contracts
+
+## Changes
+
+- Migrated `->`, `->%`, and `%<-` with phase-aware base/step contracts.
+- Migrated `apply-args` and `flipped` with callable input contracts and explicit dynamic result boundaries.
+- Migrated anonymous function shorthands `\` and `\.` with syntax inputs and callable expression outputs.
+- Migrated `[,]` with arbitrary syntax inputs and a `List<Dynamic>` expression output.
+- Added exact Snapshot assertions for every required, optional, rest, capability, and expansion field.
+
+## Contract notes
+
+- Thread steps in `->` remain unrestricted syntax because the macro deliberately accepts symbol, tag, method, function, and list forms.
+- Calcit's canonical callable schema type is `'Fn`; `'DynFn` is not the public schema spelling.
+- `%<-`, `\`, and `[,]` retain runtime empty-input diagnostics because their implementation uses rest-only parameters and the phase signature mirrors that actual binder shape.
+
+## Validation
+
+- Reachable strict expansions: `2341/2432` -> `2364/2432`; legacy bypasses: `91` -> `68`.
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `yarn compile`
+- `cargo test` (one unrelated parallel feature-policy test flaked once; isolated and full reruns passed)
+- `yarn check-all`
+- `yarn check-agent-interface`
+- Respo `be8141e`: 27 tests and JS check-only passed.
+- Recollect `6c235d0`: 9 tests, JS generation, and Node runtime passed.
+- js-ffi `25869b6`: default/node/browser checks and both runtime contracts passed.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -32,7 +32,11 @@
                 ~@ $ reverse xs
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |%err $ %{} 'CodeEntry (:doc "|Create Err variant of Result")
           :code $ quote
@@ -2563,7 +2567,10 @@
             quote $ assert= 9
               -> 2 inc $ * 3
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |->% $ %{} 'CodeEntry (:doc "|pass value as `%` into several expressions")
           :code $ quote
@@ -2577,7 +2584,11 @@
                 quasiquote $ let ~pairs ~tail
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |->> $ %{} 'CodeEntry (:doc "|thread macro passing value at end of each expression")
           :code $ quote
@@ -2952,7 +2963,10 @@
                 quasiquote $ [] ~@xs
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([])
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'List
+              :required $ []
           :tags $ #{} :macro
         |[] $ %{} 'CodeEntry (:doc "|internal function for creating lists\nSyntax: ([] & elements)\nParams: elements (any, variadic)\nReturns: list\nCreates new list from provided elements")
           :code $ quote &runtime-implementation
@@ -2985,8 +2999,10 @@
               quasiquote $ defn %\ (? % %2) ~xs
           :examples $ []
           :schema $ :: 'Macro
-            {} (:return 'Fn)
-              :args $ []
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Fn
+              :required $ []
           :tags $ #{} :macro
         |\. $ %{} 'CodeEntry (:doc "|this syntax is bared used, deprecating")
           :code $ quote
@@ -3015,8 +3031,10 @@
                             recur code $ butlast ys
           :examples $ []
           :schema $ :: 'Macro
-            {} (:return 'Fn)
-              :args $ [] 'Dynamic
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Fn
+              :required $ [] 'Syntax
           :tags $ #{} :deprecated :macro
         |abs $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -3146,7 +3164,10 @@
             quote $ assert= 15
               apply-args ([] 5 10) +
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList (:: 'Expr 'Fn)
           :tags $ #{} :macro
         |assert $ %{} 'CodeEntry (:doc "|Assert that an expression is truthy, raise with a message when false, and return Unit on success.")
           :code $ quote
@@ -4946,7 +4967,11 @@
                 ~@ $ reverse args
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Fn)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |floor $ %{} 'CodeEntry (:doc "|internal function for floor operation\nSyntax: (floor n)\nParams: n (number)\nReturns: number\nReturns largest integer less than or equal to n")
           :code $ quote &runtime-implementation

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4056,6 +4056,106 @@ mod tests {
       ));
     }
 
+    for def_name in ["->", "->%", "%<-", "apply-args", "flipped", "\\", "\\.", "[,]"] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert!(signature.optional_inputs.is_empty(), "{def_name} should not have optional inputs");
+      match def_name {
+        "->" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Expr(value)]
+              if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+        }
+        "->%" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Expr(value)]
+              if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+          assert!(matches!(
+            signature.rest_input,
+            Some(crate::calcit::MacroSyntaxType::Expr(ref value))
+              if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+        }
+        "%<-" => {
+          assert!(signature.required_inputs.is_empty());
+          assert!(matches!(
+            signature.rest_input,
+            Some(crate::calcit::MacroSyntaxType::Expr(ref value))
+              if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+        }
+        "apply-args" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [
+              crate::calcit::MacroSyntaxType::SyntaxList,
+              crate::calcit::MacroSyntaxType::Expr(value)
+            ] if matches!(value.as_ref(), CalcitTypeAnnotation::DynFn)
+          ));
+          assert!(signature.rest_input.is_none());
+        }
+        "flipped" => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Expr(value)]
+              if matches!(value.as_ref(), CalcitTypeAnnotation::DynFn)
+          ));
+          assert!(matches!(
+            signature.rest_input,
+            Some(crate::calcit::MacroSyntaxType::Expr(ref value))
+              if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+          ));
+        }
+        "\\" => {
+          assert!(signature.required_inputs.is_empty());
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+        }
+        "\\." => {
+          assert!(matches!(
+            signature.required_inputs.as_slice(),
+            [crate::calcit::MacroSyntaxType::Syntax]
+          ));
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+        }
+        "[,]" => {
+          assert!(signature.required_inputs.is_empty());
+          assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::Syntax)));
+        }
+        _ => unreachable!(),
+      }
+      if matches!(def_name, "\\" | "\\.") {
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref output)
+            if matches!(output.as_ref(), CalcitTypeAnnotation::DynFn)
+        ));
+      } else if def_name == "[,]" {
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref output)
+            if matches!(
+              output.as_ref(),
+              CalcitTypeAnnotation::List(value)
+                if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+            )
+        ));
+      } else {
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref output)
+            if matches!(output.as_ref(), CalcitTypeAnnotation::Dynamic)
+        ));
+      }
+    }
+
     for def_name in ["let", "fn"] {
       let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
         unreachable!()


### PR DESCRIPTION
## Summary

- type thread and placeholder transforms: `->`, `->%`, `%<-`
- type callable argument transforms: `apply-args`, `flipped`
- type anonymous function shorthands: `\`, `\.`
- type comma-filtered list construction: `[,]`
- lock complete phase contracts in Snapshot tests

## Coverage

- strict reachable expansions: 2341/2432 -> 2364/2432
- legacy-signature bypasses: 91 -> 68

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- Respo `be8141e`: 27 tests and JS check-only
- Recollect `6c235d0`: 9 tests, JS generation, Node runtime
- js-ffi `25869b6`: default/node/browser checks and both runtime contracts

One unrelated parallel feature-policy unit test flaked once; its isolated rerun and the complete `cargo test` rerun both passed.

Progresses #437
