### PR TITLE
docs: center Calcit design and real-time application model / 统一 Calcit 设计与实时应用模型

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,15 @@
 - **一致性**：复用现有模式，保持日志和错误信息风格统一。
 - **测试覆盖**：新功能必须补齐正常路径与异常分支的测试用例。
 
+### 语言定位与文档一致性
+
+- **以 Calcit 自身为中心**：文档直接介绍 nominal struct/enum、traits 与方法、Option/Result、静态分析、typed FFI、Cirru source model 和跨 backend 语义，不再以 “ClojureScript dialect” 或其他语言类比作为主要解释框架。
+- **历史比较只服务迁移**：Clojure/ClojureScript 等历史影响可在迁移提示中保留；只有在避免具体语法、参数顺序或语义误判时才使用比较，不把外部语言当作设计依据。
+- **统一实时应用模型**：面向 Web 应用的设计围绕 Calcium Workflow：typed operation/message envelope、串行确定性 updater、Respo/Recollect projection 与 diff/patch、revision/ack/resync、有界异步、可观测收敛。
+- **能力优先以方法暴露**：新增公共抽象优先通过 trait 与 method 形成一致 API；先强化 nominal types 和 typed boundaries，再考虑增加语法或借鉴其他语言特性。
+- **跨项目验证**：相关语言/生态改动优先在 Calcium Workflow 回归，并逐步用 TopixIM/Timegrass 类真实实时应用验证；Calcit、Respo、Recollect、WebSocket 与 native FFI 模块应保持层次清晰、职责一致。
+- **双语协作记录**：关联 Issue 与 PR 的标题、正文和阶段性进度保持中英双语，便于跨项目追踪同一设计方向。
+
 直接使用命令修改 calcit 程序时不需要调用 cargo, 直接按照文档给出的命令行示例执行即可。
 
 在开始任何 `calcit edit` / `calcit tree` 修改前，先把下面这条命令当作**硬前置步骤**执行一遍，而不是可选建议：

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-### Calcit Scripting Language
+### Calcit Programming Language
 
-> Semantically a dialect of ClojureScript. Built with Rust. Compiles to JavaScript ES Modules.
+> A typed functional language for interactive and real-time applications. Built with Rust and compiling to JavaScript ES Modules.
 
 - Home https://calcit-lang.org/
 - API Doc https://apis.calcit-lang.org/
@@ -13,7 +13,8 @@ Core design:
 - Interpreter runs on Rust, extensible with Rust FFI
 - Persistent Data Structure
 - Indentation-based Cirru syntax, friendly to plain text editing
-- Lisp macros, functional style
+- Code-as-data macros and functional style
+- Nominal structs/enums, traits, methods, Option/Result, and static analysis
 - Compiles to JavaScript in ES Modules, JavaScript Interop
 - Hot code swapping friendly
 
@@ -22,6 +23,7 @@ Current direction:
 - `calcit.cirru` is the canonical source snapshot; retired `compact.cirru` inputs receive migration guidance
 - CLI-first development with `calcit` and `caps`, designed to work well with AI agents in terminal workflows
 - Better CLI editing and validation for CI, docs lookup, module management, and incremental updates
+- Consistent support for real-time web applications: typed WebSocket messages, deterministic state updates, diff/patch synchronization, acknowledgement, and resynchronization
 
 ### Install ![GitHub Release](https://img.shields.io/github/v/release/calcit-lang/calcit)
 

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -511,7 +511,7 @@ calcit docs read-lines agent-advanced.md --start 1 --lines 80
 | ---------------------------- | --------------------------------------------------------------- |
 | Cirru 语法、AST 与常见误写   | `calcit cirru show-guide`；`calcit docs read cirru-syntax.md 'Common Mistakes'` |
 | Cirru EDN 数据层             | `calcit cirru parse-edn --help`；`calcit docs read edn.md --full`       |
-| Calcit 与 Clojure 差异       | `calcit docs read agent-advanced.md 'Calcit vs Clojure'`            |
+| 从 Clojure 迁移时的易错点    | `calcit docs read agent-advanced.md 'Migration notes for Clojure users'` |
 | tree/cursor/transaction      | `calcit docs read edit-tree.md --full`                              |
 | query/context/type-at        | `calcit docs read query.md --full`                                  |
 | 复杂重构与历史陷阱           | `calcit docs read agent-advanced.md --full`                         |

