### PR TITLE
perf: cache compact native function call shape

### DIFF
--- a/editing-history/20260826-2140-compact-runtime-call-shape.md
+++ b/editing-history/20260826-2140-compact-runtime-call-shape.md
@@ -1,0 +1,32 @@
+# Cache compact native function call shape
+
+- Continued issue #464 with a field-consumer and layout audit before changing
+  the runtime representation. On Apple arm64, `Calcit` is 88 bytes,
+  `CalcitFn` 176 bytes, `CalcitLocal` 48 bytes, and `CalcitScope` 24 bytes.
+- Function values already share `Arc<CalcitFn>`, so ordinary calls do not clone
+  generic, where-bound, return, or argument annotation graphs. Those fields are
+  cold resident metadata rather than per-call allocation traffic. Local
+  metadata is hot in the preprocessed tree, but shrinking `CalcitLocal` alone
+  cannot shrink the 88-byte `Calcit` enum; a later material memory experiment
+  needs a genuinely separate execution expression.
+- Added a 6-byte `CalcitFnCallShape` that fills existing `CalcitFn` alignment
+  padding, leaving `size_of::<CalcitFn>()` unchanged at 176 bytes. It caches the
+  fixed parameter count, continuous trailing `Option` count, and combined
+  marked/typed rest evidence after preprocessing.
+- Native `run_fn` and `run_fn_owned` now consult the compact shape before
+  optional-argument completion instead of scanning `CalcitFnArgs` and the full
+  argument annotation list on every function call. Full schema metadata remains
+  available to preprocessing, codegen, queries, effects analysis, and errors.
+- Against main `86c47a93`, an alternating 30-pair native fold benchmark with
+  200,000 callback calls changed from a 119.280 ms median to 117.647 ms; paired
+  median change was -1.34%. A 15-pair 1,000,000-call run changed from 607.412 ms
+  to 594.369 ms; paired median change was -2.09%.
+- Latest Respo main (`27bb6304`) retained all 27 native tests; its 15-sample
+  test-body median changed from 30.867 ms to 31.255 ms. Latest Recollect main
+  (`e0903a6d`) retained all 9 native tests and stayed at a 9.520 ms median.
+  These project-level differences are treated as noise rather than claimed
+  speedups. Median peak RSS moved from 48,201,728 to 47,726,592 bytes for Respo
+  and from 70,172,672 to 68,927,488 bytes for Recollect, but process-level RSS
+  variance is too high to attribute that reduction to this zero-size cache.
+- The release binary changed from 9,212,896 to 9,213,136 bytes (+240 bytes).
+  No new heap allocation is introduced by the cached shape.

--- a/src/builtins/syntax.rs
+++ b/src/builtins/syntax.rs
@@ -11,8 +11,8 @@ use crate::builtins;
 use crate::builtins::meta::{NS_SYMBOL_DICT, type_of};
 
 use crate::calcit::{
-  self, CalcitArgLabel, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitList, CalcitListView,
-  CalcitLocal, CalcitMacro, CalcitSymbolInfo, CalcitSyntax, CalcitTypeAnnotation, LocatedWarning, MacroSignature,
+  self, CalcitArgLabel, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnCallShape, CalcitFnDefRef, CalcitFnUsageMeta, CalcitList,
+  CalcitListView, CalcitLocal, CalcitMacro, CalcitSymbolInfo, CalcitSyntax, CalcitTypeAnnotation, LocatedWarning, MacroSignature,
 };
 use crate::calcit::{Calcit, CalcitEnumValue, CalcitErr, CalcitScope, gen_core_id};
 use crate::call_stack::CallStackList;
@@ -67,6 +67,7 @@ pub fn defn(expr: &CalcitListView<'_>, scope: &CalcitScope, file_ns: &str) -> Re
       }
       let runtime_body = body_items.iter().filter(|form| !is_function_metadata_hint(form)).cloned().collect();
       let is_macro_gen = s.as_ref().contains('%');
