### PR TITLE
feat: add recoverable file effect methods

### DIFF
--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -354,6 +354,14 @@
               println "|Env mode:" $ get-env |mode
               println "|Env mode:" $ option:unwrap-or (get-env |m0) "|default m0"
               eprintln "|stdout message"
+              do
+                assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .read-file)
+                assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir false)
+                assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .write-file |content)
+                assert-type (|/calcit-result-contract-does-not-exist/file .read-file) (:: 'Result 'String 'String)
+                assert-type (|/calcit-result-contract-does-not-exist .read-dir false)
+                  :: 'Result (:: 'List 'String) 'String
+                assert-type (|/calcit-result-contract-does-not-exist/file .write-file |content) (:: 'Result 'Unit 'String)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -356,10 +356,15 @@
               eprintln "|stdout message"
               do
                 assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .read-file)
-                assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir false)
+                assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir)
+                assert= true $ result:err?
+                  |/calcit-result-contract-does-not-exist .read-dir $ %some false
                 assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .write-file |content)
                 assert-type (|/calcit-result-contract-does-not-exist/file .read-file) (:: 'Result 'String 'String)
-                assert-type (|/calcit-result-contract-does-not-exist .read-dir false)
+                assert-type (|/calcit-result-contract-does-not-exist .read-dir)
+                  :: 'Result (:: 'List 'String) 'String
+                assert-type
+                  |/calcit-result-contract-does-not-exist .read-dir $ %some false
                   :: 'Result (:: 'List 'String) 'String
                 assert-type (|/calcit-result-contract-does-not-exist/file .write-file |content) (:: 'Result 'Unit 'String)
           :examples $ []

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -380,10 +380,13 @@ parsed .and-then
 `.and-then`，让错误类型转换保持可见：
 
 ```cirru.no-check
-read-file path .and-then $ fn (content)
+path .read-file .and-then $ fn (content)
   parse-data content .and-then $ fn (data)
     save-data data
 ```
+
+文件路径上的 `.read-file`、`.read-dir` 与 `.write-file` 返回 `Result<...,String>`；
+底层同名函数仍保留抛错行为以兼容旧代码。预期 I/O 失败时优先使用方法形式。
 
 `option:let` 使用普通 `let` 的 binding pair 结构。每个右侧和最终 body 都必须保持
 Option 容器；Result 错误类型需要转换时显式使用 `.map-err`。

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -381,12 +381,13 @@ parsed .and-then
 
 ```cirru.no-check
 (path .read-file) .and-then $ fn (content)
-  parse-data content .and-then $ fn (data)
+  (parse-data content) .and-then $ fn (data)
     save-data data
 ```
 
 文件路径上的 `.read-file`、`.read-dir` 与 `.write-file` 返回 `Result<...,String>`；
 底层同名函数仍保留抛错行为以兼容旧代码。预期 I/O 失败时优先使用方法形式。
+这些文件效果支持 native 与生成的 JavaScript；WASM 尚未提供宿主文件效果。
 
 `option:let` 使用普通 `let` 的 binding pair 结构。每个右侧和最终 body 都必须保持
 Option 容器；Result 错误类型需要转换时显式使用 `.map-err`。

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -380,7 +380,7 @@ parsed .and-then
 `.and-then`，让错误类型转换保持可见：
 
 ```cirru.no-check
-path .read-file .and-then $ fn (content)
+(path .read-file) .and-then $ fn (content)
   parse-data content .and-then $ fn (data)
     save-data data
 ```

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -331,9 +331,8 @@ The first argument is the value to match, the second is the default/fallback, fo
 ### Reading and Writing
 
 ```cirru.no-run
-|data.txt .read-file .and-then $ fn (content)
-  &doseq (line $ split-lines content)
-    println line
+(|data.txt .read-file) .and-then $ fn (content)
+  println content
   %ok &unit
 ```
 

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -336,7 +336,7 @@ The first argument is the value to match, the second is the default/fallback, fo
   %ok &unit
 ```
 
-The String methods `.read-file`, `.read-dir`, and `.write-file` return `Result`, so expected I/O failures stay in the typed flow. The raw `read-file`, `read-dir`, and `write-file` procedures remain raising compatibility primitives.
+The String methods `.read-file`, `.read-dir`, and `.write-file` return `Result`, so expected I/O failures stay in the typed flow. The raw `read-file`, `read-dir`, and `write-file` procedures remain raising compatibility primitives. Native and generated JavaScript support these host file effects; WASM does not yet expose them.
 
 ## Math Operations
 

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -331,13 +331,13 @@ The first argument is the value to match, the second is the default/fallback, fo
 ### Reading and Writing
 
 ```cirru.no-run
-let
-    content $ read-file |data.txt
-    lines $ split-lines content
-  println content
-  &doseq (line lines)
+|data.txt .read-file .and-then $ fn (content)
+  &doseq (line $ split-lines content)
     println line
+  %ok &unit
 ```
+
+The String methods `.read-file`, `.read-dir`, and `.write-file` return `Result`, so expected I/O failures stay in the typed flow. The raw `read-file`, `read-dir`, and `write-file` procedures remain raising compatibility primitives.
 
 ## Math Operations
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -400,8 +400,8 @@ lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
 ### Effects/IO
 
 - `echo`, `println` - output
-- `.read-file`, `.read-dir`, `.write-file` - recoverable String methods returning `Result`
-- `read-file`, `read-dir`, `write-file` - raising compatibility primitives
+- `.read-file`, `.read-dir`, `.write-file` - recoverable String methods returning `Result` (native/JS; unavailable in WASM)
+- `read-file`, `read-dir`, `write-file` - raising compatibility primitives (native/JS; unavailable in WASM)
 - `get-env` - environment variables
 - `raise` - throw error
 - `quit!` - exit program

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -400,7 +400,8 @@ lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
 ### Effects/IO
 
 - `echo`, `println` - output
-- `read-file`, `write-file` - file operations
+- `.read-file`, `.read-dir`, `.write-file` - recoverable String methods returning `Result`
+- `read-file`, `read-dir`, `write-file` - raising compatibility primitives
 - `get-env` - environment variables
 - `raise` - throw error
 - `quit!` - exit program

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -72,12 +72,13 @@ loaded .and-then $ fn (value) (validate value)
 
 ```cirru.no-check
 (path .read-file) .and-then $ fn (content)
-  parse-data content .and-then $ fn (data)
+  (parse-data content) .and-then $ fn (data)
     save-data data
 ```
 
 文件路径上的 `.read-file`、`.read-dir` 与 `.write-file` 返回 `Result<...,String>`；
 底层同名函数仍保留抛错行为以兼容旧代码。预期 I/O 失败时优先使用方法形式。
+这些文件效果支持 native 与生成的 JavaScript；WASM 尚未提供宿主文件效果。
 
 `option:let` 的 body 必须继续返回 `Option`。普通组合函数仍以接收者方法
 作为公开形式，`option:*` / `result:*` 直接函数调用主要保留给 core lowering。

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -71,7 +71,7 @@ loaded .and-then $ fn (value) (validate value)
 `.and-then`，让错误类型的转换保持可见：
 
 ```cirru.no-check
-path .read-file .and-then $ fn (content)
+(path .read-file) .and-then $ fn (content)
   parse-data content .and-then $ fn (data)
     save-data data
 ```

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -71,10 +71,13 @@ loaded .and-then $ fn (value) (validate value)
 `.and-then`，让错误类型的转换保持可见：
 
 ```cirru.no-check
-read-file path .and-then $ fn (content)
+path .read-file .and-then $ fn (content)
   parse-data content .and-then $ fn (data)
     save-data data
 ```
+
+文件路径上的 `.read-file`、`.read-dir` 与 `.write-file` 返回 `Result<...,String>`；
+底层同名函数仍保留抛错行为以兼容旧代码。预期 I/O 失败时优先使用方法形式。
 
 `option:let` 的 body 必须继续返回 `Option`。普通组合函数仍以接收者方法
 作为公开形式，`option:*` / `result:*` 直接函数调用主要保留给 core lowering。

--- a/editing-history/202608262220-result-file-effects.md
+++ b/editing-history/202608262220-result-file-effects.md
@@ -1,0 +1,26 @@
+# Result-based file effects
+
+## Summary
+
+- Added String methods `.read-file`, `.read-dir`, and `.write-file` that convert recoverable file failures into `Result<..., String>` while retaining the raising raw procedures for compatibility.
+- Added native and generated-JavaScript regression coverage for missing paths and static Result contracts.
+- Completed the JavaScript host boundary for file effects: `read_file` now returns and validates injected content, `read_dir` validates/sorts host paths, and missing injections raise stable errors that the safe methods can catch.
+- Updated type guidance and file-operation examples to prefer receiver methods.
+- Fixed a Rust 1.97 Clippy finding in the previously landed native-call-shape test so the required `-D warnings` gate remains clean.
+
+## Knowledge retained
+
+- A language-level `try` wrapper is sufficient for Result-returning effects and keeps raw primitives ABI-compatible. Because generated JavaScript `try` normalizes host exceptions to String, the same core wrapper works on native and JS.
+- Core String methods are registered in `&core-string-methods`; adding a method there makes receiver typing and method discovery reuse the wrapper function schema.
+- Node file effects are host capabilities supplied through `globalThis.__calcit_injections__`. Validate values at this Dynamic boundary before returning them to typed Calcit code. Browser `read-file` keeps its localStorage compatibility path but now raises on a missing key, matching the recoverable failure contract.
+- `read-dir` must sort injected JavaScript paths to match the native procedure's deterministic contract.
+- WASM currently skips `try`-based file wrappers and does not expose host file procedures; keep this backend limit explicit in API docs and regression output.
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `yarn check-all`
+- Latest Respo main: 27/27 tests, 111/111 documentation blocks, JS codegen
+- Latest Recollect main: 9/9 native tests, generated JS tests, production build with Node 24.4.1, required WASM checks

--- a/editing-history/202608262228-fix-result-method-doc-chain.md
+++ b/editing-history/202608262228-fix-result-method-doc-chain.md
@@ -1,0 +1,5 @@
+# Fix Result method chaining in file examples
+
+The Markdown checker exposed a Cirru association pitfall in the new examples: `path .read-file .and-then` passes `.and-then` and its callback as extra arguments to `.read-file`. Parenthesize the first receiver call as `(path .read-file) .and-then` so the Result method receives the completed `Result` value. The checked example keeps its callback body direct to avoid unrelated nested callback inference obscuring the file-effect contract.
+
+Validated with the repository-wide Markdown check.

--- a/editing-history/202608262237-result-file-review.md
+++ b/editing-history/202608262237-result-file-review.md
@@ -1,0 +1,8 @@
+# Address Result file-effect review
+
+- Grouped both receiver expressions in the documented Result chain so Cirru does not pass later method tokens as extra arguments.
+- Made `.read-dir` preserve the default non-recursive call without reintroducing a legacy nil parameter: its trailing recursion flag is `Option<Bool>`, omission supplies `%none`, and explicit recursion uses `%some true` or `%some false`.
+- Added omitted and explicit Option cases to native and generated-JavaScript tests.
+- Repeated the native/JavaScript support and WASM host-effect boundary at each public documentation entry.
+
+Validated with targeted examples/tests, native and generated JavaScript runs, and the full Markdown checker.

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -15,6 +15,24 @@ try {
 
   const runtimeA = await import(pathToFileURL(join(runtimeAPath, "calcit.procs.mjs")).href);
   const runtimeB = await import(pathToFileURL(join(runtimeBPath, "calcit.procs.mjs")).href);
+  const writes = [];
+  globalThis.__calcit_injections__ = {
+    read_file: (path) => `content:${path}`,
+    read_dir: (path, recursive) => [`${path}/z`, `${path}/${recursive ? "deep/a" : "a"}`],
+    write_file: (path, content) => writes.push([path, content]),
+  };
+  assert.equal(runtimeA.read_file("demo.txt"), "content:demo.txt", "read-file must return the injected host value");
+  assert.deepEqual(
+    runtimeA.listToArray(runtimeA.read_dir("demo", false)),
+    ["demo/a", "demo/z"],
+    "read-dir must validate, sort, and convert injected host paths"
+  );
+  assert.equal(runtimeA.write_file("demo.txt", "next"), undefined, "write-file must preserve its Unit contract");
+  assert.deepEqual(writes, [["demo.txt", "next"]]);
+  globalThis.__calcit_injections__.read_file = () => undefined;
+  assert.throws(() => runtimeA.read_file("bad.txt"), /expected a string result/);
+  globalThis.__calcit_injections__.read_dir = () => ["ok", 1];
+  assert.throws(() => runtimeA.read_dir("bad", false), /array of strings/);
   assert.equal(runtimeA.get_env, runtimeA._$n_get_env, "legacy get_env export should delegate to the raw proc");
   assert.equal(runtimeA.get_env("CALCIT_MISSING_ENV_FOR_RUNTIME_TEST", "fallback"), "fallback");
   assert.equal(
@@ -212,5 +230,6 @@ try {
 
   console.log("JS runtime identity check passed");
 } finally {
+  delete globalThis.__calcit_injections__;
   await rm(fixtureRoot, { recursive: true, force: true });
 }

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -220,7 +220,7 @@ pub fn write_file(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match (xs.first(), xs.get(1)) {
     (Some(Calcit::Str(path)), Some(Calcit::Str(content))) => match fs::write(&**path, &**content) {
       Ok(_) => Ok(Calcit::Unit),
-      Err(e) => CalcitErr::err_str(CalcitErrKind::Effect, format!("write-file failed, {e}")),
+      Err(e) => CalcitErr::err_str(CalcitErrKind::Effect, format!("write-file failed at {}: {e}", &**path)),
     },
     (Some(a), Some(b)) => {
       let msg = format!(

--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -347,7 +347,7 @@ mod tests {
     assert!(marked_shape.has_rest());
 
     let typed = CalcitFnArgs::Args(vec![1]);
-    assert!(CalcitFnCallShape::from_parts(&typed, &[crate::calcit::DYNAMIC_TYPE.clone()], true).has_rest());
+    assert!(CalcitFnCallShape::from_parts(&typed, std::slice::from_ref(&*crate::calcit::DYNAMIC_TYPE), true).has_rest());
   }
 
   #[test]

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -7683,17 +7683,20 @@
                   assert= true $ result:ok? (|1 .parse-json)
                   assert= true $ result:err? (|{ .parse-json)
                   assert-type (|1 .parse-json) (:: 'Result 'Dynamic 'String)
-        |try-read-dir $ %{} 'CodeEntry (:doc "|List directory paths as Result<List<String>,String>; failures are returned instead of raised. Prefer the .read-dir String method in user code. Native is supported; JavaScript requires a host read_dir injection, and WASM file effects are not yet supported.")
+        |try-read-dir $ %{} 'CodeEntry (:doc "|List directory paths as Result<List<String>,String>; failures are returned instead of raised. Prefer the .read-dir String method in user code. Omit the trailing Option<Bool> for non-recursive listing, or pass %some true/%some false explicitly. Native is supported; JavaScript requires a host read_dir injection, and WASM file effects are not yet supported.")
           :code $ quote
             defn try-read-dir (path recursive?)
               try
-                %ok $ read-dir path recursive?
+                %ok $ tag-match recursive?
+                  (:some recursive?) (read-dir path recursive?)
+                  (:none) (read-dir path)
                 fn (message) (%err message)
           :examples $ []
-            quote $ |/calcit-result-contract-does-not-exist .read-dir false
+            quote $ |src .read-dir
+            quote $ |src .read-dir (%some true)
           :schema $ :: 'Fn
             {}
-              :args $ [] 'String 'Bool
+              :args $ [] 'String (:: 'Option 'Bool)
               :return $ :: 'Result (:: 'List 'String) 'String
         |try-read-file $ %{} 'CodeEntry (:doc "|Read a UTF-8 file as Result<String,String>; failures are returned instead of raised. Prefer the .read-file String method in user code. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
           :code $ quote
@@ -7712,12 +7715,19 @@
               :code $ quote
                 do
                   assert= true $ result:ok? (|Cargo.toml .read-file)
-                  assert= true $ result:ok? (|src .read-dir false)
+                  assert= true $ result:ok? (|src .read-dir)
+                  assert= true $ result:ok?
+                    |src .read-dir $ %some false
                   assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .read-file)
-                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir false)
+                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir)
+                  assert= true $ result:err?
+                    |/calcit-result-contract-does-not-exist .read-dir $ %some false
                   assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .write-file |content)
                   assert-type (|/calcit-result-contract-does-not-exist/file .read-file) (:: 'Result 'String 'String)
-                  assert-type (|/calcit-result-contract-does-not-exist .read-dir false)
+                  assert-type (|/calcit-result-contract-does-not-exist .read-dir)
+                    :: 'Result (:: 'List 'String) 'String
+                  assert-type
+                    |/calcit-result-contract-does-not-exist .read-dir $ %some false
                     :: 'Result (:: 'List 'String) 'String
                   assert-type (|/calcit-result-contract-does-not-exist/file .write-file |content) (:: 'Result 'Unit 'String)
               :tags $ #{} :unit

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -436,7 +436,7 @@
           :tags $ #{} :internal
         |&core-string-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare) (:: :parse-cirru try-parse-cirru) (:: :parse-cirru-list try-parse-cirru-list) (:: :parse-cirru-edn try-parse-cirru-edn) (:: :parse-json try-parse-json)
+            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare) (:: :parse-cirru try-parse-cirru) (:: :parse-cirru-list try-parse-cirru-list) (:: :parse-cirru-edn try-parse-cirru-edn) (:: :parse-json try-parse-json) (:: :read-file try-read-file) (:: :read-dir try-read-dir) (:: :write-file try-write-file)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -5484,7 +5484,8 @@
         |js-nullish? $ %{} 'CodeEntry (:doc "|Return true when a JsNullish<T> boundary value is JavaScript null or undefined.")
           :code $ quote
             defn js-nullish? (x)
-              or (nil? x) (= :unit (type-of x))
+              or (nil? x)
+                = :unit $ type-of x
           :examples $ []
             quote $ assert= true (js-nullish? nil)
             quote $ assert= true (js-nullish? &unit)
@@ -7682,6 +7683,56 @@
                   assert= true $ result:ok? (|1 .parse-json)
                   assert= true $ result:err? (|{ .parse-json)
                   assert-type (|1 .parse-json) (:: 'Result 'Dynamic 'String)
+        |try-read-dir $ %{} 'CodeEntry (:doc "|List directory paths as Result<List<String>,String>; failures are returned instead of raised. Prefer the .read-dir String method in user code. Native is supported; JavaScript requires a host read_dir injection, and WASM file effects are not yet supported.")
+          :code $ quote
+            defn try-read-dir (path recursive?)
+              try
+                %ok $ read-dir path recursive?
+                fn (message) (%err message)
+          :examples $ []
+            quote $ |/calcit-result-contract-does-not-exist .read-dir false
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'String 'Bool
+              :return $ :: 'Result (:: 'List 'String) 'String
+        |try-read-file $ %{} 'CodeEntry (:doc "|Read a UTF-8 file as Result<String,String>; failures are returned instead of raised. Prefer the .read-file String method in user code. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
+          :code $ quote
+            defn try-read-file (path)
+              try
+                %ok $ read-file path
+                fn (message) (%err message)
+          :examples $ []
+            quote $ |/calcit-result-contract-does-not-exist/file .read-file
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'String
+              :return $ :: 'Result 'String 'String
+          :tests $ []
+            %{} 'TestEntry (:name |result-method-contract)
+              :code $ quote
+                do
+                  assert= true $ result:ok? (|Cargo.toml .read-file)
+                  assert= true $ result:ok? (|src .read-dir false)
+                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .read-file)
+                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir false)
+                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .write-file |content)
+                  assert-type (|/calcit-result-contract-does-not-exist/file .read-file) (:: 'Result 'String 'String)
+                  assert-type (|/calcit-result-contract-does-not-exist .read-dir false)
+                    :: 'Result (:: 'List 'String) 'String
+                  assert-type (|/calcit-result-contract-does-not-exist/file .write-file |content) (:: 'Result 'Unit 'String)
+              :tags $ #{} :unit
+        |try-write-file $ %{} 'CodeEntry (:doc "|Write UTF-8 content as Result<Unit,String>; failures are returned instead of raised. Prefer the .write-file String method in user code. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
+          :code $ quote
+            defn try-write-file (path content)
+              try
+                %ok $ write-file path content
+                fn (message) (%err message)
+          :examples $ []
+            quote $ |/calcit-result-contract-does-not-exist/file .write-file |content
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'String 'String
+              :return $ :: 'Result 'Unit 'String
         |tuple-enum $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn tuple-enum (_value) (raise "|`tuple-enum` was removed; use `enum-definition`, which returns Option<EnumDef>")

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1676,19 +1676,50 @@ export let buffer_$q_ = (x: CalcitValue): boolean => {
 
 export let _$n_str_$o_escape = (x: string) => JSON.stringify(x);
 
+export type CalcitFileInjections = {
+  read_file?: (path: string) => unknown;
+  read_dir?: (path: string, recursive: boolean) => unknown;
+  write_file?: (path: string, content: string) => unknown;
+};
+
+const get_file_injection = <K extends keyof CalcitFileInjections>(name: K): NonNullable<CalcitFileInjections[K]> => {
+  const injections = (globalThis as { __calcit_injections__?: CalcitFileInjections }).__calcit_injections__;
+  const injection = injections?.[name];
+  if (typeof injection !== "function") {
+    throw new Error(`${name} is unavailable: the JavaScript host did not provide a __calcit_injections__.${name} function`);
+  }
+  return injection as NonNullable<CalcitFileInjections[K]>;
+};
+
 export let read_file = (path: string): string => {
   if (inNodeJs) {
-    // TODO
-    (globalThis as any)["__calcit_injections__"].read_file(path);
+    const content = get_file_injection("read_file")(path);
+    if (typeof content !== "string") {
+      throw new TypeError(`read_file injection expected a string result, got ${typeof content}`);
+    }
+    return content;
   } else {
     // no actual File API in browser
-    return localStorage.get(path) ?? "";
+    const content = localStorage.getItem(path);
+    if (content === null) {
+      throw new Error(`read-file failed at ${path}: key not found in localStorage`);
+    }
+    return content;
   }
+};
+export let read_dir = (path: string, recursive: boolean): CalcitSliceList => {
+  if (!inNodeJs) {
+    throw new Error("read_dir is unavailable in browser JavaScript hosts");
+  }
+  const paths = get_file_injection("read_dir")(path, recursive);
+  if (!Array.isArray(paths) || !paths.every((item) => typeof item === "string")) {
+    throw new TypeError("read_dir injection expected an array of strings");
+  }
+  return new CalcitSliceList([...paths].sort());
 };
 export let write_file = (path: string, content: string): void => {
   if (inNodeJs) {
-    // TODO
-    (globalThis as any)["__calcit_injections__"].write_file(path, content);
+    get_file_injection("write_file")(path, content);
   } else {
     // no actual File API in browser
     localStorage.setItem(path, content);


### PR DESCRIPTION
## Summary

- add String-first `.read-file`, `.read-dir`, and `.write-file` methods returning typed `Result` values
- retain the raw raising procedures for compatibility and preserve IO classification
- complete and validate the JavaScript host-injection boundary, including deterministic directory ordering
- document the safe flow and cover native/generated-JS success, failure, and static type contracts
- fix the Rust 1.97 Clippy finding exposed by the required `-D warnings` gate

## API

```cirru
|data.cirru .read-file
|assets .read-dir
|assets .read-dir $ %some true
|output.cirru .write-file content
```

The inferred return types are `Result<String,String>`, `Result<List<String>,String>`, and `Result<Unit,String>`. The trailing directory recursion flag is `Option<Bool>`: omission means non-recursive, while `%some true` requests recursion. The function-form compatibility entries are `try-read-file`, `try-read-dir`, and `try-write-file`.

WASM still skips these `try`-based wrappers because host file effects are not exposed there; this limit is documented and the existing WASM suite remains green.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn check-all`
- latest Respo main: 27/27 tests, 111/111 documentation blocks, JS codegen
- latest Recollect main: 9/9 native tests, generated JS tests, production build with Node 24.4.1, required WASM checks

Recollect currently pins Calcit/`@calcit/procs` 0.13.45, so its unreleased-CLI build reports the expected version-skew warning for the new `read_dir` export; the build and WASM checks still pass. A matching runtime package is produced by the eventual Calcit release.

Part of #428.
