### PR TITLE
fix(ffi): purge queued emits on task cancellation / 取消任务时清理旧 Emit

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -242,6 +242,18 @@ keeps returning explicit `&unit` otherwise); `&ffi-task-cancel` invokes this
 hook on the host thread. An accepted cancel must eventually enqueue exactly
 one `Complete` or `Fail`; repeated cancel while Closing is idempotent.
 
+Cancellation first moves the task to Closing, which rejects every new Emit,
+then purges Emit events that were accepted but not dispatched before invoking
+the module cancel hook. If several events were already detached into one host
+drain batch, later Emits in that batch are discarded as cancellation cleanup
+rather than reported as lifecycle failures. Reserved `Complete`/`Fail` traffic
+remains accepted so the module can acknowledge cleanup exactly once.
+
+取消操作会先把 task 切换为 Closing，阻止所有新的 Emit，再清理已经接受但尚未
+dispatch 的 Emit，然后调用模块 cancel hook。若多个事件已经被 host 一次取入同一
+drain batch，批次中位于取消回调之后的 Emit 会作为取消清理静默丢弃，而不会误报为
+lifecycle failure。预留的 `Complete`/`Fail` 仍可入队，供模块 exactly-once 确认清理完成。
+
 At the Calcit adapter boundary, wrap that opaque value with `ffi:task` and
 expose the nominal `FfiTask` to application code. Lifecycle operations are
 method-oriented: `.cancel` supplies the standard cancelled reason and

--- a/editing-history/202608291125-purge-events-on-async-cancel.md
+++ b/editing-history/202608291125-purge-events-on-async-cancel.md
@@ -1,0 +1,18 @@
+# Async cancellation must purge accepted Emit events
+
+When a Calcit callback cancels its own native async task, later Emit events may
+already have been detached from the shared queue into the same host drain
+batch. Moving the registry handle to Closing blocks new producer events, but a
+queue-only purge cannot see that detached batch.
+
+The cancellation path now purges events still held by the queue immediately
+after `begin_close`. Drain also treats an Emit observed after the task entered
+Closing as cancellation cleanup: it is discarded without a lifecycle error.
+This is safe because the registry cannot reserve an Emit sequence after
+Closing. Reserved Complete/Fail events remain deliverable for exactly-once
+termination.
+
+当 Calcit callback 在同一轮 drain 中取消 native async task 时，后续 Emit 可能
+已经随 batch 从共享队列取出，普通 queue purge 无法再看到它们。取消流程现在会在
+`begin_close` 后立即清理队列；drain 遇到 Closing task 的 Emit 时将其视为取消清理，
+静默 discard，而 terminal 事件仍利用预留容量完成 exactly-once 收尾。

