### PR TITLE
feat: add C-safe blocking FFI protocol

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -7,9 +7,9 @@ WebSocket connections, and server resources.
 
 This document describes protocol version 1 as it is implemented in stages.
 The current implementation provides the handle types, lifecycle registry,
-bounded host event queue, and the native callback-v1 entry point used by
-`&call-dylib-edn-fn`. `&blocking-dylib-edn-fn` still uses the
-build-identity-guarded Rust ABI until the blocking protocol lands.
+bounded host event queue, native callback-v1, response/Server capabilities,
+and the blocking-v1 entry point used by `&blocking-dylib-edn-fn`. Both callback
+forms retain a guarded per-method Rust ABI fallback during module migration.
 
 ## Shared task model
 
@@ -229,6 +229,97 @@ Rust callback ABI. If it advertises an async protocol version other than 1,
 Calcit fails before invoking either ABI. This per-method rule lets maintained
 modules migrate incrementally without hiding an actual version mismatch.
 
+## Native blocking ABI v1
+
+`&blocking-dylib-edn-fn` probes a separate entry point so a method that owns
+the host thread cannot accidentally be started as an asynchronous task:
+
+```c
+int32_t <method>_calcit_ffi_blocking_v1(
+  const uint8_t *request_ptr,
+  size_t request_len,
+  const CalcitFfiAsyncTaskV1 *task,
+  const CalcitFfiBlockingHostV1 *host,
+  CalcitFfiBuffer *output
+);
+```
+
+It uses the same `calcit_ffi_async_version() -> 1`, generation handle,
+OneShot lifecycle, monotonic event sequence, status values, and Cirru EDN
+request encoding as callback v1. The final method result follows buffer v1:
+the module allocates `output`, and the host copies it before calling that
+module's `calcit_ffi_buffer_free`.
+
+The blocking host table is C-layout and contains three operations:
+
+```c
+typedef struct {
+  uint8_t *ptr;
+  size_t len;
+  size_t cap;
+} CalcitFfiBuffer;
+
+typedef struct {
+  uint32_t protocol_version;
+  uint32_t struct_size;
+  uint64_t context;
+  int32_t (*invoke)(
+    uint64_t context,
+    uint64_t task_handle,
+    const uint8_t *payload_ptr,
+    size_t payload_len,
+    CalcitFfiBuffer *output
+  );
+  int32_t (*finish)(uint64_t context, uint64_t task_handle);
+  int32_t (*free_buffer)(
+    uint64_t context,
+    uint64_t task_handle,
+    CalcitFfiBuffer buffer
+  );
+} CalcitFfiBlockingHostV1;
+```
+
+The function pointer signatures are equivalent to:
+
+```c
+int32_t invoke(
+  uint64_t context,
+  uint64_t task_handle,
+  const uint8_t *payload_ptr,
+  size_t payload_len,
+  CalcitFfiBuffer *output
+);
+
+int32_t finish(uint64_t context, uint64_t task_handle);
+
+int32_t free_buffer(
+  uint64_t context,
+  uint64_t task_handle,
+  CalcitFfiBuffer buffer
+);
+```
+
+`invoke` accepts a Cirru EDN argument list and runs the Calcit callback
+synchronously. It is valid only on the thread that registered the blocking
+task; a foreign-thread invocation returns `WRONG_THREAD` and never enters the
+Calcit runtime. Successful callback output is one Cirru EDN value. A callback
+failure returns `CALLBACK_ERROR` with a UTF-8 diagnostic buffer. The host owns
+both forms of callback output, records their exact pointer and length, and
+releases them only through `free_buffer`; forged metadata, duplicate free, and
+cross-task context are rejected. Any unfreed callback buffers are reclaimed
+and reported when the blocking method returns.
+
+`finish` is optional and exactly once. If the module does not call it, normal
+or failed return from the blocking method performs an implicit finish. After
+explicit finish, further `invoke` calls fail deterministically. This preserves
+main-thread event loops without introducing a queue-drain deadlock, while
+foreign-thread and long-lived work remains on callback v1's bounded queue.
+
+Missing protocol or per-method blocking symbols retain the build-identity-
+guarded Rust fallback. An advertised incompatible version, missing module
+buffer free function, malformed output, leaked host callback buffer, or
+wrong-thread callback is a hard error.
+
 ## WASM compatibility boundary
 
 WASM will not reuse C pointers or native function pointers. It can still reuse
@@ -248,12 +339,11 @@ present the same Calcit-facing behavior.
 
 ## Rollout
 
-The remaining implementation order after response/server v1 is:
+The remaining rollout order after blocking v1 is:
 
-1. blocking calls reusing the same registry and envelopes;
-2. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
+1. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
    `calcit.std`;
-3. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
-4. removal of the guarded Rust ABI fallback under issue #474.
+2. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
+3. removal of the guarded Rust ABI fallback under issue #474.
 
 See issue #482 for the full acceptance matrix and module rollout status.

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -198,6 +198,23 @@ and invalidates it after the attempt. Unresolved requests are rejected on
 timeout or when their owning task finishes; a queued request that times out is
 skipped without terminating the Server.
 
