### PR TITLE
feat: add native async FFI callback v1

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -6,10 +6,10 @@ more than one callback: it must represent timers, file watchers, HTTP work,
 WebSocket connections, and server resources.
 
 This document describes protocol version 1 as it is implemented in stages.
-The current implementation provides the handle types, lifecycle registry, and
-bounded host event queue; existing `&call-dylib-edn-fn` and
-`&blocking-dylib-edn-fn` calls still use the build-identity-guarded Rust ABI
-until the C host function table lands.
+The current implementation provides the handle types, lifecycle registry,
+bounded host event queue, and the native callback-v1 entry point used by
+`&call-dylib-edn-fn`. `&blocking-dylib-edn-fn` still uses the
+build-identity-guarded Rust ABI until the blocking protocol lands.
 
 ## Shared task model
 
@@ -97,6 +97,70 @@ converted to a Rust enum, avoiding invalid-discriminant undefined behavior.
 Business payloads will continue to use UTF-8 Cirru EDN buffers, with allocator
 ownership and matching free functions explicit in both directions.
 
+## Native callback ABI v1
+
+Before using the legacy Rust callback ABI, `&call-dylib-edn-fn` probes the
+following C symbols:
+
+```c
+uint32_t calcit_ffi_async_version(void); /* returns 1 */
+
+int32_t <method>_calcit_ffi_async_v1(
+  const uint8_t *request_ptr,
+  size_t request_len,
+  const CalcitFfiAsyncTaskV1 *task,
+  const CalcitFfiAsyncHostV1 *host
+);
+```
+
+The request is a UTF-8 Cirru EDN list and is readable only for the duration of
+the start call. The task descriptor contains the host-issued handle and must
+be copied if the module needs it after returning. The host table has process
+lifetime, although modules should copy only the fields covered by
+`struct_size` so later hosts can append functions compatibly.
+
+Callback v1 currently exposes one host operation:
+
+```c
+int32_t enqueue(
+  uint64_t context,
+  uint64_t task_handle,
+  uint32_t event_kind,
+  uint64_t response_handle,
+  const uint8_t *payload_ptr,
+  size_t payload_len
+);
+```
+
+The module may call `enqueue` from producer threads. Calcit validates the
+context, handles, kind, pointer, length, and queue capacity, copies the bytes
+before returning, and invokes the Calcit callback only while the CLI host
+thread drains the queue. The producer retains ownership of its payload and may
+reuse or free it after `enqueue` returns. A null pointer is valid only when the
+length is zero. No panic, Rust allocator, Rust callback, or executor object
+crosses the boundary.
+
+Payload rules are explicit:
+
+- `Emit` (`1`) carries a Cirru EDN list whose elements become callback
+  arguments;
+- `Complete` (`2`) carries exactly the explicit unit value `&unit` (surrounding
+  whitespace is allowed); it never uses null/nil as success;
+- `Fail` (`3`) carries one Cirru EDN diagnostic value and is reported to the
+  console with task and sequence metadata.
+
+The start function returns `0` after it has accepted responsibility for the
+task. A nonzero result makes the host purge startup events and reclaim the
+handle. Host calls return the stable `async_status` integer codes, including
+invalid/stale handle, closing/finished task, host closing, queue full, invalid
+payload, and internal error.
+
+If a dylib does not export `calcit_ffi_async_version`, or does not export the
+versioned symbol for this particular method, Calcit falls back to the guarded
+Rust callback ABI. If it advertises an async protocol version other than 1,
+Calcit fails before invoking either ABI. This per-method rule lets maintained
+modules migrate incrementally without hiding an actual version mismatch.
+
 ## WASM compatibility boundary
 
 WASM will not reuse C pointers or native function pointers. It can still reuse
@@ -116,15 +180,14 @@ present the same Calcit-facing behavior.
 
 ## Rollout
 
-The remaining implementation order is:
+The remaining implementation order after native callback v1 is:
 
-1. native C host function table and per-method callback v1 lookup;
-2. response handles, server backpressure, cancellation, timeout, and shutdown
+1. response handles, server backpressure, cancellation, timeout, and shutdown
    fixtures;
-3. blocking calls reusing the same registry and envelopes;
-4. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
+2. blocking calls reusing the same registry and envelopes;
+3. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
    `calcit.std`;
-5. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
-6. removal of the guarded Rust ABI fallback under issue #474.
+4. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
+5. removal of the guarded Rust ABI fallback under issue #474.
 
 See issue #482 for the full acceptance matrix and module rollout status.

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -24,7 +24,8 @@ pub fn demo(args: Vec<Edn>) -> Result<Edn, String> {
 }
 ```
 
-The other one is an asynchorous API, it can be called multiple times, which relies on `Arc` type(not sure if we can find a better solution yet),
+The legacy asynchronous API can be called multiple times and relies on Rust
+`Arc` trait objects:
 
 ```rust
 #[unsafe(no_mangle)]
@@ -42,7 +43,8 @@ The function `finish` is used for indicating that the task has finished. It can 
 Internally Calcit tracks with a counter to see if all asynchorous tasks are finished.
 Process need to keep running when there are tasks running.
 
