### PR TITLE
feat: reject retired compact snapshots

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -34,7 +34,7 @@ leads_to:
    calcit docs agents --full
    ```
 
-3. `calcit.cirru`（旧项目可能是 `compact.cirru`）是 **Cirru EDN 树形 Snapshot**，不是按行维护的文本源码。不要用 line patch、正则脚本或 formatter 直接改它；使用 `calcit edit`、`calcit tree`、`calcit cursor`。
+3. `calcit.cirru` 是 **Cirru EDN 树形 Snapshot**，不是按行维护的文本源码。旧项目若只有 `compact.cirru`，先按 upgrade 指南迁移；当前工具会拒绝旧文件名。不要用 line patch、正则脚本或 formatter 直接改 Snapshot；使用 `calcit edit`、`calcit tree`、`calcit cursor`。
 4. `CURSOR`、`FOLDED:*`、chunk 标题和 path annotation 都是展示信息，绝不能复制回 Snapshot。`cursor show --format json` 中 `tree` 才是真实节点，`preview_tree` 只是展示树。
 
 ### 0.1 发现 Calcit 缺陷时：定位归属仓库并提交 Issue
@@ -64,7 +64,7 @@ calcit query config
 calcit .calcit/snippets/demo.cirru query config
 ```
 
-当 cwd、`calcit.cirru` / `compact.cirru` 或多个 Snapshot 可能混淆时，先选定文件，并在后续查询、mutation、验证中始终显式传同一个路径（如 `calcit ./calcit.cirru ...`）。非默认 Snapshot 会包含在 `Command:` 回显中；默认值为减少噪音会省略，需要审计展开后的全部默认选项时加 `--verbose`。路径仍可能经过 alias 解析，必要时结合 `query config` 确认项目身份。
+当 cwd、`calcit.cirru` 或多个 Snapshot 可能混淆时，先选定文件，并在后续查询、mutation、验证中始终显式传同一个路径（如 `calcit ./calcit.cirru ...`）。遇到 `compact.cirru` 时暂停 mutation，先复制或重命名为 `calcit.cirru` 并按 upgrade 指南验证。非默认 Snapshot 会包含在 `Command:` 回显中；默认值为减少噪音会省略，需要审计展开后的全部默认选项时加 `--verbose`。必要时结合 `query config` 确认项目身份。
 
 `calcit [snapshot-file]` 默认选择 `entries.default` 并按它的 `:mode`（`:native` / `:js`）单次运行；`--entry <name>` 选择其他入口。显式 `js` 保留为覆盖方式。只有明确需要监听时才加 `-w` / `--watch`。`calcit ir` 只用于编译器/生成结果调试，不作为日常构建或完成证明。这里的 snapshot 文件不要与 `--entry <named-entry>` 混淆。
 
@@ -117,7 +117,7 @@ entry 都是独立配置，不能假设其模块继承 default。`--check-only` 
 重复传入 `--dep`。动态加载、未调用的公开 API 和外部消费者不在这些静态结果的证明范围内。
 
 注意：`config modules --entry` 与顶层 `--entry` 选择 named entry；`docs check-md --entry` 则选择用于
-检查的 snapshot 文件（如 `calcit.cirru` 或 `compact.cirru`），两者不是同一种参数。
+检查的 snapshot 文件（`calcit.cirru`），两者不是同一种参数。
 
 读取源码优先使用 human/Cirru 输出；只有需要稳定字段、自动分支或静态证据时才使用 `--format json`。`--format json` 承诺 stdout 为单个 JSON envelope；某些命令的 `--json` 只是在人类输出后附加 JSON，具体以子命令 `--help` 为准。
 

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -236,7 +236,7 @@ let
 
 ## Quotes
 
-Quoted Cirru is preserved as syntax data. This is used by runtime snapshots (`calcit.cirru`, legacy `compact.cirru`):
+Quoted Cirru is preserved as syntax data. This is used by runtime snapshots (`calcit.cirru`):
 
 ```cirru
 quote $ def a 1

--- a/docs/features/imports.md
+++ b/docs/features/imports.md
@@ -22,7 +22,7 @@ entry_for:
 
 # Imports
 
-Calcit loads namespaces from `calcit.cirru` (legacy filename: `compact.cirru`). Dependencies are tracked via `~/.config/calcit/modules/`.
+Calcit loads namespaces from `calcit.cirru`. Dependencies are installed into the project module view under `.calcit/modules/`.
 
 ## Quick Recipes
 

--- a/docs/installation/modules.md
+++ b/docs/installation/modules.md
@@ -17,7 +17,7 @@ entry_for:
 
 Packages are managed with `caps` command, which wraps `git clone` and `git pull` to manage modules.
 
-Configurations inside runtime snapshot files (`calcit.cirru`, legacy `compact.cirru`):
+Configurations inside runtime snapshot files (`calcit.cirru`):
 
 ```cirru.edn
 {}
