### PR TITLE
fix: preserve named constructors in JS / 修复 JS 具名构造器引用

### DIFF
--- a/editing-history/202608300044-direct-enum-js-codegen.md
+++ b/editing-history/202608300044-direct-enum-js-codegen.md
@@ -1,0 +1,33 @@
+# Direct named data constructors in JS codegen
+
+## Context / 背景
+
+Direct named enum calls such as `schema/Op :effect/ping` were lowered with an
+embedded compiler-only definition value. The native evaluator accepted that
+value, but JS codegen panicked because no runtime module reference remained.
+
+直接调用具名枚举（例如 `schema/Op :effect/ping`）时，预处理曾把编译期类型定义嵌入
+运行时代码。Native evaluator 可以处理该值，但 JS codegen 因缺少模块引用而 panic。
+
+## Change / 修改
+
+- Preserve the `(namespace, definition)` path from a preprocessed `Import`
+  when lowering direct Struct and Enum constructor calls.
+- Emit a regular codegen error for leaked compiler-only values instead of
+  reaching an `unreachable!` panic.
+- Cover import-path preservation and the non-panicking diagnostic with unit
+  tests.
+
+- 直接 Struct/Enum 构造器降级时保留预处理后 `Import` 的命名空间与定义路径。
+- 编译期专用值意外进入 codegen 时返回普通诊断，不再触发 `unreachable!`。
+- 增加引用路径保留及无 panic 错误路径的单元测试。
+
+## Verification / 验证
+
+- Targeted Rust tests pass.
+- A Calcium Workflow copy using direct cross-namespace `schema/Op` construction
+  completes full server-side JS emission with the patched release compiler.
+
+- Rust 定向测试通过。
+- 使用跨命名空间 `schema/Op` 直接构造的 Calcium Workflow 副本，已用修复后的
+  release 编译器完整完成 server JS 输出。

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -411,7 +411,9 @@ fn to_js_code(
         Ok(format!("new {proc_prefix}CalcitCirruQuote({})", cirru_to_js(code)?))
       }
       Calcit::RawCode(_, code) => Ok((**code).to_owned()),
-      a => unreachable!("[Error] unknown kind to gen js code: {}", a),
+      a => Err(format!(
+        "cannot emit JS for compiler-only value `{a}`; preprocessing should lower data definitions to runtime references"
+      )),
     };
 
     match (return_label, &ret) {
@@ -2632,6 +2634,27 @@ mod tests {
 
     assert!(failure.contains("raw syntax node `if`"), "unexpected error: {failure}");
     assert!(failure.contains("LLM hint"), "unexpected error: {failure}");
+  }
+
+  #[test]
+  fn compiler_only_values_fail_js_codegen_without_panicking() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let struct_def = calcit::CalcitStructDef::from_fields(EdnTag::from("Op"), vec![]);
+
+    let failure = to_js_code(
+      &Calcit::StructDef(struct_def),
+      "tests.emit-js",
+      &local_defs,
+      &file_imports,
+      &tags,
+      None,
+    )
+    .expect_err("compiler-only data definitions should be rejected in JS codegen");
+
+    assert!(failure.contains("compiler-only value"), "unexpected error: {failure}");
+    assert!(failure.contains("runtime references"), "unexpected error: {failure}");
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2722,7 +2722,12 @@ fn try_rewrite_struct_enum_constructor_head_call(
       }
     }
 
-    let struct_ref_node = build_struct_ref_node(&struct_def, ns_def_path, file_ns, def_name);
+    // `resolve_type_value` intentionally describes the definition value, but
+    // that annotation does not always retain its source path. Keep the
+    // already-resolved Import from the call head so JS codegen receives a
+    // runtime reference instead of an embedded compiler-only StructDef.
+    let constructor_path = constructor_definition_path(head_form).or(ns_def_path);
+    let struct_ref_node = build_struct_ref_node(&struct_def, constructor_path, file_ns, def_name);
     let mut struct_items: Vec<Calcit> = Vec::with_capacity(struct_def.fields.len() * 2 + 2);
     struct_items.push(Calcit::Proc(CalcitProc::NativeStruct));
     struct_items.push(struct_ref_node);
