### PR TITLE
fix: macOS 主线程 blocking FFI / main-thread blocking FFI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,20 @@ on:
 name: Test
 
 jobs:
+  macos_main_thread:
+    name: macOS main-thread CLI
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --bin calcit
+      - name: Verify the reserved process-main stack
+        run: |
+          stacksize=$(otool -l target/debug/calcit | awk '/cmd LC_MAIN/{main=1} main && /stacksize/{print $2; exit}')
+          test "$stacksize" = "33554432"
+      - run: ./target/debug/calcit -v
+
   build_and_test:
     name: Test
     runs-on: ubuntu-latest

--- a/build.rs
+++ b/build.rs
@@ -579,6 +579,13 @@ fn main() {
   println!("cargo:rerun-if-env-changed=CARGO_CFG_PANIC");
   println!("cargo:rustc-env=CALCIT_FFI_BUILD_ID={}", ffi_build_id());
 
+  let target = env::var("TARGET").expect("Cargo must provide TARGET to build scripts");
+  if target.ends_with("apple-darwin") {
+    // Calcit executes directly on the process main thread on macOS so native
+    // AppKit event loops can own it. Match the worker stack used elsewhere.
+    println!("cargo:rustc-link-arg-bin=calcit=-Wl,-stack_size,0x2000000");
+  }
+
   let out_dir = env::var_os("OUT_DIR").unwrap();
   let dest_path = Path::new(&out_dir).join("calcit-core.rmp");
 

--- a/editing-history/202608280536-macos-main-thread-blocking-ffi.md
+++ b/editing-history/202608280536-macos-main-thread-blocking-ffi.md
@@ -1,0 +1,10 @@
+# macOS main-thread blocking FFI / macOS 主线程 blocking FFI
+
+- On macOS, run the Calcit CLI on the process main thread so AppKit/winit event loops invoked through blocking FFI satisfy the platform contract.
+- 在 macOS 上让 Calcit CLI 直接运行于进程主线程，使 blocking FFI 启动的 AppKit/winit 事件循环满足平台约束。
+- Reserve a 32 MiB Mach-O main-thread stack, matching the worker stack used on other platforms and preserving preprocessing headroom.
+- 为 Mach-O 主线程预留 32 MiB 栈，与其他平台的 CLI worker 一致，避免预处理递归空间退化。
+- Verified with a real calcit-paint C-safe blocking-v1 window/callback/render smoke; the prior worker-thread build failed before EventLoop creation.
+- 使用 calcit-paint C-safe blocking-v1 的真实窗口、回调和渲染 smoke 验证；旧 worker-thread 构建会在 EventLoop 创建前失败。
+- Added a macOS CI build that checks the Mach-O `LC_MAIN` stack reservation and CLI startup.
+- 新增 macOS CI 构建，持续检查 Mach-O `LC_MAIN` 栈预留与 CLI 启动。

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -239,8 +239,18 @@ fn attach_missing_core_namespaces(snapshot: &mut snapshot::Snapshot, core_snapsh
   }
 }
 
+#[cfg(not(target_os = "macos"))]
 const CLI_STACK_SIZE: usize = 32 * 1024 * 1024;
 
+#[cfg(target_os = "macos")]
+fn main() -> Result<(), String> {
+  // AppKit event loops must be created and driven on the process main thread.
+  // The macOS binary reserves the same 32 MiB stack in build.rs, so running
+  // the CLI here preserves both the GUI contract and preprocessing headroom.
+  run_cli()
+}
+
+#[cfg(not(target_os = "macos"))]
 fn main() -> Result<(), String> {
   let worker = std::thread::Builder::new()
     .name("calcit-cli".to_owned())


### PR DESCRIPTION
## 中文

### 背景

calcit-paint 迁移到 C-safe blocking v1 后，真实 macOS smoke 发现 Calcit CLI 总是在名为 `calcit-cli` 的 worker thread 上执行。blocking ABI 保证同步占用 host thread，但 AppKit/winit 还要求事件循环位于进程主线程，因此窗口会在创建 EventLoop 时 panic。

### 修改

- macOS 上直接在进程主线程运行 `run_cli`；其他平台继续使用 32 MiB CLI worker。
- 为 macOS `calcit` Mach-O 设置 32 MiB main stack，保留原有预处理递归空间。
- 不改变 blocking v1 的线程所有权、同步 callback 和 buffer 生命周期语义。

### 验证

- `cargo test`：576 library + 258 CLI + 24 caps + 15 WASM tests。
- `cargo clippy --all-targets -- -D warnings`。
- `yarn compile`、`yarn check-all`、Agent interface 17/17、Calcit core 221/221、JS/IR/WASM。
- `otool -l target/debug/calcit` 确认 `LC_MAIN stacksize 33554432`。
- calcit-paint 真实 macOS blocking-v1 smoke：窗口创建、同步 callback、Skia render 和自动退出全部成功。

关联 #474。

## English

### Background

The calcit-paint migration to C-safe blocking v1 exposed that the Calcit CLI always executes on a named `calcit-cli` worker. Blocking v1 synchronously owns that host thread, but AppKit/winit additionally requires its event loop to run on the process main thread, so EventLoop creation panicked.

### Changes

- Run `run_cli` directly on the process main thread on macOS; retain the 32 MiB CLI worker elsewhere.
- Set a 32 MiB Mach-O main stack for the macOS `calcit` binary, preserving preprocessing recursion headroom.
- Keep blocking-v1 thread ownership, synchronous callback, and buffer-lifetime semantics unchanged.

### Validation

- `cargo test`: 576 library + 258 CLI + 24 caps + 15 WASM tests.
- `cargo clippy --all-targets -- -D warnings`.
- `yarn compile`, `yarn check-all`, Agent interface 17/17, Calcit core 221/221, and JS/IR/WASM.
- `otool -l target/debug/calcit` reports `LC_MAIN stacksize 33554432`.
- Real calcit-paint macOS blocking-v1 smoke passed window creation, synchronous callback, Skia rendering, and automatic exit.

Related to #474.
