### PR TITLE
feat(ffi): Ctrl-C 关闭 native async runtime / shut down native async runtime on Ctrl-C

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -42,6 +42,39 @@ allowed. `finish` and `release` are exactly-once operations; a finished
 tombstone remains until release so duplicate completion has a deterministic
 error instead of looking like an unknown handle.
 
+## Host shutdown / 宿主关闭
+
+The CLI owns the process Ctrl-C handler. The signal thread only records a
+shutdown request; it never enters the Calcit runtime. A callback registered by
+`on-control-c` runs once on the host thread before native task cancellation.
+This keeps application cleanup serialized with ordinary callbacks.
+
+Shutdown stops new registrations, moves every live native task and response
+capability to `Closing`, rejects open responses with `:host-shutdown`, and
+invokes each available module cancel hook. The host continues draining
+terminal events for a two-second grace period, so a cooperative module can
+still publish its exactly-once `Complete` or `Fail` acknowledgement. At the
+deadline the queue closes, then unfinished tasks are purged and released with
+diagnostics containing module, method, task handle, kind, age, purged-event
+count, and discarded-response count. Closing before forced release prevents a
+late producer from racing a reclaimed task handle.
+
+CLI watch loops and the compatibility `async-sleep` task observe the same
+shutdown request, so they cannot keep the process alive after native cleanup.
+
+Calcit CLI 统一拥有进程的 Ctrl-C handler。信号线程只记录关闭请求，
+不直接进入 Calcit runtime；`on-control-c` 注册的回调会在取消 native
+task 之前，由 host thread 串行执行一次。
+
+关闭会停止新注册，把存活的 native task 和 response capability 转为
+`Closing`，以 `:host-shutdown` 拒绝未完成 response，并调用模块的
+cancel hook。Host 在 2 秒 grace period 内继续 drain terminal event；超时任务
+会被强制 purge/release，同时输出 module、method、task handle、kind、age、
+purged event 与 discarded response 诊断。在 grace period 内，合作的模块仍可发布
+exactly-once `Complete` 或 `Fail`；deadline 到达后先关闭队列再强制 release，
+避免迟到 producer 与已回收 task handle 竞态。Watch loop 与兼容性
+`async-sleep` 也会观察同一关闭请求，不会在 native cleanup 后继续挂住进程。
+
 ## Events and ordering
 
 Each active handle owns a monotonically increasing event sequence starting at

--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -45,8 +45,8 @@ error instead of looking like an unknown handle.
 ## Host shutdown / 宿主关闭
 
 The CLI owns the process Ctrl-C handler. The signal thread only records a
-shutdown request; it never enters the Calcit runtime. A callback registered by
-`on-control-c` runs once on the host thread before native task cancellation.
+synchronized shutdown request; it never enters the Calcit runtime. A callback
+registered by `on-control-c` runs once on the host thread before native task cancellation.
 This keeps application cleanup serialized with ordinary callbacks.
 
 Shutdown stops new registrations, moves every live native task and response
@@ -61,8 +61,13 @@ late producer from racing a reclaimed task handle.
 
 CLI watch loops and the compatibility `async-sleep` task observe the same
 shutdown request, so they cannot keep the process alive after native cleanup.
+The native evaluator checks the request periodically, including at tail-recur
+boundaries, while reload and codegen check between phases. An interrupted
+once-mode run still enters bounded async cleanup before returning its error.
+The registered `on-control-c` callback temporarily suppresses evaluator
+interruption so application cleanup can finish on the host thread.
 
-Calcit CLI 统一拥有进程的 Ctrl-C handler。信号线程只记录关闭请求，
+Calcit CLI 统一拥有进程的 Ctrl-C handler。信号线程只同步记录关闭请求，
 不直接进入 Calcit runtime；`on-control-c` 注册的回调会在取消 native
 task 之前，由 host thread 串行执行一次。
 
@@ -74,6 +79,10 @@ purged event 与 discarded response 诊断。在 grace period 内，合作的模
 exactly-once `Complete` 或 `Fail`；deadline 到达后先关闭队列再强制 release，
 避免迟到 producer 与已回收 task handle 竞态。Watch loop 与兼容性
 `async-sleep` 也会观察同一关闭请求，不会在 native cleanup 后继续挂住进程。
