### PR TITLE
fix: map undefined nullish values to none

### DIFF
--- a/editing-history/20260826-1950-js-nullish-unit-boundary.md
+++ b/editing-history/20260826-1950-js-nullish-unit-boundary.md
@@ -4,5 +4,7 @@
   nullish at `JsNullish<T>` boundaries.
 - Define `js-present?` as the complement of `js-nullish?` so the two helpers
   cannot drift apart again.
+- Route `js-nullish->option` through the same predicate so JavaScript
+  `undefined` becomes `%none` instead of `%some &unit`.
 - Add examples covering both runtime representations. This prevents optional
   host fields whose value is `undefined` from being dereferenced as present.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -5470,9 +5470,10 @@
         |js-nullish->option $ %{} 'CodeEntry (:doc "|Explicitly convert a JavaScript null/undefined boundary value into nominal Option<T>. This does not validate or coerce the opaque payload type.")
           :code $ quote
             defn js-nullish->option (x)
-              if (nil? x) (%none) (%some x)
+              if (js-nullish? x) (%none) (%some x)
           :examples $ []
             quote $ assert= (%none) (js-nullish->option nil)
+            quote $ assert= (%none) (js-nullish->option &unit)
           :schema $ :: 'Fn
             {}
               :args $ [] (:: 'JsNullish 'T)


### PR DESCRIPTION
## Summary

- make `js-nullish->option` use the same predicate as `js-nullish?`
- convert JavaScript `undefined` / Calcit `&unit` to `%none`
- retain `%some` for present host values and add an `&unit` example

Follow-up for the valid review finding on calcit-lang/calcit#469, which had already merged before the review thread arrived.

## Validation

- `cargo fmt --check`
- core snapshot schema test
- `calcit exec`: `(assert= (%none) (js-nullish->option &unit))`
