### PR TITLE
Keep library dependencies WASM-safe / 保持 library 依赖对 WASM 安全

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.97.1
           components: clippy
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,12 +46,15 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 
       - run: cargo test
         env:
           RUST_MIN_STACK: "16777216"
+      - name: "check wasm32 library dependency boundary"
+        run: cargo check --lib --target wasm32-unknown-unknown
       - name: "run definition-attached core tests"
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru test --tag unit
       - run: cargo run --bin calcit -- calcit/test.cirru

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,7 @@ exclude = ["lib/*", "calcit/*", "ts-src/*", "js-out/*", "scripts/*", "docs/*", "
 # cirru_edn = { path = "/Users/chenyong/repo/cirru/edn.rs" }
 # cirru_parser = { path = "/Users/chenyong/repo/cirru/parser.rs" }
 argh = "0.1.19"
-dirs = "6.0.0"
-notify = "8.0.0"
-notify-debouncer-mini = "0.7.0"
-walkdir = "2.5.0"
 hex = "0.4.3"
-fs4 = "1.1.0"
 md-5 = "0.11.0"
 rpds = "1.2.1"
 im_ternary_tree = "0.0.21"
@@ -39,7 +34,6 @@ cirru_edn = "0.8.0"
 cirru_parser = "=0.2.15"
 bisection_key = "0.0.1"
 calcit_native_ffi = { version = "0.1.2", default-features = false }
-ureq = "3.3.0"
 rmp-serde = "1.3.0"
 semver = "1.0.28"
 regex = "1.13.1"
@@ -52,6 +46,12 @@ serde = { version = "1.0.229", features = ["derive"] }
 cirru_parser = "=0.2.15"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+dirs = "6.0.0"
+fs4 = "1.1.0"
+notify = "8.0.0"
+notify-debouncer-mini = "0.7.0"
+ureq = "3.3.0"
+walkdir = "2.5.0"
 libloading = "0.9.0"
 ctrlc = "3.5.2"
 

--- a/editing-history/202608301546-wasm-safe-library-dependencies.md
+++ b/editing-history/202608301546-wasm-safe-library-dependencies.md
@@ -5,6 +5,8 @@
 - Add a CI check that compiles the Calcit library for
   `wasm32-unknown-unknown`, preventing native CLI dependencies from leaking
   back into browser runtimes.
+- Align the Actions toolchain with `rust-toolchain.toml` so the WASM standard
+  library is installed for the compiler Cargo actually uses.
 - Keep the local JS regression command aligned with CI by installing
   `scripts/main.mjs` after code generation, so clean workspaces have a launcher.
 - Validate the boundary through the real `calcit-lang/wasm-play` embedded
@@ -13,6 +15,8 @@
   边界之后。
 - CI 新增 `wasm32-unknown-unknown` Calcit library 编译检查，防止 native CLI
   依赖重新泄漏到浏览器 runtime。
+- 将 Actions 工具链与 `rust-toolchain.toml` 对齐，确保 WASM 标准库安装到
+  Cargo 实际使用的编译器。
 - 将本地 JS 回归命令与 CI 对齐，在代码生成后安装 `scripts/main.mjs`，避免干净工作区
   因缺少启动入口失败。
 - 通过真实 `calcit-lang/wasm-play` 内嵌 runtime 升级验证该边界。

--- a/editing-history/202608301546-wasm-safe-library-dependencies.md
+++ b/editing-history/202608301546-wasm-safe-library-dependencies.md
@@ -1,0 +1,18 @@
+# 2026-08-30 WASM-safe library dependencies / WASM 安全的 library 依赖
+
+- Move CLI-only download, filesystem locking, home-directory, and file-watch
+  dependencies behind the non-wasm target boundary.
+- Add a CI check that compiles the Calcit library for
+  `wasm32-unknown-unknown`, preventing native CLI dependencies from leaking
+  back into browser runtimes.
+- Keep the local JS regression command aligned with CI by installing
+  `scripts/main.mjs` after code generation, so clean workspaces have a launcher.
+- Validate the boundary through the real `calcit-lang/wasm-play` embedded
+  runtime upgrade.
+- 将 CLI 专用的下载、文件锁、home 目录与文件监听依赖移到 non-wasm target
+  边界之后。
+- CI 新增 `wasm32-unknown-unknown` Calcit library 编译检查，防止 native CLI
+  依赖重新泄漏到浏览器 runtime。
+- 将本地 JS 回归命令与 CI 对齐，在代码生成后安装 `scripts/main.mjs`，避免干净工作区
+  因缺少启动入口失败。
+- 通过真实 `calcit-lang/wasm-play` 内嵌 runtime 升级验证该边界。

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "try-core-tests": "cargo run --bin calcit -- src/cirru/calcit-core.cirru test --tag unit --summary-only",
     "try-rs": "cargo run --bin calcit -- calcit/test.cirru",
     "warn-dyn-method": "cargo run --bin calcit -- calcit/test.cirru --warn-dyn-method",
-    "try-js-brk": "cargo run --bin calcit -- calcit/test.cirru js && node --inspect-brk js-out/main.mjs",
-    "try-js": "cargo run --bin calcit -- calcit/test.cirru js && node js-out/main.mjs",
+    "try-js-brk": "cargo run --bin calcit -- calcit/test.cirru js && cp scripts/main.mjs js-out/main.mjs && node --inspect-brk js-out/main.mjs",
+    "try-js": "cargo run --bin calcit -- calcit/test.cirru js && cp scripts/main.mjs js-out/main.mjs && node js-out/main.mjs",
     "try-ir": "cargo run --bin calcit -- calcit/test.cirru ir",
     "try-wasm": "bash scripts/test-wasm.sh"
   },


### PR DESCRIPTION
## Summary / 概要

- keep CLI-only filesystem, download, home-directory, and watcher dependencies outside the `wasm32` library graph
- add a CI `cargo check --lib --target wasm32-unknown-unknown` guard
- make the local JS regression launcher installation match CI so `yarn check-all` works from a clean workspace
- keep native CLI behavior unchanged

- 将 CLI 专用的文件系统、下载、home 目录和监听依赖隔离在 `wasm32` library 依赖图之外
- 新增 CI `cargo check --lib --target wasm32-unknown-unknown` 守门
- 让本地 JS 回归启动文件安装步骤与 CI 一致，确保干净工作区可运行 `yarn check-all`
- 保持 native CLI 行为不变

Closes #528.

## Validation / 验证

- `cargo check --lib --target wasm32-unknown-unknown`
- real `calcit-lang/wasm-play` `wasm-pack build --target web` against this branch
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (17/17)