--- a/docs/data.md
+++ b/docs/data.md
@@ -18,7 +18,7 @@ Calcit uses persistent values by default, with a small set of explicit stateful 
 - **Bool**: `true`, `false`
 - **Nil**: `nil`, used for absence at untyped boundaries
 - **Number**: `f64` in Rust, Number in JavaScript (`1`, `3.14`, `-42`)
-- **Tag**: Immutable strings starting with `:` (`:keyword`, `:demo`) - similar to Clojure keywords
+- **Tag**: Interned immutable identifiers starting with `:` (`:keyword`, `:demo`), commonly used for field names, variants, and protocol labels
 - **Symbol**: Quoted identifiers such as `'name`; unlike tags, symbols preserve code/data intent
 - **String**: Text data with special prefix syntax (`|text`, `"|with spaces"`)
 - **Buffer**: Immutable bytes, created with `&buffer`

--- a/docs/data/string.md
+++ b/docs/data/string.md
@@ -16,4 +16,4 @@ This somewhat unusual design exists because the structural editor naturally wrap
 
 ### Tag
 
-The most commonly used string type in Calcit is the Tag, which starts with a `:`, such as `:demo`. Its type is `Tag` in Rust and `string` in JavaScript. Unlike regular strings, Tags are immutable, meaning their value cannot be changed once created. This allows them to be used as keys in key-value pairs and in other scenarios where immutable values are needed. In practice, Tags are generally used to represent property keys, similar to keywords in the Clojure language.
+Calcit also provides the Tag type, written with a leading `:` such as `:demo`. Tags are interned immutable identifiers with consistent Calcit semantics across the Rust interpreter and JavaScript output. They are commonly used for struct fields, enum variants, map keys, and protocol labels; ordinary user-facing text should remain a String.

--- a/docs/features.md
+++ b/docs/features.md
@@ -24,28 +24,30 @@ leads_to:
 
 # Features
 
-Calcit inherits most features from Clojure/ClojureScript while adding its own innovations:
+Calcit's language features form one coherent model around immutable data, nominal domain types, capability-oriented methods, explicit effects, and cross-backend execution.
 
 ## Core Features
 
 - **Immutable persistent data structures** - All data is immutable by default using ternary tree implementations
 - **Functional programming** - First-class functions, higher-order functions, closures
-- **Lisp syntax** - Code as data, powerful macro system with hygienic macros
+- **Code as data** - Cirru syntax trees and macros provide language-level abstraction without adding parser syntax for every feature
 - **Hot code swapping** - Live code updates during development without state loss
 - **JavaScript interop** - Seamless integration with JS ecosystem via ES Modules
 - **Static type analysis** - Compile-time type checking and error detection
 
-## Unique to Calcit
+## Calcit-specific design
 
 - **Indentation-based syntax** - Alternative to parentheses for writing Calcit source, similar to Python/Haskell
-- **Structural editing** - Visual tree-based code editing with Calcit Editor (Electron app)
+- **Structural source operations** - CLI queries and edits operate on canonical `calcit.cirru` syntax trees
 - **ES Modules output** - Modern JavaScript module format, tree-shakeable
 - **MCP integration** - Model Context Protocol server for AI assistant tool integration
 - **Ternary tree collections** - Custom persistent data structures optimized for Rust
-- **Incremental compilation** - Fast hot reload with `.compact-inc.cirru` format
+- **State-preserving reload** - Watch mode recompiles and invokes explicit reload functions
 - **Pattern matching** - Tagged unions with compile-time validation
 - **Struct types** - Fixed-field values with required field access validation
 - **Traits & method dispatch** - Attach capability-based methods to values, with explicit disambiguation when needed
+- **Typed FFI capabilities** - Native and JavaScript host APIs retain explicit typed boundaries
+- **Revisioned application protocols** - Nominal message envelopes support deterministic incremental synchronization
 
 ## Language Features
 
@@ -83,6 +85,7 @@ Task-oriented jump map:
 - Type safety → [Static Analysis](features/static-analysis.md), [Error Handling](features/error-handling.md)
 - Extensibility → [Macros](features/macros.md), [Traits](features/traits.md), [Polymorphism](features/polymorphism.md)
 - Runtime integration → [JavaScript Interop](features/js-interop.md), [Imports](features/imports.md)
+- Real-time architecture → [Real-time Application Model](intro/realtime-applications.md)
 
 ## Development Features
 
