### PR TITLE
feat: add bounded async FFI event queue

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -6,10 +6,10 @@ more than one callback: it must represent timers, file watchers, HTTP work,
 WebSocket connections, and server resources.
 
 This document describes protocol version 1 as it is implemented in stages.
-The current implementation provides the handle types and lifecycle registry;
-existing `&call-dylib-edn-fn` and `&blocking-dylib-edn-fn` calls still use the
-build-identity-guarded Rust ABI until the event queue and C host function table
-land.
+The current implementation provides the handle types, lifecycle registry, and
+bounded host event queue; existing `&call-dylib-edn-fn` and
+`&blocking-dylib-edn-fn` calls still use the build-identity-guarded Rust ABI
+until the C host function table lands.
 
 ## Shared task model
 
@@ -44,10 +44,32 @@ error instead of looking like an unknown handle.
 ## Events and ordering
 
 Each active handle owns a monotonically increasing event sequence starting at
-1. The host reserves the sequence before enqueueing an event. The next stage
-will add the bounded host event queue and will execute Calcit callbacks only on
-the host scheduling thread. A dylib watcher/server thread may enqueue bytes but
-must never enter the Calcit runtime directly.
+1. The host reserves the sequence only after queue capacity has been secured,
+so `QUEUE_FULL` does not consume a sequence or claim a terminal event. The
+bounded queue accepts producers from foreign threads, but only the thread that
+created it may wait or drain and execute Calcit callbacks. A dylib
+watcher/server thread may enqueue bytes but must never enter the Calcit runtime
+directly.
+
+An event uses one of three stable tags: repeating `Emit`, successful terminal
+`Complete`, or failed terminal `Fail`. At most one terminal event may be queued
+for a task. Cancellation changes the task to `Closing`; already queued ordinary
+events are then discarded, while the terminal acknowledgement is still
+delivered. Terminal dispatch marks the task `Finished` before it can be
+released.
+
+Queue capacity is measured in events and every payload also has a host-side
+size limit. Full queues return `QUEUE_FULL` without blocking the producer.
+Only `Emit` events on a task registered with `COALESCE_ALLOWED` may replace an
+older queued emit for that same task; the replacement carries a newer sequence
+and the `COALESCED` event flag. Complete/fail and server request events are
+never silently dropped or coalesced.
+
+Drain returns a structured report rather than printing and forgetting
+failures. A callback failure records task/sequence metadata and its message,
+finishes the failed task, and purges its remaining queued events. Lifecycle
+rejections are reported separately. Queue entries also retain producer thread
+and queue-delay metadata for `--trace-ffi` without logging complete payloads.
 
 Streams and servers therefore do not require a Rust closure to cross the ABI.
 They keep only the opaque task handle and the C host function table. HTTP
@@ -64,6 +86,11 @@ rules.
 - a fixed numeric handle kind;
 - capability flags such as serialized events, permitted coalescing, or a
   required response.
+
+`FfiAsyncEventDescriptor` adds the event kind, event flags, task and optional
+response handles, sequence, and payload length. It contains no Rust pointer;
+the native C host function table and a WASM linear-memory adapter can wrap the
+same descriptor with different byte-copying transports.
 
 Status values are integer constants. Foreign input is validated before it is
 converted to a Rust enum, avoiding invalid-discriminant undefined behavior.
@@ -91,15 +118,13 @@ present the same Calcit-facing behavior.
 
 The remaining implementation order is:
 
-1. bounded event queue, scheduler-thread draining, trace events, and propagated
-   callback failures;
-2. native C host function table and per-method callback v1 lookup;
-3. response handles, server backpressure, cancellation, timeout, and shutdown
+1. native C host function table and per-method callback v1 lookup;
+2. response handles, server backpressure, cancellation, timeout, and shutdown
    fixtures;
-4. blocking calls reusing the same registry and envelopes;
-5. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
+3. blocking calls reusing the same registry and envelopes;
+4. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
    `calcit.std`;
-6. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
-7. removal of the guarded Rust ABI fallback under issue #474.
+5. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
+6. removal of the guarded Rust ABI fallback under issue #474.
 
 See issue #482 for the full acceptance matrix and module rollout status.

--- a/editing-history/202608271928-ffi-host-event-queue.md
+++ b/editing-history/202608271928-ffi-host-event-queue.md
@@ -1,0 +1,29 @@
+# Async FFI host event queue
+
+## Summary
+
+- Added a C-layout event descriptor for repeating emit and terminal
+  complete/fail events.
+- Added a bounded multi-producer queue that only its creating host thread may
+  wait on or drain into the Calcit runtime.
+- Kept sequence reservation atomic with queue admission, made terminal events
+  exactly once, and limited coalescing to explicitly opted-in stream events.
+- Returned callback and lifecycle failures as structured drain diagnostics;
+  callback failure finishes the task and purges its remaining queued events.
+- Retained producer-thread and queue-delay metadata for low-payload FFI traces.
+
+## Compatibility constraint
+
+Existing Rust callback and blocking dylib calls remain unchanged. This queue
+is the scheduling foundation for the next C host-function-table PR; native
+threads and a future WASM polling adapter share descriptors and lifecycle
+semantics without sharing pointers or callback layouts.
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test -- --test-threads=1`
+- `yarn compile`
+- `yarn check-agent-interface`
+- `yarn check-all`

--- a/editing-history/202608271947-preserve-ffi-drain-report.md
+++ b/editing-history/202608271947-preserve-ffi-drain-report.md
@@ -1,0 +1,15 @@
+# Preserve async FFI drain accounting
+
+## Summary
+
+- Kept malformed event-kind failures inside the structured drain report rather
+  than returning after a batch had already been removed from the queue.
+- Recorded queue-purge failures alongside callback and lifecycle failures.
+- Separated discarded batch events from events purged before drain, preserving
+  the invariant that every dequeued event is delivered or discarded.
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test ffi_async::tests -- --nocapture`

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -25,6 +25,10 @@ pub const ASYNC_METHOD_SUFFIX: &str = "_calcit_ffi_async_v1";
 pub const ASYNC_TASK_FLAG_SERIAL_EVENTS: u32 = 1 << 0;
 pub const ASYNC_TASK_FLAG_COALESCE_ALLOWED: u32 = 1 << 1;
 pub const ASYNC_TASK_FLAG_REQUIRES_RESPONSE: u32 = 1 << 2;
