### PR TITLE
docs: center operational guidance on Calcit / 以 Calcit 自身语义整理操作文档

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -336,7 +336,7 @@ div
 ### 5.2 高频字面量与求值陷阱
 
 - `hello` 是 symbol，`|hello` 是 string，`:hello` 是 tag；字符串必须保留 `|`。含空格写 `"|hello world"`，其中双引号只保护一个含空格 token，单独写 `"hello"` 仍是 symbol。
-- `[]`、`{}`、`#{}` 是 Calcit 的集合构造符号，不是 Clojure/JSON 的包围定界符。作为普通参数的裸 `[]` 是函数值，不是空 list；可靠写法是先 `init $ []` 再传 `init`，或显式使用 `([])`。
+- `[]`、`{}`、`#{}` 是 Calcit 的集合构造符号，不是包围源码的定界符。作为普通参数的裸 `[]` 是函数值，不是空 list；可靠写法是先 `init $ []` 再传 `init`，或显式使用 `([])`。
 - `let` bindings 必须是 pair list：单行写 `let ((x 1)) ...`；多行时 bindings 比 body 多缩进一层：
 
   ```cirru.no-check
@@ -346,7 +346,7 @@ div
     + x y
   ```
 
-- `map`、`filter`、`foldl` 等 Calcit 集合函数把集合放在前面；不确定参数顺序时运行 `calcit query examples calcit.core/map` 或查询对应定义，不要套用 Clojure 记忆。
+- `map`、`filter`、`foldl` 等 Calcit 集合函数把集合放在前面；不确定参数顺序时运行 `calcit query examples calcit.core/map` 或查询对应定义，以当前签名和示例为准。
 - 改动缩进、`$`、`,` 或圆括号都会改变 AST 和 path；修改后重新 show/search，或继续使用 cursor。
 
 ### 5.3 可选参数优先使用 `Option`
@@ -511,7 +511,7 @@ calcit docs read-lines agent-advanced.md --start 1 --lines 80
 | ---------------------------- | --------------------------------------------------------------- |
 | Cirru 语法、AST 与常见误写   | `calcit cirru show-guide`；`calcit docs read cirru-syntax.md 'Common Mistakes'` |
 | Cirru EDN 数据层             | `calcit cirru parse-edn --help`；`calcit docs read edn.md --full`       |
-| 从 Clojure 迁移时的易错点    | `calcit docs read agent-advanced.md 'Migration notes for Clojure users'` |
+| 历史影响与迁移说明          | `calcit docs read from-clojure.md --full`                              |
 | tree/cursor/transaction      | `calcit docs read edit-tree.md --full`                              |
 | query/context/type-at        | `calcit docs read query.md --full`                                  |
 | 复杂重构与历史陷阱           | `calcit docs read agent-advanced.md --full`                         |

--- a/docs/cirru-syntax.md
+++ b/docs/cirru-syntax.md
@@ -108,7 +108,7 @@ fn (x)
 
 ### 5. Collection Constructors Are Operators
 
