### PR TITLE
feat(ffi): 类型化方法式 capability API / typed method-oriented capability API

### DIFF
--- a/docs/architectures/typed-ffi-capabilities.cirru
+++ b/docs/architectures/typed-ffi-capabilities.cirru
@@ -1,0 +1,153 @@
+{}
+  :schema-version 1
+  :feature 'typed-ffi-capabilities
+  :doc "|Wrap native async AnyRef capabilities in nominal Calcit values and expose lifecycle operations as methods."
+  :roots $ #{} 'calcit.core/ffi:task 'calcit.core/ffi:response
+  :definitions $ {}
+    'calcit.core/FfiTask $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Nominal wrapper for a cancellable native async task capability."
+      :schema $ :: 'StructDef
+      :code $ quote
+        def FfiTask $ impl-traits
+          defstruct FfiTask $ :raw 'Dynamic
+          , FfiTaskOpsImpl
+    'calcit.core/FfiTaskOps $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Internal method contract for native async task capabilities."
+      :schema $ :: 'Trait
+      :code $ quote
+        deftrait FfiTaskOps
+          .cancel $ :: 'Fn
+            {}
+              :args $ [] 'FfiTask
+              :return 'Unit
+          .cancel-with $ :: 'Fn
+            {}
+              :generics $ [] 'T
+              :args $ [] 'FfiTask 'T
+              :return 'Unit
+    'calcit.core/FfiTaskOpsImpl $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Internal implementation of native async task methods."
+      :schema $ :: 'Impl
+      :code $ quote
+        defimpl FfiTaskOpsImpl FfiTaskOps (.cancel ffi-task:cancel) (.cancel-with ffi-task:cancel-with)
+    'calcit.core/ffi:task $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Wrap a raw native async task capability at a module adapter boundary."
+      :params $ [] 'raw
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'Dynamic
+          :return 'FfiTask
+      :code $ quote
+        defn ffi:task (raw)
+          %{} FfiTask $ :raw raw
+    'calcit.core/ffi-task:cancel $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Cancel a wrapped native async task with the default reason."
+      :params $ [] 'self
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'FfiTask
+          :return 'Unit
+      :code $ quote
+        defn ffi-task:cancel (self)
+          &ffi-task-cancel $ :raw self
+    'calcit.core/ffi-task:cancel-with $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Cancel a wrapped native async task with an explicit EDN-compatible reason."
+      :params $ [] 'self 'reason
+      :schema $ :: 'Fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'FfiTask 'T
+          :return 'Unit
+      :code $ quote
+        defn ffi-task:cancel-with (self reason)
+          &ffi-task-cancel (:raw self) reason
+    'calcit.core/FfiResponse $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Nominal wrapper for an exactly-once native async response capability."
+      :schema $ :: 'StructDef
+      :code $ quote
+        def FfiResponse $ impl-traits
+          defstruct FfiResponse $ :raw 'Dynamic
+          , FfiResponseOpsImpl
+    'calcit.core/FfiResponseOps $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Internal method contract for native async response capabilities."
+      :schema $ :: 'Trait
+      :code $ quote
+        deftrait FfiResponseOps
+          .resolve $ :: 'Fn
+            {}
+              :generics $ [] 'T
+              :args $ [] 'FfiResponse 'T
+              :return 'Unit
+          .reject $ :: 'Fn
+            {}
+              :generics $ [] 'T
+              :args $ [] 'FfiResponse 'T
+              :return 'Unit
+    'calcit.core/FfiResponseOpsImpl $ {}
+      :mode :ensure
+      :kind :data
+      :doc "|Internal implementation of native async response methods."
+      :schema $ :: 'Impl
+      :code $ quote
+        defimpl FfiResponseOpsImpl FfiResponseOps (.resolve ffi-response:resolve) (.reject ffi-response:reject)
+    'calcit.core/ffi:response $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Wrap a raw native async response capability at a module adapter boundary."
+      :params $ [] 'raw
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'Dynamic
+          :return 'FfiResponse
+      :code $ quote
+        defn ffi:response (raw)
+          %{} FfiResponse $ :raw raw
+    'calcit.core/ffi-response:resolve $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Resolve a wrapped native async response exactly once."
+      :params $ [] 'self 'value
+      :schema $ :: 'Fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'FfiResponse 'T
+          :return 'Unit
+      :code $ quote
+        defn ffi-response:resolve (self value)
+          &ffi-response-resolve (:raw self) value
+    'calcit.core/ffi-response:reject $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|Reject a wrapped native async response exactly once."
+      :params $ [] 'self 'value
+      :schema $ :: 'Fn
+        {}
+          :generics $ [] 'T
+          :args $ [] 'FfiResponse 'T
+          :return 'Unit
+      :code $ quote
+        defn ffi-response:reject (self value)
+          &ffi-response-reject (:raw self) value
+  :edges $ #{}
+    :: :type 'calcit.core/ffi:task 'calcit.core/FfiTask
+    :: :type 'calcit.core/ffi-task:cancel 'calcit.core/FfiTask
+    :: :type 'calcit.core/ffi-task:cancel-with 'calcit.core/FfiTask
+    :: :type 'calcit.core/ffi:response 'calcit.core/FfiResponse
+    :: :type 'calcit.core/ffi-response:resolve 'calcit.core/FfiResponse
+    :: :type 'calcit.core/ffi-response:reject 'calcit.core/FfiResponse

