### PR TITLE
fix: preserve embedded core schemas without source fallback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,48 +47,6 @@ pub fn quiet_tool_output() -> bool {
   QUIET_TOOL_OUTPUT.load(Ordering::Relaxed)
 }
 
-fn core_snapshot_schema_needs_fallback(snapshot: &snapshot::Snapshot) -> bool {
-  let Some(core_file) = snapshot.files.get("calcit.core") else {
-    return true;
-  };
-  let Some(map_entry) = core_file.defs.get("map") else {
-    return true;
-  };
-  let CalcitTypeAnnotation::Fn(fn_annot) = map_entry.schema.as_ref() else {
-    return true;
-  };
-
-  fn_annot.where_bounds.is_empty() || !matches!(fn_annot.arg_types.get(1).map(|arg| arg.as_ref()), Some(CalcitTypeAnnotation::Fn(_)))
-}
-
-fn load_core_snapshot_from_embedded_source() -> Result<snapshot::Snapshot, String> {
-  let content = include_str!("../src/cirru/calcit-core.cirru");
-  let data = cirru_edn::parse(content).map_err(|e| format!("Failed to parse embedded core snapshot source: {e}"))?;
-  snapshot::load_snapshot_data(&data, "calcit-internal://calcit-core.cirru")
-}
-
-fn overlay_core_schemas_from_source(snapshot: &mut snapshot::Snapshot) -> Result<(), String> {
-  let source_snapshot = load_core_snapshot_from_embedded_source()?;
-
-  for (ns, source_file) in &source_snapshot.files {
-    let Some(target_file) = snapshot.files.get_mut(ns) else {
-      continue;
-    };
-
-    for (def, source_entry) in &source_file.defs {
-      let Some(target_entry) = target_file.defs.get_mut(def) else {
-        continue;
-      };
-
-      if !matches!(source_entry.schema.as_ref(), CalcitTypeAnnotation::Dynamic) {
-        target_entry.schema = source_entry.schema.clone();
-      }
-    }
-  }
-
-  Ok(())
-}
-
 pub fn load_core_snapshot() -> Result<snapshot::Snapshot, String> {
   // load core libs
   let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/calcit-core.rmp"));
@@ -96,13 +54,64 @@ pub fn load_core_snapshot() -> Result<snapshot::Snapshot, String> {
     eprintln!("\n{e}");
     "Failed to deserialize core snapshot".to_string()
   })?;
-  if core_snapshot_schema_needs_fallback(&snapshot) {
-    overlay_core_schemas_from_source(&mut snapshot)?;
-  }
   let path = "calcit-internal://calcit-core.cirru";
   let meta_ns = format!("{}.$meta", snapshot.package);
   snapshot.files.insert(meta_ns.to_owned(), snapshot::gen_meta_ns(&meta_ns, path));
   Ok(snapshot)
