### PR TITLE
feat: add async FFI protocol foundation

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -1,0 +1,105 @@
+# Asynchronous FFI task protocol
+
+Calcit's long-term native FFI boundary uses a stable C ABI rather than Rust
+container, closure, and trait-object layouts. The asynchronous protocol covers
+more than one callback: it must represent timers, file watchers, HTTP work,
+WebSocket connections, and server resources.
+
+This document describes protocol version 1 as it is implemented in stages.
+The current implementation provides the handle types and lifecycle registry;
+existing `&call-dylib-edn-fn` and `&blocking-dylib-edn-fn` calls still use the
+build-identity-guarded Rust ABI until the event queue and C host function table
+land.
+
+## Shared task model
+
+The protocol has four handle roles:
+
+- `OneShot`: timer, HTTP client request, or other single completion;
+- `Stream`: interval, file watcher, or WebSocket connection with repeated
+  events;
+- `Server`: listener/accept resource that produces child request or connection
+  events;
+- `Response`: an exactly-once capability for an HTTP response, WebSocket
+  upgrade, or similar reply.
+
+Every handle is a non-zero `u64`. Its low 32 bits identify a registry slot and
+its high 32 bits contain a generation. Reusing a released slot changes the
+generation, so a late event cannot address the new task accidentally. Neither
+native modules nor future WASM guests receive a Rust object address.
+
+The lifecycle is:
+
+```text
+register -> Active -> Closing -> Finished -> release
+                    \----------> Finished -> release
+```
+
+Cancellation and host shutdown move an active task to `Closing`. New events
+are rejected from that point, while a final completion acknowledgement remains
+allowed. `finish` and `release` are exactly-once operations; a finished
+tombstone remains until release so duplicate completion has a deterministic
+error instead of looking like an unknown handle.
+
+## Events and ordering
+
+Each active handle owns a monotonically increasing event sequence starting at
+1. The host reserves the sequence before enqueueing an event. The next stage
+will add the bounded host event queue and will execute Calcit callbacks only on
+the host scheduling thread. A dylib watcher/server thread may enqueue bytes but
+must never enter the Calcit runtime directly.
+
+Streams and servers therefore do not require a Rust closure to cross the ABI.
+They keep only the opaque task handle and the C host function table. HTTP
+request events will carry a separate `Response` handle, allowing a Calcit
+callback to respond later while preserving exactly-once response and timeout
+rules.
+
+## Stable transport fields
+
+`FfiAsyncTaskDescriptor` is a C-layout structure containing:
+
+- protocol version and structure size;
+- the raw `u64` handle;
+- a fixed numeric handle kind;
+- capability flags such as serialized events, permitted coalescing, or a
+  required response.
+
+Status values are integer constants. Foreign input is validated before it is
+converted to a Rust enum, avoiding invalid-discriminant undefined behavior.
+Business payloads will continue to use UTF-8 Cirru EDN buffers, with allocator
+ownership and matching free functions explicit in both directions.
+
+## WASM compatibility boundary
+
+WASM will not reuse C pointers or native function pointers. It can still reuse
+the protocol semantics:
+
+- transport the handle as `i64`, or two `i32` values where required;
+- exchange UTF-8 Cirru EDN through guest linear memory;
+- submit event/finish/respond through imports and receive work through exports
+  or polling;
+- use the same kind values, flags, lifecycle, generation checks, event
+  sequence, and status codes.
+
+The shared model deliberately does not depend on Rust allocators, trait
+objects, thread-local state, an executor/waker ABI, or native threads. Native
+threaded producers and a future single-threaded WASM poll adapter can therefore
+present the same Calcit-facing behavior.
+
+## Rollout
+
+The remaining implementation order is:
+
+1. bounded event queue, scheduler-thread draining, trace events, and propagated
+   callback failures;
+2. native C host function table and per-method callback v1 lookup;
+3. response handles, server backpressure, cancellation, timeout, and shutdown
+   fixtures;
+4. blocking calls reusing the same registry and envelopes;
+5. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
+   `calcit.std`;
+6. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
+7. removal of the guarded Rust ABI fallback under issue #474.
+
+See issue #482 for the full acceptance matrix and module rollout status.

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -151,7 +151,7 @@ Protocol rules:
 - The adapter must contain panics and return an error status; unwinding across `extern "C"` is invalid.
 - Calcit rejects protocol-version mismatches, malformed buffer metadata, oversized responses, invalid UTF-8, and invalid response EDN.
 
