### PR TITLE
fix: avoid caps metadata-lock timeouts during clone

### DIFF
--- a/editing-history/202608291857-caps-clone-outside-metadata-lock.md
+++ b/editing-history/202608291857-caps-clone-outside-metadata-lock.md
@@ -1,0 +1,18 @@
+# Keep network work outside the caps metadata lock
+
+## Context
+
+`caps` resolves independent modules in parallel. A cache miss previously acquired the global `.metadata.lock` before cloning a repository and held the lock for the entire network operation. A clone lasting longer than the lock retry window caused otherwise independent workers to fail with a misleading lock timeout.
+
+## Change
+
+- Keep the first cache lookup and metadata refresh under a short lock.
+- Clone a missing repository into its process-unique temporary path without holding the global lock.
+- Reacquire the lock only to resolve an installation race, atomically rename the clone into the content-addressed store, and update metadata.
+- Preserve validation when another process installs the same commit first.
+
+## Verification
+
+- Rust tests and strict Clippy pass.
+- TypeScript compilation and the 17/17 agent-interface suite pass.
+- A real cold-cache `caps --strict --ci` run over calcium-workflow's dependency graph cloned concurrent modules without a metadata-lock timeout.

--- a/src/bin/caps_graph.rs
+++ b/src/bin/caps_graph.rs
@@ -514,27 +514,29 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
 
   eprintln!("resolving {repository}@{reference}");
   let remote = resolve_remote_ref(repository, reference, options.ci)?;
-  let source = module_cache_root(&options.modules_dir)
-    .join("git")
-    .join(owner)
-    .join(repo)
-    .join(&remote.commit)
-    .join("source");
-  let _lock = CacheMetadataLock::acquire(&module_cache_root(&options.modules_dir))?;
-  if source.exists() {
-    validate_store_source(repository, &source, &remote.commit)?;
-    ensure_store_metadata_unlocked(&source, repository, reference, &remote.commit)?;
-    let dependencies = read_module_dependencies(&source)?;
-    return Ok(ResolvedModule {
-      repository: repository.to_string(),
-      reference: reference.to_string(),
-      commit: remote.commit,
-      kind: remote.kind,
-      link_target: source.clone(),
-      source,
-      dependencies,
-    });
+  let cache_root = module_cache_root(&options.modules_dir);
+  let source = cache_root.join("git").join(owner).join(repo).join(&remote.commit).join("source");
+  {
+    let _lock = CacheMetadataLock::acquire(&cache_root)?;
+    if source.exists() {
+      validate_store_source(repository, &source, &remote.commit)?;
+      ensure_store_metadata_unlocked(&source, repository, reference, &remote.commit)?;
+      let dependencies = read_module_dependencies(&source)?;
+      return Ok(ResolvedModule {
+        repository: repository.to_string(),
+        reference: reference.to_string(),
+        commit: remote.commit,
+        kind: remote.kind,
+        link_target: source.clone(),
+        source,
+        dependencies,
+      });
+    }
   }
+
+  // Network cloning is intentionally outside the global metadata lock. Each
+  // process clones into a unique temporary path, then competes only for the
+  // short store installation/metadata critical section below.
   GitRepo::clone_to_path(&temp_path, &remote.url, reference, &remote.kind, true)
     .map_err(|e| format!("failed to clone {repository}@{reference}: {e}"))?;
   let temp_repo = GitRepo { dir: temp_path.clone() };
@@ -545,33 +547,30 @@ fn materialize_module(repository: &str, reference: &str, options: &GraphOptions)
       remote.commit
     ));
   }
-  let source = module_cache_root(&options.modules_dir)
-    .join("git")
-    .join(owner)
-    .join(repo)
-    .join(&commit)
-    .join("source");
-  if source.exists() {
-    fs::remove_dir_all(&temp_path).map_err(|e| format!("failed to clean {}: {e}", temp_path.display()))?;
-    validate_store_source(repository, &source, &commit)?;
-  } else {
-    let parent = source.parent().ok_or_else(|| format!("invalid store path {}", source.display()))?;
-    fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
-    if let Err(error) = fs::rename(&temp_path, &source) {
-      if source.exists() {
-        fs::remove_dir_all(&temp_path).map_err(|e| format!("failed to clean {} after concurrent install: {e}", temp_path.display()))?;
-        validate_store_source(repository, &source, &commit)?;
-      } else {
-        return Err(format!(
-          "failed to move {} into store {}: {error}",
-          temp_path.display(),
-          source.display()
-        ));
+  {
+    let _lock = CacheMetadataLock::acquire(&cache_root)?;
+    if source.exists() {
+      fs::remove_dir_all(&temp_path).map_err(|e| format!("failed to clean {}: {e}", temp_path.display()))?;
+      validate_store_source(repository, &source, &commit)?;
+    } else {
+      let parent = source.parent().ok_or_else(|| format!("invalid store path {}", source.display()))?;
+      fs::create_dir_all(parent).map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+      if let Err(error) = fs::rename(&temp_path, &source) {
+        if source.exists() {
+          fs::remove_dir_all(&temp_path)
+            .map_err(|e| format!("failed to clean {} after concurrent install: {e}", temp_path.display()))?;
+          validate_store_source(repository, &source, &commit)?;
+        } else {
+          return Err(format!(
+            "failed to move {} into store {}: {error}",
+            temp_path.display(),
+            source.display()
+          ));
+        }
       }
     }
+    ensure_store_metadata_unlocked(&source, repository, reference, &commit)?;
   }
-
-  ensure_store_metadata_unlocked(&source, repository, reference, &commit)?;
 
   let dependencies = read_module_dependencies(&source)?;
   Ok(ResolvedModule {


### PR DESCRIPTION
## 中文

修复 `caps` 在冷缓存并发解析模块时可能错误超时的问题。

- 缓存命中检查与元数据更新继续使用短时全局锁。
- 网络 clone 移到 `.metadata.lock` 临界区之外。
- clone 完成后仅在原子安装及处理并发安装竞态时重新获取锁。
- 保留 content-addressed store 的 commit 校验和元数据一致性。

真实回归：在隔离冷缓存中解析 calcium-workflow 的 16 个模块，所有并发下载均完成，未再出现 metadata lock timeout。

验证：

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-agent-interface`（17/17）
- `yarn check-all`

修复 #518。

## English

Fixes a false `caps` timeout while resolving modules concurrently from a cold cache.

- Keep cache-hit checks and metadata refreshes under a short global lock.
- Move network cloning outside the `.metadata.lock` critical section.
- Reacquire the lock only for atomic installation and concurrent-install race handling.
- Preserve commit validation and content-addressed store metadata consistency.

Real-world regression: resolved calcium-workflow's 16-module graph against an isolated cold cache; all concurrent downloads completed without a metadata-lock timeout.

Validation:

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all`

Fixes #518.
