### PR TITLE
ffi: 限制异步队列字节并保留终态容量 / bound async queue bytes and reserve terminals

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -60,7 +60,14 @@ delivered. Terminal dispatch marks the task `Finished` before it can be
 released.
 
 Queue capacity is measured in events and every payload also has a host-side
-size limit. Full queues return `QUEUE_FULL` without blocking the producer.
+size limit. The CLI host additionally bounds the aggregate queued payload
+bytes. Ordinary events cannot consume the event and byte reserves held for
+`Complete` and `Fail`, so a saturated stream cannot prevent cancellation or
+completion acknowledgement from entering the host loop. Full event or byte
+budgets return `QUEUE_FULL` without blocking the producer.
+The CLI defaults are 1024 total events and 64 MiB of queued payloads, with 16
+events and 64 KiB reserved for terminal traffic. `--trace-ffi` records both
+current queue counters on accepted and rejected enqueue attempts.
 Only `Emit` events on a task registered with `COALESCE_ALLOWED` may replace an
 older queued emit for that same task; the replacement carries a newer sequence
 and the `COALESCED` event flag. Complete/fail and server request events are
@@ -225,10 +232,10 @@ invalid/stale handle, closing/finished task, host closing, queue full, invalid
 payload, and internal error.
 
 If a dylib does not export `calcit_ffi_async_version`, or does not export the
-versioned symbol for this particular method, Calcit falls back to the guarded
-Rust callback ABI. If it advertises an async protocol version other than 1,
-Calcit fails before invoking either ABI. This per-method rule lets maintained
-modules migrate incrementally without hiding an actual version mismatch.
+versioned symbol for this particular method, Calcit reports a deterministic
+migration error. The legacy Rust callback ABI fallback has been removed. If a
+module advertises an async protocol version other than 1, Calcit fails before
+invoking the method.
 
 ## Native blocking ABI v1
 

--- a/editing-history/202608282333-async-queue-byte-budget.md
+++ b/editing-history/202608282333-async-queue-byte-budget.md
@@ -1,0 +1,19 @@
+# Async queue byte budget and terminal reserve
+
+## 中文
+
+- native async queue 现在可同时限制事件数和累计 payload bytes，避免大量合法但体积较大的事件在 1024 个 event slots 内消耗过多内存。
+- CLI runtime 使用 64 MiB 总字节预算，并为 `Complete`/`Fail` 预留 16 个 event slots 和 64 KiB；普通 Stream/Server emit 不能侵占这些预留资源。
+- event admission 成功后才分配 sequence；event/byte budget 失败都返回稳定的 `QUEUE_FULL`，不会误占 terminal 或 sequence。
+- coalescing 在字节压力下也能替换同一 Stream 的旧 emit，并精确维护 queued-byte accounting；drain/purge 同样回收字节账本。
+- `--trace-ffi` 的 enqueue accepted/rejected 事件现在包含当前 queued events/bytes，便于定位 slow host 或 producer pressure。
+- 修复 async protocol 文档仍描述 legacy Rust callback fallback 的过时内容。
+
+## English
+
+- The native async queue can now bound both event count and aggregate payload bytes, preventing a queue of individually valid events from consuming excessive memory.
+- The CLI runtime uses a 64 MiB byte budget and reserves 16 event slots plus 64 KiB for `Complete`/`Fail`; ordinary Stream/Server emits cannot consume those reserves.
+- Event sequences are allocated only after admission. Event-count and byte-budget failures both map to stable `QUEUE_FULL` without claiming a sequence or terminal event.
+- Coalescing can replace an older Stream emit under byte pressure while keeping queued-byte accounting exact; drain and purge release the same accounting.
+- Accepted and rejected `--trace-ffi` enqueue events now include current queued event/byte counters for diagnosing slow hosts and producer pressure.
+- Removed stale async protocol documentation that still described the deleted legacy Rust callback fallback.

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -33,6 +33,9 @@ static SILENCE_PROGRAM_OUTPUT: AtomicBool = AtomicBool::new(false);
 static TRACE_FFI_EVENT_ID: AtomicUsize = AtomicUsize::new(1);
 static TRACE_FFI_STARTED: LazyLock<Instant> = LazyLock::new(Instant::now);
 const ASYNC_EVENT_QUEUE_CAPACITY: usize = 1024;
