### PR TITLE
perf: cache pure macro expansions during reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "im_ternary_tree"
-version = "0.0.20"
+version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095dd3c9192b9cdc754f22c3d116d5fad36859fcdb25f00e332af99a88de6015"
+checksum = "b21d17f676465859589cf34e88c66d40d6bc8c2857176a34ac835f21f055919a"
 
 [[package]]
 name = "inotify"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4.3"
 fs4 = "1.1.0"
 md-5 = "0.11.0"
 rpds = "1.2.1"
-im_ternary_tree = "0.0.20"
+im_ternary_tree = "0.0.21"
 # im_ternary_tree = { path = "/Users/chenyong/repo/calcit-lang/ternary-tree.rs" }
 colored = "3.1.1"
 strum = "0.25"

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -124,11 +124,20 @@ post-preprocess times are exclusive: when a nested macro starts, its parent's
 timer pauses, so totals do not double-count recursive expansion work.
 
 The report records general-evaluator fallbacks, cache misses, miss reasons, and
-bypass reasons. Before the pure expansion cache lands, eligible strict/pure
-macros report a `cache-not-implemented` miss; legacy and effectful signatures
-report explicit bypasses rather than false invalidations. The `cacheHits` and
-`cacheInvalidations` fields are reserved for the cache implementation and stay
-at zero or empty until that implementation activates them.
+bypass reasons. Watch mode keeps a conservative raw-expansion cache for macros
+with strict signatures and no compile-time capabilities. Entries are scoped to
+stable source call sites and validate the macro identity, signature, exact input
+syntax (including locations), and gensym sequence before reuse. Legacy,
+effectful, runtime-evaluator, unstable-call-site, and non-watch calls report an
+explicit bypass reason. `cacheInvalidations` separates changed macro definitions,
+signatures, inputs, and gensym sequences; a cache hit skips macro evaluation but
+still preprocesses and type-checks the emitted expansion.
+
+The cache deliberately targets repeated preprocessing during hot reload. A
+normal once-mode build does not populate it, avoiding cold-build memory and
+cloning overhead. It does not cache post-preprocess results yet, so helper/import/
+type dependency invalidation for that higher-ceiling optimization remains future
+work.
 
 Reproducible release-mode baseline from 2026-08-25 (three warm runs, median):
 

--- a/editing-history/20260826-1108-pure-macro-expansion-cache.md
+++ b/editing-history/20260826-1108-pure-macro-expansion-cache.md
@@ -1,0 +1,17 @@
+# Conservative pure macro expansion cache
+
+- Added a watch-mode raw expansion cache for strict macros with no declared
+  compile-time capabilities. Once-mode builds bypass it to avoid cold-build
+  overhead.
+- Keyed entries by stable macro call site, macro runtime identity, phase-aware
+  signature, and exact raw syntax including source locations. Macro/helper
+  reloads recreate the macro identity; signature and input changes have separate
+  invalidation reasons in `--macro-metrics`.
+- Preserved hygiene by recording the per-definition gensym position and only
+  reusing generated-symbol expansions when the sequence still matches. Cache
+  hits advance the counter by the recorded delta.
+- Cached only successfully validated raw expansions. Emitted code is still
+  preprocessed and type-checked on every hit, so this slice cannot reuse stale
+  type/import results and does not claim the higher post-preprocess speedup yet.
+- Kept legacy and capability-bearing macros on the general evaluator with
+  explicit bypass reasons.

--- a/editing-history/20260826-1149-upgrade-ternary-tree-0021.md
+++ b/editing-history/20260826-1149-upgrade-ternary-tree-0021.md
@@ -1,0 +1,20 @@
+# Upgrade ternary-tree to 0.0.21
+
+- Upgraded `im_ternary_tree` from 0.0.20 to 0.0.21. The upstream release
+  removes redundant cloning in owned vector construction and finger-tree
+  updates, and reports substantially faster full iteration and search
+  microbenchmarks.
+- Compared optimized Calcit binaries built from the same source snapshot, with
+  only the ternary-tree version changed. Runs alternated old/new order on Apple
+  arm64 to reduce thermal and background-load drift.
+- Over 30 paired process runs, `--check-only calcit/test.cirru` improved by
+  about 0.83% at the median and the native literal-path benchmark improved by
+  about 0.39%. Over 20 paired macro-metric runs, post-preprocessing improved by
+  about 1.22%, while macro evaluation remained effectively unchanged.
+- Treat the small aggregate gains as evidence of no regression plus a modest
+  end-to-end benefit. Calcit parsing, type analysis, evaluation, and process
+  startup dominate these workloads, so the upstream collection microbenchmark
+  gains are not expected to transfer proportionally to whole-program timings.
+- Revalidated Rust formatting, Clippy with warnings denied, the full Rust test
+  suite, self-hosted compilation, Agent CLI protocol checks, native/JS/IR/WASM
+  integration tests, and collection-path performance smoke tests.

