### PR TITLE
ffi: 删除 Rust ABI fallback / remove Rust ABI fallback

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -545,39 +544,8 @@ fn parse_files(edn: Edn) -> Result<HashMap<String, FileInSnapShot>, String> {
   }
 }
 
-fn rustc_verbose_field<'a>(output: &'a str, name: &str) -> &'a str {
-  output
-    .lines()
-    .find_map(|line| line.strip_prefix(name).map(str::trim))
-    .unwrap_or_else(|| panic!("`rustc --version --verbose` did not report `{name}`"))
-}
-
-fn ffi_build_id() -> String {
-  let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
-  let output = Command::new(&rustc)
-    .args(["--version", "--verbose"])
-    .output()
-    .unwrap_or_else(|error| panic!("failed to run `{rustc} --version --verbose`: {error}"));
-  if !output.status.success() {
-    panic!("`{rustc} --version --verbose` failed with {}", output.status);
-  }
-  let verbose = String::from_utf8(output.stdout).expect("rustc verbose version must be UTF-8");
-  let release = rustc_verbose_field(&verbose, "release:");
-  let commit = rustc_verbose_field(&verbose, "commit-hash:");
-  let target = env::var("TARGET").expect("Cargo must provide TARGET to build scripts");
-  let debug_assertions = env::var_os("CARGO_CFG_DEBUG_ASSERTIONS").is_some();
-  let panic_strategy = env::var("CARGO_CFG_PANIC").expect("Cargo must provide CARGO_CFG_PANIC to build scripts");
-
-  format!("rustc={release}:{commit};target={target};debug-assertions={debug_assertions};panic={panic_strategy}")
-}
-
 fn main() {
   println!("cargo:rerun-if-changed=src/cirru/calcit-core.cirru");
-  println!("cargo:rerun-if-env-changed=RUSTC");
-  println!("cargo:rerun-if-env-changed=TARGET");
-  println!("cargo:rerun-if-env-changed=CARGO_CFG_DEBUG_ASSERTIONS");
-  println!("cargo:rerun-if-env-changed=CARGO_CFG_PANIC");
-  println!("cargo:rustc-env=CALCIT_FFI_BUILD_ID={}", ffi_build_id());
 
   let target = env::var("TARGET").expect("Cargo must provide TARGET to build scripts");
   if target.ends_with("apple-darwin") {

--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -8,8 +8,9 @@ WebSocket connections, and server resources.
 This document describes protocol version 1 as it is implemented in stages.
 The current implementation provides the handle types, lifecycle registry,
 bounded host event queue, native callback-v1, response/Server capabilities,
-and the blocking-v1 entry point used by `&blocking-dylib-edn-fn`. Both callback
-forms retain a guarded per-method Rust ABI fallback during module migration.
+and the blocking-v1 entry point used by `&blocking-dylib-edn-fn`. Callback and
+blocking calls require their C-safe v1 entry points; Rust ABI fallback has been
+removed.
 
 ## Shared task model
 
@@ -99,8 +100,8 @@ ownership and matching free functions explicit in both directions.
 
 ## Native callback ABI v1
 
-Before using the legacy Rust callback ABI, `&call-dylib-edn-fn` probes the
-following C symbols:
+`&call-dylib-edn-fn` requires the following C symbols. Missing symbols are
+deterministic migration errors; Calcit does not probe a Rust callback ABI:
 
 ```c
 uint32_t calcit_ffi_async_version(void); /* returns 1 */
@@ -315,10 +316,10 @@ explicit finish, further `invoke` calls fail deterministically. This preserves
 main-thread event loops without introducing a queue-drain deadlock, while
 foreign-thread and long-lived work remains on callback v1's bounded queue.
 
-Missing protocol or per-method blocking symbols retain the build-identity-
-guarded Rust fallback. An advertised incompatible version, missing module
-buffer free function, malformed output, leaked host callback buffer, or
-wrong-thread callback is a hard error.
+Missing protocol or per-method blocking symbols are deterministic migration
+errors. An advertised incompatible version, missing module buffer free
+function, malformed output, leaked host callback buffer, or wrong-thread
+callback is a hard error.
 
 ## WASM compatibility boundary
 
@@ -337,13 +338,10 @@ objects, thread-local state, an executor/waker ABI, or native threads. Native
 threaded producers and a future single-threaded WASM poll adapter can therefore
 present the same Calcit-facing behavior.
 
-## Rollout
+## Rollout status
 
-The remaining rollout order after blocking v1 is:
-
-1. migration and release of `calcit-fetch`, `calcit-http`, `calcit-wss`, and
-   `calcit.std`;
-2. a `calcit_wasmtime` adapter prototype after the event envelope is stable;
-3. removal of the guarded Rust ABI fallback under issue #474.
-
-See issue #482 for the full acceptance matrix and module rollout status.
+The maintained native ecosystem has migrated to C-safe v1 protocols. The
+primary modules (`calcit-fetch`, `calcit-http`, `calcit-wss`, and `calcit.std`)
+and the additional audited modules, including `calcit-paint`, no longer require
+Rust-layout entry points. See issues #474 and #482 for the acceptance matrix
+and migration history.

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -12,109 +12,32 @@ aliases:
 
 > API status: unstable.
 
-Rust supports extending with dynamic libraries. A demo project can be found at https://github.com/calcit-lang/dylib-workflow
+Rust supports extending Calcit with dynamic libraries. A complete project can
+be found at https://github.com/calcit-lang/dylib-workflow.
 
-Currently two APIs are supported, based on Cirru EDN data.
+Only versioned C-safe protocols are supported. Dynamic libraries must not
+export business methods that pass Rust `Vec`, `String`, `Result`, `AnyRef`,
+`Arc<dyn Fn>`, or `FnOnce` values across the boundary. Those layouts, vtables,
+allocators, and drop implementations are compiler-specific and are no longer
+probed or invoked by Calcit.
 
-First one is a synchronous [Edn](https://github.com/Cirru/cirru-edn.rs) API with type signature:
+The supported boundaries are:
 
-```rust
-#[unsafe(no_mangle)]
-pub fn demo(args: Vec<Edn>) -> Result<Edn, String> {
-}
-```
+- synchronous byte-buffer protocol v1;
+- asynchronous task/callback protocol v1;
+- blocking callback protocol v1;
+- opaque-resource protocol v1 for reusable native objects.
 
-The legacy asynchronous API can be called multiple times and relies on Rust
-`Arc` trait objects:
-
-```rust
-#[unsafe(no_mangle)]
-pub fn demo(
-  args: Vec<Edn>,
-  handler: Arc<dyn Fn(Vec<Edn>) -> Result<Edn, String> + Send + Sync + 'static>,
-  finish: Box<dyn FnOnce() + Send + Sync + 'static>,
-) -> Result<Edn, String> {
-}
-```
-
-in this snippet, the function `handler` is used as the callback, which could be called multiple times.
-
-The function `finish` is used for indicating that the task has finished. It can be called once, or not being called.
-Internally Calcit tracks with a counter to see if all asynchorous tasks are finished.
-Process need to keep running when there are tasks running.
-
-New callback methods should instead implement the C-safe asynchronous protocol
-described below. The Rust form remains only as a per-method migration fallback.
-
-Rust's native ABI has no stability guarantee. `Vec<Edn>`, `String`, `Result`, and callback trait objects are therefore a transitional interface rather than a portable dylib protocol. Calcit checks a C-safe build identity before invoking those Rust ABI symbols.
-
-Add a `build.rs` that derives the identity from the exact compiler, target, debug-assertion mode, and panic strategy:
-
-```rust
-use std::{env, process::Command};
-
-fn field<'a>(output: &'a str, name: &str) -> &'a str {
-  output.lines().find_map(|line| line.strip_prefix(name).map(str::trim)).unwrap()
-}
-
-fn main() {
-  let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
-  let output = Command::new(rustc).args(["--version", "--verbose"]).output().unwrap();
-  assert!(output.status.success());
-  let verbose = String::from_utf8(output.stdout).unwrap();
-  let release = field(&verbose, "release:");
-  let commit = field(&verbose, "commit-hash:");
-  let target = env::var("TARGET").unwrap();
-  let debug_assertions = env::var_os("CARGO_CFG_DEBUG_ASSERTIONS").is_some();
-  let panic_strategy = env::var("CARGO_CFG_PANIC").unwrap();
-  println!(
-    "cargo:rustc-env=CALCIT_FFI_BUILD_ID=rustc={release}:{commit};target={target};debug-assertions={debug_assertions};panic={panic_strategy}"
-  );
-}
-```
-
-Export the resulting value through a null-terminated C string. This lookup is safe to perform before any Rust-layout-dependent value crosses the library boundary:
-
-```rust
-use std::ffi::c_char;
-
-static FFI_BUILD_ID: &[u8] = concat!(env!("CALCIT_FFI_BUILD_ID"), "\0").as_bytes();
-
-#[unsafe(no_mangle)]
-pub extern "C" fn calcit_ffi_build_id() -> *const c_char {
-  FFI_BUILD_ID.as_ptr().cast()
-}
-```
-
-The existing Rust ABI version functions are still required during the migration period:
-
-```rust
-#[unsafe(no_mangle)]
-pub fn abi_version() -> String {
-  String::from("0.0.9")
-}
-
-#[unsafe(no_mangle)]
-pub fn edn_version() -> String {
-  cirru_edn::version().to_owned()
-}
-```
-
-`abi_version()` must match Calcit's FFI ABI version exactly.
-
-`edn_version()` must match the exact `cirru_edn` crate version used by the running Calcit binary. If either version differs, Calcit aborts the FFI call before invoking the target symbol.
-
-The build identity must also match exactly. Debug Calcit hosts reject dylibs that do not export `calcit_ffi_build_id`, which prevents the common debug-host/release-dylib crash before even calling `abi_version()`. Release hosts temporarily retain the legacy path with a warning so maintained modules can migrate incrementally. A matching identity reduces accidental incompatibility; it does not turn Rust's native ABI into a stable public protocol.
-
-Inspect the host side before building or debugging a module:
-
-```bash
-calcit --ffi-build-id
-```
+Each protocol advertises a fixed `extern "C"` version function. Missing
+version or per-method symbols are deterministic migration errors; there is no
+Rust-ABI fallback. Native modules should use `cdylib` and export only fixed C
+ABI symbols.
 
 ## C-safe synchronous buffer ABI
 
-New synchronous methods should use buffer protocol version 1. Calcit first looks for `<method>_calcit_ffi_v1`; only methods without that symbol fall back to the build-ID-guarded Rust ABI. Existing Calcit source calls do not change.
+Synchronous methods use buffer protocol version 1. Calcit looks for
+`<method>_calcit_ffi_v1`; missing protocol/version/free/method symbols are
+migration errors. Existing Calcit source calls do not change.
 
 The dylib exports these C ABI symbols:
 
@@ -163,17 +86,20 @@ reference is dropped.
 
 ## C-safe asynchronous callback ABI
 
-`&call-dylib-edn-fn` now probes `<method>_calcit_ffi_async_v1` before using the
-guarded legacy Rust callback. A callback-v1 module exports
+`&call-dylib-edn-fn` requires `<method>_calcit_ffi_async_v1`. A callback-v1 module exports
 `calcit_ffi_async_version() -> 1`, accepts a C-layout task descriptor and host
 function table, and publishes byte payloads through the host's `enqueue`
 function. Foreign producer threads only enqueue; Calcit copies the payload and
 runs callbacks on its host thread.
 
+An async-only module does not need to export the buffer protocol or
+`calcit_ffi_buffer_free`. Those symbols are required only by synchronous buffer
+methods and blocking methods whose final output is allocated by the module.
+
 `Emit` payloads are Cirru EDN argument lists. Successful completion must carry
 the explicit `&unit` value, and `Fail` carries a Cirru EDN diagnostic that is
-surfaced to the console. Missing version or per-method symbols retain the
-legacy fallback; an advertised incompatible version is an error. See
+surfaced to the console. Missing version or per-method symbols are migration
+errors; an advertised incompatible version is a protocol mismatch. See
 [Asynchronous FFI task protocol](ffi-async-protocol.md) for the exact C
 signatures, ownership, lifecycle, status, queue, and future WASM rules.
 
@@ -216,8 +142,8 @@ Callback results are allocated and tracked by the host and must be returned
 through the blocking host table's `free_buffer`; the method's final output is
 allocated by the module and released through `calcit_ffi_buffer_free`.
 `finish` may be called explicitly once, otherwise method return finishes the
-task implicitly. Missing per-method blocking symbols retain the guarded legacy
-fallback during migration. See
+task implicitly. Missing protocol or per-method blocking symbols are migration
+errors. See
 [Asynchronous FFI task protocol](ffi-async-protocol.md#native-blocking-abi-v1)
 for the C signatures and ownership rules.
 

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -12,18 +12,20 @@ aliases:
 
 本文描述将 Calcit FFI 动态库项目（dylib 工程）升级到最新依赖版本的完整流程，基于实际升级经验整理。
 
-## 版本与构建身份
+## 版本与协议
 
 每个 FFI 项目需要同步维护两处版本号：
 
 | 文件         | 字段                      | 说明                                                        |
 | ------------ | ------------------------- | ----------------------------------------------------------- |
-| `Cargo.toml` | `cirru_edn = "x.y.z"`     | 必须与运行时 Calcit 二进制所链接的 `cirru_edn` 版本完全一致 |
+| `Cargo.toml` | `cirru_edn = "x.y.z"`     | 模块内部使用的 Cirru EDN codec；不再与 Calcit host 的 Rust crate 版本绑定 |
 | `deps.cirru` | `:calcit-version \|x.y.z` | 必须与 `calcit --version` 输出一致，CI 会用它校验               |
 
-两者不一致都会导致 CI 失败或运行时 `dlsym failed`。
-
-此外，Rust 原生 ABI 不稳定。FFI 项目必须按 [Rust bindings](./ffi-bindings.md) 增加 `build.rs` 和 C-safe `calcit_ffi_build_id()` 导出。该身份包含精确 rustc、target、debug assertions 与 panic strategy；Calcit 会在调用 `abi_version()`、`edn_version()` 或业务 symbol 之前比较。不要把 optimization level 加入身份：Calcit 自身 release 使用体积优化，而模块通常使用 Cargo 默认 release 优化，两者可以共享相同的 ABI 构建模式。
+Calcit native FFI 只支持 [Rust bindings](./ffi-bindings.md) 中的 C-safe
+buffer/async/blocking/resource protocol v1。Host 与模块通过 UTF-8 Cirru EDN
+bytes 交换业务数据，不再要求使用同一个 rustc 或同一个 `cirru_edn`
+crate build。`calcit_ffi_build_id`、`abi_version`、`edn_version` 和 Rust-layout
+business methods 均已退役。
 
 ## 升级流程
 
@@ -73,7 +75,16 @@ calcit calcit.cirru
 
 若模块返回编译后的正则等可复用 native 对象，不要继续跨 dylib 传递 Rust `AnyRef`，也不要改成用户手动释放的整数句柄。按照 [FFI opaque resource protocol / FFI 不透明资源协议](./ffi-resource-protocol.md) 使用 buffer v1 token、generation registry 和自动 release。
 
-Calcit 与 dylib 必须使用同一 rustc 工具链。先运行 `calcit --ffi-build-id` 查看 host identity。若项目提供 `rust-toolchain.toml`，应固定到发布 Calcit 所报告的 compiler identity；本地从源码构建 Calcit 时，则用同一个 toolchain 构建 dylib。debug Calcit 会在缺少 build identity 时直接拒绝旧模块；release Calcit 在迁移期仍会接受，但会输出兼容性警告。
+验证 release dylib 的导出符号只包含固定 C ABI，并按模块实际使用的能力检查符号：
+
+- 同步 buffer：`calcit_ffi_buffer_version`、`calcit_ffi_buffer_free`、`<method>_calcit_ffi_v1`；
+- 异步 callback：`calcit_ffi_async_version`、`<method>_calcit_ffi_async_v1`；
+- blocking callback：`calcit_ffi_async_version`、`calcit_ffi_buffer_free`、`<method>_calcit_ffi_blocking_v1`；
+- opaque resource：`calcit_ffi_resource_version`、`calcit_ffi_resource_release_v1`。
+
+只实现异步 callback 的模块不需要导出 buffer protocol 或
+`calcit_ffi_buffer_free`。缺失当前调用所需符号时，Calcit 会直接报告期望的
+C-safe symbol，不会尝试同名 Rust function。
 
 ### 4. 提交、打标签并推送
 
@@ -81,7 +92,7 @@ Calcit 与 dylib 必须使用同一 rustc 工具链。先运行 `calcit --ffi-bu
 PKG_VER=$(cargo metadata --no-deps --format-version 1 \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['packages'][0]['version'])")
 
