### PR TITLE
feat: async FFI response server protocol / 异步 FFI response server 协议

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -119,7 +119,7 @@ be copied if the module needs it after returning. The host table has process
 lifetime, although modules should copy only the fields covered by
 `struct_size` so later hosts can append functions compatibly.
 
-Callback v1 currently exposes one host operation:
+Callback v1 exposes three host operations. The first publishes events:
 
 ```c
 int32_t enqueue(
@@ -139,6 +139,65 @@ thread drains the queue. The producer retains ownership of its payload and may
 reuse or free it after `enqueue` returns. A null pointer is valid only when the
 length is zero. No panic, Rust allocator, Rust callback, or executor object
 crosses the boundary.
+
+Before its first event, a module may specialize the provisional Stream task
+and install its cancellation hook:
+
+```c
+int32_t configure_task(
+  uint64_t context,
+  uint64_t task_handle,
+  uint32_t task_kind,
+  uint32_t task_flags,
+  uint64_t task_context,
+  CalcitFfiAsyncCancelFn cancel
+);
+```
+
+OneShot, Stream, and Server are valid task kinds; Response is host-issued and
+cannot be selected here. Configuration after the first event is rejected.
+Server tasks must provide a cancel function. `&call-dylib-edn-fn` returns an
+opaque native task capability when callback v1 installs a cancel hook (and
+keeps returning explicit `&unit` otherwise); `&ffi-task-cancel` invokes this
+hook on the host thread. An accepted cancel must eventually enqueue exactly
+one `Complete` or `Fail`; repeated cancel while Closing is idempotent.
+
+A Server that declares `REQUIRES_RESPONSE` opens one response capability for
+each request before enqueueing it:
+
+```c
+int32_t open_response(
+  uint64_t context,
+  uint64_t task_handle,
+  uint64_t response_context,
+  uint64_t timeout_ms,
+  CalcitFfiAsyncResolveFn resolve,
+  uint64_t *out_response_handle
+);
+```
+
+The timeout must be between 1 millisecond and 24 hours. The resulting
+host-issued handle must be attached to exactly one `Emit` from the owning
+Server. Missing handles, handles from another Server, response handles on
+terminal/ordinary Stream events, and already-resolved or expired handles are
+rejected deterministically. Request events are never coalesced; queue-full
+leaves the capability active until the module retries or the host rejects it
+at timeout.
+
+Calcit appends an opaque AnyRef response capability to the event's decoded EDN
+arguments. The callback resolves it with `&ffi-response-resolve` or rejects it
+with `&ffi-response-reject`. The host encodes that value, calls the module's
+resolve function on the host thread, and invalidates the capability after the
+module returns status 0. Reuse therefore fails as a stale generation rather
+than accidentally resolving a later request. Timeout, task completion, and
+callback failure reject every still-active owned response and release it.
+Startup failure discards host handles without calling back into module context
+whose ownership never transferred.
+
+AnyRef is deliberately a native non-serializable capability rather than a
+Calcit number: the full generation-bearing `u64` cannot safely round-trip
+through JavaScript floating-point numbers. A future WASM adapter will expose
+the same logical capability through its backend-specific handle value.
 
 Payload rules are explicit:
 
@@ -180,14 +239,12 @@ present the same Calcit-facing behavior.
 
 ## Rollout
 
-The remaining implementation order after native callback v1 is:
+The remaining implementation order after response/server v1 is:
 
-1. response handles, server backpressure, cancellation, timeout, and shutdown
-   fixtures;
-2. blocking calls reusing the same registry and envelopes;
-3. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
+1. blocking calls reusing the same registry and envelopes;
+2. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
    `calcit.std`;
-4. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
-5. removal of the guarded Rust ABI fallback under issue #474.
+3. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
+4. removal of the guarded Rust ABI fallback under issue #474.
 
 See issue #482 for the full acceptance matrix and module rollout status.

--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -114,10 +114,11 @@ int32_t <method>_calcit_ffi_async_v1(
 ```
 
 The request is a UTF-8 Cirru EDN list and is readable only for the duration of
-the start call. The task descriptor contains the host-issued handle and must
-be copied if the module needs it after returning. The host table has process
-lifetime, although modules should copy only the fields covered by
-`struct_size` so later hosts can append functions compatibly.
+the start call. The task descriptor and host table must both be copied if the
+module needs them after returning. Function pointers remain valid while the
+host is running, but the table pointer itself is call-scoped. Modules should
+copy only the fields covered by `struct_size` so later hosts can append
+functions compatibly.
 
 Callback v1 exposes three host operations. The first publishes events:
 
@@ -132,10 +133,11 @@ int32_t enqueue(
 );
 ```
 
-The module may call `enqueue` from producer threads. Calcit validates the
-context, handles, kind, pointer, length, and queue capacity, copies the bytes
-before returning, and invokes the Calcit callback only while the CLI host
-thread drains the queue. The producer retains ownership of its payload and may
+The module may call `enqueue` from producer threads. Each start receives a
+task-bound context; it cannot be reused with another task handle. Calcit
+validates the context, handles, kind, pointer, length, and queue capacity,
+copies the bytes before returning, and invokes the Calcit callback only while
+the CLI host thread drains the queue. The producer retains ownership of its payload and may
 reuse or free it after `enqueue` returns. A null pointer is valid only when the
 length is zero. No panic, Rust allocator, Rust callback, or executor object
 crosses the boundary.
@@ -176,7 +178,8 @@ int32_t open_response(
 );
 ```
 
-The timeout must be between 1 millisecond and 24 hours. The resulting
+The timeout must be between 1 millisecond and 24 hours, and one task may keep
+at most 1024 responses open concurrently. The resulting
 host-issued handle must be attached to exactly one `Emit` from the owning
 Server. Missing handles, handles from another Server, response handles on
 terminal/ordinary Stream events, and already-resolved or expired handles are
@@ -186,11 +189,17 @@ at timeout.
 
 Calcit appends an opaque AnyRef response capability to the event's decoded EDN
 arguments. The callback resolves it with `&ffi-response-resolve` or rejects it
-with `&ffi-response-reject`. The host encodes that value, calls the module's
-resolve function on the host thread, and invalidates the capability after the
-module returns status 0. Reuse therefore fails as a stale generation rather
-than accidentally resolving a later request. Timeout, task completion, and
-callback failure reject every still-active owned response and release it.
+with `&ffi-response-reject`. The host atomically claims the capability, encodes
+that value, calls the module's resolve function on the host thread, and
+invalidates the capability after the module returns, including when the module
+reports an error. Reuse or concurrent resolution therefore cannot invoke the
+module twice and fails as a closing/stale generation rather than accidentally
+resolving a later request. Timeout, task completion, and callback failure
+reject every still-active owned response and release it. A request that
+expires while waiting behind other events is rejected and skipped without
+terminating its long-lived Server. Deadline and owner indexes make timeout and
+task cleanup proportional to the responses being processed rather than all
+live FFI handles.
 Startup failure discards host handles without calling back into module context
 whose ownership never transferred.
 

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -171,6 +171,31 @@ legacy fallback; an advertised incompatible version is an error. See
 [Asynchronous FFI task protocol](ffi-async-protocol.md) for the exact C
 signatures, ownership, lifecycle, status, queue, and future WASM rules.
 
+Callback-v1 calls that install a cancel hook return an opaque native task
+capability rather than nil or a floating-point handle. Non-cancellable calls
+continue to return explicit `&unit`. Long-running tasks can be stopped
+explicitly:
+
+```cirru.no-check
+let
+    task $ &call-dylib-edn-fn lib-path |serve on-request
+  &ffi-task-cancel task :shutdown
+```
+
+For a Server request carrying a response handle, Calcit appends an opaque
+response capability after the decoded request arguments. It is exactly-once:
+
+```cirru.no-check
+defn on-request (method path response!)
+  if (= path |/health)
+    &ffi-response-resolve response! $ {} (:status 200) (:body |ok)
+    &ffi-response-reject response! $ {} (:status 404) (:body |missing)
+```
+
+The host validates ownership and deadline, invokes the dylib resolver on the
+Calcit host thread, and invalidates the capability after success. Unresolved
+requests are rejected on timeout or when their owning task finishes.
+
 ### Call in Calcit
 
 Rust code is compiled into dylibs, and then Calcit could call with:

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -192,9 +192,11 @@ defn on-request (method path response!)
     &ffi-response-reject response! $ {} (:status 404) (:body |missing)
 ```
 
-The host validates ownership and deadline, invokes the dylib resolver on the
-Calcit host thread, and invalidates the capability after success. Unresolved
-requests are rejected on timeout or when their owning task finishes.
+The host validates task-bound context, ownership, and deadline, atomically
+claims the capability, invokes the dylib resolver on the Calcit host thread,
+and invalidates it after the attempt. Unresolved requests are rejected on
+timeout or when their owning task finishes; a queued request that times out is
+skipped without terminating the Server.
 
 ### Call in Calcit
 

--- a/editing-history/202608272133-ffi-response-server-v1.md
+++ b/editing-history/202608272133-ffi-response-server-v1.md
@@ -1,0 +1,45 @@
+# Async FFI response and server protocol v1
+
+## Goal
+
+Extend native callback-v1 with cancellable Server tasks and exactly-once
+response capabilities without exposing generation handles as lossy Calcit
+numbers or allowing foreign threads to enter the runtime.
+
+## Changes
+
+- appended C-safe task configuration and response registration functions to
+  the versioned host table;
+- allowed modules to declare OneShot, Stream, or Server semantics before the
+  first event and install a Server cancellation hook;
+- returned opaque task capabilities from callback-v1 methods that install a
+  cancel hook, preserved `&unit` for non-cancellable methods, and added
+  `&ffi-task-cancel`;
+- issued opaque AnyRef response capabilities, appended them to request callback
+  arguments, and added `&ffi-response-resolve` / `&ffi-response-reject`;
+- enforced response owner, kind, active lifecycle, required-request, timeout,
+  and non-coalescing queue rules;
+- rejected and released unresolved responses on timeout or owner completion,
+  while startup rollback discards handles without entering untransferred module
+  context;
+- added registry configuration/snapshot, response queue invariants,
+  exactly-once/stale reuse, timeout, cross-server, and foreign producer tests;
+- documented the expanded C ABI, Calcit capability API, ownership, timeout,
+  cancellation, backpressure, and WASM representation boundary.
+
+## Runtime verification
+
+A standalone C dylib configured a cancellable Server, opened a response,
+published a request from a pthread, received the Calcit response on the host
+thread, enqueued explicit `&unit` completion, and released with pending task
+count zero. A second idle Server fixture verified `&ffi-task-cancel` and its
+terminal acknowledgement path.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test -- --test-threads=1`
+- `yarn compile`
+- `yarn check-agent-interface`
+- `yarn check-all`

--- a/editing-history/202608272133-ffi-response-server-v1.md
+++ b/editing-history/202608272133-ffi-response-server-v1.md
@@ -17,7 +17,7 @@ numbers or allowing foreign threads to enter the runtime.
   `&ffi-task-cancel`;
 - issued opaque AnyRef response capabilities, appended them to request callback
   arguments, and added `&ffi-response-resolve` / `&ffi-response-reject`;
-- enforced response owner, kind, active lifecycle, required-request, timeout,
+- enforced response owner, kind, active lifecycle, `REQUIRES_RESPONSE`, timeout,
   and non-coalescing queue rules;
 - rejected and released unresolved responses on timeout or owner completion,
   while startup rollback discards handles without entering untransferred module