@@ -28,6 +28,6 @@ Configurations inside runtime snapshot files (`calcit.cirru`, legacy `compact.ci
 
 Paths defined in `:modules` field are just loaded as files from `~/.config/calcit/modules/`, i.e. `~/.config/calcit/modules/memof/calcit.cirru`.
 
-Modules that ends with `/`s are automatically suffixed `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
+Modules that end with `/` are automatically suffixed with `calcit.cirru`. Retired `compact.cirru` modules are rejected with migration guidance.
 
 To load modules in CI environments, make use of `caps --ci`.

--- a/docs/intro/indentation-syntax.md
+++ b/docs/intro/indentation-syntax.md
@@ -19,7 +19,7 @@ When using the MCP (Model Context Protocol) server, each documentation or code f
 
 # Indentation-based Syntax
 
-Calcit was designed based on tools from [Cirru Project](http://cirru.org/), which means, it's suggested to be programming with [Calcit Editor](https://github.com/calcit-lang/editor/). It will emit a file `calcit.cirru` containing data of the code; the legacy filename `compact.cirru` is still supported. And the data is still written in [Cirru EDN](https://github.com/Cirru/cirru-edn#syntax), Clojure EDN but based on Cirru Syntax.
+Calcit was designed based on tools from [Cirru Project](http://cirru.org/), which means, it's suggested to be programming with [Calcit Editor](https://github.com/calcit-lang/editor/). It emits the canonical `calcit.cirru` source snapshot. The data is written in [Cirru EDN](https://github.com/Cirru/cirru-edn#syntax), Clojure EDN but based on Cirru Syntax.
 
 For Cirru Syntax, read <http://text.cirru.org/>, and you may find a live demo at <http://repo.cirru.org/parser.coffee/>. A normal snippet looks like: this
 
@@ -31,7 +31,7 @@ defn fibo (x)
 
 But also, you can write Calcit code directly in a snapshot file and run it with `calcit`.
 
-To run `calcit.cirru` (or legacy `compact.cirru`), internally it's doing steps:
+To run `calcit.cirru`, internally it's doing steps:
 
 1. parse Cirru Syntax into vectors,
 2. turn Cirru vectors into Cirru EDN, which is a piece of data,

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -32,7 +32,7 @@ calcit eval "echo |done"
 
 ## Core Commands
 
-- `calcit` - Run Calcit program (default: `calcit.cirru`, fallback: `compact.cirru`)
+- `calcit` - Run Calcit program from `calcit.cirru`; retired `compact.cirru` inputs receive migration guidance
 - `calcit eval "code"` - Evaluate code snippet
 - `calcit js` - Generate JavaScript
 - `calcit query ...` - Query definitions/usages/search
@@ -197,7 +197,7 @@ let
 ## File Structure
 
 - `calcit.cirru` - Preferred runtime snapshot and structural-editing source
-- `compact.cirru` - Legacy runtime snapshot filename kept for compatibility
+- `compact.cirru` - Retired runtime snapshot filename; migrate it to `calcit.cirru` with Calcit 0.13.48 as the final compatibility release
 - `deps.cirru` - Dependencies
 - `.compact-inc.cirru` - Hot reload trigger, including incremental changes
 

--- a/docs/run/agent-advanced.md
+++ b/docs/run/agent-advanced.md
@@ -119,7 +119,7 @@ echo 'range 10' | calcit exec
 
 以下文件**严格禁止使用文本替换或直接编辑**：
 
-- **`calcit.cirru` / `compact.cirru`** - 这是 Calcit 程序的运行时快照格式；推荐使用 `calcit.cirru`，旧文件名 `compact.cirru` 仍兼容，必须使用 `calcit edit`/`calcit tree` 进行修改
+- **`calcit.cirru`** - 这是 Calcit 程序的运行时快照格式；旧 `compact.cirru` 必须先迁移，源码使用 `calcit edit`/`calcit tree` 修改
 
 这两个文件的格式对空格和结构极其敏感，直接文本修改会破坏文件结构。请使用 `calcit query`/`calcit tree`/`calcit edit` 等 CLI 命令进行代码查询和修改。
 
@@ -131,7 +131,7 @@ echo 'range 10' | calcit exec
 
 **具体体现：**
 
-- `calcit.cirru`（兼容旧文件名 `compact.cirru`）使用 Cirru 语法存储，必须用 `calcit tree`/`calcit edit` 命令修改
+- `calcit.cirru` 使用 Cirru 语法存储，必须用 `calcit tree`/`calcit edit` 命令修改
 - `calcit cirru` 工具用于 Cirru 语法与 JSON 的转换（帮助理解和生成代码）
 - Cirru 语法特点：
   - 用缩进代替括号（类似 Python/YAML）

--- a/docs/run/agent-advanced.md
+++ b/docs/run/agent-advanced.md
@@ -121,7 +121,7 @@ echo 'range 10' | calcit exec
 
 - **`calcit.cirru`** - 这是 Calcit 程序的运行时快照格式；旧 `compact.cirru` 必须先迁移，源码使用 `calcit edit`/`calcit tree` 修改
 
-这两个文件的格式对空格和结构极其敏感，直接文本修改会破坏文件结构。请使用 `calcit query`/`calcit tree`/`calcit edit` 等 CLI 命令进行代码查询和修改。
+这个文件的格式对空格和结构极其敏感，直接文本修改会破坏文件结构。请使用 `calcit query`/`calcit tree`/`calcit edit` 等 CLI 命令进行代码查询和修改。
 
 ## Calcit 与 Cirru 的关系
 

--- a/docs/run/bundle-mode.md
+++ b/docs/run/bundle-mode.md
@@ -23,7 +23,7 @@ If you prefer to write Calcit code without the calcit-editor, that's possible to
 
 Calcit code can be written using indentation-based syntax. This means you don't need to match parentheses as in Clojure, but you must pay close attention to indentation.
 
-Use a `calcit.cirru` file (legacy filename: `compact.cirru`) with the `calcit` command to run the program.
+Use a `calcit.cirru` file with the `calcit` command to run the program. Retired `compact.cirru` inputs must be migrated first.
 
 For projects that still keep one namespace per indentation-based `.cirru` source file, the repository includes a one-shot Calcit bundler example:
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -174,7 +174,7 @@ calcit --reload-libs
 
 ### Config Entry (--entry)
 
-Use a specific entry from `calcit.cirru` (legacy filename: `compact.cirru`). Without this option Calcit selects `entries.default`; the selected entry's `:mode` chooses native execution or JS emission:
+Use a specific entry from `calcit.cirru`. Without this option Calcit selects `entries.default`; the selected entry's `:mode` chooses native execution or JS emission:
 
 ```bash
 calcit --entry test
@@ -233,7 +233,7 @@ calcit docs check-md README.md
 This defaults to `calcit.cirru` as the eval entry. If your project uses a different snapshot filename, pass it explicitly with `--entry`:
 
 ```bash
-calcit docs check-md README.md --entry compact.cirru
+calcit docs check-md README.md --entry calcit.cirru
 ```
 
 Load module dependencies with repeatable `--dep` options:

--- a/docs/run/edit-tree.md
+++ b/docs/run/edit-tree.md
@@ -42,7 +42,7 @@ The `edit` command handles high-level operations on namespaces and definitions.
 calcit edit format
 ```
 
-This command also rewrites older namespace records and top-level `:configs` into canonical shapes. It succeeds after recoverable migrations, while stderr identifies `W_LEGACY_CONFIG`, `W_LEGACY_SNAPSHOT_NAME`, `W_LEGACY_ANY`, or `W_DYNAMIC_TYPE_DEBT` when follow-up work is recommended. It does not invent concrete types; follow dynamic or unbound-slot warnings with `calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved`.
+This command also rewrites older namespace records and top-level `:configs` into canonical shapes. It succeeds after recoverable migrations, while stderr identifies `W_LEGACY_CONFIG`, `W_LEGACY_ANY`, or `W_DYNAMIC_TYPE_DEBT` when follow-up work is recommended. A retired `compact.cirru` filename is rejected before formatting. It does not invent concrete types; follow dynamic or unbound-slot warnings with `calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved`.
 
 ### Persistent Tree Cursor
 

--- a/docs/run/hot-swapping.md
+++ b/docs/run/hot-swapping.md
@@ -17,7 +17,7 @@ Since there are two platforms for running Calcit, soutions for hot swapping are 
 
 ### Rust runtime
 
-Hot swapping is built inside Rust runtime. When you specity `:reload-fn` in `calcit.cirru` (legacy filename: `compact.cirru`):
+Hot swapping is built inside Rust runtime. When you specify `:reload-fn` in `calcit.cirru`:
 
 ```cirru
 {}

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -55,7 +55,7 @@ git diff --exit-code -- calcit.cirru
 `edit format` 是可恢复的规范化步骤，不是完整 linter。它会继续完成格式化，同时对以下情况写入 stderr 告警并给出后续命令：
 
 - `W_LEGACY_CONFIG`：顶层 `:configs` 已迁移到 `:entries.default`。
-- `W_LEGACY_SNAPSHOT_NAME`：仍使用兼容文件名 `compact.cirru`。
+- `compact.cirru` 会被直接拒绝，不再进入 formatter 告警阶段。
 - `W_LEGACY_ANY`：schema 中的旧 `:any` 被规范化为 `'Dynamic`；其他旧 type tags 也会在已知类型位置改写为 quoted symbol。
 - `W_DYNAMIC_TYPE_DEBT`：本地定义仍有 unresolved dynamic；format 不会猜测类型并自动改写语义。
 
@@ -67,7 +67,7 @@ CI 中运行 `edit format` 后必须检查 diff，否则“命令成功”只说
 - 每个 entry 有明确的 `:mode :native` 或 `:mode :js`。
 - named entry 是完整配置，不继承 default 的 `:modules` 或 `:type-slots`。
 - `:init-fn` / `:reload-fn` 使用定义 symbol；旧字符串会在规范化写入时迁移。
-- `compact.cirru` 只作为兼容输入；新项目与脚本统一使用 `calcit.cirru`。
+- 项目、依赖模块和脚本只使用 `calcit.cirru`；`compact.cirru` 必须先按升级手册迁移。
 
 ## 2. 静态类型质量
 

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -51,7 +51,7 @@ caps remove --dev calcit-lang/calcit-test
 `caps outdated` and `caps upgrade --all` inspect both root groups and preserve each declaration's
 group.
 
-To load modules, use `:modules` configuration in `calcit.cirru` (legacy filename: `compact.cirru`):
+To load modules, use `:modules` configuration in `calcit.cirru`:
 
 ```cirru.edn
 {}
@@ -64,7 +64,7 @@ Paths defined in `:modules` are loaded only through `<project>/.calcit/modules/`
 this project view as links to the matching immutable revisions in the global store; it is therefore
 an error to run a project before its dependencies have been installed with `caps`.
 
-Modules that end with `/` are automatically suffixed with `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
+Modules that end with `/` are automatically suffixed with `calcit.cirru`. A module that only contains `compact.cirru` is rejected with migration guidance.
 
 ### Dependency graph
 

--- a/docs/run/project-structure.md
+++ b/docs/run/project-structure.md
@@ -17,9 +17,9 @@ entry_for:
 
 # 项目结构：`calcit.cirru` 与 `deps.cirru`
 
-## `calcit.cirru` 的 EDN 结构（兼容旧文件名 `compact.cirru`）
+## `calcit.cirru` 的 EDN 结构
 
-Agent 切到新窗口时，优先把 `calcit.cirru`（兼容旧文件名 `compact.cirru`）看成一个"可执行项目快照"，其顶层 EDN 结构通常是：
+Agent 切到新窗口时，把 `calcit.cirru` 看成一个"可执行项目快照"，其顶层 EDN 结构通常是：
 
 ```cirru.no-check
 {}
@@ -57,9 +57,9 @@ Agent 切到新窗口时，优先把 `calcit.cirru`（兼容旧文件名 `compac
 - `:description`：entry 用途的简短语义说明；只提供给人和工具阅读，不影响运行。
 - `:type-slots`：当前 entry 的编译期类型绑定（slot 名 → 完整 `namespace/definition` 路径或 `:dynamic`）。各 entry 都保存完整配置，彼此不继承。
 - `:files`：源码数据库（namespace → `:ns` + `:defs`；每个定义是 `CodeEntry`，包含 code/doc/examples/schema）。
-- `:modules`：加载的外部模块路径（通常来自 `~/.config/calcit/modules/`，目录结尾 `/` 默认补 `calcit.cirru`，并回退到 `compact.cirru`）。
+- `:modules`：加载的外部模块路径（通常来自项目 `.calcit/modules/`，目录结尾 `/` 补 `calcit.cirru`；旧 `compact.cirru` 模块会被拒绝）。
 
-一般避免直接修改 `calcit.cirru` 文件（兼容旧文件名 `compact.cirru`）, 因为可能会导致格式出错整体无法解析, 如果确实认为需要修改, 要确保修改以后立即执行 `calcit calcit.cirru edit format` 确保能够正确格式化.
+一般避免直接修改 `calcit.cirru` 文件，因为可能会导致格式出错整体无法解析；如果确实需要修改，要确保修改以后立即执行 `calcit calcit.cirru edit format`。
 
 启动解析顺序（实操最常用）：
 
@@ -116,7 +116,7 @@ project source.
 给 Agent 一个最小心智就够：
 
 - `deps.cirru`：声明"要下载哪些外部模块 + 期望的 calcit 版本 + 项目发布版本（`:version`）"。
-- `calcit.cirru`（兼容旧文件名 `compact.cirru`）：声明"运行时要加载哪些模块（`:modules`）+ 项目代码快照（`:files`）"。
+- `calcit.cirru`：声明"运行时要加载哪些模块（`:modules`）+ 项目代码快照（`:files`）"。
 
 版本号只以 `deps.cirru :version` 为权威，用 `caps version get/set/bump` 管理；`calcit.cirru :version`
 不会作为 `caps` 的回退来源。`calcit config version` / `calcit config set version` 已废弃，请改用 `caps version`。

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -45,7 +45,7 @@ related:
 git status --short
 git switch -c upgrade/calcit-latest
 calcit --version
-calcit compact.cirru                # 替换为旧项目原本可成功执行的入口命令
+calcit compact.cirru            # 仅在 0.13.48 或更早的旧工具链记录基线
 yarn test                       # 替换为项目原有的测试/构建命令
 ```
 
@@ -55,14 +55,14 @@ Snapshot 文件迁移、依赖升级和类型修复建议分别提交，任何�
 
 升级前先检查以下文件与配置是否齐全：
 
-- 运行入口：`calcit.cirru`（兼容旧文件名 `compact.cirru`）
+- 运行入口：`calcit.cirru`（严格版本不再接受 `compact.cirru`）
   - `:entries.default`（默认入口及 `:mode`）
   - `:entries.<name>`（额外入口及各自 `:mode`）
 - 命令入口：`README`、项目脚本、CI workflow
 - Node 工具链：`package.json`、`yarn.lock`、Corepack/Yarn 版本
 - 注意 git fetch 检查最新历史, 避免基于老版本操作导致变更冲突
 - 依赖边界：运行/编译期需要的模块放在 `:dependencies`；只供当前项目测试、examples、文档检查和维护脚本使用的模块放在 `:dev-dependencies`
-- 结构化编辑优先使用 `calcit edit` / `calcit tree`；若直接改过 `calcit.cirru`（或旧文件名 `compact.cirru`），提交前执行一次 `calcit calcit.cirru edit format`
+- 结构化编辑优先使用 `calcit edit` / `calcit tree`；若直接改过 `calcit.cirru`，提交前执行一次 `calcit calcit.cirru edit format`
 - 静态质量基线：`check-types`、`weak-types`、公开 namespace examples 与 Markdown 示例
 
 ### 快照文件迁移说明
@@ -72,12 +72,13 @@ Snapshot 文件迁移、依赖升级和类型修复建议分别提交，任何�
 - `calcit.cirru` — 存放完整 AST 快照，内容包含全部编译信息（带所有代码位置、类型标注等）
 - `compact.cirru` — 存放精简代码，是人工读写的主要文件
 
-当前推荐去掉旧的双文件模式，把精简 Snapshot 直接保存在 `calcit.cirru` 中，方便 `calcit` 命令直接读取使用。
+Calcit 0.13.48 是接受 `compact.cirru` 文件名的最后一个兼容版本；0.13.49 起会在反序列化前拒绝该文件名并给出迁移命令。
+严格版本只把精简 Snapshot 保存在 `calcit.cirru` 中。
 如果两个文件同时存在，不要仅凭文件名猜测哪个是有效源码；先在旧版本下分别检查 Git 历史、文件体积、
 项目脚本和实际运行入口。确认 `compact.cirru` 是当前可运行的精简 Snapshot 后再迁移：
 
 1. 确认 `compact.cirru` 是项目实际精简化代码，`calcit.cirru` 是完整 AST 快照（差异通常很大）
-2. 先在独立提交或临时分支中将 `compact.cirru` 复制/重命名为 `calcit.cirru`，不要和业务逻辑修复混在一起
+2. 使用 0.13.48 或更早的可运行工具链确认基线，再在独立提交或临时分支中将 `compact.cirru` 复制/重命名为 `calcit.cirru`，不要和业务逻辑修复混在一起
 3. 执行 `calcit calcit.cirru edit format`，审阅 diff，再对新的 `calcit.cirru` 运行 `--check-only` 和原有 entry/构建测试
 4. 新旧入口行为一致后再删除旧文件并提交；后续所有 `calcit` 命令都显式基于单一的 `calcit.cirru`
 
@@ -107,7 +108,7 @@ calcit calcit.cirru --check-only
 
 若 `rg` 没有匹配，才继续复制和格式化；如果仍有匹配，应逐个编辑 namespace 规则，而不是用全局替换，
 以免改动代码字符串中的同名文本。不要删除备份或旧文件，直到所有 entry 与原有 native/JS 测试均通过。现在反序列化错误会带上失败的
-Snapshot 路径；如果同目录存在 `compact.cirru`，还会直接给出上述恢复方向。
+Snapshot 路径；如果同目录存在 `compact.cirru`，还会直接给出上述恢复方向。严格版本不能直接格式化 `compact.cirru`；必须先复制或重命名为 `calcit.cirru`。
 
 旧 namespace 里的 `:require-macros` 也必须在 Snapshot 规范化前处理。宏与普通值现在共用
 `:require` 规则，例如把：

--- a/docs/structural-editor.md
+++ b/docs/structural-editor.md
@@ -18,7 +18,7 @@ As demonstrated in [Cirru Project](http://cirru.org/), it's for higher goals of 
 
 Structural editing makes Calcit a lot different from existing languages, even unique among Lisps.
 
-Calcit Editor uses `calcit.cirru` as the preferred snapshot file, which contains much informations. Legacy `compact.cirru` remains compatible as a runtime snapshot filename.
+Calcit Editor uses `calcit.cirru` as the canonical snapshot file. The retired `compact.cirru` filename must be migrated before current tools can load it.
 Example of a `calcit.cirru` file is more readable:
 
 ```cirru.no-check

--- a/editing-history/202608270132-reject-compact-snapshots.md
+++ b/editing-history/202608270132-reject-compact-snapshots.md
@@ -1,0 +1,8 @@
+# Reject retired compact.cirru snapshots
+
+- Reject `compact.cirru` before deserialization instead of silently running it
+  as a default or module fallback.
+- Point users to the canonical copy/rename, format, and check-only sequence.
+- Record 0.13.48 as the final compatibility release for the old filename.
+- Remove the obsolete formatter warning because formatting a retired filename
+  is no longer an accepted operation.

--- a/editing-history/202608270154-review-compact-migration-paths.md
+++ b/editing-history/202608270154-review-compact-migration-paths.md
@@ -1,0 +1,6 @@
+# Resolve compact snapshot migration review
+
+- Keep retired `compact.cirru` files out of normal module candidate resolution.
+- Detect compact-only modules separately so they retain actionable migration guidance.
+- Preserve nested module directories in the canonical destination and validation commands.
+- Correct the remaining singular snapshot wording in the agent guide.

--- a/src/bin/cli_handlers/common.rs
+++ b/src/bin/cli_handlers/common.rs
@@ -189,7 +189,7 @@ pub fn global_temp_path_guidance(path: &str, kind: GlobalTempPathKind) -> Option
       "`{path}` is under a global temporary directory. For project-local Calcit scratch input, prefer `.calcit/snippets/<name>`; keep `.calcit/` in `.gitignore`. For one-off multi-line input, omit `--file`/`--code` and pipe stdin instead."
     ),
     GlobalTempPathKind::Snapshot => format!(
-      "snapshot `{path}` is under a global temporary directory. Keep `calcit.cirru` (or legacy `compact.cirru`) at the project root so relative module paths and project-local files resolve from the intended base directory. Use `.calcit/snippets/` only for scratch files passed with `--file`, not for the project snapshot."
+      "snapshot `{path}` is under a global temporary directory. Keep `calcit.cirru` at the project root so relative module paths and project-local files resolve from the intended base directory. Use `.calcit/snippets/` only for scratch files passed with `--file`, not for the project snapshot."
     ),
   })
 }

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -284,14 +284,6 @@ fn collect_format_advisories(snapshot_file: &str, original_edn: &Edn, snapshot: 
     ));
   }
 
