### PR TITLE
feat: add C-safe synchronous FFI buffer protocol

### DIFF
--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -110,7 +110,7 @@ Inspect the host side before building or debugging a module:
 calcit --ffi-build-id
 ```
 
-### C-safe synchronous buffer ABI
+## C-safe synchronous buffer ABI
 
 New synchronous methods should use buffer protocol version 1. Calcit first looks for `<method>_calcit_ffi_v1`; only methods without that symbol fall back to the build-ID-guarded Rust ABI. Existing Calcit source calls do not change.
 

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -102,13 +102,56 @@ pub fn edn_version() -> String {
 
 `edn_version()` must match the exact `cirru_edn` crate version used by the running Calcit binary. If either version differs, Calcit aborts the FFI call before invoking the target symbol.
 
-The build identity must also match exactly. Debug Calcit hosts reject dylibs that do not export `calcit_ffi_build_id`, which prevents the common debug-host/release-dylib crash before even calling `abi_version()`. Release hosts temporarily retain the legacy path with a warning so maintained modules can migrate incrementally. A matching identity reduces accidental incompatibility; it does not turn Rust's native ABI into a stable public protocol. New FFI designs should use the planned C-safe serialized byte-buffer interface instead.
+The build identity must also match exactly. Debug Calcit hosts reject dylibs that do not export `calcit_ffi_build_id`, which prevents the common debug-host/release-dylib crash before even calling `abi_version()`. Release hosts temporarily retain the legacy path with a warning so maintained modules can migrate incrementally. A matching identity reduces accidental incompatibility; it does not turn Rust's native ABI into a stable public protocol.
 
 Inspect the host side before building or debugging a module:
 
 ```bash
 calcit --ffi-build-id
 ```
+
+### C-safe synchronous buffer ABI
+
+New synchronous methods should use buffer protocol version 1. Calcit first looks for `<method>_calcit_ffi_v1`; only methods without that symbol fall back to the build-ID-guarded Rust ABI. Existing Calcit source calls do not change.
+
+The dylib exports these C ABI symbols:
+
+```rust
+#[repr(C)]
+pub struct CalcitFfiBuffer {
+  pub ptr: *mut u8,
+  pub len: usize,
+  pub cap: usize,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn calcit_ffi_buffer_version() -> u32 { 1 }
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn calcit_ffi_buffer_free(buffer: CalcitFfiBuffer) {
+  // Reconstruct and drop the Vec in the dylib that allocated it.
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn read_file_calcit_ffi_v1(
+  request_ptr: *const u8,
+  request_len: usize,
+  output: *mut CalcitFfiBuffer,
+) -> i32 {
+  // Decode, call the implementation, and write one owned output buffer.
+  0
+}
+```
+
+Protocol rules:
+
+- Input is one UTF-8 Cirru EDN list containing the method arguments. The host owns it for the duration of the synchronous call.
+- Status `0` means the output is one UTF-8 Cirru EDN value. A nonzero status means the output is a UTF-8 error message.
+- The dylib allocates every output and Calcit copies it before calling that same dylib's `calcit_ffi_buffer_free` exactly once.
+- The adapter must contain panics and return an error status; unwinding across `extern "C"` is invalid.
+- Calcit rejects protocol-version mismatches, malformed buffer metadata, oversized responses, invalid UTF-8, and invalid response EDN.
+
+`calcit-lang/calcit_wasmtime` contains the first complete adapter. Version 1 currently covers synchronous `&call-dylib-edn`; callback and blocking APIs remain on the guarded legacy path until their ownership protocol lands.
 
 ### Call in Calcit
 

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -118,10 +118,11 @@ gh pr checks <PR_NUMBER>
 
 按顺序排查：
 
-1. `calcit_ffi_build_id()`、`abi_version()`、`edn_version()` 是否已导出
-2. `calcit_ffi_build_id()` 是否使用 `extern "C"`、静态 NUL 结尾字节串与 `*const c_char`
-3. `#[unsafe(no_mangle)]`（Rust 2024 edition）是否存在
-4. `dylibs/` 中是否已复制最新产物（`cp target/release/*.* dylibs/`）
+1. 同步方法优先检查 `calcit_ffi_buffer_version()`、`calcit_ffi_buffer_free()` 与 `<method>_calcit_ffi_v1` 是否已导出
+2. 仍在旧 Rust ABI 的方法检查 `calcit_ffi_build_id()`、`abi_version()`、`edn_version()` 是否已导出
+3. `calcit_ffi_build_id()` 是否使用 `extern "C"`、静态 NUL 结尾字节串与 `*const c_char`
+4. `#[unsafe(no_mangle)]`（Rust 2024 edition）是否存在
+5. `dylibs/` 中是否已复制最新产物（`cp target/release/*.* dylibs/`）
 
 ### FFI build identity mismatch
 

--- a/editing-history/202608270316-ffi-buffer-protocol-v1.md
+++ b/editing-history/202608270316-ffi-buffer-protocol-v1.md
@@ -1,0 +1,6 @@
+# Add the synchronous FFI byte-buffer protocol
+
+- Added a versioned C ABI for synchronous FFI calls using owned UTF-8 Cirru EDN buffers.
+- Made method migration incremental by preferring `<method>_calcit_ffi_v1` and retaining the build-ID-guarded Rust ABI as a fallback.
+- Kept output ownership in the dylib through `calcit_ffi_buffer_free`, with host-side invariant and size checks before decoding.
+- Added focused tests for protocol versioning, symbol derivation, and request encoding; callback migration remains a separate phase.

--- a/editing-history/202608270326-ffi-buffer-review-followup.md
+++ b/editing-history/202608270326-ffi-buffer-review-followup.md
@@ -1,0 +1,6 @@
+# FFI buffer protocol review follow-up
+
+- Corrected the FFI documentation heading hierarchy.
+- Made nonzero-status payloads obey the same strict UTF-8 contract as successful EDN responses.
+- Added a focused regression test that rejects malformed error bytes rather than replacing them lossily.
+- Kept the original 03:16 history timestamp because it records the actual Asia/Shanghai commit time.

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -327,6 +327,21 @@ pub fn call_dylib_edn(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Ca
   );
 
   let lib = load_dylib(&lib_name)?;
+  match calcit::ffi_abi::try_call_buffer(&lib, &lib_name, &method, ys.clone())
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?
+  {
+    Some(ret) => {
+      trace_ffi_event(
+        "return-buffer",
+        format!(
+          "lib={lib_name} symbol={method}_calcit_ffi_v1 ret={}",
+          format_edn_args_for_trace(std::slice::from_ref(&ret))
+        ),
+      );
+      return Ok(edn_to_calcit(&ret, &Calcit::Nil));
+    }
+    None => trace_ffi_event("buffer-fallback", format!("lib={lib_name} symbol={method}")),
+  }
   ensure_abi_compatible(&lib, &lib_name)?;
   trace_ffi_event("lookup-symbol", format!("lib={lib_name} symbol={method}"));
   let func: libloading::Symbol<EdnFfi> = unsafe { lib.get(method.as_bytes()) }.map_err(|e| {

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -1,13 +1,134 @@
 use std::ffi::{CStr, c_char};
+use std::{ptr, slice};
+
+use cirru_edn::{Edn, EdnListView};
 
 pub const BUILD_ID_SYMBOL: &[u8] = b"calcit_ffi_build_id";
 
 type FfiBuildId = unsafe extern "C" fn() -> *const c_char;
 
+pub const BUFFER_PROTOCOL_VERSION: u32 = 1;
+pub const BUFFER_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_buffer_version";
+pub const BUFFER_FREE_SYMBOL: &[u8] = b"calcit_ffi_buffer_free";
+const BUFFER_METHOD_SUFFIX: &str = "_calcit_ffi_v1";
+const MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
+
+/// Owned bytes allocated by an FFI module. The module must release this value
+/// through `calcit_ffi_buffer_free`; the host only copies from it.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FfiBuffer {
+  pub ptr: *mut u8,
+  pub len: usize,
+  pub cap: usize,
+}
+
+impl FfiBuffer {
+  fn empty() -> Self {
+    Self {
+      ptr: ptr::null_mut(),
+      len: 0,
+      cap: 0,
+    }
+  }
+}
+
+type FfiBufferVersion = unsafe extern "C" fn() -> u32;
+type FfiBufferFree = unsafe extern "C" fn(FfiBuffer);
+type FfiBufferCall = unsafe extern "C" fn(*const u8, usize, *mut FfiBuffer) -> i32;
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum FfiBuildCompatibility {
   Exact,
   Legacy,
+}
+
+fn buffer_method_symbol(method: &str) -> String {
+  format!("{method}{BUFFER_METHOD_SUFFIX}")
+}
+
+fn encode_buffer_request(args: Vec<Edn>) -> Result<Vec<u8>, String> {
+  cirru_edn::format(&Edn::List(EdnListView(args)), true)
+    .map(String::into_bytes)
+    .map_err(|error| format!("failed to encode FFI buffer request: {error}"))
+}
+
+unsafe fn copy_and_free_buffer(
+  buffer: FfiBuffer,
+  free: &libloading::Symbol<FfiBufferFree>,
+  lib_name: &str,
+  symbol: &str,
+) -> Result<Vec<u8>, String> {
+  if buffer.len > buffer.cap {
+    return Err(format!(
+      "FFI buffer `{symbol}` in `{lib_name}` returned len {} larger than capacity {}",
+      buffer.len, buffer.cap
+    ));
+  }
+  if buffer.len > MAX_BUFFER_BYTES {
+    return Err(format!(
+      "FFI buffer `{symbol}` in `{lib_name}` returned {} bytes, exceeding the {} byte safety limit",
+      buffer.len, MAX_BUFFER_BYTES
+    ));
+  }
+  if buffer.ptr.is_null() && (buffer.len != 0 || buffer.cap != 0) {
+    return Err(format!(
+      "FFI buffer `{symbol}` in `{lib_name}` returned a null pointer with len {} and capacity {}",
+      buffer.len, buffer.cap
+    ));
+  }
+
+  let copied = if buffer.len == 0 {
+    Vec::new()
+  } else {
+    // SAFETY: the protocol requires `ptr` to reference `len` initialized bytes
+    // until the module's matching free function is called below.
+    unsafe { slice::from_raw_parts(buffer.ptr.cast_const(), buffer.len) }.to_vec()
+  };
+  // SAFETY: ownership stays with the module that created the buffer.
+  unsafe { free(buffer) };
+  Ok(copied)
+}
+
+/// Try the C-safe synchronous byte-buffer protocol. `Ok(None)` means the
+/// library or this particular method has not migrated and may use the guarded
+/// legacy Rust ABI path.
+pub fn try_call_buffer(lib: &libloading::Library, lib_name: &str, method: &str, args: Vec<Edn>) -> Result<Option<Edn>, String> {
+  let version: libloading::Symbol<FfiBufferVersion> = match unsafe { lib.get(BUFFER_PROTOCOL_VERSION_SYMBOL) } {
+    Ok(version) => version,
+    Err(_) => return Ok(None),
+  };
+  let current_version = unsafe { version() };
+  if current_version != BUFFER_PROTOCOL_VERSION {
+    return Err(format!(
+      "FFI buffer protocol mismatch in `{lib_name}`: dylib={current_version}, host={BUFFER_PROTOCOL_VERSION}"
+    ));
+  }
+
+  let symbol = buffer_method_symbol(method);
+  let call: libloading::Symbol<FfiBufferCall> = match unsafe { lib.get(symbol.as_bytes()) } {
+    Ok(call) => call,
+    Err(_) => return Ok(None),
+  };
+  let free: libloading::Symbol<FfiBufferFree> = unsafe { lib.get(BUFFER_FREE_SYMBOL) }
+    .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` is missing `calcit_ffi_buffer_free`: {error}"))?;
+  let request = encode_buffer_request(args)?;
+  let mut output = FfiBuffer::empty();
+  let status = unsafe { call(request.as_ptr(), request.len(), &mut output) };
+  let output = unsafe { copy_and_free_buffer(output, &free, lib_name, &symbol) }?;
+
+  if status == 0 {
+    let source = std::str::from_utf8(&output)
+      .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` returned non-UTF-8 EDN: {error}"))?;
+    let value = cirru_edn::parse(source)
+      .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` returned invalid Cirru EDN: {error}"))?;
+    Ok(Some(value))
+  } else {
+    let message = String::from_utf8_lossy(&output);
+    Err(format!(
+      "FFI buffer method `{symbol}` in `{lib_name}` failed with status {status}: {message}"
+    ))
+  }
 }
 
 pub fn validate_build_id(
@@ -48,7 +169,22 @@ pub fn lookup_build_id(lib: &libloading::Library, lib_name: &str) -> Result<Opti
 
 #[cfg(test)]
 mod tests {
-  use super::{FfiBuildCompatibility, validate_build_id};
+  use super::{BUFFER_PROTOCOL_VERSION, FfiBuildCompatibility, buffer_method_symbol, encode_buffer_request, validate_build_id};
+  use cirru_edn::Edn;
+
+  #[test]
+  fn buffer_method_names_are_versioned_without_changing_source_calls() {
+    assert_eq!(buffer_method_symbol("run_wat"), "run_wat_calcit_ffi_v1");
+    assert_eq!(BUFFER_PROTOCOL_VERSION, 1);
+  }
+
+  #[test]
+  fn buffer_requests_are_canonical_edn_lists() {
+    let encoded = encode_buffer_request(vec![Edn::Number(1.0), Edn::str("two")]).expect("encode request");
+    let source = std::str::from_utf8(&encoded).expect("UTF-8 request");
+    let decoded = cirru_edn::parse(source).expect("parse request");
+    assert_eq!(decoded, Edn::List(cirru_edn::EdnListView(vec![Edn::Number(1.0), Edn::str("two")])));
+  }
 
   #[test]
   fn exact_identity_is_accepted() {

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -53,6 +53,21 @@ fn encode_buffer_request(args: Vec<Edn>) -> Result<Vec<u8>, String> {
     .map_err(|error| format!("failed to encode FFI buffer request: {error}"))
 }
 
+fn decode_buffer_response(status: i32, output: Vec<u8>, lib_name: &str, symbol: &str) -> Result<Edn, String> {
+  if status == 0 {
+    let source = std::str::from_utf8(&output)
+      .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` returned non-UTF-8 EDN: {error}"))?;
+    cirru_edn::parse(source)
+      .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` returned invalid Cirru EDN: {error}"))
+  } else {
+    let message = String::from_utf8(output)
+      .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` returned non-UTF-8 error output: {error}"))?;
+    Err(format!(
+      "FFI buffer method `{symbol}` in `{lib_name}` failed with status {status}: {message}"
+    ))
+  }
+}
+
 unsafe fn copy_and_free_buffer(
   buffer: FfiBuffer,
   free: &libloading::Symbol<FfiBufferFree>,
@@ -117,18 +132,7 @@ pub fn try_call_buffer(lib: &libloading::Library, lib_name: &str, method: &str, 
   let status = unsafe { call(request.as_ptr(), request.len(), &mut output) };
   let output = unsafe { copy_and_free_buffer(output, &free, lib_name, &symbol) }?;
 
-  if status == 0 {
-    let source = std::str::from_utf8(&output)
-      .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` returned non-UTF-8 EDN: {error}"))?;
-    let value = cirru_edn::parse(source)
-      .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` returned invalid Cirru EDN: {error}"))?;
-    Ok(Some(value))
-  } else {
-    let message = String::from_utf8_lossy(&output);
-    Err(format!(
-      "FFI buffer method `{symbol}` in `{lib_name}` failed with status {status}: {message}"
-    ))
-  }
+  decode_buffer_response(status, output, lib_name, &symbol).map(Some)
 }
 
 pub fn validate_build_id(
@@ -169,7 +173,10 @@ pub fn lookup_build_id(lib: &libloading::Library, lib_name: &str) -> Result<Opti
 
 #[cfg(test)]
 mod tests {
-  use super::{BUFFER_PROTOCOL_VERSION, FfiBuildCompatibility, buffer_method_symbol, encode_buffer_request, validate_build_id};
+  use super::{
+    BUFFER_PROTOCOL_VERSION, FfiBuildCompatibility, buffer_method_symbol, decode_buffer_response, encode_buffer_request,
+    validate_build_id,
+  };
   use cirru_edn::Edn;
 
   #[test]
@@ -184,6 +191,12 @@ mod tests {
     let source = std::str::from_utf8(&encoded).expect("UTF-8 request");
     let decoded = cirru_edn::parse(source).expect("parse request");
     assert_eq!(decoded, Edn::List(cirru_edn::EdnListView(vec![Edn::Number(1.0), Edn::str("two")])));
+  }
+
+  #[test]
+  fn buffer_error_responses_require_strict_utf8() {
+    let error = decode_buffer_response(1, vec![0xff], "demo", "read_calcit_ffi_v1").expect_err("invalid UTF-8 must fail");
+    assert!(error.contains("non-UTF-8 error output"), "error: {error}");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add synchronous FFI buffer protocol v1 over `extern "C"` and UTF-8 Cirru EDN
- prefer `<method>_calcit_ffi_v1` without changing Calcit source calls
- retain the build-ID-guarded Rust ABI only as a per-method migration fallback
- validate protocol version, output ownership metadata, response size, UTF-8, and EDN
- document the contract and keep callback/blocking migration explicitly out of this slice

## Safety model

The host owns request bytes during the synchronous call. The dylib owns response allocation and exports `calcit_ffi_buffer_free`; Calcit copies the bytes and asks the same dylib to free them. Rust values such as `Vec<Edn>`, `Result`, and `String` do not cross the new method boundary.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` (542 lib + 245 CLI + 24 caps + 4 WASM)
- docs: 56/56 files, 323/323 blocks
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all` (native, JS, IR, WASM, benchmarks)
- real `calcit_wasmtime` release dylib: debug Calcit host selected `run_wat_calcit_ffi_v1` and returned 27 despite incompatible Rust build profiles

Progresses #474. Callback and blocking ownership remain the next phase.