--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -242,6 +242,18 @@ keeps returning explicit `&unit` otherwise); `&ffi-task-cancel` invokes this
 hook on the host thread. An accepted cancel must eventually enqueue exactly
 one `Complete` or `Fail`; repeated cancel while Closing is idempotent.
 
+At the Calcit adapter boundary, wrap that opaque value with `ffi:task` and
+expose the nominal `FfiTask` to application code. Lifecycle operations are
+method-oriented: `.cancel` supplies the standard cancelled reason and
+`.cancel-with reason` supplies an explicit EDN-compatible reason. The raw
+procedure remains available for compatibility, but should not leak through a
+module's public API.
+
+在 Calcit 模块适配边界，应使用 `ffi:task` 包装这个不透明值，并向业务代码暴露
+nominal `FfiTask`。生命周期操作以方法为主：`.cancel` 使用标准取消原因，
+`.cancel-with reason` 传入显式、可编码为 EDN 的原因。底层 procedure 继续兼容，
+但不应泄漏到模块公开 API。
+
 A Server that declares `REQUIRES_RESPONSE` opens one response capability for
 each request before enqueueing it:
 
@@ -266,8 +278,10 @@ leaves the capability active until the module retries or the host rejects it
 at timeout.
 
 Calcit appends an opaque AnyRef response capability to the event's decoded EDN
-arguments. The callback resolves it with `&ffi-response-resolve` or rejects it
-with `&ffi-response-reject`. The host atomically claims the capability, encodes
+arguments. An adapter wraps it with `ffi:response`; application callbacks then
+call `.resolve value` or `.reject value` on the nominal `FfiResponse`. The raw
+`&ffi-response-resolve` and `&ffi-response-reject` procedures remain boundary
+primitives. The host atomically claims the capability, encodes
 that value, calls the module's resolve function on the host thread, and
 invalidates the capability after the module returns, including when the module
 reports an error. Reuse or concurrent resolution therefore cannot invoke the
@@ -280,6 +294,15 @@ task cleanup proportional to the responses being processed rather than all
 live FFI handles.
 Startup failure discards host handles without calling back into module context
 whose ownership never transferred.
