### PR TITLE
snapshot: formatter 接受 FileEntry struct / accept FileEntry structs in formatter

### DIFF
--- a/editing-history/202608280513-fileentry-struct-format.md
+++ b/editing-history/202608280513-fileentry-struct-format.md
@@ -1,0 +1,6 @@
+# FileEntry struct support in format migration
+
+- 修复 0.13.54 format-only migration loader 只接受 `FileEntry` map、不能读取 struct 的回归。
+- 统一 formatter 与普通严格 loader 对现代 `FileEntry` map/struct 的接受范围，不扩大 direct-quote runtime 兼容边界。
+- 增加与 Calcit 0.13.51 schema migration 输出一致的 `%FileEntry` struct 回归 fixture。
+- 缺陷由 `calcit-paint` 的真实 direct quote → strict macro schema → current formatter 升级链发现并记录为 Issue #493。

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -2441,13 +2441,32 @@ fn parse_file_for_format_with_context(
   file_name: &str,
   migration: &mut SnapshotFormatMigration,
 ) -> Result<FileInSnapShot, String> {
-  let map = data
-    .view_map()
-    .map_err(|e| format!("{file_name}: expected FileEntry map/struct: {e}; got {}", format_edn_preview(&data)))?;
-  let ns_value = map
-    .get(&Edn::tag("ns"))
-    .or_else(|| map.get(&Edn::str("ns")))
-    .ok_or_else(|| format!("{file_name}: missing `:ns` field in FileEntry"))?;
+  let (ns_value, defs_value) = match &data {
+    Edn::Map(map) => (
+      map.get(&Edn::tag("ns")).or_else(|| map.get(&Edn::str("ns"))),
+      map.get(&Edn::tag("defs")).or_else(|| map.get(&Edn::str("defs"))),
+    ),
+    Edn::Struct(struct_value) => (
+      struct_value
+        .pairs
+        .iter()
+        .find(|(key, _)| key.ref_str() == "ns")
+        .map(|(_, value)| value),
+      struct_value
+        .pairs
+        .iter()
+        .find(|(key, _)| key.ref_str() == "defs")
+        .map(|(_, value)| value),
+    ),
+    other => {
+      return Err(format!(
+        "{file_name}: expected FileEntry map/struct, got {}",
+        format_edn_preview(other)
+      ));
+    }
+  };
+  let ns_value = ns_value.ok_or_else(|| format!("{file_name}: missing `:ns` field in FileEntry"))?;
+  let defs_value = defs_value.ok_or_else(|| format!("{file_name}: missing `:defs` field in FileEntry"))?;
   let ns = match ns_value {
     Edn::Quote(code) => {
       migration.direct_quote_namespaces += 1;
@@ -2459,10 +2478,6 @@ fn parse_file_for_format_with_context(
     modern => modern.to_owned().try_into().map_err(|e: String| format!("{file_name}/:ns: {e}"))?,
   };
 
-  let defs_value = map
-    .get(&Edn::tag("defs"))
-    .or_else(|| map.get(&Edn::str("defs")))
-    .ok_or_else(|| format!("{file_name}: missing `:defs` field in FileEntry"))?;
   let defs_map = defs_value.view_map().map_err(|e| {
     format!(
       "{file_name}: failed to parse `:defs` as map: {e}; got {}",
@@ -5086,6 +5101,23 @@ mod tests {
     let legacy = legacy_direct_quote_snapshot([("custom", Edn::Bool(true))]);
     let error = load_snapshot_data_for_format(&legacy, "calcit.cirru").expect_err("unknown legacy config must not be discarded");
     assert!(error.contains("legacy configs: unknown field `:custom`"), "error: {error}");
+  }
+
+  #[test]
+  fn format_loader_accepts_fileentry_struct_written_by_schema_migration_release() {
+    let legacy = legacy_direct_quote_snapshot([]);
+    let (snapshot, _) = load_snapshot_data_for_format(&legacy, "calcit.cirru").expect("legacy fixture should migrate");
+    let rendered = render_snapshot_content(&snapshot).expect("migrated snapshot should render");
+    let canonical = cirru_edn::parse(&rendered).expect("rendered snapshot should parse");
+    let Edn::Map(root) = &canonical else { panic!("snapshot root map") };
+    let files = root.get(&Edn::tag("files")).expect("files");
+    let Edn::Map(files) = files else { panic!("files map") };
+    assert!(matches!(files.get(&Edn::str("mini.core")), Some(Edn::Struct(_))));
+
+    load_snapshot_data(&canonical, "calcit.cirru").expect("strict loader already accepts FileEntry structs");
+    let (_, migration) =
+      load_snapshot_data_for_format(&canonical, "calcit.cirru").expect("format loader should accept FileEntry structs too");
+    assert_eq!(migration, SnapshotFormatMigration::default());
   }
 
   #[test]


### PR DESCRIPTION
## 中文

### 修复

- 让 format-only migration loader 与普通严格 loader 一样接受现代 `FileEntry` map 和 struct。
- 保持 direct-quote/configs 兼容逻辑仅限 `edit format`，不扩大 runtime loader 边界。
- 增加 formatter 自己写出的 `%FileEntry` struct 再次进入 formatter 的回归测试，覆盖 0.13.51 strict macro schema 迁移后的真实链路。

### 验证

- Rust tests 全部通过（新增后 library 576 项；CLI 258、caps 24、WASM harness 15）。
- strict clippy 通过。
- `yarn check-all` 通过：core 221/221、JS/IR/WASM、Agent interface 17/17。
- 真实 `calcit-paint` 中间 Snapshot 可再次 format，随后 strict check 已进入业务源码并定位下一项旧 `[][]` 语法债务。

Closes #493.

---

## English

### Fix

- Make the format-only migration loader accept modern `FileEntry` maps and structs, matching the normal strict loader.
- Keep direct-quote/configs compatibility isolated to `edit format`; runtime-loader boundaries remain unchanged.
- Add a regression where the formatter's own `%FileEntry` struct output is fed back into the formatter, covering the real chain after the 0.13.51 strict-macro schema migration.

### Validation

- All Rust tests pass (576 library tests after this addition, plus 258 CLI, 24 caps, and 15 WASM-harness tests).
- Strict clippy passes.
- `yarn check-all` passes: core 221/221, JS/IR/WASM, and Agent interface 17/17.
- The real intermediate `calcit-paint` Snapshot can be formatted again; strict checking then reaches project code and identifies the next legacy `[][]` syntax debt.

Closes #493.
