### PR TITLE
feat(ffi): 异步 task 队列指标 / async task queue metrics

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -109,7 +109,11 @@ completion acknowledgement from entering the host loop. Full event or byte
 budgets return `QUEUE_FULL` without blocking the producer.
 The CLI defaults are 1024 total events and 64 MiB of queued payloads, with 16
 events and 64 KiB reserved for terminal traffic. `--trace-ffi` records both
-current queue counters on accepted and rejected enqueue attempts.
+current queue counters on accepted and rejected enqueue attempts. The host
+also maintains bounded per-task queue accounting: queued event count,
+queued bytes, oldest queued age, accepted/coalesced/queue-full totals, dequeued
+events, and purged events. It stores only fixed metadata alongside each queued
+event and never duplicates or logs the business payload.
 Only `Emit` events on a task registered with `COALESCE_ALLOWED` may replace an
 older queued emit for that same task; the replacement carries a newer sequence
 and the `COALESCED` event flag. Complete/fail and server request events are
@@ -120,6 +124,16 @@ failures. A callback failure records task/sequence metadata and its message,
 finishes the failed task, and purges its remaining queued events. Lifecycle
 rejections are reported separately. Queue entries also retain producer thread
 and queue-delay metadata for `--trace-ffi` without logging complete payloads.
+During shutdown, the CLI aggregates these counters by module and method, emits
+a compact `async-shutdown-summary`, includes the task-local snapshot on cancel
+and release traces, and removes the metric state when the task is released.
+
+CLI 默认总容量为 1024 个 event 与 64 MiB queued payload，并为 terminal
+traffic 预留 16 个 event 与 64 KiB。Host 同时维护有界的 per-task 索引，记录
+queued event 数、queued bytes、oldest queued age，以及 accepted、coalesced、
+queue-full、dequeued、purged 累计值。该索引只复制固定长度元数据，不复制或
+打印业务 payload。关闭时 CLI 按 module/method 聚合为紧凑的
+`async-shutdown-summary`，并在 task release 后删除对应指标状态。
 
 Streams and servers therefore do not require a Rust closure to cross the ABI.
 They keep only the opaque task handle and the C host function table. HTTP

--- a/editing-history/202608290144-async-task-queue-metrics.md
+++ b/editing-history/202608290144-async-task-queue-metrics.md
@@ -1,0 +1,19 @@
+# 异步 task 队列指标 / Async task queue metrics
+
+## 中文
+
+- 在 async queue 同一把 mutex 下维护有界的 per-task 固定元数据索引，覆盖 queued events、queued bytes、oldest age、accepted、coalesced、queue-full、dequeued 与 purged。
+- Enqueue、coalescing、drain 与 purge 的新增指标工作只更新目标 task，不扫描全 registry，也不复制业务 payload；coalescing 延续队列原有的有界定位逻辑。
+- `--trace-ffi` 在 enqueue/reject/cancel/release 展示 task-local 指标；shutdown 额外按 module/method 汇总 active/closing tasks 与 backlog。
+- Task release 时删除指标状态；forced cleanup 诊断保留最终 backlog 与累计值。
+- 单元测试覆盖 coalescing、queue-full、drain、purge、并发 producer 与 shutdown 后指标归零。
+- Fibo release 五次中位数由 251.208ms 变为 250.554ms（-0.26%，无可见回退）；真实 fswatch 0.0.9 trace 验证 `Emit → cancel → Complete → release` 且 `forced=0`。
+
+## English
+
+- Maintain a bounded fixed-metadata per-task index under the async queue mutex for queued events, queued bytes, oldest age, accepted, coalesced, queue-full, dequeued, and purged counts.
+- The added metric work for enqueue, coalescing, drain, and purge updates only the affected task without scanning the full registry or copying business payloads; coalescing retains the queue's existing bounded lookup.
+- Extend `--trace-ffi` enqueue/reject/cancel/release records with task-local metrics and aggregate active/closing tasks plus backlog by module/method during shutdown.
+- Remove metric state on task release while retaining the final backlog and cumulative counters in forced-cleanup diagnostics.
+- Cover coalescing, queue-full, drain, purge, concurrent producers, and post-shutdown metric removal in tests.
+- The five-run release fibo median changes from 251.208ms to 250.554ms (-0.26%, no visible regression); a real fswatch 0.0.9 trace verifies `Emit → cancel → Complete → release` with `forced=0`.

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -21,7 +21,7 @@ use calcit::{
     FfiAsyncHandle, FfiAsyncHandleKind, FfiAsyncHandleRegistry, FfiAsyncHostV1, FfiAsyncResponseResolve, FfiAsyncTaskCancel,
     FfiAsyncTaskDescriptor, FfiBlockingHostV1, FfiBuffer, async_status,
   },