-Asynchronous tasks are based on threads, which is currently decoupled from core features of Calcit. We may need techniques like `tokio` for better performance in the future, but current solution is quite naive yet.
+New callback methods should instead implement the C-safe asynchronous protocol
+described below. The Rust form remains only as a per-method migration fallback.
 
 Rust's native ABI has no stability guarantee. `Vec<Edn>`, `String`, `Result`, and callback trait objects are therefore a transitional interface rather than a portable dylib protocol. Calcit checks a C-safe build identity before invoking those Rust ABI symbols.
 
@@ -151,7 +153,23 @@ Protocol rules:
 - The adapter must contain panics and return an error status; unwinding across `extern "C"` is invalid.
 - Calcit rejects protocol-version mismatches, malformed buffer metadata, oversized responses, invalid UTF-8, and invalid response EDN.
 
-`calcit-lang/calcit_wasmtime` contains the first complete adapter. Version 1 currently covers synchronous `&call-dylib-edn`; callback and blocking APIs remain on the guarded legacy path until their ownership protocol lands. The staged task/event/server design, including future WASM constraints, is documented in [Asynchronous FFI task protocol](ffi-async-protocol.md).
+`calcit-lang/calcit_wasmtime` contains the first complete synchronous adapter.
+
+## C-safe asynchronous callback ABI
+
+`&call-dylib-edn-fn` now probes `<method>_calcit_ffi_async_v1` before using the
+guarded legacy Rust callback. A callback-v1 module exports
+`calcit_ffi_async_version() -> 1`, accepts a C-layout task descriptor and host
+function table, and publishes byte payloads through the host's `enqueue`
+function. Foreign producer threads only enqueue; Calcit copies the payload and
+runs callbacks on its host thread.
+
+`Emit` payloads are Cirru EDN argument lists. Successful completion must carry
+the explicit `&unit` value, and `Fail` carries a Cirru EDN diagnostic that is
+surfaced to the console. Missing version or per-method symbols retain the
+legacy fallback; an advertised incompatible version is an error. See
+[Asynchronous FFI task protocol](ffi-async-protocol.md) for the exact C
+signatures, ownership, lifecycle, status, queue, and future WASM rules.
 
 ### Call in Calcit
 