+pub const ASYNC_TASK_KNOWN_FLAGS: u32 =
+  ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_COALESCE_ALLOWED | ASYNC_TASK_FLAG_REQUIRES_RESPONSE;
+pub const ASYNC_EVENT_FLAG_COALESCED: u32 = 1 << 0;
+pub const ASYNC_EVENT_KNOWN_FLAGS: u32 = ASYNC_EVENT_FLAG_COALESCED;
 
 /// Stable status values returned by C-safe async host functions. Keep these
 /// as integer constants rather than an FFI enum so foreign callers cannot
@@ -51,6 +55,35 @@ pub enum FfiAsyncHandleKind {
   Stream = 2,
   Server = 3,
   Response = 4,
+}
+
+/// Stable event tags shared by native and future WASM transports. `Complete`
+/// and `Fail` are terminal; `Emit` may repeat while a task is active.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiAsyncEventKind {
+  Emit = 1,
+  Complete = 2,
+  Fail = 3,
+}
+
+impl FfiAsyncEventKind {
+  pub fn is_terminal(self) -> bool {
+    matches!(self, Self::Complete | Self::Fail)
+  }
+}
+
+impl TryFrom<u32> for FfiAsyncEventKind {
+  type Error = FfiAsyncHandleError;
+
+  fn try_from(value: u32) -> Result<Self, Self::Error> {
+    match value {
+      1 => Ok(Self::Emit),
+      2 => Ok(Self::Complete),
+      3 => Ok(Self::Fail),
+      _ => Err(FfiAsyncHandleError::InvalidEventKind(value)),
+    }
+  }
 }
 
 impl TryFrom<u32> for FfiAsyncHandleKind {
@@ -98,6 +131,48 @@ impl FfiAsyncTaskDescriptor {
   }
 }
 
+/// C-layout event metadata. Payload bytes are deliberately not represented by
+/// a Rust pointer here: the native host function table and a future WASM
+/// adapter provide their own copying transport around this shared descriptor.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FfiAsyncEventDescriptor {
+  pub protocol_version: u32,
+  pub struct_size: u32,
+  pub kind: u32,
+  pub flags: u32,
+  pub task_handle: u64,
+  pub response_handle: u64,
+  pub sequence: u64,
+  pub payload_len: u64,
+}
+
+impl FfiAsyncEventDescriptor {
+  pub fn new(
+    task_handle: FfiAsyncHandle,
+    response_handle: Option<FfiAsyncHandle>,
+    sequence: u64,
+    kind: FfiAsyncEventKind,
+    flags: u32,
+    payload_len: usize,
+  ) -> Result<Self, FfiAsyncHandleError> {
+    if flags & !ASYNC_EVENT_KNOWN_FLAGS != 0 {
+      return Err(FfiAsyncHandleError::InvalidEventFlags(flags));
+    }
+    let payload_len = u64::try_from(payload_len).map_err(|_| FfiAsyncHandleError::PayloadTooLarge)?;
+    Ok(Self {
+      protocol_version: ASYNC_PROTOCOL_VERSION,
+      struct_size: std::mem::size_of::<Self>() as u32,
+      kind: kind as u32,
+      flags,
+      task_handle: task_handle.raw(),
+      response_handle: response_handle.unwrap_or(FfiAsyncHandle::INVALID).raw(),
+      sequence,
+      payload_len,
+    })
+  }
+}
+
 /// Opaque generation handle. Zero is permanently invalid. The low 32 bits
 /// store slot index + 1 and the high 32 bits store a non-zero generation.
 #[repr(transparent)]