--- a/editing-history/20260826-1200-nested-macro-gensym-cache.md
+++ b/editing-history/20260826-1200-nested-macro-gensym-cache.md
@@ -1,0 +1,16 @@
+# Preserve nested macro gensym positions on cache hits
+
+- Fixed pure macro expansion caching so its replay delta contains only gensyms
+  emitted by the cached macro evaluator. The evaluator end position is captured
+  before recursively preprocessing the returned syntax tree.
+- Excluded gensyms emitted by nested macros during post-processing from the
+  outer cache entry. Nested macros still run or replay their own gensym progress
+  when the cached outer syntax is preprocessed, preventing double advancement.
+- Added a regression test that compares miss and hit paths for an outer macro
+  whose output invokes a gensym-producing inner macro, and verifies that the
+  following gensym position is identical.
+- Kept the Calcit package at 0.13.45 in this functional PR. Package versions are
+  updated together in `Cargo.toml` and `package.json` by the separate release
+  commit after the feature PR merges.
+- Validated formatting, Clippy with warnings denied, all 799 Rust tests, and the
+  full native/JS/IR/WASM integration suite through `yarn check-all`.

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -278,6 +278,10 @@ fn run_cli() -> Result<(), String> {
   runner::preprocess::set_warn_dyn_method(cli_args.warn_dyn_method);
   runner::preprocess::set_verbose_preprocess(cli_args.verbose);
   let _macro_metrics_report = runner::macro_metrics::ReportOnDrop::new(cli_args.macro_metrics);
+  let macro_cache_enabled = cli_args.watch
+    || matches!(&cli_args.subcommand, Some(CalcitCommand::EmitJs(options)) if options.watch)
+    || matches!(&cli_args.subcommand, Some(CalcitCommand::EmitIr(options)) if options.watch);
+  runner::macro_cache::reset(macro_cache_enabled);
 
   if cli_handlers::should_echo_command(&cli_args) {
     cli_handlers::suppress_command_guidance();

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -41,6 +41,28 @@ thread_local! {
   pub(crate) static CURRENT_COMPILING_DEF: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
 }
 
+pub(crate) fn current_compiling_key(file_ns: &str) -> Arc<str> {
+  CURRENT_COMPILING_DEF.with(|cell| match cell.borrow().as_ref() {
+    Some(definition) => Arc::from(definition.as_str()),
+    None => Arc::from(file_ns),
+  })
+}
+
+pub(crate) fn current_gensym_index(file_ns: &str) -> usize {
+  let key = current_compiling_key(file_ns);
+  NS_SYMBOL_DICT.lock().expect("read gensym counter").get(&key).copied().unwrap_or(1)
+}
+
+pub(crate) fn advance_gensym_index(file_ns: &str, delta: usize) {
+  if delta == 0 {
+    return;
+  }
+  let key = current_compiling_key(file_ns);
+  let mut counters = NS_SYMBOL_DICT.lock().expect("advance gensym counter");
+  let next = counters.get(&key).copied().unwrap_or(1).saturating_add(delta);
+  counters.insert(key, next);
+}
+
 /// Runs `f` with the current-compiling-def context set to `ns/def`.
 /// Restores the previous context on return (supports reentrant calls).
 /// Also resets the gensym counter for this def so gensym sequences are always stable.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,3 +1,4 @@
+pub mod macro_cache;
 pub mod macro_capability;
 pub mod macro_metrics;
 pub mod preprocess;
@@ -386,6 +387,7 @@ pub fn call_expr(
       let mut current_values: Vec<Calcit> = xs.iter().skip(1).cloned().collect();
       let macro_name = format!("{}/{}", info.def_ns, info.name);
       macro_metrics::record_expansion(&macro_name, info.signature.as_ref());
+      macro_metrics::record_cache_bypass(&macro_name, "runtime-evaluator");
 
       let next_stack = if using_stack() {
         call_stack.extend_owned(

--- a/src/runner/macro_cache.rs
+++ b/src/runner/macro_cache.rs
@@ -158,18 +158,19 @@ pub fn lookup(
   }
 }
 
-pub fn store(token: CacheMiss, output: &Calcit, file_ns: &str) {
+/// Store an expansion with the gensym position captured immediately after the
+/// macro evaluator returned, before recursively preprocessing its output.
+pub fn store(token: CacheMiss, output: &Calcit, evaluator_gensym_end: usize) {
   if !is_enabled() {
     return;
   }
-  let gensym_end = meta::current_gensym_index(file_ns);
   let entry = CachedExpansion {
     macro_id: token.macro_id,
     signature_hash: token.signature_hash,
     inputs: token.inputs,
     output: output.clone(),
     gensym_start: token.gensym_start,
-    gensym_delta: gensym_end.saturating_sub(token.gensym_start),
+    gensym_delta: evaluator_gensym_end.saturating_sub(token.gensym_start),
   };
   let mut cache = CACHE.lock().expect("write macro expansion cache");
   if cache.len() >= MAX_ENTRIES && !cache.contains_key(&token.call_site) {
@@ -222,7 +223,7 @@ mod tests {
       panic!("first lookup should miss");
     };
     assert_eq!(reason, "cold-call-site");
-    store(token, &Calcit::Number(2.0), "app.main");
+    store(token, &Calcit::Number(2.0), meta::current_gensym_index("app.main"));
 
     assert!(matches!(
       lookup(
@@ -260,7 +261,7 @@ mod tests {
     let CacheLookup::Miss { token, .. } = lookup("calcit.core/id", &old_id, &signature, &[], Some(&call_location), "app.main") else {
       panic!("first lookup should miss");
     };
-    store(token, &Calcit::Unit, "app.main");
+    store(token, &Calcit::Unit, meta::current_gensym_index("app.main"));
 
     let CacheLookup::Miss { reason, .. } = lookup(
       "calcit.core/id",
@@ -297,7 +298,7 @@ mod tests {
       };
       assert_eq!(meta::current_gensym_index("app.main"), 1);
       meta::advance_gensym_index("app.main", 2);
-      store(token, &Calcit::new_str("generated"), "app.main");
+      store(token, &Calcit::new_str("generated"), meta::current_gensym_index("app.main"));
       Ok::<(), ()>(())
     })
     .expect("store generated expansion");
@@ -335,6 +336,50 @@ mod tests {
       Ok::<(), ()>(())
     })
     .expect("reject shifted sequence");
+    reset(false);
+  }
+
+  #[test]
+  fn outer_cache_replays_only_evaluator_gensyms_before_nested_macro_expansion() {
+    let _guard = TEST_LOCK.lock().expect("serialize macro cache tests");
+    reset(true);
+    let signature = pure_signature();
+    let macro_id = Arc::from("outer-macro");
+    let call_location = location(&[8]);
+
+    let miss_following_gensym = meta::with_compiling_def("app.main", "main!", || {
+      let CacheLookup::Miss { token, .. } =
+        lookup("app.main/outer-macro", &macro_id, &signature, &[], Some(&call_location), "app.main")
+      else {
+        panic!("outer macro should initially miss");
+      };
+
+      // The outer evaluator emits one gensym, then returns code invoking an
+      // inner macro. The inner macro emits two more while that code is
+      // recursively preprocessed.
+      meta::advance_gensym_index("app.main", 1);
+      let evaluator_gensym_end = meta::current_gensym_index("app.main");
+      meta::advance_gensym_index("app.main", 2);
+      store(token, &Calcit::new_str("inner-macro-call"), evaluator_gensym_end);
+      Ok::<usize, ()>(meta::current_gensym_index("app.main"))
+    })
+    .expect("store outer expansion");
+
+    let hit_following_gensym = meta::with_compiling_def("app.main", "main!", || {
+      assert!(matches!(
+        lookup("app.main/outer-macro", &macro_id, &signature, &[], Some(&call_location), "app.main"),
+        CacheLookup::Hit(_)
+      ));
+      // Recursive preprocessing still expands the inner macro on a cache hit.
+      meta::advance_gensym_index("app.main", 2);
+      Ok::<usize, ()>(meta::current_gensym_index("app.main"))
+    })
+    .expect("replay outer expansion");
+
+    assert_eq!(
+      hit_following_gensym, miss_following_gensym,
+      "a cached outer expansion must preserve the gensym position after its nested macro"
+    );
     reset(false);
   }
 }

--- a/src/runner/macro_cache.rs
+++ b/src/runner/macro_cache.rs
@@ -1,0 +1,340 @@
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
+
+use crate::builtins::meta;
+use crate::calcit::{Calcit, MacroSignature, NodeLocation};
+
+const MAX_ENTRIES: usize = 8_192;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static CACHE: LazyLock<Mutex<HashMap<MacroCallSite, CachedExpansion>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct MacroCallSite {
+  macro_name: Arc<str>,
+  expansion_ns: Arc<str>,
+  compiling_def: Arc<str>,
+  caller_ns: Arc<str>,
+  caller_def: Arc<str>,
+  coord: Arc<Vec<u16>>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedExpansion {
+  macro_id: Arc<str>,
+  signature_hash: u64,
+  inputs: Vec<Calcit>,
+  output: Calcit,
+  gensym_start: usize,
+  gensym_delta: usize,
+}
+
+#[derive(Debug)]
+pub struct CacheMiss {
+  call_site: MacroCallSite,
+  macro_id: Arc<str>,
+  signature_hash: u64,
+  inputs: Vec<Calcit>,
+  gensym_start: usize,
+}
+
+#[derive(Debug)]
+pub enum CacheLookup {
+  Hit(Calcit),
+  Miss { token: CacheMiss, reason: &'static str },
+  Bypass(&'static str),
+}
+
+fn signature_hash(signature: &MacroSignature) -> u64 {
+  let mut hasher = DefaultHasher::new();
+  signature.hash(&mut hasher);
+  hasher.finish()
+}
+
+fn same_source_syntax(a: &Calcit, b: &Calcit) -> bool {
+  if a != b || a.get_location() != b.get_location() {
+    return false;
+  }
+  match (a, b) {
+    (Calcit::List(xs), Calcit::List(ys)) => xs.len() == ys.len() && xs.iter().zip(ys.iter()).all(|(x, y)| same_source_syntax(x, y)),
+    (Calcit::Recur(xs), Calcit::Recur(ys)) => xs.len() == ys.len() && xs.iter().zip(ys.iter()).all(|(x, y)| same_source_syntax(x, y)),
+    _ => true,
+  }
+}
+
+fn same_inputs(a: &[Calcit], b: &[Calcit]) -> bool {
+  a.len() == b.len() && a.iter().zip(b).all(|(x, y)| same_source_syntax(x, y))
+}
+
+pub fn is_enabled() -> bool {
+  ENABLED.load(Ordering::Relaxed)
+}
+
+pub fn reset(enabled: bool) {
+  ENABLED.store(enabled, Ordering::SeqCst);
+  CACHE.lock().expect("reset macro expansion cache").clear();
+}
+
+pub fn lookup(
+  macro_name: &str,
+  macro_id: &Arc<str>,
+  signature: &MacroSignature,
+  inputs: &[Calcit],
+  call_location: Option<&NodeLocation>,
+  file_ns: &str,
+) -> CacheLookup {
+  if !is_enabled() {
+    return CacheLookup::Bypass("cache-disabled");
+  }
+  if !signature.is_strict() {
+    return CacheLookup::Bypass("legacy-signature");
+  }
+  if !signature.capabilities.is_empty() {
+    return CacheLookup::Bypass("declared-capabilities");
+  }
+  let Some(location) = call_location else {
+    return CacheLookup::Bypass("unstable-call-site");
+  };
+
+  let call_site = MacroCallSite {
+    macro_name: Arc::from(macro_name),
+    expansion_ns: Arc::from(file_ns),
+    compiling_def: meta::current_compiling_key(file_ns),
+    caller_ns: location.ns.clone(),
+    caller_def: location.def.clone(),
+    coord: location.coord.clone(),
+  };
+  let signature_hash = signature_hash(signature);
+  let gensym_start = meta::current_gensym_index(file_ns);
+  let mut cache = CACHE.lock().expect("read macro expansion cache");
+
+  if let Some(entry) = cache.get(&call_site) {
+    let invalidation = if entry.macro_id != *macro_id {
+      Some("macro-definition")
+    } else if entry.signature_hash != signature_hash {
+      Some("macro-signature")
+    } else if !same_inputs(&entry.inputs, inputs) {
+      Some("input-syntax")
+    } else if entry.gensym_delta > 0 && entry.gensym_start != gensym_start {
+      Some("gensym-sequence")
+    } else {
+      None
+    };
+
+    if let Some(reason) = invalidation {
+      cache.remove(&call_site);
+      return CacheLookup::Miss {
+        token: CacheMiss {
+          call_site,
+          macro_id: macro_id.clone(),
+          signature_hash,
+          inputs: inputs.to_vec(),
+          gensym_start,
+        },
+        reason,
+      };
+    }
+
+    let output = entry.output.clone();
+    let gensym_delta = entry.gensym_delta;
+    drop(cache);
+    if gensym_delta > 0 {
+      meta::advance_gensym_index(file_ns, gensym_delta);
+    }
+    return CacheLookup::Hit(output);
+  }
+
+  CacheLookup::Miss {
+    token: CacheMiss {
+      call_site,
+      macro_id: macro_id.clone(),
+      signature_hash,
+      inputs: inputs.to_vec(),
+      gensym_start,
+    },
+    reason: "cold-call-site",
+  }
+}
+
+pub fn store(token: CacheMiss, output: &Calcit, file_ns: &str) {
+  if !is_enabled() {
+    return;
+  }
+  let gensym_end = meta::current_gensym_index(file_ns);
+  let entry = CachedExpansion {
+    macro_id: token.macro_id,
+    signature_hash: token.signature_hash,
+    inputs: token.inputs,
+    output: output.clone(),
+    gensym_start: token.gensym_start,
+    gensym_delta: gensym_end.saturating_sub(token.gensym_start),
+  };
+  let mut cache = CACHE.lock().expect("write macro expansion cache");
+  if cache.len() >= MAX_ENTRIES && !cache.contains_key(&token.call_site) {
+    cache.clear();
+  }
+  cache.insert(token.call_site, entry);
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::calcit::{MacroExpansionType, MacroSignatureCompatibility};
+  use std::collections::HashSet;
+
+  static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+  fn pure_signature() -> MacroSignature {
+    MacroSignature {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      required_inputs: Arc::new(vec![]),
+      optional_inputs: Arc::new(vec![]),
+      rest_input: None,
+      expansion: MacroExpansionType::Dynamic,
+      capabilities: Arc::new(HashSet::new()),
+      features: Arc::new(HashSet::new()),
+      compatibility: MacroSignatureCompatibility::Strict,
+    }
+  }
+
+  fn location(coord: &[u16]) -> NodeLocation {
+    NodeLocation::new(Arc::from("app.main"), Arc::from("main!"), Arc::new(coord.to_vec()))
+  }
+
+  #[test]
+  fn reuses_only_same_pure_call_site_and_inputs() {
+    let _guard = TEST_LOCK.lock().expect("serialize macro cache tests");
+    reset(true);
+    let signature = pure_signature();
+    let macro_id = Arc::from("macro-1");
+    let inputs = vec![Calcit::Number(1.0)];
+    let CacheLookup::Miss { token, reason } = lookup(
+      "calcit.core/id",
+      &macro_id,
+      &signature,
+      &inputs,
+      Some(&location(&[1, 2])),
+      "app.main",
+    ) else {
+      panic!("first lookup should miss");
+    };
+    assert_eq!(reason, "cold-call-site");
+    store(token, &Calcit::Number(2.0), "app.main");
+
+    assert!(matches!(
+      lookup(
+        "calcit.core/id",
+        &macro_id,
+        &signature,
+        &inputs,
+        Some(&location(&[1, 2])),
+        "app.main"
+      ),
+      CacheLookup::Hit(Calcit::Number(2.0))
+    ));
+
+    let CacheLookup::Miss { reason, .. } = lookup(
+      "calcit.core/id",
+      &macro_id,
+      &signature,
+      &[Calcit::Number(3.0)],
+      Some(&location(&[1, 2])),
+      "app.main",
+    ) else {
+      panic!("changed syntax should miss");
+    };
+    assert_eq!(reason, "input-syntax");
+    reset(false);
+  }
+
+  #[test]
+  fn invalidates_when_macro_identity_changes() {
+    let _guard = TEST_LOCK.lock().expect("serialize macro cache tests");
+    reset(true);
+    let signature = pure_signature();
+    let old_id = Arc::from("macro-1");
+    let call_location = location(&[3]);
+    let CacheLookup::Miss { token, .. } = lookup("calcit.core/id", &old_id, &signature, &[], Some(&call_location), "app.main") else {
+      panic!("first lookup should miss");
+    };
+    store(token, &Calcit::Unit, "app.main");
+
+    let CacheLookup::Miss { reason, .. } = lookup(
+      "calcit.core/id",
+      &Arc::from("macro-2"),
+      &signature,
+      &[],
+      Some(&call_location),
+      "app.main",
+    ) else {
+      panic!("changed macro should miss");
+    };
+    assert_eq!(reason, "macro-definition");
+    reset(false);
+  }
+
+  #[test]
+  fn replays_gensym_progress_only_from_the_same_sequence_position() {
+    let _guard = TEST_LOCK.lock().expect("serialize macro cache tests");
+    reset(true);
+    let signature = pure_signature();
+    let macro_id = Arc::from("macro-gensym");
+    let call_location = location(&[5]);
+
+    meta::with_compiling_def("app.main", "main!", || {
+      let CacheLookup::Miss { token, .. } = lookup(
+        "calcit.core/with-gensym",
+        &macro_id,
+        &signature,
+        &[],
+        Some(&call_location),
+        "app.main",
+      ) else {
+        panic!("first lookup should miss");
+      };
+      assert_eq!(meta::current_gensym_index("app.main"), 1);
+      meta::advance_gensym_index("app.main", 2);
+      store(token, &Calcit::new_str("generated"), "app.main");
+      Ok::<(), ()>(())
+    })
+    .expect("store generated expansion");
+
+    meta::with_compiling_def("app.main", "main!", || {
+      assert!(matches!(
+        lookup(
+          "calcit.core/with-gensym",
+          &macro_id,
+          &signature,
+          &[],
+          Some(&call_location),
+          "app.main"
+        ),
+        CacheLookup::Hit(_)
+      ));
+      assert_eq!(meta::current_gensym_index("app.main"), 3);
+      Ok::<(), ()>(())
+    })
+    .expect("replay generated expansion");
+
+    meta::with_compiling_def("app.main", "main!", || {
+      meta::advance_gensym_index("app.main", 1);
+      let CacheLookup::Miss { reason, .. } = lookup(
+        "calcit.core/with-gensym",
+        &macro_id,
+        &signature,
+        &[],
+        Some(&call_location),
+        "app.main",
+      ) else {
+        panic!("shifted gensym sequence should miss");
+      };
+      assert_eq!(reason, "gensym-sequence");
+      Ok::<(), ()>(())
+    })
+    .expect("reject shifted sequence");
+    reset(false);
+  }
+}

--- a/src/runner/macro_metrics.rs
+++ b/src/runner/macro_metrics.rs
@@ -56,6 +56,17 @@ fn add_reason(target: &mut BTreeMap<String, u64>, reason: &str, count: u64) {
   *target.entry(reason.to_owned()).or_default() += count;
 }
 
+fn remove_reason(target: &mut BTreeMap<String, u64>, reason: &str) -> bool {
+  let Some(count) = target.get_mut(reason) else {
+    return false;
+  };
+  *count = count.saturating_sub(1);
+  if *count == 0 {
+    target.remove(reason);
+  }
+  true
+}
+
 fn totals(metrics: &BTreeMap<String, MacroExpansionMetric>) -> MacroMetricTotals {
   let mut totals = MacroMetricTotals::default();
   for metric in metrics.values() {
@@ -92,6 +103,42 @@ fn update(name: &str, f: impl FnOnce(&mut MacroExpansionMetric)) {
 /// are bypassed with a stable reason.
 pub fn record_expansion(name: &str, signature: &MacroSignature) {
   update(name, |metric| record_expansion_metric(metric, signature));
+}
+
+pub fn record_cache_hit(name: &str) {
+  update(name, record_cache_hit_metric);
+}
+
+fn record_cache_hit_metric(metric: &mut MacroExpansionMetric) {
+  if remove_reason(&mut metric.cache_miss_reasons, "cache-not-implemented") {
+    metric.cache_misses = metric.cache_misses.saturating_sub(1);
+  }
+  metric.general_evaluator_fallbacks = metric.general_evaluator_fallbacks.saturating_sub(1);
+  metric.cache_hits += 1;
+}
+
+pub fn record_cache_miss(name: &str, reason: &'static str, invalidated: bool) {
+  update(name, |metric| record_cache_miss_metric(metric, reason, invalidated));
+}
+
+fn record_cache_miss_metric(metric: &mut MacroExpansionMetric, reason: &'static str, invalidated: bool) {
+  if remove_reason(&mut metric.cache_miss_reasons, "cache-not-implemented") {
+    add_reason(&mut metric.cache_miss_reasons, reason, 1);
+  }
+  if invalidated {
+    add_reason(&mut metric.cache_invalidations, reason, 1);
+  }
+}
+
+pub fn record_cache_bypass(name: &str, reason: &'static str) {
+  update(name, |metric| record_cache_bypass_metric(metric, reason));
+}
+
+fn record_cache_bypass_metric(metric: &mut MacroExpansionMetric, reason: &'static str) {
+  if remove_reason(&mut metric.cache_miss_reasons, "cache-not-implemented") {
+    metric.cache_misses = metric.cache_misses.saturating_sub(1);
+    add_reason(&mut metric.cache_bypasses, reason, 1);
+  }
 }
 
 fn record_expansion_metric(metric: &mut MacroExpansionMetric, signature: &MacroSignature) {
@@ -268,5 +315,28 @@ mod tests {
     assert_eq!(report["totals"]["cacheInvalidations"], serde_json::json!({}));
     assert_eq!(report["macros"]["tests/pure"]["evaluatorNanos"], 1);
     assert_eq!(report["macros"]["tests/pure"]["postPreprocessNanos"], 2);
+  }
+
+  #[test]
+  fn cache_outcomes_replace_the_placeholder_candidate_miss() {
+    let mut hit = MacroExpansionMetric::default();
+    record_expansion_metric(&mut hit, &pure_signature());
+    record_cache_hit_metric(&mut hit);
+    assert_eq!(hit.cache_hits, 1);
+    assert_eq!(hit.cache_misses, 0);
+    assert_eq!(hit.general_evaluator_fallbacks, 0);
+
+    let mut miss = MacroExpansionMetric::default();
+    record_expansion_metric(&mut miss, &pure_signature());
+    record_cache_miss_metric(&mut miss, "input-syntax", true);
+    assert_eq!(miss.cache_misses, 1);
+    assert_eq!(miss.cache_miss_reasons.get("input-syntax"), Some(&1));
+    assert_eq!(miss.cache_invalidations.get("input-syntax"), Some(&1));
+
+    let mut bypass = MacroExpansionMetric::default();
+    record_expansion_metric(&mut bypass, &pure_signature());
+    record_cache_bypass_metric(&mut bypass, "cache-disabled");
+    assert_eq!(bypass.cache_misses, 0);
+    assert_eq!(bypass.cache_bypasses.get("cache-disabled"), Some(&1));
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1746,6 +1746,7 @@ fn preprocess_list_call(
 
       let execute_macro = || -> Result<Calcit, CalcitErr> {
         let mut cache_miss = None;
+        let mut evaluator_gensym_end = None;
         loop {
           // need to handle recursion
           body_scope.restore_frame(frame_checkpoint);
@@ -1771,6 +1772,7 @@ fn preprocess_list_call(
                 // deliberately unknown and therefore cannot be considered pure.
                 evaluate_body()?
               };
+              evaluator_gensym_end = Some(builtins::meta::current_gensym_index(file_ns));
               drop(evaluator_timer);
               evaluated
             }
@@ -1802,7 +1804,11 @@ fn preprocess_list_call(
                 call_location.clone(),
               )?;
               if let Some(token) = cache_miss.take() {
-                runner::macro_cache::store(token, &code, file_ns);
+                runner::macro_cache::store(
+                  token,
+                  &code,
+                  evaluator_gensym_end.expect("cache miss evaluates the macro before storing its expansion"),
+                );
               }
               return Ok(processed);
             }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1704,7 +1704,7 @@ fn preprocess_list_call(
   // Thunk: invalid here
 
   match head_value {
-    Some(Calcit::Macro { info, .. }) => {
+    Some(Calcit::Macro { id: macro_id, info }) => {
       let macro_name = format!("{}/{}", info.def_ns, info.name);
       runner::macro_metrics::record_expansion(&macro_name, info.signature.as_ref());
       let mut current_values: Vec<Calcit> = args.to_vec();
@@ -1728,27 +1728,53 @@ fn preprocess_list_call(
       let mut body_scope = CalcitScope::default();
       let frame_checkpoint = body_scope.frame_checkpoint();
 
+      let mut cache_lookup = Some(runner::macro_cache::lookup(
+        &macro_name,
+        &macro_id,
+        info.signature.as_ref(),
+        &current_values,
+        call_location.as_ref(),
+        file_ns,
+      ));
+      match cache_lookup.as_ref().expect("macro cache lookup") {
+        runner::macro_cache::CacheLookup::Hit(_) => runner::macro_metrics::record_cache_hit(&macro_name),
+        runner::macro_cache::CacheLookup::Miss { reason, .. } => {
+          runner::macro_metrics::record_cache_miss(&macro_name, reason, *reason != "cold-call-site")
+        }
+        runner::macro_cache::CacheLookup::Bypass(reason) => runner::macro_metrics::record_cache_bypass(&macro_name, reason),
+      }
+
       let execute_macro = || -> Result<Calcit, CalcitErr> {
+        let mut cache_miss = None;
         loop {
           // need to handle recursion
           body_scope.restore_frame(frame_checkpoint);
           runner::bind_marked_args(&mut body_scope, &info.args, &current_values, &next_stack)?;
-          let evaluator_timer =
-            runner::macro_metrics::PhaseTimer::start(&macro_name, runner::macro_metrics::MacroMetricPhase::Evaluator);
-          let evaluate_body = || runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack);
-          let code = if info.signature.is_strict() {
-            runner::macro_capability::with_macro_context(
-              Arc::from(macro_name.as_str()),
-              info.signature.capabilities.clone(),
-              call_location.clone(),
-              evaluate_body,
-            )?
-          } else {
-            // Legacy Macro schemas remain compatible, but their effects are
-            // deliberately unknown and therefore cannot be considered pure.
-            evaluate_body()?
+          let code = match cache_lookup.take() {
+            Some(runner::macro_cache::CacheLookup::Hit(code)) => code,
+            lookup => {
+              if let Some(runner::macro_cache::CacheLookup::Miss { token, .. }) = lookup {
+                cache_miss = Some(token);
+              }
+              let evaluator_timer =
+                runner::macro_metrics::PhaseTimer::start(&macro_name, runner::macro_metrics::MacroMetricPhase::Evaluator);
+              let evaluate_body = || runner::evaluate_lines(&info.body.to_vec(), &body_scope, file_ns, &next_stack);
+              let evaluated = if info.signature.is_strict() {
+                runner::macro_capability::with_macro_context(
+                  Arc::from(macro_name.as_str()),
+                  info.signature.capabilities.clone(),
+                  call_location.clone(),
+                  evaluate_body,
+                )?
+              } else {
+                // Legacy Macro schemas remain compatible, but their effects are
+                // deliberately unknown and therefore cannot be considered pure.
+                evaluate_body()?
+              };
+              drop(evaluator_timer);
+              evaluated
+            }
           };
-          drop(evaluator_timer);
           match code {
             Calcit::Recur(ys) => {
               current_values = ys;
@@ -1775,6 +1801,9 @@ fn preprocess_list_call(
                 &next_stack,
                 call_location.clone(),
               )?;
+              if let Some(token) = cache_miss.take() {
+                runner::macro_cache::store(token, &code, file_ns);
+              }
               return Ok(processed);
             }
           }


### PR DESCRIPTION
## Summary

- cache successfully validated raw expansions for strict macros with no compile-time capabilities during watch/hot reload
- scope entries by macro identity, phase-aware signature, exact source syntax, expansion namespace, compiling definition, and stable call site
- preserve macro hygiene by replaying the recorded gensym delta only when the per-definition gensym sequence still matches
- report cache hits, cold misses, bypasses, and definition/signature/input/gensym invalidations through `--macro-metrics`
- keep once-mode builds and runtime macro fallback out of the cache
- upgrade `im_ternary_tree` from 0.0.20 to 0.0.21 and verify its end-to-end Calcit performance impact

Progresses #436. This is intentionally the conservative raw-expansion cache slice, not the final post-preprocess cache or typed Macro IR.

## Safety boundaries

- legacy signatures and every macro with a declared capability remain on the general evaluator
- entries are stored only after the emitted expansion preprocesses and passes its phase-result validation
- a hit skips macro evaluation only; the emitted code is still preprocessed and type-checked, so type/import results are never reused by this cache
- call-site and nested syntax locations are compared before reuse
- generated-symbol expansions require the same gensym start position; hits advance the counter by the original delta
- the cache is enabled only for watch modes, avoiding cold once-mode cloning and memory overhead

## ternary-tree 0.0.21 performance

Compared release binaries built from the same Calcit source snapshot, with only `im_ternary_tree` 0.0.20 versus 0.0.21 changed. Runs alternated old/new order on Apple arm64 to reduce thermal and background-load drift.

| Workload | Samples | 0.0.20 median | 0.0.21 median | Paired median change |
| --- | ---: | ---: | ---: | ---: |
| `--check-only calcit/test.cirru` | 30 pairs | 303.357 ms | 300.902 ms | **-0.83%** |
| native `bench-literal-paths.cirru` process | 30 pairs | 136.380 ms | 135.676 ms | **-0.39%** |
| macro evaluator metric | 20 pairs | 41.194 ms | 41.359 ms | -0.05% (flat/noise) |
| macro post-preprocess metric | 20 pairs | 104.050 ms | 102.928 ms | **-1.22%** |

The upstream release reports much larger collection-level iteration and search improvements. Calcit's aggregate workloads also include parsing, type analysis, evaluation, and process startup, so the smaller whole-program gains are expected. These results show no regression and a modest measurable benefit, especially in post-preprocessing.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` (Calcit library, CLI, dependency tool, WASM, and doc tests; 798 tests passed)
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all`
- latest `calcit-lang/js-ffi` main: browser and node check-only entries pass
- latest `calcit-lang/recollect` main: 9/9 unit tests pass; test JS entry emits successfully
- latest `Respo/respo.calcit` main checked successfully with latest `calcit-lang/js-ffi` main substituted locally

Respo's committed dependency remains js-ffi 0.1.10; that installed snapshot produces two pre-existing Unit/nil return warnings with Calcit 0.13.45. The latest js-ffi main already fixes them, and the Respo check passes against that source. No downstream working tree was changed.

## Follow-up

The issue's larger cost center remains post-expansion preprocessing. A future cache for processed output must first track helper/import/type/config dependencies precisely; this PR deliberately does not reuse those results.