--- a/editing-history/202608291143-preserve-terminal-on-cancel-purge.md
+++ b/editing-history/202608291143-preserve-terminal-on-cancel-purge.md
@@ -1,0 +1,17 @@
+# Preserve queued terminal events during cancellation purge
+
+Review identified that a task may already have queued Complete/Fail behind an
+earlier Emit when the Emit callback requests cancellation. Purging every event
+would remove that terminal while the registry still remembers its terminal
+claim, leaving the task stuck in Closing.
+
+Cancellation now performs a selective Emit-only purge. Queue metadata removes
+the same event sequences and bytes while preserving any queued terminal and
+its exactly-once claim. Tests cover an Emit and Complete already queued before
+cancel, verify only the Emit is purged, and drain the preserved terminal to a
+finished task.
+
+review 指出取消发生时 Complete/Fail 可能已经排在较早 Emit 后面。全量 purge 会
+删除 terminal，却保留 registry 的 terminal claim，导致 task 永久停在 Closing。
+现在取消只按 sequence 清理 Emit，并同步更新 bytes 与 purged metrics；测试覆盖
+取消前 Emit 与 Complete 已同时入队，确认 terminal 被保留并正常完成。

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1204,7 +1204,7 @@ fn discard_owned_responses(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle) 
 
 fn begin_async_task_cancel(runtime: &NativeAsyncRuntime, handle: FfiAsyncHandle) -> Result<usize, String> {
   runtime.registry.begin_close(handle).map_err(|error| error.to_string())?;
-  runtime.queue.discard_handle_events(handle).map_err(|error| error.to_string())
+  runtime.queue.discard_handle_emit_events(handle).map_err(|error| error.to_string())
 }
 
 fn ffi_task_cancel(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
@@ -2485,23 +2485,6 @@ mod async_callback_tests {
     );
     assert_eq!(runtime.queue.len(), Ok(1));
 
-    assert_eq!(begin_async_task_cancel(&runtime, handle), Ok(1));
-    assert_eq!(runtime.queue.len(), Ok(0));
-    assert_eq!(
-      unsafe {
-        enqueue_native_async_event(
-          &runtime,
-          handle.raw(),
-          handle.raw(),
-          FfiAsyncEventKind::Emit as u32,
-          FfiAsyncHandle::INVALID.raw(),
-          emit.as_ptr(),
-          emit.len(),
-        )
-      },
-      async_status::HANDLE_CLOSING
-    );
-
     let terminal = b"&unit";
     assert_eq!(
       unsafe {
@@ -2517,6 +2500,24 @@ mod async_callback_tests {
       },
       async_status::OK
     );
+
+    assert_eq!(begin_async_task_cancel(&runtime, handle), Ok(1));
+    assert_eq!(runtime.queue.len(), Ok(1));
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          handle.raw(),
+          handle.raw(),
+          FfiAsyncEventKind::Emit as u32,
+          FfiAsyncHandle::INVALID.raw(),
+          emit.as_ptr(),
+          emit.len(),
+        )
+      },
+      async_status::HANDLE_CLOSING
+    );
+
     let report = runtime
       .queue
       .drain(&runtime.registry, 4, |event| dispatch_native_async_event(&runtime, event))

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -1202,6 +1202,11 @@ fn discard_owned_responses(runtime: &NativeAsyncRuntime, owner: FfiAsyncHandle) 
   Ok(discarded)
 }
 
+fn begin_async_task_cancel(runtime: &NativeAsyncRuntime, handle: FfiAsyncHandle) -> Result<usize, String> {
+  runtime.registry.begin_close(handle).map_err(|error| error.to_string())?;
+  runtime.queue.discard_handle_events(handle).map_err(|error| error.to_string())
+}
+
 fn ffi_task_cancel(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calcit, CalcitErr> {
   if xs.is_empty() || xs.len() > 2 {
     return CalcitErr::err_str(
@@ -1236,16 +1241,17 @@ fn ffi_task_cancel(xs: Vec<Calcit>, _call_stack: &CallStackList) -> Result<Calci
     .map_err(|_| CalcitErr::use_str(CalcitErrKind::Unexpected, "async FFI task control lock is poisoned"))?
     .control
     .ok_or_else(|| CalcitErr::use_str(CalcitErrKind::Unexpected, "async FFI task does not provide cancellation"))?;
-  runtime
-    .registry
-    .begin_close(capability.handle)
-    .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error.to_string()))?;
+  let purged =
+    begin_async_task_cancel(runtime, capability.handle).map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
   update_task_outcomes(&task, |outcomes| {
     outcomes.cancel_requested_total = outcomes.cancel_requested_total.saturating_add(1);
   })
   .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, error))?;
   let status = unsafe { (control.cancel)(control.context, capability.handle.raw(), reason.as_ptr(), reason.len()) };
