### PR TITLE
wasm: 实现显式 comparator 的稳定 list sort / implement stable list sort with an explicit comparator

### DIFF
--- a/RFCs/04-15-wasm-compilation-feasibility.md
+++ b/RFCs/04-15-wasm-compilation-feasibility.md
@@ -253,6 +253,7 @@ WASM GC proposal（2024 年起 V8/SpiderMonkey 已发布）提供：
 2. 继续补充 `calcit.core` 常见高阶路径。
   - `foldl`、`foldl-shortcut`、`foldr-shortcut`、`sort`、`&call-spread` 仍是大量跳过项的源头。
   - 这部分不是为了追求“理论完备”，而是为了减少真实项目中被迫绕开 core helper 的情况。
+  - 2026-08：带显式 comparator 的 `sort` / `&list:sort` 已实现稳定 WASM 排序；一参数 heterogeneous total-order 仍明确拒绝，等待类型化比较协议。
 
 3. 持续扩大 `test-wasm.cirru` 的下游回归覆盖。
   - 每补一个能力，都应优先加一个最小但能锁定语义边界的 WASM 用例。

--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -1,7 +1,8 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |test-wasm) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |test-wasm)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'test-wasm.main/main!) (:mode :native) (:reload-fn 'test-wasm.main/reload!)
+      :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
   :files $ {}
@@ -39,6 +40,11 @@
         |collect-rest $ %{} 'CodeEntry (:doc "|returns rest list unchanged")
           :code $ quote
             defn collect-rest (a & xs) xs
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |compare-wasm-ascending $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn compare-wasm-ascending (a b) (&- a b)
           :examples $ []
           :schema $ :: 'Dynamic
         |factorial $ %{} 'CodeEntry (:doc "|Factorial — recursive")
@@ -528,6 +534,62 @@
             defn test-list-slice () $ &let
               xs $ &list:slice ([] 10 20 30 40 50) 1 4
               &+ (&list:count xs) (&list:first xs)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-list-sort-ascending $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-list-sort-ascending () $ &let
+              ys $ sort ([] 4 1 3 2) &-
+              +
+                * 10 $ &list:first ys
+                &list:last ys
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-list-sort-descending $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-list-sort-descending () $ &let
+              ys $ &list:sort ([] 4 1 3 2)
+                fn (a b) (- b a)
+              +
+                * 10 $ &list:first ys
+                &list:last ys
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-list-sort-dynamic-callee $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-list-sort-dynamic-callee () $ &let (comparator compare-wasm-ascending)
+              &let
+                ys $ sort ([] 4 1 3 2) comparator
+                +
+                  * 10 $ &list:first ys
+                  &list:last ys
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-list-sort-input-immutable $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-list-sort-input-immutable () $ &let
+              xs $ [] 4 1 3 2
+              &let
+                ys $ sort xs
+                  fn (a b) (- a b)
+                +
+                  * 10 $ &list:first xs
+                  &list:first ys
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |test-list-sort-stable $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-list-sort-stable () $ &let
+              xs $ [] ([] 2 20) ([] 1 10) ([] 2 21) ([] 1 11)
+              &let
+                ys $ sort xs
+                  fn (a b)
+                    - (&list:nth a 0) (&list:nth b 0)
+                +
+                  * 1000 $ &list:nth (&list:nth ys 0) 1
+                  * 100 $ &list:nth (&list:nth ys 1) 1
+                  * 10 $ &list:nth (&list:nth ys 2) 1
+                  &list:nth (&list:nth ys 3) 1
           :examples $ []
           :schema $ :: 'Dynamic
         |test-list-to-set $ %{} 'CodeEntry (:doc "|list to set deduplicates elements")

--- a/editing-history/202608280826-wasm-stable-list-sort.md
+++ b/editing-history/202608280826-wasm-stable-list-sort.md
@@ -1,0 +1,17 @@
+# WASM stable list sort / WASM 稳定列表排序
+
+## 中文
+
+- 用稳定 insertion sort 替换 `sort` 与 `&list:sort` 的静默 identity stub。
+- 排序前复制线性内存 list，保持输入不可变；comparator 复用 static、inline、native proc 与动态函数表调用路径。
+- comparator 结果仅在大于零时移动左值，因此 equal/NaN 保持原顺序。
+- 一参数 heterogeneous total-order 明确报 unsupported，不再生成语义错误的 WASM。
+- 增加升序、降序、重复 key 稳定性、输入不可变、动态 comparator 与 unsupported 路径测试。
+
+## English
+
+- Replace the silent identity stubs for `sort` and `&list:sort` with stable insertion sort.
+- Copy the linear-memory list before sorting to preserve input immutability, reusing static, inline, native-proc, and dynamic function-table comparator paths.
+- Move the left value only when the comparator is greater than zero, preserving order for equal and NaN results.
+- Reject the one-argument heterogeneous total-order form explicitly instead of generating semantically incorrect WASM.
+- Add ascending, descending, duplicate stability, input immutability, dynamic comparator, and unsupported-path tests.

