### PR TITLE
refactor: type remaining match macros

### DIFF
--- a/editing-history/20260826-0642-type-remaining-match-macros.md
+++ b/editing-history/20260826-0642-type-remaining-match-macros.md
@@ -1,0 +1,7 @@
+# Remaining core match macro contracts
+
+- Migrated `case-default`, `field-match`, and `calcit.internal/&field-match-internal` to strict phase-aware macro signatures.
+- `case-default` now validates both value/default expression inputs and requires every pattern arm to be list-shaped syntax while keeping its branch-dependent output honest as `Expr<Dynamic>`.
+- `field-match` and its recursive helper now require a map expression before expansion, so invalid values fail at the public macro boundary with `E_MACRO_INPUT_EXPR_TYPE` instead of reaching generated runtime assertions.
+- Added snapshot assertions for required inputs, rest-arm syntax, pure capability sets, and expansion categories.
+- The core suite now observes 2392 pure/cache-eligible expansions, 5 explicitly platform-dependent expansions, and only 35 legacy expansions, all of which belong to test helper macros.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -3555,7 +3555,10 @@
             quote $ assert= |fallback
               case-default 5 |fallback (1 |one) (2 |two) (3 |three)
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
           :tags $ #{} :macro
         |ceil $ %{} 'CodeEntry (:doc "|internal function for ceiling operation\nSyntax: (ceil n)\nParams: n (number)\nReturns: number\nReturns smallest integer greater than or equal to n")
           :code $ quote &runtime-implementation
@@ -4807,9 +4810,10 @@
                     internal/&field-match-internal ~value ~@body
           :examples $ []
           :schema $ :: 'Macro
-            {}
-              :args $ [] (:: 'Map 'K 'V)
-              :generics $ [] 'K 'V
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Map)
           :tags $ #{} :macro
         |filter $ %{} 'CodeEntry (:doc "|Builds a new collection containing only the elements where the predicate returns truthy, preserving the original collection type when possible.")
           :code $ quote
@@ -8616,7 +8620,10 @@
                           &field-match-internal ~value $ ~@ (&list:rest body)
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic)
+            {} (:rest 'SyntaxList)
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ [] (:: 'Expr 'Map)
         |&tag-match-internal $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro &tag-match-internal (value t & body)

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4406,7 +4406,64 @@ mod tests {
       }
     }
 
+    let CalcitTypeAnnotation::Macro(case_default) = core_file.defs["case-default"].schema.as_ref() else {
+      panic!("case-default should load as MacroSignature");
+    };
+    assert!(case_default.is_strict());
+    assert!(case_default.capabilities.is_empty());
+    assert!(matches!(
+      case_default.required_inputs.as_slice(),
+      [
+        crate::calcit::MacroSyntaxType::Expr(item),
+        crate::calcit::MacroSyntaxType::Expr(default)
+      ] if matches!(item.as_ref(), CalcitTypeAnnotation::Dynamic)
+        && matches!(default.as_ref(), CalcitTypeAnnotation::Dynamic)
+    ));
+    assert!(matches!(case_default.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+    assert!(matches!(
+      case_default.expansion,
+      crate::calcit::MacroExpansionType::Expr(ref inner)
+        if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+    ));
+
+    let CalcitTypeAnnotation::Macro(field_match) = core_file.defs["field-match"].schema.as_ref() else {
+      panic!("field-match should load as MacroSignature");
+    };
+    assert!(field_match.is_strict());
+    assert!(field_match.capabilities.is_empty());
+    assert!(matches!(
+      field_match.required_inputs.as_slice(),
+      [crate::calcit::MacroSyntaxType::Expr(value)]
+        if matches!(value.as_ref(), CalcitTypeAnnotation::Map(_, _))
+    ));
+    assert!(matches!(field_match.rest_input, Some(crate::calcit::MacroSyntaxType::SyntaxList)));
+    assert!(matches!(
+      field_match.expansion,
+      crate::calcit::MacroExpansionType::Expr(ref inner)
+        if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+    ));
+
     let internal_file = snapshot.files.get("calcit.internal").expect("calcit.internal file should exist");
+    let CalcitTypeAnnotation::Macro(field_internal) = internal_file.defs["&field-match-internal"].schema.as_ref() else {
+      panic!("&field-match-internal should load as MacroSignature");
+    };
+    assert!(field_internal.is_strict());
+    assert!(field_internal.capabilities.is_empty());
+    assert!(matches!(
+      field_internal.required_inputs.as_slice(),
+      [crate::calcit::MacroSyntaxType::Expr(value)]
+        if matches!(value.as_ref(), CalcitTypeAnnotation::Map(_, _))
+    ));
+    assert!(matches!(
+      field_internal.rest_input,
+      Some(crate::calcit::MacroSyntaxType::SyntaxList)
+    ));
+    assert!(matches!(
+      field_internal.expansion,
+      crate::calcit::MacroExpansionType::Expr(ref inner)
+        if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic)
+    ));
+
     let CalcitTypeAnnotation::Macro(tag_internal) = internal_file.defs["&tag-match-internal"].schema.as_ref() else {
       panic!("&tag-match-internal should load as MacroSignature");
     };


### PR DESCRIPTION
## Summary

- migrate `case-default`, `field-match`, and `calcit.internal/&field-match-internal` to strict phase-aware contracts
- require list-shaped pattern arms for both match families
- require `Map` input expressions for public and recursive field matching
- add snapshot assertions for input, rest, expansion, and capability contracts

## Safety and scope

- `field-match 1 (_ 2)` now fails at the public macro boundary with `E_MACRO_INPUT_EXPR_TYPE`, expected `Map`, instead of relying on generated runtime assertions
- `case-default` deliberately retains `Expr<Dynamic>` output because arm bodies are raw list syntax and cannot safely be claimed to share the default branch type
- observed core macro expansions now have no legacy signatures: 2392 are pure/cache-eligible and 5 declare `:platform-read`; the remaining 35 legacy expansions are test helpers
- caching is still not implemented, so this improves validation and cache eligibility without claiming an immediate speedup

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- current-branch Calcit against latest Respo: 27/27 tests passed
- current-branch Calcit against latest Recollect: native and JS tests passed
- current-branch Calcit against latest js-ffi: default, Node, and browser entries passed check-only