-`[]`, `{}`, and `#{}` are Calcit constructor symbols, not Clojure/JSON delimiters around source text. As a same-line argument, bare `[]` is the constructor function, not an empty list value:
+`[]`, `{}`, and `#{}` are Calcit constructor symbols rather than delimiters around source text. As a same-line argument, bare `[]` is the constructor function, not an empty list value:
 
 ```text
 type-of []       => :fn
@@ -186,7 +186,7 @@ Calcit uses strict arity checking. Many core functions like `+`, `-`, `*`, `/` h
 
 ### 5. No Inline Types in Parameters
 
-Calcit **does not** support Clojure-style `(defn name [^Type arg] ...)`.
+Calcit keeps parameter lists structural and declares types in function schemas rather than inline parameter metadata.
 
 - ❌ `defn add (a :number) ...`
 - ✅ Use function schema for parameter types (`:schema` on top-level defs, `hint-fn` for local `fn`).
@@ -291,7 +291,7 @@ When providing JSON:
 - Wrong bare indented return `x`; correct `, x`. The bare line is a one-child call list.
 - Wrong `let (x 1) ...`; correct `let ((x 1)) ...`, or use the documented multiline binding indentation.
 - Wrong empty-list argument `foldl xs [] f`; correct `foldl xs ([]) f`, or bind `init $ []` first.
-- Wrong Clojure order `map f xs`; correct Calcit order `map xs f`.
+- Wrong collection order `map f xs`; correct Calcit order `map xs f`.
 - Wrong `$ a b c` at the beginning of a line; correct `a b c`. A line is already an expression.
 - Wrong `a$b`; correct `a $ b`. Operators require token-separating spaces.
 - Wrong JSON AST `["&+", 1, 2]`; correct `["&+", "1", "2"]`. AST leaves are strings.

--- a/docs/run/agent-advanced.md
+++ b/docs/run/agent-advanced.md
@@ -722,26 +722,25 @@ calcit tree replace 'app.core/checkout' --path @3.2.1 --code 'quote calculate-di
 
 ---
 
-## 💡 Migration notes for Clojure users
+## 💡 Calcit 语义检查点
 
-本节只用于避免迁移时的具体误判，不作为 Calcit 的语言定义。新代码应以 Calcit 的 nominal types、traits/methods、Option/Result 和 typed boundaries 为准。
+遇到陌生代码或迁移旧项目时，以 Calcit 当前的 nominal types、traits/methods、Option/Result、typed boundaries 和 CLI 查询结果为准。
 
-**语法层面：**
+**源码结构：**
 
-- **定界方式不同**：`[]`、`{}`、`#{}` 是 Calcit 集合构造符号，不是 Clojure/JSON 那样包住内容的 delimiter；Cirru 主要用缩进、`$` 和圆括号建立 child list
-- **函数前缀**：Calcit 用 `&` 区分内置函数（`&+`、`&str`）和用户定义函数
+- **集合构造符号**：`[]`、`{}`、`#{}` 是普通调用位置上的构造器；Cirru 用缩进、`$` 和圆括号建立 child list
+- **函数前缀**：`&` 标识底层内置操作（如 `&+`、`&str`）；公共能力优先查询普通函数或 trait method
 
 **集合函数参数顺序（易错 ⭐⭐⭐）：**
 
-- **Calcit**: 集合在**第一位** → `map data fn` 或 `-> data (map fn)`
-- **Clojure**: 函数在第一位 → `map fn data` 或 `->> data $ map fn`
-- **症状**：`unknown data for foldl-shortcut` 报错
-- **原因**：误用 `->>` 或参数顺序错误
+- 集合在**第一位**：`map data fn` 或 `-> data (map fn)`
+- `unknown data for foldl-shortcut` 通常表示误用了 `->>` 或颠倒了集合与回调参数
+- 不确定时运行 `calcit query examples calcit.core/map`，不要凭其他语言的调用习惯猜测
 
-**其他差异：**
+**数据与宏：**
 
-- **宏系统**：Calcit 更简洁，缺少 Clojure 的 reader macro（如 `#()`）
-- **数据类型**：Calcit 的 Anonymous Enum (`%:: _`，`::` 为简写) 和 List (`[]`) 有不同用途（见"Cirru 字符串和数据类型"）
+- Anonymous Enum 使用 `%:: _`（`::` 为简写），与 List 构造器 `[]` 语义不同（见“Cirru 字符串和数据类型”）
+- 宏展开遵循 Calcit 的 Cirru AST 与 capability 约束；先用 `query`、`macroexpand` 和现有示例确认结构
 
 ---
 
@@ -859,7 +858,7 @@ calcit query error
 | `unknown symbol: xxx`                    | 符号未定义或未 import                         | `calcit query find` 确认位置，`calcit edit add-import` 引入    |
 | `expects pairs in list for let`          | `let` 绑定语法错误                            | 改为 `let ((x val)) body`（双层括号）                  |
 | `cannot be used as operator`             | 末尾符号被当作函数调用                        | 改用 `, acc` 前缀传递值，或用函数包裹                  |