--- a/scripts/test-wasm.mjs
+++ b/scripts/test-wasm.mjs
@@ -383,6 +383,11 @@ check("test-list-butlast()", 2, e["test-list-butlast"]);
 check("test-list-butlast-empty()", 0, e["test-list-butlast-empty"]);
 check("test-list-slice()", 23, e["test-list-slice"]); // count=3 + first=20
 check("test-list-reverse()", 40, e["test-list-reverse"]); // first=30 + nth(2)=10
+check("test-list-sort-ascending()", 14, e["test-list-sort-ascending"]); // first=1, last=4
+check("test-list-sort-descending()", 41, e["test-list-sort-descending"]); // first=4, last=1
+check("test-list-sort-stable()", 11321, e["test-list-sort-stable"]); // ids 10,11,20,21
+check("test-list-sort-input-immutable()", 41, e["test-list-sort-input-immutable"]); // source first=4, sorted first=1
+check("test-list-sort-dynamic-callee()", 14, e["test-list-sort-dynamic-callee"]);
 check("test-list-concat()", 44, e["test-list-concat"]); // count=4 + nth(3)=40
 check("test-list-assoc()", 99, e["test-list-assoc"]);
 check("test-list-assoc-before()", 103, e["test-list-assoc-before"]); // count=4 + nth(1)=99

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1995,15 +1995,7 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     CalcitProc::NativeListPrepend => emit_list_prepend(ctx, args),
     CalcitProc::NativeListButlast => emit_list_butlast(ctx, args),
     CalcitProc::NativeListLast => emit_list_last(ctx, args),
-    CalcitProc::NativeListSort => {
-      // Sort is not yet implemented in WASM — pass list through as stub
-      if args.is_empty() {
-        ctx.emit(f64_const(0.0));
-      } else {
-        emit_expr(ctx, &args[0])?;
-      }
-      Ok(())
-    }
+    CalcitProc::NativeListSort => emit_list_sort(ctx, args),
     CalcitProc::NativeListRange => emit_range(ctx, args),
     CalcitProc::NativeListFoldl => emit_foldl(ctx, args),
     CalcitProc::NativeListFoldlShortcut => emit_foldl_shortcut(ctx, args),
@@ -2174,17 +2166,7 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     // &number:format — formatting; stub in WASM.
     CalcitProc::NativeNumberFormat => ctx.stub_proc(args),
 
-    // sort — native sort with optional comparator; not yet supported in WASM; return first arg.
-    CalcitProc::Sort => {
-      if args.is_empty() {
-        ctx.emit(f64_const(0.0));
-      } else {
-        // Skip any non-constant args (comparator lambda). Just pass the source list through
-        // as a trivial (unsorted) stub so the function compiles.
-        emit_expr(ctx, &args[0])?;
-      }
-      Ok(())
-    }
+    CalcitProc::Sort => emit_list_sort(ctx, args),
 
     // Not yet supported
     _ => Err(format!("unsupported proc in WASM: {proc}")),

--- a/src/codegen/emit_wasm/lists.rs
+++ b/src/codegen/emit_wasm/lists.rs
@@ -277,6 +277,82 @@ pub(super) fn emit_list_reverse(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result
   Ok(())
 }
 
+/// `&list:sort list comparator` — return a stable sorted copy.
+///
+/// WASM does not yet implement Calcit's heterogeneous one-argument total
+/// ordering. Requiring an explicit comparator keeps the supported path
+/// type-directed and avoids silently returning an unsorted list.
+pub(super) fn emit_list_sort(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  if args.len() != 2 {
+    return Err("&list:sort in WASM requires a list and an explicit 2-argument comparator".into());
+  }
+
+  let src = emit_ptr_to_i32(ctx, &args[0])?;
+  let count = emit_load_count_i32(ctx, src);
+  let dst = emit_alloc_list(ctx, count);
+
+  let dst_base = emit_addr_offset(ctx, dst, 8);
+  let src_base = emit_addr_offset(ctx, src, 8);
+  emit_copy_f64_loop(ctx, dst_base, src_base, count);
+
+  // Stable insertion sort is a compact baseline for immutable Calcit lists.
+  // Equal (and NaN) comparator results do not move the left element.
+  let left = ctx.alloc_local();
+  let key = ctx.alloc_local();
+  let comparator =
+    resolve_callee_kind(ctx, &args[1], left, key).map_err(|error| format!("&list:sort comparator is not callable in WASM: {error}"))?;
+  let i = ctx.alloc_i32(1);
+  let j = ctx.alloc_local_typed(ValType::I32);
+  let previous_index = ctx.alloc_local_typed(ValType::I32);
+
+  ctx.begin_block();
+  ctx.begin_loop();
+  ctx.loop_exit_if_ge(i, count);
+
+  emit_list_load_elem(ctx, dst, i);
+  ctx.emit(Instruction::LocalSet(key));
+  ctx.emit(Instruction::LocalGet(i));
+  ctx.emit(Instruction::LocalSet(j));
+
+  ctx.begin_block();
+  ctx.begin_loop();
+
+  // j == 0 means the key belongs at the beginning.
+  ctx.emit(Instruction::LocalGet(j));
+  ctx.emit(Instruction::I32Eqz);
+  ctx.emit(Instruction::BrIf(1));
+
+  ctx.emit(Instruction::LocalGet(j));
+  ctx.emit(Instruction::I32Const(1));
+  ctx.emit(Instruction::I32Sub);
+  ctx.emit(Instruction::LocalSet(previous_index));
+  emit_list_load_elem(ctx, dst, previous_index);
+  ctx.emit(Instruction::LocalSet(left));
+
+  // Shift only when comparator(left, key) > 0. Equal and NaN results retain
+  // the original order, matching the interpreter's stable-sort behavior.
+  emit_foldl_step(ctx, &comparator, left, key)?;
+  ctx.emit(f64_const(0.0));
+  ctx.emit(Instruction::F64Gt);
+  ctx.emit(Instruction::I32Eqz);
+  ctx.emit(Instruction::BrIf(1));
+
+  emit_list_store_elem(ctx, dst, j, left);
+  ctx.emit(Instruction::LocalGet(previous_index));
+  ctx.emit(Instruction::LocalSet(j));
+  ctx.br_loop();
+
+  ctx.end_block_loop();
+  emit_list_store_elem(ctx, dst, j, key);
+
+  ctx.i32_inc(i);
+  ctx.br_loop();
+  ctx.end_block_loop();
+
+  ctx.ptr_to_f64(dst);
+  Ok(())
+}
+
 /// `&list:concat a b` — concatenate two lists.
 /// Flatten one level starting from a pre-evaluated f64 list local.
 /// Used by emit_mapcat and &list:flatten intercepts.
