### PR TITLE
feat: add typed decode Result syntax

### DIFF
--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -69,7 +69,16 @@ Runtime failures include a structural path:
 parse-cirru-edn-as failed at $.friends[2].age: expected number, got string
 ```
 
-The failure is raised like `parse-cirru-edn` errors and can be handled with `try`.
+The compatibility form raises the failure like `parse-cirru-edn`. New code that expects malformed external input should use the Result-returning syntax:
+
+```cirru.no-run
+def Person $ defstruct Person (:name 'String) (:age 'Number)
+
+defn decode-people (raw)
+  try-parse-cirru-edn-as raw $ :: 'List Person
+```
+
+Its inferred return type is `Result<List<Person>,String>`, not `Result<Dynamic,String>`. Runtime parse and recursive shape failures become `:err` with the same structural context. An invalid `TypeExpr` remains a compile-time error because it is a program definition problem rather than recoverable input.
 
 ## Decoding runtime maps into Structs
 
@@ -89,7 +98,9 @@ defstruct Response (:code 'Number)
 
 Unlike the closed text decoder, `decode-map-as` permits an explicitly declared `Dynamic` leaf for an open payload such as an HTTP response body. Keep it at the boundary and decode it again into a closed Struct/Enum before application logic depends on it. It never treats `nil` as an empty map or silently supplies required fields. Native and JavaScript support this syntax; the WASM backend does not currently support typed decoder syntaxes.
 
-The syntax is available for native execution and JavaScript code generation. The current WASM backend does not yet support either typed EDN decoder.
+Use `try-decode-map-as value TypeExpr` when a host value may legitimately fail validation. It returns `Result<T,String>` and preserves paths such as `$.friends[2].age` in the error payload. `decode-map-as` remains available for compatibility and for boundaries where invalid input should abort immediately.
+
+The raising and Result-returning typed syntaxes are available for native execution and JavaScript code generation. The current WASM backend does not yet support typed EDN decoding.
 
 Map and Set iteration order is not a semantic guarantee. The formatter applies a stable order for readable, reproducible output; callers must not use that order as application data.
 

--- a/docs/features/error-handling.md
+++ b/docs/features/error-handling.md
@@ -24,6 +24,8 @@ Calcit uses `try` / `raise` for exception-based error handling. Errors are strin
 
 `try` takes an expression body and a handler function. If the body raises an error, the handler receives the error message as a string:
 
+Native and generated JavaScript normalize caught failures to this String contract; host `Error` objects are not exposed through the handler.
+
 ```cirru
 let
     result $ try

--- a/editing-history/20260826-1006-typed-decode-result.md
+++ b/editing-history/20260826-1006-typed-decode-result.md
@@ -1,0 +1,30 @@
+# Typed decode Result syntax
+
+## Summary
+
+- Added `try-parse-cirru-edn-as text TypeExpr` and `try-decode-map-as value TypeExpr`.
+- Decoder graphs are still derived during preprocessing. Invalid or open target types remain compile-time errors.
+- Runtime parse and recursive shape failures now become nominal `Result<T,String>` errors with their structural path intact.
+- Known non-String text inputs are rejected during preprocessing; Dynamic boundaries retain runtime validation.
+- Native and generated JavaScript implement the same Result contract. WASM keeps the existing explicit typed-decoder unsupported boundary.
+
+## Backend consistency
+
+Generated JavaScript `try` handlers previously received a host `Error` object even though native Calcit and the public guide specify a String message. JS codegen now normalizes `Error.message` (or stringifies a non-Error throw) before invoking the handler. The new Result syntaxes use the same normalization, so their `:err` payload is a String on both supported backends.
+
+## Type and performance assessment
+
+The visible benefit is semantic and static: successful expressions infer `Result<T,String>` with the complete target type, malformed input is explicit in control flow, invalid target schemas fail before runtime, and known invalid text arguments are rejected during preprocessing. This slice does not claim a speedup. Decoder work is unchanged and the safe success path additionally constructs one Result value; callers should choose it for recoverable external input rather than throughput.
+
+## Validation
+
+- `cargo fmt`
+- `cargo clippy -- -D warnings`
+- `cargo test` (520 library, 246 CLI, 24 caps, 4 WASM tests)
+- `yarn compile`
+- `yarn check-all` (native, generated JS, IR, WASM, 228 core tests)
+- `yarn check-agent-interface` (17/17)
+- Native and generated-JS attached examples for success, failure, exact type, and String error payload
+- `docs/data/edn.md` 24/24 and `docs/features/error-handling.md` 9/9 markdown blocks
+- Latest Respo main: 27/27 tests and 111/111 documentation blocks
+- Latest Recollect main: 9/9 native tests, generated JS, and required WASM checks

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -644,7 +644,9 @@ pub fn handle_syntax(
     AssertType => syntax::assert_type(nodes, scope, file_ns, call_stack),
     UnsafeCoerce => syntax::unsafe_coerce(nodes, scope, file_ns, call_stack),
     ParseCirruEdnAs => syntax::parse_cirru_edn_as(nodes, scope, file_ns, call_stack),
+    TryParseCirruEdnAs => syntax::try_parse_cirru_edn_as(nodes, scope, file_ns, call_stack),
     DecodeMapAs => syntax::decode_map_as(nodes, scope, file_ns, call_stack),
+    TryDecodeMapAs => syntax::try_decode_map_as(nodes, scope, file_ns, call_stack),
     AssertTraits => syntax::assert_traits(nodes, scope, file_ns, call_stack),
     Match => syntax::syntax_match(nodes, scope, file_ns, call_stack),
   }

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -789,6 +789,30 @@ pub fn parse_cirru_edn_as(
   })
 }
 
