### PR TITLE
fix: guard Snapshot writes by project toolchain / 按项目工具链保护 Snapshot 写入

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -39,7 +39,7 @@ leads_to:
 
 会写回 Snapshot 的 `edit`、`tree`、`config` 和 cursor mutation 会先核对同目录
 `deps.cirru :calcit-version`。若项目固定版本与当前 CLI 不一致，命令会在写入前失败；应改用项目固定的
-Calcit 版本，或先显式执行 `caps upgrade --all deps.cirru` 升级项目。查询、dry-run、cursor 导航，以及尚未
+Calcit 版本，或先显式执行 `caps deps.cirru upgrade --all` 升级项目。查询、dry-run、cursor 导航，以及尚未
 声明 `:calcit-version` 的旧项目不受此门禁影响。
 
 ### 0.1 发现 Calcit 缺陷时：定位归属仓库并提交 Issue

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -37,6 +37,11 @@ leads_to:
 3. `calcit.cirru` 是 **Cirru EDN 树形 Snapshot**，不是按行维护的文本源码。旧项目若只有 `compact.cirru`，先按 upgrade 指南迁移；当前工具会拒绝旧文件名。不要用 line patch、正则脚本或 formatter 直接改 Snapshot；使用 `calcit edit`、`calcit tree`、`calcit cursor`。
 4. `CURSOR`、`FOLDED:*`、chunk 标题和 path annotation 都是展示信息，绝不能复制回 Snapshot。`cursor show --format json` 中 `tree` 才是真实节点，`preview_tree` 只是展示树。
 
+会写回 Snapshot 的 `edit`、`tree`、`config` 和 cursor mutation 会先核对同目录
+`deps.cirru :calcit-version`。若项目固定版本与当前 CLI 不一致，命令会在写入前失败；应改用项目固定的
+Calcit 版本，或先显式执行 `caps upgrade --all deps.cirru` 升级项目。查询、dry-run、cursor 导航，以及尚未
+声明 `:calcit-version` 的旧项目不受此门禁影响。
+
 ### 0.1 发现 Calcit 缺陷时：定位归属仓库并提交 Issue
 
 发现 **Calcit 语言、编译器、运行时或 CLI 工具** 的可复现问题时，必须向该工具的维护仓库提交 GitHub Issue；不要把问题只留在当前项目的提交说明、错误 sidecar 或聊天记录里。发现 **类库/模块** 问题时，也必须提交到该类库的维护仓库，而不是误报到使用它的应用项目或 Calcit 核心仓库。

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -135,6 +135,10 @@ ns app.main $ :require
 > “不再依赖 Snapshot”。`calcit edit` / `calcit tree` 会直接修改该文件。确认迁移完成后，可以移除旧的
 > `.gitattributes` generated 标记和过时的双文件生成脚本；不要把仍可能承载源码的文件直接加入 ignore。
 
+新版 CLI 在任何 Snapshot 写入前都会核对相邻 `deps.cirru :calcit-version`。这避免全局安装的新版本
+把 Snapshot 写成项目 CI 固定的旧版本无法读取的格式。版本不一致时，先决定是使用项目固定版本完成
+当前编辑，还是显式运行 `caps upgrade --all deps.cirru` 升级整条工具链；不要为了绕过门禁临时删除版本声明。
+
 ---
 
 ## 2）标准升级流程（建议顺序）

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -137,7 +137,7 @@ ns app.main $ :require
 
 新版 CLI 在任何 Snapshot 写入前都会核对相邻 `deps.cirru :calcit-version`。这避免全局安装的新版本
 把 Snapshot 写成项目 CI 固定的旧版本无法读取的格式。版本不一致时，先决定是使用项目固定版本完成
-当前编辑，还是显式运行 `caps upgrade --all deps.cirru` 升级整条工具链；不要为了绕过门禁临时删除版本声明。
+当前编辑，还是显式运行 `caps deps.cirru upgrade --all` 升级整条工具链；不要为了绕过门禁临时删除版本声明。
 
 ---
 