+## C-safe blocking callback ABI
+
+`&blocking-dylib-edn-fn` probes `<method>_calcit_ffi_blocking_v1`. This entry
+point reuses the async protocol version, generation task handle, lifecycle,
+sequence, and Cirru EDN payload rules, but invokes the Calcit callback directly
+on the host thread instead of waiting for the asynchronous queue to drain.
+Foreign-thread invocation is rejected.
+
+Callback results are allocated and tracked by the host and must be returned
+through the blocking host table's `free_buffer`; the method's final output is
+allocated by the module and released through `calcit_ffi_buffer_free`.
+`finish` may be called explicitly once, otherwise method return finishes the
+task implicitly. Missing per-method blocking symbols retain the guarded legacy
+fallback during migration. See
+[Asynchronous FFI task protocol](ffi-async-protocol.md#native-blocking-abi-v1)
+for the C signatures and ownership rules.
+
 ### Call in Calcit
 
 Rust code is compiled into dylibs, and then Calcit could call with:

--- a/editing-history/20260827-2250-ffi-blocking-protocol-v1.md
+++ b/editing-history/20260827-2250-ffi-blocking-protocol-v1.md
@@ -1,0 +1,52 @@
+# C-safe blocking FFI protocol v1
+
+## Goal
+
+Remove Rust closures, trait objects, `Vec<Edn>`, `Result`, and `FnOnce` from
+the supported `&blocking-dylib-edn-fn` boundary while preserving methods that
+must own and call back on the Calcit host thread.
+
+## Protocol decisions
+
+- use a distinct `<method>_calcit_ffi_blocking_v1` symbol so blocking and
+  asynchronous starts cannot be confused;
+- reuse `calcit_ffi_async_version() -> 1`, the generation task registry,
+  OneShot lifecycle, serial event sequence, task descriptor, status codes, and
+  Cirru EDN request encoding;
+- invoke the Calcit callback directly only on the task's owner thread instead
+  of enqueueing work that cannot drain while the dylib owns that thread;
+- let modules finish explicitly exactly once, with method return providing the
+  implicit finish when no explicit finish occurred;
+- keep callback result bytes host-owned and indexed by exact pointer/length;
+  modules release them through the task-bound host `free_buffer` function;
+- report foreign-thread access, callback failures, forged/duplicate frees, and
+  leaked host buffers even if the module ignores the returned status;
+- probe the migrated method before allocating runtime task state, preserving
+  the build-ID-guarded per-method Rust ABI fallback for unmigrated modules;
+- make legacy blocking task release exactly once on explicit finish or method
+  return, fixing the previous pending-task leak on error paths.
+
+## Tests
+
+- C-layout host table and versioned method name;
+- inline callback execution and host-owned EDN result;
+- exact buffer metadata and duplicate-free rejection;
+- owner-thread enforcement;
+- explicit finish exactly once and callback rejection after finish.
+
+## Native verification
+
+An optimized standalone C dylib was loaded by the debug Calcit host and
+verified both explicit and implicit finish. Separate methods confirmed that a
+foreign pthread callback, an unfreed callback buffer, and a Calcit callback
+error all fail deterministically and release the pending task.
+
+## Full verification
+
+- `cargo fmt -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test` (864 Rust tests)
+- `yarn compile`
+- `yarn check-agent-interface` (17/17)
+- `yarn check-all` (Calcit core 221/221, JS, IR, WASM and runtime benchmarks)
+- `bash scripts/check-docs-md.sh` (57 files, 325 blocks)

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -19,7 +19,7 @@ use calcit::{
   ffi_abi::{
     ASYNC_RESPONSE_REJECT, ASYNC_RESPONSE_RESOLVE, ASYNC_TASK_FLAG_REQUIRES_RESPONSE, ASYNC_TASK_FLAG_SERIAL_EVENTS, FfiAsyncEventKind,
     FfiAsyncHandle, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1, FfiAsyncResponseResolve, FfiAsyncTaskCancel,
-    FfiAsyncTaskDescriptor, async_status,
+    FfiAsyncTaskDescriptor, FfiBlockingHostV1, FfiBuffer, async_status,
   },
   ffi_async::{FfiAsyncDrainReport, FfiAsyncEventQueue, copy_async_payload},
   runner::track,
@@ -51,6 +51,14 @@ struct NativeAsyncTask {
   lib_name: String,
   method: String,
   control: Arc<Mutex<Option<NativeAsyncTaskControl>>>,
+  blocking: Option<NativeBlockingTask>,
+}
+
+#[derive(Clone)]
+struct NativeBlockingTask {
+  owner_thread: thread::ThreadId,
+  buffers: Arc<Mutex<HashMap<usize, Box<[u8]>>>>,
+  failures: Arc<Mutex<Vec<String>>>,
 }
 
 #[derive(Clone, Copy)]
@@ -261,6 +269,225 @@ fn async_host_table(task_handle: FfiAsyncHandle) -> FfiAsyncHostV1 {
     native_async_configure_task,
     native_async_open_response,
   )
+}
+
+fn blocking_host_table(task_handle: FfiAsyncHandle) -> FfiBlockingHostV1 {
+  FfiBlockingHostV1::new(
+    task_handle.raw(),
+    native_blocking_invoke,
+    native_blocking_finish,
+    native_blocking_free_buffer,
+  )
+}
+
+fn resolve_native_blocking_task(
+  runtime: &NativeAsyncRuntime,
+  context: u64,
+  task_handle: u64,
+) -> Result<(FfiAsyncHandle, NativeAsyncTask, NativeBlockingTask), i32> {
+  let handle = FfiAsyncHandle::from_raw(task_handle);
+  let task = match runtime.registry.clone_value(handle) {
+    Ok(NativeAsyncResource::Task(task)) => task,
+    Ok(NativeAsyncResource::Response(_)) => return Err(async_status::INVALID_HANDLE),
+    Err(error) => return Err(error.status_code()),
+  };
+  let Some(blocking) = task.blocking.clone() else {
+    return Err(async_status::INVALID_HANDLE);
+  };
+  if context != task_handle {
+    record_blocking_failure(&blocking, "blocking FFI host context does not own this task");
+    return Err(async_status::INVALID_HANDLE);
+  }
+  if blocking.owner_thread != thread::current().id() {
+    record_blocking_failure(&blocking, "blocking FFI callback was invoked from a foreign thread");
+    return Err(async_status::WRONG_THREAD);
+  }
+  Ok((handle, task, blocking))
+}
+
+fn record_blocking_failure(blocking: &NativeBlockingTask, message: impl Into<String>) {
+  if let Ok(mut failures) = blocking.failures.lock() {
+    failures.push(message.into());
+  }
+}
+
+fn store_blocking_host_buffer(blocking: &NativeBlockingTask, bytes: Vec<u8>, out: *mut FfiBuffer) -> Result<(), i32> {
+  if out.is_null() || bytes.is_empty() {
+    return Err(async_status::INVALID_PAYLOAD);
+  }
+  let mut bytes = bytes.into_boxed_slice();
+  let ptr = bytes.as_mut_ptr();
+  let len = bytes.len();
+  let key = ptr as usize;
+  let mut buffers = blocking.buffers.lock().map_err(|_| async_status::INTERNAL_ERROR)?;
+  if buffers.insert(key, bytes).is_some() {
+    return Err(async_status::INTERNAL_ERROR);
+  }
+  // SAFETY: the C caller provides a writable output descriptor for this
+  // synchronous host call. Ownership of the bytes remains in `buffers`.
+  unsafe { out.write(FfiBuffer { ptr, len, cap: len }) };
+  Ok(())
+}
+
+fn free_blocking_host_buffer(blocking: &NativeBlockingTask, buffer: FfiBuffer) -> Result<(), i32> {
+  if buffer.ptr.is_null() || buffer.len == 0 || buffer.cap != buffer.len {
+    return Err(async_status::INVALID_PAYLOAD);
+  }
+  let key = buffer.ptr as usize;
+  let mut buffers = blocking.buffers.lock().map_err(|_| async_status::INTERNAL_ERROR)?;
+  let Some(bytes) = buffers.remove(&key) else {
+    return Err(async_status::INVALID_PAYLOAD);
+  };
+  if bytes.len() != buffer.len {
+    buffers.insert(key, bytes);
+    return Err(async_status::INVALID_PAYLOAD);
+  }
+  Ok(())
+}
+
+unsafe extern "C" fn native_blocking_invoke(
+  context: u64,
+  task_handle: u64,
+  payload_ptr: *const u8,
+  payload_len: usize,
+  out: *mut FfiBuffer,
+) -> i32 {
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let runtime = match native_async_runtime() {
+      Ok(runtime) => runtime,
+      Err(_) => return async_status::HOST_CLOSING,
+    };
+    // SAFETY: forwarded from the C entry point's documented pointer contract.
+    unsafe { invoke_native_blocking(runtime, context, task_handle, payload_ptr, payload_len, out) }
+  }))
+  .unwrap_or(async_status::INTERNAL_ERROR)
+}
+
+unsafe fn invoke_native_blocking(
+  runtime: &NativeAsyncRuntime,
+  context: u64,
+  task_handle: u64,
+  payload_ptr: *const u8,
+  payload_len: usize,
+  out: *mut FfiBuffer,
+) -> i32 {
+  if out.is_null() {
+    return async_status::INVALID_PAYLOAD;
+  }
+  // SAFETY: validated non-null above; initialize before any fallible work so
+  // a rejected call never exposes uninitialized host memory.
+  unsafe { out.write(FfiBuffer::empty()) };
+  let (handle, task, blocking) = match resolve_native_blocking_task(runtime, context, task_handle) {
+    Ok(task) => task,
+    Err(status) => return status,
+  };
+  // SAFETY: the caller promises a readable payload for this synchronous call.
+  let payload = match unsafe { copy_async_payload(payload_ptr, payload_len) } {
+    Ok(payload) => payload,
+    Err(error) => {
+      record_blocking_failure(&blocking, error.to_string());
+      return error.status_code();
+    }
+  };
+  let args = match decode_async_emit(&payload) {
+    Ok(args) => args,
+    Err(error) => {
+      record_blocking_failure(&blocking, error);
+      return async_status::INVALID_PAYLOAD;
+    }
+  };
+  let sequence = match runtime.registry.next_event_sequence(handle) {
+    Ok(sequence) => sequence,
+    Err(error) => {
+      record_blocking_failure(&blocking, error.to_string());
+      return error.status_code();
+    }
+  };
+  let Calcit::Fn { info, .. } = &task.callback else {
+    return async_status::INVALID_HANDLE;
+  };
+  trace_ffi_event(
+    "blocking-callback-in-v1",
+    format!(
+      "lib={} symbol={} task={} sequence={} argc={}",
+      task.lib_name,
+      task.method,
+      handle.raw(),
+      sequence,
+      args.len()
+    ),
+  );
+  match runner::run_fn(&args, info, &task.stack) {
+    Ok(ret) => match encode_async_value(&ret) {
+      Ok(output) => match store_blocking_host_buffer(&blocking, output, out) {
+        Ok(()) => async_status::OK,
+        Err(status) => status,
+      },
+      Err(error) => {
+        let message = format!("failed to encode blocking callback result: {}", error.msg);
+        record_blocking_failure(&blocking, message.clone());
+        match store_blocking_host_buffer(&blocking, message.into_bytes(), out) {
+          Ok(()) => async_status::CALLBACK_ERROR,
+          Err(status) => status,
+        }
+      }
+    },
+    Err(error) => {
+      let _ = display_stack(
+        &format!("[Error] blocking FFI callback failed: {}", error.msg),
+        &error.stack,
+        error.location.as_ref(),
+      );
+      let message = format!("Calcit callback failed: {}", error.msg);
+      record_blocking_failure(&blocking, message.clone());
+      match store_blocking_host_buffer(&blocking, message.into_bytes(), out) {
+        Ok(()) => async_status::CALLBACK_ERROR,
+        Err(status) => status,
+      }
+    }
+  }
+}
+
+unsafe extern "C" fn native_blocking_finish(context: u64, task_handle: u64) -> i32 {
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let runtime = match native_async_runtime() {
+      Ok(runtime) => runtime,
+      Err(_) => return async_status::HOST_CLOSING,
+    };
+    let (handle, _, blocking) = match resolve_native_blocking_task(runtime, context, task_handle) {
+      Ok(task) => task,
+      Err(status) => return status,
+    };
+    match runtime.registry.finish(handle) {
+      Ok(()) => async_status::OK,
+      Err(error) => {
+        record_blocking_failure(&blocking, error.to_string());
+        error.status_code()
+      }
+    }
+  }))
+  .unwrap_or(async_status::INTERNAL_ERROR)
+}
+
+unsafe extern "C" fn native_blocking_free_buffer(context: u64, task_handle: u64, buffer: FfiBuffer) -> i32 {
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let runtime = match native_async_runtime() {
+      Ok(runtime) => runtime,
+      Err(_) => return async_status::HOST_CLOSING,
+    };
+    let (_, _, blocking) = match resolve_native_blocking_task(runtime, context, task_handle) {
+      Ok(task) => task,
+      Err(status) => return status,
+    };
+    match free_blocking_host_buffer(&blocking, buffer) {
+      Ok(()) => async_status::OK,
+      Err(status) => {
+        record_blocking_failure(&blocking, format!("blocking FFI rejected host buffer free with status {status}"));
+        status
+      }
+    }
+  }))
+  .unwrap_or(async_status::INTERNAL_ERROR)
 }
 
 unsafe extern "C" fn native_async_enqueue(
@@ -1265,6 +1492,7 @@ fn try_start_async_callback_v1(
     lib_name: lib_name.to_owned(),
     method: method.to_owned(),
     control: Arc::new(Mutex::new(None)),
+    blocking: None,
   };
   let handle = runtime
     .registry
@@ -1497,8 +1725,124 @@ pub fn call_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<
   Ok(Calcit::Unit)
 }
 