-  ffi_async::{FfiAsyncDrainReport, FfiAsyncEventQueue, copy_async_payload},
+  ffi_async::{FfiAsyncDrainReport, FfiAsyncEventQueue, FfiAsyncTaskQueueMetrics, copy_async_payload},
   runner::track,
 };
 
@@ -165,6 +165,62 @@ struct NativeAsyncRuntime {
   registry: FfiAsyncHandleRegistry<NativeAsyncResource>,
   queue: FfiAsyncEventQueue,
   responses: Mutex<NativeAsyncResponseIndex>,
+}
+
+#[derive(Debug, Default)]
+struct NativeAsyncModuleQueueMetrics {
+  active_tasks: usize,
+  closing_tasks: usize,
+  queued_events: usize,
+  queued_bytes: usize,
+  oldest_age: Option<Duration>,
+  accepted_total: u64,
+  coalesced_total: u64,
+  queue_full_total: u64,
+  dequeued_total: u64,
+  purged_total: u64,
+}
+
+impl NativeAsyncModuleQueueMetrics {
+  fn add_task(&mut self, lifecycle: calcit::ffi_abi::FfiAsyncLifecycle, metrics: FfiAsyncTaskQueueMetrics) {
+    match lifecycle {
+      calcit::ffi_abi::FfiAsyncLifecycle::Active => self.active_tasks += 1,
+      calcit::ffi_abi::FfiAsyncLifecycle::Closing => self.closing_tasks += 1,
+      calcit::ffi_abi::FfiAsyncLifecycle::Finished => {}
+    }
+    self.queued_events = self.queued_events.saturating_add(metrics.queued_events);
+    self.queued_bytes = self.queued_bytes.saturating_add(metrics.queued_bytes);
+    self.oldest_age = match (self.oldest_age, metrics.oldest_age) {
+      (Some(current), Some(candidate)) => Some(current.max(candidate)),
+      (None, Some(candidate)) => Some(candidate),
+      (current, None) => current,
+    };
+    self.accepted_total = self.accepted_total.saturating_add(metrics.accepted_total);
+    self.coalesced_total = self.coalesced_total.saturating_add(metrics.coalesced_total);
+    self.queue_full_total = self.queue_full_total.saturating_add(metrics.queue_full_total);
+    self.dequeued_total = self.dequeued_total.saturating_add(metrics.dequeued_total);
+    self.purged_total = self.purged_total.saturating_add(metrics.purged_total);
+  }
+}
+
+fn format_oldest_age(age: Option<Duration>) -> String {
+  age
+    .map(|value| format!("{:.3}", value.as_secs_f64() * 1000.0))
+    .unwrap_or_else(|| "none".to_owned())
+}
+
+fn format_task_queue_metrics(metrics: FfiAsyncTaskQueueMetrics) -> String {
+  format!(
+    "queued_events={} queued_bytes={} oldest_ms={} accepted={} coalesced={} queue_full={} dequeued={} purged={}",
+    metrics.queued_events,
+    metrics.queued_bytes,
+    format_oldest_age(metrics.oldest_age),
+    metrics.accepted_total,
+    metrics.coalesced_total,
+    metrics.queue_full_total,
+    metrics.dequeued_total,
+    metrics.purged_total
+  )
 }
 
 static NATIVE_ASYNC_RUNTIME: OnceLock<NativeAsyncRuntime> = OnceLock::new();