+Native evaluator 会周期性检查该请求（包括尾递归边界），reload 与 codegen
+也会在阶段之间检查。Once-mode 执行被中断后仍会先进入有界 async cleanup，
+再返回错误；运行 `on-control-c` 时则临时暂停 evaluator 中断，确保应用清理
+可在 host thread 完成。
 
 ## Events and ordering
 

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -141,6 +141,11 @@ let
   &ffi-task-cancel task :shutdown
 ```
 
+Ctrl-C performs the same cancellation at host scope. A function registered
+with `on-control-c` runs on the Calcit host thread before the runtime starts
+the two-second native-task shutdown grace period; the signal thread itself
+never runs Calcit code.
+
 For a Server request carrying a response handle, Calcit appends an opaque
 response capability after the decoded request arguments. It is exactly-once:
 

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -144,7 +144,9 @@ let
 Ctrl-C performs the same cancellation at host scope. A function registered
 with `on-control-c` runs on the Calcit host thread before the runtime starts
 the two-second native-task shutdown grace period; the signal thread itself
-never runs Calcit code.
+only records synchronized state and never runs Calcit code. Native evaluation,
+tail recursion, watch reload, and codegen cooperatively observe the shutdown request. Even an interrupted
+once-mode run drains and cancels native tasks before returning.
 
 For a Server request carrying a response handle, Calcit appends an opaque
 response capability after the decoded request arguments. It is exactly-once:

--- a/editing-history/202608290048-async-runtime-shutdown.md
+++ b/editing-history/202608290048-async-runtime-shutdown.md
@@ -1,0 +1,17 @@
+# 接入异步 runtime 关闭 / Wire async runtime shutdown
+
+## 中文
+
+- Calcit CLI 统一安装 Ctrl-C handler，信号线程只设置原子状态，`on-control-c` 回调改由 host thread 串行执行。
+- 调用 async registry `begin_shutdown`，拒绝未完成 response，调用模块 cancel hook，并给 terminal event 保留 2 秒 grace period。
+- grace period 结束后先关闭 host queue，再按 module/method/task/kind/age 输出诊断并强制 purge/release，避免迟到 producer 竞态。
+- Watch loop 与兼容性 `async-sleep` 共享可唤醒的 shutdown signal，避免 Ctrl-C 后长时间挂起。
+- 添加 response rejection、cancel invocation、grace timeout 强制清理测试，并使用真实 fswatch C-safe Stream 验证 cancel→Complete→release，无强制清理。
+
+## English
+
+- Install one CLI-owned Ctrl-C handler; the signal thread only updates atomic state, while `on-control-c` callbacks run serially on the host thread.
+- Invoke async-registry `begin_shutdown`, reject open responses, call module cancel hooks, and retain a two-second grace period for terminal events.
+- After the deadline, close the host queue first, then diagnose unfinished tasks by module/method/task/kind/age and force purge/release them without a late-producer race.
+- Let watch loops and compatibility `async-sleep` share a wakeable shutdown signal so Ctrl-C cannot leave the process hanging.
+- Cover response rejection, cancel invocation, and forced cleanup after grace, plus a real fswatch C-safe Stream cancel→Complete→release smoke with no forced cleanup.

--- a/editing-history/202608290107-avoid-duplicate-shutdown-cancel.md
+++ b/editing-history/202608290107-avoid-duplicate-shutdown-cancel.md
@@ -1,0 +1,13 @@
+# 避免 shutdown 重复取消 / Avoid duplicate shutdown cancellation
+
+## 中文
+
+- 在 `begin_shutdown` 之前保留 lifecycle snapshot，只向原先处于 `Active` 的 task 调用 cancel hook。
+- 如果 `on-control-c` 或业务逻辑已经把 task 转为 `Closing`，全局 shutdown 只等待 terminal，不会重复调用模块取消。
+- 测试断言已在 Closing 的 task 取消次数保持为零，同时继续受 grace timeout 和强制清理保护。
+
+## English
+
+- Preserve the lifecycle snapshot before `begin_shutdown` and invoke cancel hooks only for tasks that were originally `Active`.
+- If `on-control-c` or application logic already moved a task to `Closing`, global shutdown waits for its terminal acknowledgement without calling module cancellation twice.
+- Assert that an already-closing task receives zero additional cancel calls while remaining protected by the grace timeout and forced cleanup.

--- a/editing-history/202608290110-handle-shutdown-review.md
+++ b/editing-history/202608290110-handle-shutdown-review.md
@@ -1,0 +1,15 @@
+# 完善关闭中断路径 / Complete shutdown interruption paths
+
+## 中文
+
+- 按 condvar 谓词协议在持有 wake mutex 时记录 shutdown 并通知，消除检查状态与进入等待之间的丢失唤醒窗口。
+- Native evaluator 低频检查 shutdown 请求，覆盖普通求值与尾递归执行；`on-control-c` 回调在 host thread 运行时临时暂停该检查。
+- Watch 在收到文件事件后重新检查关闭状态；reload 与 codegen 在阶段之间检查，且无 timeout 的 codegen 也由可中断的 worker 执行。
+- Once-mode 运行出错或被中断后不再提前跳过 async runtime 清理，而是先完成有界取消与回收，再返回原始错误。
+
+## English
+
+- Record shutdown and notify while holding the condition-variable predicate mutex, closing the lost-wakeup window between checking state and waiting.
+- Poll shutdown cheaply during native evaluation, including tail recursion, while temporarily suppressing interruption for the host-thread `on-control-c` callback.
+- Recheck shutdown after watch events and between reload/codegen phases; timeout-free codegen now also runs behind an interruptible worker boundary.
+- Once-mode failures and interruptions no longer bypass async-runtime cleanup: bounded cancellation and reclamation finish before the original error returns.

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -571,18 +571,24 @@ fn run_cli() -> Result<(), String> {
     }
     let started_time = Instant::now();
 
-    let v = calcit::run_program_with_docs(entries.init_ns.to_owned(), entries.init_def.to_owned(), &[]).map_err(|e| {
-      LocatedWarning::print_list(&e.warnings);
-      e.msg
-    })?;
-
-    let duration = Instant::now().duration_since(started_time);
-    println!("{}{}", format!("took {}ms: ", duration.as_micros() as f64 / 1000.0).dimmed(), v);
-    Ok(())
+    calcit::run_program_with_docs(entries.init_ns.to_owned(), entries.init_def.to_owned(), &[])
+      .map_err(|e| {
+        LocatedWarning::print_list(&e.warnings);
+        e.msg
+      })
+      .map(|v| {
+        let duration = Instant::now().duration_since(started_time);
+        println!("{}{}", format!("took {}ms: ", duration.as_micros() as f64 / 1000.0).dimmed(), v);
+      })
   };
 
-  if eval_once {
-    task?;
+  let task_result = if eval_once {
+    if task.is_err() {
+      // Evaluation failures can leave native tasks behind. Enter the same
+      // bounded cleanup path used by Ctrl-C before returning the error.
+      runner::track::request_shutdown();
+    }
+    task
   } else {
     // error are only printed in watch mode
     match task {
@@ -591,7 +597,8 @@ fn run_cli() -> Result<(), String> {
         eprintln!("\nfailed to run, {e}");
       }
     }
-  }
+    Ok(())
+  };
 
   if !eval_once {
     runner::track::track_task_add();
@@ -602,7 +609,7 @@ fn run_cli() -> Result<(), String> {
   injection::exit_when_async_cleared()?;
   #[cfg(target_arch = "wasm32")]
   runner::track::exit_when_cleared();
-  Ok(())
+  task_result
 }
 
 #[derive(Debug, Clone)]
@@ -1134,6 +1141,9 @@ pub fn watch_files(
   while !injection::shutdown_requested() {
     match rx.recv_timeout(Duration::from_millis(100)) {
       Ok(Ok(_event)) => {
+        if injection::shutdown_requested() {
+          break;
+        }
         // load new program code
         let mut content = fs::read_to_string(&inc_path).expect("reading inc file");
         strip_shebang(&mut content);
@@ -1164,6 +1174,7 @@ fn recall_program(
   settings: &ToplevelCalcit,
   configured_run_mode: snapshot::SnapshotRunMode,
 ) -> Result<(), String> {
+  ensure_host_running("reload")?;
   println!("\n-------- file change --------\n");
 
   // Steps:
@@ -1178,6 +1189,7 @@ fn recall_program(
   })?;
   // println!("\ndata: {}", &data);
   let changes: ChangesDict = data.try_into()?;
+  ensure_host_running("reload")?;
 
   // Print change summary
   println!("{} Incremental changes detected:", "→".cyan());
@@ -1215,11 +1227,13 @@ fn recall_program(
   }
 
   program::apply_code_changes(&changes)?;
+  ensure_host_running("reload")?;
   println!("{} Changes applied to program", "✓".green());
 
   // clear invalidated runtime cache entries
   program::clear_runtime_caches_for_changes(&changes, settings.reload_libs)?;
   builtins::meta::force_reset_gensym_index()?;
+  ensure_host_running("reload")?;
   println!("cleared runtime caches and reset gensym index.");
 
   // Create a minimal snapshot for documentation lookup during incremental updates
@@ -1263,6 +1277,14 @@ fn recall_program(
   }
 
   Ok(())
+}
+
+fn ensure_host_running(operation: &str) -> Result<(), String> {
+  if injection::shutdown_requested() {
+    Err(format!("{operation} interrupted by host shutdown"))
+  } else {
+    Ok(())
+  }
 }
 
 /// Check-only mode: preprocess init_fn and reload_fn to validate code without execution
@@ -1323,9 +1345,6 @@ fn run_codegen_with_timeout(
   timeout_secs: u64,
   verbose: bool,
 ) -> Result<(), String> {
-  if timeout_secs == 0 {
-    return run_codegen(entries, emit_path, ir_mode, verbose);
-  }
   let entries = entries.clone();
   let emit_path = emit_path.to_owned();
   let (tx, rx) = channel();
@@ -1341,16 +1360,29 @@ fn run_codegen_with_timeout(
       let _ = tx.send(result);
     })
     .map_err(|err| format!("failed to start codegen thread: {err}"))?;
-  match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
-    Ok(result) => result,
-    Err(RecvTimeoutError::Timeout) => Err(format!(
-      "codegen timed out after {timeout_secs}s; re-run with --verbose or --timeout 0 for diagnosis"
-    )),
-    Err(RecvTimeoutError::Disconnected) => Err("codegen thread terminated without returning a result".into()),
+
+  let started_at = Instant::now();
+  let timeout = (timeout_secs > 0).then(|| Duration::from_secs(timeout_secs));
+  loop {
+    ensure_host_running("codegen")?;
+    let wait = timeout
+      .map(|limit| limit.saturating_sub(started_at.elapsed()).min(Duration::from_millis(40)))
+      .unwrap_or(Duration::from_millis(40));
+    if timeout.is_some() && wait.is_zero() {
+      return Err(format!(
+        "codegen timed out after {timeout_secs}s; re-run with --verbose or --timeout 0 for diagnosis"
+      ));
+    }
+    match rx.recv_timeout(wait) {
+      Ok(result) => return result,
+      Err(RecvTimeoutError::Timeout) => {}
+      Err(RecvTimeoutError::Disconnected) => return Err("codegen thread terminated without returning a result".into()),
+    }
   }
 }
 
 fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool, verbose: bool) -> Result<(), String> {
+  ensure_host_running("codegen")?;
   let started_time = Instant::now();
   let phase = |name: &str| {
     if verbose {
@@ -1392,6 +1424,7 @@ fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool, verbose
       return Err(headline);
     }
   }
+  ensure_host_running("codegen")?;
 
   // preprocess to reload
   phase("preprocessing reload entry");
@@ -1404,6 +1437,7 @@ fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool, verbose
       return Err(headline);
     }
   }
+  ensure_host_running("codegen")?;
 
   let warnings = check_warnings.borrow();
   throw_on_js_warnings(&warnings, &js_file_path)?;
@@ -1415,6 +1449,7 @@ fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool, verbose
   }
 
   if ir_mode {
+    ensure_host_running("codegen")?;
     phase("emitting IR");
     match codegen::gen_ir::emit_ir(&entries.init_fn, &entries.reload_fn, emit_path) {
       Ok(_) => (),
@@ -1424,6 +1459,7 @@ fn run_codegen(entries: &ProgramEntries, emit_path: &str, ir_mode: bool, verbose
       }
     }
   } else {
+    ensure_host_running("codegen")?;
     // TODO entry ns
     phase("emitting JavaScript");
     match codegen::emit_js::emit_js(&entries.init_ns, emit_path) {

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -1131,8 +1131,8 @@ pub fn watch_files(
     }
   };
 
-  loop {
-    match rx.recv() {
+  while !injection::shutdown_requested() {
+    match rx.recv_timeout(Duration::from_millis(100)) {
       Ok(Ok(_event)) => {
         // load new program code
         let mut content = fs::read_to_string(&inc_path).expect("reading inc file");
@@ -1146,9 +1146,14 @@ pub fn watch_files(
         };
       }
       Ok(Err(e)) => println!("watch error: {e:?}"),
-      Err(e) => eprintln!("watch error: {e:?}"),
+      Err(RecvTimeoutError::Timeout) => {}
+      Err(RecvTimeoutError::Disconnected) => {
+        eprintln!("watch error: channel disconnected");
+        break;
+      }
     }
   }
+  runner::track::track_task_release();
 }
 
 // overwrite previous state

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1184,7 +1184,7 @@ fn run_pending_ctrl_c_callback() -> Result<(), String> {
   let Calcit::Fn { info, .. } = callback.as_ref() else {
     return Err("registered Ctrl-C callback is not a function".to_owned());
   };
-  runner::run_fn(&[], info, &stack)
+  runner::run_fn_during_shutdown(&[], info, &stack)
     .map(|_| ())
     .map_err(|error| format!("Ctrl-C callback failed: {}", error.msg))
 }

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1221,8 +1221,8 @@ fn reject_response_during_shutdown(
 }
 
 fn begin_native_async_shutdown(runtime: &NativeAsyncRuntime) -> Result<usize, String> {
-  let pending = runtime.registry.begin_shutdown().map_err(|error| error.to_string())?;
   let snapshot = runtime.registry.snapshot().map_err(|error| error.to_string())?;
+  let pending = runtime.registry.begin_shutdown().map_err(|error| error.to_string())?;
 
   for (handle, state, resource) in &snapshot {
     if state.kind == FfiAsyncHandleKind::Response
@@ -1235,7 +1235,7 @@ fn begin_native_async_shutdown(runtime: &NativeAsyncRuntime) -> Result<usize, St
 
   let reason = b"{} (:code :host-shutdown)";
   for (handle, state, resource) in snapshot {
-    if state.kind == FfiAsyncHandleKind::Response || state.lifecycle == calcit::ffi_abi::FfiAsyncLifecycle::Finished {
+    if state.kind == FfiAsyncHandleKind::Response || state.lifecycle != calcit::ffi_abi::FfiAsyncLifecycle::Active {
       continue;
     }
     let NativeAsyncResource::Task(task) = resource else {
@@ -2000,7 +2000,6 @@ mod async_callback_tests {
 
   type RecordedResponse = (u64, u64, u32, Vec<u8>);
   static RESPONSE_EVENTS: LazyLock<Mutex<Vec<RecordedResponse>>> = LazyLock::new(|| Mutex::new(vec![]));
-  static SHUTDOWN_CANCELS: AtomicUsize = AtomicUsize::new(0);
 
   #[test]
   fn missing_c_safe_symbols_report_migration_without_rust_symbol_probes() {
@@ -2043,14 +2042,16 @@ mod async_callback_tests {
   }
 
   unsafe extern "C" fn record_shutdown_cancel(context: u64, _task_handle: u64, reason_ptr: *const u8, reason_len: usize) -> i32 {
-    if context != 707 || reason_ptr.is_null() {
+    if context == 0 || reason_ptr.is_null() {
       return async_status::INVALID_PAYLOAD;
     }
     let reason = unsafe { std::slice::from_raw_parts(reason_ptr, reason_len) };
     if reason != b"{} (:code :host-shutdown)" {
       return async_status::INVALID_PAYLOAD;
     }
-    SHUTDOWN_CANCELS.fetch_add(1, Ordering::Relaxed);
+    // SAFETY: shutdown tests pass a live AtomicUsize address and invoke the
+    // cancellation callback synchronously before the counter is dropped.
+    unsafe { &*(context as *const AtomicUsize) }.fetch_add(1, Ordering::Relaxed);
     async_status::OK
   }
 
@@ -2533,14 +2534,14 @@ mod async_callback_tests {
   #[test]
   fn runtime_shutdown_cancels_tasks_rejects_responses_and_force_cleans_after_grace() {
     const RESPONSE_CONTEXT: u64 = 808;
-    SHUTDOWN_CANCELS.store(0, Ordering::Relaxed);
+    let shutdown_cancels = AtomicUsize::new(0);
     let runtime = test_runtime(4);
     let task = test_task();
     let NativeAsyncResource::Task(task_state) = &task else {
       unreachable!("test task is a task resource");
     };
     *task_state.control.lock().expect("task control") = Some(NativeAsyncTaskControl {
-      context: 707,
+      context: (&shutdown_cancels as *const AtomicUsize) as u64,
       cancel: record_shutdown_cancel,
     });
     let owner = runtime
@@ -2557,7 +2558,7 @@ mod async_callback_tests {
       shutdown_native_async_runtime(&runtime, Duration::ZERO, false).expect("shutdown runtime"),
       1
     );
-    assert_eq!(SHUTDOWN_CANCELS.load(Ordering::Relaxed), 1);
+    assert_eq!(shutdown_cancels.load(Ordering::Relaxed), 1);
     assert_eq!(
       runtime.registry.state(owner),
       Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle)
@@ -2616,5 +2617,34 @@ mod async_callback_tests {
     );
     assert_eq!(runtime.registry.pending_count(), Ok(0));
     assert!(runtime.queue.is_empty().expect("empty shutdown queue"));
+  }
+
+  #[test]
+  fn runtime_shutdown_does_not_cancel_an_already_closing_task_twice() {
+    let shutdown_cancels = AtomicUsize::new(0);
+    let runtime = test_runtime(4);
+    let task = test_task();
+    let NativeAsyncResource::Task(task_state) = &task else {
+      unreachable!("test task is a task resource");
+    };
+    *task_state.control.lock().expect("task control") = Some(NativeAsyncTaskControl {
+      context: (&shutdown_cancels as *const AtomicUsize) as u64,
+      cancel: record_shutdown_cancel,
+    });
+    let owner = runtime
+      .registry
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+      .expect("register closing stream");
+    runtime.registry.begin_close(owner).expect("begin explicit close");
+
+    assert_eq!(
+      shutdown_native_async_runtime(&runtime, Duration::ZERO, false).expect("shutdown runtime"),
+      1
+    );
+    assert_eq!(shutdown_cancels.load(Ordering::Relaxed), 0);
+    assert_eq!(
+      runtime.registry.state(owner),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle)
+    );
   }
 }

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -38,6 +38,11 @@ const ASYNC_TERMINAL_EVENT_RESERVE: usize = 16;
 const ASYNC_TERMINAL_BYTE_RESERVE: usize = 64 * 1024;
 const MAX_ASYNC_RESPONSES_PER_TASK: usize = ASYNC_EVENT_QUEUE_CAPACITY;
 const MAX_ASYNC_RESPONSE_TIMEOUT_MS: u64 = 24 * 60 * 60 * 1000;
+const ASYNC_SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+
+static CTRL_C_CALLBACK_PENDING: AtomicBool = AtomicBool::new(false);
+type CtrlCCallback = (Arc<Calcit>, Arc<CallStackList>);
+static CTRL_C_CALLBACK: LazyLock<Mutex<Option<CtrlCCallback>>> = LazyLock::new(|| Mutex::new(None));
 
 #[derive(Clone)]
 struct NativeAsyncTask {
@@ -47,6 +52,7 @@ struct NativeAsyncTask {
   method: String,
   control: Arc<Mutex<Option<NativeAsyncTaskControl>>>,
   blocking: Option<NativeBlockingTask>,
+  started_at: Instant,
 }
 
 #[derive(Clone)]
@@ -261,7 +267,17 @@ pub fn init_async_runtime() -> Result<(), String> {
   };
   NATIVE_ASYNC_RUNTIME
     .set(runtime)
-    .map_err(|_| "async FFI runtime was initialized concurrently".to_owned())
+    .map_err(|_| "async FFI runtime was initialized concurrently".to_owned())?;
+  track::reset_shutdown();
+  ctrlc::set_handler(|| {
+    CTRL_C_CALLBACK_PENDING.store(true, Ordering::Release);
+    track::request_shutdown();
+  })
+  .map_err(|error| format!("failed to install Calcit Ctrl-C handler: {error}"))
+}
+
+pub fn shutdown_requested() -> bool {
+  track::shutdown_requested()
 }
 
 fn native_async_runtime() -> Result<&'static NativeAsyncRuntime, String> {
@@ -1094,8 +1110,7 @@ fn dispatch_native_async_event(runtime: &NativeAsyncRuntime, event: &calcit::ffi
   }
 }
 
-pub fn drain_async_events(limit: usize) -> Result<FfiAsyncDrainReport, String> {
-  let runtime = native_async_runtime()?;
+fn drain_async_events_from(runtime: &NativeAsyncRuntime, limit: usize) -> Result<FfiAsyncDrainReport, String> {
   expire_async_responses(runtime)?;
   let mut report = runtime
     .queue
@@ -1151,12 +1166,209 @@ pub fn drain_async_events(limit: usize) -> Result<FfiAsyncDrainReport, String> {
   Ok(report)
 }
 
+pub fn drain_async_events(limit: usize) -> Result<FfiAsyncDrainReport, String> {
+  drain_async_events_from(native_async_runtime()?, limit)
+}
+
+fn run_pending_ctrl_c_callback() -> Result<(), String> {
+  if !CTRL_C_CALLBACK_PENDING.swap(false, Ordering::AcqRel) {
+    return Ok(());
+  }
+  let callback = CTRL_C_CALLBACK
+    .lock()
+    .map_err(|_| "Ctrl-C callback lock is poisoned".to_owned())?
+    .clone();
+  let Some((callback, stack)) = callback else {
+    return Ok(());
+  };
+  let Calcit::Fn { info, .. } = callback.as_ref() else {
+    return Err("registered Ctrl-C callback is not a function".to_owned());
+  };
+  runner::run_fn(&[], info, &stack)
+    .map(|_| ())
+    .map_err(|error| format!("Ctrl-C callback failed: {}", error.msg))
+}
+
+fn reject_response_during_shutdown(
+  runtime: &NativeAsyncRuntime,
+  handle: FfiAsyncHandle,
+  response: NativeAsyncResponse,
+) -> Result<(), String> {
+  runtime
+    .responses
+    .lock()
+    .map_err(|_| "async FFI response index lock is poisoned".to_owned())?
+    .remove(handle);
+  let reason = b"{} (:code :host-shutdown)";
+  let status = unsafe { (response.resolve)(response.context, handle.raw(), ASYNC_RESPONSE_REJECT, reason.as_ptr(), reason.len()) };
+  runtime.registry.finish(handle).map_err(|error| error.to_string())?;
+  match runtime.registry.release(handle).map_err(|error| error.to_string())? {
+    NativeAsyncResource::Response(_) => {}
+    NativeAsyncResource::Task(_) => return Err(format!("async FFI response {} released a task resource", handle.raw())),
+  }
+  trace_ffi_event(
+    "async-response-shutdown",
+    format!("task={} response={} status={status}", response.owner_task.raw(), handle.raw()),
+  );
+  if status == async_status::OK {
+    Ok(())
+  } else {
+    Err(format!(
+      "async FFI response {} shutdown rejection failed with status {status}",
+      handle.raw()
+    ))
+  }
+}
+
+fn begin_native_async_shutdown(runtime: &NativeAsyncRuntime) -> Result<usize, String> {
+  let pending = runtime.registry.begin_shutdown().map_err(|error| error.to_string())?;
+  let snapshot = runtime.registry.snapshot().map_err(|error| error.to_string())?;
+
+  for (handle, state, resource) in &snapshot {
+    if state.kind == FfiAsyncHandleKind::Response
+      && let NativeAsyncResource::Response(response) = resource
+      && let Err(error) = reject_response_during_shutdown(runtime, *handle, *response)
+    {
+      eprintln!("[Error] {error}");
+    }
+  }
+
+  let reason = b"{} (:code :host-shutdown)";
+  for (handle, state, resource) in snapshot {
+    if state.kind == FfiAsyncHandleKind::Response || state.lifecycle == calcit::ffi_abi::FfiAsyncLifecycle::Finished {
+      continue;
+    }
+    let NativeAsyncResource::Task(task) = resource else {
+      continue;
+    };
+    let control = task
+      .control
+      .lock()
+      .map_err(|_| format!("async FFI task {} control lock is poisoned", handle.raw()))?
+      .to_owned();
+    let Some(control) = control else {
+      trace_ffi_event(
+        "async-shutdown-wait",
+        format!(
+          "lib={} symbol={} task={} kind={:?} cancellable=false",
+          task.lib_name,
+          task.method,
+          handle.raw(),
+          state.kind
+        ),
+      );
+      continue;
+    };
+    let status = unsafe { (control.cancel)(control.context, handle.raw(), reason.as_ptr(), reason.len()) };
+    trace_ffi_event(
+      "async-shutdown-cancel",
+      format!(
+        "lib={} symbol={} task={} kind={:?} status={status}",
+        task.lib_name,
+        task.method,
+        handle.raw(),
+        state.kind
+      ),
+    );
+    if status != async_status::OK && status != async_status::HANDLE_FINISHED {
+      eprintln!(
+        "[Error] async FFI shutdown cancellation failed: lib={} symbol={} task={} status={status}",
+        task.lib_name,
+        task.method,
+        handle.raw()
+      );
+    }
+  }
+  trace_ffi_event("async-shutdown-begin", format!("pending={}", pending.len()));
+  Ok(pending.len())
+}
+
+fn force_cleanup_native_async(runtime: &NativeAsyncRuntime, release_tracked_tasks: bool) -> Result<usize, String> {
+  let snapshot = runtime.registry.snapshot().map_err(|error| error.to_string())?;
+  let mut forced = 0;
+
+  for (handle, state, resource) in &snapshot {
+    if state.kind == FfiAsyncHandleKind::Response
+      && let NativeAsyncResource::Response(response) = resource
+      && let Err(error) = reject_response_during_shutdown(runtime, *handle, *response)
+    {
+      eprintln!("[Error] {error}");
+    }
+  }
+
+  for (handle, state, resource) in snapshot {
+    if state.kind == FfiAsyncHandleKind::Response {
+      continue;
+    }
+    let NativeAsyncResource::Task(task) = resource else {
+      continue;
+    };
+    let unfinished = state.lifecycle != calcit::ffi_abi::FfiAsyncLifecycle::Finished;
+    let purged = runtime.queue.discard_handle_events(handle).map_err(|error| error.to_string())?;
+    let discarded_responses = discard_owned_responses(runtime, handle)?;
+    if state.lifecycle != calcit::ffi_abi::FfiAsyncLifecycle::Finished {
+      runtime.registry.finish(handle).map_err(|error| error.to_string())?;
+    }
+    match runtime.registry.release(handle).map_err(|error| error.to_string())? {
+      NativeAsyncResource::Task(_) if release_tracked_tasks => track::track_task_release(),
+      NativeAsyncResource::Task(_) => {}
+      NativeAsyncResource::Response(_) => return Err(format!("async FFI task {} released a response resource", handle.raw())),
+    }
+    if unfinished {
+      forced += 1;
+      eprintln!(
+        "[Warn] force-cleaned unfinished async FFI task: lib={} symbol={} task={} kind={:?} age_ms={:.3} purged={} responses={}",
+        task.lib_name,
+        task.method,
+        handle.raw(),
+        state.kind,
+        task.started_at.elapsed().as_secs_f64() * 1000.0,
+        purged,
+        discarded_responses
+      );
+    }
+  }
+  Ok(forced)
+}
+
+fn shutdown_native_async_runtime(runtime: &NativeAsyncRuntime, grace: Duration, release_tracked_tasks: bool) -> Result<usize, String> {
+  let requested = begin_native_async_shutdown(runtime)?;
+  let deadline = Instant::now() + grace;
+  while runtime.registry.pending_count().map_err(|error| error.to_string())? > 0 && Instant::now() < deadline {
+    drain_async_events_from(runtime, 256)?;
+    if runtime.registry.pending_count().map_err(|error| error.to_string())? == 0 {
+      break;
+    }
+    let remaining = deadline.saturating_duration_since(Instant::now()).min(Duration::from_millis(40));
+    if !remaining.is_zero() {
+      runtime.queue.wait_for_event(remaining).map_err(|error| error.to_string())?;
+    }
+  }
+  drain_async_events_from(runtime, 256)?;
+  runtime.queue.close().map_err(|error| error.to_string())?;
+  let forced = force_cleanup_native_async(runtime, release_tracked_tasks)?;
+  trace_ffi_event("async-shutdown-complete", format!("requested={requested} forced={forced}"));
+  Ok(forced)
+}
+
 pub fn exit_when_async_cleared() -> Result<(), String> {
   let runtime = native_async_runtime()?;
+  let mut shutdown_complete = false;
   loop {
+    if shutdown_requested() && !shutdown_complete {
+      if let Err(error) = run_pending_ctrl_c_callback() {
+        eprintln!("[Error] {error}");
+      }
+      shutdown_native_async_runtime(runtime, ASYNC_SHUTDOWN_GRACE, true)?;
+      shutdown_complete = true;
+    }
     drain_async_events(256)?;
     if track::count_pending_tasks() == 0 && runtime.queue.is_empty().map_err(|error| error.to_string())? {
       return Ok(());
+    }
+    if shutdown_complete {
+      thread::sleep(Duration::from_millis(10));
+      continue;
     }
     if runtime.queue.is_empty().map_err(|error| error.to_string())? {
       runtime
@@ -1428,6 +1640,7 @@ fn try_start_async_callback_v1(
     method: method.to_owned(),
     control: Arc::new(Mutex::new(None)),
     blocking: None,
+    started_at: Instant::now(),
   };
   let handle = runtime
     .registry
@@ -1627,6 +1840,7 @@ fn try_call_blocking_v1(
       buffers: Arc::new(Mutex::new(HashMap::new())),
       failures: Arc::new(Mutex::new(vec![])),
     }),
+    started_at: Instant::now(),
   };
   let handle = runtime
     .registry
@@ -1764,16 +1978,16 @@ pub fn blocking_dylib_edn_fn(xs: Vec<Calcit>, call_stack: &CallStackList) -> Res
 #[unsafe(no_mangle)]
 pub fn on_ctrl_c(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if xs.len() == 1 {
-    let cb = Arc::new(xs[0].to_owned());
-    let copied_stack = Arc::new(call_stack.to_owned());
-    ctrlc::set_handler(move || {
-      if let Calcit::Fn { info, .. } = cb.as_ref()
-        && let Err(e) = runner::run_fn(&[], info, &copied_stack)
-      {
-        eprintln!("error: {e}");
-      }
-    })
-    .map_err(|e| CalcitErr::use_str(CalcitErrKind::Unexpected, format!("failed to set Ctrl-C handler: {e}")))?;
+    if !matches!(&xs[0], Calcit::Fn { .. }) {
+      return CalcitErr::err_str(
+        CalcitErrKind::Type,
+        format!("on-control-c expected a callback function, got: {}", xs[0]),
+      );
+    }
+    *CTRL_C_CALLBACK
+      .lock()
+      .map_err(|_| CalcitErr::use_str(CalcitErrKind::Unexpected, "Ctrl-C callback lock is poisoned"))? =
+      Some((Arc::new(xs[0].to_owned()), Arc::new(call_stack.to_owned())));
     Ok(Calcit::Nil)
   } else {
     CalcitErr::err_str(CalcitErrKind::Arity, format!("on-control-c expected a callback function {xs:?}"))
@@ -1786,6 +2000,7 @@ mod async_callback_tests {
 
   type RecordedResponse = (u64, u64, u32, Vec<u8>);
   static RESPONSE_EVENTS: LazyLock<Mutex<Vec<RecordedResponse>>> = LazyLock::new(|| Mutex::new(vec![]));
+  static SHUTDOWN_CANCELS: AtomicUsize = AtomicUsize::new(0);
 
   #[test]
   fn missing_c_safe_symbols_report_migration_without_rust_symbol_probes() {
@@ -1827,6 +2042,34 @@ mod async_callback_tests {
     async_status::OK
   }
 
+  unsafe extern "C" fn record_shutdown_cancel(context: u64, _task_handle: u64, reason_ptr: *const u8, reason_len: usize) -> i32 {
+    if context != 707 || reason_ptr.is_null() {
+      return async_status::INVALID_PAYLOAD;
+    }
+    let reason = unsafe { std::slice::from_raw_parts(reason_ptr, reason_len) };
+    if reason != b"{} (:code :host-shutdown)" {
+      return async_status::INVALID_PAYLOAD;
+    }
+    SHUTDOWN_CANCELS.fetch_add(1, Ordering::Relaxed);
+    async_status::OK
+  }
+
+  unsafe extern "C" fn complete_shutdown_cancel(context: u64, task_handle: u64, _reason_ptr: *const u8, _reason_len: usize) -> i32 {
+    // SAFETY: this test passes a live host-thread runtime address as context
+    // and invokes cancellation synchronously before that runtime is dropped.
+    let runtime = unsafe { &*(context as *const NativeAsyncRuntime) };
+    match runtime.queue.enqueue(
+      &runtime.registry,
+      FfiAsyncHandle::from_raw(task_handle),
+      None,
+      FfiAsyncEventKind::Complete,
+      b"&unit".to_vec(),
+    ) {
+      Ok(_) => async_status::OK,
+      Err(error) => error.status_code(),
+    }
+  }
+
   fn test_task() -> NativeAsyncResource {
     NativeAsyncResource::Task(NativeAsyncTask {
       callback: Calcit::Nil,
@@ -1835,6 +2078,7 @@ mod async_callback_tests {
       method: "server".to_owned(),
       control: Arc::new(Mutex::new(None)),
       blocking: None,
+      started_at: Instant::now(),
     })
   }
 
@@ -1860,6 +2104,7 @@ mod async_callback_tests {
         method: "blocking".to_owned(),
         control: Arc::new(Mutex::new(None)),
         blocking: Some(blocking.clone()),
+        started_at: Instant::now(),
       }),
       blocking,
     )
@@ -2283,5 +2528,93 @@ mod async_callback_tests {
       },
       async_status::INVALID_HANDLE
     );
+  }
+
+  #[test]
+  fn runtime_shutdown_cancels_tasks_rejects_responses_and_force_cleans_after_grace() {
+    const RESPONSE_CONTEXT: u64 = 808;
+    SHUTDOWN_CANCELS.store(0, Ordering::Relaxed);
+    let runtime = test_runtime(4);
+    let task = test_task();
+    let NativeAsyncResource::Task(task_state) = &task else {
+      unreachable!("test task is a task resource");
+    };
+    *task_state.control.lock().expect("task control") = Some(NativeAsyncTaskControl {
+      context: 707,
+      cancel: record_shutdown_cancel,
+    });
+    let owner = runtime
+      .registry
+      .register_with_flags(
+        FfiAsyncHandleKind::Server,
+        ASYNC_TASK_FLAG_SERIAL_EVENTS | ASYNC_TASK_FLAG_REQUIRES_RESPONSE,
+        task,
+      )
+      .expect("register shutdown server");
+    let response = register_test_response(&runtime, owner, RESPONSE_CONTEXT, Instant::now() + Duration::from_secs(1));
+
+    assert_eq!(
+      shutdown_native_async_runtime(&runtime, Duration::ZERO, false).expect("shutdown runtime"),
+      1
+    );
+    assert_eq!(SHUTDOWN_CANCELS.load(Ordering::Relaxed), 1);
+    assert_eq!(
+      runtime.registry.state(owner),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle)
+    );
+    assert_eq!(
+      runtime.registry.state(response),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle)
+    );
+    assert_eq!(runtime.registry.pending_count(), Ok(0));
+    assert!(!runtime.queue.wait_for_event(Duration::ZERO).expect("closed queue"));
+    assert_eq!(
+      runtime.registry.register(FfiAsyncHandleKind::Stream, test_task()),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::HostClosing)
+    );
+    let responses: Vec<RecordedResponse> = RESPONSE_EVENTS
+      .lock()
+      .expect("response events")
+      .iter()
+      .filter(|(context, ..)| *context == RESPONSE_CONTEXT)
+      .cloned()
+      .collect();
+    assert_eq!(
+      responses,
+      vec![(
+        RESPONSE_CONTEXT,
+        response.raw(),
+        ASYNC_RESPONSE_REJECT,
+        b"{} (:code :host-shutdown)".to_vec()
+      )]
+    );
+  }
+
+  #[test]
+  fn runtime_shutdown_drains_cooperative_terminal_before_deadline() {
+    let runtime = test_runtime(4);
+    let task = test_task();
+    let NativeAsyncResource::Task(task_state) = &task else {
+      unreachable!("test task is a task resource");
+    };
+    *task_state.control.lock().expect("task control") = Some(NativeAsyncTaskControl {
+      context: (&runtime as *const NativeAsyncRuntime) as u64,
+      cancel: complete_shutdown_cancel,
+    });
+    let owner = runtime
+      .registry
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+      .expect("register cooperative stream");
+
+    assert_eq!(
+      shutdown_native_async_runtime(&runtime, Duration::from_millis(50), false).expect("shutdown runtime"),
+      0
+    );
+    assert_eq!(
+      runtime.registry.state(owner),
+      Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle)
+    );
+    assert_eq!(runtime.registry.pending_count(), Ok(0));
+    assert!(runtime.queue.is_empty().expect("empty shutdown queue"));
   }
 }

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -1827,8 +1827,7 @@ pub fn async_sleep(xs: Vec<Calcit>, call_stack: &CallStackList) -> Result<Calcit
 
   let _handle = thread::spawn(move || {
     let ten_secs = time::Duration::from_secs(sec.round() as u64);
-    // let _now = time::Instant::now();
-    thread::sleep(ten_secs);
+    runner::track::wait_for_shutdown(ten_secs);
 
     runner::track::track_task_release();
   });

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,7 +4,7 @@ pub mod macro_metrics;
 pub mod preprocess;
 pub mod track;
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::Arc;
 use std::vec;
 
@@ -18,6 +18,52 @@ use crate::data::cirru;
 use crate::program;
 use crate::util::string::has_ns_part;
 use cirru_edn::EdnTag;
+
+const SHUTDOWN_CHECK_INTERVAL: u16 = 256;
+
+thread_local! {
+  static SHUTDOWN_CHECK_COUNTDOWN: Cell<u16> = const { Cell::new(0) };
+  static SHUTDOWN_CHECK_SUSPENDED: Cell<u16> = const { Cell::new(0) };
+}
+
+struct ShutdownCheckGuard;
+
+impl Drop for ShutdownCheckGuard {
+  fn drop(&mut self) {
+    SHUTDOWN_CHECK_SUSPENDED.with(|depth| depth.set(depth.get().saturating_sub(1)));
+  }
+}
+
+fn with_shutdown_check_suspended<T>(f: impl FnOnce() -> T) -> T {
+  SHUTDOWN_CHECK_SUSPENDED.with(|depth| depth.set(depth.get().saturating_add(1)));
+  let _guard = ShutdownCheckGuard;
+  f()
+}
+
+fn check_shutdown(call_stack: &CallStackList) -> Result<(), CalcitErr> {
+  if SHUTDOWN_CHECK_SUSPENDED.with(Cell::get) > 0 {
+    return Ok(());
+  }
+  let should_check = SHUTDOWN_CHECK_COUNTDOWN.with(|countdown| {
+    let remaining = countdown.get();
+    if remaining == 0 {
+      countdown.set(SHUTDOWN_CHECK_INTERVAL);
+      true
+    } else {
+      countdown.set(remaining - 1);
+      false
+    }
+  });
+  if should_check && track::shutdown_requested() {
+    Err(CalcitErr::use_msg_stack(
+      CalcitErrKind::Unexpected,
+      "execution interrupted by host shutdown",
+      call_stack,
+    ))
+  } else {
+    Ok(())
+  }
+}
 
 fn build_runtime_cell_error(ns: &str, def: &str, call_stack: &CallStackList, cell: program::RuntimeCell) -> CalcitErr {
   match cell {
@@ -172,6 +218,7 @@ fn evaluate_number_binary_call(
 }
 
 pub fn evaluate_expr(expr: &Calcit, scope: &CalcitScope, file_ns: &str, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  check_shutdown(call_stack)?;
   // println!("eval code: {}", expr.lisp_str());
   use Calcit::*;
 
@@ -408,6 +455,7 @@ pub fn call_expr(
       let frame_checkpoint = body_scope.frame_checkpoint();
 
       Ok(loop {
+        check_shutdown(&next_stack)?;
         // need to handle recursion
         body_scope.restore_frame(frame_checkpoint);
         bind_marked_args(&mut body_scope, &info.args, &current_values, call_stack)?;
@@ -705,6 +753,7 @@ pub fn run_fn(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) ->
   if let Calcit::Recur(xs) = v {
     let mut current_values = xs.to_vec();
     loop {
+      check_shutdown(call_stack)?;
       body_scope.restore_frame(frame_checkpoint);
       match &*info.args {
         CalcitFnArgs::Args(args) => {
@@ -725,6 +774,12 @@ pub fn run_fn(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) ->
     }
   }
   Ok(v)
+}
+
+/// Runs an application shutdown callback after the host has recorded its
+/// shutdown request, without interrupting the callback itself.
+pub fn run_fn_during_shutdown(values: &[Calcit], info: &CalcitFn, call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
+  with_shutdown_check_suspended(|| run_fn(values, info, call_stack))
 }
 
 /// quick path for `run_fn` which takes ownership of values
@@ -749,6 +804,7 @@ pub fn run_fn_owned(values: Vec<Calcit>, info: &CalcitFn, call_stack: &CallStack
   if let Calcit::Recur(xs) = v {
     let mut current_values = xs.to_vec();
     loop {
+      check_shutdown(call_stack)?;
       body_scope.restore_frame(frame_checkpoint);
       match &*info.args {
         CalcitFnArgs::Args(args) => {

--- a/src/runner/track.rs
+++ b/src/runner/track.rs
@@ -11,6 +11,10 @@ pub fn reset_shutdown() {
 }
 
 pub fn request_shutdown() {
+  // Serialize the predicate change with condvar waiters. Without this lock a
+  // waiter can observe `false`, then miss the notification just before it
+  // enters `wait_timeout_while`.
+  let _guard = SHUTDOWN_WAKE.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
   SHUTDOWN_REQUESTED.store(true, Ordering::Release);
   SHUTDOWN_WAKE.1.notify_all();
 }

--- a/src/runner/track.rs
+++ b/src/runner/track.rs
@@ -1,8 +1,35 @@
-use std::sync::atomic;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{self, AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Condvar, LazyLock, Mutex};
 use std::{thread, time};
 
 static TASK_COUNT: AtomicUsize = AtomicUsize::new(0);
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+static SHUTDOWN_WAKE: LazyLock<(Mutex<()>, Condvar)> = LazyLock::new(|| (Mutex::new(()), Condvar::new()));
+
+pub fn reset_shutdown() {
+  SHUTDOWN_REQUESTED.store(false, Ordering::Release);
+}
+
+pub fn request_shutdown() {
+  SHUTDOWN_REQUESTED.store(true, Ordering::Release);
+  SHUTDOWN_WAKE.1.notify_all();
+}
+
+pub fn shutdown_requested() -> bool {
+  SHUTDOWN_REQUESTED.load(Ordering::Acquire)
+}
+
+pub fn wait_for_shutdown(timeout: time::Duration) -> bool {
+  if shutdown_requested() {
+    return true;
+  }
+  let guard = SHUTDOWN_WAKE.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+  let _guard = SHUTDOWN_WAKE
+    .1
+    .wait_timeout_while(guard, timeout, |_| !shutdown_requested())
+    .unwrap_or_else(|poisoned| poisoned.into_inner());
+  shutdown_requested()
+}
 
 pub fn exit_when_cleared() {
   let delay = time::Duration::from_millis(40);


### PR DESCRIPTION
## 中文

推进 #501 的 Calcit core shutdown 基线。

### 改动

- Calcit CLI 统一安装 Ctrl-C handler；信号线程只设置原子 shutdown 状态，不直接进入 runtime。
- `on-control-c` 回调改为在 host thread 串行执行，然后调用 async registry `begin_shutdown`。
- shutdown 保留进入 `begin_shutdown` 前的 lifecycle snapshot，已在 `Closing` 的 task 不会重复调用 cancel hook。
- 拒绝未完成 response capability，并向所有可取消 native task 发送 `:host-shutdown`。
- 继续 drain terminal event 2 秒；deadline 后先关闭 queue，再强制 purge/release，避免迟到 producer 与已回收 handle 竞态。
- 强制清理诊断包含 module/method/task/kind/age/purged events/discarded responses，`--trace-ffi` 增加 shutdown begin/cancel/complete 轨迹。
- Watch loop 和兼容性 `async-sleep` 共享可唤醒 shutdown signal，Ctrl-C 后不再挂住进程。

### 验证

- 882 项 Rust 测试全绿，包含 cooperative terminal、deadline force-cleanup 与已 Closing task 取消幂等性。
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-all`：Calcit core 221/221，native/JS/IR/WASM 全部通过。
- `yarn check-agent-interface`：17/17。
- Markdown Cirru 示例：5/5。
- 真实 Ctrl-C smoke：once `async-sleep`、watch mode 均及时退出，`on-control-c` 确认在 host thread 执行。
- 真实 calcit-fswatch C-safe Stream：cancel 后约 41ms 收到 `Complete`，正常 release，`forced=0`。
- release warm startup 约 30ms，arm64 二进制 9,351,424 bytes。