-  if Path::new(snapshot_file).file_name().and_then(|name| name.to_str()) == Some("compact.cirru") {
-    advisories.push(
-      "[W_LEGACY_SNAPSHOT_NAME] `compact.cirru` remains compatible but is the legacy snapshot filename.\n\
-       Next: rename it to `calcit.cirru`, then update scripts, CI, and ignore/attribute rules that still name the old file."
-        .to_owned(),
-    );
-  }
-
   let selected = std::collections::BTreeSet::from([
     crate::type_coverage::WeakTypeKind::SchemaDynamic,
     crate::type_coverage::WeakTypeKind::UnresolvedTypeSlot,
@@ -2611,7 +2603,7 @@ fn handle_inc(opts: &EditIncCommand, snapshot_file: &str) -> Result<(), String> 
     let file = snapshot
       .files
       .get(ns)
-      .ok_or_else(|| format!("Namespace '{ns}' not found in snapshot. Did you save calcit.cirru (or legacy compact.cirru)?"))?;
+      .ok_or_else(|| format!("Namespace '{ns}' not found in snapshot. Did you save calcit.cirru?"))?;
     changes.added.insert(Arc::from(ns.as_str()), file.clone());
   }
 
@@ -2625,7 +2617,7 @@ fn handle_inc(opts: &EditIncCommand, snapshot_file: &str) -> Result<(), String> 
     let file = snapshot
       .files
       .get(ns)
-      .ok_or_else(|| format!("Namespace '{ns}' not found in snapshot. Did you save calcit.cirru (or legacy compact.cirru)?"))?;
+      .ok_or_else(|| format!("Namespace '{ns}' not found in snapshot. Did you save calcit.cirru?"))?;
     let entry = ensure_change_entry(&mut changed_entries, ns);
     entry.ns = Some(file.ns.code.clone());
   }