+const ASYNC_EVENT_QUEUE_BYTE_CAPACITY: usize = 64 * 1024 * 1024;
+const ASYNC_TERMINAL_EVENT_RESERVE: usize = 16;
+const ASYNC_TERMINAL_BYTE_RESERVE: usize = 64 * 1024;
 const MAX_ASYNC_RESPONSES_PER_TASK: usize = ASYNC_EVENT_QUEUE_CAPACITY;
 const MAX_ASYNC_RESPONSE_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1000;
 
@@ -247,7 +250,13 @@ pub fn init_async_runtime() -> Result<(), String> {
   }
   let runtime = NativeAsyncRuntime {
     registry: FfiAsyncHandleRegistry::new(),
-    queue: FfiAsyncEventQueue::new(ASYNC_EVENT_QUEUE_CAPACITY).map_err(|error| error.to_string())?,
+    queue: FfiAsyncEventQueue::with_limits(calcit::ffi_async::FfiAsyncQueueLimits {
+      event_capacity: ASYNC_EVENT_QUEUE_CAPACITY,
+      byte_capacity: ASYNC_EVENT_QUEUE_BYTE_CAPACITY,
+      terminal_event_reserve: ASYNC_TERMINAL_EVENT_RESERVE,
+      terminal_byte_reserve: ASYNC_TERMINAL_BYTE_RESERVE,
+    })
+    .map_err(|error| error.to_string())?,
     responses: Mutex::new(NativeAsyncResponseIndex::default()),
   };
   NATIVE_ASYNC_RUNTIME
