### PR TITLE
perf: lower core let macro natively

### DIFF
--- a/editing-history/20260826-1234-native-let-macro-lowering.md
+++ b/editing-history/20260826-1234-native-let-macro-lowering.md
@@ -6,6 +6,9 @@
   for valid binding-pair lists.
 - Invalid outer binding shapes deliberately remain on the ordinary macro path,
   preserving the established macro diagnostics and error behavior.
+- After review, native lowering was narrowed to the exact `&let` binding
+  contract: `()` or a two-item list headed by a symbol. Singleton, oversized,
+  and non-symbol-headed lists therefore retain the ordinary macro path.
 - Macro metrics now explicitly classify this route as `native-fast-path`, not
   as a general-evaluator fallback or a cache candidate.
 - Latest Respo main release-binary metrics changed from 1,418 expansions / about

--- a/editing-history/20260826-1234-native-let-macro-lowering.md
+++ b/editing-history/20260826-1234-native-let-macro-lowering.md
@@ -1,0 +1,18 @@
+# Native lowering for the core let macro
+
+- Added a compiler-native lowering for the strict, capability-free
+  `calcit.core/let` macro. It builds the same nested `&let` tree as the macro's
+  recursive quasiquote implementation, avoiding general evaluator execution
+  for valid binding-pair lists.
+- Invalid outer binding shapes deliberately remain on the ordinary macro path,
+  preserving the established macro diagnostics and error behavior.
+- Macro metrics now explicitly classify this route as `native-fast-path`, not
+  as a general-evaluator fallback or a cache candidate.
+- Latest Respo main release-binary metrics changed from 1,418 expansions / about
+  29.04 ms evaluator time to 1,255 expansions / about 22.55 ms evaluator time.
+  The `let` evaluator time became zero while its required post-preprocessing
+  still runs.
+- On Apple arm64, 20 alternating paired Respo `--check-only` processes against
+  a same-source 0.13.46 baseline improved the median from 246.12 ms to
+  237.40 ms; paired median change was about -2.96%. This is a process-level
+  check improvement, not an application-runtime claim.

--- a/src/runner/macro_metrics.rs
+++ b/src/runner/macro_metrics.rs
@@ -134,6 +134,20 @@ pub fn record_cache_bypass(name: &str, reason: &'static str) {
   update(name, |metric| record_cache_bypass_metric(metric, reason));
 }
 