@@ -135,26 +210,34 @@ impl FfiAsyncHandle {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FfiAsyncHandleError {
   InvalidKind(u32),
+  InvalidEventKind(u32),
+  InvalidFlags(u32),
+  InvalidEventFlags(u32),
   InvalidHandle,
   StaleHandle,
   HandleClosing,
   HandleFinished,
   HandleStillActive,
+  TerminalAlreadyQueued,
   HostClosing,
   RegistryExhausted,
   SequenceExhausted,
+  PayloadTooLarge,
   RegistryPoisoned,
 }
 
 impl FfiAsyncHandleError {
   pub fn status_code(&self) -> i32 {
     match self {
-      Self::InvalidKind(_) => async_status::INVALID_PAYLOAD,
+      Self::InvalidKind(_) | Self::InvalidEventKind(_) | Self::InvalidFlags(_) | Self::InvalidEventFlags(_) | Self::PayloadTooLarge => {
+        async_status::INVALID_PAYLOAD
+      }
       Self::InvalidHandle => async_status::INVALID_HANDLE,
       Self::StaleHandle => async_status::STALE_HANDLE,
       Self::HandleClosing => async_status::HANDLE_CLOSING,
       Self::HandleFinished => async_status::HANDLE_FINISHED,
       Self::HandleStillActive => async_status::HANDLE_STILL_ACTIVE,
+      Self::TerminalAlreadyQueued => async_status::HANDLE_CLOSING,
       Self::HostClosing => async_status::HOST_CLOSING,
       Self::RegistryExhausted | Self::SequenceExhausted | Self::RegistryPoisoned => async_status::INTERNAL_ERROR,
     }
@@ -165,14 +248,19 @@ impl fmt::Display for FfiAsyncHandleError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Self::InvalidKind(value) => write!(f, "invalid async FFI handle kind {value}"),
+      Self::InvalidEventKind(value) => write!(f, "invalid async FFI event kind {value}"),
+      Self::InvalidFlags(value) => write!(f, "invalid async FFI task flags 0x{value:x}"),
+      Self::InvalidEventFlags(value) => write!(f, "invalid async FFI event flags 0x{value:x}"),
       Self::InvalidHandle => f.write_str("invalid async FFI handle"),
       Self::StaleHandle => f.write_str("stale async FFI handle generation"),
       Self::HandleClosing => f.write_str("async FFI handle is closing"),
       Self::HandleFinished => f.write_str("async FFI handle is already finished"),
       Self::HandleStillActive => f.write_str("async FFI handle must finish before release"),
+      Self::TerminalAlreadyQueued => f.write_str("async FFI handle already has a terminal event queued"),
       Self::HostClosing => f.write_str("async FFI host is closing"),
       Self::RegistryExhausted => f.write_str("async FFI handle registry is exhausted"),
       Self::SequenceExhausted => f.write_str("async FFI event sequence is exhausted"),
+      Self::PayloadTooLarge => f.write_str("async FFI event payload length is too large"),
       Self::RegistryPoisoned => f.write_str("async FFI handle registry lock is poisoned"),
     }
   }
@@ -183,8 +271,10 @@ impl std::error::Error for FfiAsyncHandleError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FfiAsyncHandleState {
   pub kind: FfiAsyncHandleKind,
+  pub flags: u32,
   pub lifecycle: FfiAsyncLifecycle,
   pub next_sequence: u64,
+  pub terminal_queued: bool,
 }
 
 struct RegisteredAsyncHandle<T> {
@@ -228,6 +318,13 @@ impl<T> FfiAsyncHandleRegistry<T> {
   }
 
   pub fn register(&self, kind: FfiAsyncHandleKind, value: T) -> Result<FfiAsyncHandle, FfiAsyncHandleError> {
+    self.register_with_flags(kind, 0, value)
+  }
+
+  pub fn register_with_flags(&self, kind: FfiAsyncHandleKind, flags: u32, value: T) -> Result<FfiAsyncHandle, FfiAsyncHandleError> {
+    if flags & !ASYNC_TASK_KNOWN_FLAGS != 0 || (flags & ASYNC_TASK_FLAG_COALESCE_ALLOWED != 0 && kind != FfiAsyncHandleKind::Stream) {
+      return Err(FfiAsyncHandleError::InvalidFlags(flags));
+    }
     let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
     if registry.closing {
       return Err(FfiAsyncHandleError::HostClosing);
@@ -235,8 +332,10 @@ impl<T> FfiAsyncHandleRegistry<T> {
 
     let state = FfiAsyncHandleState {
       kind,
+      flags,
       lifecycle: FfiAsyncLifecycle::Active,
       next_sequence: 1,
+      terminal_queued: false,
     };
     while let Some(index) = registry.free_slots.pop() {
       let slot = &mut registry.slots[index];
@@ -280,17 +379,35 @@ impl<T> FfiAsyncHandleRegistry<T> {
   /// Reserve the next host sequence before an event is enqueued. Events are
   /// rejected as soon as cancellation/shutdown moves a handle to Closing.
   pub fn next_event_sequence(&self, handle: FfiAsyncHandle) -> Result<u64, FfiAsyncHandleError> {
+    self.reserve_event_sequence(handle, FfiAsyncEventKind::Emit)
+  }
+
+  /// Reserve an event sequence and atomically claim a terminal event when
+  /// needed. Queue implementations call this only after capacity is secured,
+  /// so a full queue does not leave a phantom terminal transition behind.
+  pub fn reserve_event_sequence(&self, handle: FfiAsyncHandle, kind: FfiAsyncEventKind) -> Result<u64, FfiAsyncHandleError> {
     let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
     let task = resolve_async_handle_mut(&mut registry, handle)?;
-    match task.state.lifecycle {
-      FfiAsyncLifecycle::Active => {
-        let sequence = task.state.next_sequence;
-        task.state.next_sequence = sequence.checked_add(1).ok_or(FfiAsyncHandleError::SequenceExhausted)?;
-        Ok(sequence)
+    let sequence = task.state.next_sequence;
+    let next_sequence = sequence.checked_add(1).ok_or(FfiAsyncHandleError::SequenceExhausted)?;
+    if kind.is_terminal() {
+      if task.state.lifecycle == FfiAsyncLifecycle::Finished {
+        return Err(FfiAsyncHandleError::HandleFinished);
       }
-      FfiAsyncLifecycle::Closing => Err(FfiAsyncHandleError::HandleClosing),
-      FfiAsyncLifecycle::Finished => Err(FfiAsyncHandleError::HandleFinished),
+      if task.state.terminal_queued {
+        return Err(FfiAsyncHandleError::TerminalAlreadyQueued);
+      }
+      task.state.terminal_queued = true;
+    } else {
+      match task.state.lifecycle {
+        FfiAsyncLifecycle::Active => {}
+        FfiAsyncLifecycle::Closing => return Err(FfiAsyncHandleError::HandleClosing),
+        FfiAsyncLifecycle::Finished => return Err(FfiAsyncHandleError::HandleFinished),
+      }
     }
+
+    task.state.next_sequence = next_sequence;
+    Ok(sequence)
   }
 
   /// Begin cancellation or orderly close. Completion must still be
@@ -564,7 +681,8 @@ pub fn lookup_build_id(lib: &libloading::Library, lib_name: &str) -> Result<Opti
 #[cfg(test)]
 mod tests {
   use super::{
-    ASYNC_PROTOCOL_VERSION, ASYNC_TASK_FLAG_REQUIRES_RESPONSE, ASYNC_TASK_FLAG_SERIAL_EVENTS, BUFFER_PROTOCOL_VERSION, FfiAsyncHandle,
+    ASYNC_EVENT_FLAG_COALESCED, ASYNC_PROTOCOL_VERSION, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+    ASYNC_TASK_FLAG_SERIAL_EVENTS, BUFFER_PROTOCOL_VERSION, FfiAsyncEventDescriptor, FfiAsyncEventKind, FfiAsyncHandle,
     FfiAsyncHandleError, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncLifecycle, FfiAsyncTaskDescriptor, FfiBuildCompatibility,
     async_status, buffer_method_symbol, decode_buffer_response, encode_buffer_request, validate_build_id,
   };
@@ -639,6 +757,25 @@ mod tests {
     assert_eq!(descriptor.kind, FfiAsyncHandleKind::Server as u32);
     assert_eq!(FfiAsyncHandleKind::try_from(descriptor.kind), Ok(FfiAsyncHandleKind::Server));
     assert_eq!(FfiAsyncHandleKind::try_from(99), Err(FfiAsyncHandleError::InvalidKind(99)));
+
+    let event = FfiAsyncEventDescriptor::new(handle, None, 7, FfiAsyncEventKind::Emit, ASYNC_EVENT_FLAG_COALESCED, 12)
+      .expect("create event descriptor");
+    assert_eq!(event.protocol_version, ASYNC_PROTOCOL_VERSION);
+    assert_eq!(event.struct_size as usize, std::mem::size_of::<FfiAsyncEventDescriptor>());
+    assert_eq!(event.task_handle, handle.raw());
+    assert_eq!(event.response_handle, FfiAsyncHandle::INVALID.raw());
+    assert_eq!(event.sequence, 7);
+    assert_eq!(event.payload_len, 12);
+    assert_eq!(FfiAsyncEventKind::try_from(event.kind), Ok(FfiAsyncEventKind::Emit));
+    assert_eq!(FfiAsyncEventKind::try_from(99), Err(FfiAsyncHandleError::InvalidEventKind(99)));
+    assert_eq!(
+      FfiAsyncEventDescriptor::new(handle, None, 8, FfiAsyncEventKind::Emit, 1 << 31, 0),
+      Err(FfiAsyncHandleError::InvalidEventFlags(1 << 31))
+    );
+    assert_eq!(
+      registry.register_with_flags(FfiAsyncHandleKind::Server, ASYNC_TASK_FLAG_COALESCE_ALLOWED, "invalid-server"),
+      Err(FfiAsyncHandleError::InvalidFlags(ASYNC_TASK_FLAG_COALESCE_ALLOWED))
+    );
   }
 
   #[test]

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -1,0 +1,625 @@
+//! Host-side scheduling primitives for asynchronous FFI events.
+//!
+//! Foreign producers may enqueue from any thread, but only the thread that
+//! creates the queue may drain it and enter the Calcit runtime. No Rust
+//! callback, executor, or allocator crosses the transport boundary.
+
+use std::collections::{HashSet, VecDeque};
+use std::fmt;
+use std::sync::{Condvar, Mutex};
+use std::thread::{self, ThreadId};
+use std::time::{Duration, Instant};
+
+use crate::ffi_abi::{
+  ASYNC_EVENT_FLAG_COALESCED, ASYNC_TASK_FLAG_COALESCE_ALLOWED, FfiAsyncEventDescriptor, FfiAsyncEventKind, FfiAsyncHandle,
+  FfiAsyncHandleError, FfiAsyncHandleRegistry, FfiAsyncLifecycle, async_status,
+};
+
+/// Protect the host from a single event consuming unbounded memory before the
+/// transport-specific EDN decoder can validate it.
+pub const MAX_ASYNC_EVENT_PAYLOAD_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FfiAsyncEnqueueDisposition {
+  Enqueued,
+  Coalesced,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FfiAsyncEnqueueOutcome {
+  pub sequence: u64,
+  pub disposition: FfiAsyncEnqueueDisposition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FfiAsyncQueueError {
+  InvalidCapacity,
+  PayloadTooLarge { actual: usize, limit: usize },
+  QueueClosed,
+  QueueFull { capacity: usize },
+  WrongDrainThread,
+  QueuePoisoned,
+  Handle(FfiAsyncHandleError),
+}
+
+impl FfiAsyncQueueError {
+  pub fn status_code(&self) -> i32 {
+    match self {
+      Self::PayloadTooLarge { .. } => async_status::INVALID_PAYLOAD,
+      Self::QueueClosed => async_status::HOST_CLOSING,
+      Self::QueueFull { .. } => async_status::QUEUE_FULL,
+      Self::Handle(error) => error.status_code(),
+      Self::InvalidCapacity | Self::WrongDrainThread | Self::QueuePoisoned => async_status::INTERNAL_ERROR,
+    }
+  }
+}
+
+impl fmt::Display for FfiAsyncQueueError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::InvalidCapacity => f.write_str("async FFI event queue capacity must be greater than zero"),
+      Self::PayloadTooLarge { actual, limit } => {
+        write!(f, "async FFI event payload has {actual} bytes, exceeding the {limit}-byte limit")
+      }
+      Self::QueueClosed => f.write_str("async FFI event queue is closed"),
+      Self::QueueFull { capacity } => write!(f, "async FFI event queue is full at capacity {capacity}"),
+      Self::WrongDrainThread => f.write_str("async FFI event queue must be drained by its host thread"),
+      Self::QueuePoisoned => f.write_str("async FFI event queue lock is poisoned"),
+      Self::Handle(error) => error.fmt(f),
+    }
+  }
+}
+
+impl std::error::Error for FfiAsyncQueueError {}
+
+impl From<FfiAsyncHandleError> for FfiAsyncQueueError {
+  fn from(value: FfiAsyncHandleError) -> Self {
+    Self::Handle(value)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct FfiAsyncQueuedEvent {
+  pub descriptor: FfiAsyncEventDescriptor,
+  payload: Vec<u8>,
+  producer_thread: ThreadId,
+  enqueued_at: Instant,
+}
+
+impl FfiAsyncQueuedEvent {
+  pub fn payload(&self) -> &[u8] {
+    &self.payload
+  }
+
+  pub fn task_handle(&self) -> FfiAsyncHandle {
+    FfiAsyncHandle::from_raw(self.descriptor.task_handle)
+  }
+
+  pub fn kind(&self) -> Result<FfiAsyncEventKind, FfiAsyncHandleError> {
+    FfiAsyncEventKind::try_from(self.descriptor.kind)
+  }
+
+  pub fn producer_thread(&self) -> ThreadId {
+    self.producer_thread
+  }
+
+  pub fn queued_for(&self) -> Duration {
+    self.enqueued_at.elapsed()
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct FfiAsyncDispatchFailure {
+  pub descriptor: FfiAsyncEventDescriptor,
+  pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FfiAsyncLifecycleFailure {
+  pub descriptor: FfiAsyncEventDescriptor,
+  pub error: FfiAsyncHandleError,
+}
+
+#[derive(Debug, Default)]
+pub struct FfiAsyncDrainReport {
+  pub dequeued: usize,
+  pub delivered: usize,
+  pub discarded: usize,
+  pub callback_failures: Vec<FfiAsyncDispatchFailure>,
+  pub lifecycle_failures: Vec<FfiAsyncLifecycleFailure>,
+}
+
+struct FfiAsyncQueueState {
+  events: VecDeque<FfiAsyncQueuedEvent>,
+  closed: bool,
+}
+
+/// A bounded multi-producer, single-host-thread event queue.
+pub struct FfiAsyncEventQueue {
+  capacity: usize,
+  host_thread: ThreadId,
+  state: Mutex<FfiAsyncQueueState>,
+  ready: Condvar,
+}
+
+impl FfiAsyncEventQueue {
+  pub fn new(capacity: usize) -> Result<Self, FfiAsyncQueueError> {
+    if capacity == 0 {
+      return Err(FfiAsyncQueueError::InvalidCapacity);
+    }
+    Ok(Self {
+      capacity,
+      host_thread: thread::current().id(),
+      state: Mutex::new(FfiAsyncQueueState {
+        events: VecDeque::with_capacity(capacity),
+        closed: false,
+      }),
+      ready: Condvar::new(),
+    })
+  }
+
+  pub fn capacity(&self) -> usize {
+    self.capacity
+  }
+
+  pub fn len(&self) -> Result<usize, FfiAsyncQueueError> {
+    Ok(self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?.events.len())
+  }
+
+  pub fn is_empty(&self) -> Result<bool, FfiAsyncQueueError> {
+    Ok(self.len()? == 0)
+  }
+
+  pub fn close(&self) -> Result<(), FfiAsyncQueueError> {
+    let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    queue.closed = true;
+    self.ready.notify_all();
+    Ok(())
+  }
+
+  /// Enqueue an event without blocking a foreign producer. When the queue is
+  /// full, only ordinary `Emit` events from a task that explicitly allows
+  /// coalescing may replace an older queued emit for the same task.
+  pub fn enqueue<T>(
+    &self,
+    registry: &FfiAsyncHandleRegistry<T>,
+    task_handle: FfiAsyncHandle,
+    response_handle: Option<FfiAsyncHandle>,
+    kind: FfiAsyncEventKind,
+    payload: Vec<u8>,
+  ) -> Result<FfiAsyncEnqueueOutcome, FfiAsyncQueueError> {
+    if payload.len() > MAX_ASYNC_EVENT_PAYLOAD_BYTES {
+      return Err(FfiAsyncQueueError::PayloadTooLarge {
+        actual: payload.len(),
+        limit: MAX_ASYNC_EVENT_PAYLOAD_BYTES,
+      });
+    }
+    if response_handle.is_some_and(|handle| handle == FfiAsyncHandle::INVALID) {
+      return Err(FfiAsyncHandleError::InvalidHandle.into());
+    }
+
+    let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    if queue.closed {
+      return Err(FfiAsyncQueueError::QueueClosed);
+    }
+
+    let task_state = registry.state(task_handle)?;
+    let coalesce_index = if queue.events.len() >= self.capacity
+      && kind == FfiAsyncEventKind::Emit
+      && task_state.flags & ASYNC_TASK_FLAG_COALESCE_ALLOWED != 0
+    {
+      queue.events.iter().rposition(|queued| {
+        queued.descriptor.task_handle == task_handle.raw() && queued.descriptor.kind == FfiAsyncEventKind::Emit as u32
+      })
+    } else {
+      None
+    };
+
+    if queue.events.len() >= self.capacity && coalesce_index.is_none() {
+      return Err(FfiAsyncQueueError::QueueFull { capacity: self.capacity });
+    }
+
+    let sequence = registry.reserve_event_sequence(task_handle, kind)?;
+    let descriptor_flags = if coalesce_index.is_some() { ASYNC_EVENT_FLAG_COALESCED } else { 0 };
+    let descriptor = FfiAsyncEventDescriptor::new(task_handle, response_handle, sequence, kind, descriptor_flags, payload.len())?;
+    let event = FfiAsyncQueuedEvent {
+      descriptor,
+      payload,
+      producer_thread: thread::current().id(),
+      enqueued_at: Instant::now(),
+    };
+
+    let disposition = if let Some(index) = coalesce_index {
+      queue.events[index] = event;
+      FfiAsyncEnqueueDisposition::Coalesced
+    } else {
+      queue.events.push_back(event);
+      FfiAsyncEnqueueDisposition::Enqueued
+    };
+    self.ready.notify_one();
+    Ok(FfiAsyncEnqueueOutcome { sequence, disposition })
+  }
+
+  /// Wait until work arrives, the queue closes, or the timeout expires. This
+  /// is a host-loop primitive and therefore follows the same thread rule as
+  /// `drain`.
+  pub fn wait_for_event(&self, timeout: Duration) -> Result<bool, FfiAsyncQueueError> {
+    self.ensure_host_thread()?;
+    let queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    if !queue.events.is_empty() {
+      return Ok(true);
+    }
+    if queue.closed {
+      return Ok(false);
+    }
+    let (queue, _) = self
+      .ready
+      .wait_timeout_while(queue, timeout, |state| state.events.is_empty() && !state.closed)
+      .map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    Ok(!queue.events.is_empty())
+  }
+
+  /// Drain at most `limit` events on the queue's host thread. Dispatch errors
+  /// are returned in the report, transition the task to `Finished`, and purge
+  /// its remaining queued events so failures are never silently lost or
+  /// followed by callbacks on a failed task.
+  pub fn drain<T, F>(
+    &self,
+    registry: &FfiAsyncHandleRegistry<T>,
+    limit: usize,
+    mut dispatch: F,
+  ) -> Result<FfiAsyncDrainReport, FfiAsyncQueueError>
+  where
+    F: FnMut(&FfiAsyncQueuedEvent) -> Result<(), String>,
+  {
+    self.ensure_host_thread()?;
+    if limit == 0 {
+      return Ok(FfiAsyncDrainReport::default());
+    }
+
+    let mut batch = Vec::with_capacity(limit.min(self.capacity));
+    {
+      let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+      for _ in 0..limit {
+        let Some(event) = queue.events.pop_front() else {
+          break;
+        };
+        batch.push(event);
+      }
+    }
+
+    let mut report = FfiAsyncDrainReport {
+      dequeued: batch.len(),
+      ..FfiAsyncDrainReport::default()
+    };
+    let mut failed_handles = HashSet::new();
+
+    for event in batch {
+      let handle = event.task_handle();
+      if failed_handles.contains(&handle) {
+        report.discarded += 1;
+        continue;
+      }
+
+      let kind = event.kind().map_err(FfiAsyncQueueError::Handle)?;
+      let state = match registry.state(handle) {
+        Ok(state) => state,
+        Err(error) => {
+          report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
+            descriptor: event.descriptor,
+            error,
+          });
+          report.discarded += 1;
+          continue;
+        }
+      };
+      if state.lifecycle == FfiAsyncLifecycle::Finished
+        || (state.lifecycle == FfiAsyncLifecycle::Closing && kind == FfiAsyncEventKind::Emit)
+      {
+        report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
+          descriptor: event.descriptor,
+          error: if state.lifecycle == FfiAsyncLifecycle::Finished {
+            FfiAsyncHandleError::HandleFinished
+          } else {
+            FfiAsyncHandleError::HandleClosing
+          },
+        });
+        report.discarded += 1;
+        continue;
+      }
+
+      match dispatch(&event) {
+        Ok(()) => {
+          report.delivered += 1;
+          if kind.is_terminal()
+            && let Err(error) = registry.finish(handle)
+          {
+            report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
+              descriptor: event.descriptor,
+              error,
+            });
+          }
+        }
+        Err(message) => {
+          report.callback_failures.push(FfiAsyncDispatchFailure {
+            descriptor: event.descriptor,
+            message,
+          });
+          failed_handles.insert(handle);
+          if let Err(error) = registry.finish(handle) {
+            report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
+              descriptor: event.descriptor,
+              error,
+            });
+          }
+          report.discarded += self.purge_handle(handle)?;
+        }
+      }
+    }
+
+    Ok(report)
+  }
+
+  fn purge_handle(&self, handle: FfiAsyncHandle) -> Result<usize, FfiAsyncQueueError> {
+    let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    let before = queue.events.len();
+    queue.events.retain(|event| event.descriptor.task_handle != handle.raw());
+    Ok(before - queue.events.len())
+  }
+
+  fn ensure_host_thread(&self) -> Result<(), FfiAsyncQueueError> {
+    if thread::current().id() == self.host_thread {
+      Ok(())
+    } else {
+      Err(FfiAsyncQueueError::WrongDrainThread)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::{Arc, Barrier};
+  use std::thread;
+
+  use super::*;
+  use crate::ffi_abi::{ASYNC_TASK_FLAG_COALESCE_ALLOWED, FfiAsyncHandleKind};
+
+  #[test]
+  fn bounded_queue_rejects_full_without_consuming_sequence() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let queue = FfiAsyncEventQueue::new(1).expect("create queue");
+
+    assert_eq!(
+      queue
+        .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, b"first".to_vec())
+        .expect("enqueue first")
+        .sequence,
+      1
+    );
+    assert_eq!(
+      queue.enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, b"second".to_vec()),
+      Err(FfiAsyncQueueError::QueueFull { capacity: 1 })
+    );
+    assert_eq!(registry.state(handle).expect("stream state").next_sequence, 2);
+  }
+
+  #[test]
+  fn full_queue_coalesces_only_opted_in_emit_events() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ())
+      .expect("register coalescing stream");
+    let queue = FfiAsyncEventQueue::new(1).expect("create queue");
+
+    queue
+      .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, b"old".to_vec())
+      .expect("enqueue old event");
+    let outcome = queue
+      .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, b"new".to_vec())
+      .expect("coalesce event");
+    assert_eq!(outcome.sequence, 2);
+    assert_eq!(outcome.disposition, FfiAsyncEnqueueDisposition::Coalesced);
+
+    let mut payloads = vec![];
+    let report = queue
+      .drain(&registry, 8, |event| {
+        payloads.push(event.payload().to_vec());
+        Ok(())
+      })
+      .expect("drain queue");
+    assert_eq!(payloads, vec![b"new".to_vec()]);
+    assert_eq!(report.delivered, 1);
+  }
+
+  #[test]
+  fn terminal_events_are_exactly_once_and_finish_during_drain() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::OneShot, ()).expect("register task");
+    let queue = FfiAsyncEventQueue::new(2).expect("create queue");
+
+    queue
+      .enqueue(&registry, handle, None, FfiAsyncEventKind::Complete, b"&unit".to_vec())
+      .expect("enqueue completion");
+    assert_eq!(
+      queue.enqueue(&registry, handle, None, FfiAsyncEventKind::Fail, b"late".to_vec()),
+      Err(FfiAsyncQueueError::Handle(FfiAsyncHandleError::TerminalAlreadyQueued))
+    );
+    assert_eq!(
+      registry.state(handle).expect("pending terminal").lifecycle,
+      FfiAsyncLifecycle::Active
+    );
+
+    let report = queue.drain(&registry, 1, |_| Ok(())).expect("drain completion");
+    assert_eq!(report.delivered, 1);
+    assert_eq!(
+      registry.state(handle).expect("finished task").lifecycle,
+      FfiAsyncLifecycle::Finished
+    );
+  }
+
+  #[test]
+  fn full_queue_does_not_claim_a_terminal_sequence() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let blocker = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register blocker");
+    let task = registry.register(FfiAsyncHandleKind::OneShot, ()).expect("register task");
+    let queue = FfiAsyncEventQueue::new(1).expect("create queue");
+    queue
+      .enqueue(&registry, blocker, None, FfiAsyncEventKind::Emit, vec![])
+      .expect("fill queue");
+
+    assert_eq!(
+      queue.enqueue(&registry, task, None, FfiAsyncEventKind::Complete, b"&unit".to_vec()),
+      Err(FfiAsyncQueueError::QueueFull { capacity: 1 })
+    );
+    let state = registry.state(task).expect("unclaimed task");
+    assert_eq!(state.next_sequence, 1);
+    assert!(!state.terminal_queued);
+
+    queue.drain(&registry, 1, |_| Ok(())).expect("make capacity");
+    assert_eq!(
+      queue
+        .enqueue(&registry, task, None, FfiAsyncEventKind::Complete, b"&unit".to_vec())
+        .expect("enqueue terminal")
+        .sequence,
+      1
+    );
+  }
+
+  #[test]
+  fn cancellation_discards_previously_queued_emit_but_delivers_terminal() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let queue = FfiAsyncEventQueue::new(3).expect("create queue");
+
+    queue
+      .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, b"tick".to_vec())
+      .expect("enqueue tick");
+    registry.begin_close(handle).expect("cancel stream");
+    queue
+      .enqueue(&registry, handle, None, FfiAsyncEventKind::Complete, b"&unit".to_vec())
+      .expect("enqueue close acknowledgement");
+
+    let mut kinds = vec![];
+    let report = queue
+      .drain(&registry, 3, |event| {
+        kinds.push(event.kind().expect("known kind"));
+        Ok(())
+      })
+      .expect("drain cancelled stream");
+    assert_eq!(kinds, vec![FfiAsyncEventKind::Complete]);
+    assert_eq!(report.discarded, 1);
+    assert_eq!(report.delivered, 1);
+    assert_eq!(report.lifecycle_failures.len(), 1);
+  }
+
+  #[test]
+  fn callback_failure_is_reported_finishes_task_and_purges_remaining_events() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let other = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register other stream");
+    let queue = FfiAsyncEventQueue::new(4).expect("create queue");
+    for (task, payload) in [(handle, b"bad".to_vec()), (handle, b"late".to_vec()), (other, b"ok".to_vec())] {
+      queue
+        .enqueue(&registry, task, None, FfiAsyncEventKind::Emit, payload)
+        .expect("enqueue event");
+    }
+
+    let report = queue
+      .drain(&registry, 2, |event| {
+        if event.payload() == b"bad" {
+          Err("Calcit callback failed".to_owned())
+        } else {
+          Ok(())
+        }
+      })
+      .expect("drain failing callback");
+    assert_eq!(report.callback_failures.len(), 1);
+    assert_eq!(report.callback_failures[0].message, "Calcit callback failed");
+    assert_eq!(report.discarded, 1);
+    assert_eq!(registry.state(handle).expect("failed task").lifecycle, FfiAsyncLifecycle::Finished);
+    assert_eq!(queue.len(), Ok(1));
+  }
+
+  #[test]
+  fn foreign_threads_can_enqueue_but_cannot_drain() {
+    let registry = Arc::new(FfiAsyncHandleRegistry::new());
+    let handle = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let queue = Arc::new(FfiAsyncEventQueue::new(4).expect("create queue"));
+    let barrier = Arc::new(Barrier::new(2));
+
+    let producer_registry = Arc::clone(&registry);
+    let producer_queue = Arc::clone(&queue);
+    let producer_barrier = Arc::clone(&barrier);
+    let producer = thread::spawn(move || {
+      producer_barrier.wait();
+      producer_queue
+        .enqueue(&producer_registry, handle, None, FfiAsyncEventKind::Emit, b"event".to_vec())
+        .expect("foreign producer enqueue");
+      producer_queue.drain(&producer_registry, 1, |_| Ok(()))
+    });
+    barrier.wait();
+    assert!(matches!(
+      producer.join().expect("producer thread"),
+      Err(FfiAsyncQueueError::WrongDrainThread)
+    ));
+
+    let mut producer_thread = None;
+    queue
+      .drain(&registry, 1, |event| {
+        producer_thread = Some(event.producer_thread());
+        Ok(())
+      })
+      .expect("host drain");
+    assert!(producer_thread.is_some_and(|thread_id| thread_id != thread::current().id()));
+  }
+
+  #[test]
+  fn concurrent_producers_preserve_sequence_order_in_the_queue() {
+    let registry = Arc::new(FfiAsyncHandleRegistry::new());
+    let handle = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let queue = Arc::new(FfiAsyncEventQueue::new(8).expect("create queue"));
+    let barrier = Arc::new(Barrier::new(5));
+    let mut producers = vec![];
+
+    for index in 0..4 {
+      let producer_registry = Arc::clone(&registry);
+      let producer_queue = Arc::clone(&queue);
+      let producer_barrier = Arc::clone(&barrier);
+      producers.push(thread::spawn(move || {
+        producer_barrier.wait();
+        producer_queue
+          .enqueue(&producer_registry, handle, None, FfiAsyncEventKind::Emit, vec![index])
+          .expect("concurrent enqueue")
+          .sequence
+      }));
+    }
+    barrier.wait();
+    for producer in producers {
+      producer.join().expect("producer thread");
+    }
+
+    let mut sequences = vec![];
+    queue
+      .drain(&registry, 8, |event| {
+        sequences.push(event.descriptor.sequence);
+        Ok(())
+      })
+      .expect("host drain");
+    assert_eq!(sequences, vec![1, 2, 3, 4]);
+  }
+
+  #[test]
+  fn closing_queue_wakes_host_and_rejects_new_work() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::OneShot, ()).expect("register task");
+    let queue = FfiAsyncEventQueue::new(1).expect("create queue");
+    queue.close().expect("close queue");
+
+    assert!(!queue.wait_for_event(Duration::from_millis(1)).expect("closed queue wait"));
+    assert_eq!(
+      queue.enqueue(&registry, handle, None, FfiAsyncEventKind::Complete, b"&unit".to_vec()),
+      Err(FfiAsyncQueueError::QueueClosed)
+    );
+  }
+}

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -120,13 +120,21 @@ pub struct FfiAsyncLifecycleFailure {
   pub error: FfiAsyncHandleError,
 }
 
