### PR TITLE
feat: guard Rust-native FFI build identity

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -558,8 +559,39 @@ fn parse_files(edn: Edn) -> Result<HashMap<String, FileInSnapShot>, String> {
   }
 }
 
+fn rustc_verbose_field<'a>(output: &'a str, name: &str) -> &'a str {
+  output
+    .lines()
+    .find_map(|line| line.strip_prefix(name).map(str::trim))
+    .unwrap_or_else(|| panic!("`rustc --version --verbose` did not report `{name}`"))
+}
+
+fn ffi_build_id() -> String {
+  let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
+  let output = Command::new(&rustc)
+    .args(["--version", "--verbose"])
+    .output()
+    .unwrap_or_else(|error| panic!("failed to run `{rustc} --version --verbose`: {error}"));
+  if !output.status.success() {
+    panic!("`{rustc} --version --verbose` failed with {}", output.status);
+  }
+  let verbose = String::from_utf8(output.stdout).expect("rustc verbose version must be UTF-8");
+  let release = rustc_verbose_field(&verbose, "release:");
+  let commit = rustc_verbose_field(&verbose, "commit-hash:");
+  let target = env::var("TARGET").expect("Cargo must provide TARGET to build scripts");
+  let debug_assertions = env::var_os("CARGO_CFG_DEBUG_ASSERTIONS").is_some();
+  let panic_strategy = env::var("CARGO_CFG_PANIC").expect("Cargo must provide CARGO_CFG_PANIC to build scripts");
+
+  format!("rustc={release}:{commit};target={target};debug-assertions={debug_assertions};panic={panic_strategy}")
+}
+
 fn main() {
   println!("cargo:rerun-if-changed=src/cirru/calcit-core.cirru");
+  println!("cargo:rerun-if-env-changed=RUSTC");
+  println!("cargo:rerun-if-env-changed=TARGET");
+  println!("cargo:rerun-if-env-changed=CARGO_CFG_DEBUG_ASSERTIONS");
+  println!("cargo:rerun-if-env-changed=CARGO_CFG_PANIC");
+  println!("cargo:rustc-env=CALCIT_FFI_BUILD_ID={}", ffi_build_id());
 
   let out_dir = env::var_os("OUT_DIR").unwrap();
   let dest_path = Path::new(&out_dir).join("calcit-core.rmp");

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -19,7 +19,7 @@ Currently two APIs are supported, based on Cirru EDN data.
 First one is a synchronous [Edn](https://github.com/Cirru/cirru-edn.rs) API with type signature:
 
 ```rust
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn demo(args: Vec<Edn>) -> Result<Edn, String> {
 }
 ```
@@ -27,7 +27,7 @@ pub fn demo(args: Vec<Edn>) -> Result<Edn, String> {
 The other one is an asynchorous API, it can be called multiple times, which relies on `Arc` type(not sure if we can find a better solution yet),
 
 ```rust
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn demo(
   args: Vec<Edn>,
   handler: Arc<dyn Fn(Vec<Edn>) -> Result<Edn, String> + Send + Sync + 'static>,

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -44,15 +44,55 @@ Process need to keep running when there are tasks running.
 
 Asynchronous tasks are based on threads, which is currently decoupled from core features of Calcit. We may need techniques like `tokio` for better performance in the future, but current solution is quite naive yet.
 
-Also to declare runtime compatibility, FFI dylibs need two extra functions with specific names so that Calcit could check before actually calling them:
+Rust's native ABI has no stability guarantee. `Vec<Edn>`, `String`, `Result`, and callback trait objects are therefore a transitional interface rather than a portable dylib protocol. Calcit checks a C-safe build identity before invoking those Rust ABI symbols.
+
+Add a `build.rs` that derives the identity from the exact compiler, target, debug-assertion mode, and panic strategy:
 
 ```rust
-#[no_mangle]
+use std::{env, process::Command};
+
+fn field<'a>(output: &'a str, name: &str) -> &'a str {
+  output.lines().find_map(|line| line.strip_prefix(name).map(str::trim)).unwrap()
+}
+
+fn main() {
+  let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
+  let output = Command::new(rustc).args(["--version", "--verbose"]).output().unwrap();
+  assert!(output.status.success());
+  let verbose = String::from_utf8(output.stdout).unwrap();
+  let release = field(&verbose, "release:");
+  let commit = field(&verbose, "commit-hash:");
+  let target = env::var("TARGET").unwrap();
+  let debug_assertions = env::var_os("CARGO_CFG_DEBUG_ASSERTIONS").is_some();
+  let panic_strategy = env::var("CARGO_CFG_PANIC").unwrap();
+  println!(
+    "cargo:rustc-env=CALCIT_FFI_BUILD_ID=rustc={release}:{commit};target={target};debug-assertions={debug_assertions};panic={panic_strategy}"
+  );
+}
+```
+
+Export the resulting value through a null-terminated C string. This lookup is safe to perform before any Rust-layout-dependent value crosses the library boundary:
+
+```rust
+use std::ffi::c_char;
+
+static FFI_BUILD_ID: &[u8] = concat!(env!("CALCIT_FFI_BUILD_ID"), "\0").as_bytes();
+
+#[unsafe(no_mangle)]
+pub extern "C" fn calcit_ffi_build_id() -> *const c_char {
+  FFI_BUILD_ID.as_ptr().cast()
+}
+```
+
+The existing Rust ABI version functions are still required during the migration period:
+
+```rust
+#[unsafe(no_mangle)]
 pub fn abi_version() -> String {
   String::from("0.0.9")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn edn_version() -> String {
   cirru_edn::version().to_owned()
 }
@@ -61,6 +101,14 @@ pub fn edn_version() -> String {
 `abi_version()` must match Calcit's FFI ABI version exactly.
 
 `edn_version()` must match the exact `cirru_edn` crate version used by the running Calcit binary. If either version differs, Calcit aborts the FFI call before invoking the target symbol.
+
+The build identity must also match exactly. Debug Calcit hosts reject dylibs that do not export `calcit_ffi_build_id`, which prevents the common debug-host/release-dylib crash before even calling `abi_version()`. Release hosts temporarily retain the legacy path with a warning so maintained modules can migrate incrementally. A matching identity reduces accidental incompatibility; it does not turn Rust's native ABI into a stable public protocol. New FFI designs should use the planned C-safe serialized byte-buffer interface instead.
+
+Inspect the host side before building or debugging a module:
+
+```bash
+calcit --ffi-build-id
+```
 
 ### Call in Calcit
 

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -79,7 +79,7 @@ Calcit 与 dylib 必须使用同一 rustc 工具链。先运行 `calcit --ffi-bu
 PKG_VER=$(cargo metadata --no-deps --format-version 1 \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['packages'][0]['version'])")
 
-git add Cargo.toml Cargo.lock deps.cirru
+git add Cargo.toml Cargo.lock deps.cirru build.rs
 git commit -m "chore: upgrade cirru_edn $EDN_VER, cirru_parser $PARSER_VER; bump version to $PKG_VER"
 git tag "$PKG_VER"
 git push origin <branch>

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -12,7 +12,7 @@ aliases:
 
 本文描述将 Calcit FFI 动态库项目（dylib 工程）升级到最新依赖版本的完整流程，基于实际升级经验整理。
 
-## 两个关键版本号
+## 版本与构建身份
 
 每个 FFI 项目需要同步维护两处版本号：
 
@@ -22,6 +22,8 @@ aliases:
 | `deps.cirru` | `:calcit-version \|x.y.z` | 必须与 `calcit --version` 输出一致，CI 会用它校验               |
 
 两者不一致都会导致 CI 失败或运行时 `dlsym failed`。
+
+此外，Rust 原生 ABI 不稳定。FFI 项目必须按 [Rust bindings](./ffi-bindings.md) 增加 `build.rs` 和 C-safe `calcit_ffi_build_id()` 导出。该身份包含精确 rustc、target、debug assertions 与 panic strategy；Calcit 会在调用 `abi_version()`、`edn_version()` 或业务 symbol 之前比较。不要把 optimization level 加入身份：Calcit 自身 release 使用体积优化，而模块通常使用 Cargo 默认 release 优化，两者可以共享相同的 ABI 构建模式。
 
 ## 升级流程
 
@@ -69,6 +71,8 @@ calcit calcit.cirru
 
 三步缺一不可：构建 → 复制产物 → 运行验证。如果只更新了 `target/release/` 而未复制到 `dylibs/`，运行时仍会加载旧库。
 
+Calcit 与 dylib 必须使用同一 rustc 工具链。先运行 `calcit --ffi-build-id` 查看 host identity。若项目提供 `rust-toolchain.toml`，应固定到发布 Calcit 所报告的 compiler identity；本地从源码构建 Calcit 时，则用同一个 toolchain 构建 dylib。debug Calcit 会在缺少 build identity 时直接拒绝旧模块；release Calcit 在迁移期仍会接受，但会输出兼容性警告。
+
 ### 4. 提交、打标签并推送
 
 ```bash
@@ -114,9 +118,14 @@ gh pr checks <PR_NUMBER>
 
 按顺序排查：
 
-1. `edn_version()` 函数是否已导出
-2. `#[unsafe(no_mangle)]`（Rust 2024 edition）是否存在
-3. `dylibs/` 中是否已复制最新产物（`cp target/release/*.* dylibs/`）
+1. `calcit_ffi_build_id()`、`abi_version()`、`edn_version()` 是否已导出
+2. `calcit_ffi_build_id()` 是否使用 `extern "C"`、静态 NUL 结尾字节串与 `*const c_char`
+3. `#[unsafe(no_mangle)]`（Rust 2024 edition）是否存在
+4. `dylibs/` 中是否已复制最新产物（`cp target/release/*.* dylibs/`）
+
+### FFI build identity mismatch
+
+错误会同时打印 dylib 与 host identity。逐项比较 rustc release/commit、target、debug assertions 和 panic strategy；不要绕过检查或手工伪造 identity。使用同一 toolchain 与同类 debug/release 构建重新生成二进制，再复制到 `dylibs/` 验证。
 
 ### amend 后需要重打 tag
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -44,6 +44,7 @@ calcit eval "echo |done"
 
 - `--watch` / `-w` - Watch files and rerun/rebuild on changes
 - `--disable-stack` - Disable stack trace for errors
+- `--ffi-build-id` - Print the native FFI compiler/target/build-mode identity and exit
 - `--skip-arity-check` - Skip arity check in JS codegen
 - `--emit-path <path>` - Specify output path for JS (default: `js-out/`)
 - `--init-fn <fn>` - Specify main function

--- a/editing-history/202608270214-ffi-build-handshake.md
+++ b/editing-history/202608270214-ffi-build-handshake.md
@@ -1,0 +1,15 @@
+# Guard transitional Rust-native FFI with a C-safe build handshake
+
+- Embed the exact rustc release/commit, target, debug-assertion mode, and panic
+  strategy in the Calcit host build.
+- Read an optional static C string from dylibs before invoking legacy Rust ABI
+  version or business symbols.
+- Reject mismatched identities deterministically; require identity metadata for
+  debug hosts while retaining a warned release-only migration path.
+- Apply the same check to runtime calls and `caps` native verification, and
+  include the identity in native realization receipts and cache keys.
+- Add `calcit --ffi-build-id` and document the extension-side build script and
+  export.
+- Reproduce the former debug-host/release-dylib abort with calcit_wasmtime: the
+  guarded host now rejects before `abi_version`; matching release builds still
+  return `27`.

--- a/editing-history/202608270231-ffi-build-review-followup.md
+++ b/editing-history/202608270231-ffi-build-review-followup.md
@@ -1,0 +1,5 @@
+# FFI build handshake review follow-up
+
+- Updated the introductory Rust FFI examples to use Rust 2024-compatible `#[unsafe(no_mangle)]` attributes.
+- Included the required `build.rs` identity generator in the documented upgrade staging command.
+- Kept the original `202608270214` history timestamp because it records Asia/Shanghai local time, matching the repository workflow and actual commit time.

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -1058,6 +1058,9 @@ pub fn verify_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Res
 pub fn verify_native_library(path: &Path) -> Result<(), String> {
   type VersionFn = fn() -> String;
   let library = unsafe { libloading::Library::new(path) }.map_err(|e| format!("failed to load {}: {e}", path.display()))?;
+  let lib_name = path.display().to_string();
+  let build_id = calcit::ffi_abi::lookup_build_id(&library, &lib_name)?;
+  calcit::ffi_abi::validate_build_id(&lib_name, build_id.as_deref(), calcit::FFI_BUILD_ID, cfg!(debug_assertions))?;
   let abi: libloading::Symbol<VersionFn> =
     unsafe { library.get(b"abi_version") }.map_err(|e| format!("failed to read abi_version from {}: {e}", path.display()))?;
   let actual_abi = abi();
@@ -1191,8 +1194,9 @@ fn expected_link_target(module: &ResolvedModule) -> Result<PathBuf, String> {
   }
   let target = rust_target_identity();
   let build_input = format!(
-    "{target}\ncalcit={CALCIT_VERSION}\nffi-abi={}\ncirru-edn={}\ncommit={}",
+    "{target}\ncalcit={CALCIT_VERSION}\nffi-abi={}\nffi-build={}\ncirru-edn={}\ncommit={}",
     calcit::FFI_ABI_VERSION,
+    calcit::FFI_BUILD_ID,
     cirru_edn::version(),
     module.commit
   );
@@ -1218,6 +1222,7 @@ fn write_native_receipt(module: &ResolvedModule, realization: &Path, build_key: 
   receipt.insert(Edn::tag("commit"), Edn::str(module.commit.as_str()));
   receipt.insert(Edn::tag("calcit-version"), Edn::str(CALCIT_VERSION));
   receipt.insert(Edn::tag("ffi-abi"), Edn::str(calcit::FFI_ABI_VERSION));
+  receipt.insert(Edn::tag("ffi-build"), Edn::str(calcit::FFI_BUILD_ID));
   receipt.insert(Edn::tag("cirru-edn"), Edn::str(cirru_edn::version()));
   receipt.insert(Edn::tag("build-key"), Edn::str(build_key));
   receipt.insert(
@@ -1252,6 +1257,7 @@ fn verify_native_receipt(module: &ResolvedModule, realization: &Path) -> Result<
     ("commit", module.commit.as_str()),
     ("calcit-version", CALCIT_VERSION),
     ("ffi-abi", calcit::FFI_ABI_VERSION),
+    ("ffi-build", calcit::FFI_BUILD_ID),
     ("cirru-edn", cirru_edn::version()),
     ("build-key", expected_build_key),
   ] {

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -266,6 +266,11 @@ fn run_cli() -> Result<(), String> {
     return Ok(());
   }
 
+  if cli_args.ffi_build_id {
+    println!("{}", calcit::FFI_BUILD_ID);
+    return Ok(());
+  }
+
   if let Some(level) = cli_args.tips_level.as_deref() {
     cli_handlers::set_tips_level(level)?;
   }

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1,7 +1,7 @@
 use crate::runner;
 use cirru_edn::Edn;
 use colored::Colorize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::AtomicUsize;
@@ -26,9 +26,9 @@ type EdnFfiFn = fn(
   f: Arc<dyn Fn(Vec<Edn>) -> Result<Edn, String> + Send + Sync + 'static>,
   finish: Arc<dyn FnOnce()>,
 ) -> Result<Edn, String>;
-
 /// lazily cache dylibs, in case Linux drops memory of libraries
 static DYLIBS: LazyLock<Mutex<HashMap<String, Arc<libloading::Library>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+static LEGACY_DYLIB_WARNED: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 static TRACE_FFI: AtomicBool = AtomicBool::new(false);
 static STDOUT_TO_STDERR: AtomicBool = AtomicBool::new(false);
 static SILENCE_PROGRAM_OUTPUT: AtomicBool = AtomicBool::new(false);
@@ -51,9 +51,10 @@ pub fn set_trace_ffi(v: bool) {
       format!(
         "cwd={cwd} exe={exe} abi={} edn={edn_version} host={}",
         calcit::FFI_ABI_VERSION,
-        std::env::consts::OS
+        std::env::consts::OS,
       ),
     );
+    trace_ffi_event("host-build", calcit::FFI_BUILD_ID);
   }
 }
 
@@ -125,6 +126,36 @@ fn load_dylib(lib_name: &str) -> Result<Arc<libloading::Library>, CalcitErr> {
 }
 
 fn ensure_abi_compatible(lib: &libloading::Library, lib_name: &str) -> Result<(), CalcitErr> {
+  trace_ffi_event("lookup-build-id", format!("lib={lib_name}"));
+  let dylib_build_id =
+    calcit::ffi_abi::lookup_build_id(lib, lib_name).map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  match calcit::ffi_abi::validate_build_id(lib_name, dylib_build_id.as_deref(), calcit::FFI_BUILD_ID, cfg!(debug_assertions))
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?
+  {
+    calcit::ffi_abi::FfiBuildCompatibility::Exact => trace_ffi_event(
+      "build-id",
+      format!(
+        "lib={lib_name} dylib={} host={} compatible=true",
+        dylib_build_id.as_deref().unwrap_or("<missing>"),
+        calcit::FFI_BUILD_ID
+      ),
+    ),
+    calcit::ffi_abi::FfiBuildCompatibility::Legacy => {
+      trace_ffi_event(
+        "build-id",
+        format!("lib={lib_name} dylib=<missing> host={} legacy=true", calcit::FFI_BUILD_ID),
+      );
+      let mut warned = LEGACY_DYLIB_WARNED
+        .lock()
+        .map_err(|_| CalcitErr::use_str(CalcitErrKind::Unexpected, "failed to lock legacy dylib warning cache"))?;
+      if warned.insert(lib_name.to_owned()) && !calcit::quiet_tool_output() {
+        eprintln!(
+          "[warning] Rust-native FFI library `{lib_name}` has no C-safe `calcit_ffi_build_id`; release-host compatibility is temporary and cannot prove compiler compatibility. Rebuild the module using the current FFI guide."
+        );
+      }
+    }
+  }
+
   let expected_edn_version = cirru_edn::version();
   trace_ffi_event("lookup-abi", format!("lib={lib_name}"));
   let lookup_version: libloading::Symbol<fn() -> String> = unsafe { lib.get("abi_version".as_bytes()) }.map_err(|e| {

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -25,6 +25,9 @@ pub struct ToplevelCalcit {
   /// print FFI dylib calls and callbacks for debugging native crashes
   #[argh(switch)]
   pub trace_ffi: bool,
+  /// print the Rust-native FFI host build identity and exit
+  #[argh(switch)]
+  pub ffi_build_id: bool,
   /// entry file path, defaults to "js-out/"
   #[argh(option, default = "String::from(\"js-out/\")")]
   pub emit_path: String,

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -1,0 +1,83 @@
+use std::ffi::{CStr, c_char};
+
+pub const BUILD_ID_SYMBOL: &[u8] = b"calcit_ffi_build_id";
+
+type FfiBuildId = unsafe extern "C" fn() -> *const c_char;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum FfiBuildCompatibility {
+  Exact,
+  Legacy,
+}
+
+pub fn validate_build_id(
+  lib_name: &str,
+  dylib_build_id: Option<&str>,
+  host_build_id: &str,
+  require_build_id: bool,
+) -> Result<FfiBuildCompatibility, String> {
+  match dylib_build_id {
+    Some(dylib_build_id) if dylib_build_id == host_build_id => Ok(FfiBuildCompatibility::Exact),
+    Some(dylib_build_id) => Err(format!(
+      "Refusing Rust-native FFI library `{lib_name}` before invoking a Rust ABI symbol because its build identity differs from the Calcit host. dylib: `{dylib_build_id}`; host: `{host_build_id}`. Rebuild both with the same rustc, target, debug-assertion mode, and panic strategy."
+    )),
+    None if require_build_id => Err(format!(
+      "Refusing legacy Rust-native FFI library `{lib_name}` before invoking a Rust ABI symbol: this debug Calcit host cannot prove that the dylib uses a compatible build. Export the C-safe `calcit_ffi_build_id` symbol described in the FFI guide, or run a release Calcit host built with the same toolchain as the dylib. Expected host identity: `{host_build_id}`."
+    )),
+    None => Ok(FfiBuildCompatibility::Legacy),
+  }
+}
+
+/// Read the optional static C build identity without invoking a Rust ABI symbol.
+pub fn lookup_build_id(lib: &libloading::Library, lib_name: &str) -> Result<Option<String>, String> {
+  let lookup: libloading::Symbol<FfiBuildId> = match unsafe { lib.get(BUILD_ID_SYMBOL) } {
+    Ok(lookup) => lookup,
+    Err(_) => return Ok(None),
+  };
+  let ptr = unsafe { lookup() };
+  if ptr.is_null() {
+    return Err(format!(
+      "FFI library `{lib_name}` returned a null pointer from `calcit_ffi_build_id`"
+    ));
+  }
+  let value = unsafe { CStr::from_ptr(ptr) }
+    .to_str()
+    .map_err(|error| format!("FFI library `{lib_name}` returned invalid UTF-8 from `calcit_ffi_build_id`: {error}"))?;
+  Ok(Some(value.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{FfiBuildCompatibility, validate_build_id};
+
+  #[test]
+  fn exact_identity_is_accepted() {
+    assert_eq!(
+      validate_build_id("demo", Some("same-build"), "same-build", true).expect("exact identity should pass"),
+      FfiBuildCompatibility::Exact
+    );
+  }
+
+  #[test]
+  fn mismatched_identity_is_rejected_before_rust_abi_calls() {
+    let error = validate_build_id("demo", Some("release-build"), "debug-build", false).expect_err("different identities must fail");
+    assert!(error.contains("before invoking a Rust ABI symbol"), "error: {error}");
+    assert!(error.contains("release-build"), "error: {error}");
+    assert!(error.contains("debug-build"), "error: {error}");
+  }
+
+  #[test]
+  fn debug_hosts_reject_legacy_dylibs_before_rust_abi_calls() {
+    let error = validate_build_id("demo", None, "debug-build", true).expect_err("debug host must require build identity");
+    assert!(error.contains("Refusing legacy Rust-native FFI library"), "error: {error}");
+    assert!(error.contains("calcit_ffi_build_id"), "error: {error}");
+  }
+
+  #[test]
+  fn release_hosts_keep_a_temporary_legacy_path() {
+    assert_eq!(
+      validate_build_id("demo", None, "release-build", false).expect("release compatibility path should remain"),
+      FfiBuildCompatibility::Legacy
+    );
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod codegen;
 pub mod def_diff;
 pub mod detailed_snapshot;
 pub mod effects_graph;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod ffi_abi;
 pub mod program;
 pub mod program_diff;
 pub mod project_state;
@@ -36,6 +38,7 @@ use crate::util::string::strip_shebang;
 pub const DEFAULT_SNAPSHOT_FILE: &str = "calcit.cirru";
 pub const LEGACY_SNAPSHOT_FILE: &str = "compact.cirru";
 pub const FFI_ABI_VERSION: &str = "0.0.9";
+pub const FFI_BUILD_ID: &str = env!("CALCIT_FFI_BUILD_ID");
 
 static QUIET_TOOL_OUTPUT: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
## Summary

- derive a host build identity from exact rustc release/commit, target, debug assertions, and panic strategy
- read `calcit_ffi_build_id` through a static C string before invoking any Rust ABI symbol
- reject mismatched identities deterministically in runtime calls and `caps` native verification
- require the identity for debug hosts while retaining a warned release-only legacy path during ecosystem migration
- include the identity in native realization keys/receipts and expose it with `calcit --ffi-build-id`
- document the extension-side `build.rs` and C export

## Safety boundary

This is the first mitigation phase of #474. It prevents known-incompatible builds from reaching `abi_version`, `edn_version`, callback, or business symbols, but it does not claim that Rust's native ABI is stable. Replacing `Vec<Edn>`, `String`, `Result`, and trait objects with a C-safe serialized byte-buffer protocol remains the long-term requirement.

Companion module migration: calcit-lang/calcit_wasmtime#10.

## Regression evidence

Using current `calcit_wasmtime` on macOS arm64 with rustc 1.94.0:

- old release dylib without metadata + debug host: rejected before `abi_version`, no abort
- metadata-enabled release dylib + debug host: rejected on `debug-assertions=false` vs `true`, no abort
- metadata-enabled release dylib + matching release host: `run_wat` returns `27`
- debug/release `caps __verify-native`: deterministic mismatch
- release/release `caps __verify-native`: success

## Validation

- `cargo fmt --check`
- `cargo +stable clippy -- -D warnings`
- `cargo +stable test` (540 library, 245 CLI, 24 caps, 4 WASM tests)
- `bash scripts/check-docs-md.sh` (323/323 blocks)
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all`
- debug and release Calcit/caps builds

Advances #474.
