### PR TITLE
refactor: type observability macros

### DIFF
--- a/editing-history/20260826-0629-type-observability-macros.md
+++ b/editing-history/20260826-0629-type-observability-macros.md
@@ -1,0 +1,8 @@
+# Type observability macro contracts
+
+- Migrated logging, timing, hygiene, documentation, and debug function-wrapper macros to strict phase-aware signatures.
+- Preserve expression result types for `w-log`, `wo-log`, `with-cpu-time`, and `noted` with a generic `T` contract.
+- Require callable expressions for `call-w-log` and `call-wo-log`, structural symbol/list inputs for function-definition and gensym helpers, and definition-shaped function expansions for `defn-w-log`/`defn-wo-log`.
+- Declare `:platform-read` only for macros that inspect the Calcit running mode while expanding. Runtime logging and `cpu-time` emitted into quoted code do not count as compile-time capabilities.
+- Benchmarked the full macro-contract migration against `3a7afb5e`: both release check-only medians remained about 0.15 seconds across 12 warm runs. Strict/cache-eligible expansion coverage rose from 4 to 2379 before this batch; this batch moves another 8 pure expansions to cache eligibility and classifies 5 platform-dependent expansions honestly.
+- Verified earlier, structured failures for invalid callable/list/ref macro arguments. No expansion cache exists yet, so this work provides visible diagnostics and cache prerequisites rather than a current runtime speedup.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -3485,7 +3485,11 @@
                   ~ v
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{} :platform-read
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Fn)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |call-wo-log $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -3496,7 +3500,11 @@
               quasiquote $ ~f ~@xs
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Fn)
+              :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |case $ %{} 'CodeEntry (:doc "|Match a value against pattern/result pairs. Raises when no pattern matches instead of returning nil.")
           :code $ quote
@@ -4160,7 +4168,10 @@
                   call-w-log ~f-name ~@args
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Definition 'Fn
+              :required $ [] 'SyntaxSymbol 'SyntaxList
           :tags $ #{} :macro
         |defn-wo-log $ %{} 'CodeEntry (:doc |)
           :code $ quote
@@ -4175,7 +4186,10 @@
               quasiquote $ defn ~f-name ~args ~@body
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Definition 'Fn
+              :required $ [] 'SyntaxSymbol 'SyntaxList
           :tags $ #{} :macro
         |defstruct $ %{} 'CodeEntry (:doc "|Define a StructDef with fixed fields and field types.")
           :code $ quote
@@ -6473,7 +6487,11 @@
             defmacro noted (_doc v) v
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'T
+              :generics $ [] 'T
+              :required $ [] 'Syntax (:: 'Expr 'T)
           :tags $ #{} :macro
         |nth $ %{} 'CodeEntry (:doc "|Return an indexed item from a list, string, or enum as Option<T>. Struct fields are accessed by their declared names.")
           :code $ quote
@@ -8203,7 +8221,11 @@
                     ~ x
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{} :platform-read
+              :expansion $ :: 'Expr 'T
+              :generics $ [] 'T
+              :required $ [] (:: 'Expr 'T)
           :tags $ #{} :macro
         |when $ %{} 'CodeEntry (:doc "|Conditional macro that evaluates its body only when the test expression is truthy, returning the last body value.")
           :code $ quote
@@ -8289,7 +8311,11 @@
                   ~ v
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'T
+              :generics $ [] 'T
+              :required $ [] (:: 'Expr 'T)
           :tags $ #{} :io :log :macro
         |with-gensyms $ %{} 'CodeEntry (:doc "|Macro helper for hygienic local names\nSyntax: (with-gensyms (a b ...) body...)\nBinds each symbol to a fresh gensym and evaluates body with those bindings.")
           :code $ quote
@@ -8305,7 +8331,10 @@
             quote $ with-gensyms (v)
               quasiquote $ &let (~v 1) ~v
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'Syntax)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] 'SyntaxList
           :tags $ #{} :macro
         |with-type-slot $ %{} 'CodeEntry (:doc "|Compatibility form for a local compile-time type-slot override. Syntax: (with-type-slot (:slot-name TypeExpr) body...). The form is always erased during preprocessing; it evaluates bodies in order and returns the last value. New entry points should prefer :type-slots configuration.")
           :code $ quote &runtime-implementation
@@ -8326,7 +8355,11 @@
             defmacro wo-log (x) x
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'T
+              :generics $ [] 'T
+              :required $ [] (:: 'Expr 'T)
           :tags $ #{} :macro
         |write-file $ %{} 'CodeEntry (:doc "|internal function for writing files\nSyntax: (write-file filepath content)\nParams: filepath (string), content (string)\nReturns: &unit or error\nWrites string content to file")
           :code $ quote &runtime-implementation


### PR DESCRIPTION
## Summary

- migrate logging, timing, gensym, documentation, and debug function-wrapper macros to strict phase-aware contracts
- preserve expression result types with generic contracts and require callable/symbol/list inputs where the macro body depends on those shapes
- declare `:platform-read` for `w-log` and `call-w-log`, while keeping runtime-only logging and clock operations out of compile-time capabilities
- classify `defn-w-log` and `defn-wo-log` expansions as function definitions

## Safety and performance evaluation

- invalid calls now fail at the macro boundary with structured diagnostics; for example, `flipped 1 2` reports `E_MACRO_INPUT_EXPR_TYPE` with expected `Fn`, and `swap! 1 inc` reports expected `Ref`
- across the full migration series, strict contracts increased from 4 to 2379 of 2432 observed expansions before this PR; this PR classifies another 13 expansions as 8 pure/cache-eligible and 5 intentionally platform-dependent
- 12 warm release `--check-only` runs against pre-migration commit `3a7afb5e` and current main both had an approximately 0.15s median, so there is no visible speedup or regression yet
- macro cache hits remain zero because caching is not implemented; these contracts are prerequisites for a safe cache, not a claim of current acceleration

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- latest Respo: 27/27 tests passed
- latest Recollect: Calcit and JS tests passed
- latest js-ffi: default, Node, and browser entries passed check-only
