### PR TITLE
chore: retire legacy snapshot config aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 calcit docs agents --full
 ```
 
-未先阅读最新 Agent 指南时，不要直接开始改 `calcit.cirru`（兼容旧文件名 `compact.cirru`），避免沿用过时心智模型误判命令边界。
+未先阅读最新 Agent 指南时，不要直接开始改 `calcit.cirru`；旧文件名 `compact.cirru` 已停用，必须先按升级指南迁移。
 
 ### 运行模式更新（calcit / js）
 
@@ -35,7 +35,7 @@ calcit docs agents --full
 ### calcit eval 基础与常见踩坑
 
 - **用途定位**：`calcit eval` 适合快速验证语义/类型提示与宏展开，不等同于完整项目运行。
-- **可加载外部模块**：`calcit eval` 支持重复传入 `--dep`，可加载多个模块目录（路径以 `/` 结尾时会优先读取其中的 `calcit.cirru`，并回退到 `compact.cirru`）。
+- **可加载外部模块**：`calcit eval` 支持重复传入 `--dep`，可加载多个模块目录（路径以 `/` 结尾时读取其中的 `calcit.cirru`；仅有 `compact.cirru` 的模块会被拒绝并提示迁移）。
   - ✅ `cargo run --bin calcit -- calcit/test.cirru eval --dep ~/.config/calcit/modules/respo.calcit/ -- 'ns app.demo $ :require respo.util.detect :refer $ element?\n\nelement? nil'`
 - **首表达式 `ns` 会注入当前 eval 程序**：当 snippet 第一个表达式是 `ns` 时，会把 `ns <NS> ...` 从第 3 个节点开始（通常是 `:require` 等规则）合并到运行用的 `ns app.main`，用于在 eval 中显式导入命名空间。
 - **`docs check-md` 也支持依赖模块**：`calcit docs check-md` 可通过多次 `--dep` 传参，内部会透传给 `eval`/`--check-only`。这样 markdown 代码块可配合首行 `ns ... :require ...` 访问模块函数。

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Core design:
 
 Current direction:
 
-- `calcit.cirru` is the primary source snapshot; legacy `compact.cirru` is still compatible
+- `calcit.cirru` is the canonical source snapshot; retired `compact.cirru` inputs receive migration guidance
 - CLI-first development with `calcit` and `caps`, designed to work well with AI agents in terminal workflows
 - Better CLI editing and validation for CI, docs lookup, module management, and incremental updates
 
@@ -62,18 +62,16 @@ calcit eval 'range 100'
 calcit eval -- '-> 100 range (map $ \ * % %)'
 ```
 
-Run with a runtime snapshot such as `calcit.cirru` (legacy filename: `compact.cirru`):
+Run with the canonical runtime snapshot `calcit.cirru`:
 
 ```bash
 calcit calcit.cirru # run once (default)
-calcit compact.cirru # legacy filename still works
-
-calcit # by default, it picks `calcit.cirru`, then falls back to `compact.cirru`
+calcit # reads calcit.cirru from the current directory
 
 calcit -w # watch mode (explicit flag required)
 ```
 
-By default Calcit reads `:init-fn` and `:reload-fn` from `calcit.cirru` configs (falling back to `compact.cirru`). You may also specify functions:
+By default Calcit reads `:init-fn` and `:reload-fn` from `calcit.cirru` `:entries.default`. You may also specify functions:
 
 ```bash
 calcit --init-fn='app.main/main!' --reload-fn='app.main/reload!'
@@ -150,7 +148,7 @@ Use `caps add --dev <org/repo>@<ref>` and `caps remove --dev <org/repo>` to mana
 
 `:calcit-version` helps with version checks and provides hints in [CI](https://github.com/calcit-lang/setup-calcit).
 
-To load modules, use `:modules` configuration and the runtime snapshot file `calcit.cirru` (legacy: `compact.cirru`):
+To load modules, use `:modules` configuration and the runtime snapshot file `calcit.cirru`:
 
 ```cirru.no-check
 :entries $ {}