--- a/editing-history/202608272158-ffi-response-review-fixes.md
+++ b/editing-history/202608272158-ffi-response-review-fixes.md
@@ -1,0 +1,33 @@
+# Async FFI response review fixes
+
+## 中文
+
+- 将每个 host table 的 context 绑定到对应 task handle，阻止不同任务或模块意外复用 host context；
+- 在调用 dylib resolver 前原子 claim response，保证并发 resolve/reject 只会进入模块一次，模块返回错误时也会释放 capability；
+- 使用 ordered deadline index、response lookup 与 owner index 代替每轮 drain 和 task 结束时的全 registry clone/scan；
+- 每个任务最多允许 1024 个并发未完成 response，避免只 open 不 enqueue 导致无界增长；
+- response 在队列等待期间过期时只 reject/skip 当前 request，不再把整个长期 Server 标记失败并清空后续事件；
+- 修正文档中的 `REQUIRES_RESPONSE` 术语，并补充 host table 生命周期、并发与超时语义。
+
+## English
+
+- bound each host-table context to its task handle so another task or module cannot accidentally reuse it;
+- atomically claim a response before entering the dylib resolver, ensuring concurrent resolve/reject attempts invoke the module at most once and release the capability even when the module reports an error;
+- replaced full-registry clones/scans during drains and task completion with an ordered deadline index, response lookup, and owner index;
+- capped concurrent outstanding responses at 1024 per task to prevent unbounded open-without-enqueue growth;
+- reject and skip a request that expires in the queue without failing the long-lived Server or purging later events;
+- aligned documentation with `REQUIRES_RESPONSE` terminology and clarified host-table lifetime, concurrency, and timeout semantics.
+
+## Validation
+
+- `cargo fmt --all`;
+- `cargo clippy --all-targets -- -D warnings`;
+- `cargo test -- --test-threads=1` (855 Rust tests passed);
+- `yarn compile`;
+- `yarn check-agent-interface` (17/17);
+- `yarn check-all` (Calcit core 221/221 plus JS, IR, WASM, and benchmark checks);
+- rebuilt the standalone C dylib and verified pthread Server request → Calcit
+  callback → response resolver → explicit `&unit` completion with no runtime
+  errors;
+- verified an idle Server task capability can still be cancelled and reaches
+  explicit `&unit` completion with no runtime errors.

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1,7 +1,7 @@
 use crate::runner;
 use cirru_edn::{Edn, EdnAnyRef};
 use colored::Colorize;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::atomic::AtomicUsize;
@@ -40,8 +40,8 @@ static STDOUT_TO_STDERR: AtomicBool = AtomicBool::new(false);
 static SILENCE_PROGRAM_OUTPUT: AtomicBool = AtomicBool::new(false);
 static TRACE_FFI_EVENT_ID: AtomicUsize = AtomicUsize::new(1);
 static TRACE_FFI_STARTED: LazyLock<Instant> = LazyLock::new(Instant::now);
-const ASYNC_HOST_CONTEXT: u64 = 0x4341_4c43_4954_0001;
 const ASYNC_EVENT_QUEUE_CAPACITY: usize = 1024;
+const MAX_ASYNC_RESPONSES_PER_TASK: usize = ASYNC_EVENT_QUEUE_CAPACITY;
 const MAX_ASYNC_RESPONSE_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1000;
 
 #[derive(Clone)]
@@ -73,6 +73,79 @@ enum NativeAsyncResource {
   Response(NativeAsyncResponse),
 }
 