## English

Advances the Calcit core shutdown baseline tracked by #501.

### Changes

- Install one CLI-owned Ctrl-C handler; the signal thread only records atomic shutdown state and never enters the runtime.
- Run `on-control-c` serially on the host thread, then invoke async-registry `begin_shutdown`.
- Preserve the pre-shutdown lifecycle snapshot so an already-`Closing` task does not receive its cancel hook twice.
- Reject open response capabilities and send `:host-shutdown` to every cancellable native task.
- Continue draining terminal events for two seconds; at the deadline, close the queue before forced purge/release to prevent a late producer from racing a reclaimed handle.
- Diagnose forced cleanup with module/method/task/kind/age/purged-event/discarded-response metadata and add shutdown begin/cancel/complete events to `--trace-ffi`.
- Give watch loops and compatibility `async-sleep` a shared wakeable shutdown signal so Ctrl-C cannot leave the process hanging.

### Verification

- 882 Rust tests pass, including cooperative terminal, deadline force-cleanup, and already-closing cancellation idempotency.
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-all`: Calcit core 221/221 plus native/JS/IR/WASM.
- `yarn check-agent-interface`: 17/17.
- Markdown Cirru examples: 5/5.
- Real Ctrl-C smoke: once-mode `async-sleep` and watch mode exit promptly; `on-control-c` runs on the host thread.
- Real calcit-fswatch C-safe Stream: `Complete` arrives about 41ms after cancel, releases normally, and reports `forced=0`.
- Release warm startup is about 30ms; the arm64 binary is 9,351,424 bytes.