-  trace_ffi_event("async-task-cancel", format!("task={} status={status}", capability.handle.raw()));
+  trace_ffi_event(
+    "async-task-cancel",
+    format!("task={} status={status} purged={purged}", capability.handle.raw()),
+  );
   if status == async_status::OK {
     update_task_outcomes(&task, |outcomes| {
       outcomes.cancel_succeeded_total = outcomes.cancel_succeeded_total.saturating_add(1);
@@ -2453,6 +2459,71 @@ mod async_callback_tests {
       responses: Mutex::new(NativeAsyncResponseIndex::default()),
       completed_metrics: Mutex::new(BTreeMap::new()),
     }
+  }
+
+  #[test]
+  fn task_cancel_purges_queued_emits_but_still_accepts_terminal() {
+    let runtime = test_runtime(4);
+    let handle = runtime
+      .registry
+      .register_with_flags(FfiAsyncHandleKind::Stream, ASYNC_TASK_FLAG_SERIAL_EVENTS, test_task())
+      .expect("register cancellable task");
+    let emit = b"([] |queued-before-cancel)";
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          handle.raw(),
+          handle.raw(),
+          FfiAsyncEventKind::Emit as u32,
+          FfiAsyncHandle::INVALID.raw(),
+          emit.as_ptr(),
+          emit.len(),
+        )
+      },
+      async_status::OK
+    );
+    assert_eq!(runtime.queue.len(), Ok(1));
+
+    assert_eq!(begin_async_task_cancel(&runtime, handle), Ok(1));
+    assert_eq!(runtime.queue.len(), Ok(0));
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          handle.raw(),
+          handle.raw(),
+          FfiAsyncEventKind::Emit as u32,
+          FfiAsyncHandle::INVALID.raw(),
+          emit.as_ptr(),
+          emit.len(),
+        )
+      },
+      async_status::HANDLE_CLOSING
+    );
+
+    let terminal = b"&unit";
+    assert_eq!(
+      unsafe {
+        enqueue_native_async_event(
+          &runtime,
+          handle.raw(),
+          handle.raw(),
+          FfiAsyncEventKind::Complete as u32,
+          FfiAsyncHandle::INVALID.raw(),
+          terminal.as_ptr(),
+          terminal.len(),
+        )
+      },
+      async_status::OK
+    );
+    let report = runtime
+      .queue
+      .drain(&runtime.registry, 4, |event| dispatch_native_async_event(&runtime, event))
+      .expect("drain terminal after cancel");
+    assert_eq!(report.delivered, 1);
+    assert!(report.lifecycle_failures.is_empty());
+    assert_eq!(report.finished.len(), 1);
   }
 
   fn blocking_test_task_with_callback(callback: Calcit) -> (NativeAsyncResource, NativeBlockingTask) {

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -313,6 +313,23 @@ impl FfiAsyncTaskQueueState {
     self.queued_bytes = 0;
   }
 
+  fn record_selected_purge(&mut self, sequences: &HashSet<u64>) {
+    let before = self.queued.len();
+    let mut purged_bytes = 0;
+    self.queued.retain(|sample| {
+      if sequences.contains(&sample.sequence) {
+        purged_bytes += sample.bytes;
+        false
+      } else {
+        true
+      }
+    });
+    let purged = before - self.queued.len();
+    debug_assert_eq!(purged, sequences.len(), "selective purge must match task metric samples");
+    self.queued_bytes = self.queued_bytes.saturating_sub(purged_bytes);
+    self.purged_total = self.purged_total.saturating_add(purged as u64);
+  }
+
   fn record_discarded_after_dequeue(&mut self) {
     self.purged_total = self.purged_total.saturating_add(1);
   }
@@ -419,6 +436,31 @@ impl FfiAsyncEventQueue {
   /// reclaimed before normal dispatch.
   pub fn discard_handle_events(&self, handle: FfiAsyncHandle) -> Result<usize, FfiAsyncQueueError> {
     self.purge_handle(handle)
+  }
+
+  /// Remove only ordinary Emit events for a closing task while preserving any
+  /// terminal acknowledgement that the producer already queued.
+  pub fn discard_handle_emit_events(&self, handle: FfiAsyncHandle) -> Result<usize, FfiAsyncQueueError> {
+    let mut queue = self.state.lock().map_err(|_| FfiAsyncQueueError::QueuePoisoned)?;
+    let before = queue.events.len();
+    let mut purged_bytes = 0;
+    let mut sequences = HashSet::new();
+    queue.events.retain(|event| {
+      if event.descriptor.task_handle == handle.raw() && event.descriptor.kind == FfiAsyncEventKind::Emit as u32 {
+        purged_bytes += event.payload.len();
+        sequences.insert(event.descriptor.sequence);
+        false
+      } else {
+        true
+      }
+    });
+    queue.queued_bytes = queue.queued_bytes.saturating_sub(purged_bytes);
+    let purged = before - queue.events.len();
+    if let Some(state) = queue.tasks.get_mut(&handle) {
+      state.record_selected_purge(&sequences);
+    }
+    debug_assert_eq!(purged, sequences.len(), "selective queue purge must preserve unique sequences");
+    Ok(purged)
   }
 
   /// Enqueue an event without blocking a foreign producer. When the queue is
@@ -1084,10 +1126,20 @@ mod tests {
     queue
       .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, b"tick".to_vec())
       .expect("enqueue tick");
-    registry.begin_close(handle).expect("cancel stream");
     queue
       .enqueue(&registry, handle, None, FfiAsyncEventKind::Complete, b"&unit".to_vec())
       .expect("enqueue close acknowledgement");
+    registry.begin_close(handle).expect("cancel stream");
+    assert_eq!(queue.discard_handle_emit_events(handle), Ok(1));
+    assert_eq!(queue.len(), Ok(1));
+    assert_eq!(
+      queue
+        .task_metrics(handle)
+        .expect("read metrics")
+        .expect("task metrics")
+        .purged_total,
+      1
+    );
 
     let mut kinds = vec![];
     let report = queue
@@ -1097,9 +1149,9 @@ mod tests {
       })
       .expect("drain cancelled stream");
     assert_eq!(kinds, vec![FfiAsyncEventKind::Complete]);
-    assert_eq!(report.discarded, 1);
+    assert_eq!(report.discarded, 0);
     assert_eq!(report.delivered, 1);
-    assert_eq!(report.purged, 1);
+    assert_eq!(report.purged, 0);
     assert!(report.lifecycle_failures.is_empty());
   }
 