+fn wrap_core_result_variant(name: &str, value: Calcit, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  let constructor = runner::evaluate_symbol_from_program(name, calcit::CORE_NS, None, call_stack)?;
+  match constructor {
+    Calcit::Fn { info, .. } => runner::run_fn(&[value], &info, call_stack),
+    Calcit::Proc(proc) => builtins::handle_proc(proc, &[value], call_stack),
+    other => CalcitErr::err_str(
+      CalcitErrKind::Unexpected,
+      format!("{name} expected a core Result constructor, but resolved to {other}"),
+    ),
+  }
+}
+
+pub fn try_parse_cirru_edn_as(
+  expr: &CalcitListView<'_>,
+  scope: &CalcitScope,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Calcit, CalcitErr> {
+  match parse_cirru_edn_as(expr, scope, file_ns, call_stack) {
+    Ok(value) => wrap_core_result_variant("%ok", value, call_stack),
+    Err(failure) => wrap_core_result_variant("%err", Calcit::Str(failure.msg.into()), call_stack),
+  }
+}
+
 pub fn decode_map_as(
   expr: &CalcitListView<'_>,
   scope: &CalcitScope,
@@ -834,6 +858,18 @@ pub fn decode_map_as(
       expr.first().and_then(Calcit::get_location),
     )
   })
