### PR TITLE
fix: keep release builds on stable Rust

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
 
       - uses: Swatinem/rust-cache@v2

--- a/editing-history/202608270059-fix-stable-rust-build.md
+++ b/editing-history/202608270059-fix-stable-rust-build.md
@@ -1,0 +1,7 @@
+# Keep the release path buildable on stable Rust
+
+- Replaced three unstable `if let` match guards with equivalent nested stable
+  control flow.
+- Kept enum and function-schema resolution order unchanged.
+- Changed the regular CI toolchain from nightly to stable so it matches the
+  publish workflow and catches stable-channel build blockers before release.

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2316,8 +2316,12 @@ impl CalcitTypeAnnotation {
               args.first().cloned().unwrap_or_else(|| DYNAMIC_TYPE.clone()),
             ));
           }
-          "Fn" if let Some(schema_form) = enum_value.extra.first() => {
-            if let Some(parsed) = Self::parse_fn_annotation_from_schema_form(schema_form, generics, strict_named_refs) {
+          "Fn" => {
+            if let Some(parsed) = enum_value
+              .extra
+              .first()
+              .and_then(|schema_form| Self::parse_fn_annotation_from_schema_form(schema_form, generics, strict_named_refs))
+            {
               return parsed;
             }
           }
@@ -2539,8 +2543,11 @@ impl CalcitTypeAnnotation {
                   args.first().cloned().unwrap_or_else(|| DYNAMIC_TYPE.clone()),
                 ));
               }
-              "Fn" if let Some(schema_form) = xs.get(2) => {
-                if let Some(parsed) = Self::parse_fn_annotation_from_schema_form(schema_form, generics, strict_named_refs) {
+              "Fn" => {
+                if let Some(parsed) = xs
+                  .get(2)
+                  .and_then(|schema_form| Self::parse_fn_annotation_from_schema_form(schema_form, generics, strict_named_refs))
+                {
                   return parsed;
                 }
               }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5929,10 +5929,11 @@ fn resolve_enum_type_for_match(
   let stripped = name.trim_start_matches('\'').trim_start_matches(':');
   let short_name = stripped.rsplit('/').next().unwrap_or(stripped);
   if let Some(local_type) = scope_types.get(stripped).or_else(|| scope_types.get(short_name)) {
-    match local_type.as_ref() {
-      CalcitTypeAnnotation::EnumDef(enum_def) => return Some(enum_def.as_ref().to_owned()),
-      _ if let Some(enum_def) = local_type.resolve_to_enum() => return Some(enum_def),
-      _ => {}
+    if let CalcitTypeAnnotation::EnumDef(enum_def) = local_type.as_ref() {
+      return Some(enum_def.as_ref().to_owned());
+    }
+    if let Some(enum_def) = local_type.resolve_to_enum() {
+      return Some(enum_def);
     }
   }
   let (target_ns, target_def) = if let Some((ns, def)) = stripped.rsplit_once('/') {


### PR DESCRIPTION
## Problem

Calcit `main` used three `if let` match guards. They compile in the nightly test
workflow but fail on the stable toolchain used by `publish.yaml`, so the
0.13.47 release source cannot complete its stable build.

## Changes

- replace the unstable guards with equivalent stable control flow
- preserve function-schema and enum resolution order
- run the regular test workflow on stable, matching the publish workflow

## Validation

- reproduced the failure with `cargo +stable check` on the base revision
- `cargo +stable check`
- `cargo +stable clippy -- -D warnings`
- `cargo +stable test`
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all`

This should land before the next patch release; the existing 0.13.47 tag still
points at the stable-build-blocked revision.