-/// pass callback function to FFI function, blocking the thread,
-/// used by calcit-paint, where main thread is required
+fn release_blocking_task(runtime: &NativeAsyncRuntime, handle: FfiAsyncHandle) -> Result<(usize, Vec<String>), String> {
+  match runtime.registry.state(handle).map_err(|error| error.to_string())?.lifecycle {
+    calcit::ffi_abi::FfiAsyncLifecycle::Active | calcit::ffi_abi::FfiAsyncLifecycle::Closing => {
+      runtime.registry.finish(handle).map_err(|error| error.to_string())?;
+    }
+    calcit::ffi_abi::FfiAsyncLifecycle::Finished => {}
+  }
+  let NativeAsyncResource::Task(task) = runtime.registry.release(handle).map_err(|error| error.to_string())? else {
+    return Err("blocking FFI handle released a response resource".to_owned());
+  };
+  let (leaked, failures) = match task.blocking {
+    Some(blocking) => {
+      let leaked = blocking
+        .buffers
+        .lock()
+        .map_err(|_| "blocking FFI host buffer lock is poisoned".to_owned())?
+        .len();
+      let failures = blocking
+        .failures
+        .lock()
+        .map_err(|_| "blocking FFI failure log lock is poisoned".to_owned())?
+        .clone();
+      (leaked, failures)
+    }
+    None => return Err("blocking FFI handle lost its blocking state".to_owned()),
+  };
+  track::track_task_release();
+  trace_ffi_event(
+    "blocking-task-release-v1",
+    format!(
+      "task={} leaked_buffers={leaked} pending={}",
+      handle.raw(),
+      track::count_pending_tasks()
+    ),
+  );
+  Ok((leaked, failures))
+}
+
+fn try_call_blocking_v1(
+  lib: &libloading::Library,
+  lib_name: &str,
+  method: &str,
+  args: Vec<Edn>,
+  callback: Calcit,
+  call_stack: &CallStackList,
+) -> Result<Option<Calcit>, CalcitErr> {
+  let runtime = native_async_runtime().map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  let task = NativeAsyncTask {
+    callback,
+    stack: Arc::new(call_stack.to_owned()),
+    lib_name: lib_name.to_owned(),
+    method: method.to_owned(),
+    control: Arc::new(Mutex::new(None)),
+    blocking: Some(NativeBlockingTask {
+      owner_thread: thread::current().id(),
+      buffers: Arc::new(Mutex::new(HashMap::new())),
+      failures: Arc::new(Mutex::new(vec![])),
+    }),
+  };
+  let handle = runtime
+    .registry
+    .register_with_flags(
+      FfiAsyncHandleKind::OneShot,
+      ASYNC_TASK_FLAG_SERIAL_EVENTS,
+      NativeAsyncResource::Task(task),
+    )
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
+  let descriptor = FfiAsyncTaskDescriptor::new(handle, FfiAsyncHandleKind::OneShot, ASYNC_TASK_FLAG_SERIAL_EVENTS);
+  let host = blocking_host_table(handle);
+  track::track_task_add();
+  trace_ffi_event(
+    "blocking-call-v1",
+    format!(
+      "lib={lib_name} symbol={} task={} argc={} pending={}",
+      calcit::ffi_abi::blocking_method_symbol(method),
+      handle.raw(),
+      args.len(),
+      track::count_pending_tasks()
+    ),
+  );
+
+  let outcome = calcit::ffi_abi::try_call_blocking(lib, lib_name, method, args, &descriptor, &host);
+  let (leaked, mut failures) = release_blocking_task(runtime, handle)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, format!("blocking task cleanup failed: {error}")))?;
+  let value = match outcome {
+    Ok(value) => value,
+    Err(error) => {
+      failures.insert(0, error);
+      None
+    }
+  };
+  if leaked > 0 {
+    failures.push(format!("leaked {leaked} host callback buffer(s)"));
+  }
+  if !failures.is_empty() {
+    return Err(CalcitErr::use_str(
+      CalcitErrKind::Unexpected,
+      format!("FFI blocking method `{method}` in `{lib_name}` failed: {}", failures.join("; ")),
+    ));
+  }
+  match value {
+    None => Ok(None),
+    Some(ret) => {
+      trace_ffi_event(
+        "blocking-return-v1",
+        format!(
+          "lib={lib_name} symbol={} ret={}",
+          calcit::ffi_abi::blocking_method_symbol(method),
+          format_edn_args_for_trace(std::slice::from_ref(&ret))
+        ),
+      );
+      Ok(Some(Calcit::Nil))
+    }
+  }
+}
+
+/// Pass a callback to a C-safe FFI method while the dylib owns the host
+/// thread. The guarded Rust ABI remains as a per-method migration fallback.
 pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if xs.len() < 3 {
     return CalcitErr::err_str(
@@ -1540,9 +1884,6 @@ pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Res
     );
   }
 