+
+`FfiTask` and `FfiResponse` deliberately remain separate nominal wrappers.
+Payload and reason parameters are method-level generics rather than `Dynamic`;
+only the opaque raw field is dynamic at the host boundary. The host still
+validates capability kind, owner, generation, lifecycle, and EDN encodability.
+
+`FfiTask` 与 `FfiResponse` 是两个独立的 nominal wrapper。payload 与 reason
+使用方法级泛型而不是 `Dynamic`；只有宿主边界上的不透明 raw 字段保持动态。
+宿主仍会校验 capability kind、owner、generation、lifecycle 以及 EDN 可编码性。
 
 AnyRef is deliberately a native non-serializable capability rather than a
 Calcit number: the full generation-bearing `u64` cannot safely round-trip

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -137,9 +137,19 @@ explicitly:
 
 ```cirru.no-check
 let
-    task $ &call-dylib-edn-fn lib-path |serve on-request
-  &ffi-task-cancel task :shutdown
+    task $ ffi:task $ &call-dylib-edn-fn lib-path |serve on-request
+  task.cancel-with :shutdown
 ```
+
+`ffi:task` is the adapter-boundary constructor for the nominal `FfiTask`
+wrapper. Application code should use `.cancel` or `.cancel-with`; the raw
+`&ffi-task-cancel` procedure is retained for module adapters and compatibility.
+The wrapper intentionally keeps only its opaque host value as `Dynamic`, while
+the cancellation reason remains a method-level generic type.
+
+`ffi:task` 是模块适配边界使用的 nominal `FfiTask` 构造函数。业务代码应调用
+`.cancel` 或 `.cancel-with`；底层 `&ffi-task-cancel` 只保留给模块适配层及兼容代码。
+wrapper 内只有不透明宿主值是 `Dynamic`，取消原因仍保留调用处的泛型静态类型。
 
 Ctrl-C performs the same cancellation at host scope. A function registered
 with `on-control-c` runs on the Calcit host thread before the runtime starts
@@ -153,10 +163,24 @@ response capability after the decoded request arguments. It is exactly-once:
 
 ```cirru.no-check
 defn on-request (method path response!)
-  if (= path |/health)
-    &ffi-response-resolve response! $ {} (:status 200) (:body |ok)
-    &ffi-response-reject response! $ {} (:status 404) (:body |missing)
+  let
+      response $ ffi:response response!
+    if (= path |/health)
+      response.resolve $ {} (:status 200) (:body |ok)
+      response.reject $ {} (:status 404) (:body |missing)
 ```
+
+The nominal `FfiResponse` receiver prevents task and response methods from
+being interchanged. Its `.resolve` and `.reject` payloads are generic and keep
+their caller-side type; Cirru EDN encoding remains the native boundary check.
+Constructing a wrapper around the wrong raw value is rejected deterministically
+by the host when the method is invoked. These lifecycle methods are native-only;
+generated JavaScript and WASM do not provide native dylib capabilities.
+
+nominal `FfiResponse` 接收者区分 task 与 response 方法，避免两种 capability
+被混用。`.resolve`、`.reject` 的 payload 使用泛型，保留调用侧类型，Cirru EDN
+编码仍是 native 边界检查。若适配层包装了错误的原始值，宿主会在方法调用时确定性拒绝。
+这些生命周期方法仅支持 native；生成的 JavaScript 与 WASM 不提供 native dylib capability。
 
 The host validates task-bound context, ownership, and deadline, atomically
 claims the capability, invokes the dylib resolver on the Calcit host thread,

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -404,6 +404,8 @@ lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
 - `FsPath .read-text`, `.read-dir`, `.walk-dir`, `.write-text` - recoverable file effects returning `Result` (native/JS; unavailable in WASM)
 - `try-read-file`, `try-read-dir`, `try-write-file` - String-path compatibility functions returning `Result`
 - `read-file`, `read-dir`, `write-file` - raising compatibility primitives (native/JS; unavailable in WASM)
+- `ffi:task`, `FfiTask .cancel` / `.cancel-with` - nominal native async task lifecycle API
+- `ffi:response`, `FfiResponse .resolve` / `.reject` - nominal exactly-once native response API
 - `get-env` - environment variables
 - `raise` - throw error
 - `quit!` - exit program

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -85,6 +85,12 @@ String 本身不携带文件系统语义；`try-read-file`、`try-read-dir`、
 `try-write-file` 与底层 raising procedures 仅保留为兼容入口。
 这些文件效果支持 native 与生成的 JavaScript；WASM 尚未提供宿主文件效果。
 