-| `unknown data for foldl-shortcut`        | 参数顺序错误（Calcit vs Clojure 差异）        | Calcit 集合在第一位：`map data fn`                     |
+| `unknown data for foldl-shortcut`        | 集合与回调参数顺序错误                        | Calcit 集合在第一位：`map data fn`                     |
 | 字符串被拆分成多个 token                 | 含空格字符串没有保留为一个 string token       | 使用上文的 spaced-string 写法                          |
 | `Type warning` 导致 exec 失败            | 类型不匹配（阻断执行）                        | 优先检查 `:schema` / `hint-fn` 的参数标注              |
 | `W_CLI_OPTION_UNKNOWN_KEY`               | 选项 key 拼写错误                             | 对照 Options 列表，如 `:file-path` 而非 `:file-pth`    |

--- a/editing-history/202608300052-calcit-centered-operational-docs.md
+++ b/editing-history/202608300052-calcit-centered-operational-docs.md
@@ -1,0 +1,31 @@
+# Calcit-centered operational documentation
+
+## Context / 背景
+
+The primary documentation was already repositioned around Calcit's nominal
+types, traits/methods, typed boundaries, and Calcium Workflow. A few syntax and
+agent guides still explained ordinary Calcit rules through repeated external
+language comparisons.
+
+入口文档已经围绕 Calcit 的 nominal types、traits/methods、typed boundaries 与
+Calcium Workflow 重整，但部分语法及 Agent 指南仍通过反复对比其他语言来解释普通规则。
+
+## Change / 修改
+
+- Describe collection constructors, schemas, and collection-first argument
+  order directly as Calcit semantics.
+- Replace the broad migration-comparison section in the advanced Agent guide
+  with Calcit semantic checkpoints based on CLI evidence.
+- Keep historical language references only in the dedicated migration page,
+  standard provenance notes, and historical source links.
+
+- 直接以 Calcit 语义说明集合构造器、schema 与集合优先的参数顺序。
+- 将高级 Agent 指南中的大段迁移对照改为基于 CLI 证据的 Calcit 语义检查点。
+- 仅在专门迁移页、标准来源说明和历史资料链接中保留外部语言引用。
+
+## Verification / 验证
+
+`bash scripts/check-docs-md.sh` passes all 60 documentation files and all
+325 checked Cirru blocks.
+
+`bash scripts/check-docs-md.sh` 已通过全部 60 个文档文件及 325 个 Cirru 代码块。


### PR DESCRIPTION
## 中文

继续 #522 / #523 的文档叙事整理，将主语法指南和 Agent 工作流中剩余的日常外部语言对照改为 Calcit 自身规则：

- 直接说明集合构造器、函数 schema 与集合优先参数顺序；
- 将高级 Agent 指南中的大段迁移对照改为“Calcit 语义检查点”，要求以当前签名、示例、query 和 macroexpand 结果为准；
- 主 Agent 路由只把历史影响导向专门迁移页；
- 历史语言引用仅保留在专门迁移页、EDN 标准来源说明和历史资料链接中。

验证：`bash scripts/check-docs-md.sh`，60/60 文档文件、325/325 Cirru 代码块通过。

## English

Continues the documentation narrative cleanup from #522 / #523 by replacing the remaining everyday external-language comparisons in primary syntax and Agent workflow guides with Calcit's own rules:

- describe collection constructors, function schemas, and collection-first argument order directly;
- replace the large migration comparison in the advanced Agent guide with “Calcit semantic checkpoints” grounded in current signatures, examples, query output, and macro expansion;
- route historical influence questions from the main Agent guide to the dedicated migration page;
- keep historical language references only in the dedicated migration page, EDN provenance note, and historical source links.

Verification: `bash scripts/check-docs-md.sh` passes 60/60 documentation files and 325/325 checked Cirru blocks.

Closes the in-repository operational documentation subtask of #522; the ecosystem README audit remains open.
