### PR TITLE
feat: add Result-returning parsing methods

### DIFF
--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -39,6 +39,8 @@ The available methods are `.parse-cirru`, `.parse-cirru-list`, `.parse-cirru-edn
 
 Cirru syntax has a closed result type, while Cirru EDN and JSON remain `Result<Dynamic,String>` because their data shapes are open. Use `parse-cirru-edn-as` or `decode-map-as` after the boundary when application code needs a closed nominal type. The original parser procedures remain available for compatibility and still raise on malformed input.
 
+These Result-returning parser methods currently run on the native and JavaScript backends. The WASM backend does not yet support the underlying parser procedures or `try`-based wrappers; the standard WASM validation suite confirms that unsupported parser definitions are skipped without affecting supported exports.
+
 ## Strict typed decoding
 
 `parse-cirru-edn-as` is a language syntax that derives a closed decoder graph at compile time, then validates and constructs the complete value recursively:

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -23,6 +23,22 @@ The runtime APIs are:
 
 `parse-cirru-edn` is the dynamic API: its result is `Dynamic`, and its optional type map only restores nominal identity. Use `parse-cirru-edn-as` when persisted or external data must enter typed application code.
 
+## Recoverable parsing with Result
+
+User-facing String methods return `Result` instead of raising on malformed input:
+
+```cirru
+let
+    parsed $ |[] .parse-cirru-edn
+    json $ |1 .parse-json
+  assert= true $ parsed .ok?
+  assert= true $ json .ok?
+```
+
+The available methods are `.parse-cirru`, `.parse-cirru-list`, `.parse-cirru-edn`, and `.parse-json`. Their function-form counterparts are named `try-parse-cirru`, `try-parse-cirru-list`, `try-parse-cirru-edn`, and `try-parse-json`. Parse failures carry the parser message in `Result`'s `:err` payload, including Cirru source position and nearby input where available.
+
+Cirru syntax has a closed result type, while Cirru EDN and JSON remain `Result<Dynamic,String>` because their data shapes are open. Use `parse-cirru-edn-as` or `decode-map-as` after the boundary when application code needs a closed nominal type. The original parser procedures remain available for compatibility and still raise on malformed input.
+
 ## Strict typed decoding
 
 `parse-cirru-edn-as` is a language syntax that derives a closed decoder graph at compile time, then validates and constructs the complete value recursively:

--- a/editing-history/20260826-0843-result-parsing-methods.md
+++ b/editing-history/20260826-0843-result-parsing-methods.md
@@ -1,0 +1,7 @@
+# Result-returning parsing methods
+
+- Added `.parse-cirru`, `.parse-cirru-list`, `.parse-cirru-edn`, and `.parse-json` to the core String method bag. Their function-form compatibility entry points are `try-parse-*`.
+- Recoverable parse failures now return nominal `Result` values instead of requiring user code to catch exceptions or interpret nil. CirruQuote/List successes retain their known outer shape; open EDN/JSON payloads deliberately remain Dynamic.
+- Moved detailed Cirru parser diagnostics into `CalcitErr.msg` and removed unconditional stderr printing, so a caught failure retains line/column/nearby-input context.
+- Added definition-attached native tests, native/JS examples, and EDN documentation. Full Calcit gates and latest Respo/Recollect native, JS, docs, and WASM regressions passed after refreshing locked modules and toolchains.
+- A separate narrow typed Macro IR experiment reduced the measured Respo macro-evaluator phase by about 12% but did not produce a stable end-to-end check improvement; it was not landed and the evidence is recorded on issue #436.

--- a/editing-history/20260826-0847-result-parsing-error-examples.md
+++ b/editing-history/20260826-0847-result-parsing-error-examples.md
@@ -1,0 +1,5 @@
+# Cross-backend parser failure examples
+
+- Added a malformed-input example to each Result-returning String parser method.
+- Native and JavaScript example runners now exercise both `:ok` and caught `:err` paths for Cirru, Cirru-list, Cirru-EDN, and JSON parsing.
+- The JavaScript Cirru-EDN parser still emits its existing parser-library diagnostic while returning the caught Result; this PR preserves compatibility and verifies the Result semantics without claiming that host parser output is fully silent.

--- a/editing-history/20260826-0850-document-parser-backend-boundary.md
+++ b/editing-history/20260826-0850-document-parser-backend-boundary.md
@@ -1,0 +1,4 @@
+# Document parser backend boundary
+
+- Clarified that Result-returning parser methods are currently native/JavaScript APIs.
+- Distinguished a green whole-project WASM regression from support for parser definitions: WASM deliberately skips the unsupported parser/`try` definitions while validating all supported exports.

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -204,11 +204,10 @@ pub fn parse_cirru_list(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match xs.first() {
     Some(Calcit::Str(s)) => match cirru_parser::parse(s) {
       Ok(nodes) => Ok(cirru::cirru_to_calcit(&Cirru::List(nodes))),
-      Err(e) => {
-        eprintln!("\nparse-cirru-list failed:");
-        eprintln!("{}", e.format_detailed(Some(s)));
-        CalcitErr::err_str(CalcitErrKind::Syntax, "parse-cirru-list failed")
-      }
+      Err(e) => CalcitErr::err_str(
+        CalcitErrKind::Syntax,
+        format!("parse-cirru-list failed:\n{}", e.format_detailed(Some(s))),
+      ),
     },
     Some(a) => {
       let msg = format!(
@@ -234,11 +233,10 @@ pub fn parse_cirru(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match xs.first() {
     Some(Calcit::Str(s)) => match cirru_parser::parse(s) {
       Ok(nodes) => Ok(Calcit::CirruQuote(Cirru::List(nodes))),
-      Err(e) => {
-        eprintln!("\nparse-cirru failed:");
-        eprintln!("{}", e.format_detailed(Some(s)));
-        CalcitErr::err_str(CalcitErrKind::Syntax, "parse-cirru failed")
-      }
+      Err(e) => CalcitErr::err_str(
+        CalcitErrKind::Syntax,
+        format!("parse-cirru failed:\n{}", e.format_detailed(Some(s))),
+      ),
     },
     Some(a) => {
       let msg = format!(
@@ -308,11 +306,7 @@ pub fn parse_cirru_edn(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
         Some(options) => Ok(edn::edn_to_calcit(&nodes, options)),
         None => Ok(edn::edn_to_calcit(&nodes, &Calcit::Nil)),
       },
-      Err(e) => {
-        eprintln!("\nparse-cirru-edn failed:");
-        eprintln!("{e}");
-        CalcitErr::err_str(CalcitErrKind::Syntax, "parse-cirru-edn failed")
-      }
+      Err(e) => CalcitErr::err_str(CalcitErrKind::Syntax, format!("parse-cirru-edn failed:\n{e}")),
     },
     Some(a) => {
       let msg = format!(
@@ -2178,5 +2172,36 @@ mod tests {
     let impls = collect_optional_core_impls("&missing-test-core-impls", &CallStackList::default())
       .expect("missing core impl list should be treated as unavailable");
     assert!(impls.is_empty());
+  }
+
+  #[test]
+  fn cirru_parse_errors_keep_detailed_context_in_the_error_value() {
+    let invalid = Calcit::new_str(")");
+
+    for (label, result) in [
+      ("parse-cirru", parse_cirru(std::slice::from_ref(&invalid))),
+      ("parse-cirru-list", parse_cirru_list(std::slice::from_ref(&invalid))),
+    ] {
+      let error = result.expect_err("invalid Cirru must fail");
+      assert!(error.msg.contains(label), "missing operation name: {}", error.msg);
+      assert!(
+        error.msg.contains("Unexpected closing parenthesis"),
+        "missing parser detail: {}",
+        error.msg
+      );
+      assert!(error.msg.contains("line 1, column 1"), "missing source location: {}", error.msg);
+    }
+  }
+
+  #[test]
+  fn cirru_edn_parse_errors_keep_parser_context_in_the_error_value() {
+    let error = parse_cirru_edn(&[Calcit::new_str(")")]).expect_err("invalid Cirru EDN must fail");
+    assert!(error.msg.contains("parse-cirru-edn failed"));
+    assert!(
+      error.msg.contains("Unexpected closing parenthesis"),
+      "missing parser detail: {}",
+      error.msg
+    );
+    assert!(error.msg.contains("line 1, column 1"), "missing source location: {}", error.msg);
   }
 }

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -450,7 +450,7 @@
           :tags $ #{} :internal
         |&core-string-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare)
+            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare) (:: :parse-cirru try-parse-cirru) (:: :parse-cirru-list try-parse-cirru-list) (:: :parse-cirru-edn try-parse-cirru-edn) (:: :parse-json try-parse-json)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -8006,6 +8006,89 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :control :internal :syntax
+        |try-parse-cirru $ %{} 'CodeEntry (:doc "|Parse Cirru as Result<CirruQuote,String>; errors are returned instead of raised. Prefer the .parse-cirru String method in user code.")
+          :code $ quote
+            defn try-parse-cirru (source)
+              try
+                %ok $ parse-cirru source
+                fn (message) (%err message)
+          :examples $ []
+            quote $ |a .parse-cirru
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'String
+              :return $ :: 'Result 'CirruQuote 'String
+          :tests $ []
+            %{} 'TestEntry (:name |result-method-contract)
+              :code $ quote
+                do
+                  assert= true $ result:ok? (|a .parse-cirru)
+                  assert= true $ result:err?
+                      char-from-code 41
+                      , .parse-cirru
+                  assert-type (|a .parse-cirru) (:: 'Result 'CirruQuote 'String)
+        |try-parse-cirru-edn $ %{} 'CodeEntry (:doc "|Parse Cirru EDN as Result<Dynamic,String>; the payload stays Dynamic because EDN is open data. Prefer the .parse-cirru-edn String method in user code.")
+          :code $ quote
+            defn try-parse-cirru-edn (source)
+              try
+                %ok $ parse-cirru-edn source
+                fn (message) (%err message)
+          :examples $ []
+            quote $ |[] .parse-cirru-edn
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'String
+              :return $ :: 'Result 'Dynamic 'String
+          :tests $ []
+            %{} 'TestEntry (:name |result-method-contract)
+              :code $ quote
+                do
+                  assert= true $ result:ok? (|[] .parse-cirru-edn)
+                  assert= true $ result:err?
+                      char-from-code 41
+                      , .parse-cirru-edn
+                  assert-type (|[] .parse-cirru-edn) (:: 'Result 'Dynamic 'String)
+        |try-parse-cirru-list $ %{} 'CodeEntry (:doc "|Parse a Cirru expression list as Result<List,String>; errors are returned instead of raised. Prefer the .parse-cirru-list String method in user code.")
+          :code $ quote
+            defn try-parse-cirru-list (source)
+              try
+                %ok $ parse-cirru-list source
+                fn (message) (%err message)
+          :examples $ []
+            quote $ |a .parse-cirru-list
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'String
+              :return $ :: 'Result 'List 'String
+          :tests $ []
+            %{} 'TestEntry (:name |result-method-contract)
+              :code $ quote
+                do
+                  assert= true $ result:ok? (|a .parse-cirru-list)
+                  assert= true $ result:err?
+                      char-from-code 41
+                      , .parse-cirru-list
+                  assert-type (|a .parse-cirru-list)
+                    :: 'Result (:: 'List 'Dynamic) 'String
+        |try-parse-json $ %{} 'CodeEntry (:doc "|Parse JSON as Result<Dynamic,String>; the payload stays Dynamic because JSON is open data. Prefer the .parse-json String method in user code.")
+          :code $ quote
+            defn try-parse-json (source)
+              try
+                %ok $ json-parse source
+                fn (message) (%err message)
+          :examples $ []
+            quote $ |1 .parse-json
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'String
+              :return $ :: 'Result 'Dynamic 'String
+          :tests $ []
+            %{} 'TestEntry (:name |result-method-contract)
+              :code $ quote
+                do
+                  assert= true $ result:ok? (|1 .parse-json)
+                  assert= true $ result:err? (|{ .parse-json)
+                  assert-type (|1 .parse-json) (:: 'Result 'Dynamic 'String)
         |tuple-enum $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn tuple-enum (_value) (raise "|`tuple-enum` was removed; use `enum-definition`, which returns Option<EnumDef>")

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -8014,6 +8014,9 @@
                 fn (message) (%err message)
           :examples $ []
             quote $ |a .parse-cirru
+            quote $
+              char-from-code 41
+              , .parse-cirru
           :schema $ :: 'Fn
             {}
               :args $ [] 'String
@@ -8035,6 +8038,9 @@
                 fn (message) (%err message)
           :examples $ []
             quote $ |[] .parse-cirru-edn
+            quote $
+              char-from-code 41
+              , .parse-cirru-edn
           :schema $ :: 'Fn
             {}
               :args $ [] 'String
@@ -8056,6 +8062,9 @@
                 fn (message) (%err message)
           :examples $ []
             quote $ |a .parse-cirru-list
+            quote $
+              char-from-code 41
+              , .parse-cirru-list
           :schema $ :: 'Fn
             {}
               :args $ [] 'String
@@ -8078,6 +8087,7 @@
                 fn (message) (%err message)
           :examples $ []
             quote $ |1 .parse-json
+            quote $ |{ .parse-json
           :schema $ :: 'Fn
             {}
               :args $ [] 'String


### PR DESCRIPTION
## Summary

- add Result-returning String methods: `.parse-cirru`, `.parse-cirru-list`, `.parse-cirru-edn`, and `.parse-json`
- add function-form compatibility entry points named `try-parse-*`
- preserve detailed Cirru parser diagnostics in the caught error value instead of printing details unconditionally to stderr
- document the boundary: CirruQuote/List keep their known outer type, while open Cirru EDN and JSON payloads remain `Result<Dynamic,String>`

## Type-safety impact

Malformed input is now an explicit nominal `Result` branch, so user code can use `.ok?`, `.err?`, `.and-then`, `.map-err`, or `result:let` without an outer `try` or nil convention. The methods do not pretend that open EDN/JSON has a closed application type; callers still use `parse-cirru-edn-as` or `decode-map-as` at that boundary.

The original raising parser procedures remain unchanged for compatibility.

The new methods are currently supported on native and JavaScript. WASM still skips the underlying parser procedures and `try` wrappers; the full WASM regression below validates supported exports rather than claiming parser support.

## Performance assessment

This PR does not claim a speedup; parsing dominates the small wrapper cost and the change targets error semantics and diagnostics.

A separate typed Macro IR experiment for #436 covered 1,398/1,412 Respo expansions and reduced the measured evaluator phase by about 12%, but the end-to-end check delta was only about 2% and overlapped process noise (Calcit's sample regressed). That experiment was not included here; its measurements and no-land conclusion are recorded on #436.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all` (native, JS, IR, WASM)
- `yarn check-agent-interface` (17/17)
- definition-attached Result method tests: 4/4
- native and JS definition examples: 8/8 each (success and malformed-input paths)
- `docs/data/edn.md`: 23/23 blocks
- latest Respo main after locked dependency/toolchain refresh: 27/27 tests; 111/111 docs blocks
- latest Recollect main after locked dependency/toolchain refresh: 9/9 native tests; generated-JS regression passed; WASM regression passed

Refs #428