@@ -1623,4 +1699,33 @@ pub(super) fn emit_join(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), Str
   emit_expr(ctx, &args[1])?;
   ctx.emit(Instruction::LocalSet(sep));
   emit_join_from_locals(ctx, xs, sep)
+}
+
+#[cfg(test)]
+mod sort_tests {
+  use super::*;
+
+  fn empty_context() -> WasmGenCtx {
+    WasmGenCtx::new(
+      0,
+      WasmCompileEnv {
+        fn_index: HashMap::new(),
+        fn_arity: HashMap::new(),
+        fn_has_rest: HashMap::new(),
+        runtime_fn_index: HashMap::new(),
+        tag_index: HashMap::new(),
+        struct_field_tags: HashMap::new(),
+        string_pool: HashMap::new(),
+        atom_globals: HashMap::new(),
+        value_imports: HashMap::new(),
+        fn_table_index: HashMap::new(),
+      },
+    )
+  }
+
+  #[test]
+  fn sort_rejects_the_unsupported_total_order_form() {
+    let error = emit_list_sort(&mut empty_context(), &[Calcit::Nil]).expect_err("one-argument sort must not compile as identity");
+    assert!(error.contains("explicit 2-argument comparator"), "error: {error}");
+  }
 }


### PR DESCRIPTION
## 中文

关联并关闭 #497。

### 改动

- 用稳定 insertion sort 替换 WASM 中 `sort` 与 `&list:sort` 静默返回原列表的占位实现。
- 在排序前复制线性内存中的列表，保持 Calcit 不可变集合语义。
- comparator 复用既有 callee resolver，覆盖 inline function、native proc、静态/导入函数与动态函数表调用路径。
- 仅在 `comparator(left, key) > 0` 时移动左值，确保相等元素保持原顺序。
- 显式拒绝尚未实现的一参数 heterogeneous total-order 形式，避免产生可运行但语义错误的 WASM。
- 更新 WASM RFC 进度，并补充升序、降序、稳定性、输入不可变、动态 comparator 与 unsupported 路径测试。

当前实现使用 O(n²) 的稳定 insertion sort，作为不可变小列表的紧凑正确性基线；后续可在不改变语义的前提下替换为更高效算法。

### 验证

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`（573 lib + 259 CLI + 24 deps + 16 WASM binary tests）
- `yarn compile`
- `yarn check-all`（Calcit core 221/221、JS/IR/WASM、Agent interface 17/17）
- 新增 5 个 WASM runtime sort checks 全部通过

## English

Closes #497.

### Changes

- Replace the WASM identity stubs for `sort` and `&list:sort` with a stable insertion sort.
- Copy the linear-memory list before sorting to preserve Calcit immutable collection semantics.
- Reuse the existing callee resolver for inline functions, native procs, static/imported functions, and dynamic function-table calls.
- Shift the left value only when `comparator(left, key) > 0`, preserving the original order of equal elements.
- Explicitly reject the unsupported one-argument heterogeneous total-order form instead of emitting runnable but semantically incorrect WASM.
- Update the WASM RFC progress and add ascending, descending, stability, input-immutability, dynamic-comparator, and unsupported-path tests.

The current O(n²) stable insertion sort is a compact correctness baseline for small immutable lists. It can later be replaced with a more efficient algorithm without changing semantics.

### Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (573 lib + 259 CLI + 24 deps + 16 WASM binary tests)
- `yarn compile`
- `yarn check-all` (Calcit core 221/221, JS/IR/WASM, Agent interface 17/17)
- All 5 new WASM runtime sort checks pass