-  track::track_task_add();
-  trace_ffi_event("task-add", format!("kind=blocking pending={}", track::count_pending_tasks()));
-
   trace_ffi_event(
     "blocking-call",
     format!(
@@ -1553,8 +1894,24 @@ pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Res
     ),
   );
 
-  let lib = unsafe { libloading::Library::new(&lib_name) }
-    .map_err(|e| CalcitErr::use_str(CalcitErrKind::Unexpected, format!("failed to load dylib `{lib_name}`: {e}")))?;
+  let lib = load_dylib(&lib_name)?;
+  let has_blocking_v1 = calcit::ffi_abi::has_blocking_method(&lib, &lib_name, &method)
+    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
+  if has_blocking_v1 {
+    return try_call_blocking_v1(&lib, &lib_name, &method, ys.clone(), callback.clone(), call_stack)?.ok_or_else(|| {
+      CalcitErr::use_str(
+        CalcitErrKind::Unexpected,
+        format!("FFI blocking method `{method}` in `{lib_name}` disappeared after protocol lookup"),
+      )
+    });
+  }
+  trace_ffi_event(
+    "blocking-fallback",
+    format!(
+      "lib={lib_name} symbol={} fallback={method}",
+      calcit::ffi_abi::blocking_method_symbol(&method)
+    ),
+  );
   ensure_abi_compatible(&lib, &lib_name)?;
   let copied_stack = Arc::new(call_stack.to_owned());
   let callback_method = method.clone();