--- a/src/ffi_async.rs
+++ b/src/ffi_async.rs
@@ -312,6 +312,10 @@ impl FfiAsyncTaskQueueState {
     self.queued.clear();
     self.queued_bytes = 0;
   }
+
+  fn record_discarded_after_dequeue(&mut self) {
+    self.purged_total = self.purged_total.saturating_add(1);
+  }
 }
 
 /// A bounded multi-producer, single-host-thread event queue.
@@ -625,16 +629,29 @@ impl FfiAsyncEventQueue {
           continue;
         }
       };
-      if state.lifecycle == FfiAsyncLifecycle::Finished
-        || (state.lifecycle == FfiAsyncLifecycle::Closing && kind == FfiAsyncEventKind::Emit)
-      {
+      if state.lifecycle == FfiAsyncLifecycle::Closing && kind == FfiAsyncEventKind::Emit {
+        // A drain batch is detached from the shared queue before callbacks run.
+        // Cancellation from an earlier callback can therefore close the task
+        // while later, previously accepted emits are already in this batch.
+        // New emits cannot reserve a sequence after begin_close, so discarding
+        // these detached events is cancellation cleanup, not a lifecycle error.
+        if let Some(state) = self
+          .state
+          .lock()
+          .map_err(|_| FfiAsyncQueueError::QueuePoisoned)?
+          .tasks
+          .get_mut(&handle)
+        {
+          state.record_discarded_after_dequeue();
+        }
+        report.discarded += 1;
+        report.purged += 1;
+        continue;
+      }
+      if state.lifecycle == FfiAsyncLifecycle::Finished {
         report.lifecycle_failures.push(FfiAsyncLifecycleFailure {
           descriptor: event.descriptor,
-          error: if state.lifecycle == FfiAsyncLifecycle::Finished {
-            FfiAsyncHandleError::HandleFinished
-          } else {
-            FfiAsyncHandleError::HandleClosing
-          },
+          error: FfiAsyncHandleError::HandleFinished,
         });
         report.discarded += 1;
         continue;
@@ -940,6 +957,41 @@ mod tests {
   }
 
   #[test]
+  fn cancellation_during_a_drain_batch_silently_discards_later_emits() {
+    let registry = FfiAsyncHandleRegistry::new();
+    let handle = registry.register(FfiAsyncHandleKind::Stream, ()).expect("register stream");
+    let queue = FfiAsyncEventQueue::new(2).expect("create queue");
+    for payload in [b"first".to_vec(), b"stale-after-cancel".to_vec()] {
+      queue
+        .enqueue(&registry, handle, None, FfiAsyncEventKind::Emit, payload)
+        .expect("enqueue accepted emit");
+    }
+
+    let mut delivered = vec![];
+    let report = queue
+      .drain(&registry, 2, |event| {
+        delivered.push(event.payload().to_vec());
+        registry.begin_close(handle).expect("cancel task from first callback");
+        Ok(())
+      })
+      .expect("drain cancellation batch");
+
+    assert_eq!(delivered, vec![b"first".to_vec()]);
+    assert_eq!(report.delivered, 1);
+    assert_eq!(report.discarded, 1);
+    assert_eq!(report.purged, 1);
+    assert!(report.lifecycle_failures.is_empty());
+    assert_eq!(
+      queue
+        .task_metrics(handle)
+        .expect("read metrics")
+        .expect("task metrics")
+        .purged_total,
+      1
+    );
+  }
+
+  #[test]
   fn full_queue_coalesces_only_opted_in_emit_events() {
     let registry = FfiAsyncHandleRegistry::new();
     let handle = registry
@@ -1047,7 +1099,8 @@ mod tests {
     assert_eq!(kinds, vec![FfiAsyncEventKind::Complete]);
     assert_eq!(report.discarded, 1);
     assert_eq!(report.delivered, 1);
-    assert_eq!(report.lifecycle_failures.len(), 1);
+    assert_eq!(report.purged, 1);
+    assert!(report.lifecycle_failures.is_empty());
   }
 
   #[test]


### PR DESCRIPTION
## 中文

### 问题

当 Calcit async callback 在一次 host drain batch 中取消自己的 task 时，后续 Emit 可能已经从共享队列取出但尚未 dispatch。Registry 进入 Closing 后，这些取消前已接受的事件会被误报为 `async FFI handle is closing` lifecycle error。

### 修改

- `.cancel` 在 `begin_close` 后只清理仍位于共享队列的旧 Emit，保留已排队的 Complete/Fail；
- drain batch 中位于取消回调之后的 Emit 作为取消清理静默 discard；
- 新 Emit 仍由 Closing registry 拒绝；
- 预留的 Complete/Fail 仍可投递并 exactly-once 收尾；
- detached batch discard 计入 `purged` metrics；
- 补充 queue 层与真实 task cancellation 回归测试，并更新双语协议文档。

### 验证

- `cargo test`：888 项通过；
- `cargo clippy -- -D warnings`；
- `yarn compile`；
- `yarn check-all`，包括 core 223/223、JS/IR/WASM；
- `yarn check-agent-interface`：17/17；
- 使用本分支 Calcit 与 calcit-wss 真实 dylib 完成 connect/message/send/typed-metrics/close/cancel smoke，无 lifecycle error。

## English

### Problem

When a Calcit async callback cancels its own task during one host drain batch, later Emits may already be detached from the shared queue but not yet dispatched. After the registry enters Closing, those previously accepted events were incorrectly reported as `async FFI handle is closing` lifecycle errors.

### Changes

- purge only old Emits still in the shared queue immediately after `begin_close`, preserving queued Complete/Fail events;
- silently discard later Emits in the detached drain batch as cancellation cleanup;
- continue rejecting every new Emit through the Closing registry;
- keep reserved Complete/Fail delivery available for exactly-once termination;
- count detached batch cleanup in `purged` metrics;
- add queue-level and real task-cancellation regressions and update the bilingual protocol documentation.

### Validation

- `cargo test`: 888 tests passed;
- `cargo clippy -- -D warnings`;
- `yarn compile`;
- `yarn check-all`, including core 223/223 and JS/IR/WASM;
- `yarn check-agent-interface`: 17/17;
- real calcit-wss dylib connect/message/send/typed-metrics/close/cancel smoke with this branch, with no lifecycle error.

Tracks #501.