+#[derive(Default)]
+struct NativeAsyncResponseIndex {
+  deadlines: BTreeMap<Instant, HashSet<FfiAsyncHandle>>,
+  responses: HashMap<FfiAsyncHandle, (FfiAsyncHandle, Instant)>,
+  by_owner: HashMap<FfiAsyncHandle, HashSet<FfiAsyncHandle>>,
+}
+
+impl NativeAsyncResponseIndex {
+  fn insert(&mut self, handle: FfiAsyncHandle, response: NativeAsyncResponse) -> Result<(), ()> {
+    let owner_responses = self.by_owner.entry(response.owner_task).or_default();
+    if owner_responses.len() >= MAX_ASYNC_RESPONSES_PER_TASK {
+      return Err(());
+    }
+    owner_responses.insert(handle);
+    self.responses.insert(handle, (response.owner_task, response.deadline));
+    self.deadlines.entry(response.deadline).or_default().insert(handle);
+    Ok(())
+  }
+
+  fn remove(&mut self, handle: FfiAsyncHandle) -> bool {
+    let Some((owner, deadline)) = self.responses.remove(&handle) else {
+      return false;
+    };
+    if let Some(deadline_responses) = self.deadlines.get_mut(&deadline) {
+      deadline_responses.remove(&handle);
+      if deadline_responses.is_empty() {
+        self.deadlines.remove(&deadline);
+      }
+    }
+    if let Some(owner_responses) = self.by_owner.get_mut(&owner) {
+      owner_responses.remove(&handle);
+      if owner_responses.is_empty() {
+        self.by_owner.remove(&owner);
+      }
+    }
+    true
+  }
+
+  fn take_due(&mut self, now: Instant) -> Vec<FfiAsyncHandle> {
+    let mut due = vec![];
+    while let Some((&deadline, _handles)) = self.deadlines.first_key_value() {
+      if deadline > now {
+        break;
+      }
+      let (_deadline, handles) = self.deadlines.pop_first().expect("first deadline exists");
+      for handle in handles {
+        let Some((owner, current)) = self.responses.remove(&handle) else {
+          continue;
+        };
+        debug_assert_eq!(current, deadline);
+        if let Some(owner_responses) = self.by_owner.get_mut(&owner) {
+          owner_responses.remove(&handle);
+          if owner_responses.is_empty() {
+            self.by_owner.remove(&owner);
+          }
+        }
+        due.push(handle);
+      }
+    }
+    due
+  }
+
+  fn take_owner(&mut self, owner: FfiAsyncHandle) -> Vec<FfiAsyncHandle> {
+    let Some(handles) = self.by_owner.get(&owner).cloned() else {
+      return vec![];
+    };
+    for handle in &handles {
+      self.remove(*handle);
+    }
+    handles.into_iter().collect()
+  }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct NativeAsyncCapability {
   handle: FfiAsyncHandle,
@@ -82,18 +155,10 @@ struct NativeAsyncCapability {
 struct NativeAsyncRuntime {
   registry: FfiAsyncHandleRegistry<NativeAsyncResource>,
   queue: FfiAsyncEventQueue,
+  responses: Mutex<NativeAsyncResponseIndex>,
 }
 
 static NATIVE_ASYNC_RUNTIME: OnceLock<NativeAsyncRuntime> = OnceLock::new();
-static NATIVE_ASYNC_HOST: LazyLock<FfiAsyncHostV1> = LazyLock::new(|| {
-  FfiAsyncHostV1::new(
-    ASYNC_HOST_CONTEXT,
-    native_async_enqueue,
-    native_async_configure_task,
-    native_async_open_response,
-  )
-});
-
 #[allow(dead_code)]
 pub fn set_trace_ffi(v: bool) {
   TRACE_FFI.store(v, Ordering::Relaxed);
@@ -176,6 +241,7 @@ pub fn init_async_runtime() -> Result<(), String> {
   let runtime = NativeAsyncRuntime {
     registry: FfiAsyncHandleRegistry::new(),
     queue: FfiAsyncEventQueue::new(ASYNC_EVENT_QUEUE_CAPACITY).map_err(|error| error.to_string())?,
+    responses: Mutex::new(NativeAsyncResponseIndex::default()),
   };
   NATIVE_ASYNC_RUNTIME
     .set(runtime)
@@ -188,8 +254,13 @@ fn native_async_runtime() -> Result<&'static NativeAsyncRuntime, String> {
     .ok_or_else(|| "async FFI runtime is not initialized on the CLI worker thread".to_owned())
 }
 
-fn async_host_table() -> &'static FfiAsyncHostV1 {
-  &NATIVE_ASYNC_HOST
+fn async_host_table(task_handle: FfiAsyncHandle) -> FfiAsyncHostV1 {
+  FfiAsyncHostV1::new(
+    task_handle.raw(),
+    native_async_enqueue,
+    native_async_configure_task,
+    native_async_open_response,
+  )
 }
 
 unsafe extern "C" fn native_async_enqueue(
@@ -221,9 +292,6 @@ unsafe fn enqueue_native_async_event(
   payload_ptr: *const u8,
   payload_len: usize,
 ) -> i32 {
-  if context != ASYNC_HOST_CONTEXT {
-    return async_status::INVALID_HANDLE;
-  }
   let kind = match FfiAsyncEventKind::try_from(event_kind) {
     Ok(kind) => kind,
     Err(error) => return error.status_code(),
@@ -234,6 +302,9 @@ unsafe fn enqueue_native_async_event(
     Err(error) => return error.status_code(),
   };
   let task_handle = FfiAsyncHandle::from_raw(task_handle);
+  if context != task_handle.raw() {
+    return async_status::INVALID_HANDLE;
+  }
   if !matches!(runtime.registry.clone_value(task_handle), Ok(NativeAsyncResource::Task(_))) {
     return async_status::INVALID_HANDLE;
   }
@@ -293,7 +364,7 @@ unsafe extern "C" fn native_async_configure_task(
   cancel: Option<FfiAsyncTaskCancel>,
 ) -> i32 {
   std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-    if context != ASYNC_HOST_CONTEXT {
+    if context != task_handle {
       return async_status::INVALID_HANDLE;
     }
     let runtime = match native_async_runtime() {
@@ -342,7 +413,7 @@ unsafe extern "C" fn native_async_open_response(
   out_handle: *mut u64,
 ) -> i32 {
   std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-    if context != ASYNC_HOST_CONTEXT {
+    if context != task_handle {
       return async_status::INVALID_HANDLE;
     }
     if out_handle.is_null() || timeout_ms == 0 || timeout_ms > MAX_ASYNC_RESPONSE_TIMEOUT_MS {
@@ -366,22 +437,33 @@ unsafe extern "C" fn native_async_open_response(
     {
       return async_status::INVALID_HANDLE;
     }
-    if !matches!(runtime.registry.clone_value(task_handle), Ok(NativeAsyncResource::Task(_))) {
-      return async_status::INVALID_HANDLE;
-    }
     let Some(deadline) = Instant::now().checked_add(Duration::from_millis(timeout_ms)) else {
       return async_status::INVALID_PAYLOAD;
     };
-    let response = NativeAsyncResource::Response(NativeAsyncResponse {
+    let response = NativeAsyncResponse {
       owner_task: task_handle,
       context: response_context,
       deadline,
       resolve,
-    });
-    let response_handle = match runtime.registry.register(FfiAsyncHandleKind::Response, response) {
+    };
+    let mut responses = match runtime.responses.lock() {
+      Ok(responses) => responses,
+      Err(_) => return async_status::INTERNAL_ERROR,
+    };
+    let response_handle = match runtime.registry.register_for_active_owner(
+      task_handle,
+      FfiAsyncHandleKind::Response,
+      NativeAsyncResource::Response(response),
+    ) {
       Ok(handle) => handle,
       Err(error) => return error.status_code(),
     };
+    if responses.insert(response_handle, response).is_err() {
+      let _ = runtime.registry.finish(response_handle);
+      let _ = runtime.registry.release(response_handle);
+      return async_status::QUEUE_FULL;
+    }
+    drop(responses);
     // SAFETY: the C caller provided a non-null writable out pointer for this
     // synchronous call; only one fixed-width value is written.
     unsafe { out_handle.write(response_handle.raw()) };
@@ -457,27 +539,45 @@ fn resolve_async_response_with(
   outcome: u32,
   payload: &[u8],
 ) -> Result<(), String> {
-  let state = runtime.registry.state(capability.handle).map_err(|error| error.to_string())?;
-  if state.kind != FfiAsyncHandleKind::Response || state.lifecycle != calcit::ffi_abi::FfiAsyncLifecycle::Active {
-    return Err("async FFI response capability is no longer active".to_owned());
+  let response = claim_async_response(runtime, capability.handle)?;
+  if response.deadline <= Instant::now() {
+    let reject_error =
+      finish_claimed_response(runtime, capability.handle, response, ASYNC_RESPONSE_REJECT, b"{} (:code :timeout)").err();
+    return Err(match reject_error {
+      Some(error) => format!("async FFI response capability expired; timeout rejection failed: {error}"),
+      None => "async FFI response capability has expired".to_owned(),
+    });
   }
-  let NativeAsyncResource::Response(response) = runtime.registry.clone_value(capability.handle).map_err(|error| error.to_string())?
-  else {
+  finish_claimed_response(runtime, capability.handle, response, outcome, payload)
+}
+
+fn claim_async_response(runtime: &NativeAsyncRuntime, handle: FfiAsyncHandle) -> Result<NativeAsyncResponse, String> {
+  let state = runtime.registry.state(handle).map_err(|error| error.to_string())?;
+  if state.kind != FfiAsyncHandleKind::Response {
+    return Err("async FFI capability does not reference a response".to_owned());
+  }
+  runtime.registry.begin_close(handle).map_err(|error| error.to_string())?;
+  let NativeAsyncResource::Response(response) = runtime.registry.clone_value(handle).map_err(|error| error.to_string())? else {
     return Err("async FFI capability does not reference a response".to_owned());
   };
-  if response.deadline <= Instant::now() {
-    let _ = reject_response_for_host(runtime, capability.handle, response, b"{} (:code :timeout)");
-    return Err("async FFI response capability has expired".to_owned());
-  }
-  let status = unsafe { (response.resolve)(response.context, capability.handle.raw(), outcome, payload.as_ptr(), payload.len()) };
-  if status != async_status::OK {
-    return Err(format!(
-      "async FFI response {} was rejected by the module with status {status}",
-      capability.handle.raw()
-    ));
-  }
-  runtime.registry.finish(capability.handle).map_err(|error| error.to_string())?;
-  match runtime.registry.release(capability.handle) {
+  runtime
+    .responses
+    .lock()
+    .map_err(|_| "async FFI response index lock is poisoned".to_owned())?
+    .remove(handle);
+  Ok(response)
+}
+
+fn finish_claimed_response(
+  runtime: &NativeAsyncRuntime,
+  handle: FfiAsyncHandle,
+  response: NativeAsyncResponse,
+  outcome: u32,
+  payload: &[u8],
+) -> Result<(), String> {
+  let status = unsafe { (response.resolve)(response.context, handle.raw(), outcome, payload.as_ptr(), payload.len()) };
+  runtime.registry.finish(handle).map_err(|error| error.to_string())?;
+  match runtime.registry.release(handle) {
     Ok(NativeAsyncResource::Response(_)) => {}
     Ok(NativeAsyncResource::Task(_)) => {
       return Err("async FFI response released a task resource".to_owned());
@@ -486,13 +586,16 @@ fn resolve_async_response_with(
   }
   trace_ffi_event(
     "async-response-finish",
-    format!(
-      "task={} response={} outcome={outcome}",
-      response.owner_task.raw(),
-      capability.handle.raw()
-    ),
+    format!("task={} response={} outcome={outcome}", response.owner_task.raw(), handle.raw()),
   );
-  Ok(())
+  if status == async_status::OK {
+    Ok(())
+  } else {
+    Err(format!(
+      "async FFI response {} was rejected by the module with status {status}",
+      handle.raw()
+    ))
+  }
 }
 
 fn resolve_async_response(capability: NativeAsyncCapability, outcome: u32, payload: &[u8]) -> Result<Calcit, CalcitErr> {
@@ -526,64 +629,39 @@ fn ffi_response_reject(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<C
   resolve_async_response(capability, ASYNC_RESPONSE_REJECT, &payload)
 }
 
-fn reject_response_for_host(
-  runtime: &NativeAsyncRuntime,
-  handle: FfiAsyncHandle,
-  response: NativeAsyncResponse,
-  reason: &[u8],
-) -> Option<String> {
-  let status = unsafe { (response.resolve)(response.context, handle.raw(), ASYNC_RESPONSE_REJECT, reason.as_ptr(), reason.len()) };
-  let finish_error = runtime.registry.finish(handle).err();
-  let release_error = if finish_error.is_none() {
-    runtime.registry.release(handle).err()
-  } else {
-    None
+fn reject_response_for_host(runtime: &NativeAsyncRuntime, handle: FfiAsyncHandle, reason: &[u8]) -> Option<String> {
+  let response = match claim_async_response(runtime, handle) {
+    Ok(response) => response,
+    Err(error) => return Some(format!("response {} claim failed: {error}", handle.raw())),
   };
-  trace_ffi_event(
-    "async-response-reject",
-    format!("task={} response={} status={status}", response.owner_task.raw(), handle.raw()),
-  );
-  if let Some(error) = finish_error {
-    Some(format!("response {} lifecycle error: {error}", handle.raw()))
-  } else if let Some(error) = release_error {
-    Some(format!("response {} release error: {error}", handle.raw()))
-  } else if status != async_status::OK {
-    Some(format!("response {} module reject failed with status {status}", handle.raw()))
-  } else {
-    None
-  }
+  finish_claimed_response(runtime, handle, response, ASYNC_RESPONSE_REJECT, reason).err()
 }
 
 fn expire_async_responses(runtime: &NativeAsyncRuntime) -> Result<(), String> {
   let now = Instant::now();
-  for (handle, state, resource) in runtime.registry.snapshot().map_err(|error| error.to_string())? {
-    let NativeAsyncResource::Response(response) = resource else {
-      continue;
-    };
-    if state.lifecycle == calcit::ffi_abi::FfiAsyncLifecycle::Active && response.deadline <= now {
-      if let Some(error) = reject_response_for_host(runtime, handle, response, b"{} (:code :timeout)") {
-        eprintln!("[Error] async FFI response timeout: {error}");
-      } else {
-        eprintln!(
-          "[Error] async FFI response {} for task {} timed out",
-          handle.raw(),
-          response.owner_task.raw()
-        );
-      }
+  let handles = runtime
+    .responses
+    .lock()
+    .map_err(|_| "async FFI response index lock is poisoned".to_owned())?
+    .take_due(now);
+  for handle in handles {
+    if let Some(error) = reject_response_for_host(runtime, handle, b"{} (:code :timeout)") {
+      eprintln!("[Error] async FFI response timeout: {error}");
+    } else {
+      eprintln!("[Error] async FFI response {} timed out", handle.raw());
     }
   }
   Ok(())
 }
 
 fn reject_owned_responses(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle, reason: &[u8]) -> Result<(), String> {
-  for (handle, state, resource) in runtime.registry.snapshot().map_err(|error| error.to_string())? {
-    let NativeAsyncResource::Response(response) = resource else {
-      continue;
-    };
-    if response.owner_task == owner
-      && state.lifecycle == calcit::ffi_abi::FfiAsyncLifecycle::Active
-      && let Some(error) = reject_response_for_host(runtime, handle, response, reason)
-    {
+  let handles = runtime
+    .responses
+    .lock()
+    .map_err(|_| "async FFI response index lock is poisoned".to_owned())?
+    .take_owner(owner);
+  for handle in handles {
+    if let Some(error) = reject_response_for_host(runtime, handle, reason) {
       eprintln!("[Error] async FFI response cleanup: {error}");
     }
   }
@@ -592,15 +670,15 @@ fn reject_owned_responses(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle, r
 
 fn discard_owned_responses(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle) -> Result<usize, String> {
   let mut discarded = 0;
-  for (handle, _state, resource) in runtime.registry.snapshot().map_err(|error| error.to_string())? {
-    let NativeAsyncResource::Response(response) = resource else {
-      continue;
-    };
-    if response.owner_task == owner {
-      let _ = runtime.registry.finish(handle);
-      if runtime.registry.release(handle).is_ok() {
-        discarded += 1;
-      }
+  let handles = runtime
+    .responses
+    .lock()
+    .map_err(|_| "async FFI response index lock is poisoned".to_owned())?
+    .take_owner(owner);
+  for handle in handles {
+    let _ = runtime.registry.finish(handle);
+    if runtime.registry.release(handle).is_ok() {
+      discarded += 1;
     }
   }
   Ok(discarded)
@@ -718,16 +796,31 @@ fn dispatch_native_async_event(runtime: &NativeAsyncRuntime, event: &calcit::ffi
       let mut args = decode_async_emit(event.payload())?;
       if event.descriptor.response_handle != FfiAsyncHandle::INVALID.raw() {
         let response_handle = FfiAsyncHandle::from_raw(event.descriptor.response_handle);
-        let NativeAsyncResource::Response(response) =
-          runtime.registry.clone_value(response_handle).map_err(|error| error.to_string())?
-        else {
-          return Err("async FFI event carried a non-response handle".to_owned());
+        let response = match runtime.registry.clone_value(response_handle) {
+          Ok(NativeAsyncResource::Response(response)) => response,
+          Ok(NativeAsyncResource::Task(_)) => return Err("async FFI event carried a non-response handle".to_owned()),
+          Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle | calcit::ffi_abi::FfiAsyncHandleError::HandleFinished) => {
+            trace_ffi_event(
+              "async-response-skip",
+              format!(
+                "task={} response={} sequence={} reason=expired-or-finished",
+                handle.raw(),
+                response_handle.raw(),
+                event.descriptor.sequence
+              ),
+            );
+            return Ok(());
+          }
+          Err(error) => return Err(error.to_string()),
         };
         if response.owner_task != handle {
           return Err("async FFI response handle belongs to another task".to_owned());
         }
         if response.deadline <= Instant::now() {
-          return Err("async FFI response handle expired before callback dispatch".to_owned());
+          if let Some(error) = reject_response_for_host(runtime, response_handle, b"{} (:code :timeout)") {
+            eprintln!("[Error] async FFI response expiry at dispatch: {error}");
+          }
+          return Ok(());
         }
         args.push(async_capability(response_handle, FfiAsyncHandleKind::Response));
       }
@@ -1182,7 +1275,7 @@ fn try_start_async_callback_v1(
     )
     .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
   let descriptor = FfiAsyncTaskDescriptor::new(handle, FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS);
-  let host = async_host_table();
+  let host = async_host_table(handle);
 
   track::track_task_add();
   trace_ffi_event(
@@ -1195,7 +1288,7 @@ fn try_start_async_callback_v1(
       track::count_pending_tasks()
     ),
   );
-  let status = unsafe { start(request.as_ptr(), request.len(), &descriptor, host) };
+  let status = unsafe { start(request.as_ptr(), request.len(), &descriptor, &host) };
   if status == async_status::OK {
     let state = runtime
       .registry
@@ -1220,6 +1313,7 @@ fn try_start_async_callback_v1(
     }));
   }
 
+  let _ = runtime.registry.begin_close(handle);
   let purged = runtime.queue.discard_handle_events(handle).unwrap_or(0);
   let discarded_responses = discard_owned_responses(runtime, handle).unwrap_or(0);
   let _ = runtime.registry.finish(handle);
@@ -1591,12 +1685,37 @@ mod async_callback_tests {
     })
   }
 
+  fn test_runtime(capacity: usize) -> NativeAsyncRuntime {
+    NativeAsyncRuntime {
+      registry: FfiAsyncHandleRegistry::new(),
+      queue: FfiAsyncEventQueue::new(capacity).expect("create host queue"),
+      responses: Mutex::new(NativeAsyncResponseIndex::default()),
+    }
+  }
+
+  fn register_test_response(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle, context: u64, deadline: Instant) -> FfiAsyncHandle {
+    let response = NativeAsyncResponse {
+      owner_task: owner,
+      context,
+      deadline,
+      resolve: record_response,
+    };
+    let handle = runtime
+      .registry
+      .register_for_active_owner(owner, FfiAsyncHandleKind::Response, NativeAsyncResource::Response(response))
+      .expect("register response");
+    runtime
+      .responses
+      .lock()
+      .expect("response index")
+      .insert(handle, response)
+      .expect("index response");
+    handle
+  }
+
   #[test]
   fn foreign_producer_enters_through_c_payload_boundary_and_host_drains_completion() {
-    let runtime = Arc::new(NativeAsyncRuntime {
-      registry: FfiAsyncHandleRegistry::new(),
-      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
-    });
+    let runtime = Arc::new(test_runtime(4));
     let handle = runtime
       .registry
       .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, test_task())
@@ -1609,7 +1728,7 @@ mod async_callback_tests {
       unsafe {
         enqueue_native_async_event(
           &producer_runtime,
-          ASYNC_HOST_CONTEXT,
+          handle.raw(),
           handle.raw(),
           FfiAsyncEventKind::Complete as u32,
           FfiAsyncHandle::INVALID.raw(),
@@ -1648,10 +1767,7 @@ mod async_callback_tests {
   #[test]
   fn expired_response_is_rejected_once_and_released() {
     const CONTEXT: u64 = 101;
-    let runtime = NativeAsyncRuntime {
-      registry: FfiAsyncHandleRegistry::new(),
-      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
-    };
+    let runtime = test_runtime(4);
     let owner = runtime
       .registry
       .register_with_flags(
@@ -1660,18 +1776,7 @@ mod async_callback_tests {
         test_task(),
       )
       .expect("register server");
-    let response = runtime
-      .registry
-      .register(
-        FfiAsyncHandleKind::Response,
-        NativeAsyncResource::Response(NativeAsyncResponse {
-          owner_task: owner,
-          context: CONTEXT,
-          deadline: Instant::now() - Duration::from_millis(1),
-          resolve: record_response,
-        }),
-      )
-      .expect("register response");
+    let response = register_test_response(&runtime, owner, CONTEXT, Instant::now() - Duration::from_millis(1));
 
     expire_async_responses(&runtime).expect("expire responses");
     assert_eq!(
@@ -1694,26 +1799,12 @@ mod async_callback_tests {
   #[test]
   fn response_resolution_is_exactly_once_and_rejects_stale_reuse() {
     const CONTEXT: u64 = 202;
-    let runtime = NativeAsyncRuntime {
-      registry: FfiAsyncHandleRegistry::new(),
-      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
-    };
+    let runtime = test_runtime(4);
     let owner = runtime
       .registry
       .register(FfiAsyncHandleKind::Server, test_task())
       .expect("register server");
-    let response = runtime
-      .registry
-      .register(
-        FfiAsyncHandleKind::Response,
-        NativeAsyncResource::Response(NativeAsyncResponse {
-          owner_task: owner,
-          context: CONTEXT,
-          deadline: Instant::now() + Duration::from_secs(1),
-          resolve: record_response,
-        }),
-      )
-      .expect("register response");
+    let response = register_test_response(&runtime, owner, CONTEXT, Instant::now() + Duration::from_secs(1));
     let capability = NativeAsyncCapability {
       handle: response,
       kind: FfiAsyncHandleKind::Response,
@@ -1734,11 +1825,116 @@ mod async_callback_tests {
   }
 
   #[test]
-  fn response_handle_must_belong_to_the_enqueuing_server() {
-    let runtime = NativeAsyncRuntime {
-      registry: FfiAsyncHandleRegistry::new(),
-      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
+  fn concurrent_response_resolution_invokes_module_exactly_once() {
+    const CONTEXT: u64 = 303;
+    let runtime = Arc::new(test_runtime(4));
+    let owner = runtime
+      .registry
+      .register(FfiAsyncHandleKind::Server, test_task())
+      .expect("register server");
+    let response = register_test_response(&runtime, owner, CONTEXT, Instant::now() + Duration::from_secs(1));
+    let capability = NativeAsyncCapability {
+      handle: response,
+      kind: FfiAsyncHandleKind::Response,
     };
+    let barrier = Arc::new(std::sync::Barrier::new(3));
+    let mut workers = vec![];
+    for payload in [b"|first".as_slice(), b"|second".as_slice()] {
+      let runtime = Arc::clone(&runtime);
+      let barrier = Arc::clone(&barrier);
+      workers.push(thread::spawn(move || {
+        barrier.wait();
+        resolve_async_response_with(&runtime, capability, ASYNC_RESPONSE_RESOLVE, payload)
+      }));
+    }
+    barrier.wait();
+    let outcomes: Vec<Result<(), String>> = workers
+      .into_iter()
+      .map(|worker| worker.join().expect("response resolver thread"))
+      .collect();
+
+    assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+    let events: Vec<RecordedResponse> = RESPONSE_EVENTS
+      .lock()
+      .expect("response events")
+      .iter()
+      .filter(|(context, ..)| *context == CONTEXT)
+      .cloned()
+      .collect();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].1, response.raw());
+    assert_eq!(events[0].2, ASYNC_RESPONSE_RESOLVE);
+  }
+
+  #[test]
+  fn queued_response_expiry_skips_request_without_finishing_server() {
+    const CONTEXT: u64 = 404;
+    let runtime = test_runtime(4);
+    let owner = runtime
+      .registry
+      .register_with_flags(
+        FfiAsyncHandleKind::Server,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+        test_task(),
+      )
+      .expect("register server");
+    let response = register_test_response(&runtime, owner, CONTEXT, Instant::now() + Duration::from_millis(1));
+    let request = b"[] |request";
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          owner.raw(),
+          owner.raw(),
+          FfiAsyncEventKind::Emit as u32,
+          response.raw(),
+          request.as_ptr(),
+          request.len(),
+        )
+      },
+      async_status::OK
+    );
+    thread::sleep(Duration::from_millis(5));
+    expire_async_responses(&runtime).expect("expire queued response");
+    let complete = b"&unit";
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          owner.raw(),
+          owner.raw(),
+          FfiAsyncEventKind::Complete as u32,
+          FfiAsyncHandle::INVALID.raw(),
+          complete.as_ptr(),
+          complete.len(),
+        )
+      },
+      async_status::OK
+    );
+
+    let report = runtime
+      .queue
+      .drain(&runtime.registry, 4, |event| dispatch_native_async_event(&runtime, event))
+      .expect("drain queued expiry and completion");
+    assert_eq!(report.dequeued, 2);
+    assert_eq!(report.delivered, 2);
+    assert_eq!(report.finished.len(), 1);
+    assert!(report.callback_failures.is_empty());
+    assert!(report.lifecycle_failures.is_empty());
+    let events: Vec<RecordedResponse> = RESPONSE_EVENTS
+      .lock()
+      .expect("response events")
+      .iter()
+      .filter(|(context, ..)| *context == CONTEXT)
+      .cloned()
+      .collect();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].2, ASYNC_RESPONSE_REJECT);
+  }
+
+  #[test]
+  fn response_handle_must_belong_to_the_enqueuing_server() {
+    let runtime = test_runtime(4);
     let first = runtime
       .registry
       .register_with_flags(
@@ -1755,25 +1951,14 @@ mod async_callback_tests {
         test_task(),
       )
       .expect("register second server");
-    let response = runtime
-      .registry
-      .register(
-        FfiAsyncHandleKind::Response,
-        NativeAsyncResource::Response(NativeAsyncResponse {
-          owner_task: first,
-          context: 0,
-          deadline: Instant::now() + Duration::from_secs(1),
-          resolve: record_response,
-        }),
-      )
-      .expect("register response");
+    let response = register_test_response(&runtime, first, 0, Instant::now() + Duration::from_secs(1));
     let payload = b"[] |request";
 
     assert_eq!(
       unsafe {
         enqueue_native_async_event(
           &runtime,
-          ASYNC_HOST_CONTEXT,
+          second.raw(),
           second.raw(),
           FfiAsyncEventKind::Emit as u32,
           response.raw(),
@@ -1784,5 +1969,20 @@ mod async_callback_tests {
       async_status::INVALID_HANDLE
     );
     assert_eq!(runtime.queue.len(), Ok(0));
+
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          first.raw(),
+          second.raw(),
+          FfiAsyncEventKind::Emit as u32,
+          FfiAsyncHandle::INVALID.raw(),
+          payload.as_ptr(),
+          payload.len(),
+        )
+      },
+      async_status::INVALID_HANDLE
+    );
   }
 }

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1,5 +1,5 @@
 use crate::runner;
-use cirru_edn::Edn;
+use cirru_edn::{Edn, EdnAnyRef};
 use colored::Colorize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -17,7 +17,8 @@ use calcit::{
   call_stack::{CallStackList, display_stack},
   data::edn::{calcit_to_edn, edn_to_calcit, sanitize_edn_for_format},
   ffi_abi::{
-    ASYNC_TASK_FLAG_SERIAL_EVENTS, FfiAsyncEventKind, FfiAsyncHandle, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1,
+    ASYNC_RESPONSE_REJECT, ASYNC_RESPONSE_RESOLVE, ASYNC_TASK_FLAG_REQUIRES_RESPONSE, ASYNC_TASK_FLAG_SERIAL_EVENTS, FfiAsyncEventKind,
+    FfiAsyncHandle, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1, FfiAsyncResponseResolve, FfiAsyncTaskCancel,
     FfiAsyncTaskDescriptor, async_status,
   },
   ffi_async::{FfiAsyncDrainReport, FfiAsyncEventQueue, copy_async_payload},
@@ -41,22 +42,57 @@ static TRACE_FFI_EVENT_ID: AtomicUsize = AtomicUsize::new(1);
 static TRACE_FFI_STARTED: LazyLock<Instant> = LazyLock::new(Instant::now);
 const ASYNC_HOST_CONTEXT: u64 = 0x4341_4c43_4954_0001;
 const ASYNC_EVENT_QUEUE_CAPACITY: usize = 1024;
+const MAX_ASYNC_RESPONSE_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1000;
 
 #[derive(Clone)]
-struct NativeAsyncCallback {
+struct NativeAsyncTask {
   callback: Calcit,
   stack: Arc<CallStackList>,
   lib_name: String,
   method: String,
+  control: Arc<Mutex<Option<NativeAsyncTaskControl>>>,
+}
+
+#[derive(Clone, Copy)]
+struct NativeAsyncTaskControl {
+  context: u64,
+  cancel: FfiAsyncTaskCancel,
+}
+
+#[derive(Clone, Copy)]
+struct NativeAsyncResponse {
+  owner_task: FfiAsyncHandle,
+  context: u64,
+  deadline: Instant,
+  resolve: FfiAsyncResponseResolve,
+}
+
+#[derive(Clone)]
+enum NativeAsyncResource {
+  Task(NativeAsyncTask),
+  Response(NativeAsyncResponse),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NativeAsyncCapability {
+  handle: FfiAsyncHandle,
+  kind: FfiAsyncHandleKind,
 }
 
 struct NativeAsyncRuntime {
-  registry: FfiAsyncHandleRegistry<NativeAsyncCallback>,
+  registry: FfiAsyncHandleRegistry<NativeAsyncResource>,
   queue: FfiAsyncEventQueue,
 }
 
 static NATIVE_ASYNC_RUNTIME: OnceLock<NativeAsyncRuntime> = OnceLock::new();
-static NATIVE_ASYNC_HOST: LazyLock<FfiAsyncHostV1> = LazyLock::new(|| FfiAsyncHostV1::new(ASYNC_HOST_CONTEXT, native_async_enqueue));
+static NATIVE_ASYNC_HOST: LazyLock<FfiAsyncHostV1> = LazyLock::new(|| {
+  FfiAsyncHostV1::new(
+    ASYNC_HOST_CONTEXT,
+    native_async_enqueue,
+    native_async_configure_task,
+    native_async_open_response,
+  )
+});
 
 #[allow(dead_code)]
 pub fn set_trace_ffi(v: bool) {
@@ -198,11 +234,24 @@ unsafe fn enqueue_native_async_event(
     Err(error) => return error.status_code(),
   };
   let task_handle = FfiAsyncHandle::from_raw(task_handle);
+  if !matches!(runtime.registry.clone_value(task_handle), Ok(NativeAsyncResource::Task(_))) {
+    return async_status::INVALID_HANDLE;
+  }
   let response_handle = if response_handle == FfiAsyncHandle::INVALID.raw() {
     None
   } else {
     Some(FfiAsyncHandle::from_raw(response_handle))
   };
+  if let Some(response_handle) = response_handle {
+    let response = match runtime.registry.clone_value(response_handle) {
+      Ok(NativeAsyncResource::Response(response)) if response.owner_task == task_handle => response,
+      Ok(_) => return async_status::INVALID_HANDLE,
+      Err(error) => return error.status_code(),
+    };
+    if response.deadline <= Instant::now() {
+      return async_status::HANDLE_FINISHED;
+    }
+  }
 
   match runtime
     .queue
@@ -232,6 +281,387 @@ unsafe fn enqueue_native_async_event(
       );
       error.status_code()
     }
+  }
+}
+
+unsafe extern "C" fn native_async_configure_task(
+  context: u64,
+  task_handle: u64,
+  kind: u32,
+  flags: u32,
+  task_context: u64,
+  cancel: Option<FfiAsyncTaskCancel>,
+) -> i32 {
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    if context != ASYNC_HOST_CONTEXT {
+      return async_status::INVALID_HANDLE;
+    }
+    let runtime = match native_async_runtime() {
+      Ok(runtime) => runtime,
+      Err(_) => return async_status::HOST_CLOSING,
+    };
+    let kind = match FfiAsyncHandleKind::try_from(kind) {
+      Ok(kind) if kind != FfiAsyncHandleKind::Response => kind,
+      Ok(_) => return async_status::INVALID_PAYLOAD,
+      Err(error) => return error.status_code(),
+    };
+    if kind == FfiAsyncHandleKind::Server && cancel.is_none() {
+      return async_status::INVALID_PAYLOAD;
+    }
+    let resource = match runtime.registry.clone_value(FfiAsyncHandle::from_raw(task_handle)) {
+      Ok(NativeAsyncResource::Task(task)) => task,
+      Ok(_) => return async_status::INVALID_HANDLE,
+      Err(error) => return error.status_code(),
+    };
+    if let Err(error) = runtime.registry.configure(FfiAsyncHandle::from_raw(task_handle), kind, flags) {
+      return error.status_code();
+    }
+    let mut control = match resource.control.lock() {
+      Ok(control) => control,
+      Err(_) => return async_status::INTERNAL_ERROR,
+    };
+    *control = cancel.map(|cancel| NativeAsyncTaskControl {
+      context: task_context,
+      cancel,
+    });
+    trace_ffi_event(
+      "async-configure",
+      format!("task={task_handle} kind={kind:?} flags=0x{flags:x} cancel={}", cancel.is_some()),
+    );
+    async_status::OK
+  }))
+  .unwrap_or(async_status::INTERNAL_ERROR)
+}
+
+unsafe extern "C" fn native_async_open_response(
+  context: u64,
+  task_handle: u64,
+  response_context: u64,
+  timeout_ms: u64,
+  resolve: Option<FfiAsyncResponseResolve>,
+  out_handle: *mut u64,
+) -> i32 {
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    if context != ASYNC_HOST_CONTEXT {
+      return async_status::INVALID_HANDLE;
+    }
+    if out_handle.is_null() || timeout_ms == 0 || timeout_ms > MAX_ASYNC_RESPONSE_TIMEOUT_MS {
+      return async_status::INVALID_PAYLOAD;
+    }
+    let Some(resolve) = resolve else {
+      return async_status::INVALID_PAYLOAD;
+    };
+    let runtime = match native_async_runtime() {
+      Ok(runtime) => runtime,
+      Err(_) => return async_status::HOST_CLOSING,
+    };
+    let task_handle = FfiAsyncHandle::from_raw(task_handle);
+    let task_state = match runtime.registry.state(task_handle) {
+      Ok(state) => state,
+      Err(error) => return error.status_code(),
+    };
+    if task_state.kind != FfiAsyncHandleKind::Server
+      || task_state.flags & ASYNC_TASK_FLAG_REQUIRES_RESPONSE == 0
+      || task_state.lifecycle != calcit::ffi_abi::FfiAsyncLifecycle::Active
+    {
+      return async_status::INVALID_HANDLE;
+    }
+    if !matches!(runtime.registry.clone_value(task_handle), Ok(NativeAsyncResource::Task(_))) {
+      return async_status::INVALID_HANDLE;
+    }
+    let Some(deadline) = Instant::now().checked_add(Duration::from_millis(timeout_ms)) else {
+      return async_status::INVALID_PAYLOAD;
+    };
+    let response = NativeAsyncResource::Response(NativeAsyncResponse {
+      owner_task: task_handle,
+      context: response_context,
+      deadline,
+      resolve,
+    });
+    let response_handle = match runtime.registry.register(FfiAsyncHandleKind::Response, response) {
+      Ok(handle) => handle,
+      Err(error) => return error.status_code(),
+    };
+    // SAFETY: the C caller provided a non-null writable out pointer for this
+    // synchronous call; only one fixed-width value is written.
+    unsafe { out_handle.write(response_handle.raw()) };
+    trace_ffi_event(
+      "async-response-open",
+      format!(
+        "task={} response={} timeout_ms={timeout_ms}",
+        task_handle.raw(),
+        response_handle.raw()
+      ),
+    );
+    async_status::OK
+  }))
+  .unwrap_or(async_status::INTERNAL_ERROR)
+}
+
+fn async_capability(handle: FfiAsyncHandle, kind: FfiAsyncHandleKind) -> Calcit {
+  Calcit::AnyRef(EdnAnyRef::new(NativeAsyncCapability { handle, kind }))
+}
+
+fn read_native_async_capability(value: &Calcit) -> Result<NativeAsyncCapability, CalcitErr> {
+  let Calcit::AnyRef(reference) = value else {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Type,
+      format!("expected async FFI capability, got: {value}"),
+    ));
+  };
+  let guard = reference
+    .0
+    .read()
+    .map_err(|_| CalcitErr::use_str(CalcitErrKind::Unexpected, "async FFI capability lock is poisoned"))?;
+  let Some(capability) = guard.as_any().downcast_ref::<NativeAsyncCapability>().copied() else {
+    return Err(CalcitErr::use_str(CalcitErrKind::Type, "expected async FFI capability"));
+  };
+  Ok(capability)
+}
+
+fn read_async_capability(value: &Calcit, expected: FfiAsyncHandleKind) -> Result<NativeAsyncCapability, CalcitErr> {
+  let capability = read_native_async_capability(value)?;
+  if capability.kind != expected {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Type,
+      format!("expected async FFI {expected:?} capability, got {:?}", capability.kind),
+    ));
+  }
+  Ok(capability)
+}
+
+fn read_async_task_capability(value: &Calcit) -> Result<NativeAsyncCapability, CalcitErr> {
+  let capability = read_native_async_capability(value)?;
+  if capability.kind == FfiAsyncHandleKind::Response {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Type,
+      "expected async FFI task capability, got response capability",
+    ));
+  }
+  Ok(capability)
+}
+
+fn encode_async_value(value: &Calcit) -> Result<Vec<u8>, CalcitErr> {
+  if matches!(value, Calcit::Unit) {
+    return Ok(b"&unit".to_vec());
+  }
+  let value = calcit_to_edn(value)?;
+  cirru_edn::format(&value, true)
+    .map(String::into_bytes)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, format!("failed to encode async FFI value: {error}")))
+}
+
+fn resolve_async_response_with(
+  runtime: &NativeAsyncRuntime,
+  capability: NativeAsyncCapability,
+  outcome: u32,
+  payload: &[u8],
+) -> Result<(), String> {
+  let state = runtime.registry.state(capability.handle).map_err(|error| error.to_string())?;
+  if state.kind != FfiAsyncHandleKind::Response || state.lifecycle != calcit::ffi_abi::FfiAsyncLifecycle::Active {
+    return Err("async FFI response capability is no longer active".to_owned());
+  }
+  let NativeAsyncResource::Response(response) = runtime.registry.clone_value(capability.handle).map_err(|error| error.to_string())?
+  else {
+    return Err("async FFI capability does not reference a response".to_owned());
+  };
+  if response.deadline <= Instant::now() {
+    let _ = reject_response_for_host(runtime, capability.handle, response, b"{} (:code :timeout)");
+    return Err("async FFI response capability has expired".to_owned());
+  }
+  let status = unsafe { (response.resolve)(response.context, capability.handle.raw(), outcome, payload.as_ptr(), payload.len()) };
+  if status != async_status::OK {
+    return Err(format!(
+      "async FFI response {} was rejected by the module with status {status}",
+      capability.handle.raw()
+    ));
+  }
+  runtime.registry.finish(capability.handle).map_err(|error| error.to_string())?;
+  match runtime.registry.release(capability.handle) {
+    Ok(NativeAsyncResource::Response(_)) => {}
+    Ok(NativeAsyncResource::Task(_)) => {
+      return Err("async FFI response released a task resource".to_owned());
+    }
+    Err(error) => return Err(error.to_string()),
+  }
+  trace_ffi_event(
+    "async-response-finish",
+    format!(
+      "task={} response={} outcome={outcome}",
+      response.owner_task.raw(),
+      capability.handle.raw()
+    ),
+  );
+  Ok(())
+}
+
+fn resolve_async_response(capability: NativeAsyncCapability, outcome: u32, payload: &[u8]) -> Result<Calcit, CalcitErr> {
+  let runtime = native_async_runtime().map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  resolve_async_response_with(runtime, capability, outcome, payload)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  Ok(Calcit::Unit)
+}
+
+fn ffi_response_resolve(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  if xs.len() != 2 {
+    return CalcitErr::err_str(
+      CalcitErrKind::Arity,
+      format!("&ffi-response-resolve expected 2 arguments, got: {xs:?}"),
+    );
+  }
+  let capability = read_async_capability(&xs[0], FfiAsyncHandleKind::Response)?;
+  let payload = encode_async_value(&xs[1])?;
+  resolve_async_response(capability, ASYNC_RESPONSE_RESOLVE, &payload)
+}
+
+fn ffi_response_reject(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  if xs.len() != 2 {
+    return CalcitErr::err_str(
+      CalcitErrKind::Arity,
+      format!("&ffi-response-reject expected 2 arguments, got: {xs:?}"),
+    );
+  }
+  let capability = read_async_capability(&xs[0], FfiAsyncHandleKind::Response)?;
+  let payload = encode_async_value(&xs[1])?;
+  resolve_async_response(capability, ASYNC_RESPONSE_REJECT, &payload)
+}
+
+fn reject_response_for_host(
+  runtime: &NativeAsyncRuntime,
+  handle: FfiAsyncHandle,
+  response: NativeAsyncResponse,
+  reason: &[u8],
+) -> Option<String> {
+  let status = unsafe { (response.resolve)(response.context, handle.raw(), ASYNC_RESPONSE_REJECT, reason.as_ptr(), reason.len()) };
+  let finish_error = runtime.registry.finish(handle).err();
+  let release_error = if finish_error.is_none() {
+    runtime.registry.release(handle).err()
+  } else {
+    None
+  };
+  trace_ffi_event(
+    "async-response-reject",
+    format!("task={} response={} status={status}", response.owner_task.raw(), handle.raw()),
+  );
+  if let Some(error) = finish_error {
+    Some(format!("response {} lifecycle error: {error}", handle.raw()))
+  } else if let Some(error) = release_error {
+    Some(format!("response {} release error: {error}", handle.raw()))
+  } else if status != async_status::OK {
+    Some(format!("response {} module reject failed with status {status}", handle.raw()))
+  } else {
+    None
+  }
+}
+
+fn expire_async_responses(runtime: &NativeAsyncRuntime) -> Result<(), String> {
+  let now = Instant::now();
+  for (handle, state, resource) in runtime.registry.snapshot().map_err(|error| error.to_string())? {
+    let NativeAsyncResource::Response(response) = resource else {
+      continue;
+    };
+    if state.lifecycle == calcit::ffi_abi::FfiAsyncLifecycle::Active && response.deadline <= now {
+      if let Some(error) = reject_response_for_host(runtime, handle, response, b"{} (:code :timeout)") {
+        eprintln!("[Error] async FFI response timeout: {error}");
+      } else {
+        eprintln!(
+          "[Error] async FFI response {} for task {} timed out",
+          handle.raw(),
+          response.owner_task.raw()
+        );
+      }
+    }
+  }
+  Ok(())
+}
+
+fn reject_owned_responses(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle, reason: &[u8]) -> Result<(), String> {
+  for (handle, state, resource) in runtime.registry.snapshot().map_err(|error| error.to_string())? {
+    let NativeAsyncResource::Response(response) = resource else {
+      continue;
+    };
+    if response.owner_task == owner
+      && state.lifecycle == calcit::ffi_abi::FfiAsyncLifecycle::Active
+      && let Some(error) = reject_response_for_host(runtime, handle, response, reason)
+    {
+      eprintln!("[Error] async FFI response cleanup: {error}");
+    }
+  }
+  Ok(())
+}
+
+fn discard_owned_responses(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle) -> Result<usize, String> {
+  let mut discarded = 0;
+  for (handle, _state, resource) in runtime.registry.snapshot().map_err(|error| error.to_string())? {
+    let NativeAsyncResource::Response(response) = resource else {
+      continue;
+    };
+    if response.owner_task == owner {
+      let _ = runtime.registry.finish(handle);
+      if runtime.registry.release(handle).is_ok() {
+        discarded += 1;
+      }
+    }
+  }
+  Ok(discarded)
+}
+
+fn ffi_task_cancel(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  if xs.is_empty() || xs.len() > 2 {
+    return CalcitErr::err_str(
+      CalcitErrKind::Arity,
+      format!("&ffi-task-cancel expected 1 or 2 arguments, got: {xs:?}"),
+    );
+  }
+  let capability = read_async_task_capability(&xs[0])?;
+  let reason = if xs.len() == 2 {
+    encode_async_value(&xs[1])?
+  } else {
+    b"{} (:code :cancelled)".to_vec()
+  };
+  let runtime = native_async_runtime().map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  let state = runtime
+    .registry
+    .state(capability.handle)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
+  if state.lifecycle == calcit::ffi_abi::FfiAsyncLifecycle::Closing {
+    return Ok(Calcit::Unit);
+  }
+  let NativeAsyncResource::Task(task) = runtime
+    .registry
+    .clone_value(capability.handle)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?
+  else {
+    return CalcitErr::err_str(CalcitErrKind::Unexpected, "async FFI capability does not reference a task");
+  };
+  let control = task
+    .control
+    .lock()
+    .map_err(|_| CalcitErr::use_str(CalcitErrKind::Unexpected, "async FFI task control lock is poisoned"))?
+    .to_owned()
+    .ok_or_else(|| CalcitErr::use_str(CalcitErrKind::Unexpected, "async FFI task does not provide cancellation"))?;
+  runtime
+    .registry
+    .begin_close(capability.handle)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
+  let status = unsafe { (control.cancel)(control.context, capability.handle.raw(), reason.as_ptr(), reason.len()) };
+  trace_ffi_event("async-task-cancel", format!("task={} status={status}", capability.handle.raw()));
+  if status == async_status::OK {
+    Ok(Calcit::Unit)
+  } else {
+    let _ = runtime.queue.discard_handle_events(capability.handle);
+    let _ = reject_owned_responses(runtime, capability.handle, b"{} (:code :cancel-failed)");
+    let _ = runtime.registry.finish(capability.handle);
+    if matches!(runtime.registry.release(capability.handle), Ok(NativeAsyncResource::Task(_))) {
+      track::track_task_release();
+    }
+    CalcitErr::err_str(
+      CalcitErrKind::Unexpected,
+      format!(
+        "async FFI task {} cancellation failed with status {status}",
+        capability.handle.raw()
+      ),
+    )
   }
 }
 
@@ -266,7 +696,9 @@ fn decode_async_failure(payload: &[u8]) -> Result<String, String> {
 
 fn dispatch_native_async_event(runtime: &NativeAsyncRuntime, event: &calcit::ffi_async::FfiAsyncQueuedEvent) -> Result<(), String> {
   let handle = event.task_handle();
-  let task = runtime.registry.clone_value(handle).map_err(|error| error.to_string())?;
+  let NativeAsyncResource::Task(task) = runtime.registry.clone_value(handle).map_err(|error| error.to_string())? else {
+    return Err("async FFI event targeted a non-task handle".to_owned());
+  };
   let kind = event.kind().map_err(|error| error.to_string())?;
   trace_ffi_event(
     "async-drain",
@@ -283,7 +715,22 @@ fn dispatch_native_async_event(runtime: &NativeAsyncRuntime, event: &calcit::ffi
 
   match kind {
     FfiAsyncEventKind::Emit => {
-      let args = decode_async_emit(event.payload())?;
+      let mut args = decode_async_emit(event.payload())?;
+      if event.descriptor.response_handle != FfiAsyncHandle::INVALID.raw() {
+        let response_handle = FfiAsyncHandle::from_raw(event.descriptor.response_handle);
+        let NativeAsyncResource::Response(response) =
+          runtime.registry.clone_value(response_handle).map_err(|error| error.to_string())?
+        else {
+          return Err("async FFI event carried a non-response handle".to_owned());
+        };
+        if response.owner_task != handle {
+          return Err("async FFI response handle belongs to another task".to_owned());
+        }
+        if response.deadline <= Instant::now() {
+          return Err("async FFI response handle expired before callback dispatch".to_owned());
+        }
+        args.push(async_capability(response_handle, FfiAsyncHandleKind::Response));
+      }
       let Calcit::Fn { info, .. } = &task.callback else {
         return Err("async FFI task lost its Calcit callback".to_owned());
       };
@@ -319,6 +766,7 @@ fn dispatch_native_async_event(runtime: &NativeAsyncRuntime, event: &calcit::ffi
 
 pub fn drain_async_events(limit: usize) -> Result<FfiAsyncDrainReport, String> {
   let runtime = native_async_runtime()?;
+  expire_async_responses(runtime)?;
   let mut report = runtime
     .queue
     .drain(&runtime.registry, limit, |event| dispatch_native_async_event(runtime, event))
@@ -345,11 +793,18 @@ pub fn drain_async_events(limit: usize) -> Result<FfiAsyncDrainReport, String> {
 
   for descriptor in report.finished.clone() {
     let handle = FfiAsyncHandle::from_raw(descriptor.task_handle);
-    if let Err(error) = runtime.registry.release(handle) {
-      report
-        .lifecycle_failures
-        .push(calcit::ffi_async::FfiAsyncLifecycleFailure { descriptor, error });
-      continue;
+    reject_owned_responses(runtime, handle, b"{} (:code :owner-finished)")?;
+    match runtime.registry.release(handle) {
+      Ok(NativeAsyncResource::Task(_)) => {}
+      Ok(NativeAsyncResource::Response(_)) => {
+        return Err(format!("async FFI task {} released a response resource", handle.raw()));
+      }
+      Err(error) => {
+        report
+          .lifecycle_failures
+          .push(calcit::ffi_async::FfiAsyncLifecycleFailure { descriptor, error });
+        continue;
+      }
     }
     track::track_task_release();
     trace_ffi_event(
@@ -545,6 +1000,30 @@ pub fn inject_platform_apis() {
       tags: proc_tags(["interop", "io"]),
     },
   );
+  for (name, proc, arity_min, arity_max) in [
+    (
+      "&ffi-response-resolve",
+      ffi_response_resolve as calcit::builtins::FnType,
+      2,
+      Some(2),
+    ),
+    ("&ffi-response-reject", ffi_response_reject as calcit::builtins::FnType, 2, Some(2)),
+    ("&ffi-task-cancel", ffi_task_cancel as calcit::builtins::FnType, 1, Some(2)),
+  ] {
+    builtins::register_import_proc_with_descriptor(
+      name,
+      proc,
+      RegisteredProcDescriptor {
+        arity_min,
+        arity_max,
+        platforms: vec![RegisteredProcPlatform::Native],
+        stability: RegisteredProcStability::Public,
+        docs_hint: Some(Arc::from("Fix: use a capability received from native async FFI.")),
+        callback_last: false,
+        tags: proc_tags(["interop", "io"]),
+      },
+    );
+  }
   builtins::register_import_proc_with_descriptor(
     "async-sleep",
     builtins::meta::async_sleep,
@@ -687,15 +1166,20 @@ fn try_start_async_callback_v1(
   };
   let runtime = native_async_runtime().map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
   let request = calcit::ffi_abi::encode_buffer_request(args).map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
-  let task = NativeAsyncCallback {
+  let task = NativeAsyncTask {
     callback,
     stack: Arc::new(call_stack.to_owned()),
     lib_name: lib_name.to_owned(),
     method: method.to_owned(),
+    control: Arc::new(Mutex::new(None)),
   };
   let handle = runtime
     .registry
-    .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+    .register_with_flags(
+      FfiAsyncHandleKind::Stream,
+      ASYNC_TASK_FLAG_SERIAL_EVENTS,
+      NativeAsyncResource::Task(task),
+    )
     .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
   let descriptor = FfiAsyncTaskDescriptor::new(handle, FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS);
   let host = async_host_table();
@@ -713,17 +1197,38 @@ fn try_start_async_callback_v1(
   );
   let status = unsafe { start(request.as_ptr(), request.len(), &descriptor, host) };
   if status == async_status::OK {
-    return Ok(Some(Calcit::Unit));
+    let state = runtime
+      .registry
+      .state(handle)
+      .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
+    let NativeAsyncResource::Task(task) = runtime
+      .registry
+      .clone_value(handle)
+      .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?
+    else {
+      return CalcitErr::err_str(CalcitErrKind::Unexpected, "async FFI start replaced its task resource").map(Some);
+    };
+    let cancellable = task
+      .control
+      .lock()
+      .map_err(|_| CalcitErr::use_str(CalcitErrKind::Unexpected, "async FFI task control lock is poisoned"))?
+      .is_some();
+    return Ok(Some(if cancellable {
+      async_capability(handle, state.kind)
+    } else {
+      Calcit::Unit
+    }));
   }
 
   let purged = runtime.queue.discard_handle_events(handle).unwrap_or(0);
+  let discarded_responses = discard_owned_responses(runtime, handle).unwrap_or(0);
   let _ = runtime.registry.finish(handle);
   let _ = runtime.registry.release(handle);
   track::track_task_release();
   trace_ffi_event(
     "async-start-failed",
     format!(
-      "lib={lib_name} symbol={} task={} status={status} purged={purged} pending={}",
+      "lib={lib_name} symbol={} task={} status={status} purged={purged} discarded_responses={discarded_responses} pending={}",
       calcit::ffi_abi::async_method_symbol(method),
       handle.raw(),
       track::count_pending_tasks()
@@ -1053,6 +1558,39 @@ pub fn on_ctrl_c(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calcit, 
 mod async_callback_tests {
   use super::*;
 
+  type RecordedResponse = (u64, u64, u32, Vec<u8>);
+  static RESPONSE_EVENTS: LazyLock<Mutex<Vec<RecordedResponse>>> = LazyLock::new(|| Mutex::new(vec![]));
+
+  unsafe extern "C" fn record_response(
+    context: u64,
+    response_handle: u64,
+    outcome: u32,
+    payload_ptr: *const u8,
+    payload_len: usize,
+  ) -> i32 {
+    let payload = if payload_len == 0 {
+      vec![]
+    } else {
+      // SAFETY: test callers pass a readable payload for this synchronous call.
+      unsafe { std::slice::from_raw_parts(payload_ptr, payload_len) }.to_vec()
+    };
+    RESPONSE_EVENTS
+      .lock()
+      .expect("response event lock")
+      .push((context, response_handle, outcome, payload));
+    async_status::OK
+  }
+
+  fn test_task() -> NativeAsyncResource {
+    NativeAsyncResource::Task(NativeAsyncTask {
+      callback: Calcit::Nil,
+      stack: Arc::new(CallStackList::default()),
+      lib_name: "fixture".to_owned(),
+      method: "server".to_owned(),
+      control: Arc::new(Mutex::new(None)),
+    })
+  }
+
   #[test]
   fn foreign_producer_enters_through_c_payload_boundary_and_host_drains_completion() {
     let runtime = Arc::new(NativeAsyncRuntime {
@@ -1061,16 +1599,7 @@ mod async_callback_tests {
     });
     let handle = runtime
       .registry
-      .register_with_flags(
-        FfiAsyncHandleKind::Stream,
-        ASYNC_TASK_FLAG_SERIAL_EVENTS,
-        NativeAsyncCallback {
-          callback: Calcit::Nil,
-          stack: Arc::new(CallStackList::default()),
-          lib_name: "fixture".to_owned(),
-          method: "complete".to_owned(),
-        },
-      )
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, test_task())
       .expect("register fixture task");
 
     let producer_runtime = Arc::clone(&runtime);
@@ -1114,5 +1643,146 @@ mod async_callback_tests {
       decode_async_failure(b"{} (:code :closed)").expect("decode failure"),
       "{} $ :code :closed"
     );
+  }
+
+  #[test]
+  fn expired_response_is_rejected_once_and_released() {
+    const CONTEXT: u64 = 101;
+    let runtime = NativeAsyncRuntime {
+      registry: FfiAsyncHandleRegistry::new(),
+      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
+    };
+    let owner = runtime
+      .registry
+      .register_with_flags(
+        FfiAsyncHandleKind::Server,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+        test_task(),
+      )
+      .expect("register server");
+    let response = runtime
+      .registry
+      .register(
+        FfiAsyncHandleKind::Response,
+        NativeAsyncResource::Response(NativeAsyncResponse {
+          owner_task: owner,
+          context: CONTEXT,
+          deadline: Instant::now() - Duration::from_millis(1),
+          resolve: record_response,
+        }),
+      )
+      .expect("register response");
+
+    expire_async_responses(&runtime).expect("expire responses");
+    assert_eq!(
+      runtime.registry.state(response),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle)
+    );
+    let events: Vec<RecordedResponse> = RESPONSE_EVENTS
+      .lock()
+      .expect("response events")
+      .iter()
+      .filter(|(context, ..)| *context == CONTEXT)
+      .cloned()
+      .collect();
+    assert_eq!(
+      events,
+      vec![(CONTEXT, response.raw(), ASYNC_RESPONSE_REJECT, b"{} (:code :timeout)".to_vec())]
+    );
+  }
+
+  #[test]
+  fn response_resolution_is_exactly_once_and_rejects_stale_reuse() {
+    const CONTEXT: u64 = 202;
+    let runtime = NativeAsyncRuntime {
+      registry: FfiAsyncHandleRegistry::new(),
+      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
+    };
+    let owner = runtime
+      .registry
+      .register(FfiAsyncHandleKind::Server, test_task())
+      .expect("register server");
+    let response = runtime
+      .registry
+      .register(
+        FfiAsyncHandleKind::Response,
+        NativeAsyncResource::Response(NativeAsyncResponse {
+          owner_task: owner,
+          context: CONTEXT,
+          deadline: Instant::now() + Duration::from_secs(1),
+          resolve: record_response,
+        }),
+      )
+      .expect("register response");
+    let capability = NativeAsyncCapability {
+      handle: response,
+      kind: FfiAsyncHandleKind::Response,
+    };
+
+    resolve_async_response_with(&runtime, capability, ASYNC_RESPONSE_RESOLVE, b"|ok").expect("resolve response");
+    let error =
+      resolve_async_response_with(&runtime, capability, ASYNC_RESPONSE_RESOLVE, b"|late").expect_err("stale response must fail");
+    assert!(error.contains("stale"), "error: {error}");
+    let events: Vec<RecordedResponse> = RESPONSE_EVENTS
+      .lock()
+      .expect("response events")
+      .iter()
+      .filter(|(context, ..)| *context == CONTEXT)
+      .cloned()
+      .collect();
+    assert_eq!(events, vec![(CONTEXT, response.raw(), ASYNC_RESPONSE_RESOLVE, b"|ok".to_vec())]);
+  }
+
+  #[test]
+  fn response_handle_must_belong_to_the_enqueuing_server() {
+    let runtime = NativeAsyncRuntime {
+      registry: FfiAsyncHandleRegistry::new(),
+      queue: FfiAsyncEventQueue::new(4).expect("create host queue"),
+    };
+    let first = runtime
+      .registry
+      .register_with_flags(
+        FfiAsyncHandleKind::Server,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+        test_task(),
+      )
+      .expect("register first server");
+    let second = runtime
+      .registry
+      .register_with_flags(
+        FfiAsyncHandleKind::Server,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+        test_task(),
+      )
+      .expect("register second server");
+    let response = runtime
+      .registry
+      .register(
+        FfiAsyncHandleKind::Response,
+        NativeAsyncResource::Response(NativeAsyncResponse {
+          owner_task: first,
+          context: 0,
+          deadline: Instant::now() + Duration::from_secs(1),
+          resolve: record_response,
+        }),
+      )
+      .expect("register response");
+    let payload = b"[] |request";
+
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          ASYNC_HOST_CONTEXT,
+          second.raw(),
+          FfiAsyncEventKind::Emit as u32,
+          response.raw(),
+          payload.as_ptr(),
+          payload.len(),
+        )
+      },
+      async_status::INVALID_HANDLE
+    );
+    assert_eq!(runtime.queue.len(), Ok(0));
   }
 }

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -38,6 +38,29 @@ pub type FfiAsyncHostEnqueue = unsafe extern "C" fn(
   payload_ptr: *const u8,
   payload_len: usize,
 ) -> i32;
+pub type FfiAsyncTaskCancel =
+  unsafe extern "C" fn(task_context: u64, task_handle: u64, reason_ptr: *const u8, reason_len: usize) -> i32;
+pub type FfiAsyncResponseResolve =
+  unsafe extern "C" fn(response_context: u64, response_handle: u64, outcome: u32, payload_ptr: *const u8, payload_len: usize) -> i32;
+pub type FfiAsyncHostConfigureTask = unsafe extern "C" fn(
+  context: u64,
+  task_handle: u64,
+  kind: u32,
+  flags: u32,
+  task_context: u64,
+  cancel: Option<FfiAsyncTaskCancel>,
+) -> i32;
+pub type FfiAsyncHostOpenResponse = unsafe extern "C" fn(
+  context: u64,
+  task_handle: u64,
+  response_context: u64,
+  timeout_ms: u64,
+  resolve: Option<FfiAsyncResponseResolve>,
+  out_handle: *mut u64,
+) -> i32;
+
+pub const ASYNC_RESPONSE_RESOLVE: u32 = 1;
+pub const ASYNC_RESPONSE_REJECT: u32 = 2;
 
 /// Native host functions that an async dylib may copy and call from producer
 /// threads. The integer context is opaque and avoids exposing a Rust object
@@ -49,15 +72,24 @@ pub struct FfiAsyncHostV1 {
   pub struct_size: u32,
   pub context: u64,
   pub enqueue: Option<FfiAsyncHostEnqueue>,
+  pub configure_task: Option<FfiAsyncHostConfigureTask>,
+  pub open_response: Option<FfiAsyncHostOpenResponse>,
 }
 
 impl FfiAsyncHostV1 {
-  pub fn new(context: u64, enqueue: FfiAsyncHostEnqueue) -> Self {
+  pub fn new(
+    context: u64,
+    enqueue: FfiAsyncHostEnqueue,
+    configure_task: FfiAsyncHostConfigureTask,
+    open_response: FfiAsyncHostOpenResponse,
+  ) -> Self {
     Self {
       protocol_version: ASYNC_PROTOCOL_VERSION,
       struct_size: std::mem::size_of::<Self>() as u32,
       context,
       enqueue: Some(enqueue),
+      configure_task: Some(configure_task),
+      open_response: Some(open_response),
     }
   }
 }
@@ -251,6 +283,9 @@ pub enum FfiAsyncHandleError {
   HandleFinished,
   HandleStillActive,
   TerminalAlreadyQueued,
+  TaskAlreadyStarted,
+  MissingResponse,
+  UnexpectedResponse,
   HostClosing,
   RegistryExhausted,
   SequenceExhausted,
@@ -261,9 +296,14 @@ pub enum FfiAsyncHandleError {
 impl FfiAsyncHandleError {
   pub fn status_code(&self) -> i32 {
     match self {
-      Self::InvalidKind(_) | Self::InvalidEventKind(_) | Self::InvalidFlags(_) | Self::InvalidEventFlags(_) | Self::PayloadTooLarge => {
-        async_status::INVALID_PAYLOAD
-      }
+      Self::InvalidKind(_)
+      | Self::InvalidEventKind(_)
+      | Self::InvalidFlags(_)
+      | Self::InvalidEventFlags(_)
+      | Self::TaskAlreadyStarted
+      | Self::MissingResponse
+      | Self::UnexpectedResponse
+      | Self::PayloadTooLarge => async_status::INVALID_PAYLOAD,
       Self::InvalidHandle => async_status::INVALID_HANDLE,
       Self::StaleHandle => async_status::STALE_HANDLE,
       Self::HandleClosing => async_status::HANDLE_CLOSING,
@@ -289,6 +329,9 @@ impl fmt::Display for FfiAsyncHandleError {
       Self::HandleFinished => f.write_str("async FFI handle is already finished"),
       Self::HandleStillActive => f.write_str("async FFI handle must finish before release"),
       Self::TerminalAlreadyQueued => f.write_str("async FFI handle already has a terminal event queued"),
+      Self::TaskAlreadyStarted => f.write_str("async FFI task cannot be configured after its first event"),
+      Self::MissingResponse => f.write_str("async FFI server event requires a response handle"),
+      Self::UnexpectedResponse => f.write_str("async FFI response handle is not valid for this event"),
       Self::HostClosing => f.write_str("async FFI host is closing"),
       Self::RegistryExhausted => f.write_str("async FFI handle registry is exhausted"),
       Self::SequenceExhausted => f.write_str("async FFI event sequence is exhausted"),
@@ -354,9 +397,7 @@ impl<T> FfiAsyncHandleRegistry<T> {
   }
 
   pub fn register_with_flags(&self, kind: FfiAsyncHandleKind, flags: u32, value: T) -> Result<FfiAsyncHandle, FfiAsyncHandleError> {
-    if flags & !ASYNC_TASK_KNOWN_FLAGS != 0 || (flags & ASYNC_TASK_FLAG_COALESCE_ALLOWED != 0 && kind != FfiAsyncHandleKind::Stream) {
-      return Err(FfiAsyncHandleError::InvalidFlags(flags));
-    }
+    validate_async_task_flags(kind, flags)?;
     let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
     if registry.closing {
       return Err(FfiAsyncHandleError::HostClosing);
@@ -395,6 +436,24 @@ impl<T> FfiAsyncHandleRegistry<T> {
   pub fn state(&self, handle: FfiAsyncHandle) -> Result<FfiAsyncHandleState, FfiAsyncHandleError> {
     let registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
     Ok(resolve_async_handle(&registry, handle)?.state)
+  }
+
+  /// Configure a task before its first event. Async start functions use this
+  /// to specialize the host's default Stream descriptor into OneShot or
+  /// Server and to declare response/coalescing policy.
+  pub fn configure(&self, handle: FfiAsyncHandle, kind: FfiAsyncHandleKind, flags: u32) -> Result<(), FfiAsyncHandleError> {
+    validate_async_task_flags(kind, flags)?;
+    if kind == FfiAsyncHandleKind::Response {
+      return Err(FfiAsyncHandleError::InvalidKind(kind as u32));
+    }
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    let task = resolve_async_handle_mut(&mut registry, handle)?;
+    if task.state.lifecycle != FfiAsyncLifecycle::Active || task.state.next_sequence != 1 || task.state.terminal_queued {
+      return Err(FfiAsyncHandleError::TaskAlreadyStarted);
+    }
+    task.state.kind = kind;
+    task.state.flags = flags;
+    Ok(())
   }
 
   /// Clone host-owned metadata/callback state without holding the registry
@@ -525,6 +584,33 @@ impl<T> FfiAsyncHandleRegistry<T> {
         })
         .count(),
     )
+  }
+
+  /// Snapshot registered handles without holding the registry lock while the
+  /// host invokes module control functions or performs timeout processing.
+  pub fn snapshot(&self) -> Result<Vec<(FfiAsyncHandle, FfiAsyncHandleState, T)>, FfiAsyncHandleError>
+  where
+    T: Clone,
+  {
+    let registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    let mut values = vec![];
+    for (index, slot) in registry.slots.iter().enumerate() {
+      if let Some(task) = &slot.task {
+        values.push((FfiAsyncHandle::from_parts(index, slot.generation), task.state, task.value.clone()));
+      }
+    }
+    Ok(values)
+  }
+}
+
+fn validate_async_task_flags(kind: FfiAsyncHandleKind, flags: u32) -> Result<(), FfiAsyncHandleError> {
+  if flags & !ASYNC_TASK_KNOWN_FLAGS != 0
+    || (flags & ASYNC_TASK_FLAG_COALESCE_ALLOWED != 0 && kind != FfiAsyncHandleKind::Stream)
+    || (flags & ASYNC_TASK_FLAG_REQUIRES_RESPONSE != 0 && kind != FfiAsyncHandleKind::Server)
+  {
+    Err(FfiAsyncHandleError::InvalidFlags(flags))
+  } else {
+    Ok(())
   }
 }
 
@@ -775,14 +861,38 @@ mod tests {
     async_status::OK
   }
 
+  unsafe extern "C" fn test_configure(
+    _context: u64,
+    _task_handle: u64,
+    _kind: u32,
+    _flags: u32,
+    _task_context: u64,
+    _cancel: Option<super::FfiAsyncTaskCancel>,
+  ) -> i32 {
+    async_status::OK
+  }
+
+  unsafe extern "C" fn test_open_response(
+    _context: u64,
+    _task_handle: u64,
+    _response_context: u64,
+    _timeout_ms: u64,
+    _resolve: Option<super::FfiAsyncResponseResolve>,
+    _out_handle: *mut u64,
+  ) -> i32 {
+    async_status::OK
+  }
+
   #[test]
   fn async_host_table_and_method_names_are_c_stable() {
-    let host = FfiAsyncHostV1::new(42, test_enqueue);
+    let host = FfiAsyncHostV1::new(42, test_enqueue, test_configure, test_open_response);
     assert_eq!(async_method_symbol("watch"), "watch_calcit_ffi_async_v1");
     assert_eq!(host.protocol_version, ASYNC_PROTOCOL_VERSION);
     assert_eq!(host.struct_size as usize, std::mem::size_of::<FfiAsyncHostV1>());
     assert_eq!(host.context, 42);
     assert!(host.enqueue.is_some());
+    assert!(host.configure_task.is_some());
+    assert!(host.open_response.is_some());
   }
 
   #[test]
@@ -881,6 +991,52 @@ mod tests {
     assert_eq!(registry.next_event_sequence(handle), Err(FfiAsyncHandleError::HandleFinished));
     assert_eq!(registry.release(handle), Ok("watcher"));
     assert_eq!(registry.release(handle), Err(FfiAsyncHandleError::StaleHandle));
+  }
+
+  #[test]
+  fn async_task_configuration_is_pre_event_and_kind_aware() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, "server")
+      .expect("register provisional task");
+    registry
+      .configure(
+        handle,
+        FfiAsyncHandleKind::Server,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+      )
+      .expect("configure server");
+    let state = registry.state(handle).expect("configured state");
+    assert_eq!(state.kind, FfiAsyncHandleKind::Server);
+    assert_eq!(state.flags, ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE);
+    assert_eq!(registry.next_event_sequence(handle), Ok(1));
+    assert_eq!(
+      registry.configure(handle, FfiAsyncHandleKind::OneShot, ASYNC_TASK_FLAG_SERIAL_EVENTS),
+      Err(FfiAsyncHandleError::TaskAlreadyStarted)
+    );
+    assert_eq!(
+      registry.register_with_flags(
+        FfiAsyncHandleKind::Stream,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+        "invalid-stream"
+      ),
+      Err(FfiAsyncHandleError::InvalidFlags(
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE
+      ))
+    );
+  }
+
+  #[test]
+  fn async_registry_snapshot_preserves_handle_kind_and_value() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let task = registry.register(FfiAsyncHandleKind::Server, "server").expect("register server");
+    let response = registry
+      .register(FfiAsyncHandleKind::Response, "response")
+      .expect("register response");
+    let snapshot = registry.snapshot().expect("snapshot handles");
+    assert_eq!(snapshot.len(), 2);
+    assert!(snapshot.contains(&(task, registry.state(task).expect("task state"), "server")));
+    assert!(snapshot.contains(&(response, registry.state(response).expect("response state"), "response")));
   }
 
   #[test]

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -410,27 +410,37 @@ impl<T> FfiAsyncHandleRegistry<T> {
       next_sequence: 1,
       terminal_queued: false,
     };
-    while let Some(index) = registry.free_slots.pop() {
-      let slot = &mut registry.slots[index];
-      let Some(generation) = slot.generation.checked_add(1) else {
-        // A wrapped generation could make a very old stale handle valid
-        // again, so permanently retire slots that exhaust the counter.
-        continue;
-      };
-      slot.generation = generation;
-      slot.task = Some(RegisteredAsyncHandle { state, value });
-      return Ok(FfiAsyncHandle::from_parts(index, slot.generation));
-    }
+    register_async_handle(&mut registry, state, value)
+  }
 
-    if registry.slots.len() >= u32::MAX as usize {
-      return Err(FfiAsyncHandleError::RegistryExhausted);
+  /// Register a child capability only while its owner is still active and has
+  /// not queued a terminal event. Native response adapters hold their owner
+  /// index lock around this call so owner completion cannot miss a new child.
+  pub fn register_for_active_owner(
+    &self,
+    owner: FfiAsyncHandle,
+    kind: FfiAsyncHandleKind,
+    value: T,
+  ) -> Result<FfiAsyncHandle, FfiAsyncHandleError> {
+    validate_async_task_flags(kind, 0)?;
+    let mut registry = self.state.lock().map_err(|_| FfiAsyncHandleError::RegistryPoisoned)?;
+    if registry.closing {
+      return Err(FfiAsyncHandleError::HostClosing);
     }
-    let index = registry.slots.len();
-    registry.slots.push(AsyncHandleSlot {
-      generation: 1,
-      task: Some(RegisteredAsyncHandle { state, value }),
-    });
-    Ok(FfiAsyncHandle::from_parts(index, 1))
+    let owner_state = resolve_async_handle(&registry, owner)?.state;
+    match owner_state.lifecycle {
+      FfiAsyncLifecycle::Active if !owner_state.terminal_queued => {}
+      FfiAsyncLifecycle::Active | FfiAsyncLifecycle::Closing => return Err(FfiAsyncHandleError::HandleClosing),
+      FfiAsyncLifecycle::Finished => return Err(FfiAsyncHandleError::HandleFinished),
+    }
+    let state = FfiAsyncHandleState {
+      kind,
+      flags: 0,
+      lifecycle: FfiAsyncLifecycle::Active,
+      next_sequence: 1,
+      terminal_queued: false,
+    };
+    register_async_handle(&mut registry, state, value)
   }
 
   pub fn state(&self, handle: FfiAsyncHandle) -> Result<FfiAsyncHandleState, FfiAsyncHandleError> {
@@ -601,6 +611,34 @@ impl<T> FfiAsyncHandleRegistry<T> {
     }
     Ok(values)
   }
+}
+
+fn register_async_handle<T>(
+  registry: &mut AsyncHandleRegistryState<T>,
+  state: FfiAsyncHandleState,
+  value: T,
+) -> Result<FfiAsyncHandle, FfiAsyncHandleError> {
+  while let Some(index) = registry.free_slots.pop() {
+    let slot = &mut registry.slots[index];
+    let Some(generation) = slot.generation.checked_add(1) else {
+      // A wrapped generation could make a very old stale handle valid again,
+      // so permanently retire slots that exhaust the counter.
+      continue;
+    };
+    slot.generation = generation;
+    slot.task = Some(RegisteredAsyncHandle { state, value });
+    return Ok(FfiAsyncHandle::from_parts(index, slot.generation));
+  }
+
+  if registry.slots.len() >= u32::MAX as usize {
+    return Err(FfiAsyncHandleError::RegistryExhausted);
+  }
+  let index = registry.slots.len();
+  registry.slots.push(AsyncHandleSlot {
+    generation: 1,
+    task: Some(RegisteredAsyncHandle { state, value }),
+  });
+  Ok(FfiAsyncHandle::from_parts(index, 1))
 }
 
 fn validate_async_task_flags(kind: FfiAsyncHandleKind, flags: u32) -> Result<(), FfiAsyncHandleError> {
@@ -1023,6 +1061,26 @@ mod tests {
       Err(FfiAsyncHandleError::InvalidFlags(
         ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE
       ))
+    );
+  }
+
+  #[test]
+  fn async_child_registration_requires_an_active_owner_without_terminal_event() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let owner = registry.register(FfiAsyncHandleKind::Server, "server").expect("register owner");
+    let response = registry
+      .register_for_active_owner(owner, FfiAsyncHandleKind::Response, "response")
+      .expect("register response for active owner");
+    assert_eq!(registry.state(response).expect("response state").kind, FfiAsyncHandleKind::Response);
+    assert_eq!(registry.reserve_event_sequence(owner, FfiAsyncEventKind::Complete), Ok(1));
+    assert_eq!(
+      registry.register_for_active_owner(owner, FfiAsyncHandleKind::Response, "late-response"),
+      Err(FfiAsyncHandleError::HandleClosing)
+    );
+    registry.finish(owner).expect("finish owner");
+    assert_eq!(
+      registry.register_for_active_owner(owner, FfiAsyncHandleKind::Response, "finished-response"),
+      Err(FfiAsyncHandleError::HandleFinished)
     );
   }
 

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -248,6 +248,15 @@ impl FfiAsyncEventQueue {
     }
 
     let task_state = registry.state(task_handle)?;
+    if kind == FfiAsyncEventKind::Emit && task_state.flags & crate::ffi_abi::ASYNC_TASK_FLAG_REQUIRES_RESPONSE != 0 {
+      let response_handle = response_handle.ok_or(FfiAsyncHandleError::MissingResponse)?;
+      let response_state = registry.state(response_handle)?;
+      if response_state.kind != crate::ffi_abi::FfiAsyncHandleKind::Response || response_state.lifecycle != FfiAsyncLifecycle::Active {
+        return Err(FfiAsyncHandleError::UnexpectedResponse.into());
+      }
+    } else if response_handle.is_some() {
+      return Err(FfiAsyncHandleError::UnexpectedResponse.into());
+    }
     let coalesce_index = if queue.events.len() >= self.capacity
       && kind == FfiAsyncEventKind::Emit
       && task_state.flags & ASYNC_TASK_FLAG_COALESCE_ALLOWED != 0
@@ -579,6 +588,44 @@ mod tests {
     assert_eq!(report.discarded, 1);
     assert_eq!(report.delivered, 1);
     assert_eq!(report.lifecycle_failures.len(), 1);
+  }
+
+  #[test]
+  fn server_request_requires_one_active_response_handle() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let server = registry
+      .register_with_flags(
+        FfiAsyncHandleKind::Server,
+        crate::ffi_abi::ASYNC_TASK_FLAG_SERIAL_EVENTS | crate::ffi_abi::ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+        (),
+      )
+      .expect("register server");
+    let response = registry.register(FfiAsyncHandleKind::Response, ()).expect("register response");
+    let queue = FfiAsyncEventQueue::new(3).expect("create queue");
+
+    assert_eq!(
+      queue.enqueue(&registry, server, None, FfiAsyncEventKind::Emit, vec![]),
+      Err(FfiAsyncQueueError::Handle(FfiAsyncHandleError::MissingResponse))
+    );
+    queue
+      .enqueue(&registry, server, Some(response), FfiAsyncEventKind::Emit, b"request".to_vec())
+      .expect("enqueue request with response");
+    assert_eq!(
+      queue.enqueue(&registry, server, Some(response), FfiAsyncEventKind::Complete, b"&unit".to_vec()),
+      Err(FfiAsyncQueueError::Handle(FfiAsyncHandleError::UnexpectedResponse))
+    );
+  }
+
+  #[test]
+  fn ordinary_stream_rejects_unexpected_response_capabilities() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let stream = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let response = registry.register(FfiAsyncHandleKind::Response, ()).expect("register response");
+    let queue = FfiAsyncEventQueue::new(1).expect("create queue");
+    assert_eq!(
+      queue.enqueue(&registry, stream, Some(response), FfiAsyncEventKind::Emit, vec![]),
+      Err(FfiAsyncQueueError::Handle(FfiAsyncHandleError::UnexpectedResponse))
+    );
   }
 
   #[test]


### PR DESCRIPTION
## 中文概要

- 在异步 host table 中追加 C-safe task 配置与 response 注册接口；
- 支持可取消的 Server task，并用不透明 native capability 代替有精度损失的数字 handle；
- 将 exactly-once AnyRef response capability 追加到 Server request callback 参数；
- 新增 `&ffi-response-resolve`、`&ffi-response-reject` 与 `&ffi-task-cancel`；
- 校验 owner、kind、lifecycle、timeout、`REQUIRES_RESPONSE` 与 backpressure 规则；
- timeout、owner 完成或 callback 失败时 reject/release 未完成 response，启动回滚时安全丢弃尚未转移的 handle；
- 文档化扩展后的 ABI、Calcit API、所有权、取消语义与未来 WASM transport 边界。

### Review 修复

- 排队期间过期的 request 现在只会被 reject/skip，不再终止长期 Server 或清空后续事件；
- response 在进入 dylib resolver 前原子 claim，并发 resolve/reject 最多调用模块一次；resolver 返回错误时 capability 也会完成释放；
- 使用 ordered deadline/owner index 代替每轮 drain 和 task 结束时 clone/scan 全 registry，并限制每个 task 最多 1024 个未完成 response；
- host context 按 task 绑定，避免跨 task/module 意外复用；owner 与 child response 注册保持原子关系，消除完成/启动回滚竞态；
- 修正历史记录中的 `REQUIRES_RESPONSE` 术语。

### 运行时验证

真实 C dylib 配置 Server、打开 response、从 pthread 发布 request、在 Calcit host thread 执行 callback 并返回 response，随后发布显式 `&unit` completion；进程以 pending=0 退出。另一个 idle Server fixture 验证 task cancel 与 terminal acknowledgement。两条路径均无 runtime error。

### 验证

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`（855 项通过）
- `yarn compile`
- `yarn check-agent-interface`（17/17）
- `yarn check-all`（Calcit core 221/221，JS/IR/WASM 与 benchmark 全部通过）

## English summary

- append C-safe task configuration and response registration to the async host table;
- support cancellable Server tasks and opaque native task capabilities without lossy numeric handles;
- append exactly-once AnyRef response capabilities to Server request callbacks;
- add `&ffi-response-resolve`, `&ffi-response-reject`, and `&ffi-task-cancel`;
- enforce owner, kind, lifecycle, timeout, `REQUIRES_RESPONSE`, and backpressure rules;
- reject unresolved responses on timeout, owner completion, or callback failure, and safely discard startup rollback handles;
- document the expanded ABI, Calcit API, ownership, cancellation, and future WASM transport boundary.

### Review fixes

- an expired queued request is rejected/skipped without terminating the long-lived Server or purging later events;
- responses are atomically claimed before entering the dylib resolver, so concurrent resolve/reject attempts invoke the module at most once and release the capability even when the resolver reports an error;
- ordered deadline and owner indexes replace full-registry clone/scans, with a limit of 1024 outstanding responses per task;
- host contexts are task-bound, and owner/child registration is atomic with cleanup, preventing accidental cross-task use and completion/startup rollback races;
- aligned history terminology with `REQUIRES_RESPONSE`.

### Runtime verification

A real C dylib configured a Server, opened a response, published a request from a pthread, ran the callback on the Calcit host thread, returned through the module resolver, and published explicit `&unit` completion before exiting with pending=0. A second idle Server fixture verified task cancellation and terminal acknowledgement. Neither path reported a runtime error.

### Verification

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (855 passed)
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all` (Calcit core 221/221 plus JS, IR, WASM, and benchmarks)

Part of #482.