@@ -1566,7 +1923,11 @@ pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Res
       format!("failed to load FFI symbol `{method}` in `{lib_name}`: {e}"),
     )
   })?;
-  match func(
+  let released = Arc::new(AtomicBool::new(false));
+  let finish_released = Arc::clone(&released);
+  track::track_task_add();
+  trace_ffi_event("task-add", format!("kind=blocking-legacy pending={}", track::count_pending_tasks()));
+  let result = func(
     ys.to_owned(),
     Arc::new(move |ps: Vec<Edn>| -> Result<Edn, String> {
       trace_ffi_event(
@@ -1604,8 +1965,20 @@ pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Res
         Err(format!("expected last argument to be callback fn, got: {callback}"))
       }
     }),
-    Arc::new(track::track_task_release),
-  ) {
+    Arc::new(move || {
+      if !finish_released.swap(true, Ordering::AcqRel) {
+        track::track_task_release();
+      }
+    }),
+  );
+  if !released.swap(true, Ordering::AcqRel) {
+    track::track_task_release();
+    trace_ffi_event(
+      "task-release",
+      format!("kind=blocking-legacy implicit=true pending={}", track::count_pending_tasks()),
+    );
+  }
+  match result {
     Ok(ret) => {
       trace_ffi_event(
         "blocking-return",
@@ -1618,8 +1991,6 @@ pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Res
     }
     Err(e) => {
       trace_ffi_event("blocking-error", format!("lib={lib_name} symbol={method} {e}"));
-      // TODO for more accurate tracking, need to place tracker inside foreign function
-      // track::track_task_release();
       let _ = display_stack(&format!("failed to call request: {e}"), call_stack, None);
       return CalcitErr::err_str(CalcitErrKind::Unexpected, e);
     }
@@ -1682,6 +2053,7 @@ mod async_callback_tests {
       lib_name: "fixture".to_owned(),
       method: "server".to_owned(),
       control: Arc::new(Mutex::new(None)),
+      blocking: None,
     })
   }
 
@@ -1690,6 +2062,50 @@ mod async_callback_tests {
       registry: FfiAsyncHandleRegistry::new(),
       queue: FfiAsyncEventQueue::new(capacity).expect("create host queue"),
       responses: Mutex::new(NativeAsyncResponseIndex::default()),
+    }
+  }
+
+  fn blocking_test_task_with_callback(callback: Calcit) -> (NativeAsyncResource, NativeBlockingTask) {
+    let blocking = NativeBlockingTask {
+      owner_thread: thread::current().id(),
+      buffers: Arc::new(Mutex::new(HashMap::new())),
+      failures: Arc::new(Mutex::new(vec![])),
+    };
+    (
+      NativeAsyncResource::Task(NativeAsyncTask {
+        callback,
+        stack: Arc::new(CallStackList::default()),
+        lib_name: "fixture".to_owned(),
+        method: "blocking".to_owned(),
+        control: Arc::new(Mutex::new(None)),
+        blocking: Some(blocking.clone()),
+      }),
+      blocking,
+    )
+  }
+
+  fn blocking_test_task() -> (NativeAsyncResource, NativeBlockingTask) {
+    blocking_test_task_with_callback(Calcit::Nil)
+  }
+
+  fn constant_callback(value: &str) -> Calcit {
+    Calcit::Fn {
+      id: Arc::from("blocking-fixture-callback"),
+      info: Arc::new(calcit::calcit::CalcitFn {
+        name: Arc::from("blocking-fixture-callback"),
+        def_ns: Arc::from("tests.ffi"),
+        def_ref: None,
+        usage: calcit::calcit::CalcitFnUsageMeta::default(),
+        scope: Arc::new(calcit::calcit::CalcitScope::default()),
+        args: Arc::new(calcit::calcit::CalcitFnArgs::Args(vec![])),
+        call_shape: calcit::calcit::CalcitFnCallShape::fixed(0),
+        body: vec![Calcit::Str(Arc::from(value))],
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        return_type: calcit::calcit::DYNAMIC_TYPE.clone(),
+        arg_types: vec![],
+        rest_type: None,
+      }),
     }
   }
 