@@ -555,10 +564,11 @@ unsafe fn enqueue_native_async_event(
     .enqueue(&runtime.registry, task_handle, response_handle, kind, payload)
   {
     Ok(outcome) => {
+      let (queued_events, queued_bytes) = runtime.queue.usage().unwrap_or((0, 0));
       trace_ffi_event(
         "async-enqueue",
         format!(
-          "task={} kind={kind:?} sequence={} disposition={:?} producer={:?}",
+          "task={} kind={kind:?} sequence={} disposition={:?} queued_events={queued_events} queued_bytes={queued_bytes} producer={:?}",
           task_handle.raw(),
           outcome.sequence,
           outcome.disposition,
@@ -568,10 +578,11 @@ unsafe fn enqueue_native_async_event(
       async_status::OK
     }
     Err(error) => {
+      let (queued_events, queued_bytes) = runtime.queue.usage().unwrap_or((0, 0));
       trace_ffi_event(
         "async-enqueue-rejected",
         format!(
-          "task={} kind={kind:?} status={} error={error}",
+          "task={} kind={kind:?} status={} queued_events={queued_events} queued_bytes={queued_bytes} error={error}",
           task_handle.raw(),
           error.status_code()
         ),

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -20,6 +20,25 @@ use crate::ffi_abi::{
 pub const MAX_ASYNC_EVENT_PAYLOAD_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FfiAsyncQueueLimits {
+  pub event_capacity: usize,
+  pub byte_capacity: usize,
+  pub terminal_event_reserve: usize,
+  pub terminal_byte_reserve: usize,
+}
+
+impl FfiAsyncQueueLimits {
+  pub const fn event_only(event_capacity: usize) -> Self {
+    Self {
+      event_capacity,
+      byte_capacity: usize::MAX,
+      terminal_event_reserve: 0,
+      terminal_byte_reserve: 0,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FfiAsyncEnqueueDisposition {
   Enqueued,
   Coalesced,
@@ -34,10 +53,13 @@ pub struct FfiAsyncEnqueueOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FfiAsyncQueueError {
   InvalidCapacity,
+  InvalidByteCapacity,
+  InvalidTerminalReserve,
   NullPayload,
   PayloadTooLarge { actual: usize, limit: usize },
   QueueClosed,
   QueueFull { capacity: usize },
+  QueueBytesFull { capacity: usize, queued: usize, incoming: usize },
   WrongDrainThread,
   QueuePoisoned,
   Handle(FfiAsyncHandleError),
@@ -48,9 +70,13 @@ impl FfiAsyncQueueError {
     match self {
       Self::NullPayload | Self::PayloadTooLarge { .. } => async_status::INVALID_PAYLOAD,
       Self::QueueClosed => async_status::HOST_CLOSING,
-      Self::QueueFull { .. } => async_status::QUEUE_FULL,
+      Self::QueueFull { .. } | Self::QueueBytesFull { .. } => async_status::QUEUE_FULL,
       Self::Handle(error) => error.status_code(),
-      Self::InvalidCapacity | Self::WrongDrainThread | Self::QueuePoisoned => async_status::INTERNAL_ERROR,
+      Self::InvalidCapacity
+      | Self::InvalidByteCapacity
+      | Self::InvalidTerminalReserve
+      | Self::WrongDrainThread
+      | Self::QueuePoisoned => async_status::INTERNAL_ERROR,
     }
   }
 }
@@ -59,12 +85,22 @@ impl fmt::Display for FfiAsyncQueueError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
       Self::InvalidCapacity => f.write_str("async FFI event queue capacity must be greater than zero"),
+      Self::InvalidByteCapacity => f.write_str("async FFI event queue byte capacity must be greater than zero"),
+      Self::InvalidTerminalReserve => f.write_str("async FFI terminal reserve must not exceed the queue capacity"),
       Self::NullPayload => f.write_str("async FFI event payload pointer is null for a non-empty payload"),
       Self::PayloadTooLarge { actual, limit } => {
         write!(f, "async FFI event payload has {actual} bytes, exceeding the {limit}-byte limit")
       }
       Self::QueueClosed => f.write_str("async FFI event queue is closed"),
       Self::QueueFull { capacity } => write!(f, "async FFI event queue is full at capacity {capacity}"),
+      Self::QueueBytesFull {
+        capacity,
+        queued,
+        incoming,
+      } => write!(
+        f,
+        "async FFI event queue byte budget is full: queued={queued}, incoming={incoming}, capacity={capacity}"
+      ),
       Self::WrongDrainThread => f.write_str("async FFI event queue must be drained by its host thread"),
       Self::QueuePoisoned => f.write_str("async FFI event queue lock is poisoned"),
       Self::Handle(error) => error.fmt(f),
@@ -169,12 +205,13 @@ pub unsafe fn copy_async_payload(payload_ptr: *const u8, payload_len: usize) -> 
 
 struct FfiAsyncQueueState {
   events: VecDeque<FfiAsyncQueuedEvent>,
+  queued_bytes: usize,
   closed: bool,
 }
 
 /// A bounded multi-producer, single-host-thread event queue.
 pub struct FfiAsyncEventQueue {
-  capacity: usize,
+  limits: FfiAsyncQueueLimits,
   host_thread: ThreadId,
   state: Mutex<FfiAsyncQueueState>,
   ready: Condvar,
@@ -182,14 +219,25 @@ pub struct FfiAsyncEventQueue {
 
 impl FfiAsyncEventQueue {
   pub fn new(capacity: usize) -> Result<Self, FfiAsyncQueueError> {
-    if capacity == 0 {
+    Self::with_limits(FfiAsyncQueueLimits::event_only(capacity))
+  }
+
+  pub fn with_limits(limits: FfiAsyncQueueLimits) -> Result<Self, FfiAsyncQueueError> {
+    if limits.event_capacity == 0 {
       return Err(FfiAsyncQueueError::InvalidCapacity);
     }
+    if limits.byte_capacity == 0 {
+      return Err(FfiAsyncQueueError::InvalidByteCapacity);
+    }
+    if limits.terminal_event_reserve > limits.event_capacity || limits.terminal_byte_reserve > limits.byte_capacity {
+      return Err(FfiAsyncQueueError::InvalidTerminalReserve);
+    }
     Ok(Self {
-      capacity,
+      limits,
       host_thread: thread::current().id(),
       state: Mutex::new(FfiAsyncQueueState {
-        events: VecDeque::with_capacity(capacity),
+        events: VecDeque::with_capacity(limits.event_capacity),
+        queued_bytes: 0,
         closed: false,
       }),
       ready: Condvar::new(),
@@ -197,7 +245,20 @@ impl FfiAsyncEventQueue {
   }
 
   pub fn capacity(&self) -> usize {
-    self.capacity
+    self.limits.event_capacity
+  }
+
+  pub fn byte_capacity(&self) -> usize {
+    self.limits.byte_capacity
+  }
+
+  pub fn queued_bytes(&self) -> Result<usize, FfiAsyncQueueError> {
+    Ok(self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?.queued_bytes)
+  }
+
+  pub fn usage(&self) -> Result<(usize, usize), FfiAsyncQueueError> {
+    let queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    Ok((queue.events.len(), queue.queued_bytes))
   }
 
   pub fn len(&self) -> Result<usize, FfiAsyncQueueError> {
@@ -257,7 +318,20 @@ impl FfiAsyncEventQueue {
     } else if response_handle.is_some() {
       return Err(FfiAsyncHandleError::UnexpectedResponse.into());
     }
-    let coalesce_index = if queue.events.len() >= self.capacity
+    let terminal = kind.is_terminal();
+    let event_limit = if terminal {
+      self.limits.event_capacity
+    } else {
+      self.limits.event_capacity - self.limits.terminal_event_reserve
+    };
+    let byte_limit = if terminal {
+      self.limits.byte_capacity
+    } else {
+      self.limits.byte_capacity - self.limits.terminal_byte_reserve
+    };
+    let exceeds_event_limit = queue.events.len() >= event_limit;
+    let exceeds_byte_limit = queue.queued_bytes.checked_add(payload.len()).is_none_or(|total| total > byte_limit);
+    let coalesce_index = if (exceeds_event_limit || exceeds_byte_limit)
       && kind == FfiAsyncEventKind::Emit
       && task_state.flags & ASYNC_TASK_FLAG_COALESCE_ALLOWED != 0
     {
@@ -268,8 +342,27 @@ impl FfiAsyncEventQueue {
       None
     };
 
-    if queue.events.len() >= self.capacity && coalesce_index.is_none() {
-      return Err(FfiAsyncQueueError::QueueFull { capacity: self.capacity });
+    if coalesce_index.is_none() {
+      if exceeds_event_limit {
+        return Err(FfiAsyncQueueError::QueueFull { capacity: event_limit });
+      }
+      if exceeds_byte_limit {
+        return Err(FfiAsyncQueueError::QueueBytesFull {
+          capacity: byte_limit,
+          queued: queue.queued_bytes,
+          incoming: payload.len(),
+        });
+      }
+    } else if let Some(index) = coalesce_index {
+      let replaced_bytes = queue.events[index].payload.len();
+      let coalesced_bytes = queue.queued_bytes.saturating_sub(replaced_bytes).checked_add(payload.len());
+      if coalesced_bytes.is_none_or(|total| total > byte_limit) {
+        return Err(FfiAsyncQueueError::QueueBytesFull {
+          capacity: byte_limit,
+          queued: queue.queued_bytes.saturating_sub(replaced_bytes),
+          incoming: payload.len(),
+        });
+      }
     }
 
     let sequence = registry.reserve_event_sequence(task_handle, kind)?;
@@ -283,9 +376,11 @@ impl FfiAsyncEventQueue {
     };
 
     let disposition = if let Some(index) = coalesce_index {
+      queue.queued_bytes = queue.queued_bytes.saturating_sub(queue.events[index].payload.len()) + event.payload.len();
       queue.events[index] = event;
       FfiAsyncEnqueueDisposition::Coalesced
     } else {
+      queue.queued_bytes += event.payload.len();
       queue.events.push_back(event);
       FfiAsyncEnqueueDisposition::Enqueued
     };
@@ -330,13 +425,14 @@ impl FfiAsyncEventQueue {
       return Ok(FfiAsyncDrainReport::default());
     }
 
-    let mut batch = Vec::with_capacity(limit.min(self.capacity));
+    let mut batch = Vec::with_capacity(limit.min(self.limits.event_capacity));
     {
       let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
       for _ in 0..limit {
         let Some(event) = queue.events.pop_front() else {
           break;
         };
+        queue.queued_bytes = queue.queued_bytes.saturating_sub(event.payload.len());
         batch.push(event);
       }
     }
@@ -438,7 +534,16 @@ impl FfiAsyncEventQueue {
   fn purge_handle(&self, handle: FfiAsyncHandle) -> Result<usize, FfiAsyncQueueError> {
     let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
     let before = queue.events.len();
-    queue.events.retain(|event| event.descriptor.task_handle != handle.raw());
+    let mut purged_bytes = 0;
+    queue.events.retain(|event| {
+      if event.descriptor.task_handle == handle.raw() {
+        purged_bytes += event.payload.len();
+        false
+      } else {
+        true
+      }
+    });
+    queue.queued_bytes = queue.queued_bytes.saturating_sub(purged_bytes);
     Ok(before - queue.events.len())
   }
 
@@ -477,6 +582,145 @@ mod tests {
       Err(FfiAsyncQueueError::QueueFull { capacity: 1 })
     );
     assert_eq!(registry.state(handle).expect("stream state").next_sequence, 2);
+  }
+
+  #[test]
+  fn queue_limits_validate_byte_capacity_and_terminal_reserve() {
+    assert!(matches!(
+      FfiAsyncEventQueue::with_limits(FfiAsyncQueueLimits {
+        event_capacity: 1,
+        byte_capacity: 0,
+        terminal_event_reserve: 0,
+        terminal_byte_reserve: 0,
+      }),
+      Err(FfiAsyncQueueError::InvalidByteCapacity)
+    ));
+    assert!(matches!(
+      FfiAsyncEventQueue::with_limits(FfiAsyncQueueLimits {
+        event_capacity: 1,
+        byte_capacity: 8,
+        terminal_event_reserve: 2,
+        terminal_byte_reserve: 0,
+      }),
+      Err(FfiAsyncQueueError::InvalidTerminalReserve)
+    ));
+    assert!(matches!(
+      FfiAsyncEventQueue::with_limits(FfiAsyncQueueLimits {
+        event_capacity: 1,
+        byte_capacity: 8,
+        terminal_event_reserve: 0,
+        terminal_byte_reserve: 9,
+      }),
+      Err(FfiAsyncQueueError::InvalidTerminalReserve)
+    ));
+  }
+
+  #[test]
+  fn byte_budget_rejects_emit_without_consuming_sequence_but_accepts_reserved_terminal() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let stream = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let task = registry.register(FfiAsyncHandleKind::OneShot, ()).expect("register one-shot");
+    let queue = FfiAsyncEventQueue::with_limits(FfiAsyncQueueLimits {
+      event_capacity: 3,
+      byte_capacity: 12,
+      terminal_event_reserve: 1,
+      terminal_byte_reserve: 5,
+    })
+    .expect("create byte-bounded queue");
+
+    queue
+      .enqueue(&registry, stream, None, FfiAsyncEventKind::Emit, vec![1; 7])
+      .expect("fill ordinary byte budget");
+    assert_eq!(
+      queue.enqueue(&registry, stream, None, FfiAsyncEventKind::Emit, vec![2]),
+      Err(FfiAsyncQueueError::QueueBytesFull {
+        capacity: 7,
+        queued: 7,
+        incoming: 1,
+      })
+    );
+    assert_eq!(registry.state(stream).expect("stream state").next_sequence, 2);
+
+    queue
+      .enqueue(&registry, task, None, FfiAsyncEventKind::Complete, b"&unit".to_vec())
+      .expect("terminal event uses reserved bytes");
+    assert_eq!(queue.queued_bytes(), Ok(12));
+    let report = queue.drain(&registry, 3, |_| Ok(())).expect("drain byte-bounded queue");
+    assert_eq!(report.delivered, 2);
+    assert_eq!(queue.queued_bytes(), Ok(0));
+  }
+
+  #[test]
+  fn ordinary_events_cannot_consume_terminal_event_reserve() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let first = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register first stream");
+    let second = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register second stream");
+    let third = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register third stream");
+    let terminal = registry.register(FfiAsyncHandleKind::OneShot, ()).expect("register terminal task");
+    let queue = FfiAsyncEventQueue::with_limits(FfiAsyncQueueLimits {
+      event_capacity: 3,
+      byte_capacity: 128,
+      terminal_event_reserve: 1,
+      terminal_byte_reserve: 8,
+    })
+    .expect("create reserved queue");
+
+    for handle in [first, second] {
+      queue
+        .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, vec![])
+        .expect("fill ordinary event slots");
+    }
+    assert_eq!(
+      queue.enqueue(&registry, third, None, FfiAsyncEventKind::Emit, vec![]),
+      Err(FfiAsyncQueueError::QueueFull { capacity: 2 })
+    );
+    queue
+      .enqueue(&registry, terminal, None, FfiAsyncEventKind::Complete, b"&unit".to_vec())
+      .expect("terminal event uses reserved slot");
+    assert_eq!(queue.len(), Ok(3));
+  }
+
+  #[test]
+  fn byte_pressure_coalescing_replaces_payload_and_keeps_accounting_exact() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ())
+      .expect("register coalescing stream");
+    let queue = FfiAsyncEventQueue::with_limits(FfiAsyncQueueLimits {
+      event_capacity: 4,
+      byte_capacity: 10,
+      terminal_event_reserve: 1,
+      terminal_byte_reserve: 2,
+    })
+    .expect("create byte-bounded queue");
+
+    queue
+      .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, vec![1; 6])
+      .expect("enqueue initial event");
+    let outcome = queue
+      .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, vec![2; 7])
+      .expect("coalesce under byte pressure");
+    assert_eq!(outcome.disposition, FfiAsyncEnqueueDisposition::Coalesced);
+    assert_eq!(queue.queued_bytes(), Ok(7));
+    assert_eq!(
+      queue.enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, vec![3; 9]),
+      Err(FfiAsyncQueueError::QueueBytesFull {
+        capacity: 8,
+        queued: 0,
+        incoming: 9,
+      })
+    );
+    assert_eq!(queue.queued_bytes(), Ok(7));
+
+    let mut payload = vec![];
+    queue
+      .drain(&registry, 1, |event| {
+        payload = event.payload().to_vec();
+        Ok(())
+      })
+      .expect("drain coalesced event");
+    assert_eq!(payload, vec![2; 7]);
+    assert_eq!(queue.queued_bytes(), Ok(0));
   }
 
   #[test]


### PR DESCRIPTION
## 中文

关联 #501，落实实时协同异步可靠性基线的第一步。

### 变更

- 为 native async queue 增加累计 payload byte budget，不再只限制 event count。
- CLI runtime 配置为 1024 个事件、64 MiB queued payload。
- 为 `Complete`/`Fail` 保留 16 个 event slots 和 64 KiB，普通 Stream/Server emit 无法侵占。
- event/byte admission 失败统一映射稳定的 `QUEUE_FULL`，且不会消耗 sequence 或抢占 terminal。
- coalescing 在 byte pressure 下可替换旧 Stream emit，并精确维护 drain/purge 后的 queued-byte accounting。
- `--trace-ffi` 的 enqueue accepted/rejected 记录当前 queued events/bytes。
- 修复文档仍描述已删除 Rust callback ABI fallback 的过时段落。

### 效果

- 之前 1024 个 event slots、单 payload 16 MiB 的组合理论上允许接近 16 GiB queued payload；CLI 现在把聚合 payload 明确限制为 64 MiB。
- 普通实时事件饱和时，取消确认和任务终态仍能进入 host loop。
- 业务 payload、C ABI、状态码和正常事件顺序保持不变。

### 验证

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`：577 library + 259 CLI suite + 24 caps + 16 wasm binary
- `yarn compile`
- `yarn check-all`：Calcit core 221/221、JS/IR/WASM 与性能回归
- `yarn check-agent-interface`：17/17

## English

Related to #501. This is the first reliability baseline for real-time collaboration async workloads.

### Changes

- Add an aggregate payload-byte budget to the native async queue instead of limiting only event count.
- Configure the CLI runtime for 1024 events and 64 MiB of queued payloads.
- Reserve 16 event slots and 64 KiB for `Complete`/`Fail`; ordinary Stream/Server emits cannot consume them.
- Map event/byte admission failures to stable `QUEUE_FULL` without consuming a sequence or claiming a terminal event.
- Allow coalescing to replace an older Stream emit under byte pressure while keeping drain/purge byte accounting exact.
- Include current queued events/bytes in accepted and rejected `--trace-ffi` enqueue records.
- Fix stale documentation that still described the removed Rust callback ABI fallback.

### Impact

- The previous combination of 1024 event slots and a 16 MiB per-payload limit theoretically allowed nearly 16 GiB of queued payloads; the CLI now has an explicit 64 MiB aggregate limit.
- Cancellation acknowledgements and task terminals can still enter the host loop when ordinary real-time traffic is saturated.
- Business payloads, C ABI, status codes, and normal event ordering remain unchanged.

### Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`: 577 library + 259 CLI suite + 24 caps + 16 wasm binary
- `yarn compile`
- `yarn check-all`: Calcit core 221/221, JS/IR/WASM, and performance regressions
- `yarn check-agent-interface`: 17/17
