### PR TITLE
refactor: type binding and update macros

### DIFF
--- a/editing-history/20260826-0214-binding-update-macro-contracts.md
+++ b/editing-history/20260826-0214-binding-update-macro-contracts.md
@@ -1,0 +1,14 @@
+# Binding and update macro contracts
+
+## Changes
+
+- Migrated `let-destruct`, `let-sugar`, `let[]`, `let{}`, and `loop` to phase-aware binding and body contracts.
+- Migrated `struct-with`, `swap!`, and `&doseq` with concrete struct/ref/callable inputs and struct/Unit outputs where proven.
+- Added `assert-type pair 'List` inside `let-sugar` so strict macro-body analysis retains the list evidence already guaranteed by its runtime validation.
+- Added exact Snapshot assertions for all contract fields.
+
+## Validation
+
+- Reachable strict expansions: `2364/2432` -> `2379/2432`; legacy bypasses: `68` -> `53`.
+- Full `cargo fmt`, Clippy, compile, Rust tests, `yarn check-all`, and Agent interface gates passed.
+- Latest Respo `be8141e`, Recollect `6c235d0`, and js-ffi `25869b6` regressions passed.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -509,8 +509,11 @@
                 reset! *seen $ append (deref *seen) n
               assert= ([] 1 2) (deref *seen)
           :schema $ :: 'Macro
-            {} (:return 'Unit)
-              :args $ [] 'Dynamic
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] 'SyntaxList
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :effect :internal :macro
           :tests $ []
             %{} 'TestEntry (:name |returns-unit-after-body)
@@ -5966,7 +5969,11 @@
                   raise $ str-spaced "|Unknown structure to destruct:" pattern
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'Syntax (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |let-sugar $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -5978,6 +5985,7 @@
                 quasiquote $ &let () ~@body
                 &let
                   pair $ &list:nth pairs 0
+                  assert-type pair 'List
                   if
                     not $ &= 2 (&list:count pair)
                     raise $ str-spaced "|expected pair length of 2, got:" pair
@@ -5990,7 +5998,11 @@
                         ~@ body
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |let[] $ %{} 'CodeEntry (:doc "|Destructures a sequential value inside `let`, assigning each position to declared names and supporting `&` rest bindings.")
           :code $ quote
@@ -6031,7 +6043,11 @@
             quote $ let[] (x y) ([] 1 2) (+ x y)
             quote $ let[] (head & tail) ([] 9 8 7) (count tail)
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |let{} $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -6050,7 +6066,11 @@
                     ~@ body
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList (:: 'Expr 'Dynamic)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |list-match $ %{} 'CodeEntry (:doc "|Two-branch list destructuring macro. Provides separate clauses for the empty list and a head/tail pattern, useful for simple recursion or guards.")
           :code $ quote
@@ -6146,7 +6166,11 @@
                   + total $ first xs
                   rest xs
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |macro? $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -7663,7 +7687,10 @@
                 ~@ $ &list:concat & pairs
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Struct
+              :required $ [] (:: 'Expr 'Struct)
           :tags $ #{} :macro
         |struct? $ %{} 'CodeEntry (:doc "|Predicate that checks struct values, including nominal and anonymous structs. Passing a StructDef reports a migration error.")
           :code $ quote &runtime-implementation
@@ -7688,7 +7715,11 @@
             quote $ do (defatom *state 1) (swap! *state + 2)
               assert= 3 $ deref *state
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Unit
+              :required $ [] (:: 'Expr 'Ref) (:: 'Expr 'Fn)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro :state
         |symbol? $ %{} 'CodeEntry (:doc "|Predicate that checks whether a value is a symbol literal (as opposed to strings, keywords, or other data).")
           :code $ quote &runtime-implementation

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4156,6 +4156,73 @@ mod tests {
       }
     }
 
+    for def_name in [
+      "let-destruct",
+      "let-sugar",
+      "let[]",
+      "let{}",
+      "loop",
+      "struct-with",
+      "swap!",
+      "&doseq",
+    ] {
+      let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
+        panic!("{def_name} should load as MacroSignature");
+      };
+      assert!(signature.is_strict(), "{def_name} should use a phase-aware contract");
+      assert!(signature.capabilities.is_empty(), "{def_name} should be compile-time pure");
+      assert!(signature.optional_inputs.is_empty(), "{def_name} should not have optional inputs");
+      match def_name {
+        "let-destruct" => assert!(matches!(
+          signature.required_inputs.as_slice(),
+          [crate::calcit::MacroSyntaxType::Syntax, crate::calcit::MacroSyntaxType::Expr(value)]
+            if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+        )),
+        "let-sugar" | "loop" | "&doseq" => assert!(matches!(
+          signature.required_inputs.as_slice(),
+          [crate::calcit::MacroSyntaxType::SyntaxList]
+        )),
+        "let[]" | "let{}" => assert!(matches!(
+          signature.required_inputs.as_slice(),
+          [crate::calcit::MacroSyntaxType::SyntaxList, crate::calcit::MacroSyntaxType::Expr(value)]
+            if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+        )),
+        "struct-with" => assert!(matches!(
+          signature.required_inputs.as_slice(),
+          [crate::calcit::MacroSyntaxType::Expr(value)]
+            if matches!(value.as_ref(), CalcitTypeAnnotation::Custom(kind) if kind.as_ref() == &Calcit::tag("struct"))
+        )),
+        "swap!" => assert!(matches!(
+          signature.required_inputs.as_slice(),
+          [crate::calcit::MacroSyntaxType::Expr(reference), crate::calcit::MacroSyntaxType::Expr(function)]
+            if matches!(reference.as_ref(), CalcitTypeAnnotation::Ref(value) if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic))
+              && matches!(function.as_ref(), CalcitTypeAnnotation::DynFn)
+        )),
+        _ => unreachable!(),
+      }
+      if def_name == "struct-with" {
+        assert!(matches!(signature.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref output)
+            if matches!(output.as_ref(), CalcitTypeAnnotation::Custom(kind) if kind.as_ref() == &Calcit::tag("struct"))
+        ));
+      } else {
+        assert!(matches!(
+          signature.rest_input,
+          Some(crate::calcit::MacroSyntaxType::Expr(ref value))
+            if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
+        ));
+        let expected_unit = matches!(def_name, "swap!" | "&doseq");
+        assert!(matches!(
+          signature.expansion,
+          crate::calcit::MacroExpansionType::Expr(ref output)
+            if (expected_unit && matches!(output.as_ref(), CalcitTypeAnnotation::Unit))
+              || (!expected_unit && matches!(output.as_ref(), CalcitTypeAnnotation::Dynamic))
+        ));
+      }
+    }
+
     for def_name in ["let", "fn"] {
       let CalcitTypeAnnotation::Macro(signature) = core_file.defs[def_name].schema.as_ref() else {
         unreachable!()


### PR DESCRIPTION
## Summary

- type destructuring and loop macros: `let-destruct`, `let-sugar`, `let[]`, `let{}`, `loop`
- type update/effect macros: `struct-with`, `swap!`, `&doseq`
- preserve `let-sugar` list evidence for strict macro-body checking
- lock complete contracts in Snapshot tests

## Coverage

- strict reachable expansions: 2364/2432 -> 2379/2432
- legacy-signature bypasses: 68 -> 53

## Validation

- full formatting, Clippy, compile, Rust tests, `yarn check-all`, and Agent interface gates
- Respo `be8141e`: 27 tests and JS check-only
- Recollect `6c235d0`: 9 tests, JS generation, Node runtime
- js-ffi `25869b6`: default/node/browser checks and both runtime contracts

Progresses #437
