### PR TITLE
feat: C-safe 不透明资源协议 / C-safe opaque-resource protocol

### DIFF
--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -155,6 +155,12 @@ Protocol rules:
 
 `calcit-lang/calcit_wasmtime` contains the first complete synchronous adapter.
 
+Methods that create reusable native objects use the C-safe
+[opaque resource protocol](ffi-resource-protocol.md). The host turns reserved
+buffer-v1 tokens into automatically released Calcit `AnyRef` values, validates
+module ownership on later calls, and pins the creating dylib until the final
+reference is dropped.
+
 ## C-safe asynchronous callback ABI
 
 `&call-dylib-edn-fn` now probes `<method>_calcit_ffi_async_v1` before using the

--- a/docs/installation/ffi-resource-protocol.md
+++ b/docs/installation/ffi-resource-protocol.md
@@ -1,0 +1,105 @@
+---
+title: "FFI opaque resource protocol / FFI 不透明资源协议"
+scope: "core"
+kind: "reference"
+category: "installation"
+aliases:
+  - "ffi resource"
+  - "opaque resource"
+---
+
+# FFI opaque resource protocol / FFI 不透明资源协议
+
+## 中文
+
+同步 buffer v1 只传递 Cirru EDN 字节，普通 `AnyRef` 不能跨动态库边界。resource v1 在不暴露 Rust layout、trait object、allocator ownership 或裸对象地址的前提下，让模块返回带自动析构语义的 native 对象。编译后的正则表达式是首个使用场景。
+
+### 模块导出
+
+使用 resource v1 的动态库必须在同步 buffer v1 导出之外提供：
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn calcit_ffi_resource_version() -> u32 { 1 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn calcit_ffi_resource_release_v1(
+  handle: u64,
+  generation: u64,
+) -> i32 {
+  // 0 表示释放成功；非 0 是可诊断的模块状态码。
+  0
+}
+```
+
+创建资源的方法仍返回普通 buffer v1 Cirru EDN。资源位置使用保留结构：
+
+```cirru-edn
+%{} 'CalcitFfiResourceV1 (:token $ buf 01 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00)
+```
+
+`:token` 必须是恰好 16 字节的 buffer：前 8 字节是 little-endian `u64` handle，后 8 字节是 little-endian `u64` generation；两者都必须非零。该结构可以嵌套在 list、set、map、enum、struct 或 atom 中。
+
+### 生命周期与所有权
+
+- 模块拥有 registry 中的 native 对象，宿主只保存 `(module, handle, generation)`。
+- Calcit 将返回 token 转换为宿主管理的 `AnyRef`，并在资源存活期间固定创建它的 dylib。
+- Calcit 值的 clone 只共享宿主引用，不调用模块 retain；最后一个宿主引用析构时 exactly-once 调用 `calcit_ffi_resource_release_v1`。
+- `release` 可能在任意宿主线程执行，模块实现必须线程安全、不得 panic 或跨 FFI unwind。
+- 模块必须用 generation 拒绝 stale handle，并确定性处理未知或重复释放的 token。
+- 只有创建资源的同一个模块可以接收该资源参数。宿主在调用前拒绝 wrong-module、普通 AnyRef 和用户直接构造的保留 token。
+- 普通 Cirru EDN 格式化不会序列化资源；仅同模块的 buffer v1 adapter 会临时还原 token。
+- `calcit --trace-ffi` 会记录 `resource-create` 与 `resource-release` 的模块、handle、generation 和 release 状态，不记录对象内容。
+
+不需要也不应向 Calcit 用户暴露手动 `drop`。模块 registry 可以在 dylib shutdown 时报告剩余槽位，但正常资源释放由宿主引用计数驱动。
+
+### 模块 registry 建议
+
+registry 应放在同步锁之后，并为每个槽位维护 generation。复用空槽位时递增 generation；generation 溢出时永久退役该槽位。每次方法调用和 release 都同时校验 handle 与 generation。不要把 Rust 对象地址编码成 handle，也不要让 `Vec`、`Arc`、`Box` 或 `Result` 穿过 C ABI。
+
+## English
+
+Synchronous buffer v1 transports only Cirru EDN bytes, so an ordinary `AnyRef` cannot cross a dylib boundary. Resource v1 lets a module return native objects with automatic destruction without exposing Rust layouts, trait objects, allocator ownership, or raw object addresses. Compiled regular expressions are the first adopter.
+
+### Module exports
+
+A resource-v1 dylib exports these symbols in addition to synchronous buffer v1:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn calcit_ffi_resource_version() -> u32 { 1 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn calcit_ffi_resource_release_v1(
+  handle: u64,
+  generation: u64,
+) -> i32 {
+  // 0 means released; nonzero values are diagnosable module status codes.
+  0
+}
+```
+
+A resource-creating method still returns ordinary buffer-v1 Cirru EDN. A resource position uses this reserved struct:
+
+```cirru-edn
+%{} 'CalcitFfiResourceV1 (:token $ buf 01 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00)
+```
+
+`:token` must be exactly 16 bytes: a little-endian `u64` handle followed by a little-endian `u64` generation. Both must be nonzero. The struct may be nested in lists, sets, maps, enums, structs, or atoms.
+
+### Lifecycle and ownership
+
+- The module owns native objects in its registry; the host stores only `(module, handle, generation)`.
+- Calcit converts a returned token into a host-managed `AnyRef` and pins its creating dylib while the resource is alive.
+- Cloning a Calcit value shares the host reference and does not call a module retain function. Dropping the final host reference calls `calcit_ffi_resource_release_v1` exactly once.
+- `release` may run on any host thread. It must be thread-safe and must not panic or unwind across FFI.
+- The module validates generation on every call, rejects stale handles, and handles unknown or duplicate releases deterministically.
+- Only the creating module may receive the resource as an argument. Before invocation, the host rejects wrong-module resources, ordinary AnyRefs, and directly forged reserved tokens.
+- Ordinary Cirru EDN formatting never serializes a resource. Only the matching module's buffer-v1 adapter temporarily restores its token.
+- `calcit --trace-ffi` records module, handle, generation, and release status for `resource-create` and `resource-release` events without logging object contents.
+
+Calcit users neither need nor receive a manual `drop` API. A module may diagnose remaining registry slots during dylib shutdown, while normal release follows host reference ownership.
+
+### Recommended module registry
+
+Protect the registry with a synchronization primitive and keep a generation for every slot. Increment generation when reusing an empty slot; permanently retire a slot if its generation would overflow. Validate both handle and generation on every method call and release. Do not encode Rust object addresses as handles, and never pass `Vec`, `Arc`, `Box`, or `Result` through the C ABI.

--- a/docs/installation/ffi-resource-protocol.md
+++ b/docs/installation/ffi-resource-protocol.md
@@ -44,7 +44,7 @@ pub extern "C" fn calcit_ffi_resource_release_v1(
 
 - 模块拥有 registry 中的 native 对象，宿主只保存 `(module, handle, generation)`。
 - Calcit 将返回 token 转换为宿主管理的 `AnyRef`，并在资源存活期间固定创建它的 dylib。
-- Calcit 值的 clone 只共享宿主引用，不调用模块 retain；最后一个宿主引用析构时 exactly-once 调用 `calcit_ffi_resource_release_v1`。
+- Calcit 会按 `(module, handle, generation)` 复用同一宿主 lease；无论 token 在同一或不同响应中出现多少次，clone/alias 都不调用模块 retain，最后一个宿主引用析构时才 exactly-once 调用 `calcit_ffi_resource_release_v1`。
 - `release` 可能在任意宿主线程执行，模块实现必须线程安全、不得 panic 或跨 FFI unwind。
 - 模块必须用 generation 拒绝 stale handle，并确定性处理未知或重复释放的 token。
 - 只有创建资源的同一个模块可以接收该资源参数。宿主在调用前拒绝 wrong-module、普通 AnyRef 和用户直接构造的保留 token。
@@ -91,7 +91,7 @@ A resource-creating method still returns ordinary buffer-v1 Cirru EDN. A resourc
 
 - The module owns native objects in its registry; the host stores only `(module, handle, generation)`.
 - Calcit converts a returned token into a host-managed `AnyRef` and pins its creating dylib while the resource is alive.
-- Cloning a Calcit value shares the host reference and does not call a module retain function. Dropping the final host reference calls `calcit_ffi_resource_release_v1` exactly once.
+- Calcit interns one host lease per `(module, handle, generation)`. No matter how often a token appears within or across responses, clones and aliases do not call a module retain function; dropping the final host reference calls `calcit_ffi_resource_release_v1` exactly once.
 - `release` may run on any host thread. It must be thread-safe and must not panic or unwind across FFI.
 - The module validates generation on every call, rejects stale handles, and handles unknown or duplicate releases deterministically.
 - Only the creating module may receive the resource as an argument. Before invocation, the host rejects wrong-module resources, ordinary AnyRefs, and directly forged reserved tokens.

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -71,6 +71,8 @@ calcit calcit.cirru
 
 三步缺一不可：构建 → 复制产物 → 运行验证。如果只更新了 `target/release/` 而未复制到 `dylibs/`，运行时仍会加载旧库。
 
+若模块返回编译后的正则等可复用 native 对象，不要继续跨 dylib 传递 Rust `AnyRef`，也不要改成用户手动释放的整数句柄。按照 [FFI opaque resource protocol / FFI 不透明资源协议](./ffi-resource-protocol.md) 使用 buffer v1 token、generation registry 和自动 release。
+
 Calcit 与 dylib 必须使用同一 rustc 工具链。先运行 `calcit --ffi-build-id` 查看 host identity。若项目提供 `rust-toolchain.toml`，应固定到发布 Calcit 所报告的 compiler identity；本地从源码构建 Calcit 时，则用同一个 toolchain 构建 dylib。debug Calcit 会在缺少 build identity 时直接拒绝旧模块；release Calcit 在迁移期仍会接受，但会输出兼容性警告。
 
 ### 4. 提交、打标签并推送

--- a/editing-history/20260828-0312-c-safe-opaque-resource-v1.md
+++ b/editing-history/20260828-0312-c-safe-opaque-resource-v1.md
@@ -1,0 +1,8 @@
+# C-safe opaque resource v1
+
+- 在同步 buffer v1 上增加保留的 `CalcitFfiResourceV1` token，以 little-endian `u64` handle 和 generation 表示模块资源。
+- 宿主将 token 水合为自动生命周期的 `AnyRef`，固定创建资源的 dylib，并在最后一个引用释放时 exactly-once 调用模块 C ABI release。
+- 调用前递归校验资源归属；拒绝 wrong-module、普通 AnyRef、伪造 token 和畸形 token。
+- 覆盖嵌套资源、并发 clone/drop、错误边界和协议格式测试，并为 `--trace-ffi` 增加资源创建与释放事件。
+- 新增中英双语协议文档，并从 FFI bindings 与升级手册链接。
+

--- a/editing-history/20260828-0327-intern-ffi-resource-leases.md
+++ b/editing-history/20260828-0327-intern-ffi-resource-leases.md
@@ -1,0 +1,7 @@
+# Intern FFI resource leases
+
+- 根据 review 修复重复 resource token 产生独立 lease、提前释放和重复释放的问题。
+- 宿主按 `(module, handle, generation)` 保存 weak intern entry；同一响应及跨响应 alias 复用同一 lease。
+- 最后一个强引用析构后 exactly-once release，并清理失效的 weak entry。
+- 增加同响应重复 token 与跨响应重复 token 的回归测试，并同步协议文档。
+

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -239,6 +239,13 @@ fn trace_ffi_event(label: &str, message: impl AsRef<str>) {
   }
 }
 
+fn trace_ffi_resource_event(label: &str, lib_name: &str, handle: u64, generation: u64, status: i32) {
+  trace_ffi_event(
+    label,
+    format!("lib={lib_name} handle={handle} generation={generation} status={status}"),
+  );
+}
+
 /// Bind the async queue to the CLI worker thread before any dylib can publish
 /// work. Tests that only inject proc metadata do not initialize global runtime
 /// state and therefore cannot accidentally claim host-thread ownership.
@@ -1401,7 +1408,7 @@ pub fn call_dylib_edn(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Ca
   );
 
   let lib = load_dylib(&lib_name)?;
-  match calcit::ffi_abi::try_call_buffer(&lib, &lib_name, &method, ys.clone())
+  match calcit::ffi_abi::try_call_buffer(&lib, &lib_name, &method, ys.clone(), Some(trace_ffi_resource_event))
     .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?
   {
     Some(ret) => {

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::ffi::{CStr, c_char};
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, Weak};
 use std::{ptr, slice};
 
 use cirru_edn::{Edn, EdnAnyRef, EdnEnumView, EdnListView, EdnMapView, EdnSetView, EdnStructView};
@@ -776,6 +777,16 @@ struct NativeFfiResourceLease {
   _library: Option<Arc<libloading::Library>>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct FfiResourceKey {
+  lib_name: Arc<str>,
+  handle: u64,
+  generation: u64,
+}
+
+static RESOURCE_LEASES: LazyLock<Mutex<HashMap<FfiResourceKey, Weak<NativeFfiResourceLease>>>> =
+  LazyLock::new(|| Mutex::new(HashMap::new()));
+
 impl fmt::Debug for NativeFfiResourceLease {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("NativeFfiResourceLease")
@@ -788,12 +799,23 @@ impl fmt::Debug for NativeFfiResourceLease {
 
 impl Drop for NativeFfiResourceLease {
   fn drop(&mut self) {
+    let key = FfiResourceKey {
+      lib_name: self.lib_name.clone(),
+      handle: self.handle,
+      generation: self.generation,
+    };
+    let leases = RESOURCE_LEASES.lock();
     // SAFETY: the function pointer belongs to `_library`, which is dropped
     // after this method returns. Resource v1 requires release to accept any
     // token and report stale/duplicate values through its status code.
     let status = unsafe { (self.release)(self.handle, self.generation) };
     if let Some(trace) = self.trace {
       trace("resource-release", &self.lib_name, self.handle, self.generation, status);
+    }
+    if let Ok(mut leases) = leases
+      && leases.get(&key).is_some_and(|lease| lease.upgrade().is_none())
+    {
+      leases.remove(&key);
     }
     if status != 0 {
       eprintln!(
@@ -822,6 +844,34 @@ struct FfiResourceAdapter {
   release: FfiResourceRelease,
   trace: Option<FfiResourceTrace>,
   library: Option<Arc<libloading::Library>>,
+}
+
+fn intern_resource_lease(adapter: &FfiResourceAdapter, handle: u64, generation: u64) -> Result<Arc<NativeFfiResourceLease>, String> {
+  let key = FfiResourceKey {
+    lib_name: adapter.lib_name.clone(),
+    handle,
+    generation,
+  };
+  let mut leases = RESOURCE_LEASES
+    .lock()
+    .map_err(|_| "failed to lock the FFI resource lease registry".to_owned())?;
+  if let Some(lease) = leases.get(&key).and_then(Weak::upgrade) {
+    return Ok(lease);
+  }
+
+  let lease = Arc::new(NativeFfiResourceLease {
+    lib_name: adapter.lib_name.clone(),
+    handle,
+    generation,
+    release: adapter.release,
+    trace: adapter.trace,
+    _library: adapter.library.clone(),
+  });
+  leases.insert(key, Arc::downgrade(&lease));
+  if let Some(trace) = adapter.trace {
+    trace("resource-create", &adapter.lib_name, handle, generation, 0);
+  }
+  Ok(lease)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -992,18 +1042,8 @@ fn hydrate_resource_tokens(value: Edn, adapter: &FfiResourceAdapter) -> Result<E
   match value {
     Edn::Struct(resource) if resource.name.as_ref() == RESOURCE_TOKEN_STRUCT => {
       let (handle, generation) = decode_resource_token(&resource)?;
-      if let Some(trace) = adapter.trace {
-        trace("resource-create", &adapter.lib_name, handle, generation, 0);
-      }
       Ok(Edn::AnyRef(EdnAnyRef::new(NativeFfiResource {
-        lease: Arc::new(NativeFfiResourceLease {
-          lib_name: adapter.lib_name.clone(),
-          handle,
-          generation,
-          release: adapter.release,
-          trace: adapter.trace,
-          _library: adapter.library.clone(),
-        }),
+        lease: intern_resource_lease(adapter, handle, generation)?,
       })))
     }
     Edn::List(EdnListView(xs)) => Ok(Edn::List(EdnListView(
@@ -1430,6 +1470,27 @@ mod tests {
     });
     assert_eq!(RESOURCE_RELEASES.load(Ordering::SeqCst), 0);
     drop(resource);
+    assert_eq!(RESOURCE_RELEASES.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn duplicate_tokens_share_one_lease_within_and_across_responses() {
+    let _guard = RESOURCE_TEST_LOCK.lock().expect("resource test lock");
+    RESOURCE_RELEASES.store(0, Ordering::SeqCst);
+    let token = encode_resource_token(29, 5);
+    let hydrated = hydrate_resource_tokens(Edn::List(EdnListView(vec![token.clone(), token.clone()])), &test_resource_adapter())
+      .expect("hydrate duplicate tokens");
+    let Edn::List(EdnListView(mut aliases)) = hydrated else {
+      panic!("duplicate response should stay a list")
+    };
+    let first = aliases.pop().expect("first alias");
+    let second = aliases.pop().expect("second alias");
+    let across_response = hydrate_resource_tokens(token, &test_resource_adapter()).expect("hydrate across response");
+
+    drop(first);
+    drop(second);
+    assert_eq!(RESOURCE_RELEASES.load(Ordering::SeqCst), 0);
+    drop(across_response);
     assert_eq!(RESOURCE_RELEASES.load(Ordering::SeqCst), 1);
   }
 

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -1,9 +1,9 @@
 use std::ffi::{CStr, c_char};
 use std::fmt;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::{ptr, slice};
 
-use cirru_edn::{Edn, EdnListView};
+use cirru_edn::{Edn, EdnAnyRef, EdnEnumView, EdnListView, EdnMapView, EdnSetView, EdnStructView};
 
 pub const BUILD_ID_SYMBOL: &[u8] = b"calcit_ffi_build_id";
 
@@ -14,6 +14,13 @@ pub const BUFFER_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_buffer_version";
 pub const BUFFER_FREE_SYMBOL: &[u8] = b"calcit_ffi_buffer_free";
 const BUFFER_METHOD_SUFFIX: &str = "_calcit_ffi_v1";
 const MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
+
+pub const RESOURCE_PROTOCOL_VERSION: u32 = 1;
+pub const RESOURCE_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_resource_version";
+pub const RESOURCE_RELEASE_SYMBOL: &[u8] = b"calcit_ffi_resource_release_v1";
+pub const RESOURCE_TOKEN_STRUCT: &str = "CalcitFfiResourceV1";
+const RESOURCE_TOKEN_FIELD: &str = "token";
+const RESOURCE_TOKEN_BYTES: usize = 16;
 
 /// Version of the transport-neutral asynchronous task semantics. Native C ABI
 /// adapters and future WASM adapters must preserve the same handle lifecycle,
@@ -739,6 +746,9 @@ impl FfiBuffer {
 type FfiBufferVersion = unsafe extern "C" fn() -> u32;
 type FfiBufferFree = unsafe extern "C" fn(FfiBuffer);
 type FfiBufferCall = unsafe extern "C" fn(*const u8, usize, *mut FfiBuffer) -> i32;
+type FfiResourceVersion = unsafe extern "C" fn() -> u32;
+type FfiResourceRelease = unsafe extern "C" fn(u64, u64) -> i32;
+pub type FfiResourceTrace = fn(&str, &str, u64, u64, i32);
 type FfiAsyncVersion = unsafe extern "C" fn() -> u32;
 pub type FfiAsyncStart = unsafe extern "C" fn(
   request_ptr: *const u8,
@@ -753,6 +763,66 @@ pub type FfiBlockingCall = unsafe extern "C" fn(
   host: *const FfiBlockingHostV1,
   output: *mut FfiBuffer,
 ) -> i32;
+
+struct NativeFfiResourceLease {
+  lib_name: Arc<str>,
+  handle: u64,
+  generation: u64,
+  release: FfiResourceRelease,
+  trace: Option<FfiResourceTrace>,
+  // Keep the creator loaded until the final Calcit reference has released its
+  // resource. This remains necessary even if the process-wide dylib cache is
+  // changed to permit unloading in the future.
+  _library: Option<Arc<libloading::Library>>,
+}
+
+impl fmt::Debug for NativeFfiResourceLease {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("NativeFfiResourceLease")
+      .field("lib_name", &self.lib_name)
+      .field("handle", &self.handle)
+      .field("generation", &self.generation)
+      .finish_non_exhaustive()
+  }
+}
+
+impl Drop for NativeFfiResourceLease {
+  fn drop(&mut self) {
+    // SAFETY: the function pointer belongs to `_library`, which is dropped
+    // after this method returns. Resource v1 requires release to accept any
+    // token and report stale/duplicate values through its status code.
+    let status = unsafe { (self.release)(self.handle, self.generation) };
+    if let Some(trace) = self.trace {
+      trace("resource-release", &self.lib_name, self.handle, self.generation, status);
+    }
+    if status != 0 {
+      eprintln!(
+        "[Warn] FFI resource release failed: lib={} handle={} generation={} status={status}",
+        self.lib_name, self.handle, self.generation
+      );
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+struct NativeFfiResource {
+  lease: Arc<NativeFfiResourceLease>,
+}
+
+impl PartialEq for NativeFfiResource {
+  fn eq(&self, other: &Self) -> bool {
+    self.lease.lib_name == other.lease.lib_name
+      && self.lease.handle == other.lease.handle
+      && self.lease.generation == other.lease.generation
+  }
+}
+
+struct FfiResourceAdapter {
+  lib_name: Arc<str>,
+  release: FfiResourceRelease,
+  trace: Option<FfiResourceTrace>,
+  library: Option<Arc<libloading::Library>>,
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum FfiBuildCompatibility {
@@ -800,6 +870,179 @@ pub fn encode_buffer_request(args: Vec<Edn>) -> Result<Vec<u8>, String> {
   cirru_edn::format(&Edn::List(EdnListView(args)), true)
     .map(String::into_bytes)
     .map_err(|error| format!("failed to encode FFI buffer request: {error}"))
+}
+
+fn encode_resource_token(handle: u64, generation: u64) -> Edn {
+  let mut token = Vec::with_capacity(RESOURCE_TOKEN_BYTES);
+  token.extend_from_slice(&handle.to_le_bytes());
+  token.extend_from_slice(&generation.to_le_bytes());
+  let mut value = EdnStructView::new(RESOURCE_TOKEN_STRUCT);
+  value.insert(RESOURCE_TOKEN_FIELD, Edn::Buffer(token));
+  value.into()
+}
+
+fn decode_resource_token(value: &EdnStructView) -> Result<(u64, u64), String> {
+  if value.pairs.len() != 1 || !value.pairs[0].0.matches(RESOURCE_TOKEN_FIELD) {
+    return Err(format!(
+      "FFI resource token `{RESOURCE_TOKEN_STRUCT}` must contain exactly one `:{RESOURCE_TOKEN_FIELD}` field"
+    ));
+  }
+  let Edn::Buffer(bytes) = &value.pairs[0].1 else {
+    return Err(format!(
+      "FFI resource token `{RESOURCE_TOKEN_STRUCT}` field `:{RESOURCE_TOKEN_FIELD}` must be a buffer"
+    ));
+  };
+  if bytes.len() != RESOURCE_TOKEN_BYTES {
+    return Err(format!(
+      "FFI resource token `{RESOURCE_TOKEN_STRUCT}` must contain {RESOURCE_TOKEN_BYTES} bytes, got {}",
+      bytes.len()
+    ));
+  }
+  let handle = u64::from_le_bytes(bytes[..8].try_into().expect("resource handle byte width"));
+  let generation = u64::from_le_bytes(bytes[8..].try_into().expect("resource generation byte width"));
+  if handle == 0 || generation == 0 {
+    return Err(format!(
+      "FFI resource token `{RESOURCE_TOKEN_STRUCT}` requires non-zero handle and generation"
+    ));
+  }
+  Ok((handle, generation))
+}
+
+fn transform_resource_args(value: &Edn, lib_name: &str) -> Result<Edn, String> {
+  match value {
+    Edn::AnyRef(reference) => {
+      let value = reference
+        .0
+        .read()
+        .map_err(|_| "failed to read FFI resource AnyRef because its lock is poisoned".to_owned())?;
+      let Some(resource) = value.as_any().downcast_ref::<NativeFfiResource>() else {
+        return Err(format!(
+          "C-safe FFI buffer method in `{lib_name}` cannot serialize a non-resource AnyRef"
+        ));
+      };
+      if resource.lease.lib_name.as_ref() != lib_name {
+        return Err(format!(
+          "FFI resource belongs to `{}`, but the attempted call targets `{lib_name}`",
+          resource.lease.lib_name
+        ));
+      }
+      Ok(encode_resource_token(resource.lease.handle, resource.lease.generation))
+    }
+    Edn::List(EdnListView(xs)) => Ok(Edn::List(EdnListView(
+      xs.iter()
+        .map(|item| transform_resource_args(item, lib_name))
+        .collect::<Result<Vec<_>, _>>()?,
+    ))),
+    Edn::Set(xs) => {
+      let mut output = EdnSetView::default();
+      for item in &xs.0 {
+        output.insert(transform_resource_args(item, lib_name)?);
+      }
+      Ok(output.into())
+    }
+    Edn::Map(xs) => {
+      let mut output = EdnMapView::default();
+      for (key, item) in &xs.0 {
+        output.insert(transform_resource_args(key, lib_name)?, transform_resource_args(item, lib_name)?);
+      }
+      Ok(output.into())
+    }
+    Edn::Enum(EdnEnumView { variant, type_name, extra }) => Ok(Edn::Enum(EdnEnumView {
+      variant: variant.clone(),
+      type_name: type_name.clone(),
+      extra: extra
+        .iter()
+        .map(|item| transform_resource_args(item, lib_name))
+        .collect::<Result<Vec<_>, _>>()?,
+    })),
+    Edn::Struct(EdnStructView { name, pairs }) => {
+      if name.as_ref() == RESOURCE_TOKEN_STRUCT {
+        return Err(format!(
+          "`{RESOURCE_TOKEN_STRUCT}` is reserved for host-managed FFI resources and cannot be supplied directly"
+        ));
+      }
+      let mut output = EdnStructView::new(name.clone());
+      for (key, item) in pairs {
+        output.insert(key.clone(), transform_resource_args(item, lib_name)?);
+      }
+      Ok(output.into())
+    }
+    Edn::Atom(inner) => Ok(Edn::Atom(Box::new(transform_resource_args(inner, lib_name)?))),
+    other => Ok(other.clone()),
+  }
+}
+
+fn contains_resource_token(value: &Edn) -> bool {
+  match value {
+    Edn::Struct(value) if value.name.as_ref() == RESOURCE_TOKEN_STRUCT => true,
+    Edn::List(xs) => xs.0.iter().any(contains_resource_token),
+    Edn::Set(xs) => xs.0.iter().any(contains_resource_token),
+    Edn::Map(xs) => xs
+      .0
+      .iter()
+      .any(|(key, value)| contains_resource_token(key) || contains_resource_token(value)),
+    Edn::Enum(value) => value.extra.iter().any(contains_resource_token),
+    Edn::Struct(value) => value.pairs.iter().any(|(_, value)| contains_resource_token(value)),
+    Edn::Atom(inner) => contains_resource_token(inner),
+    _ => false,
+  }
+}
+
+fn hydrate_resource_tokens(value: Edn, adapter: &FfiResourceAdapter) -> Result<Edn, String> {
+  match value {
+    Edn::Struct(resource) if resource.name.as_ref() == RESOURCE_TOKEN_STRUCT => {
+      let (handle, generation) = decode_resource_token(&resource)?;
+      if let Some(trace) = adapter.trace {
+        trace("resource-create", &adapter.lib_name, handle, generation, 0);
+      }
+      Ok(Edn::AnyRef(EdnAnyRef::new(NativeFfiResource {
+        lease: Arc::new(NativeFfiResourceLease {
+          lib_name: adapter.lib_name.clone(),
+          handle,
+          generation,
+          release: adapter.release,
+          trace: adapter.trace,
+          _library: adapter.library.clone(),
+        }),
+      })))
+    }
+    Edn::List(EdnListView(xs)) => Ok(Edn::List(EdnListView(
+      xs.into_iter()
+        .map(|item| hydrate_resource_tokens(item, adapter))
+        .collect::<Result<Vec<_>, _>>()?,
+    ))),
+    Edn::Set(xs) => {
+      let mut output = EdnSetView::default();
+      for item in xs.0 {
+        output.insert(hydrate_resource_tokens(item, adapter)?);
+      }
+      Ok(output.into())
+    }
+    Edn::Map(xs) => {
+      let mut output = EdnMapView::default();
+      for (key, item) in xs.0 {
+        output.insert(hydrate_resource_tokens(key, adapter)?, hydrate_resource_tokens(item, adapter)?);
+      }
+      Ok(output.into())
+    }
+    Edn::Enum(EdnEnumView { variant, type_name, extra }) => Ok(Edn::Enum(EdnEnumView {
+      variant,
+      type_name,
+      extra: extra
+        .into_iter()
+        .map(|item| hydrate_resource_tokens(item, adapter))
+        .collect::<Result<Vec<_>, _>>()?,
+    })),
+    Edn::Struct(EdnStructView { name, pairs }) => {
+      let mut output = EdnStructView::new(name);
+      for (key, item) in pairs {
+        output.insert(key, hydrate_resource_tokens(item, adapter)?);
+      }
+      Ok(output.into())
+    }
+    Edn::Atom(inner) => Ok(Edn::Atom(Box::new(hydrate_resource_tokens(*inner, adapter)?))),
+    other => Ok(other),
+  }
 }
 
 /// Probe a C-safe async method without touching the guarded Rust ABI. A
@@ -920,7 +1163,13 @@ unsafe fn copy_and_free_buffer(
 /// Try the C-safe synchronous byte-buffer protocol. `Ok(None)` means the
 /// library or this particular method has not migrated and may use the guarded
 /// legacy Rust ABI path.
-pub fn try_call_buffer(lib: &libloading::Library, lib_name: &str, method: &str, args: Vec<Edn>) -> Result<Option<Edn>, String> {
+pub fn try_call_buffer(
+  lib: &Arc<libloading::Library>,
+  lib_name: &str,
+  method: &str,
+  args: Vec<Edn>,
+  resource_trace: Option<FfiResourceTrace>,
+) -> Result<Option<Edn>, String> {
   let version: libloading::Symbol<FfiBufferVersion> = match unsafe { lib.get(BUFFER_PROTOCOL_VERSION_SYMBOL) } {
     Ok(version) => version,
     Err(_) => return Ok(None),
@@ -939,12 +1188,42 @@ pub fn try_call_buffer(lib: &libloading::Library, lib_name: &str, method: &str, 
   };
   let free: libloading::Symbol<FfiBufferFree> = unsafe { lib.get(BUFFER_FREE_SYMBOL) }
     .map_err(|error| format!("FFI buffer method `{symbol}` in `{lib_name}` is missing `calcit_ffi_buffer_free`: {error}"))?;
+  let args = args
+    .iter()
+    .map(|value| transform_resource_args(value, lib_name))
+    .collect::<Result<Vec<_>, _>>()?;
   let request = encode_buffer_request(args)?;
   let mut output = FfiBuffer::empty();
   let status = unsafe { call(request.as_ptr(), request.len(), &mut output) };
   let output = unsafe { copy_and_free_buffer(output, &free, lib_name, &symbol) }?;
+  let output = decode_buffer_response(status, output, lib_name, &symbol)?;
+  if !contains_resource_token(&output) {
+    return Ok(Some(output));
+  }
 
-  decode_buffer_response(status, output, lib_name, &symbol).map(Some)
+  let version: libloading::Symbol<FfiResourceVersion> = unsafe { lib.get(RESOURCE_PROTOCOL_VERSION_SYMBOL) }.map_err(|error| {
+    format!(
+      "FFI buffer method `{symbol}` in `{lib_name}` returned a resource token but is missing `calcit_ffi_resource_version`: {error}"
+    )
+  })?;
+  let current_version = unsafe { version() };
+  if current_version != RESOURCE_PROTOCOL_VERSION {
+    return Err(format!(
+      "FFI resource protocol mismatch in `{lib_name}`: dylib={current_version}, host={RESOURCE_PROTOCOL_VERSION}"
+    ));
+  }
+  let release: libloading::Symbol<FfiResourceRelease> = unsafe { lib.get(RESOURCE_RELEASE_SYMBOL) }.map_err(|error| {
+    format!(
+      "FFI buffer method `{symbol}` in `{lib_name}` returned a resource token but is missing `calcit_ffi_resource_release_v1`: {error}"
+    )
+  })?;
+  let adapter = FfiResourceAdapter {
+    lib_name: Arc::from(lib_name),
+    release: *release,
+    trace: resource_trace,
+    library: Some(lib.clone()),
+  };
+  hydrate_resource_tokens(output, &adapter).map(Some)
 }
 
 pub fn validate_build_id(
@@ -989,10 +1268,34 @@ mod tests {
     ASYNC_EVENT_FLAG_COALESCED, ASYNC_PROTOCOL_VERSION, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
     ASYNC_TASK_FLAG_SERIAL_EVENTS, BUFFER_PROTOCOL_VERSION, FfiAsyncEventDescriptor, FfiAsyncEventKind, FfiAsyncHandle,
     FfiAsyncHandleError, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1, FfiAsyncLifecycle, FfiAsyncTaskDescriptor,
-    FfiBlockingHostV1, FfiBuffer, FfiBuildCompatibility, async_method_symbol, async_status, blocking_method_symbol,
-    buffer_method_symbol, decode_buffer_response, encode_buffer_request, validate_build_id,
+    FfiBlockingHostV1, FfiBuffer, FfiBuildCompatibility, FfiResourceAdapter, RESOURCE_PROTOCOL_VERSION, RESOURCE_TOKEN_BYTES,
+    RESOURCE_TOKEN_STRUCT, async_method_symbol, async_status, blocking_method_symbol, buffer_method_symbol, decode_buffer_response,
+    decode_resource_token, encode_buffer_request, encode_resource_token, hydrate_resource_tokens, transform_resource_args,
+    validate_build_id,
   };
-  use cirru_edn::Edn;
+  use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+  };
+
+  use cirru_edn::{Edn, EdnAnyRef, EdnListView, EdnStructView};
+
+  static RESOURCE_RELEASES: AtomicUsize = AtomicUsize::new(0);
+  static RESOURCE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+  unsafe extern "C" fn test_resource_release(_handle: u64, _generation: u64) -> i32 {
+    RESOURCE_RELEASES.fetch_add(1, Ordering::SeqCst);
+    0
+  }
+
+  fn test_resource_adapter() -> FfiResourceAdapter {
+    FfiResourceAdapter {
+      lib_name: Arc::from("demo"),
+      release: test_resource_release,
+      trace: None,
+      library: None,
+    }
+  }
 
   #[test]
   fn buffer_method_names_are_versioned_without_changing_source_calls() {
@@ -1081,6 +1384,65 @@ mod tests {
     let source = std::str::from_utf8(&encoded).expect("UTF-8 request");
     let decoded = cirru_edn::parse(source).expect("parse request");
     assert_eq!(decoded, Edn::List(cirru_edn::EdnListView(vec![Edn::Number(1.0), Edn::str("two")])));
+  }
+
+  #[test]
+  fn resource_tokens_use_fixed_non_zero_handle_and_generation() {
+    let Edn::Struct(token) = encode_resource_token(7, 11) else {
+      panic!("resource token should be a struct")
+    };
+    assert_eq!(token.name.as_ref(), RESOURCE_TOKEN_STRUCT);
+    assert_eq!(decode_resource_token(&token).expect("valid resource token"), (7, 11));
+
+    let mut malformed = EdnStructView::new(RESOURCE_TOKEN_STRUCT);
+    malformed.insert("token", Edn::Buffer(vec![0; RESOURCE_TOKEN_BYTES]));
+    let error = decode_resource_token(&malformed).expect_err("zero token must fail");
+    assert!(error.contains("non-zero handle and generation"), "error: {error}");
+  }
+
+  #[test]
+  fn nested_resources_round_trip_only_to_their_creator_module() {
+    let _guard = RESOURCE_TEST_LOCK.lock().expect("resource test lock");
+    RESOURCE_RELEASES.store(0, Ordering::SeqCst);
+    let encoded = Edn::List(EdnListView(vec![Edn::str("prefix"), encode_resource_token(7, 11)]));
+    let hydrated = hydrate_resource_tokens(encoded.clone(), &test_resource_adapter()).expect("hydrate resource");
+    assert_eq!(
+      transform_resource_args(&hydrated, "demo").expect("encode matching resource"),
+      encoded
+    );
+
+    let error = transform_resource_args(&hydrated, "other").expect_err("wrong module must fail");
+    assert!(error.contains("belongs to `demo`"), "error: {error}");
+    drop(hydrated);
+    assert_eq!(RESOURCE_RELEASES.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn cloned_resources_release_once_after_concurrent_final_drop() {
+    let _guard = RESOURCE_TEST_LOCK.lock().expect("resource test lock");
+    RESOURCE_RELEASES.store(0, Ordering::SeqCst);
+    let resource = hydrate_resource_tokens(encode_resource_token(17, 3), &test_resource_adapter()).expect("hydrate resource");
+    let clones = (0..8).map(|_| resource.clone()).collect::<Vec<_>>();
+    std::thread::scope(|scope| {
+      for clone in clones {
+        scope.spawn(move || drop(clone));
+      }
+    });
+    assert_eq!(RESOURCE_RELEASES.load(Ordering::SeqCst), 0);
+    drop(resource);
+    assert_eq!(RESOURCE_RELEASES.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn c_safe_buffer_rejects_unmanaged_any_refs_and_forged_tokens() {
+    let unmanaged = Edn::AnyRef(EdnAnyRef::new(String::from("native")));
+    let error = transform_resource_args(&unmanaged, "demo").expect_err("unmanaged AnyRef must fail");
+    assert!(error.contains("non-resource AnyRef"), "error: {error}");
+
+    let forged = encode_resource_token(1, 1);
+    let error = transform_resource_args(&forged, "demo").expect_err("direct resource token must fail");
+    assert!(error.contains("reserved for host-managed"), "error: {error}");
+    assert_eq!(RESOURCE_PROTOCOL_VERSION, 1);
   }
 
   #[test]


### PR DESCRIPTION
## 中文

### 背景

同步 buffer v1 可以安全传递 Cirru EDN，但不能承载带自动析构语义的 native 对象。`calcit-regex` 当前仍通过 Rust `AnyRef<Arc<Regex>>` 跨 dylib，阻塞 #474 的 Rust ABI fallback 退役。

### 改动

- 新增 C-safe opaque resource v1：模块通过保留的 `CalcitFfiResourceV1` EDN struct 返回 16 字节 `(handle, generation)` token；
- 宿主把 token 水合为自动生命周期 `AnyRef`，固定创建它的 dylib，并在最后一个宿主引用释放时 exactly-once 调用 `calcit_ffi_resource_release_v1`；
- Calcit clone 只共享宿主 lease，不增加模块 retain ABI；
- 在后续 buffer v1 调用前递归还原同模块 token，并确定性拒绝 wrong-module、普通 AnyRef、伪造 token 与畸形 token；
- 支持 list/set/map/enum/struct/atom 中的嵌套资源；
- `--trace-ffi` 新增 `resource-create` / `resource-release` 事件；
- 增加中英双语协议文档和 FFI 升级指引。

### 验证

- `cargo test`：571 + 258 + 24 + 15 全部通过；
- `cargo clippy --all-targets -- -D warnings`；
- `yarn compile`；
- `yarn check-all`：Calcit core 221/221，JS/IR/WASM 全部通过；
- `yarn check-agent-interface`：17/17；
- resource 单测覆盖固定 token、嵌套 round-trip、并发 clone/drop exactly-once、wrong-module、非资源 AnyRef 与伪造/畸形 token。

### 后续

合并并发布 Calcit 后，立即迁移 `calcit-regex` 作为真实 release dylib adopter，补齐 stale generation、重复 release 与端到端 trace smoke，再更新 #489。

属于 #489 的宿主协议阶段；待 `calcit-regex` 验证完成后再关闭 Issue。

---

## English

### Background

Synchronous buffer v1 safely transports Cirru EDN, but cannot carry native objects with automatic destruction. `calcit-regex` still crosses the dylib boundary as Rust `AnyRef<Arc<Regex>>`, blocking removal of the Rust ABI fallback in #474.

### Changes

- Add C-safe opaque resource v1. A module returns a reserved `CalcitFfiResourceV1` EDN struct containing a 16-byte `(handle, generation)` token.
- Hydrate tokens into automatically managed host `AnyRef` values, pin the creating dylib, and call `calcit_ffi_resource_release_v1` exactly once when the final host reference drops.
- Calcit clones share the host lease, avoiding a separate module retain ABI.
- Recursively restore matching-module tokens before later buffer-v1 calls, while deterministically rejecting wrong-module resources, ordinary AnyRefs, forged tokens, and malformed tokens.
- Support resources nested in lists, sets, maps, enums, structs, and atoms.
- Add `resource-create` / `resource-release` events to `--trace-ffi`.
- Add bilingual protocol documentation and FFI upgrade guidance.

### Validation

- `cargo test`: all 571 + 258 + 24 + 15 tests passed.
- `cargo clippy --all-targets -- -D warnings`.
- `yarn compile`.
- `yarn check-all`: Calcit core 221/221 plus JS/IR/WASM passed.
- `yarn check-agent-interface`: 17/17.
- Resource tests cover fixed tokens, nested round trips, concurrent clone/drop exactly-once behavior, wrong-module use, unmanaged AnyRefs, and forged/malformed tokens.

### Follow-up

After merging and releasing Calcit, migrate `calcit-regex` immediately as the real release-dylib adopter, add stale-generation, duplicate-release, and end-to-end trace smokes, then update #489.

This is the host-protocol stage of #489; keep the issue open until the `calcit-regex` adoption is verified.
