### PR TITLE
fix: keep flipped compatible with host callables

### DIFF
--- a/editing-history/20260826-1905-flipped-dynamic-callable-boundary.md
+++ b/editing-history/20260826-1905-flipped-dynamic-callable-boundary.md
@@ -1,0 +1,10 @@
+# Keep `flipped` compatible with host callables
+
+- Relaxed `flipped`'s first macro input from statically known `Fn` to `Dynamic`.
+- The macro only reverses call syntax; JavaScript host symbols such as
+  `js/setTimeout` are intentionally dynamic and cannot satisfy the native
+  callable schema before host lowering.
+- Kept the rest arguments and expansion result explicitly dynamic, while the
+  macro remains compile-time pure and phase-aware.
+- Validated the change against current Respo UI usage, which relies on
+  `flipped js/setTimeout ...`.

--- a/editing-history/20260826-1905-flipped-dynamic-callable-boundary.md
+++ b/editing-history/20260826-1905-flipped-dynamic-callable-boundary.md
@@ -1,6 +1,7 @@
 # Keep `flipped` compatible with host callables
 
-- Relaxed `flipped`'s first macro input from statically known `Fn` to `Dynamic`.
+- Relaxed `flipped`'s first macro input from source schema `Fn` (represented
+  internally as `DynFn`) to `Dynamic`.
 - The macro only reverses call syntax; JavaScript host symbols such as
   `js/setTimeout` are intentionally dynamic and cannot satisfy the native
   callable schema before host lowering.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -4793,7 +4793,7 @@
             {}
               :capabilities $ #{}
               :expansion $ :: 'Expr 'Dynamic
-              :required $ [] (:: 'Expr 'Fn)
+              :required $ [] (:: 'Expr 'Dynamic)
               :rest $ :: 'Expr 'Dynamic
           :tags $ #{} :macro
         |floor $ %{} 'CodeEntry (:doc "|internal function for floor operation\nSyntax: (floor n)\nParams: n (number)\nReturns: number\nReturns largest integer less than or equal to n")

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4161,7 +4161,7 @@ mod tests {
           assert!(matches!(
             signature.required_inputs.as_slice(),
             [crate::calcit::MacroSyntaxType::Expr(value)]
-              if matches!(value.as_ref(), CalcitTypeAnnotation::DynFn)
+              if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic)
           ));
           assert!(matches!(
             signature.rest_input,


### PR DESCRIPTION
## Summary

- relax the first `flipped` macro input from statically known `Fn` to `Dynamic`
- preserve the phase-aware expansion and compile-time capability contract
- document why JavaScript host symbols cannot satisfy a native callable schema before host lowering

## Validation

- `cargo test core_snapshot_tests::generated_core_snapshot_preserves_strict_macro_schemas`
- `cargo build --release`
- latest `Respo/respo-ui.calcit@0.7.10` through `b-conf/conf-mar`: `calcit calcit.cirru --check-only`

This fixes the false positive triggered by the maintained Respo usage `flipped js/setTimeout ...`.