+      let call_shape = CalcitFnCallShape::from_parts(&parsed_args, &arg_types, rest_type.is_some());
       Ok(Calcit::Fn {
         id: gen_core_id(),
         info: Arc::new(CalcitFn {
@@ -82,6 +83,7 @@ pub fn defn(expr: &CalcitListView<'_>, scope: &CalcitScope, file_ns: &str) -> Re
           usage: CalcitFnUsageMeta::default(),
           scope: Arc::new(scope.to_owned()),
           args: Arc::new(parsed_args),
+          call_shape,
           body: runtime_body,
           generics,
           where_bounds,
@@ -318,6 +320,9 @@ mod tests {
         assert!(matches!(info.return_type.as_ref(), CalcitTypeAnnotation::Number));
         assert_eq!(info.arg_types.len(), 1, "single parameter function should track one arg type slot");
         assert!(info.arg_types.iter().all(|slot| matches!(**slot, CalcitTypeAnnotation::Dynamic)));
+        assert_eq!(info.call_shape.param_len(), 1);
+        assert_eq!(info.call_shape.trailing_optionals(), 0);
+        assert!(!info.call_shape.has_rest());
         assert_eq!(info.body, vec![body_expr], "function metadata hint must not execute as body code");
       }
       other => panic!("expected function, got {other}"),
@@ -362,6 +367,8 @@ mod tests {
       panic!("expected function");
     };
     assert!(matches!(info.rest_type.as_deref(), Some(CalcitTypeAnnotation::Number)));
+    assert_eq!(info.call_shape.param_len(), 2);
+    assert!(info.call_shape.has_rest());
     assert!(matches!(
       info.arg_types.last().map(AsRef::as_ref),
       Some(CalcitTypeAnnotation::Variadic(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Number)

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -39,7 +39,7 @@ pub use calcit_struct::CalcitStructDef;
 pub use calcit_trait::{CalcitTrait, CalcitTraitMemberKind};
 pub use enum_value::CalcitEnumValue;
 pub(crate) use fns::trailing_option_arg_count;
-pub use fns::{CalcitArgLabel, CalcitFn, CalcitFnArgs, CalcitFnDefRef, CalcitFnUsageMeta, CalcitMacro, CalcitScope};
+pub use fns::{CalcitArgLabel, CalcitFn, CalcitFnArgs, CalcitFnCallShape, CalcitFnDefRef, CalcitFnUsageMeta, CalcitMacro, CalcitScope};
 pub use fns::{ParamShape, ParamShapeToken, compare_param_shapes};
 pub use list::{CalcitCallKind, CalcitList, CalcitListView, CalcitNumberBinaryOp};
 pub use local::CalcitLocal;
@@ -1676,6 +1676,7 @@ mod tests {
           usage: CalcitFnUsageMeta::default(),
           scope: Arc::new(CalcitScope::default()),
           args: Arc::new(CalcitFnArgs::Args(vec![])),
+          call_shape: CalcitFnCallShape::fixed(0),
           body: vec![Calcit::Str(Arc::from("ok"))],
           generics: Arc::new(vec![]),
           where_bounds: Arc::new(vec![]),

--- a/src/calcit/calcit_trait.rs
+++ b/src/calcit/calcit_trait.rs
@@ -287,6 +287,7 @@ mod tests {
       usage: CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
       args: Arc::new(CalcitFnArgs::Args(vec![1])),
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(1),
       body: vec![crate::Calcit::Nil; body_len],
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),

--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -160,6 +160,52 @@ pub enum CalcitFnArgs {
   Args(Vec<u16>),
 }
 
+/// Execution-only callable shape cached after typed preprocessing.
+///
+/// Native calls should not have to walk argument annotations merely to decide
+/// arity and trailing `Option` completion. The full annotations stay on
+/// `CalcitFn` for codegen, queries, and diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalcitFnCallShape {
+  param_len: u16,
+  trailing_optionals: u16,
+  has_rest: bool,
+}
+
+impl CalcitFnCallShape {
+  pub fn fixed(param_len: usize) -> Self {
+    Self {
+      param_len: u16::try_from(param_len).expect("function parameter count exceeds local index capacity"),
+      trailing_optionals: 0,
+      has_rest: false,
+    }
+  }
+
+  pub fn from_parts(args: &CalcitFnArgs, arg_types: &[Arc<CalcitTypeAnnotation>], has_typed_rest: bool) -> Self {
+    let param_len = args.param_len();
+    let has_marked_rest =
+      matches!(args, CalcitFnArgs::MarkedArgs(labels) if labels.iter().any(|label| matches!(label, CalcitArgLabel::RestMark)));
+    Self {
+      param_len: u16::try_from(param_len).expect("function parameter count exceeds local index capacity"),
+      trailing_optionals: u16::try_from(trailing_option_arg_count(arg_types, param_len))
+        .expect("optional parameter count exceeds local index capacity"),
+      has_rest: has_typed_rest || has_marked_rest,
+    }
+  }
+
+  pub fn param_len(self) -> usize {
+    usize::from(self.param_len)
+  }
+
+  pub fn trailing_optionals(self) -> usize {
+    usize::from(self.trailing_optionals)
+  }
+
+  pub fn has_rest(self) -> bool {
+    self.has_rest
+  }
+}
+
 impl CalcitFnArgs {
   /// Counts positional parameters(either indexed locals or symbols) while ignoring markers.
   pub fn param_len(&self) -> usize {
@@ -186,6 +232,8 @@ pub struct CalcitFn {
   pub usage: CalcitFnUsageMeta,
   pub scope: Arc<CalcitScope>,
   pub args: Arc<CalcitFnArgs>,
+  /// compact arity facts used by the native call path
+  pub call_shape: CalcitFnCallShape,
   pub body: Vec<Calcit>,
   /// generics declared by hint-fn
   pub generics: Arc<Vec<Arc<str>>>,
@@ -272,6 +320,34 @@ mod tests {
     let types = vec![Arc::new(CalcitTypeAnnotation::Number), option_number.clone(), option_number];
     assert_eq!(trailing_option_arg_count(&types, 3), 2);
     assert_eq!(trailing_option_arg_count(&types, 4), 0, "partial metadata must keep exact arity");
+  }
+
+  #[test]
+  fn caches_runtime_call_shape_from_typed_arguments() {
+    let option_number = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    let args = CalcitFnArgs::Args(vec![1, 2, 3]);
+    let shape = CalcitFnCallShape::from_parts(
+      &args,
+      &[Arc::new(CalcitTypeAnnotation::Number), option_number.clone(), option_number],
+      false,
+    );
+    assert_eq!(shape.param_len(), 3);
+    assert_eq!(shape.trailing_optionals(), 2);
+    assert!(!shape.has_rest());
+  }
+
+  #[test]
+  fn runtime_call_shape_combines_marked_and_typed_rest_evidence() {
+    let marked = CalcitFnArgs::MarkedArgs(vec![CalcitArgLabel::Idx(1), CalcitArgLabel::RestMark, CalcitArgLabel::Idx(2)]);
+    let marked_shape = CalcitFnCallShape::from_parts(&marked, &[], false);
+    assert_eq!(marked_shape.param_len(), 2);
+    assert!(marked_shape.has_rest());
+
+    let typed = CalcitFnArgs::Args(vec![1]);
+    assert!(CalcitFnCallShape::from_parts(&typed, &[crate::calcit::DYNAMIC_TYPE.clone()], true).has_rest());
   }
 
   #[test]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,7 +12,6 @@ use crate::builtins;
 use crate::calcit::{
   CORE_NS, Calcit, CalcitArgLabel, CalcitCallKind, CalcitEnumValue, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitImport,
   CalcitList, CalcitListView, CalcitLocal, CalcitNumberBinaryOp, CalcitProc, CalcitScope, CalcitSyntax, MethodKind, NodeLocation,
-  trailing_option_arg_count,
 };
 use crate::call_stack::{CallStackList, StackKind, using_stack};
 use crate::data::cirru;
@@ -667,14 +666,12 @@ fn option_none_value(expected_type: &crate::calcit::CalcitTypeAnnotation) -> Opt
 /// Fill only a continuous trailing run of omitted `Option<T>` parameters.
 /// A rest parameter keeps the function variadic and therefore disables this sugar.
 fn complete_trailing_option_args(values: &[Calcit], info: &CalcitFn) -> Option<Vec<Calcit>> {
-  if info.rest_type.is_some()
-    || matches!(info.args.as_ref(), CalcitFnArgs::MarkedArgs(args) if args.iter().any(|arg| matches!(arg, CalcitArgLabel::RestMark)))
-  {
+  if info.call_shape.has_rest() {
     return None;
   }
 
-  let param_len = info.args.param_len();
-  let optional_count = trailing_option_arg_count(&info.arg_types, param_len);
+  let param_len = info.call_shape.param_len();
+  let optional_count = info.call_shape.trailing_optionals();
   let required_len = param_len.saturating_sub(optional_count);
   if optional_count == 0 || values.len() < required_len || values.len() >= param_len {
     return None;
@@ -1130,14 +1127,16 @@ mod tests {
   }
 
   fn fn_info(arg_types: Vec<Arc<CalcitTypeAnnotation>>) -> CalcitFn {
-    let args = (0..arg_types.len()).map(|idx| idx as u16).collect();
+    let args = CalcitFnArgs::Args((0..arg_types.len()).map(|idx| idx as u16).collect());
+    let call_shape = crate::calcit::CalcitFnCallShape::from_parts(&args, &arg_types, false);
     CalcitFn {
       name: Arc::from("with-options"),
       def_ns: Arc::from("tests.runner"),
       def_ref: None,
       usage: CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
-      args: Arc::new(CalcitFnArgs::Args(args)),
+      args: Arc::new(args),
+      call_shape,
       body: vec![],
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),
@@ -1300,18 +1299,22 @@ mod tests {
 
     let mut closure_scope = CalcitScope::default();
     closure_scope.insert_mut(captured, Calcit::Number(42.0));
+    let args = CalcitFnArgs::Args(vec![x, acc]);
+    let arg_types = vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::Number)];
+    let call_shape = crate::calcit::CalcitFnCallShape::from_parts(&args, &arg_types, false);
     let info = CalcitFn {
       name: Arc::from("tail-loop"),
       def_ns: Arc::from("tests.runner"),
       def_ref: None,
       usage: CalcitFnUsageMeta::default(),
       scope: Arc::new(closure_scope),
-      args: Arc::new(CalcitFnArgs::Args(vec![x, acc])),
+      args: Arc::new(args),
+      call_shape,
       body: vec![body],
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),
       return_type: Arc::new(CalcitTypeAnnotation::Number),
-      arg_types: vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::Number)],
+      arg_types,
       rest_type: None,
     };
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -9515,6 +9515,7 @@ mod tests {
             usage: CalcitFnUsageMeta::default(),
             scope: Arc::new(CalcitScope::default()),
             args: Arc::new(CalcitFnArgs::Args(vec![CalcitLocal::track_sym(&Arc::from("x"))])),
+            call_shape: crate::calcit::CalcitFnCallShape::fixed(1),
             body: vec![],
             generics: Arc::new(vec![generic_name.clone()]),
             where_bounds: Arc::new(vec![]),
@@ -11360,6 +11361,7 @@ mod tests {
       usage: crate::calcit::CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
       args: Arc::new(CalcitFnArgs::Args(vec![0])),
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(1),
       body: vec![Calcit::Nil],
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),
@@ -11414,6 +11416,7 @@ mod tests {
       usage: crate::calcit::CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
       args: Arc::new(CalcitFnArgs::Args(vec![0, 1])), // two args
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(2),
       body: vec![Calcit::Nil],
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),
@@ -11506,6 +11509,7 @@ mod tests {
       usage: CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
       args: Arc::new(CalcitFnArgs::Args(vec![0])),
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(1),
       body: vec![Calcit::Nil],
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),
@@ -11617,6 +11621,7 @@ mod tests {
       usage: crate::calcit::CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
       args: Arc::new(CalcitFnArgs::Args(vec![0])),
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(1),
       body: vec![hint_form],
       generics: Arc::new(vec![Arc::from("T")]),
       where_bounds: Arc::new(vec![crate::calcit::CalcitGenericBound {
@@ -12007,6 +12012,7 @@ mod tests {
       usage: crate::calcit::CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
       args: Arc::new(CalcitFnArgs::Args(vec![1, 2])), // 2 parameters
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(2),
       body: vec![Calcit::Nil],
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -705,6 +705,7 @@ mod tests {
       usage: Default::default(),
       scope: Arc::new(Default::default()),
       args: Arc::new(crate::calcit::CalcitFnArgs::Args(vec![])),
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(0),
       body: vec![],
       generics: Arc::new(vec![Arc::from("T")]),
       where_bounds: Arc::new(vec![]),

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -1887,6 +1887,7 @@ mod tests {
       usage: CalcitFnUsageMeta::default(),
       scope: Arc::new(CalcitScope::default()),
       args: Arc::new(CalcitFnArgs::Args(vec![0])),
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(1),
       body: vec![],
       generics: Arc::new(vec![Arc::from("T")]),
       where_bounds: Arc::new(vec![]),


### PR DESCRIPTION
## Summary

- cache fixed arity, trailing `Option` count, and rest evidence in a compact native call shape
- stop scanning typed argument metadata on every `run_fn` / `run_fn_owned` call
- retain the full function schema for preprocessing, codegen, queries, effects analysis, and diagnostics
- record the runtime-IR field audit and repeated A/B measurements

Progresses #464.

## Representation audit

Apple arm64 layout before the prototype:

| value | size |
| --- | ---: |
| `Calcit` | 88 B |
| `CalcitFn` | 176 B |
| `CalcitLocal` | 48 B |
| `CalcitScope` | 24 B |

`Calcit::Fn` already shares an `Arc<CalcitFn>`, so normal calls do not clone the generic, bound, return, or argument annotation graphs. The observed hot metadata read was optional/rest call-shape discovery. `CalcitFnCallShape` is 6 bytes and fills existing alignment padding, leaving `CalcitFn` at 176 bytes and adding no heap allocation.

Shrinking `CalcitLocal` in place cannot shrink the 88-byte `Calcit` enum. A later material-memory prototype therefore needs a genuinely separate execution expression rather than merely rearranging metadata fields.

## Benchmarks

Baseline: main `86c47a93`; Apple arm64 release builds; alternating process order for focused A/B runs.

| workload | main median | branch median | paired median change |
| --- | ---: | ---: | ---: |
| native fold, 200,000 callback calls, 30 pairs | 119.280 ms | 117.647 ms | -1.34% |
| native fold, 1,000,000 callback calls, 15 pairs | 607.412 ms | 594.369 ms | -2.09% |

Latest-project test-body medians remained in noise:

| project | main | branch | result |
| --- | ---: | ---: | --- |
| Respo `27bb6304`, 15 samples | 30.867 ms | 31.255 ms | 27/27 passed |
| Recollect `e0903a6d`, 15 samples | 9.520 ms | 9.520 ms | 9/9 passed |

Median peak RSS moved from 48,201,728 to 47,726,592 bytes for Respo and from 70,172,672 to 68,927,488 bytes for Recollect, but process-level variance is too high to claim a memory reduction. Release binary size changed from 9,212,896 to 9,213,136 bytes (+240 bytes).

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface` (17/17)
- globally installed branch build reports Calcit 0.13.46
- latest Respo: 27/27 native tests and JS check-only
- latest Recollect: 9/9 native tests and generated-JS test entry