+Native 异步 FFI capability 也遵循相同边界原则。模块适配层用 `ffi:task`、
+`ffi:response` 把不透明 AnyRef 提升为 nominal `FfiTask`、`FfiResponse`，业务层调用
+`.cancel`、`.cancel-with`、`.resolve`、`.reject`。raw 字段保持 `Dynamic`，但
+reason/payload 使用方法级泛型，因此不会为了宿主编码而抹掉调用侧类型。底层
+`&ffi-task-cancel`、`&ffi-response-*` 只作为适配与兼容入口。
+
 `option:let` 的 body 必须继续返回 `Option`。普通组合函数仍以接收者方法
 作为公开形式，`option:*` / `result:*` 直接函数调用主要保留给 core lowering。
 

--- a/editing-history/202608290227-typed-ffi-capabilities.md
+++ b/editing-history/202608290227-typed-ffi-capabilities.md
@@ -1,0 +1,17 @@
+# 类型化 FFI capability / Typed FFI capabilities
+
+## 中文
+
+- 在 core 中增加 nominal `FfiTask` 与 `FfiResponse`，把 native async AnyRef 限制在各自 wrapper 的 `Dynamic` raw 字段中。
+- 公开生命周期操作采用方法形式：task 使用 `.cancel` / `.cancel-with`，response 使用 `.resolve` / `.reject`；底层 `&ffi-*` procedure 仅由内部适配函数调用。
+- reason 与 payload 使用方法级泛型 `T`。Calcit trait 禁止方法签名包含 `Dynamic`，因此用户值不会在进入 FFI 编码前丢失静态类型。
+- 两种 capability 使用不同 nominal receiver；错误 receiver 会被 method dispatch 确定性拒绝，错误 raw capability 仍由 native 宿主校验 kind、owner、generation 与 lifecycle。
+- 增加可重放的 architecture scaffold、core 构造测试，以及中英双语协议和使用文档。
+
+## English
+
+- Added nominal core `FfiTask` and `FfiResponse` wrappers, confining native async AnyRef values to each wrapper's `Dynamic` raw field.
+- Exposed lifecycle operations as methods: `.cancel` / `.cancel-with` for tasks and `.resolve` / `.reject` for responses. Internal adapters are the only callers of the raw `&ffi-*` procedures.
+- Kept reason and payload values typed with method-level generic `T`. Calcit traits reject `Dynamic` method signatures, so caller-side types survive until FFI encoding.
+- Kept task and response capabilities as distinct nominal receivers. Method dispatch rejects a wrong receiver deterministically, while the native host still validates raw capability kind, owner, generation, and lifecycle.
+- Added a replayable architecture scaffold, core constructor tests, and bilingual protocol and usage documentation.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2822,6 +2822,65 @@
           :examples $ []
           :schema $ :: 'Trait
           :tags $ #{} :trait
