### PR TITLE
feat: add nominal filesystem paths

### DIFF
--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -354,19 +354,18 @@
               println "|Env mode:" $ get-env |mode
               println "|Env mode:" $ option:unwrap-or (get-env |m0) "|default m0"
               eprintln "|stdout message"
-              do
-                assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .read-file)
-                assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir)
-                assert= true $ result:err?
-                  |/calcit-result-contract-does-not-exist .read-dir $ %some false
-                assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .write-file |content)
-                assert-type (|/calcit-result-contract-does-not-exist/file .read-file) (:: 'Result 'String 'String)
-                assert-type (|/calcit-result-contract-does-not-exist .read-dir)
-                  :: 'Result (:: 'List 'String) 'String
-                assert-type
-                  |/calcit-result-contract-does-not-exist .read-dir $ %some false
-                  :: 'Result (:: 'List 'String) 'String
-                assert-type (|/calcit-result-contract-does-not-exist/file .write-file |content) (:: 'Result 'Unit 'String)
+              let
+                  missing-file $ fs:path |/calcit-result-contract-does-not-exist/file
+                  missing-dir $ fs:path |/calcit-result-contract-does-not-exist
+                do
+                  assert= true $ result:err? missing-file.read-text
+                  assert= true $ result:err? missing-dir.read-dir
+                  assert= true $ result:err? missing-dir.walk-dir
+                  assert= true $ result:err? (missing-file.write-text |content)
+                  assert-type missing-file.read-text $ :: 'Result 'String 'String
+                  assert-type missing-dir.read-dir $ :: 'Result (:: 'List 'FsPath) 'String
+                  assert-type missing-dir.walk-dir $ :: 'Result (:: 'List 'FsPath) 'String
+                  assert-type (missing-file.write-text |content) (:: 'Result 'Unit 'String)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -380,13 +380,18 @@ parsed .and-then
 `.and-then`，让错误类型转换保持可见：
 
 ```cirru.no-check
-(path .read-file) .and-then $ fn (content)
-  (parse-data content) .and-then $ fn (data)
-    save-data data
+let
+    source $ fs:path |data.cirru
+    content-result source.read-text
+  content-result.and-then $ fn (content)
+    (parse-data content) .and-then $ fn (data)
+      save-data data
 ```
 
-文件路径上的 `.read-file`、`.read-dir` 与 `.write-file` 返回 `Result<...,String>`；
-底层同名函数仍保留抛错行为以兼容旧代码。预期 I/O 失败时优先使用方法形式。
+`fs:path` 把 UTF-8 字符串显式构造成 `FsPath`，不执行规范化或文件系统访问。
+`FsPath` 上的 `.read-text`、`.read-dir`、`.walk-dir` 与 `.write-text` 返回
+`Result<...,String>`；String 不提供文件效果方法。`try-read-file`、`try-read-dir`、
+`try-write-file` 以及底层 raising procedures 仍作为兼容入口。
 这些文件效果支持 native 与生成的 JavaScript；WASM 尚未提供宿主文件效果。
 
 `option:let` 使用普通 `let` 的 binding pair 结构。每个右侧和最终 body 都必须保持

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -331,12 +331,15 @@ The first argument is the value to match, the second is the default/fallback, fo
 ### Reading and Writing
 
 ```cirru.no-run
-(|data.txt .read-file) .and-then $ fn (content)
-  println content
-  %ok &unit
+let
+    source $ fs:path |data.txt
+    content-result source.read-text
+  content-result.and-then $ fn (content)
+    println content
+    %ok &unit
 ```
 
-The String methods `.read-file`, `.read-dir`, and `.write-file` return `Result`, so expected I/O failures stay in the typed flow. The raw `read-file`, `read-dir`, and `write-file` procedures remain raising compatibility primitives. Native and generated JavaScript support these host file effects; WASM does not yet expose them.
+`fs:path` constructs a nominal `FsPath` without normalizing or touching the filesystem. Its `.read-text`, `.read-dir`, `.walk-dir`, and `.write-text` methods return `Result`, so expected I/O failures stay in the typed flow; `.read-dir` lists immediate children and `.walk-dir` recurses. String has no file-effect methods. The `try-read-*`/`try-write-file` functions and raw raising procedures remain compatibility entries. Native and generated JavaScript support these host file effects; WASM does not yet expose them.
 
 ## Math Operations
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -401,7 +401,9 @@ lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
 ### Effects/IO
 
 - `echo`, `println` - output
-- `.read-file`, `.read-dir`, `.write-file` - recoverable String methods returning `Result` (native/JS; unavailable in WASM)
+- `fs:path` - construct a nominal `FsPath` from a UTF-8 String without normalization
+- `FsPath .read-text`, `.read-dir`, `.walk-dir`, `.write-text` - recoverable file effects returning `Result` (native/JS; unavailable in WASM)
+- `try-read-file`, `try-read-dir`, `try-write-file` - String-path compatibility functions returning `Result`
 - `read-file`, `read-dir`, `write-file` - raising compatibility primitives (native/JS; unavailable in WASM)
 - `get-env` - environment variables
 - `raise` - throw error

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -71,13 +71,18 @@ loaded .and-then $ fn (value) (validate value)
 `.and-then`，让错误类型的转换保持可见：
 
 ```cirru.no-check
-(path .read-file) .and-then $ fn (content)
-  (parse-data content) .and-then $ fn (data)
-    save-data data
+let
+    source $ fs:path |data.cirru
+    content-result source.read-text
+  content-result.and-then $ fn (content)
+    (parse-data content) .and-then $ fn (data)
+      save-data data
 ```
 
-文件路径上的 `.read-file`、`.read-dir` 与 `.write-file` 返回 `Result<...,String>`；
-底层同名函数仍保留抛错行为以兼容旧代码。预期 I/O 失败时优先使用方法形式。
+先用 `fs:path` 把 UTF-8 String 提升为 nominal `FsPath`，再调用 `.read-text`、
+`.read-dir`、`.walk-dir` 或 `.write-text`，这些方法返回 `Result<...,String>`。
+String 本身不携带文件系统语义；`try-read-file`、`try-read-dir`、
+`try-write-file` 与底层 raising procedures 仅保留为兼容入口。
 这些文件效果支持 native 与生成的 JavaScript；WASM 尚未提供宿主文件效果。
 
 `option:let` 的 body 必须继续返回 `Option`。普通组合函数仍以接收者方法

--- a/editing-history/202608270956-fs-path-file-effects.md
+++ b/editing-history/202608270956-fs-path-file-effects.md
@@ -1,0 +1,33 @@
+# FsPath file-effect boundary
+
+## Summary
+
+- Removed `.read-file`, `.read-dir`, and `.write-file` from the built-in String method table.
+- Added the nominal, UTF-8-backed `FsPath` type and the explicit `fs:path` constructor.
+- Added `FsPath` methods `.read-text`, `.write-text`, `.read-dir`, `.walk-dir`, and `.to-string` through a nominal trait implementation.
+- Kept `try-read-file`, `try-read-dir`, `try-write-file` and the raw raising primitives as String-path compatibility APIs.
+
+## Design notes
+
+- `path` remains available for generic AST, data, and query path concepts; the filesystem-specific type is named `FsPath`.
+- Calcit uses one immutable path value rather than copying Rust's borrowed `Path` versus owned mutable `PathBuf` split.
+- `fs:path` stores the original UTF-8 text without lexical normalization or filesystem access.
+- `.read-dir` is non-recursive and `.walk-dir` is recursive, avoiding an `Option<Bool>` mode in the new public method API.
+- Text operations are named `.read-text` and `.write-text` so future byte-oriented operations have an unambiguous place.
+
+## Implementation lesson
+
+Keep `defstruct FsPath` directly inside the public `FsPath` definition before `impl-traits`, matching the core `Result` pattern. Hiding the base struct in an intermediate `FsPath0` definition prevents required-field analysis from resolving `:value` through the nominal reference.
+
+For an expression receiver, prefix method syntax such as `.read-text $ fs:path |file` is always explicit. The ergonomic suffix form should use a typed binding such as `source.read-text`; `(fs:path |file) .read-text` is not a general runtime rewrite for arbitrary expression receivers.
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `yarn check-all`
+- changed Markdown snippets via `calcit docs check-md`
+- latest Respo main: 27/27 tests, 111/111 documentation blocks, JS codegen
+- latest Recollect main: 9/9 native tests, generated-JS tests, production build, and required WASM checks
+

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -436,10 +436,19 @@
           :tags $ #{} :internal
         |&core-string-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare) (:: :parse-cirru try-parse-cirru) (:: :parse-cirru-list try-parse-cirru-list) (:: :parse-cirru-edn try-parse-cirru-edn) (:: :parse-json try-parse-json) (:: :read-file try-read-file) (:: :read-dir try-read-dir) (:: :write-file try-write-file)
+            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare) (:: :parse-cirru try-parse-cirru) (:: :parse-cirru-list try-parse-cirru-list) (:: :parse-cirru-edn try-parse-cirru-edn) (:: :parse-json try-parse-json)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
+          :tests $ []
+            %{} 'TestEntry (:name |excludes-file-effects)
+              :code $ quote
+                let
+                    methods $ &methods-of |plain-text
+                  do
+                    assert= false $ includes? methods .read-file
+                    assert= false $ includes? methods .read-dir
+                    assert= false $ includes? methods .write-file
         |&core-struct-impls $ %{} 'CodeEntry (:doc "|Built-in implementation list for struct values.")
           :code $ quote
             def &core-struct-impls $ [] &core-struct-methods (&impl::new Debug internal/&core-debug-impl) (&impl::new Eq internal/&core-eq-impl) (&impl::new Countable internal/&core-countable-struct-impl) (&impl::new Contains internal/&core-contains-struct-impl)
@@ -2813,6 +2822,46 @@
           :examples $ []
           :schema $ :: 'Trait
           :tags $ #{} :trait
+        |FsPath $ %{} 'CodeEntry (:doc "|Nominal UTF-8 host filesystem path. Construct with fs:path; file effects are exposed on FsPath rather than String.")
+          :code $ quote
+            def FsPath $ impl-traits
+              defstruct FsPath $ :value 'String
+              , FsPathOpsImpl
+          :examples $ []
+          :schema $ :: 'StructDef
+          :tags $ #{} :core :data
+        |FsPathOps $ %{} 'CodeEntry (:doc "|Internal method contract for FsPath values.")
+          :code $ quote
+            deftrait FsPathOps
+              .read-text $ :: 'Fn
+                {}
+                  :args $ [] 'FsPath
+                  :return $ :: 'Result 'String 'String
+              .write-text $ :: 'Fn
+                {}
+                  :args $ [] 'FsPath 'String
+                  :return $ :: 'Result 'Unit 'String
+              .read-dir $ :: 'Fn
+                {}
+                  :args $ [] 'FsPath
+                  :return $ :: 'Result (:: 'List 'FsPath) 'String
+              .walk-dir $ :: 'Fn
+                {}
+                  :args $ [] 'FsPath
+                  :return $ :: 'Result (:: 'List 'FsPath) 'String
+              .to-string $ :: 'Fn
+                {}
+                  :args $ [] 'FsPath
+                  :return 'String
+          :examples $ []
+          :schema $ :: 'Trait
+          :tags $ #{} :internal :trait
+        |FsPathOpsImpl $ %{} 'CodeEntry (:doc "|Internal FsPath method implementation.")
+          :code $ quote
+            defimpl FsPathOpsImpl FsPathOps (.read-text fs-path:read-text) (.write-text fs-path:write-text) (.read-dir fs-path:read-dir) (.walk-dir fs-path:walk-dir) (.to-string fs-path:to-string)
+          :examples $ []
+          :schema $ :: 'Impl
+          :tags $ #{} :internal :trait-impl
         |Len $ %{} 'CodeEntry (:doc "|Core trait: Len")
           :code $ quote
             deftrait Len $ .len
@@ -5002,6 +5051,99 @@
                 assert= (&{} 1 1 2 2 3 3)
                   frequencies $ [] 1 2 2 3 3 3
               :tags $ #{} :core :unit
+        |fs-path:read-dir $ %{} 'CodeEntry (:doc "|List immediate children as Result<List<FsPath>,String>.")
+          :code $ quote
+            defn fs-path:read-dir (self)
+              result:map
+                try-read-dir (:value self) (%none)
+                fn (paths) (map paths fs:path)
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'FsPath
+              :return $ :: 'Result (:: 'List 'FsPath) 'String
+          :tags $ #{} :file :internal :io
+        |fs-path:read-text $ %{} 'CodeEntry (:doc "|Read an FsPath as UTF-8 text and return Result<String,String>.")
+          :code $ quote
+            defn fs-path:read-text (self)
+              try-read-file $ :value self
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'FsPath
+              :return $ :: 'Result 'String 'String
+          :tags $ #{} :file :internal :io
+        |fs-path:to-string $ %{} 'CodeEntry (:doc "|Return the stored UTF-8 path string.")
+          :code $ quote
+            defn fs-path:to-string (self) (:value self)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ [] 'FsPath
+          :tags $ #{} :internal
+        |fs-path:walk-dir $ %{} 'CodeEntry (:doc "|Recursively list descendants as Result<List<FsPath>,String>.")
+          :code $ quote
+            defn fs-path:walk-dir (self)
+              result:map
+                try-read-dir (:value self) (%some true)
+                fn (paths) (map paths fs:path)
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'FsPath
+              :return $ :: 'Result (:: 'List 'FsPath) 'String
+          :tags $ #{} :file :internal :io
+        |fs-path:write-text $ %{} 'CodeEntry (:doc "|Write UTF-8 text to an FsPath and return Result<Unit,String>.")
+          :code $ quote
+            defn fs-path:write-text (self content)
+              try-write-file (:value self) content
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'FsPath 'String
+              :return $ :: 'Result 'Unit 'String
+          :tags $ #{} :file :internal :io
+        |fs:path $ %{} 'CodeEntry (:doc "|Construct an FsPath from a UTF-8 path string without normalization or filesystem access.")
+          :code $ quote
+            defn fs:path (value)
+              %{} FsPath $ :value value
+          :examples $ []
+            quote $ fs:path |assets/data.cirru
+            quote $ .read-text (fs:path |assets/data.cirru)
+            quote $ .read-dir (fs:path |assets)
+          :schema $ :: 'Fn
+            {} (:return 'FsPath)
+              :args $ [] 'String
+          :tags $ #{} :core
+          :tests $ []
+            %{} 'TestEntry (:name |fs-path-contract)
+              :code $ quote
+                do
+                  assert= |Cargo.toml $ .to-string (fs:path |Cargo.toml)
+                  assert= true $ result:ok?
+                    .read-text $ fs:path |Cargo.toml
+                  assert= true $ result:ok?
+                    .read-dir $ fs:path |src
+                  assert= true $ result:ok?
+                    .walk-dir $ fs:path |src
+                  assert= true $ result:err?
+                    .read-text $ fs:path |/calcit-result-contract-does-not-exist/file
+                  assert= true $ result:err?
+                    .read-dir $ fs:path |/calcit-result-contract-does-not-exist
+                  assert= true $ result:err?
+                    .write-text (fs:path |/calcit-result-contract-does-not-exist/file) |content
+                  assert-type
+                    .read-text $ fs:path |/calcit-result-contract-does-not-exist/file
+                    :: 'Result 'String 'String
+                  assert-type
+                    .read-dir $ fs:path |/calcit-result-contract-does-not-exist
+                    :: 'Result (:: 'List 'FsPath) 'String
+                  assert-type
+                    .walk-dir $ fs:path |/calcit-result-contract-does-not-exist
+                    :: 'Result (:: 'List 'FsPath) 'String
+                  assert-type
+                    .write-text (fs:path |/calcit-result-contract-does-not-exist/file) |content
+                    :: 'Result 'Unit 'String
         |generate-id! $ %{} 'CodeEntry (:doc "|internal function for generating unique IDs\nSyntax: (generate-id!)\nParams: none\nReturns: unique string ID\nGenerates a unique identifier string for runtime use")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -7683,7 +7825,7 @@
                   assert= true $ result:ok? (|1 .parse-json)
                   assert= true $ result:err? (|{ .parse-json)
                   assert-type (|1 .parse-json) (:: 'Result 'Dynamic 'String)
-        |try-read-dir $ %{} 'CodeEntry (:doc "|List directory paths as Result<List<String>,String>; failures are returned instead of raised. Prefer the .read-dir String method in user code. Omit the trailing Option<Bool> for non-recursive listing, or pass %some true/%some false explicitly. Native is supported; JavaScript requires a host read_dir injection, and WASM file effects are not yet supported.")
+        |try-read-dir $ %{} 'CodeEntry (:doc "|Compatibility function that lists a directory String as Result<List<String>,String>. Omit the trailing Option<Bool> for non-recursive listing, or pass %some true for recursion. New code should use FsPath .read-dir or .walk-dir. Native is supported; JavaScript requires a host read_dir injection, and WASM file effects are not yet supported.")
           :code $ quote
             defn try-read-dir (path recursive?)
               try
@@ -7692,53 +7834,32 @@
                   (:none) (read-dir path)
                 fn (message) (%err message)
           :examples $ []
-            quote $ |src .read-dir
-            quote $ |src .read-dir (%some true)
+            quote $ try-read-dir |src
+            quote $ try-read-dir |src (%some true)
           :schema $ :: 'Fn
             {}
               :args $ [] 'String (:: 'Option 'Bool)
               :return $ :: 'Result (:: 'List 'String) 'String
-        |try-read-file $ %{} 'CodeEntry (:doc "|Read a UTF-8 file as Result<String,String>; failures are returned instead of raised. Prefer the .read-file String method in user code. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
+        |try-read-file $ %{} 'CodeEntry (:doc "|Compatibility function that reads a UTF-8 path String as Result<String,String>. New code should construct FsPath with fs:path and call .read-text. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
           :code $ quote
             defn try-read-file (path)
               try
                 %ok $ read-file path
                 fn (message) (%err message)
           :examples $ []
-            quote $ |/calcit-result-contract-does-not-exist/file .read-file
+            quote $ try-read-file |/calcit-result-contract-does-not-exist/file
           :schema $ :: 'Fn
             {}
               :args $ [] 'String
               :return $ :: 'Result 'String 'String
-          :tests $ []
-            %{} 'TestEntry (:name |result-method-contract)
-              :code $ quote
-                do
-                  assert= true $ result:ok? (|Cargo.toml .read-file)
-                  assert= true $ result:ok? (|src .read-dir)
-                  assert= true $ result:ok?
-                    |src .read-dir $ %some false
-                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .read-file)
-                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist .read-dir)
-                  assert= true $ result:err?
-                    |/calcit-result-contract-does-not-exist .read-dir $ %some false
-                  assert= true $ result:err? (|/calcit-result-contract-does-not-exist/file .write-file |content)
-                  assert-type (|/calcit-result-contract-does-not-exist/file .read-file) (:: 'Result 'String 'String)
-                  assert-type (|/calcit-result-contract-does-not-exist .read-dir)
-                    :: 'Result (:: 'List 'String) 'String
-                  assert-type
-                    |/calcit-result-contract-does-not-exist .read-dir $ %some false
-                    :: 'Result (:: 'List 'String) 'String
-                  assert-type (|/calcit-result-contract-does-not-exist/file .write-file |content) (:: 'Result 'Unit 'String)
-              :tags $ #{} :unit
-        |try-write-file $ %{} 'CodeEntry (:doc "|Write UTF-8 content as Result<Unit,String>; failures are returned instead of raised. Prefer the .write-file String method in user code. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
+        |try-write-file $ %{} 'CodeEntry (:doc "|Compatibility function that writes UTF-8 content to a path String as Result<Unit,String>. New code should construct FsPath with fs:path and call .write-text. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
           :code $ quote
             defn try-write-file (path content)
               try
                 %ok $ write-file path content
                 fn (message) (%err message)
           :examples $ []
-            quote $ |/calcit-result-contract-does-not-exist/file .write-file |content
+            quote $ try-write-file |/calcit-result-contract-does-not-exist/file |content
           :schema $ :: 'Fn
             {}
               :args $ [] 'String 'String


### PR DESCRIPTION
## Summary

- replace the file-effect methods added to `String` in #472 with a nominal UTF-8-backed `FsPath`
- add the explicit `fs:path` constructor and `FsPath` methods `.read-text`, `.write-text`, `.read-dir`, `.walk-dir`, and `.to-string`
- keep `try-read-file`, `try-read-dir`, `try-write-file`, and the raw raising primitives as String-path compatibility APIs
- separate non-recursive `.read-dir` from recursive `.walk-dir` instead of exposing `Option<Bool>` on the new method API
- document that construction performs no normalization or filesystem access

## Design

`path` remains available for generic AST, data, and query paths. `FsPath` identifies the host-filesystem domain without copying Rust's borrowed `Path` versus owned mutable `PathBuf` split, which does not fit Calcit's immutable value model.

String method introspection now explicitly verifies that file effects are absent. `FsPath` tests cover native success and failure paths plus the complete nominal `Result` contracts.

## Compatibility

The newly added String method syntax is removed. Existing function-form Result wrappers and raising primitives remain available, so callers can migrate incrementally by constructing `FsPath` values with `fs:path`.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn check-all`
- changed Markdown snippets via `calcit docs check-md`
- latest Respo main: 27/27 tests, 111/111 documentation blocks, JS codegen
- latest Recollect main: 9/9 native tests, generated-JS tests, production build, required WASM checks