@@ -1711,6 +2127,108 @@ mod async_callback_tests {
       .insert(handle, response)
       .expect("index response");
     handle
+  }
+
+  #[test]
+  fn blocking_host_buffers_require_exact_metadata_and_free_once() {
+    let (_, blocking) = blocking_test_task();
+    let mut output = FfiBuffer::empty();
+    store_blocking_host_buffer(&blocking, b"|callback-result".to_vec(), &mut output).expect("store host buffer");
+    assert_eq!(blocking.buffers.lock().expect("host buffers").len(), 1);
+
+    let forged = FfiBuffer {
+      ptr: output.ptr,
+      len: output.len - 1,
+      cap: output.cap,
+    };
+    assert_eq!(free_blocking_host_buffer(&blocking, forged), Err(async_status::INVALID_PAYLOAD));
+    assert_eq!(blocking.buffers.lock().expect("host buffers").len(), 1);
+    assert_eq!(free_blocking_host_buffer(&blocking, output), Ok(()));
+    assert_eq!(free_blocking_host_buffer(&blocking, output), Err(async_status::INVALID_PAYLOAD));
+  }
+
+  #[test]
+  fn blocking_callback_runs_inline_and_returns_host_owned_edn() {
+    let runtime = test_runtime(4);
+    let (task, blocking) = blocking_test_task_with_callback(constant_callback("ok"));
+    let handle = runtime
+      .registry
+      .register_with_flags(FfiAsyncHandleKind::OneShot, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+      .expect("register blocking task");
+    let payload = b"[]";
+    let mut output = FfiBuffer::empty();
+    assert_eq!(
+      unsafe { invoke_native_blocking(&runtime, handle.raw(), handle.raw(), payload.as_ptr(), payload.len(), &mut output) },
+      async_status::OK
+    );
+    let output_bytes = unsafe { std::slice::from_raw_parts(output.ptr.cast_const(), output.len) };
+    let output_edn = cirru_edn::parse(std::str::from_utf8(output_bytes).expect("callback UTF-8")).expect("callback EDN");
+    assert_eq!(output_edn, Edn::str("ok"));
+    assert_eq!(free_blocking_host_buffer(&blocking, output), Ok(()));
+    assert_eq!(runtime.registry.state(handle).expect("blocking state").next_sequence, 2);
+
+    assert_eq!(runtime.registry.finish(handle), Ok(()));
+    let mut late_output = FfiBuffer::empty();
+    assert_eq!(
+      unsafe {
+        invoke_native_blocking(
+          &runtime,
+          handle.raw(),
+          handle.raw(),
+          payload.as_ptr(),
+          payload.len(),
+          &mut late_output,
+        )
+      },
+      async_status::HANDLE_FINISHED
+    );
+    assert!(late_output.ptr.is_null());
+    assert!(matches!(runtime.registry.release(handle), Ok(NativeAsyncResource::Task(_))));
+  }
+
+  #[test]
+  fn blocking_task_rejects_callback_dispatch_from_a_foreign_thread() {
+    let runtime = Arc::new(test_runtime(4));
+    let (task, blocking) = blocking_test_task();
+    let handle = runtime
+      .registry
+      .register_with_flags(FfiAsyncHandleKind::OneShot, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+      .expect("register blocking task");
+    assert!(resolve_native_blocking_task(&runtime, handle.raw(), handle.raw()).is_ok());
+
+    let foreign_runtime = Arc::clone(&runtime);
+    let status = thread::spawn(move || {
+      resolve_native_blocking_task(&foreign_runtime, handle.raw(), handle.raw())
+        .err()
+        .expect("foreign thread must fail")
+    })
+    .join()
+    .expect("foreign thread");
+    assert_eq!(status, async_status::WRONG_THREAD);
+    assert_eq!(
+      blocking.failures.lock().expect("blocking failures").as_slice(),
+      ["blocking FFI callback was invoked from a foreign thread"]
+    );
+  }
+
+  #[test]
+  fn blocking_explicit_finish_is_exactly_once_and_prevents_late_callbacks() {
+    let runtime = test_runtime(4);
+    let (task, _) = blocking_test_task();
+    let handle = runtime
+      .registry
+      .register_with_flags(FfiAsyncHandleKind::OneShot, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+      .expect("register blocking task");
+    assert_eq!(runtime.registry.finish(handle), Ok(()));
+    assert_eq!(
+      runtime.registry.finish(handle),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::HandleFinished)
+    );
+    assert_eq!(
+      runtime.registry.next_event_sequence(handle),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::HandleFinished)
+    );
+    assert!(matches!(runtime.registry.release(handle), Ok(NativeAsyncResource::Task(_))));
   }
 
   #[test]

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -21,6 +21,7 @@ const MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
 pub const ASYNC_PROTOCOL_VERSION: u32 = 1;
 pub const ASYNC_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_async_version";
 pub const ASYNC_METHOD_SUFFIX: &str = "_calcit_ffi_async_v1";
+pub const BLOCKING_METHOD_SUFFIX: &str = "_calcit_ffi_blocking_v1";
 
 pub const ASYNC_TASK_FLAG_SERIAL_EVENTS: u32 = 1 << 0;
 pub const ASYNC_TASK_FLAG_COALESCE_ALLOWED: u32 = 1 << 1;
@@ -58,6 +59,10 @@ pub type FfiAsyncHostOpenResponse = unsafe extern "C" fn(
   resolve: Option<FfiAsyncResponseResolve>,
   out_handle: *mut u64,
 ) -> i32;
+pub type FfiBlockingHostInvoke =
+  unsafe extern "C" fn(context: u64, task_handle: u64, payload_ptr: *const u8, payload_len: usize, out: *mut FfiBuffer) -> i32;
+pub type FfiBlockingHostFinish = unsafe extern "C" fn(context: u64, task_handle: u64) -> i32;
+pub type FfiBlockingHostFreeBuffer = unsafe extern "C" fn(context: u64, task_handle: u64, buffer: FfiBuffer) -> i32;
 
 pub const ASYNC_RESPONSE_RESOLVE: u32 = 1;
 pub const ASYNC_RESPONSE_REJECT: u32 = 2;
@@ -94,6 +99,39 @@ impl FfiAsyncHostV1 {
   }
 }
 