+        |FfiResponse $ %{} 'CodeEntry (:doc "|Nominal wrapper for an exactly-once native async response capability.")
+          :code $ quote
+            def FfiResponse $ impl-traits
+              defstruct FfiResponse $ :raw 'Dynamic
+              , FfiResponseOpsImpl
+          :examples $ []
+          :schema $ :: 'StructDef
+          :tags $ #{} :core :data :ffi
+        |FfiResponseOps $ %{} 'CodeEntry (:doc "|Internal method contract for native async response capabilities.")
+          :code $ quote
+            deftrait FfiResponseOps
+              .resolve $ :: 'Fn
+                {}
+                  :generics $ [] 'T
+                  :args $ [] 'FfiResponse 'T
+                  :return 'Unit
+              .reject $ :: 'Fn
+                {}
+                  :generics $ [] 'T
+                  :args $ [] 'FfiResponse 'T
+                  :return 'Unit
+          :examples $ []
+          :schema $ :: 'Trait
+          :tags $ #{} :internal :trait
+        |FfiResponseOpsImpl $ %{} 'CodeEntry (:doc "|Internal implementation of native async response methods.")
+          :code $ quote
+            defimpl FfiResponseOpsImpl FfiResponseOps (.resolve ffi-response:resolve) (.reject ffi-response:reject)
+          :examples $ []
+          :schema $ :: 'Impl
+          :tags $ #{} :internal :trait-impl
+        |FfiTask $ %{} 'CodeEntry (:doc "|Nominal wrapper for a cancellable native async task capability.")
+          :code $ quote
+            def FfiTask $ impl-traits
+              defstruct FfiTask $ :raw 'Dynamic
+              , FfiTaskOpsImpl
+          :examples $ []
+          :schema $ :: 'StructDef
+          :tags $ #{} :core :data :ffi
+        |FfiTaskOps $ %{} 'CodeEntry (:doc "|Internal method contract for native async task capabilities.")
+          :code $ quote
+            deftrait FfiTaskOps
+              .cancel $ :: 'Fn
+                {}
+                  :args $ [] 'FfiTask
+                  :return 'Unit
+              .cancel-with $ :: 'Fn
+                {}
+                  :generics $ [] 'T
+                  :args $ [] 'FfiTask 'T
+                  :return 'Unit
+          :examples $ []
+          :schema $ :: 'Trait
+          :tags $ #{} :internal :trait
+        |FfiTaskOpsImpl $ %{} 'CodeEntry (:doc "|Internal implementation of native async task methods.")
+          :code $ quote
+            defimpl FfiTaskOpsImpl FfiTaskOps (.cancel ffi-task:cancel) (.cancel-with ffi-task:cancel-with)
+          :examples $ []
+          :schema $ :: 'Impl
+          :tags $ #{} :internal :trait-impl
         |FsPath $ %{} 'CodeEntry (:doc "|Nominal UTF-8 host filesystem path. Construct with fs:path; file effects are exposed on FsPath rather than String.")
           :code $ quote
             def FsPath $ impl-traits