--- a/editing-history/202608291811-snapshot-mutation-version-guard.md
+++ b/editing-history/202608291811-snapshot-mutation-version-guard.md
@@ -1,0 +1,24 @@
+# Snapshot mutation toolchain guard
+
+## Context
+
+Calcit 0.13.60 writes canonical symbol keys for Snapshot namespaces and definitions. A globally installed newer CLI could therefore rewrite a project whose `deps.cirru` and CI still pin an older reader, leaving the project unreadable to its declared toolchain.
+
+## Change
+
+- Added a shared preflight that reads the `deps.cirru` adjacent to the selected Snapshot.
+- Snapshot-writing `edit`, `tree`, `config`, and cursor operations now reject an exact `:calcit-version` mismatch before loading or writing the target file.
+- Read-only commands, dry-runs, cursor navigation, projects without `deps.cirru`, and legacy manifests without `:calcit-version` remain usable.
+- Invalid non-string or non-semver declarations fail with a manifest-specific diagnostic.
+- The failure explains both safe paths: use the pinned Calcit release, or explicitly upgrade the project with `caps upgrade --all`.
+
+## Verification
+
+- Unit coverage for matching, absent, mismatched, and invalid declarations.
+- Real-project smoke confirmed `config show` remains readable while `edit format` is blocked without changing the Snapshot hash.
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-agent-interface` (17/17)
+- `yarn check-all` (Calcit core 223/223, JS/IR/WASM and performance checks)

--- a/editing-history/202608291811-snapshot-mutation-version-guard.md
+++ b/editing-history/202608291811-snapshot-mutation-version-guard.md
@@ -10,7 +10,7 @@ Calcit 0.13.60 writes canonical symbol keys for Snapshot namespaces and definiti
 - Snapshot-writing `edit`, `tree`, `config`, and cursor operations now reject an exact `:calcit-version` mismatch before loading or writing the target file.
 - Read-only commands, dry-runs, cursor navigation, projects without `deps.cirru`, and legacy manifests without `:calcit-version` remain usable.
 - Invalid non-string or non-semver declarations fail with a manifest-specific diagnostic.
-- The failure explains both safe paths: use the pinned Calcit release, or explicitly upgrade the project with `caps upgrade --all`.
+- The failure explains both safe paths: use the pinned Calcit release, or explicitly upgrade the project with `caps <deps-file> upgrade --all`.
 
 ## Verification
 

--- a/editing-history/202608291814-caps-manifest-argument-order.md
+++ b/editing-history/202608291814-caps-manifest-argument-order.md
@@ -1,0 +1,3 @@
+# Preserve `caps` manifest argument order in mutation guidance
+
+The custom `deps.cirru` path is a top-level `caps` positional argument. Guidance must use `caps <deps-file> upgrade --all`; placing the path after `upgrade --all` makes argh parse it as a dependency package name. The mismatch regression test now locks the correct ordering.

--- a/editing-history/202608291822-quote-mutation-guard-path.md
+++ b/editing-history/202608291822-quote-mutation-guard-path.md
@@ -1,0 +1,3 @@
+# Quote the manifest path in mutation guidance
+
+The Snapshot toolchain guard now renders the adjacent `deps.cirru` path with the existing shell quoting helper. A regression fixture uses a directory containing whitespace and verifies the suggested `caps '<deps-file>' upgrade --all` command remains a single shell argument. The fixture identity also combines a timestamp with an atomic sequence so parallel tests cannot share a manifest.

--- a/src/bin/cli_handlers/common.rs
+++ b/src/bin/cli_handlers/common.rs
@@ -98,7 +98,7 @@ pub fn guard_snapshot_mutation_toolchain(snapshot_path: &str) -> Result<(), Stri
 
   Err(format!(
     "Snapshot mutation blocked: {deps_path} pins Calcit {declared}, but the running CLI is {running}.\n\
-     Re-run this edit with Calcit {declared}, or explicitly upgrade the project first with `caps upgrade --all {deps_path}`.\n\
+     Re-run this edit with Calcit {declared}, or explicitly upgrade the project first with `caps {deps_path} upgrade --all`.\n\
      No changes were written to {snapshot_path}."
   ))
 }
@@ -579,6 +579,10 @@ mod tests {
     let error = guard_snapshot_mutation_toolchain(snapshot.to_str().unwrap()).unwrap_err();
     assert!(error.contains("Snapshot mutation blocked"), "error: {error}");
     assert!(error.contains("pins Calcit 0.1.0"), "error: {error}");
+    assert!(
+      error.contains("caps ") && error.contains("deps.cirru upgrade --all"),
+      "error: {error}"
+    );
     assert!(error.contains("No changes were written"), "error: {error}");
     fs::remove_dir_all(dir).unwrap();
   }

--- a/src/bin/cli_handlers/common.rs
+++ b/src/bin/cli_handlers/common.rs
@@ -1,5 +1,6 @@
 //! Common utilities shared between CLI handlers
 
+use cirru_edn::Edn;
 use cirru_parser::Cirru;
 use std::fs;
 use std::path::Path;
@@ -67,6 +68,39 @@ pub fn deps_path_for_snapshot(snapshot_path: &str) -> String {
     .join("deps.cirru")
     .display()
     .to_string()
+}
+
+/// Refuse to rewrite a Snapshot with a different Calcit release than the one
+/// pinned by the adjacent deps.cirru. Snapshot serialization can evolve between
+/// releases, so a newer global CLI must not silently produce data that the
+/// project's pinned toolchain cannot read.
+pub fn guard_snapshot_mutation_toolchain(snapshot_path: &str) -> Result<(), String> {
+  let deps_path = deps_path_for_snapshot(snapshot_path);
+  if !Path::new(&deps_path).exists() {
+    return Ok(());
+  }
+
+  let content = fs::read_to_string(&deps_path).map_err(|error| format!("Failed to read {deps_path}: {error}"))?;
+  let data = cirru_edn::parse(&content).map_err(|error| format!("Failed to parse {deps_path}: {error}"))?;
+  let deps = data
+    .view_map()
+    .map_err(|error| format!("Invalid dependency manifest {deps_path}: {error}"))?;
+  let declared = match deps.get_or_nil("calcit-version") {
+    Edn::Str(version) if !version.trim().is_empty() => version.to_string(),
+    Edn::Str(_) | Edn::Nil => return Ok(()),
+    value => return Err(format!("Invalid :calcit-version in {deps_path}: expected a string, got {value}")),
+  };
+  semver::Version::parse(&declared).map_err(|error| format!("Invalid :calcit-version '{declared}' in {deps_path}: {error}"))?;
+  let running = env!("CARGO_PKG_VERSION");
+  if declared == running {
+    return Ok(());
+  }
+
+  Err(format!(
+    "Snapshot mutation blocked: {deps_path} pins Calcit {declared}, but the running CLI is {running}.\n\
+     Re-run this edit with Calcit {declared}, or explicitly upgrade the project first with `caps upgrade --all {deps_path}`.\n\
+     No changes were written to {snapshot_path}."
+  ))
 }
 
 fn is_shell_sensitive_char(ch: char) -> bool {
@@ -394,10 +428,24 @@ pub fn parse_input_to_cirru(raw: &str) -> Result<Cirru, String> {
 #[cfg(test)]
 mod tests {
   use super::{
-    GlobalTempPathKind, format_path, format_path_with_separator, global_temp_path_guidance, parse_input_to_cirru, parse_path,
-    parse_quoted_cirru_nodes, resolve_definition_lookup, shell_quote,
+    GlobalTempPathKind, format_path, format_path_with_separator, global_temp_path_guidance, guard_snapshot_mutation_toolchain,
+    parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes, resolve_definition_lookup, shell_quote,
   };
   use cirru_parser::Cirru;
+  use std::fs;
+  use std::time::{SystemTime, UNIX_EPOCH};
+
+  fn mutation_guard_fixture(deps_content: Option<&str>) -> (std::path::PathBuf, std::path::PathBuf) {
+    let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let dir = std::env::temp_dir().join(format!("calcit-mutation-guard-{}-{nonce}", std::process::id()));
+    fs::create_dir_all(&dir).unwrap();
+    let snapshot = dir.join("calcit.cirru");
+    fs::write(&snapshot, "{}\n").unwrap();
+    if let Some(content) = deps_content {
+      fs::write(dir.join("deps.cirru"), content).unwrap();
+    }
+    (dir, snapshot)
+  }
 
   fn leaf(value: &str) -> Cirru {
     Cirru::Leaf(value.into())
@@ -513,5 +561,33 @@ mod tests {
     assert!(err.contains("Found multiple shell-sensitive candidates starting with 'value-'"));
     assert!(err.contains("'value->text'"));
     assert!(err.contains("'value->debug'"));
+  }
+
+  #[test]
+  fn snapshot_mutation_guard_accepts_matching_or_unpinned_projects() {
+    let matching = format!("{{}} (:calcit-version |{})\n", env!("CARGO_PKG_VERSION"));
+    for deps in [Some(matching.as_str()), Some("{} (:dependencies $ {})\n"), None] {
+      let (dir, snapshot) = mutation_guard_fixture(deps);
+      guard_snapshot_mutation_toolchain(snapshot.to_str().unwrap()).unwrap();
+      fs::remove_dir_all(dir).unwrap();
+    }
+  }
+
+  #[test]
+  fn snapshot_mutation_guard_rejects_version_mismatch() {
+    let (dir, snapshot) = mutation_guard_fixture(Some("{} (:calcit-version |0.1.0)\n"));
+    let error = guard_snapshot_mutation_toolchain(snapshot.to_str().unwrap()).unwrap_err();
+    assert!(error.contains("Snapshot mutation blocked"), "error: {error}");
+    assert!(error.contains("pins Calcit 0.1.0"), "error: {error}");
+    assert!(error.contains("No changes were written"), "error: {error}");
+    fs::remove_dir_all(dir).unwrap();
+  }
+
+  #[test]
+  fn snapshot_mutation_guard_rejects_invalid_declared_version() {
+    let (dir, snapshot) = mutation_guard_fixture(Some("{} (:calcit-version |latest)\n"));
+    let error = guard_snapshot_mutation_toolchain(snapshot.to_str().unwrap()).unwrap_err();
+    assert!(error.contains("Invalid :calcit-version 'latest'"), "error: {error}");
+    fs::remove_dir_all(dir).unwrap();
   }
 }

--- a/src/bin/cli_handlers/common.rs
+++ b/src/bin/cli_handlers/common.rs
@@ -95,10 +95,11 @@ pub fn guard_snapshot_mutation_toolchain(snapshot_path: &str) -> Result<(), Stri
   if declared == running {
     return Ok(());
   }
+  let quoted_deps_path = shell_quote(&deps_path);
 
   Err(format!(
     "Snapshot mutation blocked: {deps_path} pins Calcit {declared}, but the running CLI is {running}.\n\
-     Re-run this edit with Calcit {declared}, or explicitly upgrade the project first with `caps {deps_path} upgrade --all`.\n\
+     Re-run this edit with Calcit {declared}, or explicitly upgrade the project first with `caps {quoted_deps_path} upgrade --all`.\n\
      No changes were written to {snapshot_path}."
   ))
 }
@@ -433,11 +434,15 @@ mod tests {
   };
   use cirru_parser::Cirru;
   use std::fs;
+  use std::sync::atomic::{AtomicU64, Ordering};
   use std::time::{SystemTime, UNIX_EPOCH};
+
+  static FIXTURE_ID: AtomicU64 = AtomicU64::new(0);
 
   fn mutation_guard_fixture(deps_content: Option<&str>) -> (std::path::PathBuf, std::path::PathBuf) {
     let nonce = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    let dir = std::env::temp_dir().join(format!("calcit-mutation-guard-{}-{nonce}", std::process::id()));
+    let fixture_id = FIXTURE_ID.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("calcit mutation guard-{}-{nonce}-{fixture_id}", std::process::id()));
     fs::create_dir_all(&dir).unwrap();
     let snapshot = dir.join("calcit.cirru");
     fs::write(&snapshot, "{}\n").unwrap();
@@ -580,7 +585,7 @@ mod tests {
     assert!(error.contains("Snapshot mutation blocked"), "error: {error}");
     assert!(error.contains("pins Calcit 0.1.0"), "error: {error}");
     assert!(
-      error.contains("caps ") && error.contains("deps.cirru upgrade --all"),
+      error.contains("caps '") && error.contains("deps.cirru' upgrade --all"),
       "error: {error}"
     );
     assert!(error.contains("No changes were written"), "error: {error}");

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use super::common::deps_path_for_snapshot;
+use super::common::{deps_path_for_snapshot, guard_snapshot_mutation_toolchain};
 use super::edit::{load_snapshot, save_snapshot};
 
 fn load_snapshot_for_display(input_path: &str) -> Result<snapshot::Snapshot, String> {
@@ -32,6 +32,14 @@ fn load_snapshot_for_display(input_path: &str) -> Result<snapshot::Snapshot, Str
 }
 
 pub fn handle_config_command(cmd: &ConfigCommand, snapshot_file: &str) -> Result<(), String> {
+  let mutates_snapshot = match &cmd.subcommand {
+    ConfigSubcommand::Show(_) | ConfigSubcommand::Modules(_) | ConfigSubcommand::TypeSlots(_) | ConfigSubcommand::Version(_) => false,
+    ConfigSubcommand::Set(opts) => opts.key != "version",
+    _ => true,
+  };
+  if mutates_snapshot {
+    guard_snapshot_mutation_toolchain(snapshot_file)?;
+  }
   match &cmd.subcommand {
     ConfigSubcommand::Show(opts) => handle_show(opts, snapshot_file),
     ConfigSubcommand::Modules(opts) => handle_modules(opts, snapshot_file),

--- a/src/bin/cli_handlers/cursor.rs
+++ b/src/bin/cli_handlers/cursor.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use super::atomic_write::{StagedFile, stage_atomic_file};
-use super::common::{cirru_to_json_value, format_path, parse_path};
+use super::common::{cirru_to_json_value, format_path, guard_snapshot_mutation_toolchain, parse_path};
 use super::edit::{apply_operation_at_path, check_ns_editable, load_snapshot, navigate_to_path, parse_target};
 use super::tree_mutation::{
   TreeCursorMutation, TreeOperation, adjusted_source_path_after_insertion, transform_cursor_path, transform_delete,
@@ -95,6 +95,19 @@ pub fn set_cursor_after_mode(mode: &str) -> Result<(), String> {
 }
 
 pub fn handle_cursor_command(cmd: &CursorCommand, snapshot_file: &str) -> Result<(), String> {
+  if matches!(
+    &cmd.subcommand,
+    CursorSubcommand::Cut(_)
+      | CursorSubcommand::Paste(_)
+      | CursorSubcommand::Apply(_)
+      | CursorSubcommand::SlurpNext(_)
+      | CursorSubcommand::SlurpPrev(_)
+      | CursorSubcommand::BarfLast(_)
+      | CursorSubcommand::BarfFirst(_)
+      | CursorSubcommand::Duplicate(_)
+  ) {
+    guard_snapshot_mutation_toolchain(snapshot_file)?;
+  }
   match &cmd.subcommand {
     CursorSubcommand::Set(opts) => {
       if opts.path == "@cursor" {

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -38,8 +38,8 @@ use calcit::util::string::strip_shebang;
 
 use super::atomic_write::stage_atomic_file;
 use super::common::{
-  ERR_CODE_INPUT_REQUIRED, format_path, parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes, print_cli_warning_block,
-  read_code_input, resolve_definition_lookup, shell_quote,
+  ERR_CODE_INPUT_REQUIRED, format_path, guard_snapshot_mutation_toolchain, parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes,
+  print_cli_warning_block, read_code_input, resolve_definition_lookup, shell_quote,
 };
 use super::cursor::{
   maintain_cursor_after_any_mutation, maintain_cursor_after_definition_delete, maintain_cursor_after_definition_move,
@@ -81,6 +81,9 @@ pub(crate) fn process_node_with_references(
 }
 
 pub fn handle_edit_command(cmd: &EditCommand, snapshot_file: &str) -> Result<(), String> {
+  if edit_mutates_snapshot(&cmd.subcommand) {
+    guard_snapshot_mutation_toolchain(snapshot_file)?;
+  }
   let mut resolved = cmd.clone();
   resolve_edit_cursor_references(&mut resolved, snapshot_file)?;
   let result = match &resolved.subcommand {
@@ -113,6 +116,16 @@ pub fn handle_edit_command(cmd: &EditCommand, snapshot_file: &str) -> Result<(),
   };
   result?;
   maintain_cursor_after_edit(&resolved, snapshot_file)
+}
+
+fn edit_mutates_snapshot(cmd: &EditSubcommand) -> bool {
+  match cmd {
+    EditSubcommand::Transaction(opts) => !opts.dry_run,
+    EditSubcommand::Scaffold(opts) => !opts.dry_run,
+    EditSubcommand::Tags(opts) => opts.tags.is_some(),
+    EditSubcommand::Inc(_) => false,
+    _ => true,
+  }
 }
 
 fn resolve_edit_cursor_references(cmd: &mut EditCommand, snapshot_file: &str) -> Result<(), String> {

--- a/src/bin/cli_handlers/tree.rs
+++ b/src/bin/cli_handlers/tree.rs
@@ -4,8 +4,8 @@ use std::fmt::Write as _;
 
 use super::chunk_display::{ChunkDisplayOptions, ChunkedDisplay, fragment_nesting_level, maybe_chunk_node};
 use super::common::{
-  ERR_CODE_INPUT_REQUIRED, cirru_to_json, emit_cli_output, format_path, parse_input_to_cirru, parse_path, print_cli_warning_block,
-  read_code_input, resolve_definition_lookup,
+  ERR_CODE_INPUT_REQUIRED, cirru_to_json, emit_cli_output, format_path, guard_snapshot_mutation_toolchain, parse_input_to_cirru,
+  parse_path, print_cli_warning_block, read_code_input, resolve_definition_lookup,
 };
 use super::cursor::{
   maintain_cursor_after_tree_mutation, resolve_active_cursor_reference, resolve_cursor_path_argument, resolve_cursor_target_argument,
@@ -31,6 +31,9 @@ use super::tree_mutation::{TreeCursorMutation, TreeOperation};
 
 /// Main handler for code command
 pub fn handle_tree_command(cmd: &TreeCommand, snapshot_file: &str) -> Result<(), String> {
+  if !matches!(&cmd.subcommand, TreeSubcommand::Show(_)) {
+    guard_snapshot_mutation_toolchain(snapshot_file)?;
+  }
   let mut resolved = cmd.clone();
   resolve_tree_cursor_references(&mut resolved, snapshot_file)?;
   let cursor_mutation = prepare_cursor_mutation(&resolved, snapshot_file)?;


### PR DESCRIPTION
## 中文

修复 #515，防止全局安装的新版 Calcit CLI 静默改写由旧版工具链固定的 Snapshot。

### 改动

- 所有会写回 Snapshot 的 `edit`、`tree`、`config` 与 cursor mutation 在执行前核对相邻 `deps.cirru :calcit-version`
- 版本不一致、声明类型错误或 semver 非法时，在任何写入前失败并给出迁移路径
- 保持查询、dry-run、cursor 导航、无 `deps.cirru` 及未声明版本的旧项目兼容
- 补充 Agent 与升级文档

### 验证

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`（17/17）
- `yarn check-all`（Calcit core 223/223，JS/IR/WASM 与性能检查）
- 真实旧项目副本：查询成功；`edit format` 被阻断；Snapshot 哈希保持不变

## English

Fixes #515 by preventing a globally installed newer Calcit CLI from silently rewriting a Snapshot pinned to an older project toolchain.

### Changes

- Preflight every Snapshot-writing `edit`, `tree`, `config`, and cursor mutation against the adjacent `deps.cirru :calcit-version`
- Reject mismatches, invalid value types, and invalid semver declarations before any write, with actionable migration guidance
- Keep queries, dry-runs, cursor navigation, projects without `deps.cirru`, and legacy manifests without a version declaration compatible
- Document the guard in the Agent and upgrade guides

### Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all` (Calcit core 223/223, JS/IR/WASM, and performance checks)
- Real old-project copy: queries succeed; `edit format` is blocked; Snapshot hash remains unchanged
