### PR TITLE
fix: export async FFI stubs for JavaScript

### DIFF
--- a/editing-history/202608291918-js-async-ffi-proc-stubs.md
+++ b/editing-history/202608291918-js-async-ffi-proc-stubs.md
@@ -1,0 +1,19 @@
+# Link native async FFI procedures in JavaScript output
+
+## Context
+
+The shared core Snapshot contains typed `FfiResponse` and `FfiTask` adapters. JS
+codegen therefore imports their underlying registered procedure names even in
+browser programs that never call the native-only APIs. The npm runtime omitted
+those exports, so bundlers diagnosed statically undefined imports.
+
+## Change
+
+- Export the response resolve/reject and task cancel names through the existing
+  JavaScript `unavailableProc` boundary.
+- Assert that all generated async FFI procedure imports are linkable from the
+  compiled npm runtime.
+
+Native behavior remains unchanged. The stubs only make the shared JS module
+graph complete and retain the established unsupported-procedure behavior if a
+native-only API is accidentally reached on JavaScript.

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -34,6 +34,9 @@ try {
   globalThis.__calcit_injections__.read_dir = () => ["ok", 1];
   assert.throws(() => runtimeA.read_dir("bad", false), /array of strings/);
   assert.equal(runtimeA.get_env, runtimeA._$n_get_env, "legacy get_env export should delegate to the raw proc");
+  assert.equal(typeof runtimeA._$n_ffi_response_resolve, "function", "generated async FFI response imports must link on JS");
+  assert.equal(typeof runtimeA._$n_ffi_response_reject, "function", "generated async FFI rejection imports must link on JS");
+  assert.equal(typeof runtimeA._$n_ffi_task_cancel, "function", "generated async FFI task imports must link on JS");
   assert.equal(runtimeA.get_env("CALCIT_MISSING_ENV_FOR_RUNTIME_TEST", "fallback"), "fallback");
   assert.equal(
     runtimeA._$n_str_$o_replace("a&a&", "&", "&amp;"),

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -2759,6 +2759,9 @@ export let macroexpand_all = unavailableProc;
 export let _$n_get_calcit_running_mode = unavailableProc;
 export let _$n_get_def_doc = unavailableProc;
 export let _$n_get_def_schema = unavailableProc;
+export let _$n_ffi_response_resolve = unavailableProc;
+export let _$n_ffi_response_reject = unavailableProc;
+export let _$n_ffi_task_cancel = unavailableProc;
 
 // already handled in code emitter
 export let raise = unavailableProc;


### PR DESCRIPTION
## 中文

补齐 JS runtime 对共享 core Snapshot 中 native-only async FFI procedures 的链接边界。

- 导出 `&ffi-response-resolve`、`&ffi-response-reject` 和 `&ffi-task-cancel` 对应的 JS 名称。
- 复用现有 `unavailableProc`，不改变 native async FFI 行为。
- 增加 runtime identity 回归，确保 npm runtime 始终提供 codegen 会引用的 exports。
- 使用本地编译 runtime 在 ws-edn + Vite 8 中验证，原有 `IMPORT_IS_UNDEFINED` warnings 已消失。

验证：Rust tests、strict Clippy、JS runtime、agent interface 17/17、`yarn check-all` 全部通过。

修复 #520。

## English

Complete the JavaScript linking boundary for native-only async FFI procedures referenced by the shared core Snapshot.

- Export the JS names for `&ffi-response-resolve`, `&ffi-response-reject`, and `&ffi-task-cancel`.
- Reuse the existing `unavailableProc` boundary without changing native async FFI behavior.
- Add a runtime identity regression ensuring the npm runtime always provides exports referenced by codegen.
- Verify with the locally compiled runtime in ws-edn + Vite 8; the previous `IMPORT_IS_UNDEFINED` warnings disappear.

Validation: Rust tests, strict Clippy, JS runtime, agent interface 17/17, and `yarn check-all` all pass.

Fixes #520.