+}
+
+#[cfg(test)]
+mod core_snapshot_tests {
+  use super::*;
+
+  #[test]
+  fn generated_core_snapshot_preserves_generic_function_schemas() {
+    let snapshot = load_core_snapshot().expect("load generated core snapshot");
+    let map_entry = snapshot
+      .files
+      .get("calcit.core")
+      .and_then(|file| file.defs.get("map"))
+      .expect("calcit.core/map should exist");
+    let CalcitTypeAnnotation::Fn(signature) = map_entry.schema.as_ref() else {
+      panic!("calcit.core/map should retain its function schema");
+    };
+
+    assert_eq!(signature.generics.as_ref(), &[Arc::from("C"), Arc::from("T"), Arc::from("U")]);
+    assert_eq!(signature.where_bounds.len(), 1);
+    assert_eq!(signature.where_bounds[0].name.as_ref(), "C");
+    assert_eq!(signature.where_bounds[0].traits.len(), 1);
+    assert_eq!(signature.where_bounds[0].traits[0].name.ref_str(), "Mappable");
+
+    let Some(nested_mapper) = signature.arg_types.get(1) else {
+      panic!("calcit.core/map should retain its mapper argument");
+    };
+    let CalcitTypeAnnotation::Fn(mapper_signature) = nested_mapper.as_ref() else {
+      panic!("calcit.core/map mapper argument should retain its nested function schema");
+    };
+    assert!(
+      matches!(mapper_signature.arg_types.as_slice(), [arg] if matches!(arg.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "T"))
+    );
+    assert!(matches!(mapper_signature.return_type.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "U"));
+  }
+
+  #[test]
+  fn generated_core_snapshot_preserves_strict_macro_schemas() {
+    let snapshot = load_core_snapshot().expect("load generated core snapshot");
+    let let_entry = snapshot
+      .files
+      .get("calcit.core")
+      .and_then(|file| file.defs.get("let"))
+      .expect("calcit.core/let should exist");
+    let CalcitTypeAnnotation::Macro(signature) = let_entry.schema.as_ref() else {
+      panic!("calcit.core/let should retain its strict macro schema");
+    };
+
+    assert!(signature.is_strict());
+    assert_eq!(signature.required_inputs.len(), 1);
+    assert!(signature.optional_inputs.is_empty());
+    assert!(signature.rest_input.is_some());
+    assert!(signature.capabilities.is_empty());
+  }
 }
 
 #[derive(Clone, Debug)]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -78,8 +78,10 @@ fn normalize_schema_map(map: &EdnMapView) -> EdnMapView {
   for (key, value) in map.0.iter() {
     let normalized_key = match key {
       Edn::Tag(tag) => Edn::tag(tag.ref_str()),
-      Edn::Str(text) => canonical_schema_field_name(text).map(Edn::tag).unwrap_or_else(|| key.clone()),
-      Edn::Symbol(text) => canonical_schema_field_name(text).map(Edn::tag).unwrap_or_else(|| key.clone()),
+      Edn::Str(text) | Edn::Symbol(text) => canonical_schema_field_name(text)
+        .map(Edn::tag)
+        .or_else(|| text.strip_prefix('\'').map(|name| Edn::Symbol(Arc::from(name))))
+        .unwrap_or_else(|| key.clone()),
       _ => key.clone(),
     };
 
@@ -87,13 +89,26 @@ fn normalize_schema_map(map: &EdnMapView) -> EdnMapView {
       (Edn::Tag(tag), Edn::Str(text)) | (Edn::Tag(tag), Edn::Symbol(text)) if tag.ref_str() == "kind" => {
         canonical_schema_kind_name(text).map(Edn::tag).unwrap_or_else(|| value.clone())
       }
-      _ => value.clone(),
+      _ => normalize_schema_value(value),
     };
 
     normalized.insert(normalized_key, normalized_value);
   }
 
   normalized
+}
+
+fn normalize_schema_value(value: &Edn) -> Edn {
+  match value {
+    Edn::Map(map) => Edn::Map(normalize_schema_map(map)),
+    Edn::List(items) => Edn::List(EdnListView(items.0.iter().map(normalize_schema_value).collect())),
+    Edn::Enum(view) => {
+      let mut normalized = view.clone();
+      normalized.extra = view.extra.iter().map(normalize_schema_value).collect();
+      Edn::Enum(normalized)
+    }
+    _ => value.clone(),
+  }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #461

## What changed

- recursively normalize schema maps decoded from the generated MessagePack snapshot
- restore quoted generic keys such as `C` in nested `:where` maps
- verify the generated snapshot preserves `calcit.core/map` generics, trait bounds, nested callback types, and strict `let` macro metadata
- remove the embedded `calcit-core.cirru` schema detection, source parser, and overlay fallback

## Root cause

MessagePack decoding stringifies nested EDN map keys. The loader normalized only the top-level schema map, so nested `:where` and callback schema maps lost their canonical key forms. The runtime source overlay masked that serialization defect while also embedding the full core source a second time.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib -- --test-threads=1` — 532 passed
- core attached tests — 228 passed
- native Calcit suite
- JS runtime identity and JS suite
- agent interface — 17/17
- IR generation
- literal-path and typed-method specialization checks
- latest Respo with latest local js-ffi — 27/27
- latest Recollect native — 9/9; JS runtime completed without errors
- WASM intentionally skipped because this cleanup does not target the internal validation backend

## Measurements

- release binary: 9,641,776 -> 9,229,472 bytes (-412,304, -4.28%)
- Respo `--check-only`, 20 runs: median 241.604ms -> 176.882ms (-26.8%); new min 174.435ms, max 191.880ms

The cached Respo js-ffi revision still has two known `nil` versus `Unit` warnings. Repointing only the local validation module link to the latest js-ffi main (`&unit`) makes all 27 tests pass; the link was restored afterward.