-git add Cargo.toml Cargo.lock deps.cirru build.rs
+git add Cargo.toml Cargo.lock deps.cirru
 git commit -m "chore: upgrade cirru_edn $EDN_VER, cirru_parser $PARSER_VER; bump version to $PKG_VER"
 git tag "$PKG_VER"
 git push origin <branch>
@@ -121,14 +132,11 @@ gh pr checks <PR_NUMBER>
 按顺序排查：
 
 1. 同步方法优先检查 `calcit_ffi_buffer_version()`、`calcit_ffi_buffer_free()` 与 `<method>_calcit_ffi_v1` 是否已导出
-2. 仍在旧 Rust ABI 的方法检查 `calcit_ffi_build_id()`、`abi_version()`、`edn_version()` 是否已导出
-3. `calcit_ffi_build_id()` 是否使用 `extern "C"`、静态 NUL 结尾字节串与 `*const c_char`
-4. `#[unsafe(no_mangle)]`（Rust 2024 edition）是否存在
-5. `dylibs/` 中是否已复制最新产物（`cp target/release/*.* dylibs/`）
-
-### FFI build identity mismatch
-
-错误会同时打印 dylib 与 host identity。逐项比较 rustc release/commit、target、debug assertions 和 panic strategy；不要绕过检查或手工伪造 identity。使用同一 toolchain 与同类 debug/release 构建重新生成二进制，再复制到 `dylibs/` 验证。
+2. async 方法检查 `calcit_ffi_async_version()` 与 `<method>_calcit_ffi_async_v1`
+3. blocking 方法检查 `calcit_ffi_async_version()`、`calcit_ffi_buffer_free()` 与 `<method>_calcit_ffi_blocking_v1`
+4. opaque resource 方法检查 `calcit_ffi_resource_version()` 与 `calcit_ffi_resource_release_v1`
+5. 所有导出是否使用 `extern "C"` 与 `#[unsafe(no_mangle)]`（Rust 2024 edition）
+6. `dylibs/` 中是否已复制最新产物（`cp target/release/*.* dylibs/`）
 
 ### amend 后需要重打 tag
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -44,7 +44,6 @@ calcit eval "echo |done"
 
 - `--watch` / `-w` - Watch files and rerun/rebuild on changes
 - `--disable-stack` - Disable stack trace for errors
