### PR TITLE
docs: 记录共享 native FFI rollout / document shared native FFI rollout

### DIFF
--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -33,6 +33,22 @@ version or per-method symbols are deterministic migration errors; there is no
 Rust-ABI fallback. Native modules should use `cdylib` and export only fixed C
 ABI symbols.
 
+Rust module authors should use
+[`calcit_native_ffi`](https://crates.io/crates/calcit_native_ffi) instead of
+copying protocol structs and transport adapters into each repository. The
+crate provides the v1 descriptors, status/task/event constants, buffer
+ownership helpers, Cirru EDN transport, backpressure policy, async/blocking
+host helpers, and final-dylib export macros. This document remains the
+normative host protocol; the shared crate is the maintained Rust
+implementation for modules.
+
+Rust 模块作者应优先使用
+[`calcit_native_ffi`](https://crates.io/crates/calcit_native_ffi)，不要在每个
+仓库复制 protocol struct 和 transport adapter。该 crate 统一提供 v1
+descriptor、status/task/event 常量、buffer ownership、Cirru EDN transport、
+backpressure、async/blocking host helper 以及 final-dylib export macro。本页
+仍是 host protocol 的规范定义，共享 crate 是模块侧维护的 Rust 实现。
+
 ## C-safe synchronous buffer ABI
 
 Synchronous methods use buffer protocol version 1. Calcit looks for
@@ -76,7 +92,8 @@ Protocol rules:
 - The adapter must contain panics and return an error status; unwinding across `extern "C"` is invalid.
 - Calcit rejects protocol-version mismatches, malformed buffer metadata, oversized responses, invalid UTF-8, and invalid response EDN.
 
-`calcit-lang/calcit_wasmtime` contains the first complete synchronous adapter.
+`calcit-lang/calcit_wasmtime` contains a complete synchronous adapter and uses
+the shared crate starting with version 0.1.5.
 
 Methods that create reusable native objects use the C-safe
 [opaque resource protocol](ffi-resource-protocol.md). The host turns reserved
@@ -180,3 +197,10 @@ Currently there are some early extensions:
 - [HTTP server binding](https://github.com/calcit-lang/calcit-http)
 - [Wasmtime binding](https://github.com/calcit-lang/calcit_wasmtime)
 - [fswatch](https://github.com/calcit-lang/calcit-fswatch)
+
+The first shared-crate rollout is available in `calcit-http 0.3.8`,
+`calcit-wss 0.2.17`, `calcit-fetch 0.0.17`, `calcit_wasmtime 0.1.5`, and
+`calcit.std 0.2.22`.
+
+首批共享 crate 迁移版本为 `calcit-http 0.3.8`、`calcit-wss 0.2.17`、
+`calcit-fetch 0.0.17`、`calcit_wasmtime 0.1.5` 和 `calcit.std 0.2.22`。

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -204,3 +204,12 @@ The first shared-crate rollout is available in `calcit-http 0.3.8`,
 
 首批共享 crate 迁移版本为 `calcit-http 0.3.8`、`calcit-wss 0.2.17`、
 `calcit-fetch 0.0.17`、`calcit_wasmtime 0.1.5` 和 `calcit.std 0.2.22`。
+
+The second rollout is available in `calcit-json 0.0.14`,
+`calcit-clipboard 0.0.10`, `calcit-command 0.0.6`, and `calcit-regex 0.0.15`.
+Regex keeps its module-owned opaque-resource registry while sharing the
+buffer-v1 transport adapter.
+
+第二批迁移版本为 `calcit-json 0.0.14`、`calcit-clipboard 0.0.10`、
+`calcit-command 0.0.6` 和 `calcit-regex 0.0.15`。Regex 继续由模块维护
+opaque-resource registry，只共享 buffer-v1 transport adapter。

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -27,6 +27,21 @@ bytes 交换业务数据，不再要求使用同一个 rustc 或同一个 `cirru
 crate build。`calcit_ffi_build_id`、`abi_version`、`edn_version` 和 Rust-layout
 business methods 均已退役。
 
+Rust 模块应依赖已发布的 `calcit_native_ffi`，复用版本化 descriptor、buffer
+ownership、Cirru EDN transport、async backpressure 和 blocking adapter。只有
+模块业务逻辑、task registry 与 cancel 生命周期留在模块仓库；不要复制协议
+模板。共享 crate 不足时，先在
+[`calcit-lang/calcit-native-ffi`](https://github.com/calcit-lang/calcit-native-ffi)
+扩展契约和测试，再升级消费者。
+
+Rust modules should depend on the published `calcit_native_ffi` crate for
+versioned descriptors, buffer ownership, Cirru EDN transport, async
+backpressure, and blocking adapters. Keep only domain behavior, task
+registries, and cancellation lifecycles in the module repository. If a shared
+capability is missing, extend and test the contract in
+[`calcit-lang/calcit-native-ffi`](https://github.com/calcit-lang/calcit-native-ffi)
+before upgrading consumers.
+
 ## 升级流程
 
 ### 0. 导出版本变量（所有后续步骤均复用）
@@ -54,6 +69,16 @@ sed -i "s/^cirru_parser = .*/cirru_parser = \"$PARSER_VER\"/" Cargo.toml
 ```
 
 同时将 `[package] version` bump 一个 patch 版本（若项目有版本号发布需求）。
+
+对于 Rust native 模块，同时使用稳定版本引用：
+
+```toml
+[dependencies]
+calcit_native_ffi = "0.1.0"
+```
+
+不要使用 git branch 或 commit hash 作为日常模块依赖；crate version 与模块
+lockfile 才是可重复发布边界。
 
 ### 2. 更新 deps.cirru
 
@@ -151,11 +176,11 @@ git push origin "$PKG_VER" --force
 通过 GitHub CLI 快速检查所有 FFI 项目的最新版本和 CI 状态：
 
 ```bash
-for repo in calcit-lang/calcit-std calcit-lang/dylib-workflow \
+for repo in calcit-lang/calcit.std calcit-lang/dylib-workflow \
             calcit-lang/calcit-fetch calcit-lang/calcit-http \
             calcit-lang/calcit-regex calcit-lang/calcit-wss \
             calcit-lang/calcit-command calcit-lang/calcit-clipboard \
-            calcit-lang/calcit-wasmtime calcit-lang/calcit-fswatch \
+            calcit-lang/calcit_wasmtime calcit-lang/calcit-fswatch \
             calcit-lang/calcit-graphviz; do
   echo "=== $repo ==="
   gh release list --repo "$repo" --limit 1

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -28,17 +28,18 @@ crate build。`calcit_ffi_build_id`、`abi_version`、`edn_version` 和 Rust-lay
 business methods 均已退役。
 
 Rust 模块应依赖已发布的 `calcit_native_ffi`，复用版本化 descriptor、buffer
-ownership、Cirru EDN transport、async backpressure 和 blocking adapter。只有
-模块业务逻辑、task registry 与 cancel 生命周期留在模块仓库；不要复制协议
-模板。共享 crate 不足时，先在
+ownership、Cirru EDN transport、async backpressure 和 blocking adapter。模块
+仓库继续负责业务参数与逻辑、thread、connection/task registry、cancel state、
+server lifecycle 及其他领域状态；不要复制协议模板。共享 crate 不足时，先在
 [`calcit-lang/calcit-native-ffi`](https://github.com/calcit-lang/calcit-native-ffi)
 扩展契约和测试，再升级消费者。
 
 Rust modules should depend on the published `calcit_native_ffi` crate for
 versioned descriptors, buffer ownership, Cirru EDN transport, async
-backpressure, and blocking adapters. Keep only domain behavior, task
-registries, and cancellation lifecycles in the module repository. If a shared
-capability is missing, extend and test the contract in
+backpressure, and blocking adapters. Module repositories continue to own
+domain arguments and behavior, threads, connection/task registries,
+cancellation state, server lifecycles, and other domain-specific state. If a
+shared capability is missing, extend and test the contract in
 [`calcit-lang/calcit-native-ffi`](https://github.com/calcit-lang/calcit-native-ffi)
 before upgrading consumers.
 

--- a/editing-history/202608281155-document-shared-native-ffi.md
+++ b/editing-history/202608281155-document-shared-native-ffi.md
@@ -1,0 +1,13 @@
+# 记录共享 native FFI crate rollout / Document the shared native FFI crate rollout
+
+## 中文
+
+- 在 FFI bindings 与升级手册中推荐使用已发布的 `calcit_native_ffi`，明确 protocol 文档与模块侧实现的职责边界。
+- 记录首批迁移并发布的五个模块版本。
+- 修正升级手册中的 GitHub 仓库名称，并要求稳定 crate version 而非 git hash。
+
+## English
+
+- Recommend the published `calcit_native_ffi` in the FFI bindings and upgrade guide, clarifying the boundary between normative protocol docs and the maintained module-side implementation.
+- Record the first five migrated and released module versions.
+- Fix repository names in the upgrade guide and require stable crate versions instead of git hashes.

--- a/editing-history/202608281215-review-ffi-responsibility-wording.md
+++ b/editing-history/202608281215-review-ffi-responsibility-wording.md
@@ -1,0 +1,11 @@
+# 修正文档责任边界措辞 / Clarify responsibility-boundary wording
+
+## 中文
+
+- 根据 PR review 将模块职责改为非穷举表述。
+- 明确业务参数与逻辑、thread、connection/task registry、cancel state、server lifecycle 和其他领域状态仍由模块维护。
+
+## English
+
+- Make the module-responsibility wording non-exhaustive in response to PR review.
+- Clarify that modules continue to own domain arguments and behavior, threads, connection/task registries, cancellation state, server lifecycles, and other domain-specific state.

--- a/editing-history/202608281225-document-second-native-ffi-rollout.md
+++ b/editing-history/202608281225-document-second-native-ffi-rollout.md
@@ -1,0 +1,11 @@
+# 记录第二批 native FFI rollout / Document the second native FFI rollout
+
+## 中文
+
+- 记录 JSON、Clipboard、Command 与 Regex 的共享 crate 发布版本。
+- 明确 Regex 的 opaque-resource registry 仍属于模块，仅 buffer-v1 transport adapter 进入共享层。
+
+## English
+
+- Record the shared-crate releases for JSON, Clipboard, Command, and Regex.
+- Clarify that Regex retains its module-owned opaque-resource registry and shares only the buffer-v1 transport adapter.


### PR DESCRIPTION
## 中文

### 变更

- 在 Rust FFI bindings 中推荐使用已发布的 `calcit_native_ffi 0.1.0`，明确 protocol 文档仍是 host 规范，共享 crate 是模块侧维护实现。
- 在升级手册中说明共享 descriptor、buffer ownership、Cirru EDN transport、backpressure 与 blocking adapter 的维护边界。
- 记录首批完成迁移并发布的版本：HTTP 0.3.8、WSS 0.2.17、Fetch 0.0.17、Wasmtime 0.1.5、STD 0.2.22。
- 修正升级脚本中的 `calcit.std` 与 `calcit_wasmtime` 仓库名，并要求依赖稳定 crate version 而非 git hash。

### 验证

- `git diff --check`
- 两份更新文档均通过 `calcit docs check-md --entry calcit/test.cirru --failures-only`

## English

### Changes

- Recommend the published `calcit_native_ffi 0.1.0` in Rust FFI bindings, clarifying that protocol docs remain normative for the host while the shared crate is the maintained module-side implementation.
- Document the ownership boundary for shared descriptors, buffer ownership, Cirru EDN transport, backpressure, and blocking adapters in the upgrade guide.
- Record the first migrated releases: HTTP 0.3.8, WSS 0.2.17, Fetch 0.0.17, Wasmtime 0.1.5, and STD 0.2.22.
- Fix the `calcit.std` and `calcit_wasmtime` repository names and require stable crate versions instead of git hashes.

### Verification

- `git diff --check`
- Both updated documents pass `calcit docs check-md --entry calcit/test.cirru --failures-only`