+#[derive(Debug, Clone)]
+pub struct FfiAsyncQueueFailure {
+  pub descriptor: FfiAsyncEventDescriptor,
+  pub error: FfiAsyncQueueError,
+}
+
 #[derive(Debug, Default)]
 pub struct FfiAsyncDrainReport {
   pub dequeued: usize,
   pub delivered: usize,
   pub discarded: usize,
+  pub purged: usize,
   pub callback_failures: Vec<FfiAsyncDispatchFailure>,
   pub lifecycle_failures: Vec<FfiAsyncLifecycleFailure>,
+  pub queue_failures: Vec<FfiAsyncQueueFailure>,
 }
 
 struct FfiAsyncQueueState {
@@ -301,7 +309,17 @@ impl FfiAsyncEventQueue {
         continue;
       }
 
-      let kind = event.kind().map_err(FfiAsyncQueueError::Handle)?;
+      let kind = match event.kind() {
+        Ok(kind) => kind,
+        Err(error) => {
+          report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
+            descriptor: event.descriptor,
+            error,
+          });
+          report.discarded += 1;
+          continue;
+        }
+      };
       let state = match registry.state(handle) {
         Ok(state) => state,
         Err(error) => {
@@ -345,6 +363,7 @@ impl FfiAsyncEventQueue {
             descriptor: event.descriptor,
             message,
           });
+          report.discarded += 1;
           failed_handles.insert(handle);
           if let Err(error) = registry.finish(handle) {
             report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
@@ -352,7 +371,13 @@ impl FfiAsyncEventQueue {
               error,
             });
           }