+/// Reclassify a recorded macro expansion that used a compiler-native lowering
+/// instead of entering the general macro evaluator.
+pub fn record_native_fast_path(name: &str) {
+  update(name, record_native_fast_path_metric);
+}
+
+fn record_native_fast_path_metric(metric: &mut MacroExpansionMetric) {
+  metric.general_evaluator_fallbacks = metric.general_evaluator_fallbacks.saturating_sub(1);
+  if remove_reason(&mut metric.cache_miss_reasons, "cache-not-implemented") {
+    metric.cache_misses = metric.cache_misses.saturating_sub(1);
+    add_reason(&mut metric.cache_bypasses, "native-fast-path", 1);
+  }
+}
+
 fn record_cache_bypass_metric(metric: &mut MacroExpansionMetric, reason: &'static str) {
   if remove_reason(&mut metric.cache_miss_reasons, "cache-not-implemented") {
     metric.cache_misses = metric.cache_misses.saturating_sub(1);
@@ -338,5 +352,15 @@ mod tests {
     record_cache_bypass_metric(&mut bypass, "cache-disabled");
     assert_eq!(bypass.cache_misses, 0);
     assert_eq!(bypass.cache_bypasses.get("cache-disabled"), Some(&1));
+  }
+
+  #[test]
+  fn native_fast_path_is_not_reported_as_a_general_evaluator_fallback() {
+    let mut metric = MacroExpansionMetric::default();
+    record_expansion_metric(&mut metric, &pure_signature());
+    record_native_fast_path_metric(&mut metric);
+    assert_eq!(metric.general_evaluator_fallbacks, 0);
+    assert_eq!(metric.cache_misses, 0);
+    assert_eq!(metric.cache_bypasses.get("native-fast-path"), Some(&1));
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -975,7 +975,13 @@ fn try_lower_core_let_macro(args: &CalcitList, file_ns: &str) -> Option<Calcit> 
   let Calcit::List(pairs) = args.first()? else {
     return None;
   };
-  if !pairs.iter().all(|pair| matches!(pair, Calcit::List(_))) {
+  if !pairs.iter().all(|pair| {
+    matches!(
+      pair,
+      Calcit::List(binding)
+        if binding.is_empty() || (binding.len() == 2 && matches!(binding.first(), Some(Calcit::Symbol { .. })))
+    )
+  }) {
     return None;
   }
 
@@ -7439,10 +7445,20 @@ mod tests {
   }
 
   #[test]
-  fn leaves_invalid_core_let_pairs_on_the_general_macro_path() {
-    let invalid_pairs = Calcit::from(vec![Calcit::Number(1.0)]);
-    let args = CalcitList::from(&[invalid_pairs, Calcit::Number(2.0)] as &[Calcit]);
-    assert!(try_lower_core_let_macro(&args, "tests.core-let").is_none());
+  fn leaves_malformed_core_let_pairs_on_the_general_macro_path() {
+    for pair in [
+      Calcit::from(vec![test_symbol("x")]),
+      Calcit::from(vec![test_symbol("x"), Calcit::Number(1.0), Calcit::Number(2.0)]),
+      Calcit::from(vec![Calcit::Number(1.0), Calcit::Number(2.0)]),
+    ] {
+      let pairs = Calcit::from(vec![pair]);
+      let args = CalcitList::from(&[pairs, Calcit::Number(2.0)] as &[Calcit]);
+      assert!(try_lower_core_let_macro(&args, "tests.core-let").is_none());
+    }
+
+    let empty_pair = Calcit::from(CalcitList::default());
+    let args = CalcitList::from(&[Calcit::from(vec![empty_pair]), Calcit::Number(2.0)] as &[Calcit]);
+    assert!(try_lower_core_let_macro(&args, "tests.core-let").is_some());
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -968,6 +968,33 @@ fn generated_let(binding: Calcit, value: Calcit, body: Calcit, file_ns: &str) ->
   ])
 }
 
+/// Lower the strict core `let` macro without executing its small recursive
+/// macro body. Invalid binding shapes deliberately keep the general path so
+/// the macro retains its established diagnostics.
+fn try_lower_core_let_macro(args: &CalcitList, file_ns: &str) -> Option<Calcit> {
+  let Calcit::List(pairs) = args.first()? else {
+    return None;
+  };
+  if !pairs.iter().all(|pair| matches!(pair, Calcit::List(_))) {
+    return None;
+  }
+
+  let core_let = || Calcit::Syntax(CalcitSyntax::CoreLet, Arc::from(file_ns));
+  let mut body: Vec<Calcit> = args.iter().skip(1).cloned().collect();
+  if pairs.is_empty() {
+    let mut items = vec![core_let(), Calcit::from(CalcitList::default())];
+    items.append(&mut body);
+    return Some(Calcit::from(CalcitList::from(items.as_slice())));
+  }
+
+  for index in (0..pairs.len()).rev() {
+    let mut items = vec![core_let(), pairs[index].to_owned()];
+    items.append(&mut body);
+    body = vec![Calcit::from(CalcitList::from(items.as_slice()))];
+  }
+  body.pop()
+}
+
 /// Wrap a body in left-to-right generated temporary bindings.
 fn generated_lets(bindings: Vec<(Calcit, Calcit)>, mut body: Calcit, file_ns: &str) -> Calcit {
   for (binding, value) in bindings.into_iter().rev() {
@@ -1724,6 +1751,16 @@ fn preprocess_list_call(
 
       let code = Calcit::List(Arc::new(xs.to_owned()));
       let next_stack = call_stack.extend_owned(&info.def_ns, &info.name, StackKind::Macro, code, args.to_vec());
+
+      if info.def_ns.as_ref() == calcit::CORE_NS
+        && info.name.as_ref() == "let"
+        && let Some(lowered) = try_lower_core_let_macro(&args, file_ns)
+      {
+        runner::macro_metrics::record_native_fast_path(&macro_name);
+        let _post_preprocess_timer =
+          runner::macro_metrics::PhaseTimer::start(&macro_name, runner::macro_metrics::MacroMetricPhase::PostPreprocess);
+        return preprocess_expr(&lowered, scope_defs, scope_types, file_ns, check_warnings, &next_stack);
+      }
 
       let mut body_scope = CalcitScope::default();
       let frame_checkpoint = body_scope.frame_checkpoint();
@@ -7378,6 +7415,34 @@ mod tests {
       }),
       location: Some(Arc::from(vec![1, 2, 3])),
     }
+  }
+
+  #[test]
+  fn lowers_valid_core_let_pairs_to_nested_core_let_forms() {
+    let pair_a = Calcit::from(vec![test_symbol("a"), Calcit::Number(1.0)]);
+    let pair_b = Calcit::from(vec![test_symbol("b"), Calcit::Number(2.0)]);
+    let pairs = Calcit::from(vec![pair_a.clone(), pair_b.clone()]);
+    let body = test_symbol("b");
+    let args = CalcitList::from(&[pairs, body] as &[Calcit]);
+
+    let lowered = try_lower_core_let_macro(&args, "tests.core-let").expect("valid pairs use native lowering");
+    let Calcit::List(outer) = lowered else {
+      panic!("expected outer core let")
+    };
+    assert!(matches!(outer.first(), Some(Calcit::Syntax(CalcitSyntax::CoreLet, _))));
+    assert_eq!(outer.get(1), Some(&pair_a));
+    let Some(Calcit::List(inner)) = outer.get(2) else {
+      panic!("multiple pairs should nest core lets")
+    };
+    assert!(matches!(inner.first(), Some(Calcit::Syntax(CalcitSyntax::CoreLet, _))));
+    assert_eq!(inner.get(1), Some(&pair_b));
+  }
+
+  #[test]
+  fn leaves_invalid_core_let_pairs_on_the_general_macro_path() {
+    let invalid_pairs = Calcit::from(vec![Calcit::Number(1.0)]);
+    let args = CalcitList::from(&[invalid_pairs, Calcit::Number(2.0)] as &[Calcit]);
+    assert!(try_lower_core_let_macro(&args, "tests.core-let").is_none());
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- lower valid `calcit.core/let` binding lists directly to nested `&let` forms, avoiding execution of the core macro's recursive quasiquote body
- keep invalid outer binding shapes on the existing macro evaluator route, preserving its diagnostics and behavior
- report this route as `native-fast-path` in macro metrics instead of an evaluator fallback/cache miss

## Performance

On latest `respo/respo.calcit` main with the release binary:

- macro evaluator time: 29.04 ms -> 22.55 ms
- macro expansions: 1,418 -> 1,255
- `let` evaluator time: 5.80 ms -> 0 ms
- 20 alternating `--check-only` process pairs on Apple arm64: median 246.12 ms -> 237.40 ms; paired median change -2.96%

This is compile/check performance, not an application-runtime claim.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` (802 tests)
- `yarn check-all`
- latest Respo: `calcit calcit.cirru js --check-only`
- latest Recollect: `yarn test` (Calcit unit tests plus emitted JS runtime tests)

Progresses #436.
