### PR TITLE
fix: preserve JS interop runtime boundaries

### DIFF
--- a/editing-history/20260826-1940-prevent-js-module-self-imports.md
+++ b/editing-history/20260826-1940-prevent-js-module-self-imports.md
@@ -1,0 +1,8 @@
+# Prevent generated JavaScript module self-imports
+
+- Keep resolved definitions from the current namespace local even when a
+  type-directed rewrite conservatively marks them as referred imports.
+- Add a codegen regression test proving that the local definition remains a
+  direct identifier and does not enter the ESM import collection.
+- Validated with skir's same-namespace `Request` and `Response` struct
+  constructors, which previously produced duplicate declaration errors.

--- a/editing-history/20260826-1950-js-nullish-unit-boundary.md
+++ b/editing-history/20260826-1950-js-nullish-unit-boundary.md
@@ -1,0 +1,8 @@
+# Keep JS nullish checks aligned with `&unit`
+
+- Treat both `nil` (JavaScript `null`) and `&unit` (JavaScript `undefined`) as
+  nullish at `JsNullish<T>` boundaries.
+- Define `js-present?` as the complement of `js-nullish?` so the two helpers
+  cannot drift apart again.
+- Add examples covering both runtime representations. This prevents optional
+  host fields whose value is `undefined` from being dereferenced as present.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -5482,9 +5482,11 @@
           :tags $ #{} :interop
         |js-nullish? $ %{} 'CodeEntry (:doc "|Return true when a JsNullish<T> boundary value is JavaScript null or undefined.")
           :code $ quote
-            defn js-nullish? (x) (nil? x)
+            defn js-nullish? (x)
+              or (nil? x) (= :unit (type-of x))
           :examples $ []
             quote $ assert= true (js-nullish? nil)
+            quote $ assert= true (js-nullish? &unit)
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] (:: 'JsNullish 'T)
@@ -5516,9 +5518,10 @@
         |js-present? $ %{} 'CodeEntry (:doc "|Return true when a JsNullish<T> boundary contains a non-null JavaScript value.")
           :code $ quote
             defn js-present? (x)
-              not $ nil? x
+              not $ js-nullish? x
           :examples $ []
             quote $ assert= false (js-present? nil)
+            quote $ assert= false (js-present? &unit)
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] (:: 'JsNullish 'T)

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -329,7 +329,13 @@ fn to_js_code(
             Ok(escape_var(alias))
           }
           _ => {
-            file_imports.borrow_mut().insert(item.to_owned());
+            // Type-directed rewrites may conservatively preserve a referred-import
+            // marker even when the resolved definition lives in this module.  A
+            // named self-import is invalid ESM once the same definition is exported
+            // below, so keep same-namespace references local at the emitter boundary.
+            if item.ns.as_ref() != ns {
+              file_imports.borrow_mut().insert(item.to_owned());
+            }
             Ok(escape_var(def))
           }
         }
@@ -2689,6 +2695,31 @@ mod tests {
 
     assert_eq!(unit, "void 0");
     assert_eq!(nil, "null");
+  }
+
+  #[test]
+  fn same_namespace_referred_defs_do_not_generate_self_imports() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let request = Calcit::Import(CalcitImport {
+      ns: Arc::from("tests.emit-js"),
+      def: Arc::from("Request"),
+      info: Arc::new(ImportInfo::NsReferDef {
+        at_ns: Arc::from("tests.consumer"),
+        at_def: Arc::from("request"),
+      }),
+      def_id: None,
+    });
+
+    let code = to_js_code(&request, "tests.emit-js", &local_defs, &file_imports, &tags, None)
+      .expect("same-namespace definition should compile as a local reference");
+
+    assert_eq!(code, "Request");
+    assert!(
+      file_imports.borrow().is_empty(),
+      "same-namespace reference must not create an ESM self-import"
+    );
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- prevent generated ESM modules from importing named definitions from themselves
- treat both JavaScript `null`/Calcit `nil` and JavaScript `undefined`/Calcit `&unit` as nullish
- make `js-present?` the complement of `js-nullish?`
- add a focused codegen regression test and editing-history entries

## Runtime failures fixed

- skir generated `import { Request } from "./skir.schema.mjs"` before exporting `Request`, causing a duplicate declaration syntax error
- optional fields omitted by `@google/genai` 2.x arrived as JavaScript `undefined`, but `js-present?` incorrectly treated them as present after the `&unit` split

## Validation

- `cargo fmt --check`
- `cargo test --lib -- --test-threads=1` (532 passed)
- release build
- regenerated skir and started `Memkits/tco-redirect`; exercised missing-URL and asynchronous proxy request paths without Calcit runtime errors
- upgraded and ran `Memkits/genai.calcit` against `gemini-2.5-flash-lite` and `gemini-3.7-flash`; both completed successfully

The default parallel Rust test run exposed three existing shared-state races in snapshot tests; each failed test passes alone, and the complete serial suite passes.