+/// Host operations available while a C-safe blocking method owns the CLI
+/// thread. `invoke` executes the Calcit callback synchronously and is accepted
+/// only from the thread that registered the task. Callback output remains
+/// host-owned until the module calls `free_buffer`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FfiBlockingHostV1 {
+  pub protocol_version: u32,
+  pub struct_size: u32,
+  pub context: u64,
+  pub invoke: Option<FfiBlockingHostInvoke>,
+  pub finish: Option<FfiBlockingHostFinish>,
+  pub free_buffer: Option<FfiBlockingHostFreeBuffer>,
+}
+
+impl FfiBlockingHostV1 {
+  pub fn new(
+    context: u64,
+    invoke: FfiBlockingHostInvoke,
+    finish: FfiBlockingHostFinish,
+    free_buffer: FfiBlockingHostFreeBuffer,
+  ) -> Self {
+    Self {
+      protocol_version: ASYNC_PROTOCOL_VERSION,
+      struct_size: std::mem::size_of::<Self>() as u32,
+      context,
+      invoke: Some(invoke),
+      finish: Some(finish),
+      free_buffer: Some(free_buffer),
+    }
+  }
+}
+
 /// Stable status values returned by C-safe async host functions. Keep these
 /// as integer constants rather than an FFI enum so foreign callers cannot
 /// construct an invalid Rust discriminant.
@@ -108,6 +146,8 @@ pub mod async_status {
   pub const QUEUE_FULL: i32 = 7;
   pub const INVALID_PAYLOAD: i32 = 8;
   pub const INTERNAL_ERROR: i32 = 9;
+  pub const CALLBACK_ERROR: i32 = 10;
+  pub const WRONG_THREAD: i32 = 11;
 }
 
 /// Semantic role of a host-owned handle. Values are fixed for C and future
