### PR TITLE
docs: include hidden modules in macro audits

### DIFF
--- a/docs/MacroSignature.md
+++ b/docs/MacroSignature.md
@@ -79,14 +79,19 @@ Calcit workspace rather than relying on its presence in documentation or the
 core definition itself:
 
 ```bash
-rg -n -F --glob '*.cirru' --glob '!**/src/cirru/calcit-core.cirru' -- 'MACRO_NAME' /path/to/workspace
+rg --hidden --follow -n -F \
+  --glob '*.cirru' \
+  --glob '!**/.git/**' \
+  --glob '!**/src/cirru/calcit-core.cirru' \
+  -- 'MACRO_NAME' /path/to/workspace
 ```
 
-Use the literal matches as an audit candidate list, then manually distinguish
-executable call sites from definitions, docs, comments, quoted code, and longer
-symbols. Record the executable call sites in the promotion PR. Zero-call-site
-syntax should normally stay in a module or be removed instead of becoming
-permanent core surface.
+`--hidden --follow` includes sources reached through project-local
+`.calcit/modules/` links. Use the literal matches as an audit candidate list,
+then manually distinguish executable call sites from definitions, docs,
+comments, quoted code, and longer symbols. Record the executable call sites in
+the promotion PR. Zero-call-site syntax should normally stay in a module or be
+removed instead of becoming permanent core surface.
 
 Some strict contracts still contain intentional `Dynamic` positions. Broad
 collection helpers such as `first`, `nth`, and `get` accept several runtime


### PR DESCRIPTION
Follow-up to #466.

- include hidden `.calcit/modules/` sources when auditing experimental macro adoption
- follow module symlinks and explicitly exclude `.git` plus the bundled core definition
- retain literal matching and manual classification of definitions, docs, quoted code, and executable call sites

Validation: `bash scripts/check-docs-md.sh` — 56 files and 323 Cirru blocks passed.