@@ -114,4 +117,4 @@ Calcit's static analysis provides:
 - **Optimized compilation** - JavaScript output with tree-shaking support
 - **Type-directed optimizations** - Compile-time rewrites for struct field access/update when types are known (e.g., `&struct:assoc` → `&struct:assoc-at`)
 
-Calcit is designed to be familiar to Clojure developers while providing modern tooling, type safety, and excellent development experience.
+Calcit is designed as its own language: historical influences remain useful context, but current APIs and documentation follow Calcit's nominal types, traits, method-oriented capabilities, typed effects, and real-time application model.

--- a/docs/features/macros.md
+++ b/docs/features/macros.md
@@ -10,7 +10,7 @@ aliases:
 ---
 # Macros
 
-Like Clojure, Calcit uses macros to support new syntax. And macros ared evaluated during building to expand syntax tree. A `defmacro` block returns list and symbols, as well as literals:
+Calcit macros extend the language by transforming syntax trees during preprocessing. A `defmacro` block returns lists, symbols, and literals:
 
 ## Quick Recipes
 
@@ -55,7 +55,7 @@ defmacro swap! (a b)
         reset! ~b ~tmp
 ```
 
-Calcit was not designed to be identical to Clojure, so there are many details here and there.
+Macros operate on Calcit syntax and values; use Calcit examples and macro-expansion tools rather than assuming forms from another language.
 
 ### Macros and Static Analysis
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,20 +10,20 @@ aliases:
 ---
 # Introduction
 
-Calcit is a scripting language that combines the power of Clojure-like functional programming with modern tooling and hot code swapping.
+Calcit is a typed functional language designed for interactive programs, real-time web applications, and concise native scripting.
 
-> An interpreter for Calcit snapshots with hot code swapping support, built with Rust.
+> One language model across a Rust interpreter and JavaScript ES Module output, with state-preserving reload and typed host boundaries.
 
-Calcit is primarily inspired by ClojureScript and designed for interactive development. It can run natively via the Rust interpreter or compile to JavaScript in ES Modules syntax for web development.
+Calcit runs natively through its Rust interpreter and compiles to JavaScript ES Modules for browser and Node.js applications. Its current language model combines immutable persistent data, code-as-data macros, nominal structs and enums, traits and method dispatch, Option/Result composition, pattern matching, static analysis, and typed host boundaries.
 
 ## Key Features
 
 - **Immutable persistent data structures** - All data is immutable by default using ternary tree implementations
-- **Structural editing** - Visual tree-based code editing with Calcit Editor
-- **Hot code swapping** - Live code updates during development without losing state
+- **Nominal types and traits** - Model domain values explicitly and expose capabilities as methods
+- **Hot code swapping** - Live code updates during development without losing application state
 - **JavaScript interop** - Seamless integration with JS ecosystem and ES Modules
 - **Indentation-based syntax** - Alternative to parentheses for cleaner code
-- **Static type analysis** - Compile-time type checking and error detection
+- **Static type analysis** - Compile-time checking across functions, enums, structs, traits, and FFI contracts
 - **MCP (Model Context Protocol)** server - Tool integration for AI assistants
 - **Fast compilation** - Rust-based interpreter with excellent performance
 
@@ -41,20 +41,20 @@ cargo install calcit
 
 Calcit experiments with several interesting ideas:
 
-- **Code as data** - Code is stored in EDN snapshot files (`.cirru`), enabling structural editing and powerful metaprogramming
+- **Code as data** - Canonical source is stored in `calcit.cirru`, enabling structural CLI edits and metaprogramming
 - **Pattern matching** - Tagged unions and enum types with compile-time validation
 - **Type inference** - Static analysis without requiring extensive type annotations
-- **Incremental compilation** - Hot reload with `.compact-inc.cirru` for fast iteration
+- **Deterministic updates** - Keep business-state transitions serial and explicit while asynchronous work remains at system boundaries
 - **Ternary tree collections** - Custom persistent data structures optimized for performance
-- **File-as-key/value model** - MCP server integration uses Markdown docs as knowledge base
+- **Typed capabilities** - Traits and method-oriented APIs keep reusable behavior explicit without erasing domain types
 
-Most other features are inherited from ClojureScript. Calcit-js is commonly used for web development with [Respo](https://respo-mvc.org/), a virtual DOM library migrated from ClojureScript.
+One central Calcit use case is a real-time application built with [Respo](https://respo-mvc.org/), Recollect, WebSocket modules, and [Calcium Workflow](https://github.com/Cumulo/calcium-workflow): the browser sends typed operations, the server applies deterministic state updates, and revisioned diff/patch messages incrementally synchronize client projections. See [Real-time Application Model](intro/realtime-applications.md).
 
 ## Use Cases
 
-- **Web development** - Compile to JS and use with Respo or other frameworks
+- **Real-time web applications** - Share typed operations and revisioned incremental projections across browser and server
 - **Scripting** - Fast native execution for CLI tools and automation
 - **Interactive development** - REPL-driven development with hot code swapping
-- **Teaching** - Clean syntax and structural editor for learning functional programming
+- **Typed native modules** - Expose system capabilities through C FFI while preserving typed Calcit APIs
 
-For more details, see [Overview](intro/overview.md) and [From Clojure](intro/from-clojure.md).
+For more details, see [Overview](intro/overview.md), [Real-time Application Model](intro/realtime-applications.md), and [Historical Influences and Migration Notes](intro/from-clojure.md).

--- a/docs/intro/from-clojure.md
+++ b/docs/intro/from-clojure.md
@@ -1,43 +1,44 @@
 ---
-title: "Features from Clojure"
+title: "Historical Influences and Migration Notes"
 scope: "core"
 kind: "guide"
 category: "intro"
 aliases:
-  - "clojure dialect"
-  - "clojurescript dialect"
+  - "clojure migration"
+  - "clojurescript migration"
   - "from clojure"
 ---
-# Features from Clojure
+# Historical Influences and Migration Notes
 
-Calcit is mostly a ClojureScript dialect. So it should also be considered a Clojure dialect.
+Early Calcit borrowed important ideas from Clojure and ClojureScript, including immutable persistent data, namespaces, code-as-data macros, higher-order functions, and interactive development. That history can help readers recognize some surface concepts, but it no longer defines the language.
 
-There are some significant features Calcit is learning from Clojure,
+Modern Calcit has its own semantic center:
 
-- Runtime persistent data by default, you can only simulate states with `Ref`s.
-- Namespaces
-- Hygienic macros(although less powerful)
-- Higher order functions
-- Keywords, although Calcit changed the name to "tag" since `0.7`
-- Compiles to JavaScript, interops
-- Hot code swapping while code modified, and trigger an `on-reload` function
-- HUD for JavaScript errors
+- nominal structs and enums with validated construction and pattern matching;
+- traits, implementations, and method-oriented capability APIs;
+- static type analysis with generics, Option, Result, and explicit Dynamic boundaries;
+- canonical Cirru source snapshots and structural CLI editing;
+- native Rust execution, typed C FFI capabilities, and JavaScript ES Module output;
+- deterministic real-time application updates with revisioned diff/patch synchronization.
 
-Also there are some differences:
+Do not assume a Clojure form, argument order, collection delimiter, polymorphism rule, or host interop behavior applies to Calcit. Query Calcit directly:
 
-| Feature           | Calcit                                           | Clojure                                      |
-| ----------------- | ------------------------------------------------ | -------------------------------------------- |
-| Host Language     | Rust, and use `dylib`s for extending             | Java/Clojure, import Mavan packages          |
-| Syntax            | Indentations / Syntax Tree Editor                | Parentheses                                  |
-| Persistent data   | unbalanced 2-3 Tree, with tricks from FingerTree | HAMT / RRB-tree                              |
-| Package manager   | `git clone` to a folder                          | Clojars                                      |
-| bundle js modules | ES Modules, with ESBuild/Vite                    | Google Closure Compiler / Webpack            |
-| operand order     | at first                                         | at last                                      |
-| Polymorphism      | at runtime, slow `.map ([] 1 2 3) f`             | at compile time, also supports multi-arities |
-| REPL              | only at command line: `calcit eval "+ 1 2"`          | a real REPL                                  |
-| `[]` syntax       | `[]` is a built-in function                      | builtin syntax                               |
-| `{}` syntax       | `{} (:a b)` is macro, expands to `&{} :a :b`     | builtin syntax                               |
+```bash
+calcit query examples calcit.core/map
+calcit query type "'String"
+calcit docs search trait
+```
 
-also Calcit is a one-person language, it has too few features compared to Clojure.
+Useful migration differences include:
 
-Calcit shares many paradiams I learnt while using ClojureScript. But meanwhile it's designed to be more friendly with ES Modules ecosystem.
+| Area | Calcit behavior |
+| --- | --- |
+| Source syntax | Cirru indentation, `$`, and local parentheses build syntax trees; `[]`, `{}`, and `#{}` are constructor symbols |
+| Collection transforms | Collection arguments generally come before callbacks, such as `map xs f` |
+| Domain values | Prefer nominal `defstruct` and `defenum` definitions over untyped map/tag conventions |
+| Polymorphism | Prefer traits and methods, with explicit trait calls for disambiguation |
+| Recoverable absence/failure | Use Option and Result methods and matching rather than nil/exception conventions |
+| Native extension | Typed C FFI modules expose capabilities through Calcit-facing APIs |
+| Web applications | JavaScript ES Modules, Respo projections, and revisioned WebSocket synchronization are first-class ecosystem patterns |
+
+This page is intentionally a migration aid, not the primary explanation of Calcit. New documentation should introduce Calcit concepts on their own terms and use comparisons only when they prevent a concrete migration mistake.