+}
+
+pub fn try_decode_map_as(
+  expr: &CalcitListView<'_>,
+  scope: &CalcitScope,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Calcit, CalcitErr> {
+  match decode_map_as(expr, scope, file_ns, call_stack) {
+    Ok(value) => wrap_core_result_variant("%ok", value, call_stack),
+    Err(failure) => wrap_core_result_variant("%err", Calcit::Str(failure.msg.into()), call_stack),
+  }
 }
 
 pub fn assert_traits(

--- a/src/calcit/syntax_name.rs
+++ b/src/calcit/syntax_name.rs
@@ -84,9 +84,15 @@ pub enum CalcitSyntax {
   /// Parse Cirru EDN and deeply validate/construct the declared closed type.
   #[strum(serialize = "parse-cirru-edn-as")]
   ParseCirruEdnAs,
+  /// Parse Cirru EDN into a closed type and return runtime failures as Result.
+  #[strum(serialize = "try-parse-cirru-edn-as")]
+  TryParseCirruEdnAs,
   /// Decode an evaluated Calcit Map into a declared typed data shape.
   #[strum(serialize = "decode-map-as")]
   DecodeMapAs,
+  /// Decode an evaluated value into a closed type and return runtime failures as Result.
+  #[strum(serialize = "try-decode-map-as")]
+  TryDecodeMapAs,
   /// placeholder for trait requirement assertions
   #[strum(serialize = "assert-traits")]
   AssertTraits,
@@ -172,7 +178,17 @@ impl CalcitSyntax {
         param_types: vec![Arc::new(CalcitTypeAnnotation::String), dyn_t.clone()],
         return_type: dyn_t.clone(),
       }),
+      TryParseCirruEdnAs => Some(SyntaxTypeSignature {
+        param_names: vec!["text", "type"],
+        param_types: vec![Arc::new(CalcitTypeAnnotation::String), dyn_t.clone()],
+        return_type: dyn_t.clone(),
+      }),
       DecodeMapAs => Some(SyntaxTypeSignature {
+        param_names: vec!["value", "type"],
+        param_types: vec![dyn_t.clone(), dyn_t.clone()],
+        return_type: dyn_t.clone(),
+      }),
+      TryDecodeMapAs => Some(SyntaxTypeSignature {
         param_names: vec!["value", "type"],
         param_types: vec![dyn_t.clone(), dyn_t.clone()],
         return_type: dyn_t.clone(),

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -8006,6 +8006,27 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :control :internal :syntax
+        |try-decode-map-as $ %{} 'CodeEntry (:doc "|Decode an evaluated Calcit value into a compile-time-derived type and return Result<T,String>. Runtime shape failures become :err with a structural path; invalid TypeExpr decoder derivation remains a compile-time error. Syntax: (try-decode-map-as value TypeExpr). Native and JavaScript are supported; WASM typed decoding is not yet supported.")
+          :code $ quote (def try-decode-map-as &runtime-implementation)
+          :examples $ []
+            quote $ try-decode-map-as 1 'Number
+            quote $ try-decode-map-as |bad 'Number
+            quote $ tag-match (try-decode-map-as |bad 'Number)
+              (:err message)
+                assert= true $ string? message
+              (:ok _) false
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] 'Dynamic 'Dynamic
+          :tags $ #{} :builtin :data :syntax
+          :tests $ []
+            %{} 'TestEntry (:name |result-contract)
+              :code $ quote
+                do
+                  assert= true $ result:ok? (try-decode-map-as 1 'Number)
+                  assert= true $ result:err? (try-decode-map-as |bad 'Number)
+                  assert-type (try-decode-map-as 1 'Number) (:: 'Result 'Number 'String)
+              :tags $ #{} :unit
         |try-parse-cirru $ %{} 'CodeEntry (:doc "|Parse Cirru as Result<CirruQuote,String>; errors are returned instead of raised. Prefer the .parse-cirru String method in user code.")
           :code $ quote
             defn try-parse-cirru (source)
@@ -8054,6 +8075,32 @@
                       char-from-code 41
                       , .parse-cirru-edn
                   assert-type (|[] .parse-cirru-edn) (:: 'Result 'Dynamic 'String)
+        |try-parse-cirru-edn-as $ %{} 'CodeEntry (:doc "|Parse Cirru EDN into a compile-time-derived closed type and return Result<T,String>. Runtime parse and shape failures become :err; invalid TypeExpr decoder derivation remains a compile-time error. Syntax: (try-parse-cirru-edn-as text TypeExpr). Native and JavaScript are supported; WASM typed decoding is not yet supported.")
+          :code $ quote (def try-parse-cirru-edn-as &runtime-implementation)
+          :examples $ []
+            quote $ try-parse-cirru-edn-as "|[] 1 2" (:: 'List 'Number)
+            quote $ try-parse-cirru-edn-as "|[] 1 |bad" (:: 'List 'Number)
+            quote $ tag-match
+              try-parse-cirru-edn-as "|[] 1 |bad" $ :: 'List 'Number
+              (:err message)
+                assert= true $ string? message
+              (:ok _) false
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] 'String 'Dynamic
+          :tags $ #{} :builtin :data :syntax
+          :tests $ []
+            %{} 'TestEntry (:name |result-contract)
+              :code $ quote
+                do
+                  assert= true $ result:ok?
+                    try-parse-cirru-edn-as "|[] 1 2" $ :: 'List 'Number
+                  assert= true $ result:err?
+                    try-parse-cirru-edn-as "|[] 1 |bad" $ :: 'List 'Number
+                  assert-type
+                    try-parse-cirru-edn-as "|[] 1 2" $ :: 'List 'Number
+                    :: 'Result (:: 'List 'Number) 'String
+              :tags $ #{} :unit
         |try-parse-cirru-list $ %{} 'CodeEntry (:doc "|Parse a Cirru expression list as Result<List,String>; errors are returned instead of raised. Prefer the .parse-cirru-list String method in user code.")
           :code $ quote
             defn try-parse-cirru-list (source)

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -566,6 +566,34 @@ fn gen_call_code(
           }
           _ => Err(format!("parse-cirru-edn-as expected a string and a type expression, got: {body}")),
         },
+        CalcitSyntax::TryParseCirruEdnAs => match (body.first(), body.get(1)) {
+          (Some(text), Some(type_form)) if body.len() == 2 || body.len() == 3 => {
+            let graph = match body.get(2).and_then(DataShapeGraph::from_calcit_handle) {
+              Some(graph) => graph,
+              None => {
+                let target = calcit::CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
+                Arc::new(DataShapeGraph::build(target.as_ref(), ns).map_err(|error| error.to_string())?)
+              }
+            };
+            let graph_code = data_shape_graph_to_js(graph.as_ref(), ns, file_imports)?;
+            let text_code = to_js_code(text, ns, local_defs, file_imports, tags, None)?;
+            let call_code = format!("{}parse_cirru_edn_as({text_code}, {graph_code})", get_proc_prefix(ns));
+            let result_code = snippets::tmpl_result_try(
+              &call_code,
+              &format!("{var_prefix}{}", escape_var("%ok")),
+              &format!("{var_prefix}{}", escape_var("%err")),
+            );
+            Ok(wrap_call_with_prelude(
+              String::new(),
+              result_code,
+              return_label,
+              detect_await(&body),
+            ))
+          }
+          _ => Err(format!(
+            "try-parse-cirru-edn-as expected a string and a type expression, got: {body}"
+          )),
+        },
         CalcitSyntax::DecodeMapAs => match (body.first(), body.get(1)) {
           (Some(value), Some(type_form)) if body.len() == 2 || body.len() == 3 => {
             let graph = match body.get(2).and_then(DataShapeGraph::from_calcit_handle) {
@@ -581,6 +609,32 @@ fn gen_call_code(
             Ok(wrap_call_with_prelude(String::new(), call_code, return_label, detect_await(&body)))
           }
           _ => Err(format!("decode-map-as expected a value and a type expression, got: {body}")),
+        },
+        CalcitSyntax::TryDecodeMapAs => match (body.first(), body.get(1)) {
+          (Some(value), Some(type_form)) if body.len() == 2 || body.len() == 3 => {
+            let graph = match body.get(2).and_then(DataShapeGraph::from_calcit_handle) {
+              Some(graph) => graph,
+              None => {
+                let target = calcit::CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
+                Arc::new(DataShapeGraph::build_open(target.as_ref(), ns).map_err(|error| error.to_string())?)
+              }
+            };
+            let graph_code = data_shape_graph_to_js(graph.as_ref(), ns, file_imports)?;
+            let value_code = to_js_code(value, ns, local_defs, file_imports, tags, None)?;
+            let call_code = format!("{}decode_map_as({value_code}, {graph_code})", get_proc_prefix(ns));
+            let result_code = snippets::tmpl_result_try(
+              &call_code,
+              &format!("{var_prefix}{}", escape_var("%ok")),
+              &format!("{var_prefix}{}", escape_var("%err")),
+            );
+            Ok(wrap_call_with_prelude(
+              String::new(),
+              result_code,
+              return_label,
+              detect_await(&body),
+            ))
+          }
+          _ => Err(format!("try-decode-map-as expected a value and a type expression, got: {body}")),
         },
         CalcitSyntax::AssertTraits => match body.first() {
           Some(value) => to_js_code(value, ns, local_defs, file_imports, tags, return_label),

--- a/src/codegen/emit_js/snippets.rs
+++ b/src/codegen/emit_js/snippets.rs
@@ -5,12 +5,29 @@ use super::runtime::get_proc_prefix;
 pub const CALCIT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn tmpl_try(err_var: String, body: String, handler: String, return_code: &str) -> String {
+  let message_var = js_gensym("errMessage");
   format!(
     "try {{
   {body}
 }} catch ({err_var}) {{
-  {return_code} ({handler})({err_var})
+  let {message_var} = {err_var} instanceof Error ? {err_var}.message : `${{{err_var}}}`;
+  {return_code} ({handler})({message_var})
 }}",
+  )
+}
+
+pub fn tmpl_result_try(call_code: &str, ok_code: &str, err_code: &str) -> String {
+  let err_var = js_gensym("err");
+  let message_var = js_gensym("errMessage");
+  format!(
+    "(function __fn__(){{
+  try {{
+    return {ok_code}({call_code});
+  }} catch ({err_var}) {{
+    let {message_var} = {err_var} instanceof Error ? {err_var}.message : `${{{err_var}}}`;
+    return {err_code}({message_var});
+  }}
+}})()"
   )
 }
 
@@ -154,6 +171,22 @@ mod tests {
   fn args_fewer_than_zero_arity_returns_empty() {
     let code = tmpl_args_fewer_than("f%", 0, "app.main");
     assert!(code.is_empty());
+  }
+
+  #[test]
+  fn try_handler_receives_a_string_message() {
+    let code = tmpl_try("caught".to_owned(), "return risky()".to_owned(), "handler".to_owned(), "return");
+    assert!(code.contains("caught instanceof Error ? caught.message"));
+    assert!(code.contains("(handler)(errMessage"));
+    assert!(!code.contains("(handler)(caught)"));
+  }
+
+  #[test]
+  fn result_try_wraps_success_and_normalizes_failure() {
+    let code = tmpl_result_try("decode()", "ok", "err");
+    assert!(code.contains("return ok(decode());"));
+    assert!(code.contains("instanceof Error"));
+    assert!(code.contains("return err(errMessage"));
   }
 
   #[test]

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1119,7 +1119,9 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
         }
         emit_expr(ctx, &args_list[0])
       }
-      CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::DecodeMapAs => Err(format!("{syn} is not yet supported in WASM codegen")),
+      CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::TryParseCirruEdnAs | CalcitSyntax::DecodeMapAs | CalcitSyntax::TryDecodeMapAs => {
+        Err(format!("{syn} is not yet supported in WASM codegen"))
+      }
       CalcitSyntax::Defn => {
         // A `fn`/`defn` form in value position creates a closure capturing outer variables.
         // Closures with captured upvalues can't be represented as static WASM function

--- a/src/data/cirru.rs
+++ b/src/data/cirru.rs
@@ -31,7 +31,9 @@ pub fn code_to_calcit(xs: &Cirru, ns: &str, def: &str, coord: Vec<u16>) -> Resul
       "defwasm-import" => Ok(Calcit::Syntax(CalcitSyntax::DefWasmImport, ns.into())),
       "unsafe-coerce" => Ok(Calcit::Syntax(CalcitSyntax::UnsafeCoerce, ns.into())),
       "parse-cirru-edn-as" => Ok(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs, ns.into())),
+      "try-parse-cirru-edn-as" => Ok(Calcit::Syntax(CalcitSyntax::TryParseCirruEdnAs, ns.into())),
       "decode-map-as" => Ok(Calcit::Syntax(CalcitSyntax::DecodeMapAs, ns.into())),
+      "try-decode-map-as" => Ok(Calcit::Syntax(CalcitSyntax::TryDecodeMapAs, ns.into())),
       "assert-traits" => Ok(Calcit::Syntax(CalcitSyntax::AssertTraits, ns.into())),
       "" => Err(String::from("Empty string is invalid")),
       // anonymous enum constructor syntax
@@ -341,6 +343,21 @@ mod tests {
   }
 
   #[test]
+  fn parses_safe_strict_edn_decode_as_syntax() {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("try-parse-cirru-edn-as"),
+      Cirru::leaf("|do 1"),
+      Cirru::leaf("Number"),
+    ]);
+
+    let calcit = code_to_calcit(&expr, "tests.ns", "demo", vec![]).expect("parse safe strict EDN decoder");
+    let Calcit::List(items) = calcit else {
+      panic!("expected list");
+    };
+    assert!(matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::TryParseCirruEdnAs, _))));
+  }
+
+  #[test]
   fn parses_runtime_map_decode_as_syntax() {
     let expr = Cirru::List(vec![Cirru::leaf("decode-map-as"), Cirru::leaf("value"), Cirru::leaf("Response")]);
 
@@ -349,6 +366,21 @@ mod tests {
       panic!("expected list");
     };
     assert!(matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::DecodeMapAs, _))));