@@ -687,7 +727,7 @@ pub struct FfiBuffer {
 }
 
 impl FfiBuffer {
-  fn empty() -> Self {
+  pub fn empty() -> Self {
     Self {
       ptr: ptr::null_mut(),
       len: 0,
@@ -706,6 +746,13 @@ pub type FfiAsyncStart = unsafe extern "C" fn(
   task: *const FfiAsyncTaskDescriptor,
   host: *const FfiAsyncHostV1,
 ) -> i32;
+pub type FfiBlockingCall = unsafe extern "C" fn(
+  request_ptr: *const u8,
+  request_len: usize,
+  task: *const FfiAsyncTaskDescriptor,
+  host: *const FfiBlockingHostV1,
+  output: *mut FfiBuffer,
+) -> i32;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum FfiBuildCompatibility {
@@ -719,6 +766,34 @@ fn buffer_method_symbol(method: &str) -> String {
 
 pub fn async_method_symbol(method: &str) -> String {
   format!("{method}{ASYNC_METHOD_SUFFIX}")
+}
+
+pub fn blocking_method_symbol(method: &str) -> String {
+  format!("{method}{BLOCKING_METHOD_SUFFIX}")
+}
+
+/// Check whether one blocking method has completed the C-safe migration before
+/// allocating host task state. An advertised incompatible protocol or a
+/// migrated method without its matching module-side free function is a hard
+/// error; an absent version/method retains transitional fallback.
+pub fn has_blocking_method(lib: &libloading::Library, lib_name: &str, method: &str) -> Result<bool, String> {
+  let version: libloading::Symbol<FfiAsyncVersion> = match unsafe { lib.get(ASYNC_PROTOCOL_VERSION_SYMBOL) } {
+    Ok(version) => version,
+    Err(_) => return Ok(false),
+  };
+  let current_version = unsafe { version() };
+  if current_version != ASYNC_PROTOCOL_VERSION {
+    return Err(format!(
+      "FFI async protocol mismatch in `{lib_name}`: dylib={current_version}, host={ASYNC_PROTOCOL_VERSION}"
+    ));
+  }
+  let symbol = blocking_method_symbol(method);
+  if unsafe { lib.get::<FfiBlockingCall>(symbol.as_bytes()) }.is_err() {
+    return Ok(false);
+  }
+  unsafe { lib.get::<FfiBufferFree>(BUFFER_FREE_SYMBOL) }
+    .map_err(|error| format!("FFI blocking method `{symbol}` in `{lib_name}` is missing `calcit_ffi_buffer_free`: {error}"))?;
+  Ok(true)
 }
 
 pub fn encode_buffer_request(args: Vec<Edn>) -> Result<Vec<u8>, String> {
@@ -751,6 +826,43 @@ pub fn lookup_async_start<'lib>(
     Ok(start) => Ok(Some(start)),
     Err(_) => Ok(None),
   }
+}
+
+/// Probe and invoke a C-safe blocking callback method. It shares the async
+/// protocol version and task descriptor while using a distinct method symbol,
+/// so blocking and asynchronous entry points cannot be confused. Missing
+/// protocol or method symbols retain the guarded per-method fallback.
+pub fn try_call_blocking(
+  lib: &libloading::Library,
+  lib_name: &str,
+  method: &str,
+  args: Vec<Edn>,
+  task: &FfiAsyncTaskDescriptor,
+  host: &FfiBlockingHostV1,
+) -> Result<Option<Edn>, String> {
+  let version: libloading::Symbol<FfiAsyncVersion> = match unsafe { lib.get(ASYNC_PROTOCOL_VERSION_SYMBOL) } {
+    Ok(version) => version,
+    Err(_) => return Ok(None),
+  };
+  let current_version = unsafe { version() };
+  if current_version != ASYNC_PROTOCOL_VERSION {
+    return Err(format!(
+      "FFI async protocol mismatch in `{lib_name}`: dylib={current_version}, host={ASYNC_PROTOCOL_VERSION}"
+    ));
+  }
+
+  let symbol = blocking_method_symbol(method);
+  let call: libloading::Symbol<FfiBlockingCall> = match unsafe { lib.get(symbol.as_bytes()) } {
+    Ok(call) => call,
+    Err(_) => return Ok(None),
+  };
+  let free: libloading::Symbol<FfiBufferFree> = unsafe { lib.get(BUFFER_FREE_SYMBOL) }
+    .map_err(|error| format!("FFI blocking method `{symbol}` in `{lib_name}` is missing `calcit_ffi_buffer_free`: {error}"))?;
+  let request = encode_buffer_request(args)?;
+  let mut output = FfiBuffer::empty();
+  let status = unsafe { call(request.as_ptr(), request.len(), task, host, &mut output) };
+  let output = unsafe { copy_and_free_buffer(output, &free, lib_name, &symbol) }?;
+  decode_buffer_response(status, output, lib_name, &symbol).map(Some)
 }
 
 fn decode_buffer_response(status: i32, output: Vec<u8>, lib_name: &str, symbol: &str) -> Result<Edn, String> {
@@ -877,8 +989,8 @@ mod tests {
     ASYNC_EVENT_FLAG_COALESCED, ASYNC_PROTOCOL_VERSION, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
     ASYNC_TASK_FLAG_SERIAL_EVENTS, BUFFER_PROTOCOL_VERSION, FfiAsyncEventDescriptor, FfiAsyncEventKind, FfiAsyncHandle,
     FfiAsyncHandleError, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1, FfiAsyncLifecycle, FfiAsyncTaskDescriptor,
-    FfiBuildCompatibility, async_method_symbol, async_status, buffer_method_symbol, decode_buffer_response, encode_buffer_request,
-    validate_build_id,
+    FfiBlockingHostV1, FfiBuffer, FfiBuildCompatibility, async_method_symbol, async_status, blocking_method_symbol,
+    buffer_method_symbol, decode_buffer_response, encode_buffer_request, validate_build_id,
   };
   use cirru_edn::Edn;
 
@@ -921,6 +1033,24 @@ mod tests {
     async_status::OK
   }
 
+  unsafe extern "C" fn test_blocking_invoke(
+    _context: u64,
+    _task_handle: u64,
+    _payload_ptr: *const u8,
+    _payload_len: usize,
+    _out: *mut FfiBuffer,
+  ) -> i32 {
+    async_status::OK
+  }
+
+  unsafe extern "C" fn test_blocking_finish(_context: u64, _task_handle: u64) -> i32 {
+    async_status::OK
+  }
+
+  unsafe extern "C" fn test_blocking_free(_context: u64, _task_handle: u64, _buffer: FfiBuffer) -> i32 {
+    async_status::OK
+  }
+
   #[test]
   fn async_host_table_and_method_names_are_c_stable() {
     let host = FfiAsyncHostV1::new(42, test_enqueue, test_configure, test_open_response);
@@ -931,6 +1061,18 @@ mod tests {
     assert!(host.enqueue.is_some());
     assert!(host.configure_task.is_some());
     assert!(host.open_response.is_some());
+  }
+
+  #[test]
+  fn blocking_host_table_and_method_names_are_c_stable() {
+    let host = FfiBlockingHostV1::new(42, test_blocking_invoke, test_blocking_finish, test_blocking_free);
+    assert_eq!(blocking_method_symbol("read_lines"), "read_lines_calcit_ffi_blocking_v1");
+    assert_eq!(host.protocol_version, ASYNC_PROTOCOL_VERSION);
+    assert_eq!(host.struct_size as usize, std::mem::size_of::<FfiBlockingHostV1>());
+    assert_eq!(host.context, 42);
+    assert!(host.invoke.is_some());
+    assert!(host.finish.is_some());
+    assert!(host.free_buffer.is_some());
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add the C-safe `<method>_calcit_ffi_blocking_v1` entry point and task-bound blocking host table
- reuse async protocol v1 handles, lifecycle, sequencing, status codes, and Cirru EDN buffers without crossing Rust closures or containers
- execute blocking callbacks synchronously only on the owner host thread, with explicit or implicit exactly-once finish
- track host-owned callback buffers and surface callback, thread, forged-free, and leak failures even when a module ignores the host status
- retain per-method build-ID-guarded Rust ABI fallback and make legacy task release exactly once

Advances #482 Phase 5. Module rollout remains a separate phase.

## Ownership and scheduling

- module final output is module-owned and released with `calcit_ffi_buffer_free`
- callback output is host-owned and released only through the blocking host table's `free_buffer`
- callbacks from foreign threads return `WRONG_THREAD`; long-lived and cross-thread work continues to use async callback v1
- method return implicitly finishes an active task; an explicit `finish` is accepted once and rejects later callbacks

## Verification

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 864 tests
- `yarn compile`
- `yarn check-agent-interface` — 17/17
- `yarn check-all` — core 221/221 plus JS, IR, WASM and benchmarks
- `bash scripts/check-docs-md.sh` — 57 files, 325 blocks
- optimized C dylib loaded by debug Calcit: explicit/implicit finish succeed; callback error, foreign-thread invoke, and leaked callback buffer fail deterministically