--- a/docs/intro/indentation-syntax.md
+++ b/docs/intro/indentation-syntax.md
@@ -19,7 +19,7 @@ When using the MCP (Model Context Protocol) server, each documentation or code f
 
 # Indentation-based Syntax
 
-Calcit was designed based on tools from [Cirru Project](http://cirru.org/), which means, it's suggested to be programming with [Calcit Editor](https://github.com/calcit-lang/editor/). It emits the canonical `calcit.cirru` source snapshot. The data is written in [Cirru EDN](https://github.com/Cirru/cirru-edn#syntax), Clojure EDN but based on Cirru Syntax.
+Calcit source uses tools from the [Cirru Project](http://cirru.org/). The canonical `calcit.cirru` snapshot is written as Cirru EDN and can be inspected or updated through Calcit CLI query/edit/tree commands. Cirru EDN is Calcit's typed interchange notation expressed with Cirru syntax.
 
 For Cirru Syntax, read <http://text.cirru.org/>, and you may find a live demo at <http://repo.cirru.org/parser.coffee/>. A normal snippet looks like: this
 

--- a/docs/intro/overview.md
+++ b/docs/intro/overview.md
@@ -10,22 +10,26 @@ aliases:
 ---
 # Overview
 
-- Immutable Data
+## Immutable values and deterministic state
 
-Values and states are represented in different data structures, which is the semantics from functional programming. Internally it's [im](https://crates.io/crates/im) in Rust and a custom [finger tree](https://github.com/calcit-lang/ternary-tree.ts) in JavaScript.
+Calcit uses persistent immutable collections in both the Rust interpreter and JavaScript output. Application state changes are expressed as explicit operations passed through a deterministic updater. This keeps replay, diffing, hot reload, and synchronization understandable.
 
-- Lisp(Code is Data)
+## Nominal domain modeling
 
-Calcit-js was designed based on experiences from ClojureScript, with a bunch of builtin macros. It offers similar experiences to ClojureScript. So Calcit offers much power via macros, while keeping its core simple.
+Structs and enums describe application data and protocol envelopes. Pattern matching validates enum variants, while Option and Result make missing values and recoverable failures explicit. Static analysis preserves these relationships through function calls and collection operations.
 
-- Indentations
+## Traits and method-oriented capabilities
 
-With the `calcit` command, Calcit code can be written as an indentation-based language directly. So you don't have to match parentheses like in Clojure. It also means now you need to handle indentations very carefully.
+Traits describe capabilities independently from concrete data representation. Public APIs generally expose those capabilities as methods, with explicit trait calls available when dispatch needs disambiguation. This is the preferred extension model for collections, typed host objects, and reusable application abstractions.
 
-- Hot code swapping
+## Code as data with Cirru syntax
 
-Calcit was built with hot swapping in mind. Combined with [calcit-editor](https://github.com/calcit-lang/editor), it watches code changes by specifying `-w`, and re-runs program on updates. For calcit-js, it works with Vite and Webpack to reload, learning from Elm, ClojureScript and React.
+Calcit macros transform syntax trees. Source is stored canonically in `calcit.cirru` and written with indentation, `$`, and local parentheses rather than delimiter-heavy collection syntax. CLI tree operations can inspect and update this source structurally.
 
-- ES Modules Syntax
+## Native and JavaScript execution
 
-To leverage the power of modern browsers with help of Vite, we need another ClojureScript that emits `import`/`export` for Vite. Calcit-js does this! And this page is built with Calcit-js as well, open Console to find out more.
+The Rust interpreter supports native scripts and typed C FFI modules. JavaScript codegen emits ES Modules for browser and Node.js ecosystems. Both paths aim to preserve the same Calcit semantics while keeping host-specific effects at explicit boundaries.
+
+## Interactive real-time applications
+
+Calcit hot reload is designed to preserve running application state. In Calcium-style applications, a serial server updater produces typed client projections, Recollect computes structural differences, and revision/ack/resync messages keep browser state convergent over WebSocket. See [Real-time Application Model](realtime-applications.md).

--- a/docs/intro/realtime-applications.md
+++ b/docs/intro/realtime-applications.md
@@ -1,0 +1,51 @@
+---
+title: "Real-time Application Model"
+scope: "core"
+kind: "guide"
+category: "intro"
+aliases:
+  - "calcium workflow"
+  - "realtime web"
+  - "websocket diff patch"
+  - "incremental synchronization"
+---
+# Real-time Application Model
+
+Calcit's primary web-application model is a stateful real-time system rather than a collection of unrelated framework conventions. [Calcium Workflow](https://github.com/Cumulo/calcium-workflow) is the reference template for this design.
+
+## One deterministic state transition path
+
+The server receives a typed operation and applies it through one serial updater. Business state transitions stay synchronous and deterministic. Timers, WebSocket transport, filesystem access, HTTP, and other asynchronous capabilities deliver events back to that path instead of mutating application state concurrently.
+
+## Typed protocol boundaries
+
+Untrusted WebSocket EDN is decoded once into nominal client/server message enums. Revisions, operations, snapshots, patch batches, and recoverable decode failures remain typed after that boundary. Dynamic is appropriate at host and wire boundaries, not throughout updater or projection code.
+
+## Projection before transport
+
+The server derives a client-visible projection from authoritative state. Respo renders the browser view, while Recollect provides structural diff/patch operations for incremental synchronization. Projection functions and memoization must remain pure and deterministic so unchanged state does not produce artificial patches.
+
+## Revision, acknowledgement, and resynchronization
+
+Every snapshot and patch belongs to a monotonic revision. A patch states its base revision; the client applies it only when that base matches local state and acknowledges successful advancement. Missing, invalid, reordered, or oversized patches trigger a full snapshot rather than allowing silent divergence.
+
+## Bounded asynchronous work
+
+Ordinary dispatches coalesce briefly so rapid operations produce one incremental update. Backpressure retries use a separate, slower schedule. Native async FFI queues are bounded and cancellable, and transport outcomes are typed so accepted, backpressured, oversized, and closed sends cannot be confused.
+
+## Observable convergence
+
+Application metrics should cover diff latency, patch bytes, pending acknowledgements, resyncs, and slow-client state. Transport metrics should cover queue depth, queued bytes, age, retries, and disconnect causes. Fault-injection tests should verify skipped patches, reconnects, background recovery, and slow readers converge to the latest snapshot.
+
+## Design consistency
+
+When adding a language or ecosystem feature for this model:
+
+- strengthen nominal types and traits before adding ad hoc syntax;
+- expose reusable capabilities primarily as methods;
+- preserve one deterministic business-state path;
+- keep host effects and Dynamic values at documented boundaries;
+- prefer revisioned, testable protocols over implicit timing assumptions;
+- validate changes in Calcium Workflow and at least one real application such as TopixIM or Timegrass.
+
+These principles also guide Calcit core, Respo, Recollect, `calcit-wss`, `ws-edn.calcit`, `cumulo-util.calcit`, and related native modules. Each project owns a specific layer, but the combined application model should remain coherent.

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -79,7 +79,7 @@ calcit eval "echo |done"
 
 - **Numbers**: `1`, `3.14`
 - **Strings**: `|text`, `"|with spaces"`, `"\"escaped"`(old style)
-- **Tags**: `:keyword` (immutable strings, like Clojure keywords)
+- **Tags**: `:keyword` (interned immutable identifiers for fields, variants, and protocol labels)
 - **Lists**: `[] 1 2 3`
 - **HashMaps**: `{} (:a 1) (:b 2)`
 - **HashSets**: `#{} :a :b :c`

--- a/docs/run/agent-advanced.md
+++ b/docs/run/agent-advanced.md
@@ -125,8 +125,8 @@ echo 'range 10' | calcit exec
 
 ## Calcit 与 Cirru 的关系
 
-- **Calcit** 是编程语言本身（一门类似 Clojure 的函数式编程语言）
-- **Cirru** 是语法格式（缩进风格的 S-expression，类似去掉括号改用缩进的 Lisp）
+- **Calcit** 是编程语言本身，当前语义中心包括 nominal struct/enum、trait 与方法、Option/Result、静态分析及 typed FFI。
+- **Cirru** 是表达 Calcit syntax tree 的缩进语法格式，通过缩进、`$` 与局部圆括号组织节点。
 - **关系**：Calcit 代码使用 Cirru 语法书写和存储
 
 **具体体现：**
@@ -221,8 +221,8 @@ echo 'range 10' | calcit exec
 比较容易犯的错误：
 
 - Calcit 中只有保留 `|` 前缀的 token 才是 string；`|x` 对应 JavaScript 字符串 `"x"`。双引号只负责保护含空格的 token，`"x"` 仍是 symbol。
-- Calcit 采用 Cirru 缩进语法，可以理解成去掉跨行括号改用缩进的 Lisp 变种。用 `calcit cirru parse` 和 `calcit cirru format` 互相转化试验。
-- Calcit 跟 Clojure 在语义上比较像，但 Cirru 主要用缩进、`$` 和圆括号建立 child list；`[]`、`{}`、`#{}` 是集合构造符号，不是包围内容的 delimiter。
+- Calcit 采用 Cirru 缩进语法；用 `calcit cirru parse` 和 `calcit cirru format` 观察语法树与格式化结果，不要从其他语言的 delimiter 规则猜测结构。
+- Cirru 主要用缩进、`$` 和圆括号建立 child list；`[]`、`{}`、`#{}` 是 Calcit 集合构造符号，不是包围内容的 delimiter。
 
 ## 开发调试
 
@@ -722,7 +722,9 @@ calcit tree replace 'app.core/checkout' --path @3.2.1 --code 'quote calculate-di
 
 ---
 
-## 💡 Calcit vs Clojure 关键差异
+## 💡 Migration notes for Clojure users
+
+本节只用于避免迁移时的具体误判，不作为 Calcit 的语言定义。新代码应以 Calcit 的 nominal types、traits/methods、Option/Result 和 typed boundaries 为准。
 
 **语法层面：**
 

--- a/docs/run/bundle-mode.md
+++ b/docs/run/bundle-mode.md
@@ -21,7 +21,7 @@ calcit eval "+ 1 2"
 
 If you prefer to write Calcit code without the calcit-editor, that's possible too. See the example in [minimal-calcit](https://github.com/calcit-lang/minimal-calcit).
 
-Calcit code can be written using indentation-based syntax. This means you don't need to match parentheses as in Clojure, but you must pay close attention to indentation.
+Calcit code uses indentation-based Cirru syntax, where indentation, `$`, and local parentheses determine syntax-tree structure. Format and inspect the tree with Calcit CLI commands rather than guessing structure from visual layout alone.
 
 Use a `calcit.cirru` file with the `calcit` command to run the program. Retired `compact.cirru` inputs must be migrated first.
 

--- a/docs/structural-editor.md
+++ b/docs/structural-editor.md
@@ -16,7 +16,7 @@ id: core/structural-editor
 
 As demonstrated in [Cirru Project](http://cirru.org/), it's for higher goals of auto-layout code editor. [Calcit Editor](https://github.com/calcit-lang/editor) was incubated in Cirru.
 
-Structural editing makes Calcit a lot different from existing languages, even unique among Lisps.
+Structural editing follows directly from Calcit's canonical syntax-tree source model: definitions and internal nodes can be queried, validated, and changed without treating source as unstructured text.
 
 Calcit Editor uses `calcit.cirru` as the canonical snapshot file. The retired `compact.cirru` filename must be migrated before current tools can load it.
 Example of a `calcit.cirru` file is more readable:

--- a/editing-history/202608300019-calcit-design-narrative.md
+++ b/editing-history/202608300019-calcit-design-narrative.md
@@ -1,0 +1,22 @@
+# Calcit design narrative and real-time application model / Calcit 设计叙事与实时应用模型
+
+## Summary / 概要
+
+- Repositioned Calcit as its own typed functional language rather than a ClojureScript dialect.
+- 将 Calcit 重新定位为独立的 typed functional language，不再以 ClojureScript dialect 作为主要身份。
+- Rewrote the README, introduction, overview, and feature hub around nominal structs/enums, traits and methods, Option/Result, static analysis, typed FFI, canonical Cirru source, and deterministic state updates.
+- README、introduction、overview 与 feature hub 改为围绕 nominal struct/enum、trait/method、Option/Result、静态分析、typed FFI、canonical Cirru source 与确定性状态更新组织。
+- Converted the former Clojure comparison page into a historical influence and migration aid. Comparisons remain only where they prevent a concrete migration mistake.
+- 原 Clojure 对比页改为历史影响与迁移提示；仅在防止具体迁移误判时保留比较。
+- Added a real-time application model centered on Calcium Workflow, Respo, Recollect, typed WebSocket envelopes, revision/ack/resync, bounded async work, observability, and convergence testing.
+- 新增以 Calcium Workflow、Respo、Recollect、typed WebSocket envelope、revision/ack/resync、有界异步、可观测性与收敛测试为中心的实时应用模型。
+- Updated agent, syntax, Tag, macro, bundle, and structural-source wording so supporting docs follow the same design vocabulary.
+- 更新 agent、syntax、Tag、macro、bundle 与 structural-source 文案，使辅助文档采用一致的设计词汇。
+- Added the same language-positioning, Calcium architecture, method-first API, cross-project validation, and bilingual tracking policy to `AGENTS.md` so future work keeps the direction.
+- 将语言定位、Calcium architecture、method-first API、跨项目验证及双语追踪规则写入 `AGENTS.md`，使后续工作持续遵循该方向。
+
+## Policy / 约束
+
+Future documentation should explain Calcit concepts on their own terms. Historical comparisons are migration aids, not design authorities. Language and ecosystem changes for web applications should preserve one coherent Calcium-style model: typed boundaries, serial deterministic business updates, pure projections, revisioned incremental synchronization, bounded effects, and observable convergence.
+
+后续文档应直接解释 Calcit 自身概念；历史比较只用于迁移，不作为设计依据。面向 Web 应用的语言和生态改动应保持一致的 Calcium 模型：typed boundary、串行确定性业务更新、纯 projection、revisioned incremental synchronization、有界 effect 与可观测收敛。


### PR DESCRIPTION
## Summary / 概要

- Reposition Calcit as its own typed functional programming language instead of a ClojureScript dialect.
- 将 Calcit 重新定位为独立的 typed functional programming language，不再以 ClojureScript dialect 作为主要身份。
- Rewrite README, Introduction, Overview, and Features around nominal structs/enums, traits and methods, Option/Result, static analysis, typed FFI, canonical Cirru source, and cross-backend semantics.
- README、Introduction、Overview 与 Features 改为围绕 nominal struct/enum、trait/method、Option/Result、静态分析、typed FFI、canonical Cirru source 与跨 backend 语义组织。
- Convert the former Clojure comparison page into historical influences and concrete migration notes. Remaining comparisons are limited to preventing specific migration mistakes.
- 原 Clojure 对比页改为历史影响与具体迁移提示；其他比较仅用于防止明确的迁移误判。
- Add a Calcium Workflow-centered real-time application model covering typed operations/envelopes, serial deterministic updates, Respo/Recollect projection and diff/patch, revision/ack/resync, bounded async work, observability, and convergence testing.
- 新增以 Calcium Workflow 为中心的实时应用模型，覆盖 typed operation/envelope、串行确定性更新、Respo/Recollect projection 与 diff/patch、revision/ack/resync、有界异步、可观测性与收敛测试。
- Persist the same policy in `AGENTS.md`: method-first public capabilities, typed boundaries before added syntax, Calcium/TopixIM validation, and bilingual Issues/PRs.
- 将相同约束写入 `AGENTS.md`：公共能力 method-first、先 typed boundary 后新增语法、Calcium/TopixIM 验证及双语 Issue/PR。

## Validation / 验证

- `calcit docs graph check`: 25 nodes, 53 edges, passed.
- `calcit docs graph check`：25 nodes、53 edges，通过。
- Full `CI=true ./scripts/check-docs-md.sh`: 60/60 Markdown files passed.
- 完整 `CI=true ./scripts/check-docs-md.sh`：60/60 Markdown 文件通过。
- `git diff --check` passed.
- `git diff --check` 通过。

Tracks #522.
Related to #501 and Cumulo/calcium-workflow#33.