-`calcit-lang/calcit_wasmtime` contains the first complete adapter. Version 1 currently covers synchronous `&call-dylib-edn`; callback and blocking APIs remain on the guarded legacy path until their ownership protocol lands.
+`calcit-lang/calcit_wasmtime` contains the first complete adapter. Version 1 currently covers synchronous `&call-dylib-edn`; callback and blocking APIs remain on the guarded legacy path until their ownership protocol lands. The staged task/event/server design, including future WASM constraints, is documented in [Asynchronous FFI task protocol](ffi-async-protocol.md).
 
 ### Call in Calcit
 

--- a/editing-history/202608271831-ffi-async-protocol-foundation.md
+++ b/editing-history/202608271831-ffi-async-protocol-foundation.md
@@ -1,0 +1,28 @@
+# Async FFI protocol foundation
+
+## Summary
+
+- Defined a versioned, C-safe async task descriptor for one-shot, stream,
+  server, and response handles without changing the existing synchronous FFI.
+- Added a thread-safe generational handle registry with ordered event
+  sequences, explicit close/finish/release transitions, and host shutdown.
+- Retired exhausted generation slots so stale handles cannot become valid
+  again after counter wraparound.
+- Documented the transport-neutral lifecycle intended for timers, watchers,
+  HTTP/WebSocket servers, and a future WASM adapter.
+
+## Compatibility constraint
+
+Native libraries must enqueue events for the Calcit host instead of invoking
+Calcit callbacks from foreign threads. The protocol models stable integer
+handles and byte payloads; a WASM adapter may map them to imports/exports
+without reproducing native pointers or function pointers.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy -- -D warnings`
+- `cargo test -- --test-threads=1`
+- `yarn compile`
+- `yarn check-agent-interface`
+- `yarn check-all`

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -1,4 +1,6 @@
 use std::ffi::{CStr, c_char};
+use std::fmt;
+use std::sync::Mutex;
 use std::{ptr, slice};
 
 use cirru_edn::{Edn, EdnListView};
@@ -12,6 +14,394 @@ pub const BUFFER_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_buffer_version";
 pub const BUFFER_FREE_SYMBOL: &[u8] = b"calcit_ffi_buffer_free";
 const BUFFER_METHOD_SUFFIX: &str = "_calcit_ffi_v1";
 const MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
+
+/// Version of the transport-neutral asynchronous task semantics. Native C ABI
+/// adapters and future WASM adapters must preserve the same handle lifecycle,
+/// even though their memory transports differ.
+pub const ASYNC_PROTOCOL_VERSION: u32 = 1;
+pub const ASYNC_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_async_version";
+pub const ASYNC_METHOD_SUFFIX: &str = "_calcit_ffi_async_v1";
+
+pub const ASYNC_TASK_FLAG_SERIAL_EVENTS: u32 = 1 << 0;
+pub const ASYNC_TASK_FLAG_COALESCE_ALLOWED: u32 = 1 << 1;
+pub const ASYNC_TASK_FLAG_REQUIRES_RESPONSE: u32 = 1 << 2;
+
+/// Stable status values returned by C-safe async host functions. Keep these
+/// as integer constants rather than an FFI enum so foreign callers cannot
+/// construct an invalid Rust discriminant.
+pub mod async_status {
+  pub const OK: i32 = 0;
+  pub const INVALID_HANDLE: i32 = 1;
+  pub const STALE_HANDLE: i32 = 2;
+  pub const HANDLE_CLOSING: i32 = 3;
+  pub const HANDLE_FINISHED: i32 = 4;
+  pub const HANDLE_STILL_ACTIVE: i32 = 5;
+  pub const HOST_CLOSING: i32 = 6;
+  pub const QUEUE_FULL: i32 = 7;
+  pub const INVALID_PAYLOAD: i32 = 8;
+  pub const INTERNAL_ERROR: i32 = 9;
+}
+
+/// Semantic role of a host-owned handle. Values are fixed for C and future
+/// WASM adapters; unknown raw values must be rejected before conversion.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiAsyncHandleKind {
+  OneShot = 1,
+  Stream = 2,
+  Server = 3,
+  Response = 4,
+}
+
+impl TryFrom<u32> for FfiAsyncHandleKind {
+  type Error = FfiAsyncHandleError;
+
+  fn try_from(value: u32) -> Result<Self, Self::Error> {
+    match value {
+      1 => Ok(Self::OneShot),
+      2 => Ok(Self::Stream),
+      3 => Ok(Self::Server),
+      4 => Ok(Self::Response),
+      _ => Err(FfiAsyncHandleError::InvalidKind(value)),
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiAsyncLifecycle {
+  Active,
+  Closing,
+  Finished,
+}
+
+/// C-layout task metadata. The handle remains a raw `u64` so a WASM adapter
+/// may transport it as i64 or two i32 values without exposing host pointers.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FfiAsyncTaskDescriptor {
+  pub protocol_version: u32,
+  pub struct_size: u32,
+  pub handle: u64,
+  pub kind: u32,
+  pub flags: u32,
+}
+
+impl FfiAsyncTaskDescriptor {
+  pub fn new(handle: FfiAsyncHandle, kind: FfiAsyncHandleKind, flags: u32) -> Self {
+    Self {
+      protocol_version: ASYNC_PROTOCOL_VERSION,
+      struct_size: std::mem::size_of::<Self>() as u32,
+      handle: handle.raw(),
+      kind: kind as u32,
+      flags,
+    }
+  }
+}
+
+/// Opaque generation handle. Zero is permanently invalid. The low 32 bits
+/// store slot index + 1 and the high 32 bits store a non-zero generation.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FfiAsyncHandle(u64);
+
+impl FfiAsyncHandle {
+  pub const INVALID: Self = Self(0);
+
+  pub fn from_raw(raw: u64) -> Self {
+    Self(raw)
+  }
+
+  pub fn raw(self) -> u64 {
+    self.0
+  }
+
+  fn from_parts(index: usize, generation: u32) -> Self {
+    debug_assert!(generation != 0);
+    debug_assert!(index < u32::MAX as usize);
+    Self(((generation as u64) << 32) | (index as u64 + 1))
+  }
+
+  fn parts(self) -> Option<(usize, u32)> {
+    let slot = self.0 as u32;
+    let generation = (self.0 >> 32) as u32;
+    if slot == 0 || generation == 0 {
+      None
+    } else {
+      Some(((slot - 1) as usize, generation))
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FfiAsyncHandleError {
+  InvalidKind(u32),
+  InvalidHandle,
+  StaleHandle,
+  HandleClosing,
+  HandleFinished,
+  HandleStillActive,
+  HostClosing,
+  RegistryExhausted,
+  SequenceExhausted,
+  RegistryPoisoned,
+}
+
+impl FfiAsyncHandleError {
+  pub fn status_code(&self) -> i32 {
+    match self {
+      Self::InvalidKind(_) => async_status::INVALID_PAYLOAD,
+      Self::InvalidHandle => async_status::INVALID_HANDLE,
+      Self::StaleHandle => async_status::STALE_HANDLE,
+      Self::HandleClosing => async_status::HANDLE_CLOSING,
+      Self::HandleFinished => async_status::HANDLE_FINISHED,
+      Self::HandleStillActive => async_status::HANDLE_STILL_ACTIVE,
+      Self::HostClosing => async_status::HOST_CLOSING,
+      Self::RegistryExhausted | Self::SequenceExhausted | Self::RegistryPoisoned => async_status::INTERNAL_ERROR,
+    }
+  }
+}
+
+impl fmt::Display for FfiAsyncHandleError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::InvalidKind(value) => write!(f, "invalid async FFI handle kind {value}"),
+      Self::InvalidHandle => f.write_str("invalid async FFI handle"),
+      Self::StaleHandle => f.write_str("stale async FFI handle generation"),
+      Self::HandleClosing => f.write_str("async FFI handle is closing"),
+      Self::HandleFinished => f.write_str("async FFI handle is already finished"),
+      Self::HandleStillActive => f.write_str("async FFI handle must finish before release"),
+      Self::HostClosing => f.write_str("async FFI host is closing"),
+      Self::RegistryExhausted => f.write_str("async FFI handle registry is exhausted"),
+      Self::SequenceExhausted => f.write_str("async FFI event sequence is exhausted"),
+      Self::RegistryPoisoned => f.write_str("async FFI handle registry lock is poisoned"),
+    }
+  }
+}
+
+impl std::error::Error for FfiAsyncHandleError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FfiAsyncHandleState {
+  pub kind: FfiAsyncHandleKind,
+  pub lifecycle: FfiAsyncLifecycle,
+  pub next_sequence: u64,
+}
+
+struct RegisteredAsyncHandle<T> {
+  state: FfiAsyncHandleState,
+  value: T,
+}
+
+struct AsyncHandleSlot<T> {
+  generation: u32,
+  task: Option<RegisteredAsyncHandle<T>>,
+}
+
+struct AsyncHandleRegistryState<T> {
+  slots: Vec<AsyncHandleSlot<T>>,
+  free_slots: Vec<usize>,
+  closing: bool,
+}
+
+/// Thread-safe lifecycle registry shared by one-shot tasks, streams, servers,
+/// and one-use response capabilities. It intentionally contains no executor
+/// or Rust callback object, so native and WASM transports can share its rules.
+pub struct FfiAsyncHandleRegistry<T> {
+  state: Mutex<AsyncHandleRegistryState<T>>,
+}
+
+impl<T> Default for FfiAsyncHandleRegistry<T> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<T> FfiAsyncHandleRegistry<T> {
+  pub fn new() -> Self {
+    Self {
+      state: Mutex::new(AsyncHandleRegistryState {
+        slots: vec![],
+        free_slots: vec![],
+        closing: false,
+      }),
+    }
+  }
+
+  pub fn register(&self, kind: FfiAsyncHandleKind, value: T) -> Result<FfiAsyncHandle, FfiAsyncHandleError> {
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    if registry.closing {
+      return Err(FfiAsyncHandleError::HostClosing);
+    }
+
+    let state = FfiAsyncHandleState {
+      kind,
+      lifecycle: FfiAsyncLifecycle::Active,
+      next_sequence: 1,
+    };
+    while let Some(index) = registry.free_slots.pop() {
+      let slot = &mut registry.slots[index];
+      let Some(generation) = slot.generation.checked_add(1) else {
+        // A wrapped generation could make a very old stale handle valid
+        // again, so permanently retire slots that exhaust the counter.
+        continue;
+      };
+      slot.generation = generation;
+      slot.task = Some(RegisteredAsyncHandle { state, value });
+      return Ok(FfiAsyncHandle::from_parts(index, slot.generation));
+    }
+
+    if registry.slots.len() >= u32::MAX as usize {
+      return Err(FfiAsyncHandleError::RegistryExhausted);
+    }
+    let index = registry.slots.len();
+    registry.slots.push(AsyncHandleSlot {
+      generation: 1,
+      task: Some(RegisteredAsyncHandle { state, value }),
+    });
+    Ok(FfiAsyncHandle::from_parts(index, 1))
+  }
+
+  pub fn state(&self, handle: FfiAsyncHandle) -> Result<FfiAsyncHandleState, FfiAsyncHandleError> {
+    let registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    Ok(resolve_async_handle(&registry, handle)?.state)
+  }
+
+  /// Clone host-owned metadata/callback state without holding the registry
+  /// lock while user code runs. The lifecycle is still checked separately by
+  /// event reservation and terminal transitions.
+  pub fn clone_value(&self, handle: FfiAsyncHandle) -> Result<T, FfiAsyncHandleError>
+  where
+    T: Clone,
+  {
+    let registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    Ok(resolve_async_handle(&registry, handle)?.value.clone())
+  }
+
+  /// Reserve the next host sequence before an event is enqueued. Events are
+  /// rejected as soon as cancellation/shutdown moves a handle to Closing.
+  pub fn next_event_sequence(&self, handle: FfiAsyncHandle) -> Result<u64, FfiAsyncHandleError> {
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    let task = resolve_async_handle_mut(&mut registry, handle)?;
+    match task.state.lifecycle {
+      FfiAsyncLifecycle::Active => {
+        let sequence = task.state.next_sequence;
+        task.state.next_sequence = sequence.checked_add(1).ok_or(FfiAsyncHandleError::SequenceExhausted)?;
+        Ok(sequence)
+      }
+      FfiAsyncLifecycle::Closing => Err(FfiAsyncHandleError::HandleClosing),
+      FfiAsyncLifecycle::Finished => Err(FfiAsyncHandleError::HandleFinished),
+    }
+  }
+
+  /// Begin cancellation or orderly close. Completion must still be
+  /// acknowledged through `finish` before the handle can be released.
+  pub fn begin_close(&self, handle: FfiAsyncHandle) -> Result<(), FfiAsyncHandleError> {
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    let task = resolve_async_handle_mut(&mut registry, handle)?;
+    match task.state.lifecycle {
+      FfiAsyncLifecycle::Active => {
+        task.state.lifecycle = FfiAsyncLifecycle::Closing;
+        Ok(())
+      }
+      FfiAsyncLifecycle::Closing => Err(FfiAsyncHandleError::HandleClosing),
+      FfiAsyncLifecycle::Finished => Err(FfiAsyncHandleError::HandleFinished),
+    }
+  }
+
+  /// Mark completion exactly once. The tombstone remains until `release`, so
+  /// duplicate completion is distinguishable from an unknown handle.
+  pub fn finish(&self, handle: FfiAsyncHandle) -> Result<(), FfiAsyncHandleError> {
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    let task = resolve_async_handle_mut(&mut registry, handle)?;
+    match task.state.lifecycle {
+      FfiAsyncLifecycle::Active | FfiAsyncLifecycle::Closing => {
+        task.state.lifecycle = FfiAsyncLifecycle::Finished;
+        Ok(())
+      }
+      FfiAsyncLifecycle::Finished => Err(FfiAsyncHandleError::HandleFinished),
+    }
+  }
+
+  pub fn release(&self, handle: FfiAsyncHandle) -> Result<T, FfiAsyncHandleError> {
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    let (index, generation) = handle.parts().ok_or(FfiAsyncHandleError::InvalidHandle)?;
+    let task = {
+      let slot = registry.slots.get_mut(index).ok_or(FfiAsyncHandleError::InvalidHandle)?;
+      if slot.generation != generation || slot.task.is_none() {
+        return Err(FfiAsyncHandleError::StaleHandle);
+      }
+      if slot
+        .task
+        .as_ref()
+        .is_some_and(|task| task.state.lifecycle != FfiAsyncLifecycle::Finished)
+      {
+        return Err(FfiAsyncHandleError::HandleStillActive);
+      }
+      slot.task.take().ok_or(FfiAsyncHandleError::StaleHandle)?
+    };
+    registry.free_slots.push(index);
+    Ok(task.value)
+  }
+
+  /// Stop new registrations and move every active handle into Closing. The
+  /// returned handles are the tasks the host must cancel or diagnose.
+  pub fn begin_shutdown(&self) -> Result<Vec<FfiAsyncHandle>, FfiAsyncHandleError> {
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    registry.closing = true;
+    let mut pending = vec![];
+    for (index, slot) in registry.slots.iter_mut().enumerate() {
+      if let Some(task) = &mut slot.task {
+        match task.state.lifecycle {
+          FfiAsyncLifecycle::Active => task.state.lifecycle = FfiAsyncLifecycle::Closing,
+          FfiAsyncLifecycle::Closing => {}
+          FfiAsyncLifecycle::Finished => continue,
+        }
+        pending.push(FfiAsyncHandle::from_parts(index, slot.generation));
+      }
+    }
+    Ok(pending)
+  }
+
+  pub fn pending_count(&self) -> Result<usize, FfiAsyncHandleError> {
+    let registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    Ok(
+      registry
+        .slots
+        .iter()
+        .filter(|slot| {
+          slot
+            .task
+            .as_ref()
+            .is_some_and(|task| task.state.lifecycle != FfiAsyncLifecycle::Finished)
+        })
+        .count(),
+    )
+  }
+}
+
+fn resolve_async_handle<T>(
+  registry: &AsyncHandleRegistryState<T>,
+  handle: FfiAsyncHandle,
+) -> Result<&RegisteredAsyncHandle<T>, FfiAsyncHandleError> {
+  let (index, generation) = handle.parts().ok_or(FfiAsyncHandleError::InvalidHandle)?;
+  let slot = registry.slots.get(index).ok_or(FfiAsyncHandleError::InvalidHandle)?;
+  if slot.generation != generation {
+    return Err(FfiAsyncHandleError::StaleHandle);
+  }
+  slot.task.as_ref().ok_or(FfiAsyncHandleError::StaleHandle)
+}
+
+fn resolve_async_handle_mut<T>(
+  registry: &mut AsyncHandleRegistryState<T>,
+  handle: FfiAsyncHandle,
+) -> Result<&mut RegisteredAsyncHandle<T>, FfiAsyncHandleError> {
+  let (index, generation) = handle.parts().ok_or(FfiAsyncHandleError::InvalidHandle)?;
+  let slot = registry.slots.get_mut(index).ok_or(FfiAsyncHandleError::InvalidHandle)?;
+  if slot.generation != generation {
+    return Err(FfiAsyncHandleError::StaleHandle);
+  }
+  slot.task.as_mut().ok_or(FfiAsyncHandleError::StaleHandle)
+}
 
 /// Owned bytes allocated by an FFI module. The module must release this value
 /// through `calcit_ffi_buffer_free`; the host only copies from it.
@@ -174,8 +564,9 @@ pub fn lookup_build_id(lib: &libloading::Library, lib_name: &str) -> Result<Opti
 #[cfg(test)]
 mod tests {
   use super::{
-    BUFFER_PROTOCOL_VERSION, FfiBuildCompatibility, buffer_method_symbol, decode_buffer_response, encode_buffer_request,
-    validate_build_id,
+    ASYNC_PROTOCOL_VERSION, ASYNC_TASK_FLAG_REQUIRES_RESPONSE, ASYNC_TASK_FLAG_SERIAL_EVENTS, BUFFER_PROTOCOL_VERSION, FfiAsyncHandle,
+    FfiAsyncHandleError, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncLifecycle, FfiAsyncTaskDescriptor, FfiBuildCompatibility,
+    async_status, buffer_method_symbol, decode_buffer_response, encode_buffer_request, validate_build_id,
   };
   use cirru_edn::Edn;
 
@@ -228,5 +619,121 @@ mod tests {
       validate_build_id("demo", None, "release-build", false).expect("release compatibility path should remain"),
       FfiBuildCompatibility::Legacy
     );
+  }
+
+  #[test]
+  fn async_descriptor_has_stable_version_size_and_raw_tags() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry
+      .register(FfiAsyncHandleKind::Server, "http-server")
+      .expect("register server");
+    let descriptor = FfiAsyncTaskDescriptor::new(
+      handle,
+      FfiAsyncHandleKind::Server,
+      ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+    );
+
+    assert_eq!(descriptor.protocol_version, ASYNC_PROTOCOL_VERSION);
+    assert_eq!(descriptor.struct_size as usize, std::mem::size_of::<FfiAsyncTaskDescriptor>());
+    assert_eq!(descriptor.handle, handle.raw());
+    assert_eq!(descriptor.kind, FfiAsyncHandleKind::Server as u32);
+    assert_eq!(FfiAsyncHandleKind::try_from(descriptor.kind), Ok(FfiAsyncHandleKind::Server));
+    assert_eq!(FfiAsyncHandleKind::try_from(99), Err(FfiAsyncHandleError::InvalidKind(99)));
+  }
+
+  #[test]
+  fn async_registry_orders_events_and_finishes_exactly_once() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::Stream, "watcher").expect("register watcher");
+
+    assert_eq!(registry.next_event_sequence(handle), Ok(1));
+    assert_eq!(registry.next_event_sequence(handle), Ok(2));
+    assert_eq!(registry.finish(handle), Ok(()));
+    assert_eq!(registry.finish(handle), Err(FfiAsyncHandleError::HandleFinished));
+    assert_eq!(registry.next_event_sequence(handle), Err(FfiAsyncHandleError::HandleFinished));
+    assert_eq!(registry.release(handle), Ok("watcher"));
+    assert_eq!(registry.release(handle), Err(FfiAsyncHandleError::StaleHandle));
+  }
+
+  #[test]
+  fn async_registry_rejects_events_after_cancel_but_allows_finish() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::OneShot, "timer").expect("register timer");
+
+    assert_eq!(registry.begin_close(handle), Ok(()));
+    assert_eq!(registry.begin_close(handle), Err(FfiAsyncHandleError::HandleClosing));
+    assert_eq!(registry.next_event_sequence(handle), Err(FfiAsyncHandleError::HandleClosing));
+    assert_eq!(registry.finish(handle), Ok(()));
+    assert_eq!(registry.release(handle), Ok("timer"));
+  }
+
+  #[test]
+  fn async_registry_generation_rejects_reused_stale_handles() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let first = registry
+      .register(FfiAsyncHandleKind::Response, "first-response")
+      .expect("register first response");
+    registry.finish(first).expect("finish first response");
+    assert_eq!(registry.release(first), Ok("first-response"));
+
+    let second = registry
+      .register(FfiAsyncHandleKind::Response, "second-response")
+      .expect("reuse response slot");
+    assert_ne!(first, second);
+    assert_eq!(registry.state(first), Err(FfiAsyncHandleError::StaleHandle));
+    assert_eq!(
+      registry.state(second).expect("current response").lifecycle,
+      FfiAsyncLifecycle::Active
+    );
+  }
+
+  #[test]
+  fn async_registry_retires_exhausted_generation_slots() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let first = registry
+      .register(FfiAsyncHandleKind::Response, "first-response")
+      .expect("register first response");
+    registry.finish(first).expect("finish first response");
+    assert_eq!(registry.release(first), Ok("first-response"));
+
+    registry.state.lock().expect("registry lock").slots[0].generation = u32::MAX;
+
+    let second = registry
+      .register(FfiAsyncHandleKind::Response, "second-response")
+      .expect("register after exhausted slot");
+    assert_eq!(second.parts().map(|(index, _)| index), Some(1));
+    assert_eq!(registry.state(first), Err(FfiAsyncHandleError::StaleHandle));
+  }
+
+  #[test]
+  fn async_shutdown_closes_pending_handles_and_rejects_new_tasks() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let timer = registry.register(FfiAsyncHandleKind::OneShot, "timer").expect("register timer");
+    let server = registry.register(FfiAsyncHandleKind::Server, "server").expect("register server");
+    let completed = registry
+      .register(FfiAsyncHandleKind::OneShot, "completed")
+      .expect("register completed task");
+    registry.finish(completed).expect("finish completed task");
+
+    let pending = registry.begin_shutdown().expect("start shutdown");
+    assert_eq!(pending, vec![timer, server]);
+    assert_eq!(registry.pending_count(), Ok(2));
+    assert_eq!(registry.state(timer).expect("timer state").lifecycle, FfiAsyncLifecycle::Closing);
+    assert_eq!(registry.state(server).expect("server state").lifecycle, FfiAsyncLifecycle::Closing);
+    assert_eq!(
+      registry.register(FfiAsyncHandleKind::Stream, "late watcher"),
+      Err(FfiAsyncHandleError::HostClosing)
+    );
+  }
+
+  #[test]
+  fn async_invalid_handles_have_stable_status_codes() {
+    let registry = FfiAsyncHandleRegistry::<()>::new();
+    let error = registry
+      .state(FfiAsyncHandle::INVALID)
+      .expect_err("zero handle must remain invalid");
+    assert_eq!(error, FfiAsyncHandleError::InvalidHandle);
+    assert_eq!(error.status_code(), async_status::INVALID_HANDLE);
+    assert_eq!(FfiAsyncHandleError::StaleHandle.status_code(), async_status::STALE_HANDLE);
   }
 }


### PR DESCRIPTION
## Summary

- add versioned C-safe task descriptors for one-shot, stream, server, and response handles
- add a thread-safe generational lifecycle registry with ordered event sequences, cancellation, completion, release, and shutdown semantics
- document the transport-neutral native/WASM boundary and staged migration for timer, watcher, HTTP, WebSocket, and existing FFI modules

This is Phase 1 of #482. It does not switch the existing callback APIs yet; the current guarded Rust ABI stays intact until the bounded event queue and C host function table land.

## Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`

Refs #482
Refs #474