-          report.discarded += self.purge_handle(handle)?;
+          match self.purge_handle(handle) {
+            Ok(purged) => report.purged += purged,
+            Err(error) => report.queue_failures.push(FfiAsyncQueueFailure {
+              descriptor: event.descriptor,
+              error,
+            }),
+          }
         }
       }
     }
@@ -526,7 +551,7 @@ mod tests {
     }
 
     let report = queue
-      .drain(&registry, 2, |event| {
+      .drain(&registry, 1, |event| {
         if event.payload() == b"bad" {
           Err("Calcit callback failed".to_owned())
         } else {
@@ -537,8 +562,35 @@ mod tests {
     assert_eq!(report.callback_failures.len(), 1);
     assert_eq!(report.callback_failures[0].message, "Calcit callback failed");
     assert_eq!(report.discarded, 1);
+    assert_eq!(report.purged, 1);
+    assert_eq!(report.dequeued, report.delivered + report.discarded);
     assert_eq!(registry.state(handle).expect("failed task").lifecycle, FfiAsyncLifecycle::Finished);
     assert_eq!(queue.len(), Ok(1));
+  }
+
+  #[test]
+  fn malformed_batch_event_is_reported_without_losing_drain_accounting() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let malformed = registry
+      .register(FfiAsyncHandleKind::Stream, ())
+      .expect("register malformed stream");
+    let valid = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register valid stream");
+    let queue = FfiAsyncEventQueue::new(2).expect("create queue");
+    queue
+      .enqueue(&registry, malformed, None, FfiAsyncEventKind::Emit, vec![])
+      .expect("enqueue malformed event placeholder");
+    queue
+      .enqueue(&registry, valid, None, FfiAsyncEventKind::Emit, vec![])
+      .expect("enqueue valid event");
+    queue.state.lock().expect("queue lock").events[0].descriptor.kind = 99;
+
+    let report = queue.drain(&registry, 2, |_| Ok(())).expect("degraded drain report");
+    assert_eq!(report.dequeued, 2);
+    assert_eq!(report.delivered, 1);
+    assert_eq!(report.discarded, 1);
+    assert_eq!(report.lifecycle_failures.len(), 1);
+    assert_eq!(report.lifecycle_failures[0].error, FfiAsyncHandleError::InvalidEventKind(99));
+    assert_eq!(report.dequeued, report.delivered + report.discarded);
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod detailed_snapshot;
 pub mod effects_graph;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ffi_abi;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod ffi_async;
 pub mod program;
 pub mod program_diff;
 pub mod project_state;


### PR DESCRIPTION
## Summary

- add a stable C-layout async event descriptor for emit/complete/fail envelopes
- add a bounded multi-producer queue that only its creating host thread may drain into Calcit
- make queue admission, per-handle sequencing, terminal claiming, cancellation, and shutdown deterministic
- support explicit stream coalescing while never coalescing server/terminal work
- propagate callback and lifecycle failures through structured drain reports and retain low-payload trace metadata

This is Phase 2 of #482. Existing Rust callback and blocking dylib paths remain unchanged. The next phase adds the native C host function table and per-method callback-v1 lookup on top of this queue.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`

Refs #482
Refs #474