+  }
+
+  #[test]
+  fn parses_safe_runtime_map_decode_as_syntax() {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("try-decode-map-as"),
+      Cirru::leaf("value"),
+      Cirru::leaf("Response"),
+    ]);
+
+    let calcit = code_to_calcit(&expr, "tests.ns", "demo", vec![]).expect("parse safe runtime map decoder");
+    let Calcit::List(items) = calcit else {
+      panic!("expected list");
+    };
+    assert!(matches!(items.first(), Some(Calcit::Syntax(CalcitSyntax::TryDecodeMapAs, _))));
   }
 
   #[test]

--- a/src/program.rs
+++ b/src/program.rs
@@ -351,7 +351,10 @@ fn collect_compiled_dep_keys(code: &Calcit, deps: &mut Vec<(Arc<str>, Arc<str>)>
     Calcit::List(xs) => {
       if matches!(
         xs.first(),
-        Some(Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::DecodeMapAs, _))
+        Some(Calcit::Syntax(
+          CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::TryParseCirruEdnAs | CalcitSyntax::DecodeMapAs | CalcitSyntax::TryDecodeMapAs,
+          _,
+        ))
       ) && let Some(graph) = xs.get(3).and_then(DataShapeGraph::from_calcit_handle)
       {
         deps.extend(graph.nominal_paths());

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2052,11 +2052,11 @@ fn preprocess_list_call(
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           preprocess_unsafe_coerce(name, name_ns, &args, &mut ctx)
         }
-        CalcitSyntax::ParseCirruEdnAs => {
+        CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::TryParseCirruEdnAs => {
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           preprocess_parse_cirru_edn_as(name, name_ns, &args, &mut ctx)
         }
-        CalcitSyntax::DecodeMapAs => {
+        CalcitSyntax::DecodeMapAs | CalcitSyntax::TryDecodeMapAs => {
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           preprocess_decode_map_as(name, name_ns, &args, &mut ctx)
         }
@@ -6901,12 +6901,22 @@ pub fn preprocess_parse_cirru_edn_as(
     ctx.check_warnings,
     ctx.call_stack,
   )?;
+  if let Some(actual) = resolve_type_value(&text_form, ctx.scope_types)
+    && !matches!(actual.as_ref(), CalcitTypeAnnotation::String | CalcitTypeAnnotation::Dynamic)
+  {
+    return Err(CalcitErr::use_msg_stack_location(
+      CalcitErrKind::Type,
+      format!("{head} expected String input, got {}", actual.to_brief_string()),
+      ctx.call_stack,
+      text_form.get_location(),
+    ));
+  }
   let type_form = args.get(1).expect("validated parse-cirru-edn-as type");
   let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
   let decoder = crate::calcit::data_shape::DataShapeGraph::build(target.as_ref(), ctx.file_ns).map_err(|error| {
     CalcitErr::use_msg_stack_location(
       CalcitErrKind::Type,
-      format!("parse-cirru-edn-as cannot derive a decoder: {error}"),
+      format!("{head} cannot derive a decoder: {error}"),
       ctx.call_stack,
       type_form.get_location(),
     )
@@ -6947,7 +6957,7 @@ pub fn preprocess_decode_map_as(
   let decoder = crate::calcit::data_shape::DataShapeGraph::build_open(target.as_ref(), ctx.file_ns).map_err(|error| {
     CalcitErr::use_msg_stack_location(
       CalcitErrKind::Type,
-      format!("decode-map-as cannot derive a runtime map decoder: {error}"),
+      format!("{head} cannot derive a runtime map decoder: {error}"),
       ctx.call_stack,
       type_form.get_location(),
     )
@@ -8527,6 +8537,27 @@ mod tests {
     let error = preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.edn", &warnings, &stack)
       .expect_err("Dynamic decoder must be rejected before runtime");
     assert!(error.msg.contains("Dynamic is forbidden"), "unexpected error: {error:?}");
+  }
+
+  #[test]
+  fn safe_strict_edn_decode_rejects_known_non_string_input() {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("try-parse-cirru-edn-as"),
+      Cirru::leaf("1"),
+      Cirru::leaf(":number"),
+    ]);
+    let code = code_to_calcit(&expr, "tests.edn", "main", vec![]).expect("parse safe strict decoder");
+    let scope_defs: HashSet<Arc<str>> = HashSet::new();
+    let mut scope_types: ScopeTypes = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default();
+
+    let error = preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.edn", &warnings, &stack)
+      .expect_err("known non-String input must be rejected before runtime");
+    assert!(
+      error.msg.contains("expected String input, got :number"),
+      "unexpected error: {error:?}"
+    );
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -663,6 +663,14 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           .get(2)
           .map(|form| CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[])),
 
+        Calcit::Syntax(CalcitSyntax::TryParseCirruEdnAs | CalcitSyntax::TryDecodeMapAs, _) => xs.get(2).map(|form| {
+          let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[]);
+          Arc::new(CalcitTypeAnnotation::TypeRef(
+            Arc::from("calcit.core/Result"),
+            Arc::new(vec![target, Arc::new(CalcitTypeAnnotation::String)]),
+          ))
+        }),
+
         // Local variable as head (function call)
         // If it's a function type, return its return type
         Calcit::Local(local) => {
@@ -1965,6 +1973,31 @@ mod tests {
       assert!(matches!(
         infer_static_type_from_expr(&expression).as_deref(),
         Some(CalcitTypeAnnotation::List(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)
+      ));
+    }
+  }
+
+  #[test]
+  fn safe_typed_decode_expression_has_result_target_type() {
+    let target = Calcit::Enum(calcit::CalcitEnumValue {
+      tag: Arc::new(Calcit::tag("list")),
+      extra: vec![Calcit::tag("number")],
+      sum_type: None,
+    });
+    for syntax in [CalcitSyntax::TryParseCirruEdnAs, CalcitSyntax::TryDecodeMapAs] {
+      let expression = Calcit::from(vec![
+        Calcit::Syntax(syntax, Arc::from(calcit::CORE_NS)),
+        Calcit::Str(Arc::from("[] 1 2")),
+        target.clone(),
+      ]);
+
+      let inferred = infer_static_type_from_expr(&expression).expect("safe decoder type");
+      assert!(matches!(
+        inferred.as_ref(),
+        CalcitTypeAnnotation::TypeRef(name, args)
+          if name.as_ref() == "calcit.core/Result"
+            && matches!(args.first().map(AsRef::as_ref), Some(CalcitTypeAnnotation::List(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number))
+            && matches!(args.get(1).map(AsRef::as_ref), Some(CalcitTypeAnnotation::String))
       ));
     }
   }


### PR DESCRIPTION
## Summary

- add `try-parse-cirru-edn-as text TypeExpr` and `try-decode-map-as value TypeExpr`
- infer the complete `Result<T,String>` target from the compile-time type expression
- retain decoder graphs and nominal dependencies in preprocessed code
- normalize generated-JS `try` handlers to the documented String error contract

## Semantic boundary

Decoder derivation remains a compile-time operation. Invalid/open target types are still compiler errors and are not hidden in `Result`.

Malformed Cirru EDN and runtime shape mismatches are recoverable input failures, so the new syntaxes return `%err` with the existing parser message and structural path. The original raising syntaxes remain compatible.

Known non-String text inputs are rejected during preprocessing. Dynamic host boundaries retain runtime validation.

Native and generated JavaScript support the new syntaxes. WASM keeps the existing explicit unsupported typed-decoder boundary.

## Type-safety impact

- `try-parse-cirru-edn-as raw (:: 'List Person)` infers `Result<List<Person>,String>` rather than `Result<Dynamic,String>`.
- callers can compose validation with Result methods without exception-style control flow.
- JS no longer places a host `Error` object into an API declared as `Result<T,String>`.

## Performance assessment

This PR does not claim a speedup. Decoder derivation and decode work are unchanged; the safe success path additionally constructs one Result value. The benefit is explicit, statically preserved failure handling at untrusted data boundaries.

## Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test` (520 library, 246 CLI, 24 caps, 4 WASM tests)
- `yarn compile`
- `yarn check-all` (native, generated JS, IR, WASM, 228 core tests)
- `yarn check-agent-interface` (17/17)
- native and generated-JS examples for success, failure, exact Result type, and String error payload
- `docs/data/edn.md` 24/24 blocks
- `docs/features/error-handling.md` 9/9 blocks
- latest Respo main: 27/27 tests and 111/111 documentation blocks
- latest Recollect main: 9/9 native tests, generated JS, and required WASM checks

Refs #428