@@ -4685,6 +4744,93 @@
                 assert= (#{} 3)
                   exclude (#{} 1 2 3) 1 2
               :tags $ #{} :core :unit
+        |ffi-response:reject $ %{} 'CodeEntry (:doc "|Reject a wrapped native async response exactly once.")
+          :code $ quote
+            defn ffi-response:reject (self value)
+              &ffi-response-reject (:raw self) value
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] 'FfiResponse 'T
+              :generics $ [] 'T
+          :tags $ #{} :ffi :internal
+        |ffi-response:resolve $ %{} 'CodeEntry (:doc "|Resolve a wrapped native async response exactly once.")
+          :code $ quote
+            defn ffi-response:resolve (self value)
+              &ffi-response-resolve (:raw self) value
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] 'FfiResponse 'T
+              :generics $ [] 'T
+          :tags $ #{} :ffi :internal
+        |ffi-task:cancel $ %{} 'CodeEntry (:doc "|Cancel a wrapped native async task with the default reason.")
+          :code $ quote
+            defn ffi-task:cancel (self)
+              &ffi-task-cancel $ :raw self
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] 'FfiTask
+          :tags $ #{} :ffi :internal
+        |ffi-task:cancel-with $ %{} 'CodeEntry (:doc "|Cancel a wrapped native async task with an explicit EDN-compatible reason.")
+          :code $ quote
+            defn ffi-task:cancel-with (self reason)
+              &ffi-task-cancel (:raw self) reason
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] 'FfiTask 'T
+              :generics $ [] 'T
+          :tags $ #{} :ffi :internal
+        |ffi:response $ %{} 'CodeEntry (:doc "|Wrap a raw native async response capability at a module adapter boundary.")
+          :code $ quote
+            defn ffi:response (raw)
+              %{} FfiResponse $ :raw raw
+          :examples $ []
+            quote $ ffi:response raw-response-capability
+            quote $ let
+                response $ ffi:response raw-response-capability
+              response.resolve payload
+            quote $ let
+                response $ ffi:response raw-response-capability
+              response.reject error
+          :schema $ :: 'Fn
+            {} (:return 'FfiResponse)
+              :args $ [] 'Dynamic
+          :tags $ #{} :core :ffi
+          :tests $ []
+            %{} 'TestEntry (:name |wraps-response-capability)
+              :code $ quote
+                let
+                    response $ ffi:response nil
+                  assert-type response 'FfiResponse
+                  , true
+              :tags $ #{} :unit
+        |ffi:task $ %{} 'CodeEntry (:doc "|Wrap a raw native async task capability at a module adapter boundary.")
+          :code $ quote
+            defn ffi:task (raw)
+              %{} FfiTask $ :raw raw
+          :examples $ []
+            quote $ ffi:task raw-task-capability
+            quote $ let
+                task $ ffi:task raw-task-capability
+              , task.cancel
+            quote $ let
+                task $ ffi:task raw-task-capability
+              task.cancel-with :shutdown
+          :schema $ :: 'Fn
+            {} (:return 'FfiTask)
+              :args $ [] 'Dynamic
+          :tags $ #{} :core :ffi
+          :tests $ []
+            %{} 'TestEntry (:name |wraps-task-capability)
+              :code $ quote
+                let
+                    task $ ffi:task nil
+                  assert-type task 'FfiTask
+                  , true
+              :tags $ #{} :unit
         |filter $ %{} 'CodeEntry (:doc "|Builds a new collection containing only the elements where the predicate returns truthy, preserving the original collection type when possible.")
           :code $ quote
             defn filter (xs f)


### PR DESCRIPTION
## 中文

完成 #508 的第一阶段：在 Calcit core 中为 native async FFI capability 提供类型化、方法式 API。

- 增加 nominal `FfiTask` 与 `FfiResponse` wrapper，只在不透明 raw 字段保留 `Dynamic`
- task 暴露 `.cancel` / `.cancel-with`，response 暴露 `.resolve` / `.reject`
- reason 与 payload 使用方法级泛型 `T`，不把业务值降级为 `Dynamic`
- 底层 `&ffi-*` procedure 收敛到内部 adapter，实现层继续执行 kind、owner、generation、lifecycle 与 EDN 编码校验
- 增加可重放 architecture scaffold、223 项 core 测试中的构造类型测试，以及中英双语协议／使用说明

本 PR 不修改 parser、C ABI 或 executor，也不立即迁移下游模块；后续将在发布 core 后逐个迁移 calcit-http、calcit-wss、calcit-fetch 与 calcit.std。

## English

Implements the first stage of #508: typed, method-oriented native async FFI capabilities in Calcit core.

- Adds nominal `FfiTask` and `FfiResponse` wrappers, with `Dynamic` confined to the opaque raw field
- Exposes `.cancel` / `.cancel-with` for tasks and `.resolve` / `.reject` for responses
- Uses method-level generic `T` for reasons and payloads instead of erasing application values to `Dynamic`
- Keeps raw `&ffi-*` procedures behind internal adapters while preserving native kind, owner, generation, lifecycle, and EDN encoding validation
- Adds a replayable architecture scaffold, constructor typing coverage in the 223 core tests, and bilingual protocol/usage documentation

This PR does not change parser syntax, the C ABI, or the executor, and it does not migrate downstream modules yet. After the core release, follow-up changes will migrate calcit-http, calcit-wss, calcit-fetch, and calcit.std.

## 验证 / Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q` (883 tests)
- `yarn check-all`
- Calcit core `223/223`
- Agent interface `17/17`
- Native, generated JavaScript, IR, and WASM regression suites
- Modified Markdown snippets checked with `calcit docs check-md`
- Architecture scaffold reconciles with zero operations

Progresses #508