@@ -581,13 +637,15 @@ unsafe fn enqueue_native_async_event(
   {
     Ok(outcome) => {
       let (queued_events, queued_bytes) = runtime.queue.usage().unwrap_or((0, 0));
+      let task_metrics = runtime.queue.task_metrics(task_handle).ok().flatten().unwrap_or_default();
       trace_ffi_event(
         "async-enqueue",
         format!(
-          "task={} kind={kind:?} sequence={} disposition={:?} queued_events={queued_events} queued_bytes={queued_bytes} producer={:?}",
+          "task={} kind={kind:?} sequence={} disposition={:?} global_queued_events={queued_events} global_queued_bytes={queued_bytes} {} producer={:?}",
           task_handle.raw(),
           outcome.sequence,
           outcome.disposition,
+          format_task_queue_metrics(task_metrics),
           thread::current().id()
         ),
       );
@@ -595,12 +653,14 @@ unsafe fn enqueue_native_async_event(
     }
     Err(error) => {
       let (queued_events, queued_bytes) = runtime.queue.usage().unwrap_or((0, 0));
+      let task_metrics = runtime.queue.task_metrics(task_handle).ok().flatten().unwrap_or_default();
       trace_ffi_event(
         "async-enqueue-rejected",
         format!(
-          "task={} kind={kind:?} status={} queued_events={queued_events} queued_bytes={queued_bytes} error={error}",
+          "task={} kind={kind:?} status={} global_queued_events={queued_events} global_queued_bytes={queued_bytes} {} error={error}",
           task_handle.raw(),
-          error.status_code()
+          error.status_code(),
+          format_task_queue_metrics(task_metrics)
         ),
       );
       error.status_code()
@@ -983,9 +1043,23 @@ fn ffi_task_cancel(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calci
     let _ = runtime.queue.discard_handle_events(capability.handle);
     let _ = reject_owned_responses(runtime, capability.handle, b"{} (:code :cancel-failed)");
     let _ = runtime.registry.finish(capability.handle);
+    let metrics = runtime
+      .queue
+      .take_task_metrics(capability.handle)
+      .ok()
+      .flatten()
+      .unwrap_or_default();
     if matches!(runtime.registry.release(capability.handle), Ok(NativeAsyncResource::Task(_))) {
       track::track_task_release();
     }
+    trace_ffi_event(
+      "async-task-cancel-failed",
+      format!(
+        "task={} status={status} {}",
+        capability.handle.raw(),
+        format_task_queue_metrics(metrics)
+      ),
+    );
     CalcitErr::err_str(
       CalcitErrKind::Unexpected,
       format!(
@@ -1139,8 +1213,8 @@ fn drain_async_events_from(runtime: &NativeAsyncRuntime, limit: usize) -> Result
   for descriptor in report.finished.clone() {
     let handle = FfiAsyncHandle::from_raw(descriptor.task_handle);
     reject_owned_responses(runtime, handle, b"{} (:code :owner-finished)")?;
-    match runtime.registry.release(handle) {
-      Ok(NativeAsyncResource::Task(_)) => {}
+    let task = match runtime.registry.release(handle) {
+      Ok(NativeAsyncResource::Task(task)) => task,
       Ok(NativeAsyncResource::Response(_)) => {
         return Err(format!("async FFI task {} released a response resource", handle.raw()));
       }
@@ -1150,14 +1224,22 @@ fn drain_async_events_from(runtime: &NativeAsyncRuntime, limit: usize) -> Result
           .push(calcit::ffi_async::FfiAsyncLifecycleFailure { descriptor, error });
         continue;
       }
-    }
+    };
+    let metrics = runtime
+      .queue
+      .take_task_metrics(handle)
+      .map_err(|error| error.to_string())?
+      .unwrap_or_default();
     track::track_task_release();
     trace_ffi_event(
       "async-task-release",
       format!(
-        "task={} sequence={} pending={}",
+        "lib={} symbol={} task={} sequence={} {} pending={}",
+        task.lib_name,
+        task.method,
         handle.raw(),
         descriptor.sequence,
+        format_task_queue_metrics(metrics),
         track::count_pending_tasks()
       ),
     );
@@ -1222,6 +1304,39 @@ fn reject_response_during_shutdown(
 
 fn begin_native_async_shutdown(runtime: &NativeAsyncRuntime) -> Result<usize, String> {
   let snapshot = runtime.registry.snapshot().map_err(|error| error.to_string())?;
+  let queue_metrics: HashMap<FfiAsyncHandle, FfiAsyncTaskQueueMetrics> = runtime
+    .queue
+    .task_metrics_snapshot()
+    .map_err(|error| error.to_string())?
+    .into_iter()
+    .collect();
+  let mut module_metrics: BTreeMap<(String, String), NativeAsyncModuleQueueMetrics> = BTreeMap::new();
+  for (handle, state, resource) in &snapshot {
+    if let NativeAsyncResource::Task(task) = resource {
+      module_metrics
+        .entry((task.lib_name.clone(), task.method.clone()))
+        .or_default()
+        .add_task(state.lifecycle, queue_metrics.get(handle).copied().unwrap_or_default());
+    }
+  }
+  for ((lib_name, method), metrics) in module_metrics {
+    trace_ffi_event(
+      "async-shutdown-summary",
+      format!(
+        "lib={lib_name} symbol={method} active={} closing={} queued_events={} queued_bytes={} oldest_ms={} accepted={} coalesced={} queue_full={} dequeued={} purged={}",
+        metrics.active_tasks,
+        metrics.closing_tasks,
+        metrics.queued_events,
+        metrics.queued_bytes,
+        format_oldest_age(metrics.oldest_age),
+        metrics.accepted_total,
+        metrics.coalesced_total,
+        metrics.queue_full_total,
+        metrics.dequeued_total,
+        metrics.purged_total
+      ),
+    );
+  }
   let pending = runtime.registry.begin_shutdown().map_err(|error| error.to_string())?;
 
   for (handle, state, resource) in &snapshot {
@@ -1250,11 +1365,12 @@ fn begin_native_async_shutdown(runtime: &NativeAsyncRuntime) -> Result<usize, St
       trace_ffi_event(
         "async-shutdown-wait",
         format!(
-          "lib={} symbol={} task={} kind={:?} cancellable=false",
+          "lib={} symbol={} task={} kind={:?} cancellable=false {}",
           task.lib_name,
           task.method,
           handle.raw(),
-          state.kind
+          state.kind,
+          format_task_queue_metrics(queue_metrics.get(&handle).copied().unwrap_or_default())
         ),
       );
       continue;
@@ -1263,11 +1379,12 @@ fn begin_native_async_shutdown(runtime: &NativeAsyncRuntime) -> Result<usize, St
     trace_ffi_event(
       "async-shutdown-cancel",
       format!(
-        "lib={} symbol={} task={} kind={:?} status={status}",
+        "lib={} symbol={} task={} kind={:?} status={status} {}",
         task.lib_name,
         task.method,
         handle.raw(),
-        state.kind
+        state.kind,
+        format_task_queue_metrics(queue_metrics.get(&handle).copied().unwrap_or_default())
       ),
     );
     if status != async_status::OK && status != async_status::HANDLE_FINISHED {
@@ -1314,17 +1431,23 @@ fn force_cleanup_native_async(runtime: &NativeAsyncRuntime, release_tracked_task
       NativeAsyncResource::Task(_) => {}
       NativeAsyncResource::Response(_) => return Err(format!("async FFI task {} released a response resource", handle.raw())),
     }
+    let metrics = runtime
+      .queue
+      .take_task_metrics(handle)
+      .map_err(|error| error.to_string())?
+      .unwrap_or_default();
     if unfinished {
       forced += 1;
       eprintln!(
-        "[Warn] force-cleaned unfinished async FFI task: lib={} symbol={} task={} kind={:?} age_ms={:.3} purged={} responses={}",
+        "[Warn] force-cleaned unfinished async FFI task: lib={} symbol={} task={} kind={:?} age_ms={:.3} purged={} responses={} {}",
         task.lib_name,
         task.method,
         handle.raw(),
         state.kind,
         task.started_at.elapsed().as_secs_f64() * 1000.0,
         purged,
-        discarded_responses
+        discarded_responses,
+        format_task_queue_metrics(metrics)
       );
     }
   }
@@ -1693,14 +1816,16 @@ fn try_start_async_callback_v1(
   let purged = runtime.queue.discard_handle_events(handle).unwrap_or(0);
   let discarded_responses = discard_owned_responses(runtime, handle).unwrap_or(0);
   let _ = runtime.registry.finish(handle);
+  let metrics = runtime.queue.take_task_metrics(handle).ok().flatten().unwrap_or_default();
   let _ = runtime.registry.release(handle);
   track::track_task_release();
   trace_ffi_event(
     "async-start-failed",
     format!(
-      "lib={lib_name} symbol={} task={} status={status} purged={purged} discarded_responses={discarded_responses} pending={}",
+      "lib={lib_name} symbol={} task={} status={status} purged={purged} discarded_responses={discarded_responses} {} pending={}",
       calcit::ffi_abi::async_method_symbol(method),
       handle.raw(),
+      format_task_queue_metrics(metrics),
       track::count_pending_tasks()
     ),
   );
@@ -2568,6 +2693,7 @@ mod async_callback_tests {
       Err(calcit::ffi_abi::FfiAsyncHandleError::StaleHandle)
     );
     assert_eq!(runtime.registry.pending_count(), Ok(0));
+    assert_eq!(runtime.queue.task_metrics(owner), Ok(None));
     assert!(!runtime.queue.wait_for_event(Duration::ZERO).expect("closed queue"));
     assert_eq!(
       runtime.registry.register(FfiAsyncHandleKind::Stream, test_task()),
@@ -2617,6 +2743,7 @@ mod async_callback_tests {
     );
     assert_eq!(runtime.registry.pending_count(), Ok(0));
     assert!(runtime.queue.is_empty().expect("empty shutdown queue"));
+    assert_eq!(runtime.queue.task_metrics(owner), Ok(None));
   }
 
   #[test]

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -4,7 +4,7 @@
 //! creates the queue may drain it and enter the Calcit runtime. No Rust
 //! callback, executor, or allocator crosses the transport boundary.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::sync::{Condvar, Mutex};
 use std::thread::{self, ThreadId};
@@ -48,6 +48,20 @@ pub enum FfiAsyncEnqueueDisposition {
 pub struct FfiAsyncEnqueueOutcome {
   pub sequence: u64,
   pub disposition: FfiAsyncEnqueueDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// A point-in-time snapshot of one async task's queue usage and cumulative
+/// enqueue outcomes. Payload bytes are counted but never copied into metrics.
+pub struct FfiAsyncTaskQueueMetrics {
+  pub queued_events: usize,
+  pub queued_bytes: usize,
+  pub oldest_age: Option<Duration>,
+  pub accepted_total: u64,
+  pub coalesced_total: u64,
+  pub queue_full_total: u64,
+  pub dequeued_total: u64,
+  pub purged_total: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -206,7 +220,98 @@ pub unsafe fn copy_async_payload(payload_ptr: *const u8, payload_len: usize) -> 
 struct FfiAsyncQueueState {
   events: VecDeque<FfiAsyncQueuedEvent>,
   queued_bytes: usize,
+  tasks: HashMap<FfiAsyncHandle, FfiAsyncTaskQueueState>,
   closed: bool,
+}
+
+#[derive(Debug, Clone)]
+struct FfiAsyncQueuedSample {
+  sequence: u64,
+  bytes: usize,
+  enqueued_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct FfiAsyncTaskQueueState {
+  queued: VecDeque<FfiAsyncQueuedSample>,
+  queued_bytes: usize,
+  accepted_total: u64,
+  coalesced_total: u64,
+  queue_full_total: u64,
+  dequeued_total: u64,
+  purged_total: u64,
+}
+
+impl FfiAsyncTaskQueueState {
+  fn snapshot(&self, now: Instant) -> FfiAsyncTaskQueueMetrics {
+    FfiAsyncTaskQueueMetrics {
+      queued_events: self.queued.len(),
+      queued_bytes: self.queued_bytes,
+      oldest_age: self.queued.front().map(|sample| now.saturating_duration_since(sample.enqueued_at)),
+      accepted_total: self.accepted_total,
+      coalesced_total: self.coalesced_total,
+      queue_full_total: self.queue_full_total,
+      dequeued_total: self.dequeued_total,
+      purged_total: self.purged_total,
+    }
+  }
+
+  fn record_enqueued(&mut self, sequence: u64, bytes: usize, enqueued_at: Instant) {
+    self.accepted_total = self.accepted_total.saturating_add(1);
+    self.queued_bytes = self.queued_bytes.saturating_add(bytes);
+    self.queued.push_back(FfiAsyncQueuedSample {
+      sequence,
+      bytes,
+      enqueued_at,
+    });
+  }
+
+  fn record_queue_full(&mut self) {
+    self.queue_full_total = self.queue_full_total.saturating_add(1);
+  }
+
+  fn record_coalesced(&mut self, replaced_sequence: u64, sequence: u64, bytes: usize, enqueued_at: Instant) {
+    self.accepted_total = self.accepted_total.saturating_add(1);
+    self.coalesced_total = self.coalesced_total.saturating_add(1);
+    let replaced = if let Some(sample) = self.queued.iter_mut().find(|sample| sample.sequence == replaced_sequence) {
+      self.queued_bytes = self.queued_bytes.saturating_sub(sample.bytes).saturating_add(bytes);
+      *sample = FfiAsyncQueuedSample {
+        sequence,
+        bytes,
+        enqueued_at,
+      };
+      true
+    } else {
+      false
+    };
+    debug_assert!(replaced, "coalesced async event must have a matching task metric sample");
+  }
+
+  fn record_dequeued(&mut self, sequence: u64) {
+    self.dequeued_total = self.dequeued_total.saturating_add(1);
+    if self.queued.front().is_some_and(|sample| sample.sequence == sequence)
+      && let Some(sample) = self.queued.pop_front()
+    {
+      self.queued_bytes = self.queued_bytes.saturating_sub(sample.bytes);
+      return;
+    }
+    let removed = if let Some(index) = self.queued.iter().position(|sample| sample.sequence == sequence)
+      && let Some(sample) = self.queued.remove(index)
+    {
+      self.queued_bytes = self.queued_bytes.saturating_sub(sample.bytes);
+      true
+    } else {
+      false
+    };
+    debug_assert!(removed, "dequeued async event must have a matching task metric sample");
+  }
+
+  fn record_purged(&mut self, count: usize) {
+    debug_assert_eq!(self.queued.len(), count, "purged async event count must match task metric samples");
+    self.purged_total = self.purged_total.saturating_add(count as u64);
+    self.queued.clear();
+    self.queued_bytes = 0;
+  }
 }
 
 /// A bounded multi-producer, single-host-thread event queue.
@@ -238,6 +343,7 @@ impl FfiAsyncEventQueue {
       state: Mutex::new(FfiAsyncQueueState {
         events: VecDeque::with_capacity(limits.event_capacity),
         queued_bytes: 0,
+        tasks: HashMap::new(),
         closed: false,
       }),
       ready: Condvar::new(),
@@ -259,6 +365,35 @@ impl FfiAsyncEventQueue {
   pub fn usage(&self) -> Result<(usize, usize), FfiAsyncQueueError> {
     let queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
     Ok((queue.events.len(), queue.queued_bytes))
+  }
+
+  /// Snapshot metrics for one task without changing their lifecycle.
+  pub fn task_metrics(&self, handle: FfiAsyncHandle) -> Result<Option<FfiAsyncTaskQueueMetrics>, FfiAsyncQueueError> {
+    let queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    let now = Instant::now();
+    Ok(queue.tasks.get(&handle).map(|state| state.snapshot(now)))
+  }
+
+  /// Snapshot every tracked task. This is intended for diagnostics such as
+  /// shutdown summaries rather than event-queue hot paths.
+  pub fn task_metrics_snapshot(&self) -> Result<Vec<(FfiAsyncHandle, FfiAsyncTaskQueueMetrics)>, FfiAsyncQueueError> {
+    let queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    let now = Instant::now();
+    Ok(queue.tasks.iter().map(|(handle, state)| (*handle, state.snapshot(now))).collect())
+  }
+
+  /// Remove and return a task's final metrics after its queued events have
+  /// drained or been purged.
+  pub fn take_task_metrics(&self, handle: FfiAsyncHandle) -> Result<Option<FfiAsyncTaskQueueMetrics>, FfiAsyncQueueError> {
+    let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    let now = Instant::now();
+    Ok(queue.tasks.remove(&handle).map(|state| {
+      debug_assert!(
+        state.queued.is_empty(),
+        "task metrics must only be removed after queued events are cleared"
+      );
+      state.snapshot(now)
+    }))
   }
 
   pub fn len(&self) -> Result<usize, FfiAsyncQueueError> {
@@ -344,9 +479,11 @@ impl FfiAsyncEventQueue {
 
     if coalesce_index.is_none() {
       if exceeds_event_limit {
+        queue.tasks.entry(task_handle).or_default().record_queue_full();
         return Err(FfiAsyncQueueError::QueueFull { capacity: event_limit });
       }
       if exceeds_byte_limit {
+        queue.tasks.entry(task_handle).or_default().record_queue_full();
         return Err(FfiAsyncQueueError::QueueBytesFull {
           capacity: byte_limit,
           queued: queue.queued_bytes,
@@ -357,6 +494,7 @@ impl FfiAsyncEventQueue {
       let replaced_bytes = queue.events[index].payload.len();
       let coalesced_bytes = queue.queued_bytes.saturating_sub(replaced_bytes).checked_add(payload.len());
       if coalesced_bytes.is_none_or(|total| total > byte_limit) {
+        queue.tasks.entry(task_handle).or_default().record_queue_full();
         return Err(FfiAsyncQueueError::QueueBytesFull {
           capacity: byte_limit,
           queued: queue.queued_bytes.saturating_sub(replaced_bytes),
@@ -374,13 +512,25 @@ impl FfiAsyncEventQueue {
       producer_thread: thread::current().id(),
       enqueued_at: Instant::now(),
     };
+    let enqueued_at = event.enqueued_at;
 
     let disposition = if let Some(index) = coalesce_index {
+      let replaced_sequence = queue.events[index].descriptor.sequence;
       queue.queued_bytes = queue.queued_bytes.saturating_sub(queue.events[index].payload.len()) + event.payload.len();
+      queue
+        .tasks
+        .entry(task_handle)
+        .or_default()
+        .record_coalesced(replaced_sequence, sequence, event.payload.len(), enqueued_at);
       queue.events[index] = event;
       FfiAsyncEnqueueDisposition::Coalesced
     } else {
       queue.queued_bytes += event.payload.len();
+      queue
+        .tasks
+        .entry(task_handle)
+        .or_default()
+        .record_enqueued(sequence, event.payload.len(), enqueued_at);
       queue.events.push_back(event);
       FfiAsyncEnqueueDisposition::Enqueued
     };
@@ -433,6 +583,9 @@ impl FfiAsyncEventQueue {
           break;
         };
         queue.queued_bytes = queue.queued_bytes.saturating_sub(event.payload.len());
+        if let Some(state) = queue.tasks.get_mut(&event.task_handle()) {
+          state.record_dequeued(event.descriptor.sequence);
+        }
         batch.push(event);
       }
     }
@@ -544,7 +697,11 @@ impl FfiAsyncEventQueue {
       }
     });
     queue.queued_bytes = queue.queued_bytes.saturating_sub(purged_bytes);
-    Ok(before - queue.events.len())
+    let purged = before - queue.events.len();
+    if let Some(state) = queue.tasks.get_mut(&handle) {
+      state.record_purged(purged);
+    }
+    Ok(purged)
   }
 
   fn ensure_host_thread(&self) -> Result<(), FfiAsyncQueueError> {
@@ -721,6 +878,65 @@ mod tests {
       .expect("drain coalesced event");
     assert_eq!(payload, vec![2; 7]);
     assert_eq!(queue.queued_bytes(), Ok(0));
+  }
+
+  #[test]
+  fn task_metrics_track_coalescing_rejection_drain_and_purge_without_global_scans() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let coalescing = registry
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_COALESCE_ALLOWED, ())
+      .expect("register coalescing stream");
+    let ordinary = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register ordinary stream");
+    let queue = FfiAsyncEventQueue::new(2).expect("create queue");
+
+    queue
+      .enqueue(&registry, coalescing, None, FfiAsyncEventKind::Emit, b"old".to_vec())
+      .expect("enqueue old coalescing event");
+    queue
+      .enqueue(&registry, ordinary, None, FfiAsyncEventKind::Emit, b"x".to_vec())
+      .expect("fill queue with ordinary event");
+    queue
+      .enqueue(&registry, coalescing, None, FfiAsyncEventKind::Emit, b"newer".to_vec())
+      .expect("coalesce latest task event");
+    assert_eq!(
+      queue.enqueue(&registry, ordinary, None, FfiAsyncEventKind::Emit, b"blocked".to_vec()),
+      Err(FfiAsyncQueueError::QueueFull { capacity: 2 })
+    );
+
+    let coalescing_metrics = queue
+      .task_metrics(coalescing)
+      .expect("read coalescing metrics")
+      .expect("metrics exist");
+    assert_eq!(coalescing_metrics.queued_events, 1);
+    assert_eq!(coalescing_metrics.queued_bytes, 5);
+    assert!(coalescing_metrics.oldest_age.is_some());
+    assert_eq!(coalescing_metrics.accepted_total, 2);
+    assert_eq!(coalescing_metrics.coalesced_total, 1);
+    assert_eq!(coalescing_metrics.queue_full_total, 0);
+
+    let ordinary_metrics = queue.task_metrics(ordinary).expect("read ordinary metrics").expect("metrics exist");
+    assert_eq!(ordinary_metrics.queued_events, 1);
+    assert_eq!(ordinary_metrics.queued_bytes, 1);
+    assert_eq!(ordinary_metrics.accepted_total, 1);
+    assert_eq!(ordinary_metrics.queue_full_total, 1);
+
+    queue.drain(&registry, 1, |_| Ok(())).expect("drain coalesced event");
+    let coalescing_metrics = queue
+      .task_metrics(coalescing)
+      .expect("read drained metrics")
+      .expect("metrics exist");
+    assert_eq!(coalescing_metrics.queued_events, 0);
+    assert_eq!(coalescing_metrics.queued_bytes, 0);
+    assert_eq!(coalescing_metrics.oldest_age, None);
+    assert_eq!(coalescing_metrics.dequeued_total, 1);
+
+    assert_eq!(queue.discard_handle_events(ordinary), Ok(1));
+    let ordinary_metrics = queue.task_metrics(ordinary).expect("read purged metrics").expect("metrics exist");
+    assert_eq!(ordinary_metrics.queued_events, 0);
+    assert_eq!(ordinary_metrics.purged_total, 1);
+    assert_eq!(queue.task_metrics_snapshot().expect("snapshot metrics").len(), 2);
+    assert!(queue.take_task_metrics(coalescing).expect("take metrics").is_some());
+    assert_eq!(queue.task_metrics(coalescing), Ok(None));
   }
 
   #[test]
@@ -994,6 +1210,11 @@ mod tests {
       })
       .expect("host drain");
     assert_eq!(sequences, vec![1, 2, 3, 4]);
+    let metrics = queue.task_metrics(handle).expect("read concurrent metrics").expect("metrics exist");
+    assert_eq!(metrics.accepted_total, 4);
+    assert_eq!(metrics.dequeued_total, 4);
+    assert_eq!(metrics.queued_events, 0);
+    assert_eq!(metrics.queued_bytes, 0);
   }
 
   #[test]


### PR DESCRIPTION
## 中文

关联 #505，完成异步队列可观测性的第一阶段：

- 在 async queue 内维护有界的 per-task 固定元数据索引，记录当前 queued events/bytes、oldest age，以及 accepted、coalesced、queue-full、dequeued、purged 累计值
- `--trace-ffi` 的 enqueue、reject、cancel、release 记录携带 task-local 指标；shutdown 按 module/method 输出聚合摘要
- task 正常完成、启动/取消失败或强制清理后移除指标状态，避免生命周期泄漏
- 不复制或打印业务 payload；新增指标热路径不扫描完整 registry
- 补充协议文档、队列/并发/shutdown 测试与性能记录

验证：

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`（883 项 Rust 测试）
- `yarn compile`
- `yarn check-all`（Calcit core 221/221、JS、IR、WASM）
- `calcit docs check-md --entry calcit/test.cirru docs/installation/ffi-async-protocol.md`
- fswatch 0.0.9 真实 cancel/complete/release trace，`forced=0`
- release fibo 五次中位数 251.208ms → 250.554ms（-0.26%，无可见性能回退）

## English

This implements the first observability stage of #505:

- maintain a bounded fixed-metadata per-task index inside the async queue for current queued events/bytes, oldest age, and cumulative accepted, coalesced, queue-full, dequeued, and purged counts
- include task-local metrics in `--trace-ffi` enqueue, rejection, cancellation, and release records, plus aggregate shutdown summaries by module/method
- remove metric state after normal completion, startup/cancel failure, or forced cleanup to avoid lifecycle leaks
- never copy or log business payloads, and avoid full-registry scans on the added metric hot paths
- document the protocol and add queue, concurrency, shutdown, and performance coverage

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q` (883 Rust tests)
- `yarn compile`
- `yarn check-all` (Calcit core 221/221, JS, IR, and WASM)
- `calcit docs check-md --entry calcit/test.cirru docs/installation/ffi-async-protocol.md`
- real fswatch 0.0.9 cancel/complete/release trace with `forced=0`
- five-run release fibo median 251.208ms → 250.554ms (-0.26%, no visible regression)
