### PR TITLE
refactor: 消费共享 native FFI raw ABI / consume the shared native FFI raw ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ version = "0.13.57"
 dependencies = [
  "argh",
  "bisection_key",
+ "calcit_native_ffi",
  "cirru_edn",
  "cirru_parser",
  "colored",
@@ -141,6 +142,12 @@ dependencies = [
  "walkdir",
  "wasm-encoder",
 ]
+
+[[package]]
+name = "calcit_native_ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a8cfaff7caed355a63e9df68c57cea5af1d01b1b37734ed812a4a9ed2faeed"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0.151"
 cirru_edn = "0.8.0"
 cirru_parser = "=0.2.15"
 bisection_key = "0.0.1"
+calcit_native_ffi = { version = "0.1.2", default-features = false }
 ureq = "3.3.0"
 rmp-serde = "1.3.0"
 semver = "1.0.28"

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -42,12 +42,22 @@ host helpers, and final-dylib export macros. This document remains the
 normative host protocol; the shared crate is the maintained Rust
 implementation for modules.
 
+Calcit itself consumes the same crate with default features disabled for raw
+protocol versions, symbols, function signatures, resource-token constants,
+and C-layout descriptors. Dynamic loading, task/resource registries, callback
+queues, dylib pinning, and lifecycle enforcement remain runtime-owned.
+
 Rust 模块作者应优先使用
 [`calcit_native_ffi`](https://crates.io/crates/calcit_native_ffi)，不要在每个
 仓库复制 protocol struct 和 transport adapter。该 crate 统一提供 v1
 descriptor、status/task/event 常量、buffer ownership、Cirru EDN transport、
 backpressure、async/blocking host helper 以及 final-dylib export macro。本页
 仍是 host protocol 的规范定义，共享 crate 是模块侧维护的 Rust 实现。
+
+Calcit runtime 也通过关闭默认 feature 直接消费同一 crate 的 raw protocol
+version、symbol、function signature、resource token 常量与 C-layout descriptor。
+动态加载、task/resource registry、callback queue、dylib pin 与 lifecycle 检查
+仍由 runtime 维护。
 
 ## C-safe synchronous buffer ABI
 

--- a/editing-history/202608281430-consume-shared-raw-abi.md
+++ b/editing-history/202608281430-consume-shared-raw-abi.md
@@ -1,0 +1,13 @@
+# 消费共享 raw ABI / Consume the shared raw ABI
+
+## 中文
+
+- Calcit runtime 直接依赖 `calcit_native_ffi 0.1.2` 的 no-default-features raw contract。
+- 删除 host 内重复的 buffer/async/blocking/resource version、symbol、function pointer、C-layout descriptor 与数值常量定义。
+- 保留类型安全 handle/event enum、event queue、task/resource registry、lease、dylib cache 与 callback lifecycle 在 Calcit host。
+
+## English
+
+- Made the Calcit runtime consume the no-default-features raw contract from `calcit_native_ffi 0.1.2` directly.
+- Removed host-local copies of buffer/async/blocking/resource versions, symbols, function pointers, C-layout descriptors, and numeric constants.
+- Kept typed handle/event enums, the event queue, task/resource registries, leases, the dylib cache, and callback lifecycle in the Calcit host.

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1426,7 +1426,7 @@ fn try_start_async_callback_v1(
       NativeAsyncResource::Task(task),
     )
     .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
-  let descriptor = FfiAsyncTaskDescriptor::new(handle, FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS);
+  let descriptor = FfiAsyncTaskDescriptor::new(handle.raw(), FfiAsyncHandleKind::Stream as u32, ASYNC_TASK_FLAG_SERIAL_EVENTS);
   let host = async_host_table(handle);
 
   track::track_task_add();
@@ -1625,7 +1625,7 @@ fn try_call_blocking_v1(
       NativeAsyncResource::Task(task),
     )
     .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
-  let descriptor = FfiAsyncTaskDescriptor::new(handle, FfiAsyncHandleKind::OneShot, ASYNC_TASK_FLAG_SERIAL_EVENTS);
+  let descriptor = FfiAsyncTaskDescriptor::new(handle.raw(), FfiAsyncHandleKind::OneShot as u32, ASYNC_TASK_FLAG_SERIAL_EVENTS);
   let host = blocking_host_table(handle);
   track::track_task_add();
   trace_ffi_event(

--- a/src/ffi_abi.rs
+++ b/src/ffi_abi.rs
@@ -1,167 +1,47 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::slice;
 use std::sync::{Arc, LazyLock, Mutex, Weak};
-use std::{ptr, slice};
 
+pub use calcit_native_ffi::{
+  ASYNC_METHOD_SUFFIX, ASYNC_PROTOCOL_VERSION, ASYNC_PROTOCOL_VERSION_SYMBOL, BLOCKING_METHOD_SUFFIX, BUFFER_FREE_SYMBOL,
+  BUFFER_METHOD_SUFFIX, BUFFER_PROTOCOL_VERSION, BUFFER_PROTOCOL_VERSION_SYMBOL, MAX_BUFFER_BYTES, RESOURCE_PROTOCOL_VERSION,
+  RESOURCE_PROTOCOL_VERSION_SYMBOL, RESOURCE_RELEASE_SYMBOL, RESOURCE_TOKEN_BYTES, RESOURCE_TOKEN_FIELD, RESOURCE_TOKEN_STRUCT,
+  async_method_symbol, blocking_method_symbol, buffer_method_symbol, status as async_status,
+};
+pub use calcit_native_ffi::{
+  AsyncHostConfigure as FfiAsyncHostConfigureTask, AsyncHostEnqueue as FfiAsyncHostEnqueue,
+  AsyncHostOpenResponse as FfiAsyncHostOpenResponse, AsyncMethodV1 as FfiAsyncStart, AsyncResponseResolve as FfiAsyncResponseResolve,
+  AsyncTaskCancel as FfiAsyncTaskCancel, AsyncVersionFn as FfiAsyncVersion, BlockingHostFinish as FfiBlockingHostFinish,
+  BlockingHostFreeBuffer as FfiBlockingHostFreeBuffer, BlockingHostInvoke as FfiBlockingHostInvoke,
+  BlockingMethodV1 as FfiBlockingCall, BufferFreeFn as FfiBufferFree, BufferMethodV1 as FfiBufferCall,
+  BufferVersionFn as FfiBufferVersion, CalcitFfiAsyncHostV1 as FfiAsyncHostV1, CalcitFfiAsyncTaskV1 as FfiAsyncTaskDescriptor,
+  CalcitFfiBlockingHostV1 as FfiBlockingHostV1, CalcitFfiBuffer as FfiBuffer, ResourceReleaseV1 as FfiResourceRelease,
+  ResourceVersionFn as FfiResourceVersion,
+};
 use cirru_edn::{Edn, EdnAnyRef, EdnEnumView, EdnListView, EdnMapView, EdnSetView, EdnStructView};
-
-pub const BUFFER_PROTOCOL_VERSION: u32 = 1;
-pub const BUFFER_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_buffer_version";
-pub const BUFFER_FREE_SYMBOL: &[u8] = b"calcit_ffi_buffer_free";
-const BUFFER_METHOD_SUFFIX: &str = "_calcit_ffi_v1";
-const MAX_BUFFER_BYTES: usize = 256 * 1024 * 1024;
-
-pub const RESOURCE_PROTOCOL_VERSION: u32 = 1;
-pub const RESOURCE_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_resource_version";
-pub const RESOURCE_RELEASE_SYMBOL: &[u8] = b"calcit_ffi_resource_release_v1";
-pub const RESOURCE_TOKEN_STRUCT: &str = "CalcitFfiResourceV1";
-const RESOURCE_TOKEN_FIELD: &str = "token";
-const RESOURCE_TOKEN_BYTES: usize = 16;
 
 /// Version of the transport-neutral asynchronous task semantics. Native C ABI
 /// adapters and future WASM adapters must preserve the same handle lifecycle,
 /// even though their memory transports differ.
-pub const ASYNC_PROTOCOL_VERSION: u32 = 1;
-pub const ASYNC_PROTOCOL_VERSION_SYMBOL: &[u8] = b"calcit_ffi_async_version";
-pub const ASYNC_METHOD_SUFFIX: &str = "_calcit_ffi_async_v1";
-pub const BLOCKING_METHOD_SUFFIX: &str = "_calcit_ffi_blocking_v1";
-
-pub const ASYNC_TASK_FLAG_SERIAL_EVENTS: u32 = 1 << 0;
-pub const ASYNC_TASK_FLAG_COALESCE_ALLOWED: u32 = 1 << 1;
-pub const ASYNC_TASK_FLAG_REQUIRES_RESPONSE: u32 = 1 << 2;
-pub const ASYNC_TASK_KNOWN_FLAGS: u32 =
-  ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_COALESCE_ALLOWED | ASYNC_TASK_FLAG_REQUIRES_RESPONSE;
-pub const ASYNC_EVENT_FLAG_COALESCED: u32 = 1 << 0;
-pub const ASYNC_EVENT_KNOWN_FLAGS: u32 = ASYNC_EVENT_FLAG_COALESCED;
-
-pub type FfiAsyncHostEnqueue = unsafe extern "C" fn(
-  context: u64,
-  task_handle: u64,
-  event_kind: u32,
-  response_handle: u64,
-  payload_ptr: *const u8,
-  payload_len: usize,
-) -> i32;
-pub type FfiAsyncTaskCancel =
-  unsafe extern "C" fn(task_context: u64, task_handle: u64, reason_ptr: *const u8, reason_len: usize) -> i32;
-pub type FfiAsyncResponseResolve =
-  unsafe extern "C" fn(response_context: u64, response_handle: u64, outcome: u32, payload_ptr: *const u8, payload_len: usize) -> i32;
-pub type FfiAsyncHostConfigureTask = unsafe extern "C" fn(
-  context: u64,
-  task_handle: u64,
-  kind: u32,
-  flags: u32,
-  task_context: u64,
-  cancel: Option<FfiAsyncTaskCancel>,
-) -> i32;
-pub type FfiAsyncHostOpenResponse = unsafe extern "C" fn(
-  context: u64,
-  task_handle: u64,
-  response_context: u64,
-  timeout_ms: u64,
-  resolve: Option<FfiAsyncResponseResolve>,
-  out_handle: *mut u64,
-) -> i32;
-pub type FfiBlockingHostInvoke =
-  unsafe extern "C" fn(context: u64, task_handle: u64, payload_ptr: *const u8, payload_len: usize, out: *mut FfiBuffer) -> i32;
-pub type FfiBlockingHostFinish = unsafe extern "C" fn(context: u64, task_handle: u64) -> i32;
-pub type FfiBlockingHostFreeBuffer = unsafe extern "C" fn(context: u64, task_handle: u64, buffer: FfiBuffer) -> i32;
-
-pub const ASYNC_RESPONSE_RESOLVE: u32 = 1;
-pub const ASYNC_RESPONSE_REJECT: u32 = 2;
-
-/// Native host functions that an async dylib may copy and call from producer
-/// threads. The integer context is opaque and avoids exposing a Rust object
-/// pointer or allocator across the ABI.
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct FfiAsyncHostV1 {
-  pub protocol_version: u32,
-  pub struct_size: u32,
-  pub context: u64,
-  pub enqueue: Option<FfiAsyncHostEnqueue>,
-  pub configure_task: Option<FfiAsyncHostConfigureTask>,
-  pub open_response: Option<FfiAsyncHostOpenResponse>,
-}
-
-impl FfiAsyncHostV1 {
-  pub fn new(
-    context: u64,
-    enqueue: FfiAsyncHostEnqueue,
-    configure_task: FfiAsyncHostConfigureTask,
-    open_response: FfiAsyncHostOpenResponse,
-  ) -> Self {
-    Self {
-      protocol_version: ASYNC_PROTOCOL_VERSION,
-      struct_size: std::mem::size_of::<Self>() as u32,
-      context,
-      enqueue: Some(enqueue),
-      configure_task: Some(configure_task),
-      open_response: Some(open_response),
-    }
-  }
-}
-
-/// Host operations available while a C-safe blocking method owns the CLI
-/// thread. `invoke` executes the Calcit callback synchronously and is accepted
-/// only from the thread that registered the task. Callback output remains
-/// host-owned until the module calls `free_buffer`.
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct FfiBlockingHostV1 {
-  pub protocol_version: u32,
-  pub struct_size: u32,
-  pub context: u64,
-  pub invoke: Option<FfiBlockingHostInvoke>,
-  pub finish: Option<FfiBlockingHostFinish>,
-  pub free_buffer: Option<FfiBlockingHostFreeBuffer>,
-}
-
-impl FfiBlockingHostV1 {
-  pub fn new(
-    context: u64,
-    invoke: FfiBlockingHostInvoke,
-    finish: FfiBlockingHostFinish,
-    free_buffer: FfiBlockingHostFreeBuffer,
-  ) -> Self {
-    Self {
-      protocol_version: ASYNC_PROTOCOL_VERSION,
-      struct_size: std::mem::size_of::<Self>() as u32,
-      context,
-      invoke: Some(invoke),
-      finish: Some(finish),
-      free_buffer: Some(free_buffer),
-    }
-  }
-}
-
-/// Stable status values returned by C-safe async host functions. Keep these
-/// as integer constants rather than an FFI enum so foreign callers cannot
-/// construct an invalid Rust discriminant.
-pub mod async_status {
-  pub const OK: i32 = 0;
-  pub const INVALID_HANDLE: i32 = 1;
-  pub const STALE_HANDLE: i32 = 2;
-  pub const HANDLE_CLOSING: i32 = 3;
-  pub const HANDLE_FINISHED: i32 = 4;
-  pub const HANDLE_STILL_ACTIVE: i32 = 5;
-  pub const HOST_CLOSING: i32 = 6;
-  pub const QUEUE_FULL: i32 = 7;
-  pub const INVALID_PAYLOAD: i32 = 8;
-  pub const INTERNAL_ERROR: i32 = 9;
-  pub const CALLBACK_ERROR: i32 = 10;
-  pub const WRONG_THREAD: i32 = 11;
-}
+pub const ASYNC_TASK_FLAG_SERIAL_EVENTS: u32 = calcit_native_ffi::task_flags::SERIAL_EVENTS;
+pub const ASYNC_TASK_FLAG_COALESCE_ALLOWED: u32 = calcit_native_ffi::task_flags::COALESCE_ALLOWED;
+pub const ASYNC_TASK_FLAG_REQUIRES_RESPONSE: u32 = calcit_native_ffi::task_flags::REQUIRES_RESPONSE;
+pub const ASYNC_TASK_KNOWN_FLAGS: u32 = calcit_native_ffi::task_flags::KNOWN;
+pub const ASYNC_EVENT_FLAG_COALESCED: u32 = calcit_native_ffi::event_flags::COALESCED;
+pub const ASYNC_EVENT_KNOWN_FLAGS: u32 = calcit_native_ffi::event_flags::KNOWN;
+pub const ASYNC_RESPONSE_RESOLVE: u32 = calcit_native_ffi::response_outcome::RESOLVE;
+pub const ASYNC_RESPONSE_REJECT: u32 = calcit_native_ffi::response_outcome::REJECT;
 
 /// Semantic role of a host-owned handle. Values are fixed for C and future
 /// WASM adapters; unknown raw values must be rejected before conversion.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FfiAsyncHandleKind {
-  OneShot = 1,
-  Stream = 2,
-  Server = 3,
-  Response = 4,
+  OneShot = calcit_native_ffi::task_kind::ONE_SHOT,
+  Stream = calcit_native_ffi::task_kind::STREAM,
+  Server = calcit_native_ffi::task_kind::SERVER,
+  Response = calcit_native_ffi::task_kind::RESPONSE,
 }
 
 /// Stable event tags shared by native and future WASM transports. `Complete`
@@ -169,9 +49,9 @@ pub enum FfiAsyncHandleKind {
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FfiAsyncEventKind {
-  Emit = 1,
-  Complete = 2,
-  Fail = 3,
+  Emit = calcit_native_ffi::event_kind::EMIT,
+  Complete = calcit_native_ffi::event_kind::COMPLETE,
+  Fail = calcit_native_ffi::event_kind::FAIL,
 }
 
 impl FfiAsyncEventKind {
@@ -185,9 +65,9 @@ impl TryFrom<u32> for FfiAsyncEventKind {
 
   fn try_from(value: u32) -> Result<Self, Self::Error> {
     match value {
-      1 => Ok(Self::Emit),
-      2 => Ok(Self::Complete),
-      3 => Ok(Self::Fail),
+      calcit_native_ffi::event_kind::EMIT => Ok(Self::Emit),
+      calcit_native_ffi::event_kind::COMPLETE => Ok(Self::Complete),
+      calcit_native_ffi::event_kind::FAIL => Ok(Self::Fail),
       _ => Err(FfiAsyncHandleError::InvalidEventKind(value)),
     }
   }
@@ -198,10 +78,10 @@ impl TryFrom<u32> for FfiAsyncHandleKind {
 
   fn try_from(value: u32) -> Result<Self, Self::Error> {
     match value {
-      1 => Ok(Self::OneShot),
-      2 => Ok(Self::Stream),
-      3 => Ok(Self::Server),
-      4 => Ok(Self::Response),
+      calcit_native_ffi::task_kind::ONE_SHOT => Ok(Self::OneShot),
+      calcit_native_ffi::task_kind::STREAM => Ok(Self::Stream),
+      calcit_native_ffi::task_kind::SERVER => Ok(Self::Server),
+      calcit_native_ffi::task_kind::RESPONSE => Ok(Self::Response),
       _ => Err(FfiAsyncHandleError::InvalidKind(value)),
     }
   }
@@ -212,30 +92,6 @@ pub enum FfiAsyncLifecycle {
   Active,
   Closing,
   Finished,
-}
-
-/// C-layout task metadata. The handle remains a raw `u64` so a WASM adapter
-/// may transport it as i64 or two i32 values without exposing host pointers.
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FfiAsyncTaskDescriptor {
-  pub protocol_version: u32,
-  pub struct_size: u32,
-  pub handle: u64,
-  pub kind: u32,
-  pub flags: u32,
-}
-
-impl FfiAsyncTaskDescriptor {
-  pub fn new(handle: FfiAsyncHandle, kind: FfiAsyncHandleKind, flags: u32) -> Self {
-    Self {
-      protocol_version: ASYNC_PROTOCOL_VERSION,
-      struct_size: std::mem::size_of::<Self>() as u32,
-      handle: handle.raw(),
-      kind: kind as u32,
-      flags,
-    }
-  }
 }
 
 /// C-layout event metadata. Payload bytes are deliberately not represented by
@@ -719,46 +575,7 @@ fn resolve_async_handle_mut<T>(
   slot.task.as_mut().ok_or(FfiAsyncHandleError::StaleHandle)
 }
 
-/// Owned bytes allocated by an FFI module. The module must release this value
-/// through `calcit_ffi_buffer_free`; the host only copies from it.
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct FfiBuffer {
-  pub ptr: *mut u8,
-  pub len: usize,
-  pub cap: usize,
-}
-
-impl FfiBuffer {
-  pub fn empty() -> Self {
-    Self {
-      ptr: ptr::null_mut(),
-      len: 0,
-      cap: 0,
-    }
-  }
-}
-
-type FfiBufferVersion = unsafe extern "C" fn() -> u32;
-pub type FfiBufferFree = unsafe extern "C" fn(FfiBuffer);
-type FfiBufferCall = unsafe extern "C" fn(*const u8, usize, *mut FfiBuffer) -> i32;
-type FfiResourceVersion = unsafe extern "C" fn() -> u32;
-pub type FfiResourceRelease = unsafe extern "C" fn(u64, u64) -> i32;
 pub type FfiResourceTrace = fn(&str, &str, u64, u64, i32);
-type FfiAsyncVersion = unsafe extern "C" fn() -> u32;
-pub type FfiAsyncStart = unsafe extern "C" fn(
-  request_ptr: *const u8,
-  request_len: usize,
-  task: *const FfiAsyncTaskDescriptor,
-  host: *const FfiAsyncHostV1,
-) -> i32;
-pub type FfiBlockingCall = unsafe extern "C" fn(
-  request_ptr: *const u8,
-  request_len: usize,
-  task: *const FfiAsyncTaskDescriptor,
-  host: *const FfiBlockingHostV1,
-  output: *mut FfiBuffer,
-) -> i32;
 
 struct NativeFfiResourceLease {
   lib_name: Arc<str>,
@@ -867,18 +684,6 @@ fn intern_resource_lease(adapter: &FfiResourceAdapter, handle: u64, generation: 
     trace("resource-create", &adapter.lib_name, handle, generation, 0);
   }
   Ok(lease)
-}
-
-pub fn buffer_method_symbol(method: &str) -> String {
-  format!("{method}{BUFFER_METHOD_SUFFIX}")
-}
-
-pub fn async_method_symbol(method: &str) -> String {
-  format!("{method}{ASYNC_METHOD_SUFFIX}")
-}
-
-pub fn blocking_method_symbol(method: &str) -> String {
-  format!("{method}{BLOCKING_METHOD_SUFFIX}")
 }
 
 /// Check whether one blocking method has completed the C-safe migration before
@@ -1472,8 +1277,8 @@ mod tests {
       .register(FfiAsyncHandleKind::Server, "http-server")
       .expect("register server");
     let descriptor = FfiAsyncTaskDescriptor::new(
-      handle,
-      FfiAsyncHandleKind::Server,
+      handle.raw(),
+      FfiAsyncHandleKind::Server as u32,
       ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
     );
 


### PR DESCRIPTION
## 中文

Calcit host 直接依赖已发布的 `calcit_native_ffi 0.1.2`（关闭默认 feature），消除 runtime 与 native module 之间的 raw ABI 定义漂移。

- 删除 host 内重复的 buffer/async/blocking/resource protocol version、symbol、method suffix、function pointer、status/flag 与 C-layout descriptor 定义；
- typed handle/event enum 的数值直接绑定共享常量；
- 保留 event queue、handle/task/resource registry、lease intern、dylib cache/pin、cancel、callback 与 lifecycle enforcement 在 Calcit host；
- 净删除 184 行实现，外部 ABI v1、Calcit API 与 runtime 行为不变；
- 文档记录 host/module 的共享 contract 和职责边界。

验证：

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- FFI 定向测试：20 个 `ffi_abi` + 13 个 `ffi_async`
- 全量 Rust：573 + 259 + 24 + 16 tests
- `yarn check-all`：221 core tests、JS runtime、CLI agent interface、Rust/JS/IR/WASM 与性能 smoke 全通过
- release runtime：`dylib-workflow 0.0.4` 同步 buffer 调用返回 `true false` / `&unit`
- release runtime：`calcit-fswatch 0.0.7` 完成 async start/configure，真实文件创建事件成功 enqueue/drain/callback，无 runtime error

关联 / Related: calcit-lang/calcit-native-ffi#1

## English

Make the Calcit host depend directly on released `calcit_native_ffi 0.1.2` with default features disabled, eliminating raw ABI definition drift between the runtime and native modules.

- Remove host-local copies of buffer/async/blocking/resource protocol versions, symbols, method suffixes, function pointers, statuses/flags, and C-layout descriptors.
- Bind typed handle/event enum discriminants directly to shared constants.
- Keep event queues, handle/task/resource registries, lease interning, dylib caching/pinning, cancellation, callbacks, and lifecycle enforcement in the Calcit host.
- Remove 184 net implementation lines without changing ABI v1, the Calcit API, or runtime behavior.
- Document the shared host/module contract and responsibility boundary.

Validation:

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- focused FFI tests: 20 `ffi_abi` + 13 `ffi_async`
- full Rust suite: 573 + 259 + 24 + 16 tests
- `yarn check-all`: 221 core tests, JS runtime, CLI agent interface, Rust/JS/IR/WASM, and performance smokes all pass
- release runtime: `dylib-workflow 0.0.4` synchronous buffer calls return `true false` / `&unit`
- release runtime: `calcit-fswatch 0.0.7` completes async start/configure and successfully enqueues, drains, and dispatches a real file-create event without runtime errors

Related: calcit-lang/calcit-native-ffi#1