-- `--ffi-build-id` - Print the native FFI compiler/target/build-mode identity and exit
 - `--skip-arity-check` - Skip arity check in JS codegen
 - `--emit-path <path>` - Specify output path for JS (default: `js-out/`)
 - `--init-fn <fn>` - Specify main function

--- a/editing-history/202608280637-remove-rust-ffi-fallback.md
+++ b/editing-history/202608280637-remove-rust-ffi-fallback.md
@@ -1,0 +1,21 @@
+# Remove Rust FFI fallback / 删除 Rust FFI fallback
+
+## 中文
+
+- sync、callback、blocking 调用缺少 C-safe version/method/free symbol 时直接返回包含期望符号的迁移错误，不再查找或调用 Rust `Vec<Edn>`/trait-object function pointer。
+- 删除 `EdnFfi`、`EdnFfiFn`、release-host legacy warning、build identity validation，以及 `abi_version`/`edn_version` probes。
+- 删除 `--ffi-build-id` 与 build.rs 中 rustc/target/debug/panic identity 生成，C-safe wire protocol 不再绑定 host 与 dylib 的 Rust toolchain。
+- native capability verifier 改为验证 buffer/async/resource protocol versions 和配套 free/release symbols；realization key/receipt 记录 protocol versions，并继续校验 artifact size/hash。
+- 更新 FFI bindings、async protocol、upgrade guide 与 quick reference，明确 C-safe v1 是唯一支持边界。
+- 明确 version、method、free 和 release 符号按模块实际能力要求；只实现异步 callback 的模块不导出 buffer protocol。
+- 真实验证：当前 debug Calcit host 加载 release calcit-paint dylib 的 macOS blocking GUI smoke 通过，paint 也通过 verifier；只导出 legacy symbol 的 C fixture 在 caps 和 sync/async/blocking runtime 都确定性拒绝，且不会进入 Rust symbol。
+
+## English
+
+- Sync, callback, and blocking calls now return migration errors naming the expected C-safe version/method/free symbols; they no longer look up or invoke Rust `Vec<Edn>`/trait-object function pointers.
+- Removed `EdnFfi`, `EdnFfiFn`, release-host legacy warnings, build-identity validation, and `abi_version`/`edn_version` probes.
+- Removed `--ffi-build-id` and build.rs rustc/target/debug/panic identity generation; the C-safe wire protocol no longer couples host and dylib Rust toolchains.
+- Native capability verification now checks buffer/async/resource protocol versions and matching free/release symbols. Realization keys/receipts record protocol versions while retaining artifact size/hash integrity checks.
+- Updated FFI bindings, async protocol, upgrade guide, and quick reference to make C-safe v1 the only supported boundary.
+- Clarified that required version, method, free, and release symbols are capability-specific; async-only modules do not export the buffer protocol.
+- Real validation: the current debug Calcit host passes a macOS blocking GUI smoke against the release calcit-paint dylib, which also passes verification; a C fixture exporting only a legacy symbol is deterministically rejected by caps and sync/async/blocking runtime paths without entering that Rust symbol.

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -1056,29 +1056,58 @@ pub fn verify_project_view(graph: &ResolvedGraph, options: &GraphOptions) -> Res
 }
 
 pub fn verify_native_library(path: &Path) -> Result<(), String> {
-  type VersionFn = fn() -> String;
+  type VersionFn = unsafe extern "C" fn() -> u32;
   let library = unsafe { libloading::Library::new(path) }.map_err(|e| format!("failed to load {}: {e}", path.display()))?;
-  let lib_name = path.display().to_string();
-  let build_id = calcit::ffi_abi::lookup_build_id(&library, &lib_name)?;
-  calcit::ffi_abi::validate_build_id(&lib_name, build_id.as_deref(), calcit::FFI_BUILD_ID, cfg!(debug_assertions))?;
-  let abi: libloading::Symbol<VersionFn> =
-    unsafe { library.get(b"abi_version") }.map_err(|e| format!("failed to read abi_version from {}: {e}", path.display()))?;
-  let actual_abi = abi();
-  if actual_abi != calcit::FFI_ABI_VERSION {
+  let mut advertised = vec![];
+  for (name, symbol, expected) in [
+    (
+      "buffer",
+      calcit::ffi_abi::BUFFER_PROTOCOL_VERSION_SYMBOL,
+      calcit::ffi_abi::BUFFER_PROTOCOL_VERSION,
+    ),
+    (
+      "async",
+      calcit::ffi_abi::ASYNC_PROTOCOL_VERSION_SYMBOL,
+      calcit::ffi_abi::ASYNC_PROTOCOL_VERSION,
+    ),
+    (
+      "resource",
+      calcit::ffi_abi::RESOURCE_PROTOCOL_VERSION_SYMBOL,
+      calcit::ffi_abi::RESOURCE_PROTOCOL_VERSION,
+    ),
+  ] {
+    let Ok(version) = (unsafe { library.get::<VersionFn>(symbol) }) else {
+      continue;
+    };
+    let actual = unsafe { version() };
+    if actual != expected {
+      return Err(format!(
+        "FFI {name} protocol mismatch in {}: found {actual}, expected {expected}",
+        path.display()
+      ));
+    }
+    advertised.push(name);
+  }
+  if advertised.is_empty() {
     return Err(format!(
-      "FFI ABI mismatch in {}: found {actual_abi}, expected {}",
-      path.display(),
-      calcit::FFI_ABI_VERSION
+      "{} does not advertise a supported C-safe FFI protocol; expected `calcit_ffi_buffer_version` or `calcit_ffi_async_version`",
+      path.display()
     ));
   }
-  let edn: libloading::Symbol<VersionFn> =
-    unsafe { library.get(b"edn_version") }.map_err(|e| format!("failed to read edn_version from {}: {e}", path.display()))?;
-  let actual_edn = edn();
-  if actual_edn != cirru_edn::version() {
+  if advertised.contains(&"buffer")
+    && unsafe { library.get::<calcit::ffi_abi::FfiBufferFree>(calcit::ffi_abi::BUFFER_FREE_SYMBOL) }.is_err()
+  {
     return Err(format!(
-      "cirru_edn mismatch in {}: found {actual_edn}, expected {}",
+      "{} advertises C-safe buffer protocol but is missing `calcit_ffi_buffer_free`",
       path.display(),
-      cirru_edn::version()
+    ));
+  }
+  if advertised.contains(&"resource")
+    && unsafe { library.get::<calcit::ffi_abi::FfiResourceRelease>(calcit::ffi_abi::RESOURCE_RELEASE_SYMBOL) }.is_err()
+  {
+    return Err(format!(
+      "{} advertises C-safe resource protocol but is missing `calcit_ffi_resource_release_v1`",
+      path.display(),
     ));
   }
   Ok(())
@@ -1194,10 +1223,10 @@ fn expected_link_target(module: &ResolvedModule) -> Result<PathBuf, String> {
   }
   let target = rust_target_identity();
   let build_input = format!(
-    "{target}\ncalcit={CALCIT_VERSION}\nffi-abi={}\nffi-build={}\ncirru-edn={}\ncommit={}",
-    calcit::FFI_ABI_VERSION,
-    calcit::FFI_BUILD_ID,
-    cirru_edn::version(),
+    "{target}\ncalcit={CALCIT_VERSION}\nffi-buffer={}\nffi-async={}\nffi-resource={}\ncommit={}",
+    calcit::ffi_abi::BUFFER_PROTOCOL_VERSION,
+    calcit::ffi_abi::ASYNC_PROTOCOL_VERSION,
+    calcit::ffi_abi::RESOURCE_PROTOCOL_VERSION,
     module.commit
   );
   let build_key = hex::encode(Md5::digest(build_input.as_bytes()));
@@ -1221,9 +1250,15 @@ fn write_native_receipt(module: &ResolvedModule, realization: &Path, build_key: 
   receipt.insert(Edn::tag("module"), Edn::str(module.repository.as_str()));
   receipt.insert(Edn::tag("commit"), Edn::str(module.commit.as_str()));
   receipt.insert(Edn::tag("calcit-version"), Edn::str(CALCIT_VERSION));
-  receipt.insert(Edn::tag("ffi-abi"), Edn::str(calcit::FFI_ABI_VERSION));
-  receipt.insert(Edn::tag("ffi-build"), Edn::str(calcit::FFI_BUILD_ID));
-  receipt.insert(Edn::tag("cirru-edn"), Edn::str(cirru_edn::version()));
+  receipt.insert(
+    Edn::tag("ffi-buffer"),
+    Edn::str(calcit::ffi_abi::BUFFER_PROTOCOL_VERSION.to_string()),
+  );
+  receipt.insert(Edn::tag("ffi-async"), Edn::str(calcit::ffi_abi::ASYNC_PROTOCOL_VERSION.to_string()));
+  receipt.insert(
+    Edn::tag("ffi-resource"),
+    Edn::str(calcit::ffi_abi::RESOURCE_PROTOCOL_VERSION.to_string()),
+  );
   receipt.insert(Edn::tag("build-key"), Edn::str(build_key));
   receipt.insert(
     Edn::tag("artifacts"),
@@ -1252,13 +1287,16 @@ fn verify_native_receipt(module: &ResolvedModule, realization: &Path) -> Result<
     .map_err(|e| format!("failed to parse {}: {e}", receipt_path.display()))?
     .view_map()?;
   let expected_build_key = realization.file_name().and_then(|name| name.to_str()).unwrap_or("unknown");
+  let buffer_version = calcit::ffi_abi::BUFFER_PROTOCOL_VERSION.to_string();
+  let async_version = calcit::ffi_abi::ASYNC_PROTOCOL_VERSION.to_string();
+  let resource_version = calcit::ffi_abi::RESOURCE_PROTOCOL_VERSION.to_string();
   for (key, expected) in [
     ("module", module.repository.as_str()),
     ("commit", module.commit.as_str()),
     ("calcit-version", CALCIT_VERSION),
-    ("ffi-abi", calcit::FFI_ABI_VERSION),
-    ("ffi-build", calcit::FFI_BUILD_ID),
-    ("cirru-edn", cirru_edn::version()),
+    ("ffi-buffer", buffer_version.as_str()),
+    ("ffi-async", async_version.as_str()),
+    ("ffi-resource", resource_version.as_str()),
     ("build-key", expected_build_key),
   ] {
     let actual = receipt

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -276,11 +276,6 @@ fn run_cli() -> Result<(), String> {
     return Ok(());
   }
 
-  if cli_args.ffi_build_id {
-    println!("{}", calcit::FFI_BUILD_ID);
-    return Ok(());
-  }
-
   if let Some(level) = cli_args.tips_level.as_deref() {
     cli_handlers::set_tips_level(level)?;
   }

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -25,16 +25,8 @@ use calcit::{
   runner::track,
 };
 
-/// FFI protocol types
-type EdnFfi = fn(args: Vec<Edn>) -> Result<Edn, String>;
-type EdnFfiFn = fn(
-  args: Vec<Edn>,
-  f: Arc<dyn Fn(Vec<Edn>) -> Result<Edn, String> + Send + Sync + 'static>,
-  finish: Arc<dyn FnOnce()>,
-) -> Result<Edn, String>;
 /// lazily cache dylibs, in case Linux drops memory of libraries
 static DYLIBS: LazyLock<Mutex<HashMap<String, Arc<libloading::Library>>>> = LazyLock::new(|| Mutex::new(HashMap::new()));
-static LEGACY_DYLIB_WARNED: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 static TRACE_FFI: AtomicBool = AtomicBool::new(false);
 static STDOUT_TO_STDERR: AtomicBool = AtomicBool::new(false);
 static SILENCE_PROGRAM_OUTPUT: AtomicBool = AtomicBool::new(false);
@@ -171,7 +163,6 @@ static NATIVE_ASYNC_RUNTIME: OnceLock<NativeAsyncRuntime> = OnceLock::new();
 pub fn set_trace_ffi(v: bool) {
   TRACE_FFI.store(v, Ordering::Relaxed);
   if v {
-    let edn_version = cirru_edn::version();
     let cwd = std::env::current_dir()
       .map(|p| p.display().to_string())
       .unwrap_or_else(|_| "<unknown-cwd>".to_string());
@@ -181,12 +172,13 @@ pub fn set_trace_ffi(v: bool) {
     trace_ffi_event(
       "enable",
       format!(
-        "cwd={cwd} exe={exe} abi={} edn={edn_version} host={}",
-        calcit::FFI_ABI_VERSION,
+        "cwd={cwd} exe={exe} buffer={} async={} resource={} host={}",
+        calcit::ffi_abi::BUFFER_PROTOCOL_VERSION,
+        calcit::ffi_abi::ASYNC_PROTOCOL_VERSION,
+        calcit::ffi_abi::RESOURCE_PROTOCOL_VERSION,
         std::env::consts::OS,
       ),
     );
-    trace_ffi_event("host-build", calcit::FFI_BUILD_ID);
   }
 }
 
@@ -1182,78 +1174,13 @@ fn load_dylib(lib_name: &str) -> Result<Arc<libloading::Library>, CalcitErr> {
   Ok(lib)
 }
 
-fn ensure_abi_compatible(lib: &libloading::Library, lib_name: &str) -> Result<(), CalcitErr> {
-  trace_ffi_event("lookup-build-id", format!("lib={lib_name}"));
-  let dylib_build_id =
-    calcit::ffi_abi::lookup_build_id(lib, lib_name).map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
-  match calcit::ffi_abi::validate_build_id(lib_name, dylib_build_id.as_deref(), calcit::FFI_BUILD_ID, cfg!(debug_assertions))
-    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?
-  {
-    calcit::ffi_abi::FfiBuildCompatibility::Exact => trace_ffi_event(
-      "build-id",
-      format!(
-        "lib={lib_name} dylib={} host={} compatible=true",
-        dylib_build_id.as_deref().unwrap_or("<missing>"),
-        calcit::FFI_BUILD_ID
-      ),
+fn c_safe_migration_error(kind: &str, protocol: &str, lib_name: &str, method: &str, expected: &str) -> CalcitErr {
+  CalcitErr::use_str(
+    CalcitErrKind::Unexpected,
+    format!(
+      "FFI {kind} method `{method}` in `{lib_name}` does not provide C-safe {protocol}. Expected {expected}; the legacy Rust-ABI fallback has been removed. Upgrade and rebuild the native module."
     ),
-    calcit::ffi_abi::FfiBuildCompatibility::Legacy => {
-      trace_ffi_event(
-        "build-id",
-        format!("lib={lib_name} dylib=<missing> host={} legacy=true", calcit::FFI_BUILD_ID),
-      );
-      let mut warned = LEGACY_DYLIB_WARNED
-        .lock()
-        .map_err(|_| CalcitErr::use_str(CalcitErrKind::Unexpected, "failed to lock legacy dylib warning cache"))?;
-      if warned.insert(lib_name.to_owned()) && !calcit::quiet_tool_output() {
-        eprintln!(
-          "[warning] Rust-native FFI library `{lib_name}` has no C-safe `calcit_ffi_build_id`; release-host compatibility is temporary and cannot prove compiler compatibility. Rebuild the module using the current FFI guide."
-        );
-      }
-    }
-  }
-
-  let expected_edn_version = cirru_edn::version();
-  trace_ffi_event("lookup-abi", format!("lib={lib_name}"));
-  let lookup_version: libloading::Symbol<fn() -> String> = unsafe { lib.get("abi_version".as_bytes()) }.map_err(|e| {
-    CalcitErr::use_str(
-      CalcitErrKind::Unexpected,
-      format!("failed to lookup `abi_version` in `{lib_name}`: {e}"),
-    )
-  })?;
-  let current = lookup_version();
-  trace_ffi_event(
-    "abi-version",
-    format!("lib={lib_name} current={current} expected={}", calcit::FFI_ABI_VERSION),
-  );
-  if current != calcit::FFI_ABI_VERSION {
-    return CalcitErr::err_str(
-      CalcitErrKind::Unexpected,
-      format!("ABI versions mismatch: {current} {}", calcit::FFI_ABI_VERSION),
-    )
-    .map(|_| ());
-  }
-
-  trace_ffi_event("lookup-edn-version", format!("lib={lib_name}"));
-  let lookup_edn_version: libloading::Symbol<fn() -> String> = unsafe { lib.get("edn_version".as_bytes()) }.map_err(|e| {
-    CalcitErr::use_str(
-      CalcitErrKind::Unexpected,
-      format!("failed to lookup `edn_version` in `{lib_name}`: {e}"),
-    )
-  })?;
-  let current_edn = lookup_edn_version();
-  trace_ffi_event(
-    "edn-version",
-    format!("lib={lib_name} current={current_edn} expected={expected_edn_version}"),
-  );
-  if current_edn != expected_edn_version {
-    return CalcitErr::err_str(
-      CalcitErrKind::Unexpected,
-      format!("cirru_edn versions mismatch: {current_edn} {expected_edn_version}"),
-    )
-    .map(|_| ());
-  }
-  Ok(())
+  )
 }
 
 static PLATFORM_APIS_INJECTED: AtomicBool = AtomicBool::new(false);
@@ -1419,30 +1346,20 @@ pub fn call_dylib_edn(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Ca
           format_edn_args_for_trace(std::slice::from_ref(&ret))
         ),
       );
-      return Ok(edn_to_calcit(&ret, &Calcit::Nil));
+      Ok(edn_to_calcit(&ret, &Calcit::Nil))
     }
-    None => trace_ffi_event("buffer-fallback", format!("lib={lib_name} symbol={method}")),
+    None => {
+      let symbol = calcit::ffi_abi::buffer_method_symbol(&method);
+      trace_ffi_event("buffer-required", format!("lib={lib_name} symbol={symbol} missing=true"));
+      Err(c_safe_migration_error(
+        "synchronous",
+        "buffer protocol v1",
+        &lib_name,
+        &method,
+        &format!("`calcit_ffi_buffer_version`, `{symbol}`, and `calcit_ffi_buffer_free`"),
+      ))
+    }
   }
-  ensure_abi_compatible(&lib, &lib_name)?;
-  trace_ffi_event("lookup-symbol", format!("lib={lib_name} symbol={method}"));
-  let func: libloading::Symbol<EdnFfi> = unsafe { lib.get(method.as_bytes()) }.map_err(|e| {
-    CalcitErr::use_str(
-      CalcitErrKind::Unexpected,
-      format!("failed to load FFI symbol `{method}` in `{lib_name}`: {e}"),
-    )
-  })?;
-  let ret = func(ys.to_owned()).map_err(|e| {
-    trace_ffi_event("error", format!("lib={lib_name} symbol={method} {e}"));
-    e
-  })?;
-  trace_ffi_event(
-    "return",
-    format!(
-      "lib={lib_name} symbol={method} ret={}",
-      format_edn_args_for_trace(std::slice::from_ref(&ret))
-    ),
-  );
-  Ok(edn_to_calcit(&ret, &Calcit::Nil))
 }
 
 pub fn stdout_println(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
@@ -1630,106 +1547,15 @@ pub fn call_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<
   if let Some(result) = try_start_async_callback_v1(&lib, &lib_name, &method, ys.clone(), callback.clone(), call_stack)? {
     return Ok(result);
   }
-  trace_ffi_event(
-    "async-fallback",
-    format!(
-      "lib={lib_name} symbol={} fallback={method}",
-      calcit::ffi_abi::async_method_symbol(&method)
-    ),
-  );
-  ensure_abi_compatible(&lib, &lib_name)?;
-  track::track_task_add();
-  trace_ffi_event("task-add", format!("kind=callback pending={}", track::count_pending_tasks()));
-  let copied_stack_1 = Arc::new(call_stack.to_owned());
-  let method_name = method.clone();
-  let lib_name_for_thread = lib_name.clone();
-
-  let _handle = thread::spawn(move || {
-    trace_ffi_event(
-      "thread-start",
-      format!(
-        "lib={lib_name_for_thread} symbol={method_name} pending={}",
-        track::count_pending_tasks()
-      ),
-    );
-    let callback_method_name = method_name.clone();
-    let callback_lib_name = lib_name_for_thread.clone();
-    trace_ffi_event("lookup-symbol", format!("lib={lib_name_for_thread} symbol={method_name}"));
-    let func: libloading::Symbol<EdnFfiFn> = match unsafe { lib.get(method_name.as_bytes()) } {
-      Ok(f) => f,
-      Err(e) => {
-        track::track_task_release();
-        trace_ffi_event("task-release", format!("kind=callback pending={}", track::count_pending_tasks()));
-        return CalcitErr::err_str(
-          CalcitErrKind::Unexpected,
-          format!("failed to load FFI symbol `{method_name}` in `{lib_name_for_thread}`: {e}"),
-        );
-      }
-    };
-    let copied_stack = copied_stack_1.to_owned();
-    match func(
-      ys.to_owned(),
-      Arc::new(move |ps: Vec<Edn>| -> Result<Edn, String> {
-        trace_ffi_event(
-          "callback-in",
-          format!(
-            "lib={callback_lib_name} symbol={callback_method_name} argc={} args={}",
-            ps.len(),
-            format_edn_args_for_trace(&ps)
-          ),
-        );
-        if let Calcit::Fn { info, .. } = &callback {
-          let mut real_args: Vec<Calcit> = vec![];
-          for p in ps {
-            real_args.push(edn_to_calcit(&p, &Calcit::Nil));
-          }
-          let r = runner::run_fn(&real_args, info, &copied_stack);
-          match r {
-            Ok(ret) => {
-              let ret_edn = calcit_to_edn(&ret)?;
-              trace_ffi_event(
-                "callback-out",
-                format!(
-                  "lib={callback_lib_name} symbol={callback_method_name} ret={}",
-                  format_edn_args_for_trace(std::slice::from_ref(&ret_edn))
-                ),
-              );
-              Ok(ret_edn)
-            }
-            Err(e) => {
-              display_stack(&format!("[Error] thread callback failed: {}", e.msg), &e.stack, e.location.as_ref())?;
-              Err(format!("Error: {e}"))
-            }
-          }
-        } else {
-          Err(format!("expected last argument to be callback fn, got: {callback}"))
-        }
-      }),
-      Arc::new(track::track_task_release),
-    ) {
-      Ok(ret) => {
-        trace_ffi_event(
-          "return-callback",
-          format!(
-            "lib={lib_name_for_thread} symbol={method_name} ret={}",
-            format_edn_args_for_trace(std::slice::from_ref(&ret))
-          ),
-        );
-        edn_to_calcit(&ret, &Calcit::Nil)
-      }
-      Err(e) => {
-        track::track_task_release();
-        trace_ffi_event("task-release", format!("kind=callback pending={}", track::count_pending_tasks()));
-        trace_ffi_event("error-callback", format!("lib={lib_name_for_thread} symbol={method_name} {e}"));
-        // let _ = display_stack(&format!("failed to call request: {}", e), &copied_stack_1);
-        eprintln!("failure inside ffi thread: {e}");
-        return CalcitErr::err_str(CalcitErrKind::Unexpected, e);
-      }
-    };
-    Ok(Calcit::Nil)
-  });
-
-  Ok(Calcit::Unit)
+  let symbol = calcit::ffi_abi::async_method_symbol(&method);
+  trace_ffi_event("async-required", format!("lib={lib_name} symbol={symbol} missing=true"));
+  Err(c_safe_migration_error(
+    "callback",
+    "async protocol v1",
+    &lib_name,
+    &method,
+    &format!("`calcit_ffi_async_version` and `{symbol}`"),
+  ))
 }
 
 fn release_blocking_task(runtime: &NativeAsyncRuntime, handle: FfiAsyncHandle) -> Result<(usize, Vec<String>), String> {
@@ -1849,7 +1675,7 @@ fn try_call_blocking_v1(
 }
 
 /// Pass a callback to a C-safe FFI method while the dylib owns the host
-/// thread. The guarded Rust ABI remains as a per-method migration fallback.
+/// thread. Missing C-safe protocol or method symbols are migration errors.
 pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if xs.len() < 3 {
     return CalcitErr::err_str(
@@ -1912,98 +1738,15 @@ pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Res
       )
     });
   }
-  trace_ffi_event(
-    "blocking-fallback",
-    format!(
-      "lib={lib_name} symbol={} fallback={method}",
-      calcit::ffi_abi::blocking_method_symbol(&method)
-    ),
-  );
-  ensure_abi_compatible(&lib, &lib_name)?;
-  let copied_stack = Arc::new(call_stack.to_owned());
-  let callback_method = method.clone();
-  let callback_lib_name = lib_name.clone();
-
-  let func: libloading::Symbol<EdnFfiFn> = unsafe { lib.get(method.as_bytes()) }.map_err(|e| {
-    CalcitErr::use_str(
-      CalcitErrKind::Unexpected,
-      format!("failed to load FFI symbol `{method}` in `{lib_name}`: {e}"),
-    )
-  })?;
-  let released = Arc::new(AtomicBool::new(false));
-  let finish_released = Arc::clone(&released);
-  track::track_task_add();
-  trace_ffi_event("task-add", format!("kind=blocking-legacy pending={}", track::count_pending_tasks()));
-  let result = func(
-    ys.to_owned(),
-    Arc::new(move |ps: Vec<Edn>| -> Result<Edn, String> {
-      trace_ffi_event(
-        "blocking-callback-in",
-        format!(
-          "lib={callback_lib_name} symbol={callback_method} argc={} args={}",
-          ps.len(),
-          format_edn_args_for_trace(&ps)
-        ),
-      );
-      if let Calcit::Fn { info, .. } = &callback {
-        let mut real_args: Vec<Calcit> = vec![];
-        for p in ps {
-          real_args.push(edn_to_calcit(&p, &Calcit::Nil));
-        }
-        let r = runner::run_fn(&real_args, info, &copied_stack);
-        match r {
-          Ok(ret) => {
-            let ret_edn = calcit_to_edn(&ret)?;
-            trace_ffi_event(
-              "blocking-callback-out",
-              format!(
-                "lib={callback_lib_name} symbol={callback_method} ret={}",
-                format_edn_args_for_trace(std::slice::from_ref(&ret_edn))
-              ),
-            );
-            Ok(ret_edn)
-          }
-          Err(e) => {
-            display_stack(&format!("[Error] thread callback failed: {}", e.msg), &e.stack, e.location.as_ref())?;
-            Err(format!("Error: {e}"))
-          }
-        }
-      } else {
-        Err(format!("expected last argument to be callback fn, got: {callback}"))
-      }
-    }),
-    Arc::new(move || {
-      if !finish_released.swap(true, Ordering::AcqRel) {
-        track::track_task_release();
-      }
-    }),
-  );
-  if !released.swap(true, Ordering::AcqRel) {
-    track::track_task_release();
-    trace_ffi_event(
-      "task-release",
-      format!("kind=blocking-legacy implicit=true pending={}", track::count_pending_tasks()),
-    );
-  }
-  match result {
-    Ok(ret) => {
-      trace_ffi_event(
-        "blocking-return",
-        format!(
-          "lib={lib_name} symbol={method} ret={}",
-          format_edn_args_for_trace(std::slice::from_ref(&ret))
-        ),
-      );
-      edn_to_calcit(&ret, &Calcit::Nil)
-    }
-    Err(e) => {
-      trace_ffi_event("blocking-error", format!("lib={lib_name} symbol={method} {e}"));
-      let _ = display_stack(&format!("failed to call request: {e}"), call_stack, None);
-      return CalcitErr::err_str(CalcitErrKind::Unexpected, e);
-    }
-  };
-
-  Ok(Calcit::Nil)
+  let symbol = calcit::ffi_abi::blocking_method_symbol(&method);
+  trace_ffi_event("blocking-required", format!("lib={lib_name} symbol={symbol} missing=true"));
+  Err(c_safe_migration_error(
+    "blocking",
+    "blocking protocol v1",
+    &lib_name,
+    &method,
+    &format!("`calcit_ffi_async_version`, `{symbol}`, and `calcit_ffi_buffer_free`"),
+  ))
 }
 
 /// need to put it here since the crate does not compile for dylib
@@ -2032,6 +1775,26 @@ mod async_callback_tests {
 
   type RecordedResponse = (u64, u64, u32, Vec<u8>);
   static RESPONSE_EVENTS: LazyLock<Mutex<Vec<RecordedResponse>>> = LazyLock::new(|| Mutex::new(vec![]));
+
+  #[test]
+  fn missing_c_safe_symbols_report_migration_without_rust_symbol_probes() {
+    for (kind, protocol, expected) in [
+      ("synchronous", "buffer protocol v1", "`read_calcit_ffi_v1`"),
+      ("callback", "async protocol v1", "`serve_calcit_ffi_async_v1`"),
+      ("blocking", "blocking protocol v1", "`paint_calcit_ffi_blocking_v1`"),
+    ] {
+      let error = c_safe_migration_error(kind, protocol, "fixture.so", "demo", expected);
+      assert!(error.msg.contains(protocol), "error: {}", error.msg);
+      assert!(error.msg.contains(expected), "error: {}", error.msg);
+      assert!(
+        error.msg.contains("legacy Rust-ABI fallback has been removed"),
+        "error: {}",
+        error.msg
+      );
+      assert!(!error.msg.contains("abi_version"), "error: {}", error.msg);
+      assert!(!error.msg.contains("edn_version"), "error: {}", error.msg);
+    }
+  }
 
   unsafe extern "C" fn record_response(
     context: u64,

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -25,9 +25,6 @@ pub struct ToplevelCalcit {
   /// print FFI dylib calls and callbacks for debugging native crashes
   #[argh(switch)]
   pub trace_ffi: bool,
-  /// print the Rust-native FFI host build identity and exit
-  #[argh(switch)]
-  pub ffi_build_id: bool,
   /// entry file path, defaults to "js-out/"
   #[argh(option, default = "String::from(\"js-out/\")")]
   pub emit_path: String,

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -1,14 +1,9 @@
 use std::collections::HashMap;
-use std::ffi::{CStr, c_char};
 use std::fmt;
 use std::sync::{Arc, LazyLock, Mutex, Weak};
 use std::{ptr, slice};
 
 use cirru_edn::{Edn, EdnAnyRef, EdnEnumView, EdnListView, EdnMapView, EdnSetView, EdnStructView};
-
-pub const BUILD_ID_SYMBOL: &[u8] = b"calcit_ffi_build_id";
-
-type FfiBuildId = unsafe extern "C" fn() -> *const c_char;
 
 pub const BUFFER_PROTOCOL_VERSION: u32 = 1;
 pub const BUFFER_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_buffer_version";
@@ -745,10 +740,10 @@ impl FfiBuffer {
 }
 
 type FfiBufferVersion = unsafe extern "C" fn() -> u32;
-type FfiBufferFree = unsafe extern "C" fn(FfiBuffer);
+pub type FfiBufferFree = unsafe extern "C" fn(FfiBuffer);
 type FfiBufferCall = unsafe extern "C" fn(*const u8, usize, *mut FfiBuffer) -> i32;
 type FfiResourceVersion = unsafe extern "C" fn() -> u32;
-type FfiResourceRelease = unsafe extern "C" fn(u64, u64) -> i32;
+pub type FfiResourceRelease = unsafe extern "C" fn(u64, u64) -> i32;
 pub type FfiResourceTrace = fn(&str, &str, u64, u64, i32);
 type FfiAsyncVersion = unsafe extern "C" fn() -> u32;
 pub type FfiAsyncStart = unsafe extern "C" fn(
@@ -874,13 +869,7 @@ fn intern_resource_lease(adapter: &FfiResourceAdapter, handle: u64, generation: 
   Ok(lease)
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum FfiBuildCompatibility {
-  Exact,
-  Legacy,
-}
-
-fn buffer_method_symbol(method: &str) -> String {
+pub fn buffer_method_symbol(method: &str) -> String {
   format!("{method}{BUFFER_METHOD_SUFFIX}")
 }
 
@@ -895,7 +884,8 @@ pub fn blocking_method_symbol(method: &str) -> String {
 /// Check whether one blocking method has completed the C-safe migration before
 /// allocating host task state. An advertised incompatible protocol or a
 /// migrated method without its matching module-side free function is a hard
-/// error; an absent version/method retains transitional fallback.
+/// error; an absent version/method returns `false` so the caller can report a
+/// deterministic C-safe migration error before allocating host task state.
 pub fn has_blocking_method(lib: &libloading::Library, lib_name: &str, method: &str) -> Result<bool, String> {
   let version: libloading::Symbol<FfiAsyncVersion> = match unsafe { lib.get(ASYNC_PROTOCOL_VERSION_SYMBOL) } {
     Ok(version) => version,
@@ -1085,9 +1075,9 @@ fn hydrate_resource_tokens(value: Edn, adapter: &FfiResourceAdapter) -> Result<E
   }
 }
 
-/// Probe a C-safe async method without touching the guarded Rust ABI. A
-/// missing protocol or per-method symbol returns `None` for transitional
-/// fallback; an advertised but incompatible version is a hard error.
+/// Probe a C-safe async method. A missing protocol or per-method symbol returns
+/// `None` so the caller can report a deterministic migration error; an
+/// advertised but incompatible version is a hard error.
 pub fn lookup_async_start<'lib>(
   lib: &'lib libloading::Library,
   lib_name: &str,
@@ -1114,7 +1104,7 @@ pub fn lookup_async_start<'lib>(
 /// Probe and invoke a C-safe blocking callback method. It shares the async
 /// protocol version and task descriptor while using a distinct method symbol,
 /// so blocking and asynchronous entry points cannot be confused. Missing
-/// protocol or method symbols retain the guarded per-method fallback.
+/// protocol or method symbols are reported by the caller as migration errors.
 pub fn try_call_blocking(
   lib: &libloading::Library,
   lib_name: &str,
@@ -1201,8 +1191,8 @@ unsafe fn copy_and_free_buffer(
 }
 
 /// Try the C-safe synchronous byte-buffer protocol. `Ok(None)` means the
-/// library or this particular method has not migrated and may use the guarded
-/// legacy Rust ABI path.
+/// library or this particular method is missing required C-safe symbols; the
+/// caller must report a deterministic migration error.
 pub fn try_call_buffer(
   lib: &Arc<libloading::Library>,
   lib_name: &str,
@@ -1266,52 +1256,15 @@ pub fn try_call_buffer(
   hydrate_resource_tokens(output, &adapter).map(Some)
 }
 
-pub fn validate_build_id(
-  lib_name: &str,
-  dylib_build_id: Option<&str>,
-  host_build_id: &str,
-  require_build_id: bool,
-) -> Result<FfiBuildCompatibility, String> {
-  match dylib_build_id {
-    Some(dylib_build_id) if dylib_build_id == host_build_id => Ok(FfiBuildCompatibility::Exact),
-    Some(dylib_build_id) => Err(format!(
-      "Refusing Rust-native FFI library `{lib_name}` before invoking a Rust ABI symbol because its build identity differs from the Calcit host. dylib: `{dylib_build_id}`; host: `{host_build_id}`. Rebuild both with the same rustc, target, debug-assertion mode, and panic strategy."
-    )),
-    None if require_build_id => Err(format!(
-      "Refusing legacy Rust-native FFI library `{lib_name}` before invoking a Rust ABI symbol: this debug Calcit host cannot prove that the dylib uses a compatible build. Export the C-safe `calcit_ffi_build_id` symbol described in the FFI guide, or run a release Calcit host built with the same toolchain as the dylib. Expected host identity: `{host_build_id}`."
-    )),
-    None => Ok(FfiBuildCompatibility::Legacy),
-  }
-}
-
-/// Read the optional static C build identity without invoking a Rust ABI symbol.
-pub fn lookup_build_id(lib: &libloading::Library, lib_name: &str) -> Result<Option<String>, String> {
-  let lookup: libloading::Symbol<FfiBuildId> = match unsafe { lib.get(BUILD_ID_SYMBOL) } {
-    Ok(lookup) => lookup,
-    Err(_) => return Ok(None),
-  };
-  let ptr = unsafe { lookup() };
-  if ptr.is_null() {
-    return Err(format!(
-      "FFI library `{lib_name}` returned a null pointer from `calcit_ffi_build_id`"
-    ));
-  }
-  let value = unsafe { CStr::from_ptr(ptr) }
-    .to_str()
-    .map_err(|error| format!("FFI library `{lib_name}` returned invalid UTF-8 from `calcit_ffi_build_id`: {error}"))?;
-  Ok(Some(value.to_owned()))
-}
-
 #[cfg(test)]
 mod tests {
   use super::{
     ASYNC_EVENT_FLAG_COALESCED, ASYNC_PROTOCOL_VERSION, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
     ASYNC_TASK_FLAG_SERIAL_EVENTS, BUFFER_PROTOCOL_VERSION, FfiAsyncEventDescriptor, FfiAsyncEventKind, FfiAsyncHandle,
     FfiAsyncHandleError, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1, FfiAsyncLifecycle, FfiAsyncTaskDescriptor,
-    FfiBlockingHostV1, FfiBuffer, FfiBuildCompatibility, FfiResourceAdapter, RESOURCE_PROTOCOL_VERSION, RESOURCE_TOKEN_BYTES,
-    RESOURCE_TOKEN_STRUCT, async_method_symbol, async_status, blocking_method_symbol, buffer_method_symbol, decode_buffer_response,
-    decode_resource_token, encode_buffer_request, encode_resource_token, hydrate_resource_tokens, transform_resource_args,
-    validate_build_id,
+    FfiBlockingHostV1, FfiBuffer, FfiResourceAdapter, RESOURCE_PROTOCOL_VERSION, RESOURCE_TOKEN_BYTES, RESOURCE_TOKEN_STRUCT,
+    async_method_symbol, async_status, blocking_method_symbol, buffer_method_symbol, decode_buffer_response, decode_resource_token,
+    encode_buffer_request, encode_resource_token, hydrate_resource_tokens, transform_resource_args,
   };
   use std::sync::{
     Arc, Mutex,
@@ -1510,37 +1463,6 @@ mod tests {
   fn buffer_error_responses_require_strict_utf8() {
     let error = decode_buffer_response(1, vec![0xff], "demo", "read_calcit_ffi_v1").expect_err("invalid UTF-8 must fail");
     assert!(error.contains("non-UTF-8 error output"), "error: {error}");
-  }
-
-  #[test]
-  fn exact_identity_is_accepted() {
-    assert_eq!(
-      validate_build_id("demo", Some("same-build"), "same-build", true).expect("exact identity should pass"),
-      FfiBuildCompatibility::Exact
-    );
-  }
-
-  #[test]
-  fn mismatched_identity_is_rejected_before_rust_abi_calls() {
-    let error = validate_build_id("demo", Some("release-build"), "debug-build", false).expect_err("different identities must fail");
-    assert!(error.contains("before invoking a Rust ABI symbol"), "error: {error}");
-    assert!(error.contains("release-build"), "error: {error}");
-    assert!(error.contains("debug-build"), "error: {error}");
-  }
-
-  #[test]
-  fn debug_hosts_reject_legacy_dylibs_before_rust_abi_calls() {
-    let error = validate_build_id("demo", None, "debug-build", true).expect_err("debug host must require build identity");
-    assert!(error.contains("Refusing legacy Rust-native FFI library"), "error: {error}");
-    assert!(error.contains("calcit_ffi_build_id"), "error: {error}");
-  }
-
-  #[test]
-  fn release_hosts_keep_a_temporary_legacy_path() {
-    assert_eq!(
-      validate_build_id("demo", None, "release-build", false).expect("release compatibility path should remain"),
-      FfiBuildCompatibility::Legacy
-    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,6 @@ use crate::util::string::strip_shebang;
 
 pub const DEFAULT_SNAPSHOT_FILE: &str = "calcit.cirru";
 pub const LEGACY_SNAPSHOT_FILE: &str = "compact.cirru";
-pub const FFI_ABI_VERSION: &str = "0.0.9";
-pub const FFI_BUILD_ID: &str = env!("CALCIT_FFI_BUILD_ID");
-
 static QUIET_TOOL_OUTPUT: AtomicBool = AtomicBool::new(false);
 
 pub fn set_quiet_tool_output(v: bool) {


### PR DESCRIPTION
## 中文

### 背景

Issue #474 的四个主模块与八个额外 native 模块已经全部迁移、发布或明确退役，最后一个 `calcit-paint 0.0.7` 也已通过真实 macOS/Linux GUI smoke。继续保留 Rust-layout fallback 会让缺少 C-safe symbol 的旧模块仍有机会跨 dylib 传递 `Vec<Edn>`、`Result`、`String`、trait object、allocator ownership 和 drop glue，因此 Phase 4 应当删除这条不稳定边界。

### 修改

- 删除 sync/callback/blocking 的 `EdnFfi` / `EdnFfiFn` lookup 与调用；缺少 version/method/free symbol 时返回包含精确期望 symbol 的确定性迁移错误。
- 删除 release-host legacy warning、`LEGACY_DYLIB_WARNED`、build identity validation、`abi_version` 与 `edn_version` probes。
- 删除 `--ffi-build-id`，以及 build.rs 中 rustc/target/debug-assertions/panic identity 生成；C-safe wire protocol 不再绑定 host 与 dylib 的 Rust toolchain。
- native capability verifier 改为验证 buffer/async/resource protocol versions，并检查对应 `calcit_ffi_buffer_free` / `calcit_ffi_resource_release_v1`。
- native realization key/receipt 改为记录三个 C-safe protocol version，继续保留 module commit、Calcit version 与 artifact size/hash 完整性验证。
- 更新 FFI bindings、async protocol、upgrade guide 与 quick reference，明确 C-safe v1 是唯一支持的 native 边界。

### 验证

- Rust：572 项 library tests、259 项 CLI tests、24 项 caps tests、15 项 WASM tests 通过。
- `cargo fmt --check` 与 strict `cargo clippy --all-targets -- -D warnings` 通过。
- `yarn check-all` 通过：TypeScript、JS runtime identity、Agent interface 17/17、Calcit core 221/221、Rust/JS/IR/WASM 与性能 smoke 全绿。
- 当前 debug Calcit host 加载 release calcit-paint dylib，真实 macOS blocking GUI/callback/Skia/return smoke 通过；同一 dylib 通过新的 capability verifier。
- 只导出 `legacy_method` 的 C dylib fixture 被 caps verifier 与 sync/async/blocking runtime 全部确定性拒绝，错误只要求 C-safe symbols，没有进入 legacy symbol。

Closes #474.

## English

### Background

All four primary modules and eight additional native modules tracked by #474 are migrated, released, or explicitly retired. The final module, `calcit-paint 0.0.7`, also passes real macOS/Linux GUI smokes. Keeping the Rust-layout fallback would still let old modules missing C-safe symbols pass `Vec<Edn>`, `Result`, `String`, trait objects, allocator ownership, and drop glue across dylibs, so Phase 4 removes that unstable boundary.

### Changes

- Remove sync/callback/blocking `EdnFfi` / `EdnFfiFn` lookup and invocation. Missing version/method/free symbols now return deterministic migration errors naming the exact expected symbols.
- Remove release-host legacy warnings, `LEGACY_DYLIB_WARNED`, build-identity validation, and `abi_version` / `edn_version` probes.
- Remove `--ffi-build-id` and build.rs rustc/target/debug-assertions/panic identity generation; the C-safe wire protocol no longer couples host and dylib Rust toolchains.
- Make native capability verification check buffer/async/resource protocol versions and matching `calcit_ffi_buffer_free` / `calcit_ffi_resource_release_v1` symbols.
- Record the three C-safe protocol versions in native realization keys/receipts while retaining module commit, Calcit version, and artifact size/hash integrity checks.
- Update FFI bindings, async protocol, upgrade guide, and quick reference so C-safe v1 is the only supported native boundary.

### Validation

- Rust: 572 library tests, 259 CLI tests, 24 caps tests, and 15 WASM tests pass.
- `cargo fmt --check` and strict `cargo clippy --all-targets -- -D warnings` pass.
- `yarn check-all` passes: TypeScript, JS runtime identity, Agent interface 17/17, Calcit core 221/221, Rust/JS/IR/WASM, and performance smokes.
- The current debug Calcit host loads the release calcit-paint dylib and passes a real macOS blocking GUI/callback/Skia/return smoke; the same dylib passes the new capability verifier.
- A C dylib fixture exporting only `legacy_method` is deterministically rejected by caps and all sync/async/blocking runtime paths; diagnostics require only C-safe symbols and never enter the legacy symbol.

Closes #474.