@@ -2670,9 +2662,7 @@ fn handle_inc(opts: &EditIncCommand, snapshot_file: &str) -> Result<(), String> 
   }
 
   if changes.added.is_empty() && changes.removed.is_empty() && changes.changed.is_empty() {
-    return Err(
-      "No change data collected. Confirm the flags match definitions saved in calcit.cirru (or legacy compact.cirru).".to_string(),
-    );
+    return Err("No change data collected. Confirm the flags match definitions saved in calcit.cirru.".to_string());
   }
 
   let namespace_total = changes.added.len() + changes.removed.len() + changes.changed.len();
@@ -2870,13 +2860,12 @@ mod tests {
   }
 
   #[test]
-  fn format_advisories_cover_legacy_structure_filename_and_dynamic_debt() {
+  fn format_advisories_cover_legacy_structure_and_dynamic_debt() {
     let snapshot = load_snapshot("calcit/test.cirru").expect("fixture snapshot should load");
     let original_edn = cirru_edn::parse("{} (:configs $ {}) (:schema :any)").expect("legacy markers should parse");
-    let advisories = collect_format_advisories("compact.cirru", &original_edn, &snapshot).join("\n");
+    let advisories = collect_format_advisories("calcit.cirru", &original_edn, &snapshot).join("\n");
 
     assert!(advisories.contains("W_LEGACY_CONFIG"), "advisories: {advisories}");
-    assert!(advisories.contains("W_LEGACY_SNAPSHOT_NAME"), "advisories: {advisories}");
     assert!(advisories.contains("W_LEGACY_ANY"), "advisories: {advisories}");
     assert!(advisories.contains("W_DYNAMIC_TYPE_DEBT"), "advisories: {advisories}");
     assert!(advisories.contains("analyze weak-types"), "advisories: {advisories}");

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -39,7 +39,7 @@ struct WasmArgs {
   /// print version only
   #[argh(switch, short = 'v')]
   version: bool,
-  /// input source file, defaults to "calcit.cirru" and falls back to "compact.cirru"
+  /// input source file, defaults to "calcit.cirru"; retired compact.cirru inputs receive migration guidance
   #[argh(positional, default = "String::from(calcit::DEFAULT_SNAPSHOT_FILE)")]
   input: String,
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -43,7 +43,7 @@ pub struct ToplevelCalcit {
   #[argh(option)]
   /// specify a path to watch assets changes
   pub watch_dir: Option<String>,
-  /// input source file, defaults to "calcit.cirru" and falls back to "compact.cirru"
+  /// input source file, defaults to "calcit.cirru"; retired compact.cirru inputs receive migration guidance
   #[argh(positional, default = "String::from(crate::DEFAULT_SNAPSHOT_FILE)")]
   pub input: String,
   /// print version only
@@ -1128,7 +1128,7 @@ pub struct DocsCheckMdCommand {
   /// entry .cirru file for eval context (default: calcit.cirru)
   #[argh(option, default = "String::from(\"calcit.cirru\")")]
   pub entry: String,
-  /// extra dependency module path for eval context, can be provided multiple times; defaults to modules from entries.default.modules; paths ending with '/' prefer calcit.cirru and fall back to compact.cirru
+  /// extra dependency module path for eval context, can be provided multiple times; defaults to modules from entries.default.modules; paths ending with '/' resolve calcit.cirru and reject retired compact.cirru modules
   #[argh(option)]
   pub dep: Vec<String>,
   /// suppress successful block logs; still prints failures and summary on error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,6 +443,25 @@ mod module_resolution_tests {
   }
 
   #[test]
+  fn compact_only_module_is_rejected_with_migration_guidance() {
+    let root = temp_root("retired-compact-module");
+    let project = root.join("project");
+    let module_dir = project.join(".calcit/modules/demo");
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(
+      module_dir.join("compact.cirru"),
+      "{} (:package |demo)\n  :entries $ {}\n    :default $ {} (:mode :native) (:init-fn 'demo/main!) (:reload-fn 'demo/main!)\n      :modules $ []\n  :files $ {}\n",
+    )
+    .unwrap();
+
+    let module_folder = project_module_folder(&project);
+    let error = load_module("demo/", &project, &module_folder).expect_err("compact-only module should be rejected");
+    assert!(error.contains("filename `compact.cirru` is retired"), "error: {error}");
+    assert!(error.contains("calcit calcit.cirru edit format"), "error: {error}");
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
   fn named_modules_do_not_fall_back_to_the_global_store() {
     let root = temp_root("no-global-fallback");
     let project = root.join("project");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,16 +144,7 @@ pub fn resolve_snapshot_path_alias(path: &Path) -> PathBuf {
 
 fn module_path_candidates(path: &str) -> Vec<String> {
   if path.ends_with('/') {
-    vec![format!("{path}{DEFAULT_SNAPSHOT_FILE}"), format!("{path}{LEGACY_SNAPSHOT_FILE}")]
-  } else if path.ends_with(DEFAULT_SNAPSHOT_FILE) {
-    vec![
-      path.to_string(),
-      format!(
-        "{}{}",
-        path.strip_suffix(DEFAULT_SNAPSHOT_FILE).unwrap_or(path),
-        LEGACY_SNAPSHOT_FILE
-      ),
-    ]
+    vec![format!("{path}{DEFAULT_SNAPSHOT_FILE}")]
   } else {
     vec![path.to_string()]
   }
@@ -284,6 +275,18 @@ fn load_module_recursive(
 ) -> Result<snapshot::Snapshot, String> {
   let candidates = resolve_module_snapshot_candidates(path, base_dir, module_folder);
   let mut last_error: Option<String> = None;
+
+  if let Some((_, canonical_path, _)) = candidates.first()
+    && !canonical_path.exists()
+    && canonical_path.file_name().and_then(|name| name.to_str()) == Some(DEFAULT_SNAPSHOT_FILE)
+  {
+    let retired_path = canonical_path.with_file_name(LEGACY_SNAPSHOT_FILE);
+    if retired_path.is_file()
+      && let Some(error) = snapshot::retired_snapshot_migration_error(&retired_path)
+    {
+      return Err(format!("Failed to load snapshot '{}': {error}", retired_path.display()));
+    }
+  }
 
   for (_, fullpath, display_path) in candidates {
     if loaded.contains(&fullpath) {
@@ -437,8 +440,9 @@ mod module_resolution_tests {
 
     let module_folder = project_module_folder(&project);
     let candidates = resolve_module_snapshot_candidates("demo/", &project, &module_folder);
-    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/compact.cirru"));
-    assert_eq!(candidates[0].2, "<mods>/demo/compact.cirru");
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/calcit.cirru"));
+    assert_eq!(candidates[0].2, "<mods>/demo/calcit.cirru");
     fs::remove_dir_all(root).unwrap();
   }
 
@@ -457,7 +461,10 @@ mod module_resolution_tests {
     let module_folder = project_module_folder(&project);
     let error = load_module("demo/", &project, &module_folder).expect_err("compact-only module should be rejected");
     assert!(error.contains("filename `compact.cirru` is retired"), "error: {error}");
-    assert!(error.contains("calcit calcit.cirru edit format"), "error: {error}");
+    assert!(
+      error.contains(&format!("calcit {} edit format", module_dir.join("calcit.cirru").display())),
+      "error: {error}"
+    );
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -2122,16 +2122,26 @@ fn legacy_snapshot_recovery_hint(path: &str) -> Option<String> {
   }
 }
 
+/// Build migration guidance when `path` uses the retired snapshot filename.
+pub fn retired_snapshot_migration_error(path: &Path) -> Option<String> {
+  if path.file_name().and_then(|name| name.to_str()) != Some(crate::LEGACY_SNAPSHOT_FILE) {
+    return None;
+  }
+
+  let canonical_path = path.with_file_name(crate::DEFAULT_SNAPSHOT_FILE);
+  Some(format!(
+    "Snapshot filename `{}` is retired. Copy or rename the last runnable snapshot to `{}`, then run `calcit {} edit format` and `calcit {} --check-only`. The published Calcit 0.13.48 release is the final release that accepts the old filename.",
+    crate::LEGACY_SNAPSHOT_FILE,
+    canonical_path.display(),
+    canonical_path.display(),
+    canonical_path.display()
+  ))
+}
+
 /// Parse a Snapshot while preserving the source path in deserialization errors.
 pub fn load_snapshot_data(data: &Edn, path: &str) -> Result<Snapshot, String> {
-  if Path::new(path).file_name().and_then(|name| name.to_str()) == Some(crate::LEGACY_SNAPSHOT_FILE) {
-    return Err(format!(
-      "Snapshot filename `{}` is retired. Copy or rename the last runnable snapshot to `{}`, then run `calcit {} edit format` and `calcit {} --check-only`. The published Calcit 0.13.48 release is the final release that accepts the old filename.",
-      crate::LEGACY_SNAPSHOT_FILE,
-      crate::DEFAULT_SNAPSHOT_FILE,
-      crate::DEFAULT_SNAPSHOT_FILE,
-      crate::DEFAULT_SNAPSHOT_FILE
-    ));
+  if let Some(error) = retired_snapshot_migration_error(Path::new(path)) {
+    return Err(error);
   }
   load_snapshot_data_inner(data, path).map_err(|error| {
     let mut message = format!("Failed to load Snapshot `{path}`: {error}");

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1836,7 +1836,7 @@ fn normalize_schema_for_code(code: &Cirru, schema: &Arc<CalcitTypeAnnotation>) -
   }
 }
 
-/// structure of runtime snapshot files such as `calcit.cirru` (legacy: `compact.cirru`)
+/// structure of canonical runtime snapshot files such as `calcit.cirru`
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Snapshot {
   pub package: String,
@@ -2124,6 +2124,15 @@ fn legacy_snapshot_recovery_hint(path: &str) -> Option<String> {
 
 /// Parse a Snapshot while preserving the source path in deserialization errors.
 pub fn load_snapshot_data(data: &Edn, path: &str) -> Result<Snapshot, String> {
+  if Path::new(path).file_name().and_then(|name| name.to_str()) == Some(crate::LEGACY_SNAPSHOT_FILE) {
+    return Err(format!(
+      "Snapshot filename `{}` is retired. Copy or rename the last runnable snapshot to `{}`, then run `calcit {} edit format` and `calcit {} --check-only`. The published Calcit 0.13.48 release is the final release that accepts the old filename.",
+      crate::LEGACY_SNAPSHOT_FILE,
+      crate::DEFAULT_SNAPSHOT_FILE,
+      crate::DEFAULT_SNAPSHOT_FILE,
+      crate::DEFAULT_SNAPSHOT_FILE
+    ));
+  }
   load_snapshot_data_inner(data, path).map_err(|error| {
     let mut message = format!("Failed to load Snapshot `{path}`: {error}");
     if let Some(hint) = legacy_snapshot_recovery_hint(path) {
@@ -2831,6 +2840,19 @@ mod tests {
     assert!(error.contains("calcit calcit.cirru --check-only"), "error: {error}");
 
     fs::remove_dir_all(root).expect("remove legacy snapshot fixture directory");
+  }
+
+  #[test]
+  fn compact_snapshot_filename_is_rejected_with_migration_commands() {
+    let error = load_snapshot_data(&Edn::Nil, "compact.cirru").expect_err("retired snapshot filename should fail before parsing");
+
+    assert!(error.contains("filename `compact.cirru` is retired"), "error: {error}");
+    assert!(error.contains("calcit.cirru"), "error: {error}");
+    assert!(error.contains("calcit calcit.cirru edit format"), "error: {error}");
+    assert!(
+      error.contains("published Calcit 0.13.48 release is the final release"),
+      "error: {error}"
+    );
   }
 
   fn revision_test_entry(tags: &[&str]) -> CodeEntry {


### PR DESCRIPTION
## Summary

- reject the retired `compact.cirru` filename before snapshot deserialization
- surface the canonical copy/rename, format, and check-only migration sequence for project and module snapshots
- remove formatter/help text that still implied the old filename was accepted
- document published Calcit 0.13.48 as the final filename-compatible release

## Compatibility boundary

This change is intended for Calcit 0.13.49. It deliberately makes the snapshot filename stricter while preserving legacy snapshot schema normalization, including top-level `:configs`, for the later cleanup phases tracked in #463.

## Validation

- `cargo fmt`
- `cargo +stable clippy -- -D warnings`
- `cargo +stable test` (536 library, 245 CLI, 24 caps, 4 WASM tests)
- `bash scripts/check-docs-md.sh` (323/323 blocks)
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all`
- manual default-path and explicit-path rejection checks for a project containing only `compact.cirru`

Part of #463.