@@ -161,7 +159,7 @@ To load modules, use `:modules` configuration and the runtime snapshot file `cal
 Paths defined in `:modules` load from the snapshot directory's `.calcit/modules/`, e.g.
 `.calcit/modules/memof/calcit.cirru`. Run `caps` to materialize or refresh that project-local view.
 
-Modules ending with `/` are automatically suffixed with `calcit.cirru`, and still fall back to `compact.cirru` for compatibility.
+Modules ending with `/` are automatically suffixed with `calcit.cirru`. A module containing only retired `compact.cirru` is rejected with migration guidance.
 
 Inspect and verify the resolved graph with:
 
@@ -203,7 +201,7 @@ yarn check-all
 ```
 
 - [Cirru Parser](https://github.com/Cirru/parser.rs) for indentation-based syntax parsing.
-- [Cirru EDN](https://github.com/Cirru/cirru-edn.rs) for runtime snapshot file parsing (`calcit.cirru` / legacy `compact.cirru`).
+- [Cirru EDN](https://github.com/Cirru/cirru-edn.rs) for canonical runtime snapshot parsing (`calcit.cirru`).
 - [Ternary Tree](https://github.com/calcit-lang/ternary-tree.rs) for immutable list data structure.
 
 Other tools:

--- a/RFCs/05-12-program-diff-rfc.md
+++ b/RFCs/05-12-program-diff-rfc.md
@@ -11,7 +11,7 @@
 
 - `calcit analyze program-diff <GIT REF>`
 
-该命令从 Git 中读取指定版本的完整运行时快照文件（默认沿用当前 `calcit` 的输入文件路径，优先 `calcit.cirru`，兼容旧文件名 `compact.cirru`），确保**历史版本**与**当前工作区版本**都能被正确解析为 Calcit snapshot，然后做**结构化 diff**。
+该命令从 Git 中读取指定版本的完整运行时快照文件（默认沿用当前 `calcit` 的 canonical `calcit.cirru` 输入路径；退休的 `compact.cirru` 会被拒绝并提示迁移），确保**历史版本**与**当前工作区版本**都能被正确解析为 Calcit snapshot，然后做**结构化 diff**。
 
 输出目标不是纯文本行 diff，而是面向程序结构的树形 diff：
 
@@ -27,7 +27,7 @@
 
 当前针对运行时快照文件的版本对比主要依赖 Git 行 diff，但它有几个明显问题：
 
-1. **对结构不友好**：`calcit.cirru`（兼容旧文件名 `compact.cirru`）是机器生成的 snapshot，行 diff 容易受格式、字段顺序和长表达式影响；
+1. **对结构不友好**：`calcit.cirru` 是机器生成的 snapshot，行 diff 容易受格式、字段顺序和长表达式影响；
 2. **对表达式内部变化不友好**：definition 代码改动往往是局部子树变化，行 diff 很难快速看出 AST 层面的增删改；
 3. **对 LLM / CLI 阅读不友好**：调用 `git diff` 后很难一眼区分“只是某个 def 变了”还是“整个 namespace 被搬动了”；
 4. **缺少 parse guard**：历史版本文件如果本身损坏，应该先明确报解析失败，而不是直接进入错误 diff。
@@ -43,7 +43,7 @@ calcit analyze program-diff <GIT REF>
 语义：
 
 - `<GIT REF>` 可以是 `HEAD~1`、tag、branch、commit SHA 等；
-- 当前侧使用 `calcit` 输入路径（默认优先 `calcit.cirru`，兼容旧文件名 `compact.cirru`）；
+- 当前侧使用 `calcit` 输入路径（默认是 canonical `calcit.cirru`；退休的 `compact.cirru` 不参与 diff）；
 - 历史侧使用 `git show <ref>:<repo-relative-input-path>` 读取文件内容；
 - 两边都必须先经过：
   1. `cirru_edn::parse`
@@ -177,7 +177,7 @@ list 内部子节点对比采用“带替换代价的序列对齐”策略：
 
 ## 7. 预期收益
 
-- 更适合 review `calcit.cirru`（兼容旧文件名 `compact.cirru`）的语义变化；
+- 更适合 review canonical `calcit.cirru` 的语义变化；
 - 更容易理解大型 definition 的局部 AST 改动；
 - 对 agent/LLM 更友好，能直接拿到层级化变化；
 - 为后续抽象成 Cirru diff 模块提供实现样本。

--- a/build.rs
+++ b/build.rs
@@ -65,20 +65,6 @@ pub struct SnapshotEntry {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LegacySnapshotConfigs {
-  #[serde(rename = "init-fn", deserialize_with = "deserialize_ns_def")]
-  pub init_fn: String,
-  #[serde(rename = "reload-fn", deserialize_with = "deserialize_ns_def")]
-  pub reload_fn: String,
-  #[serde(default)]
-  pub modules: Vec<String>,
-  #[serde(default)]
-  pub version: String,
-  #[serde(default, rename = "type-slots")]
-  pub type_slots: HashMap<String, String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodeEntry {
   pub doc: String,
   #[serde(default)]
@@ -613,30 +599,15 @@ fn main() {
 
   let files = parse_files(data.get_or_nil("files")).unwrap_or_else(|e| panic!("failed to parse calcit-core `:files`: {e}"));
 
-  let legacy_configs = match data.get_or_nil("configs") {
-    Edn::Nil => None,
-    value => {
-      Some(from_edn::<LegacySnapshotConfigs>(value).unwrap_or_else(|e| panic!("failed to parse calcit-core legacy `:configs`: {e}")))
-    }
-  };
-  let mut entries = parse_entries(data.get_or_nil("entries")).unwrap_or_else(|e| panic!("failed to parse calcit-core `:entries`: {e}"));
-  if let Some(configs) = &legacy_configs {
-    entries.insert(
-      "default".to_owned(),
-      SnapshotEntry {
-        mode: SnapshotRunMode::Native,
-        init_fn: configs.init_fn.clone(),
-        reload_fn: configs.reload_fn.clone(),
-        description: String::new(),
-        modules: configs.modules.clone(),
-        type_slots: configs.type_slots.clone(),
-        feature_policy: HashMap::new(),
-        target: None,
-      },
-    );
+  if data.contains_key("configs") {
+    panic!("calcit-core uses retired top-level `:configs`; migrate it with Calcit 0.13.50 before building")
+  }
+  let entries = parse_entries(data.get_or_nil("entries")).unwrap_or_else(|e| panic!("failed to parse calcit-core `:entries`: {e}"));
+  if !entries.contains_key("default") {
+    panic!("calcit-core `:entries` must contain `:default`");
   }
   let version = match data.get_or_nil("version") {
-    Edn::Nil => legacy_configs.map(|configs| configs.version).unwrap_or_default(),
+    Edn::Nil => String::new(),
     value => from_edn(value).unwrap_or_else(|e| panic!("failed to parse calcit-core `:version`: {e}")),
   };
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -27,7 +27,7 @@ entry_for:
 calcit --help
 ```
 
-Quick note: `calcit edit format` rewrites the target snapshot using canonical serialization without guessing semantic changes. It normalizes legacy namespace records and top-level `:configs`, and rewrites legacy schema type tags such as `:string` and `:ref` to quoted symbols such as `'String` and `'Ref` only in known type positions. Ordinary tag data stays unchanged. It then emits recoverable stderr advisories for legacy filenames, legacy `:any`, and unresolved dynamic type debt. Use `calcit analyze weak-types` for exact paths and recommendations; format warnings do not turn the command into a type-quality gate.
+Quick note: `calcit edit format` rewrites the target snapshot using canonical serialization without guessing semantic changes. Retired `compact.cirru` filenames and top-level `:configs` are rejected with migration guidance; use the final compatible Calcit 0.13.50 release to convert them first. Current formatting normalizes older namespace records and rewrites legacy schema type tags such as `:string` and `:ref` to quoted symbols such as `'String` and `'Ref` only in known type positions. Ordinary tag data stays unchanged. It emits recoverable stderr advisories for legacy `:any` and unresolved dynamic type debt. Use `calcit analyze weak-types` for exact paths and recommendations; format warnings do not turn the command into a type-quality gate.
 
 For feature-level planning, use `calcit edit scaffold`. Its primary input is a
 Cirru EDN architecture plan, preferably stored under

--- a/docs/run/edit-tree.md
+++ b/docs/run/edit-tree.md
@@ -42,7 +42,7 @@ The `edit` command handles high-level operations on namespaces and definitions.
 calcit edit format
 ```
 
-This command also rewrites older namespace records and top-level `:configs` into canonical shapes. It succeeds after recoverable migrations, while stderr identifies `W_LEGACY_CONFIG`, `W_LEGACY_ANY`, or `W_DYNAMIC_TYPE_DEBT` when follow-up work is recommended. A retired `compact.cirru` filename is rejected before formatting. It does not invent concrete types; follow dynamic or unbound-slot warnings with `calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved`.
+This command also rewrites older namespace records into canonical shapes. Retired `compact.cirru` filenames and top-level `:configs` are rejected before formatting; use the final compatible Calcit 0.13.50 release for that one-way migration. For accepted snapshots, stderr identifies `W_LEGACY_ANY` or `W_DYNAMIC_TYPE_DEBT` when follow-up work is recommended. It does not invent concrete types; follow dynamic or unbound-slot warnings with `calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved`.
 
 ### Persistent Tree Cursor
 

--- a/docs/run/entries.md
+++ b/docs/run/entries.md
@@ -65,4 +65,4 @@ calcit config type-slots --entry server
 
 The type-slot environment is selected before preprocessing starts, so the binding applies to the whole reachable call graph. Entry functions do not need a `with-type-slot` wrapper.
 
-Legacy snapshots containing top-level `:configs` still load. Calcit maps that object to `entries.default` with `:mode :native`; the next canonical snapshot write emits only the unified format.
+Top-level `:configs` is retired. If an old snapshot still contains it, use the final compatible Calcit 0.13.50 release to run `calcit calcit.cirru edit format`, review the generated `entries.default`, and then validate it with the current release. Current Calcit rejects the old shape instead of guessing an implicit `:mode :native`.

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -54,8 +54,7 @@ git diff --exit-code -- calcit.cirru
 
 `edit format` 是可恢复的规范化步骤，不是完整 linter。它会继续完成格式化，同时对以下情况写入 stderr 告警并给出后续命令：
 
-- `W_LEGACY_CONFIG`：顶层 `:configs` 已迁移到 `:entries.default`。
-- `compact.cirru` 会被直接拒绝，不再进入 formatter 告警阶段。
+- 顶层 `:configs` 和 `compact.cirru` 会被直接拒绝，不再进入 formatter 告警阶段。使用最后兼容版本 Calcit 0.13.50 完成格式迁移，再回到当前版本验证。
 - `W_LEGACY_ANY`：schema 中的旧 `:any` 被规范化为 `'Dynamic`；其他旧 type tags 也会在已知类型位置改写为 quoted symbol。
 - `W_DYNAMIC_TYPE_DEBT`：本地定义仍有 unresolved dynamic；format 不会猜测类型并自动改写语义。
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -424,14 +424,14 @@ fallback 必须与 payload 类型兼容；需要区分缺失分支时改用 `if-
 
 ### 3.3 统一 entries
 
-顶层 `:configs` 是兼容输入，不应继续作为新配置写法。执行：
+顶层 `:configs` 已停止加载。先使用最后兼容版本 Calcit 0.13.50 执行：
 
 ```bash
 calcit calcit.cirru edit format
 calcit calcit.cirru config show
 ```
 
-format 会把旧 `:configs` 迁移为 `:entries.default`，并输出 `W_LEGACY_CONFIG`。随后应审阅：
+0.13.50 的 format 会把旧 `:configs` 迁移为 `:entries.default`。当前严格版本只输出包含 Snapshot 路径和上述命令的错误，不再保留双格式解码分支。迁移后应审阅：
 
 - 每个 entry 都有明确的 `:mode :native` 或 `:mode :js`。
 - named entry 是完整配置，不继承 default 的 modules/type slots。

--- a/editing-history/20260827-1225-retire-snapshot-configs.md
+++ b/editing-history/20260827-1225-retire-snapshot-configs.md
@@ -1,0 +1,6 @@
+# Retire legacy Snapshot config aliases
+
+- Stop decoding top-level `:configs` at runtime and while embedding `calcit.core`; point legacy projects to Calcit 0.13.50 for the one-way `:entries.default` migration.
+- Remove silent `calcit.cirru` to `compact.cirru` path aliasing across runtime, query, docs, and diff commands while retaining sibling detection for an actionable error.
+- Remove the formatter advisory for a shape that current Calcit no longer loads, and align README, Agent guidance, and Snapshot docs with the released filename cutoff.
+- Validate the strict loader against the latest `Respo/respo` and `calcit-lang/recollect` main branches: native checks/tests, Markdown examples, generated JavaScript tests, quality gates, and production Vite builds remain green.

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -339,10 +339,6 @@ fn find_map_value_mut<'a>(map: &'a mut EdnMapView, key: &str) -> Option<&'a mut 
   map.0.get_mut(&Edn::str(key))
 }
 
-fn find_map_value<'a>(map: &'a EdnMapView, key: &str) -> Option<&'a Edn> {
-  map.get(&Edn::tag(key)).or_else(|| map.get(&Edn::str(key)))
-}
-
 fn type_slots_as_edn(type_slots: &HashMap<String, String>) -> Edn {
   let mut slots = EdnMapView::default();
   for (slot, type_path) in type_slots {
@@ -371,38 +367,14 @@ fn save_type_slots_preserving_snapshot(
   let Edn::Map(root) = &mut data else {
     return Err("Snapshot root must be an EDN map".to_owned());
   };
-  let has_default_entry = match find_map_value(root, "entries") {
-    Some(Edn::Map(entries)) => find_map_value(entries, snapshot::DEFAULT_ENTRY_NAME).is_some(),
-    _ => false,
+  let entry_name = entry.unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
+  let entries_value = find_map_value_mut(root, "entries").ok_or_else(|| "Snapshot is missing :entries".to_owned())?;
+  let Edn::Map(entries) = entries_value else {
+    return Err("Snapshot :entries must be an EDN map".to_owned());
   };
-
-  let configs = if let Some(entry_name) = entry {
-    let entries_value = find_map_value_mut(root, "entries").ok_or_else(|| "Snapshot is missing :entries".to_owned())?;
-    let Edn::Map(entries) = entries_value else {
-      return Err("Snapshot :entries must be an EDN map".to_owned());
-    };
-    let entry_value = find_map_value_mut(entries, entry_name).ok_or_else(|| format!("Entry '{entry_name}' not found"))?;
-    let Edn::Map(entry_configs) = entry_value else {
-      return Err(format!("Entry '{entry_name}' config must be an EDN map"));
-    };
-    entry_configs
-  } else if has_default_entry {
-    let entries_value = find_map_value_mut(root, "entries").ok_or_else(|| "Snapshot is missing :entries".to_owned())?;
-    let Edn::Map(entries) = entries_value else {
-      return Err("Snapshot :entries must be an EDN map".to_owned());
-    };
-    let entry_value =
-      find_map_value_mut(entries, snapshot::DEFAULT_ENTRY_NAME).ok_or_else(|| "Snapshot is missing :entries.default".to_owned())?;
-    let Edn::Map(entry_configs) = entry_value else {
-      return Err("Entry 'default' config must be an EDN map".to_owned());
-    };
-    entry_configs
-  } else {
-    let configs_value = find_map_value_mut(root, "configs").ok_or_else(|| "Snapshot is missing :entries or :configs".to_owned())?;
-    let Edn::Map(configs) = configs_value else {
-      return Err("Snapshot :configs must be an EDN map".to_owned());
-    };
-    configs
+  let entry_value = find_map_value_mut(entries, entry_name).ok_or_else(|| format!("Entry '{entry_name}' not found"))?;
+  let Edn::Map(configs) = entry_value else {
+    return Err(format!("Entry '{entry_name}' config must be an EDN map"));
   };
 
   configs.insert_key("type-slots", type_slots_as_edn(type_slots));
@@ -487,7 +459,7 @@ mod tests {
     fs::create_dir_all(global.join("demo")).unwrap();
     let snapshot = |package: &str| {
       format!(
-        "{{}} (:package |{package})\n  :configs $ {{}} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!) (:version |0.0.1)\n    :modules $ []\n  :files $ {{}}\n"
+        "{{}} (:package |{package})\n  :entries $ {{}}\n    :default $ {{}} (:mode :native) (:init-fn |app.main/main!) (:reload-fn |app.main/reload!)\n      :modules $ []\n  :files $ {{}}\n"
       )
     };
     fs::write(project.join(".calcit/modules/demo/compact.cirru"), "invalid snapshot").unwrap();
@@ -516,9 +488,9 @@ mod tests {
   #[test]
   fn type_slot_edn_mutation_preserves_unrelated_snapshot_data() {
     let source = r#"{} (:package |demo)
-  :configs $ {} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!) (:version |0.0.1)
-    :modules $ []
   :entries $ {}
+    :default $ {} (:mode :native) (:init-fn |app.main/main!) (:reload-fn |app.main/reload!)
+      :modules $ []
   :files $ {}
     |app.main $ %{} :FileEntry
       :defs $ {}
@@ -559,8 +531,11 @@ mod tests {
       read_definition_field(&before_root, "schema"),
       read_definition_field(&after_root, "schema")
     );
-    let Edn::Map(configs) = after_root.get_or_nil("configs") else {
-      panic!("configs")
+    let Edn::Map(entries) = after_root.get_or_nil("entries") else {
+      panic!("entries")
+    };
+    let Edn::Map(configs) = entries.get_or_nil(snapshot::DEFAULT_ENTRY_NAME) else {
+      panic!("entries.default")
     };
     let Edn::Map(saved_slots) = configs.get_or_nil("type-slots") else {
       panic!("type slots")

--- a/src/bin/cli_handlers/docs.rs
+++ b/src/bin/cli_handlers/docs.rs
@@ -1488,17 +1488,18 @@ fn ensure_runtime_initialized() {
 }
 
 fn collect_check_md_module_paths(entry: &str, deps: &[String]) -> Result<Vec<String>, String> {
-  let resolved_entry = calcit::resolve_snapshot_path_alias(Path::new(entry));
+  let resolved_entry = Path::new(entry);
+  calcit::validate_snapshot_path(resolved_entry)?;
   let mut content =
-    fs::read_to_string(&resolved_entry).map_err(|e| format!("Failed to read entry file '{}': {e}", resolved_entry.display()))?;
+    fs::read_to_string(resolved_entry).map_err(|e| format!("Failed to read entry file '{}': {e}", resolved_entry.display()))?;
   util::string::strip_shebang(&mut content);
   let data = cirru_edn::parse(&content).map_err(|e| format!("Failed to parse entry file '{}': {e}", resolved_entry.display()))?;
 
-  // Extract entries.default.modules (or legacy configs.modules) directly from raw EDN.
-  // This is necessary because old-format snapshots (with %{} :Expr code entries) cannot
-  // be deserialized via load_snapshot_data, but we only need the module list here.
+  // Extract entries.default.modules directly from raw EDN. This is necessary
+  // because older code-entry encodings may not fully deserialize, while docs
+  // checking only needs the module list.
   // Fail fast on malformed modules to avoid silently dropping dependencies.
-  let module_paths_from_entry: Vec<String> = extract_modules_from_edn(&data)?;
+  let module_paths_from_entry: Vec<String> = extract_modules_from_edn(&data, entry)?;
 
   let mut module_paths = module_paths_from_entry;
   module_paths.extend(deps.iter().cloned());
@@ -1511,7 +1512,7 @@ fn collect_check_md_module_paths(entry: &str, deps: &[String]) -> Result<Vec<Str
 /// Extract the default entry's module list from an EDN snapshot value without fully
 /// deserializing the snapshot. This tolerates old-format entries (e.g. `%{} :Expr`)
 /// that `load_snapshot_data` cannot handle.
-fn extract_modules_from_edn(data: &cirru_edn::Edn) -> Result<Vec<String>, String> {
+fn extract_modules_from_edn(data: &cirru_edn::Edn, source_path: &str) -> Result<Vec<String>, String> {
   use cirru_edn::Edn;
 
   // Both old and new snapshot formats use a top-level Map or Struct.
@@ -1523,15 +1524,15 @@ fn extract_modules_from_edn(data: &cirru_edn::Edn) -> Result<Vec<String>, String
     }
   };
 
+  if get_field(data, "configs").is_some() {
+    return Err(snapshot::retired_snapshot_configs_error(source_path));
+  }
   let entry = match get_field(data, "entries") {
     Some(entries) => match get_field(&entries, snapshot::DEFAULT_ENTRY_NAME) {
       Some(entry) => entry,
       None => return Err("Snapshot `:entries` is missing `:default`".to_owned()),
     },
-    None => match get_field(data, "configs") {
-      Some(configs) => configs,
-      None => return Ok(vec![]),
-    },
+    None => return Ok(vec![]),
   };
   let modules_edn = match get_field(&entry, "modules") {
     Some(modules) => modules,
@@ -1562,9 +1563,10 @@ fn extract_modules_from_edn(data: &cirru_edn::Edn) -> Result<Vec<String>, String
 }
 
 pub(crate) fn load_entry_snapshot_for_check_md(entry: &str) -> Result<snapshot::Snapshot, String> {
-  let resolved_entry = calcit::resolve_snapshot_path_alias(Path::new(entry));
+  let resolved_entry = Path::new(entry);
+  calcit::validate_snapshot_path(resolved_entry)?;
   let mut content =
-    fs::read_to_string(&resolved_entry).map_err(|e| format!("Failed to read entry file '{}': {e}", resolved_entry.display()))?;
+    fs::read_to_string(resolved_entry).map_err(|e| format!("Failed to read entry file '{}': {e}", resolved_entry.display()))?;
   util::string::strip_shebang(&mut content);
   let data = cirru_edn::parse(&content).map_err(|e| format!("Failed to parse entry file '{}': {e}", resolved_entry.display()))?;
   snapshot::load_snapshot_data(&data, &resolved_entry.display().to_string())

--- a/src/bin/cli_handlers/docs_tests.rs
+++ b/src/bin/cli_handlers/docs_tests.rs
@@ -147,6 +147,27 @@ fn collect_check_md_module_paths_merges_entry_modules_with_cli_deps() {
 }
 
 #[test]
+fn collect_check_md_module_paths_rejects_retired_configs() {
+  let root = unique_temp_dir("check-md-retired-configs");
+  let entry = root.join("mini snapshot.cirru");
+  let content = r#"{} (:package |mini)
+  :configs $ {} (:init-fn |mini/main!) (:reload-fn |mini/main!)
+    :modules $ [] |respo.calcit/
+  :entries $ {}
+  :files $ {}
+"#;
+  write_file(&entry, content);
+
+  let error = collect_check_md_module_paths(entry.to_str().expect("entry path should be utf-8"), &[])
+    .expect_err("docs dependency discovery must reject retired configs");
+  assert!(error.contains("Top-level `:configs` is retired"), "error: {error}");
+  assert!(error.contains("Calcit 0.13.50"), "error: {error}");
+  assert!(error.contains("mini snapshot.cirru"), "error: {error}");
+
+  fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn load_entry_snapshot_for_check_md_reads_respo_project() {
   let entry = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../respo/respo/calcit.cirru");
   if !entry.exists() {

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -277,13 +277,6 @@ fn collect_format_advisories(snapshot_file: &str, original_edn: &Edn, snapshot: 
   let mut advisories = vec![];
   let snapshot_arg = shell_quote(snapshot_file);
 
-  if original_edn.view_map().is_ok_and(|root| root.contains_key("configs")) {
-    advisories.push(format!(
-      "[W_LEGACY_CONFIG] Migrated top-level `:configs` to `:entries.default`; canonical formatting keeps the project runnable.\n\
-       Next: run `calcit {snapshot_arg} config show` and set an explicit `:mode` plus any named entries with `calcit {snapshot_arg} config set ...`."
-    ));
-  }
-
   let selected = std::collections::BTreeSet::from([
     crate::type_coverage::WeakTypeKind::SchemaDynamic,
     crate::type_coverage::WeakTypeKind::UnresolvedTypeSlot,
@@ -2860,12 +2853,11 @@ mod tests {
   }
 
   #[test]
-  fn format_advisories_cover_legacy_structure_and_dynamic_debt() {
+  fn format_advisories_cover_dynamic_debt() {
     let snapshot = load_snapshot("calcit/test.cirru").expect("fixture snapshot should load");
-    let original_edn = cirru_edn::parse("{} (:configs $ {}) (:schema :any)").expect("legacy markers should parse");
+    let original_edn = cirru_edn::parse("{} (:schema :any)").expect("legacy markers should parse");
     let advisories = collect_format_advisories("calcit.cirru", &original_edn, &snapshot).join("\n");
 
-    assert!(advisories.contains("W_LEGACY_CONFIG"), "advisories: {advisories}");
     assert!(advisories.contains("W_LEGACY_ANY"), "advisories: {advisories}");
     assert!(advisories.contains("W_DYNAMIC_TYPE_DEBT"), "advisories: {advisories}");
     assert!(advisories.contains("analyze weak-types"), "advisories: {advisories}");

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -1805,7 +1805,8 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
   let format = parse_query_render_format(&opts.format)?;
   let target_path = parse_type_at_path(&opts.path)?;
   let (namespace, requested_definition) = parse_target(&opts.target)?;
-  let resolved_input = calcit::resolve_snapshot_path_alias(Path::new(input_path));
+  let resolved_input = Path::new(input_path);
+  calcit::validate_snapshot_path(resolved_input)?;
   let snapshot = if resolved_input.exists() {
     load_snapshot(input_path)?
   } else if namespace == calcit::calcit::CORE_NS || namespace == "calcit.internal" {
@@ -2671,7 +2672,8 @@ fn handle_context(input_path: &str, opts: &QueryContextCommand) -> Result<(), St
   }
   let format = parse_query_render_format(&opts.format)?;
   let (namespace, requested_definition) = parse_target(&opts.target)?;
-  let resolved_input = calcit::resolve_snapshot_path_alias(Path::new(input_path));
+  let resolved_input = Path::new(input_path);
+  calcit::validate_snapshot_path(resolved_input)?;
   let snapshot = if resolved_input.exists() {
     load_snapshot(input_path)?
   } else if namespace == calcit::calcit::CORE_NS || namespace == "calcit.internal" {
@@ -2724,13 +2726,14 @@ fn load_snapshot(input_path: &str) -> Result<snapshot::Snapshot, String> {
 }
 
 fn load_main_snapshot(input_path: &str) -> Result<snapshot::Snapshot, String> {
-  let resolved_input_path = calcit::resolve_snapshot_path_alias(Path::new(input_path));
+  let resolved_input_path = Path::new(input_path);
+  calcit::validate_snapshot_path(resolved_input_path)?;
   let resolved_input_str = resolved_input_path.to_string_lossy().to_string();
   if !resolved_input_path.exists() {
     return Err(format!("{} does not exist", resolved_input_path.display()));
   }
 
-  let mut content = fs::read_to_string(&resolved_input_path).map_err(|e| format!("Failed to read file: {e}"))?;
+  let mut content = fs::read_to_string(resolved_input_path).map_err(|e| format!("Failed to read file: {e}"))?;
   strip_shebang(&mut content);
   let data = cirru_edn::parse(&content).map_err(|e| {
     eprintln!("\nFailed to parse file '{}':", resolved_input_path.display());

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -377,7 +377,7 @@ fn run_cli() -> Result<(), String> {
     }
   }
 
-  let input_path = calcit::resolve_snapshot_path_alias(&PathBuf::from(&cli_args.input));
+  let input_path = PathBuf::from(&cli_args.input);
   let input_path_str = input_path.to_string_lossy().to_string();
   let base_dir = input_path.parent().expect("extract parent");
   let module_folder = calcit::project_module_folder(base_dir);
@@ -419,6 +419,7 @@ fn run_cli() -> Result<(), String> {
       calcit::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
     }
   } else {
+    calcit::validate_snapshot_path(&input_path)?;
     if !input_path.exists() {
       return Err(format!("{} does not exist", input_path.display()));
     }

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -59,7 +59,8 @@ fn main() -> Result<(), String> {
 
   let core_snapshot = calcit::load_core_snapshot()?;
 
-  let input_path = calcit::resolve_snapshot_path_alias(&PathBuf::from(&cli_args.input));
+  let input_path = PathBuf::from(&cli_args.input);
+  calcit::validate_snapshot_path(&input_path)?;
   let input_path_str = input_path.to_string_lossy().to_string();
   if !input_path.exists() {
     return Err(format!("{} does not exist", input_path.display()));

--- a/src/call_graph_diff.rs
+++ b/src/call_graph_diff.rs
@@ -381,10 +381,10 @@ fn resolve_input_path(cwd: &Path, input_path: &str) -> Result<PathBuf, String> {
   } else {
     cwd.join(input)
   };
-  let resolved = crate::resolve_snapshot_path_alias(&full_path);
-  resolved
+  crate::validate_snapshot_path(&full_path)?;
+  full_path
     .canonicalize()
-    .map_err(|e| format!("Failed to resolve input path '{}': {e}", resolved.display()))
+    .map_err(|e| format!("Failed to resolve input path '{}': {e}", full_path.display()))
 }
 
 fn git_root(cwd: &Path) -> Result<PathBuf, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,18 +131,24 @@ pub fn run_program(init_ns: Arc<str>, init_def: Arc<str>, params: &[Calcit]) -> 
   run_program_with_docs(init_ns, init_def, params)
 }
 
-pub fn resolve_snapshot_path_alias(path: &Path) -> PathBuf {
-  if path.exists() {
-    return path.to_path_buf();
+/// Reject retired Snapshot inputs without silently resolving them as aliases.
+///
+/// A missing canonical path still checks for a sibling `compact.cirru` solely
+/// to report the actionable migration error instead of a generic not-found
+/// message. The retired path is never returned to a caller for loading.
+pub fn validate_snapshot_path(path: &Path) -> Result<(), String> {
+  if let Some(error) = snapshot::retired_snapshot_migration_error(path) {
+    return Err(error);
   }
-
-  match path.file_name().and_then(|name| name.to_str()) {
-    Some(DEFAULT_SNAPSHOT_FILE) => {
-      let fallback = path.with_file_name(LEGACY_SNAPSHOT_FILE);
-      if fallback.exists() { fallback } else { path.to_path_buf() }
+  if !path.exists() && path.file_name().and_then(|name| name.to_str()) == Some(DEFAULT_SNAPSHOT_FILE) {
+    let retired_path = path.with_file_name(LEGACY_SNAPSHOT_FILE);
+    if retired_path.is_file()
+      && let Some(error) = snapshot::retired_snapshot_migration_error(&retired_path)
+    {
+      return Err(error);
     }
-    _ => path.to_path_buf(),
   }
+  Ok(())
 }
 
 fn module_path_candidates(path: &str) -> Vec<String> {
@@ -405,7 +411,10 @@ pub fn merge_project_module_files(
 
 #[cfg(test)]
 mod module_resolution_tests {
-  use super::{load_module, merge_module_files, merge_project_module_files, project_module_folder, resolve_module_snapshot_candidates};
+  use super::{
+    load_module, merge_module_files, merge_project_module_files, project_module_folder, resolve_module_snapshot_candidates,
+    validate_snapshot_path,
+  };
   use std::fs;
   use std::path::{Path, PathBuf};
 
@@ -446,6 +455,21 @@ mod module_resolution_tests {
     assert_eq!(candidates.len(), 1);
     assert_eq!(candidates[0].1, project.join(".calcit/modules/demo/calcit.cirru"));
     assert_eq!(candidates[0].2, "<mods>/demo/calcit.cirru");
+    fs::remove_dir_all(root).unwrap();
+  }
+
+  #[test]
+  fn canonical_path_does_not_alias_retired_sibling() {
+    let root = temp_root("retired-top-level-compact");
+    fs::create_dir_all(&root).unwrap();
+    let canonical = root.join("calcit.cirru");
+    let retired = root.join("compact.cirru");
+    fs::write(&retired, "retired").unwrap();
+
+    let error = validate_snapshot_path(&canonical).expect_err("retired sibling must be rejected, not loaded as an alias");
+    assert!(error.contains("filename `compact.cirru` is retired"), "error: {error}");
+    assert!(error.contains(&canonical.display().to_string()), "error: {error}");
+    assert!(!canonical.exists(), "validation must not materialize or alias the canonical path");
     fs::remove_dir_all(root).unwrap();
   }
 

--- a/src/program_diff.rs
+++ b/src/program_diff.rs
@@ -300,10 +300,10 @@ pub(crate) fn resolve_input_path(cwd: &Path, input_path: &str) -> Result<PathBuf
   } else {
     cwd.join(input)
   };
-  let resolved = crate::resolve_snapshot_path_alias(&full_path);
-  resolved
+  crate::validate_snapshot_path(&full_path)?;
+  full_path
     .canonicalize()
-    .map_err(|e| format!("Failed to resolve input path '{}': {e}", resolved.display()))
+    .map_err(|e| format!("Failed to resolve input path '{}': {e}", full_path.display()))
 }
 
 pub(crate) fn git_root(cwd: &Path) -> Result<PathBuf, String> {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -2138,6 +2138,14 @@ pub fn retired_snapshot_migration_error(path: &Path) -> Option<String> {
   ))
 }
 
+/// Build migration guidance for the retired top-level `:configs` shape.
+pub fn retired_snapshot_configs_error(path: &str) -> String {
+  let path_arg = format!("'{}'", path.replace('\'', "'\"'\"'"));
+  format!(
+    "Top-level `:configs` is retired in Snapshot `{path}`. Use the final compatible Calcit 0.13.50 release to run `calcit {path_arg} edit format`, review the generated `:entries.default` with `calcit {path_arg} config show`, then retry with the current `calcit {path_arg} --check-only`."
+  )
+}
+
 /// Parse a Snapshot while preserving the source path in deserialization errors.
 pub fn load_snapshot_data(data: &Edn, path: &str) -> Result<Snapshot, String> {
   if let Some(error) = retired_snapshot_migration_error(Path::new(path)) {
@@ -2155,6 +2163,9 @@ pub fn load_snapshot_data(data: &Edn, path: &str) -> Result<Snapshot, String> {
 
 fn load_snapshot_data_inner(data: &Edn, path: &str) -> Result<Snapshot, String> {
   let data = data.view_map()?;
+  if data.contains_key("configs") {
+    return Err(retired_snapshot_configs_error(path));
+  }
   let pkg: Arc<str> = data.get_or_nil("package").try_into()?;
   let mut files: HashMap<String, FileInSnapShot> = parse_files_with_context(&data.get_or_nil("files"))?;
   let about = match data.get_or_nil("about") {
@@ -2166,33 +2177,13 @@ fn load_snapshot_data_inner(data: &Edn, path: &str) -> Result<Snapshot, String> 
   };
   let meta_ns = format!("{pkg}.$meta");
   files.insert(meta_ns.to_owned(), gen_meta_ns(&meta_ns, path));
-  let legacy_configs = data.get(&Edn::tag("configs"));
-  let mut entries = parse_entries_with_context(&data.get_or_nil("entries"), legacy_configs.is_none())?;
+  let entries = parse_entries_with_context(&data.get_or_nil("entries"), true)?;
   let version = match data.get(&Edn::tag("version")) {
     Some(_) => parse_snapshot_config_string_field(&data, "version", "snapshot")?,
-    None => match legacy_configs {
-      Some(configs) => {
-        let configs_map = configs
-          .view_map()
-          .map_err(|e| format!("configs: failed to parse config map: {e}; got {}", format_edn_preview(configs)))?;
-        match configs_map.get(&Edn::tag("version")) {
-          Some(_) => parse_snapshot_config_string_field(&configs_map, "version", "configs")?,
-          None => default_version(),
-        }
-      }
-      None => default_version(),
-    },
+    None => default_version(),
   };
 
-  if let Some(configs) = legacy_configs {
-    if entries.contains_key(DEFAULT_ENTRY_NAME) {
-      return Err("Snapshot cannot contain both legacy `:configs` and `:entries.default`".to_owned());
-    }
-    entries.insert(
-      DEFAULT_ENTRY_NAME.to_owned(),
-      parse_snapshot_entry_with_context(configs.to_owned(), "entries.default", false)?,
-    );
-  } else if !entries.contains_key(DEFAULT_ENTRY_NAME) {
+  if !entries.contains_key(DEFAULT_ENTRY_NAME) {
     return Err("Snapshot `:entries` must contain a `:default` entry".to_owned());
   }
 
@@ -4888,7 +4879,7 @@ mod tests {
   }
 
   #[test]
-  fn legacy_configs_migrate_to_default_native_entry() {
+  fn legacy_configs_are_rejected_with_versioned_migration_guidance() {
     let content = r#"{} (:package |mini)
   :configs $ {} (:init-fn |mini/main!) (:reload-fn |mini/reload!) (:version |1.2.3)
     :modules $ [] |legacy/
@@ -4896,17 +4887,11 @@ mod tests {
   :files $ {}
 "#;
     let edn_data = cirru_edn::parse(content).expect("legacy snapshot text should parse");
-    let snapshot = load_snapshot_data(&edn_data, "mini.cirru").expect("legacy snapshot should load");
-    let default_entry = snapshot.entries.get(DEFAULT_ENTRY_NAME).expect("migrated default entry");
-    assert_eq!(snapshot.version, "1.2.3");
-    assert_eq!(default_entry.mode, SnapshotRunMode::Native);
-    assert_eq!(default_entry.modules, vec!["legacy/"]);
-    assert!(default_entry.description.is_empty());
-
-    let rendered = render_snapshot_content(&snapshot).expect("legacy snapshot should render canonically");
-    assert!(!rendered.contains(":version"));
-    assert!(rendered.contains(":default $ {}") && rendered.contains(":mode :native"));
-    assert!(!rendered.contains(":configs"));
+    let error = load_snapshot_data(&edn_data, "fixtures/mini.cirru").expect_err("legacy configs must be rejected");
+    assert!(error.contains("Top-level `:configs` is retired"), "error: {error}");
+    assert!(error.contains("Calcit 0.13.50"), "error: {error}");
+    assert!(error.contains("calcit 'fixtures/mini.cirru' edit format"), "error: {error}");
+    assert!(error.contains("calcit 'fixtures/mini.cirru' --check-only"), "error: {error}");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- reject retired top-level `:configs` with path-aware Calcit 0.13.50 migration guidance
- remove runtime/build-time legacy config decoding and the silent `calcit.cirru` to `compact.cirru` alias
- retain sibling detection only to produce an actionable retired-filename error, and align CLI handlers, tests, docs, and Agent guidance

Advances #463. The separate legacy macro-schema compatibility audit remains tracked there.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn compile`
- `bash scripts/check-docs-md.sh` (323/323 blocks)
- `yarn check-agent-interface` (17/17)
- `yarn check-all` (native, JS, IR, WASM, runtime and benchmarks)
- latest `Respo/respo` main: check-only, 27/27 tests, 111/111 Markdown blocks, JS codegen and Vite production build
- latest `calcit-lang/recollect` main: check-only, dynamic-method zero gate, quality baseline, native test entry, generated-JS tests and Vite production build

The downstream projects still pin older `@calcit/procs` releases, so their Vite builds retain the existing `read_dir` export/version-skew warning; both builds and exercised runtime tests pass.