@@ -2803,7 +2808,11 @@ fn try_rewrite_struct_enum_constructor_head_call(
       return Ok(None);
     }
 
-    let enum_ref_node = build_enum_ref_node(enum_def, ns_def_path, file_ns, def_name);
+    // Direct `Op :variant` calls reach here with an Import head. Preserve its
+    // namespace/definition path: lowering to an embedded enum prototype works
+    // in the native evaluator but cannot be emitted as JavaScript.
+    let constructor_path = constructor_definition_path(head_form).or(ns_def_path);
+    let enum_ref_node = build_enum_ref_node(enum_def, constructor_path, file_ns, def_name);
     let mut items: Vec<Calcit> = Vec::with_capacity(args.len() + 1);
     items.push(Calcit::Proc(CalcitProc::NativeNamedEnumNew));
     items.push(enum_ref_node);
@@ -2813,6 +2822,13 @@ fn try_rewrite_struct_enum_constructor_head_call(
   }
 
   Ok(None)
+}
+
+fn constructor_definition_path(head_form: &Calcit) -> Option<(Arc<str>, Arc<str>)> {
+  match head_form {
+    Calcit::Import(CalcitImport { ns, def, .. }) => Some((ns.clone(), def.clone())),
+    _ => None,
+  }
 }
 
 fn data_definition_kind(ns: &str, def: &str) -> Option<&'static str> {
@@ -10290,6 +10306,25 @@ mod tests {
     }
     assert_eq!(*items.get(2).expect("tag key"), Calcit::Tag(EdnTag::from("ok")));
     assert_eq!(items.len(), 3);
+  }
+
+  #[test]
+  fn preserves_import_path_for_direct_named_enum_constructor() {
+    let head = Calcit::Import(CalcitImport {
+      ns: Arc::from("tests.schema"),
+      def: Arc::from("Op"),
+      info: Arc::new(ImportInfo::NsAs {
+        alias: Arc::from("schema"),
+        at_ns: Arc::from("tests.consumer"),
+        at_def: Arc::from("make-op"),
+      }),
+      def_id: Some(7),
+    });
+
+    assert_eq!(
+      constructor_definition_path(&head),
+      Some((Arc::from("tests.schema"), Arc::from("Op")))
+    );
   }
 
   #[test]


### PR DESCRIPTION
## 中文

修复 #524：直接调用具名 Enum/Struct 构造器时，预处理现在会保留已解析 `Import` 的命名空间与定义路径，避免把编译期类型定义对象嵌入 JS 运行时代码。

同时将 JS codegen 对意外编译期值的 `unreachable!` 改为普通错误诊断，确保类似预处理不变量失效时不会再导致编译器 panic。

验证：

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`（583 + 266 + 24 + 20）
- `yarn compile`
- `yarn check-agent-interface`（17/17）
- Core tests（223/223）、IR、WASM 及路径基准检查
- 使用修复后的 release 编译器，在 Calcium Workflow 副本中把 `%:: schema/Op :session/connect` 改为 `schema/Op :session/connect`，server JS 全量输出成功

说明：本地 `yarn check-all` 的 `try-js` 阶段仍引用既有旧路径 `js-out/main.mjs`，而当前产物为 `js-out/app.main.mjs`；使用仓库自身的 `yarn procs-link` 后，正确入口运行成功。该测试脚本问题与本修复无关。

## English

Fixes #524. Preprocessing now preserves the resolved `Import` namespace and definition path when lowering direct named Enum/Struct constructor calls, instead of embedding a compiler-only data definition in JavaScript runtime code.

JS codegen also returns a regular diagnostic for leaked compiler-only values instead of reaching `unreachable!`, so a future preprocessing invariant failure cannot crash the compiler in this path.

Verification:

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test` (583 + 266 + 24 + 20)
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- Core tests (223/223), IR, WASM, and literal-path checks
- A Calcium Workflow copy was changed from `%:: schema/Op :session/connect` to `schema/Op :session/connect`; full server-side JS emission succeeds with the patched release compiler

Note: local `yarn check-all` still has a pre-existing `try-js` path mismatch: it invokes `js-out/main.mjs`, while the current compiler emits `js-out/app.main.mjs`. After the repository's `yarn procs-link`, the correct generated entry runs successfully. That harness issue is independent of this fix.
