### PR TITLE
feat: track compile-time macro logging

### DIFF
--- a/calcit/test-hygienic.cirru
+++ b/calcit/test-hygienic.cirru
@@ -17,7 +17,10 @@
                   [] (~ a) (~ b) c (~ c) (add-2 8)
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{} :log
+              :expansion $ :: 'Expr 'List
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
         |add-11-safe $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro add-11-safe (a b)
@@ -27,7 +30,10 @@
                     [] (~ a) (~ b) ~c
           :examples $ []
           :schema $ :: 'Macro
-            {} $ :args ([] 'Dynamic 'Dynamic)
+            {}
+              :capabilities $ #{}
+              :expansion $ :: 'Expr 'List
+              :required $ [] (:: 'Expr 'Dynamic) (:: 'Expr 'Dynamic)
         |add-2 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn add-2 (x) (&+ x 2)

--- a/calcit/util.cirru
+++ b/calcit/util.cirru
@@ -16,8 +16,10 @@
                 quasiquote $ do (println "|env: not eval. tests skipped")
           :examples $ []
           :schema $ :: 'Macro
-            {} (:rest 'Dynamic)
-              :args $ [] 'Dynamic
+            {} (:rest 'Syntax)
+              :capabilities $ #{} :platform-read
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
         |inside-js: $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro inside-js: (& body)
@@ -27,8 +29,10 @@
                 quasiquote $ do (println "|env: not js. tests skipped")
           :examples $ []
           :schema $ :: 'Macro
-            {} (:rest 'Dynamic)
-              :args $ [] 'Dynamic
+            {} (:rest 'Syntax)
+              :capabilities $ #{} :platform-read
+              :expansion $ :: 'Expr 'Dynamic
+              :required $ []
         |log-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn log-title (title) (println) (println title) (println)

--- a/docs/MacroSignature.md
+++ b/docs/MacroSignature.md
@@ -81,7 +81,9 @@ evaluated must be declared separately from runtime/backend `:features`:
 ```
 
 Allowed opt-in capabilities are `:env-read`, `:fs-read`, `:platform-read`,
-`:clock-read`, `:mutable-state`, and `:dynamic-eval`. Any declared capability
+`:clock-read`, `:log`, `:mutable-state`, and `:dynamic-eval`. `:log` covers
+compile-time calls to `echo`, `println`, and `eprintln`; merely emitting those
+calls into quoted runtime syntax stays pure. Any declared capability
 makes the expansion ineligible for the pure-macro cache planned by the macro
 roadmap. Legacy signatures have unknown effects and are likewise ineligible.
 

--- a/editing-history/20260826-0654-macro-log-capability.md
+++ b/editing-history/20260826-0654-macro-log-capability.md
@@ -1,0 +1,8 @@
+# Compile-time macro log capability
+
+- Added the opt-in `:log` macro capability for compile-time `echo`, `println`, and `eprintln` calls.
+- Registered procedures remain forbidden host FFI by default; the three platform console aliases are the narrow exception and still require an explicit capability declaration.
+- Documented that quoted runtime logging stays pure while logging actually executed during expansion is observable and therefore cache-ineligible.
+- Added positive, missing-capability, and unrelated-host-procedure tests for the policy plus schema round-trip coverage for `:log`.
+- Migrated the final test helper macros: `inside-eval:`/`inside-js:` declare `:platform-read`, `add-11` declares `:log`, and the hygienic no-log helper remains pure.
+- Macro metrics now report zero legacy bypasses: 2393 pure/cache-eligible expansions and 39 explicitly capability-dependent expansions out of 2432 total. Cache hits remain zero until the planned cache implementation lands.

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -370,6 +370,7 @@ pub enum MacroCapability {
   FsRead,
   PlatformRead,
   ClockRead,
+  Log,
   MutableState,
   DynamicEval,
   FsWrite,
@@ -384,6 +385,7 @@ impl MacroCapability {
       Self::FsRead => "fs-read",
       Self::PlatformRead => "platform-read",
       Self::ClockRead => "clock-read",
+      Self::Log => "log",
       Self::MutableState => "mutable-state",
       Self::DynamicEval => "dynamic-eval",
       Self::FsWrite => "fs-write",
@@ -398,6 +400,7 @@ impl MacroCapability {
       "fs-read" => Some(Self::FsRead),
       "platform-read" => Some(Self::PlatformRead),
       "clock-read" => Some(Self::ClockRead),
+      "log" => Some(Self::Log),
       "mutable-state" => Some(Self::MutableState),
       "dynamic-eval" => Some(Self::DynamicEval),
       "fs-write" => Some(Self::FsWrite),
@@ -4141,7 +4144,11 @@ mod tests {
     map.insert_key("expansion", Edn::enum_value("Expr", vec![Edn::Symbol(Arc::from("T"))]));
     map.insert_key(
       "capabilities",
-      Edn::Set(EdnSetView(HashSet::from([Edn::tag("env-read"), Edn::tag("fs-read")]))),
+      Edn::Set(EdnSetView(HashSet::from([
+        Edn::tag("env-read"),
+        Edn::tag("fs-read"),
+        Edn::tag("log"),
+      ]))),
     );
     let schema = Edn::enum_value("Macro", vec![Edn::Map(map)]);
 
@@ -4160,6 +4167,7 @@ mod tests {
     assert!(matches!(signature.expansion, MacroExpansionType::Expr(_)));
     assert!(signature.capabilities.contains(&MacroCapability::EnvRead));
     assert!(signature.capabilities.contains(&MacroCapability::FsRead));
+    assert!(signature.capabilities.contains(&MacroCapability::Log));
     assert!(!signature.is_cache_eligible());
 
     let reloaded = CalcitTypeAnnotation::parse_macro_signature_from_edn(&signature.to_wrapped_schema_edn()).expect("round trip");

--- a/src/runner/macro_capability.rs
+++ b/src/runner/macro_capability.rs
@@ -158,7 +158,11 @@ pub fn check_syntax(syntax: &CalcitSyntax, call_stack: &CallStackList) -> Result
 }
 
 pub fn check_registered(alias: &str, call_stack: &CallStackList) -> Result<(), CalcitErr> {
-  check_policy(CapabilityPolicy::Forbidden(MacroCapability::HostFfi), alias, call_stack)
+  let policy = match alias {
+    "echo" | "println" | "eprintln" => CapabilityPolicy::Requires(MacroCapability::Log),
+    _ => CapabilityPolicy::Forbidden(MacroCapability::HostFfi),
+  };
+  check_policy(policy, alias, call_stack)
 }
 
 pub fn check_host_ffi(operation: &str, call_stack: &CallStackList) -> Result<(), CalcitErr> {
@@ -199,6 +203,35 @@ mod tests {
       check_proc(CalcitProc::GetEnv, &CallStackList::default())
     })
     .expect("declared env read should pass");
+  }
+
+  #[test]
+  fn registered_console_output_requires_log_capability() {
+    for alias in ["echo", "println", "eprintln"] {
+      let error = with_macro_context(Arc::from("app/log"), Arc::new(HashSet::new()), None, || {
+        check_registered(alias, &CallStackList::default())
+      })
+      .expect_err("compile-time console output must need a declaration");
+      assert_eq!(error.code(), Some("E_MACRO_CAPABILITY_MISSING"));
+      assert!(error.msg.contains(":log"));
+
+      let declared = Arc::new(HashSet::from([MacroCapability::Log]));
+      with_macro_context(Arc::from("app/log"), declared, None, || {
+        check_registered(alias, &CallStackList::default())
+      })
+      .expect("declared compile-time console output should pass");
+    }
+  }
+
+  #[test]
+  fn unrelated_registered_procedures_remain_forbidden_host_ffi() {
+    let declared = Arc::new(HashSet::from([MacroCapability::Log]));
+    let error = with_macro_context(Arc::from("app/ffi"), declared, None, || {
+      check_registered("custom-host-proc", &CallStackList::default())
+    })
+    .expect_err("log capability must not permit arbitrary registered procedures");
+    assert_eq!(error.code(), Some("E_MACRO_CAPABILITY_DISALLOWED"));
+    assert!(error.msg.contains(":host-ffi"));
   }
 
   #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1697,7 +1697,7 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
       }
       if crate::calcit::MacroCapability::parse(name).is_none() {
         return Err(format!(
-          "Unknown macro capability `{name}`. Expected one of: :env-read, :fs-read, :platform-read, :clock-read, :mutable-state, :dynamic-eval, :fs-write, :process, :host-ffi"
+          "Unknown macro capability `{name}`. Expected one of: :env-read, :fs-read, :platform-read, :clock-read, :log, :mutable-state, :dynamic-eval, :fs-write, :process, :host-ffi"
         ));
       }
     }


### PR DESCRIPTION
## Summary

- add an explicit `:log` compile-time macro capability for `echo`, `println`, and `eprintln`
- keep all unrelated registered procedures forbidden as host FFI
- document the distinction between logging during expansion and emitting quoted runtime logging
- migrate the final test helper macros to strict signatures with honest `:log` or `:platform-read` effects

## Why this matters

A macro that prints while expanding has observable behavior. Treating it as pure would let the planned macro cache suppress later output. The new capability keeps these macros strict and auditable while making them intentionally cache-ineligible.

After this change, the observed 2432 macro expansions contain:

- 2393 pure/cache-eligible expansions
- 39 explicitly capability-dependent expansions
- 0 legacy-signature bypasses
- 0 cache hits, because caching is not implemented yet

## Verification

- added tests for missing and declared `:log`, plus unrelated registered-procedure rejection
- added schema round-trip coverage for `:log`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test` (511 library tests plus CLI/deps/WASM suites)
- `yarn check-all`
- `yarn check-agent-interface`
- current-branch Calcit against latest Respo: 27/27 tests passed
- current-branch Calcit against latest Recollect: native and JS tests passed
- current-branch Calcit against latest js-ffi: default, Node, and browser entries passed check-only