--- a/editing-history/202608272013-native-ffi-callback-v1.md
+++ b/editing-history/202608272013-native-ffi-callback-v1.md
@@ -1,0 +1,31 @@
+# Native C-safe callback FFI v1
+
+## Goal
+
+Move `&call-dylib-edn-fn` onto the versioned asynchronous C ABI without
+breaking modules that still expose the guarded Rust callback ABI.
+
+## Changes
+
+- added the versioned native async start symbol and process-lifetime C host
+  function table;
+- copied and validated foreign byte payloads before placing them in the
+  bounded host queue;
+- decoded `Emit` arguments on the CLI host thread, required explicit `&unit`
+  completion, and surfaced structured `Fail` diagnostics;
+- reclaimed handles and tracking state on terminal delivery, callback failure,
+  and start failure;
+- kept per-method fallback to the build-identity-guarded Rust ABI while making
+  an advertised version mismatch a hard error;
+- added ABI, payload, foreign-producer, host-drain, lifecycle, and failure
+  regression coverage;
+- documented symbols, ownership, payload rules, statuses, and rollout.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test -- --test-threads=1`
+- `yarn compile`
+- `yarn check-agent-interface`
+- `yarn check-all`

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -297,7 +297,10 @@ fn run_cli() -> Result<(), String> {
   builtins::effects::init_effects_states();
 
   #[cfg(not(target_arch = "wasm32"))]
-  injection::inject_platform_apis();
+  {
+    injection::init_async_runtime()?;
+    injection::inject_platform_apis();
+  }
 
   // Handle standalone commands that don't need full program loading
   match &cli_args.subcommand {
@@ -590,6 +593,9 @@ fn run_cli() -> Result<(), String> {
     let args = cli_args.clone();
     std::thread::spawn(move || watch_files(entries, args, assets_watch, configured_run_mode));
   }
+  #[cfg(not(target_arch = "wasm32"))]
+  injection::exit_when_async_cleared()?;
+  #[cfg(target_arch = "wasm32")]
   runner::track::exit_when_cleared();
   Ok(())
 }

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 #[cfg(not(target_arch = "wasm32"))]
+#[allow(dead_code)]
 mod injection;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -6,9 +6,9 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use calcit::{
   builtins,
@@ -16,6 +16,11 @@ use calcit::{
   calcit::{Calcit, CalcitErr, CalcitErrKind},
   call_stack::{CallStackList, display_stack},
   data::edn::{calcit_to_edn, edn_to_calcit, sanitize_edn_for_format},
+  ffi_abi::{
+    ASYNC_TASK_FLAG_SERIAL_EVENTS, FfiAsyncEventKind, FfiAsyncHandle, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1,
+    FfiAsyncTaskDescriptor, async_status,
+  },
+  ffi_async::{FfiAsyncDrainReport, FfiAsyncEventQueue, copy_async_payload},
   runner::track,
 };
 
@@ -34,6 +39,24 @@ static STDOUT_TO_STDERR: AtomicBool = AtomicBool::new(false);
 static SILENCE_PROGRAM_OUTPUT: AtomicBool = AtomicBool::new(false);
 static TRACE_FFI_EVENT_ID: AtomicUsize = AtomicUsize::new(1);
 static TRACE_FFI_STARTED: LazyLock<Instant> = LazyLock::new(Instant::now);
+const ASYNC_HOST_CONTEXT: u64 = 0x4341_4c43_4954_0001;
+const ASYNC_EVENT_QUEUE_CAPACITY: usize = 1024;
+
+#[derive(Clone)]
+struct NativeAsyncCallback {
+  callback: Calcit,
+  stack: Arc<CallStackList>,
+  lib_name: String,
+  method: String,
+}
+
+struct NativeAsyncRuntime {
+  registry: FfiAsyncHandleRegistry<NativeAsyncCallback>,
+  queue: FfiAsyncEventQueue,
+}
+
+static NATIVE_ASYNC_RUNTIME: OnceLock<NativeAsyncRuntime> = OnceLock::new();
+static NATIVE_ASYNC_HOST: LazyLock<FfiAsyncHostV1> = LazyLock::new(|| FfiAsyncHostV1::new(ASYNC_HOST_CONTEXT, native_async_enqueue));
 
 #[allow(dead_code)]
 pub fn set_trace_ffi(v: bool) {
@@ -104,6 +127,258 @@ fn trace_ffi_event(label: &str, message: impl AsRef<str>) {
       thread::current().id(),
       message.as_ref()
     );
+  }
+}
+
+/// Bind the async queue to the CLI worker thread before any dylib can publish
+/// work. Tests that only inject proc metadata do not initialize global runtime
+/// state and therefore cannot accidentally claim host-thread ownership.
+pub fn init_async_runtime() -> Result<(), String> {
+  if NATIVE_ASYNC_RUNTIME.get().is_some() {
+    return Ok(());
+  }
+  let runtime = NativeAsyncRuntime {
+    registry: FfiAsyncHandleRegistry::new(),
+    queue: FfiAsyncEventQueue::new(ASYNC_EVENT_QUEUE_CAPACITY).map_err(|error| error.to_string())?,
+  };
+  NATIVE_ASYNC_RUNTIME
+    .set(runtime)
+    .map_err(|_| "async FFI runtime was initialized concurrently".to_owned())
+}
+
+fn native_async_runtime() -> Result<&'static NativeAsyncRuntime, String> {
+  NATIVE_ASYNC_RUNTIME
+    .get()
+    .ok_or_else(|| "async FFI runtime is not initialized on the CLI worker thread".to_owned())
+}
+
+fn async_host_table() -> &'static FfiAsyncHostV1 {
+  &NATIVE_ASYNC_HOST
+}
+
+unsafe extern "C" fn native_async_enqueue(
+  context: u64,
+  task_handle: u64,
+  event_kind: u32,
+  response_handle: u64,
+  payload_ptr: *const u8,
+  payload_len: usize,
+) -> i32 {
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let runtime = match native_async_runtime() {
+      Ok(runtime) => runtime,
+      Err(_) => return async_status::HOST_CLOSING,
+    };
+    // SAFETY: the C caller promises that a non-empty payload remains readable
+    // for this call. The helper validates length/null and copies immediately.
+    unsafe { enqueue_native_async_event(runtime, context, task_handle, event_kind, response_handle, payload_ptr, payload_len) }
+  }))
+  .unwrap_or(async_status::INTERNAL_ERROR)
+}
+
+unsafe fn enqueue_native_async_event(
+  runtime: &NativeAsyncRuntime,
+  context: u64,
+  task_handle: u64,
+  event_kind: u32,
+  response_handle: u64,
+  payload_ptr: *const u8,
+  payload_len: usize,
+) -> i32 {
+  if context != ASYNC_HOST_CONTEXT {
+    return async_status::INVALID_HANDLE;
+  }
+  let kind = match FfiAsyncEventKind::try_from(event_kind) {
+    Ok(kind) => kind,
+    Err(error) => return error.status_code(),
+  };
+  // SAFETY: forwarded from the C entry point's documented pointer contract.
+  let payload = match unsafe { copy_async_payload(payload_ptr, payload_len) } {
+    Ok(payload) => payload,
+    Err(error) => return error.status_code(),
+  };
+  let task_handle = FfiAsyncHandle::from_raw(task_handle);
+  let response_handle = if response_handle == FfiAsyncHandle::INVALID.raw() {
+    None
+  } else {
+    Some(FfiAsyncHandle::from_raw(response_handle))
+  };
+
+  match runtime
+    .queue
+    .enqueue(&runtime.registry, task_handle, response_handle, kind, payload)
+  {
+    Ok(outcome) => {
+      trace_ffi_event(
+        "async-enqueue",
+        format!(
+          "task={} kind={kind:?} sequence={} disposition={:?} producer={:?}",
+          task_handle.raw(),
+          outcome.sequence,
+          outcome.disposition,
+          thread::current().id()
+        ),
+      );
+      async_status::OK
+    }
+    Err(error) => {
+      trace_ffi_event(
+        "async-enqueue-rejected",
+        format!(
+          "task={} kind={kind:?} status={} error={error}",
+          task_handle.raw(),
+          error.status_code()
+        ),
+      );
+      error.status_code()
+    }
+  }
+}
+
+fn decode_async_emit(payload: &[u8]) -> Result<Vec<Calcit>, String> {
+  let source = std::str::from_utf8(payload).map_err(|error| format!("async FFI event payload is not UTF-8: {error}"))?;
+  let value = cirru_edn::parse(source).map_err(|error| format!("async FFI event payload is not valid Cirru EDN: {error}"))?;
+  let Edn::List(cirru_edn::EdnListView(args)) = value else {
+    return Err(format!("async FFI Emit payload must be a Cirru EDN list, got: {value}"));
+  };
+  Ok(args.iter().map(|arg| edn_to_calcit(arg, &Calcit::Nil)).collect())
+}
+
+fn validate_async_completion(payload: &[u8]) -> Result<(), String> {
+  let source = std::str::from_utf8(payload).map_err(|error| format!("async FFI completion payload is not UTF-8: {error}"))?;
+  if source.trim() == "&unit" {
+    Ok(())
+  } else {
+    Err(format!(
+      "async FFI Complete payload must be explicit `&unit`, got: {}",
+      source.trim()
+    ))
+  }
+}
+
+fn decode_async_failure(payload: &[u8]) -> Result<String, String> {
+  let source = std::str::from_utf8(payload).map_err(|error| format!("async FFI failure payload is not UTF-8: {error}"))?;
+  let value = cirru_edn::parse(source).map_err(|error| format!("async FFI failure payload is not valid Cirru EDN: {error}"))?;
+  cirru_edn::format(&sanitize_edn_for_format(&value), true)
+    .map(|message| message.trim().to_owned())
+    .map_err(|error| format!("failed to format async FFI failure payload: {error}"))
+}
+
+fn dispatch_native_async_event(runtime: &NativeAsyncRuntime, event: &calcit::ffi_async::FfiAsyncQueuedEvent) -> Result<(), String> {
+  let handle = event.task_handle();
+  let task = runtime.registry.clone_value(handle).map_err(|error| error.to_string())?;
+  let kind = event.kind().map_err(|error| error.to_string())?;
+  trace_ffi_event(
+    "async-drain",
+    format!(
+      "lib={} symbol={} task={} kind={kind:?} sequence={} producer={:?} queued_ms={:.3}",
+      task.lib_name,
+      task.method,
+      handle.raw(),
+      event.descriptor.sequence,
+      event.producer_thread(),
+      event.queued_for().as_secs_f64() * 1000.0
+    ),
+  );
+
+  match kind {
+    FfiAsyncEventKind::Emit => {
+      let args = decode_async_emit(event.payload())?;
+      let Calcit::Fn { info, .. } = &task.callback else {
+        return Err("async FFI task lost its Calcit callback".to_owned());
+      };
+      match runner::run_fn(&args, info, &task.stack) {
+        Ok(ret) => {
+          trace_ffi_event(
+            "async-callback-out",
+            format!(
+              "lib={} symbol={} task={} sequence={} ret={}",
+              task.lib_name,
+              task.method,
+              handle.raw(),
+              event.descriptor.sequence,
+              ret.turn_string()
+            ),
+          );
+          Ok(())
+        }
+        Err(error) => {
+          let _ = display_stack(
+            &format!("[Error] async FFI callback failed: {}", error.msg),
+            &error.stack,
+            error.location.as_ref(),
+          );
+          Err(format!("Calcit callback failed: {}", error.msg))
+        }
+      }
+    }
+    FfiAsyncEventKind::Complete => validate_async_completion(event.payload()),
+    FfiAsyncEventKind::Fail => Err(format!("async FFI task failed: {}", decode_async_failure(event.payload())?)),
+  }
+}
+
+pub fn drain_async_events(limit: usize) -> Result<FfiAsyncDrainReport, String> {
+  let runtime = native_async_runtime()?;
+  let mut report = runtime
+    .queue
+    .drain(&runtime.registry, limit, |event| dispatch_native_async_event(runtime, event))
+    .map_err(|error| error.to_string())?;
+
+  for failure in &report.callback_failures {
+    eprintln!(
+      "[Error] async FFI task {} sequence {}: {}",
+      failure.descriptor.task_handle, failure.descriptor.sequence, failure.message
+    );
+  }
+  for failure in &report.lifecycle_failures {
+    eprintln!(
+      "[Error] async FFI lifecycle task {} sequence {}: {}",
+      failure.descriptor.task_handle, failure.descriptor.sequence, failure.error
+    );
+  }
+  for failure in &report.queue_failures {
+    eprintln!(
+      "[Error] async FFI queue task {} sequence {}: {}",
+      failure.descriptor.task_handle, failure.descriptor.sequence, failure.error
+    );
+  }
+
+  for descriptor in report.finished.clone() {
+    let handle = FfiAsyncHandle::from_raw(descriptor.task_handle);
+    if let Err(error) = runtime.registry.release(handle) {
+      report
+        .lifecycle_failures
+        .push(calcit::ffi_async::FfiAsyncLifecycleFailure { descriptor, error });
+      continue;
+    }
+    track::track_task_release();
+    trace_ffi_event(
+      "async-task-release",
+      format!(
+        "task={} sequence={} pending={}",
+        handle.raw(),
+        descriptor.sequence,
+        track::count_pending_tasks()
+      ),
+    );
+  }
+
+  Ok(report)
+}
+
+pub fn exit_when_async_cleared() -> Result<(), String> {
+  let runtime = native_async_runtime()?;
+  loop {
+    drain_async_events(256)?;
+    if track::count_pending_tasks() == 0 && runtime.queue.is_empty().map_err(|error| error.to_string())? {
+      return Ok(());
+    }
+    if runtime.queue.is_empty().map_err(|error| error.to_string())? {
+      runtime
+        .queue
+        .wait_for_event(Duration::from_millis(40))
+        .map_err(|error| error.to_string())?;
+    }
   }
 }
 
@@ -397,6 +672,73 @@ pub fn stderr_println(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Ca
   Ok(Calcit::Nil)
 }
 
+fn try_start_async_callback_v1(
+  lib: &libloading::Library,
+  lib_name: &str,
+  method: &str,
+  args: Vec<Edn>,
+  callback: Calcit,
+  call_stack: &CallStackList,
+) -> Result<Option<Calcit>, CalcitErr> {
+  let Some(start) =
+    calcit::ffi_abi::lookup_async_start(lib, lib_name, method).map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?
+  else {
+    return Ok(None);
+  };
+  let runtime = native_async_runtime().map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  let request = calcit::ffi_abi::encode_buffer_request(args).map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  let task = NativeAsyncCallback {
+    callback,
+    stack: Arc::new(call_stack.to_owned()),
+    lib_name: lib_name.to_owned(),
+    method: method.to_owned(),
+  };
+  let handle = runtime
+    .registry
+    .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
+  let descriptor = FfiAsyncTaskDescriptor::new(handle, FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS);
+  let host = async_host_table();
+
+  track::track_task_add();
+  trace_ffi_event(
+    "async-start",
+    format!(
+      "lib={lib_name} symbol={} task={} request_bytes={} pending={}",
+      calcit::ffi_abi::async_method_symbol(method),
+      handle.raw(),
+      request.len(),
+      track::count_pending_tasks()
+    ),
+  );
+  let status = unsafe { start(request.as_ptr(), request.len(), &descriptor, host) };
+  if status == async_status::OK {
+    return Ok(Some(Calcit::Unit));
+  }
+
+  let purged = runtime.queue.discard_handle_events(handle).unwrap_or(0);
+  let _ = runtime.registry.finish(handle);
+  let _ = runtime.registry.release(handle);
+  track::track_task_release();
+  trace_ffi_event(
+    "async-start-failed",
+    format!(
+      "lib={lib_name} symbol={} task={} status={status} purged={purged} pending={}",
+      calcit::ffi_abi::async_method_symbol(method),
+      handle.raw(),
+      track::count_pending_tasks()
+    ),
+  );
+  CalcitErr::err_str(
+    CalcitErrKind::Unexpected,
+    format!(
+      "FFI async method `{}` in `{lib_name}` failed to start with status {status}",
+      calcit::ffi_abi::async_method_symbol(method)
+    ),
+  )
+  .map(Some)
+}
+
 /// pass callback function to FFI function, so it can call multiple times
 /// currently for HTTP servers
 pub fn call_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
@@ -440,9 +782,6 @@ pub fn call_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<
     );
   }
 
-  track::track_task_add();
-  trace_ffi_event("task-add", format!("kind=callback pending={}", track::count_pending_tasks()));
-
   trace_ffi_event(
     "spawn-callback",
     format!(
@@ -454,7 +793,19 @@ pub fn call_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<
   );
 
   let lib = load_dylib(&lib_name)?;
+  if let Some(result) = try_start_async_callback_v1(&lib, &lib_name, &method, ys.clone(), callback.clone(), call_stack)? {
+    return Ok(result);
+  }
+  trace_ffi_event(
+    "async-fallback",
+    format!(
+      "lib={lib_name} symbol={} fallback={method}",
+      calcit::ffi_abi::async_method_symbol(&method)
+    ),
+  );
   ensure_abi_compatible(&lib, &lib_name)?;
+  track::track_task_add();
+  trace_ffi_event("task-add", format!("kind=callback pending={}", track::count_pending_tasks()));
   let copied_stack_1 = Arc::new(call_stack.to_owned());
   let method_name = method.clone();
   let lib_name_for_thread = lib_name.clone();
@@ -544,7 +895,7 @@ pub fn call_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<
     Ok(Calcit::Nil)
   });
 
-  Ok(Calcit::Nil)
+  Ok(Calcit::Unit)
 }
 
 /// pass callback function to FFI function, blocking the thread,
@@ -695,5 +1046,73 @@ pub fn on_ctrl_c(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calcit, 
     Ok(Calcit::Nil)
   } else {
     CalcitErr::err_str(CalcitErrKind::Arity, format!("on-control-c expected a callback function {xs:?}"))
+  }
+}
+
+#[cfg(test)]
+mod async_callback_tests {
+  use super::*;
+
+  #[test]
+  fn foreign_producer_enters_through_c_payload_boundary_and_host_drains_completion() {
+    let runtime = Arc::new(NativeAsyncRuntime {
+      registry: FfiAsyncHandleRegistry::new(),
+      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
+    });
+    let handle = runtime
+      .registry
+      .register_with_flags(
+        FfiAsyncHandleKind::Stream,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS,
+        NativeAsyncCallback {
+          callback: Calcit::Nil,
+          stack: Arc::new(CallStackList::default()),
+          lib_name: "fixture".to_owned(),
+          method: "complete".to_owned(),
+        },
+      )
+      .expect("register fixture task");
+
+    let producer_runtime = Arc::clone(&runtime);
+    let producer = thread::spawn(move || {
+      let payload = b"&unit";
+      // SAFETY: the payload is readable for the duration of the call.
+      unsafe {
+        enqueue_native_async_event(
+          &producer_runtime,
+          ASYNC_HOST_CONTEXT,
+          handle.raw(),
+          FfiAsyncEventKind::Complete as u32,
+          FfiAsyncHandle::INVALID.raw(),
+          payload.as_ptr(),
+          payload.len(),
+        )
+      }
+    });
+    assert_eq!(producer.join().expect("producer thread"), async_status::OK);
+
+    let report = runtime
+      .queue
+      .drain(&runtime.registry, 4, |event| dispatch_native_async_event(&runtime, event))
+      .expect("host-thread drain");
+    assert_eq!(report.dequeued, 1);
+    assert_eq!(report.delivered, 1);
+    assert_eq!(report.finished.len(), 1);
+    assert_eq!(report.finished[0].task_handle, handle.raw());
+    assert!(report.callback_failures.is_empty());
+    assert!(report.lifecycle_failures.is_empty());
+  }
+
+  #[test]
+  fn async_payload_decoders_require_list_unit_and_structured_failure() {
+    let args = decode_async_emit(b"[] 1 |two").expect("decode emit list");
+    assert_eq!(args.len(), 2);
+    assert!(decode_async_emit(b"{} (:not-a-list true)").is_err());
+    assert_eq!(validate_async_completion(b"  &unit\n"), Ok(()));
+    assert!(validate_async_completion(b"nil").is_err());
+    assert_eq!(
+      decode_async_failure(b"{} (:code :closed)").expect("decode failure"),
+      "{} $ :code :closed"
+    );
   }
 }

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -30,6 +30,38 @@ pub const ASYNC_TASK_KNOWN_FLAGS: u32 =
 pub const ASYNC_EVENT_FLAG_COALESCED: u32 = 1 << 0;
 pub const ASYNC_EVENT_KNOWN_FLAGS: u32 = ASYNC_EVENT_FLAG_COALESCED;
 
+pub type FfiAsyncHostEnqueue = unsafe extern "C" fn(
+  context: u64,
+  task_handle: u64,
+  event_kind: u32,
+  response_handle: u64,
+  payload_ptr: *const u8,
+  payload_len: usize,
+) -> i32;
+
+/// Native host functions that an async dylib may copy and call from producer
+/// threads. The integer context is opaque and avoids exposing a Rust object
+/// pointer or allocator across the ABI.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FfiAsyncHostV1 {
+  pub protocol_version: u32,
+  pub struct_size: u32,
+  pub context: u64,
+  pub enqueue: Option<FfiAsyncHostEnqueue>,
+}
+
+impl FfiAsyncHostV1 {
+  pub fn new(context: u64, enqueue: FfiAsyncHostEnqueue) -> Self {
+    Self {
+      protocol_version: ASYNC_PROTOCOL_VERSION,
+      struct_size: std::mem::size_of::<Self>() as u32,
+      context,
+      enqueue: Some(enqueue),
+    }
+  }
+}
+
 /// Stable status values returned by C-safe async host functions. Keep these
 /// as integer constants rather than an FFI enum so foreign callers cannot
 /// construct an invalid Rust discriminant.
@@ -543,6 +575,13 @@ impl FfiBuffer {
 type FfiBufferVersion = unsafe extern "C" fn() -> u32;
 type FfiBufferFree = unsafe extern "C" fn(FfiBuffer);
 type FfiBufferCall = unsafe extern "C" fn(*const u8, usize, *mut FfiBuffer) -> i32;
+type FfiAsyncVersion = unsafe extern "C" fn() -> u32;
+pub type FfiAsyncStart = unsafe extern "C" fn(
+  request_ptr: *const u8,
+  request_len: usize,
+  task: *const FfiAsyncTaskDescriptor,
+  host: *const FfiAsyncHostV1,
+) -> i32;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum FfiBuildCompatibility {
@@ -554,10 +593,40 @@ fn buffer_method_symbol(method: &str) -> String {
   format!("{method}{BUFFER_METHOD_SUFFIX}")
 }
 
-fn encode_buffer_request(args: Vec<Edn>) -> Result<Vec<u8>, String> {
+pub fn async_method_symbol(method: &str) -> String {
+  format!("{method}{ASYNC_METHOD_SUFFIX}")
+}
+
+pub fn encode_buffer_request(args: Vec<Edn>) -> Result<Vec<u8>, String> {
   cirru_edn::format(&Edn::List(EdnListView(args)), true)
     .map(String::into_bytes)
     .map_err(|error| format!("failed to encode FFI buffer request: {error}"))
+}
+
+/// Probe a C-safe async method without touching the guarded Rust ABI. A
+/// missing protocol or per-method symbol returns `None` for transitional
+/// fallback; an advertised but incompatible version is a hard error.
+pub fn lookup_async_start<'lib>(
+  lib: &'lib libloading::Library,
+  lib_name: &str,
+  method: &str,
+) -> Result<Option<libloading::Symbol<'lib, FfiAsyncStart>>, String> {
+  let version: libloading::Symbol<FfiAsyncVersion> = match unsafe { lib.get(ASYNC_PROTOCOL_VERSION_SYMBOL) } {
+    Ok(version) => version,
+    Err(_) => return Ok(None),
+  };
+  let current_version = unsafe { version() };
+  if current_version != ASYNC_PROTOCOL_VERSION {
+    return Err(format!(
+      "FFI async protocol mismatch in `{lib_name}`: dylib={current_version}, host={ASYNC_PROTOCOL_VERSION}"
+    ));
+  }
+
+  let symbol = async_method_symbol(method);
+  match unsafe { lib.get(symbol.as_bytes()) } {
+    Ok(start) => Ok(Some(start)),
+    Err(_) => Ok(None),
+  }
 }
 
 fn decode_buffer_response(status: i32, output: Vec<u8>, lib_name: &str, symbol: &str) -> Result<Edn, String> {
@@ -683,8 +752,9 @@ mod tests {
   use super::{
     ASYNC_EVENT_FLAG_COALESCED, ASYNC_PROTOCOL_VERSION, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
     ASYNC_TASK_FLAG_SERIAL_EVENTS, BUFFER_PROTOCOL_VERSION, FfiAsyncEventDescriptor, FfiAsyncEventKind, FfiAsyncHandle,
-    FfiAsyncHandleError, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncLifecycle, FfiAsyncTaskDescriptor, FfiBuildCompatibility,
-    async_status, buffer_method_symbol, decode_buffer_response, encode_buffer_request, validate_build_id,
+    FfiAsyncHandleError, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1, FfiAsyncLifecycle, FfiAsyncTaskDescriptor,
+    FfiBuildCompatibility, async_method_symbol, async_status, buffer_method_symbol, decode_buffer_response, encode_buffer_request,
+    validate_build_id,
   };
   use cirru_edn::Edn;
 
@@ -692,6 +762,27 @@ mod tests {
   fn buffer_method_names_are_versioned_without_changing_source_calls() {
     assert_eq!(buffer_method_symbol("run_wat"), "run_wat_calcit_ffi_v1");
     assert_eq!(BUFFER_PROTOCOL_VERSION, 1);
+  }
+
+  unsafe extern "C" fn test_enqueue(
+    _context: u64,
+    _task_handle: u64,
+    _event_kind: u32,
+    _response_handle: u64,
+    _payload_ptr: *const u8,
+    _payload_len: usize,
+  ) -> i32 {
+    async_status::OK
+  }
+
+  #[test]
+  fn async_host_table_and_method_names_are_c_stable() {
+    let host = FfiAsyncHostV1::new(42, test_enqueue);
+    assert_eq!(async_method_symbol("watch"), "watch_calcit_ffi_async_v1");
+    assert_eq!(host.protocol_version, ASYNC_PROTOCOL_VERSION);
+    assert_eq!(host.struct_size as usize, std::mem::size_of::<FfiAsyncHostV1>());
+    assert_eq!(host.context, 42);
+    assert!(host.enqueue.is_some());
   }
 
   #[test]

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -34,6 +34,7 @@ pub struct FfiAsyncEnqueueOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FfiAsyncQueueError {
   InvalidCapacity,
+  NullPayload,
   PayloadTooLarge { actual: usize, limit: usize },
   QueueClosed,
   QueueFull { capacity: usize },
@@ -45,7 +46,7 @@ pub enum FfiAsyncQueueError {
 impl FfiAsyncQueueError {
   pub fn status_code(&self) -> i32 {
     match self {
-      Self::PayloadTooLarge { .. } => async_status::INVALID_PAYLOAD,
+      Self::NullPayload | Self::PayloadTooLarge { .. } => async_status::INVALID_PAYLOAD,
       Self::QueueClosed => async_status::HOST_CLOSING,
       Self::QueueFull { .. } => async_status::QUEUE_FULL,
       Self::Handle(error) => error.status_code(),
@@ -58,6 +59,7 @@ impl fmt::Display for FfiAsyncQueueError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Self::InvalidCapacity => f.write_str("async FFI event queue capacity must be greater than zero"),
+      Self::NullPayload => f.write_str("async FFI event payload pointer is null for a non-empty payload"),
       Self::PayloadTooLarge { actual, limit } => {
         write!(f, "async FFI event payload has {actual} bytes, exceeding the {limit}-byte limit")
       }
@@ -135,6 +137,34 @@ pub struct FfiAsyncDrainReport {
   pub callback_failures: Vec<FfiAsyncDispatchFailure>,
   pub lifecycle_failures: Vec<FfiAsyncLifecycleFailure>,
   pub queue_failures: Vec<FfiAsyncQueueFailure>,
+  pub finished: Vec<FfiAsyncEventDescriptor>,
+}
+
+/// Validate and copy a foreign payload before it enters the host queue. A null
+/// pointer is accepted only for an empty payload. As with every C ABI, a
+/// non-null pointer must remain readable for the declared length during this
+/// call; the host cannot validate arbitrary dangling addresses.
+///
+/// # Safety
+///
+/// For a non-zero `payload_len`, `payload_ptr` must point to at least that many
+/// initialized, readable bytes for the duration of this call.
+pub unsafe fn copy_async_payload(payload_ptr: *const u8, payload_len: usize) -> Result<Vec<u8>, FfiAsyncQueueError> {
+  if payload_len > MAX_ASYNC_EVENT_PAYLOAD_BYTES {
+    return Err(FfiAsyncQueueError::PayloadTooLarge {
+      actual: payload_len,
+      limit: MAX_ASYNC_EVENT_PAYLOAD_BYTES,
+    });
+  }
+  if payload_len == 0 {
+    return Ok(vec![]);
+  }
+  if payload_ptr.is_null() {
+    return Err(FfiAsyncQueueError::NullPayload);
+  }
+  // SAFETY: the caller upholds readability for `payload_len`; bounds and null
+  // were checked above, and the bytes are copied before returning across FFI.
+  Ok(unsafe { std::slice::from_raw_parts(payload_ptr, payload_len) }.to_vec())
 }
 
 struct FfiAsyncQueueState {
@@ -183,6 +213,12 @@ impl FfiAsyncEventQueue {
     queue.closed = true;
     self.ready.notify_all();
     Ok(())
+  }
+
+  /// Remove queued work for a task that failed during startup or was otherwise
+  /// reclaimed before normal dispatch.
+  pub fn discard_handle_events(&self, handle: FfiAsyncHandle) -> Result<usize, FfiAsyncQueueError> {
+    self.purge_handle(handle)
   }
 
   /// Enqueue an event without blocking a foreign producer. When the queue is
@@ -356,6 +392,8 @@ impl FfiAsyncEventQueue {
               descriptor: event.descriptor,
               error,
             });
+          } else if kind.is_terminal() {
+            report.finished.push(event.descriptor);
           }
         }
         Err(message) => {
@@ -365,11 +403,14 @@ impl FfiAsyncEventQueue {
           });
           report.discarded += 1;
           failed_handles.insert(handle);
-          if let Err(error) = registry.finish(handle) {
-            report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
-              descriptor: event.descriptor,
-              error,
-            });
+          match registry.finish(handle) {
+            Ok(()) => report.finished.push(event.descriptor),
+            Err(error) => {
+              report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
+                descriptor: event.descriptor,
+                error,
+              });
+            }
           }
           match self.purge_handle(handle) {
             Ok(purged) => report.purged += purged,
@@ -477,6 +518,8 @@ mod tests {
 
     let report = queue.drain(&registry, 1, |_| Ok(())).expect("drain completion");
     assert_eq!(report.delivered, 1);
+    assert_eq!(report.finished.len(), 1);
+    assert_eq!(report.finished[0].task_handle, handle.raw());
     assert_eq!(
       registry.state(handle).expect("finished task").lifecycle,
       FfiAsyncLifecycle::Finished
@@ -564,6 +607,7 @@ mod tests {
     assert_eq!(report.discarded, 1);
     assert_eq!(report.purged, 1);
     assert_eq!(report.dequeued, report.delivered + report.discarded);
+    assert_eq!(report.finished.len(), 1);
     assert_eq!(registry.state(handle).expect("failed task").lifecycle, FfiAsyncLifecycle::Finished);
     assert_eq!(queue.len(), Ok(1));
   }
@@ -673,5 +717,25 @@ mod tests {
       queue.enqueue(&registry, handle, None, FfiAsyncEventKind::Complete, b"&unit".to_vec()),
       Err(FfiAsyncQueueError::QueueClosed)
     );
+  }
+
+  #[test]
+  fn foreign_payload_copy_checks_null_size_and_ownership() {
+    assert_eq!(unsafe { copy_async_payload(std::ptr::null(), 0) }, Ok(vec![]));
+    assert_eq!(
+      unsafe { copy_async_payload(std::ptr::null(), 1) },
+      Err(FfiAsyncQueueError::NullPayload)
+    );
+    assert_eq!(
+      unsafe { copy_async_payload(std::ptr::null(), MAX_ASYNC_EVENT_PAYLOAD_BYTES + 1) },
+      Err(FfiAsyncQueueError::PayloadTooLarge {
+        actual: MAX_ASYNC_EVENT_PAYLOAD_BYTES + 1,
+        limit: MAX_ASYNC_EVENT_PAYLOAD_BYTES,
+      })
+    );
+
+    let source = b"([] 1 2)".to_vec();
+    let copied = unsafe { copy_async_payload(source.as_ptr(), source.len()) }.expect("copy payload");
+    assert_eq!(copied, source);
   }
 }


### PR DESCRIPTION
## Summary

- add a process-lifetime C host function table and versioned per-method async start lookup
- route foreign producer events through the bounded queue and execute Calcit callbacks only on the CLI host thread
- require explicit &unit completion, surface structured Fail and callback diagnostics, and reclaim handles on terminal/start failure
- retain per-method fallback to the build-ID-guarded Rust callback ABI
- document the ABI, payload ownership, statuses, and staged rollout

## Verification

- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test -- --test-threads=1
- yarn compile
- yarn check-agent-interface
- yarn check-all

Part of #482.