### PR TITLE
Diagnose Dynamic Option/Result method receivers / 诊断 Dynamic Option/Result method 接收者

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -48,6 +48,7 @@
 - `E_SCHEMA_DEF_MISMATCH`：定义与 `:schema` 的 `:kind` / `:args` / `:rest` 不匹配
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配
 - `W_METHOD_ARG_TYPE_MISMATCH`：静态方法调用参数类型不匹配
+- `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`：Option/Result method 的接收者仍为 Dynamic，需先收窄或在明确边界使用函数形式
 - `W_PROC_ARG_TYPE_MISMATCH`：内建 proc 参数类型不匹配
 - `W_CORE_FN_ARG_TYPE_MISMATCH`：`calcit.core` 函数参数类型不匹配
 - `W_FN_RETURN_TYPE_MISMATCH`：函数声明返回类型与函数体实际返回类型不匹配

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -255,6 +255,15 @@ them to their internal direct implementations. Direct names such as
 `option:unwrap-or` and `result:unwrap-or` are core implementation details, not
 the public call style.
 
+That rule has one explicit boundary exception: postfix nominal methods require
+a receiver that preprocessing can identify as `Option` or `Result`. If legacy
+data, configuration, or FFI erases the receiver to `Dynamic`, preprocessing
+reports `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`. Add a schema or narrow the value
+before using method syntax; when the boundary intentionally remains Dynamic,
+use the corresponding `option:*` or `result:*` function explicitly. This keeps
+the escape hatch visible and prevents a runtime Option/Result value from being
+evaluated as an operator.
+
 For longer sequential Option pipelines, the experimental `option:let` macro
 reuses the ordinary `let` binding shape and lowers entirely to nested
 `.and-then` calls. Result pipelines use explicit receiver-first `.and-then`

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -252,8 +252,9 @@ do
 
 For a statically known receiver, preprocessing resolves these methods and lowers
 them to their internal direct implementations. Direct names such as
-`option:unwrap-or` and `result:unwrap-or` are core implementation details, not
-the public call style.
+`option:unwrap-or` and `result:unwrap-or` are supported lower-level forms for
+intentional Dynamic boundaries; method syntax remains the preferred public
+style for typed code.
 
 That rule has one explicit boundary exception: postfix nominal methods require
 a receiver that preprocessing can identify as `Option` or `Result`. If legacy

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -423,6 +423,12 @@ get-env-or |mode |release
 `get-in-or`、`first-or`、`last-or`、`nth-or` 同样改为对应查询后调用 `.unwrap-or`。
 fallback 必须与 payload 类型兼容；需要区分缺失分支时改用 `if-let` 或穷尽 `match`。
 
+上述 method 迁移要求查询接收者能静态推断为 `Option<T>`。如果 legacy Map、配置或 FFI
+边界仍把查询结果擦除为 `Dynamic`，检查器会报告 `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`，而不是
+允许代码在运行时把 Option 值误当作 operator。优先为边界补 schema 或先 narrow；确实需要保留
+Dynamic 时，使用明确的函数形式，例如 `option:unwrap-or (get config :port) 6000`。这类函数形式
+只作为未类型化边界逃生口，类型化业务代码仍使用接收者 method。
+
 #### `.trim` / `.blank?` 接收者迁移
 
 `.trim` 与 `.blank?` 只对静态推断为 String 的接收者可用。若错误写成 `unknown method .trim for map`，

--- a/editing-history/202608301729-dynamic-nominal-method-receiver.md
+++ b/editing-history/202608301729-dynamic-nominal-method-receiver.md
@@ -1,0 +1,17 @@
+# Dynamic nominal method receiver diagnostics / Dynamic nominal method 接收者诊断
+
+## 中文
+
+- 修复 #527：当 postfix Option/Result method（如 `.unwrap-or`）的接收者仍为 `Dynamic` 时，预处理器不再静默回退为普通参数调用。
+- 新增 `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`，要求先通过 schema/assertion 收窄接收者；有意保留的 Dynamic 边界可显式使用对应 `option:*` / `result:*` 函数。
+- 诊断只覆盖 Option/Result 的 nominal container methods，其他 Dynamic postfix methods 继续由现有 `--warn-dyn-method` / `analyze dynamic-methods` 策略审计，避免无关兼容性扩大。
+- 补充单元测试、完整 snippet 预处理回归，以及 upgrade/polymorphism 文档。
+- 验证通过：strict rustfmt/clippy、全部 Rust tests、Calcit core 223/223、native/JS/IR/WASM、Agent interface 17/17；使用新编译器检查最新 copyboard 与 calcium-workflow main 均通过。
+
+## English
+
+- Fix #527: when a postfix Option/Result method such as `.unwrap-or` still has a `Dynamic` receiver, preprocessing no longer silently falls back to treating the method token as an ordinary argument.
+- Add `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`, requiring a schema/assertion-based narrowing step; an intentionally Dynamic boundary may explicitly call the corresponding `option:*` / `result:*` function.
+- Scope the unconditional diagnostic to nominal Option/Result container methods. Other Dynamic postfix methods remain under the existing `--warn-dyn-method` / `analyze dynamic-methods` policy to avoid broad unrelated compatibility changes.
+- Add a unit regression, a full snippet preprocessing regression, and upgrade/polymorphism documentation.
+- Verification passes strict rustfmt/clippy, all Rust tests, Calcit core 223/223, native/JS/IR/WASM, and Agent interface 17/17; the new compiler also checks the latest copyboard and calcium-workflow main branches successfully.

--- a/editing-history/202608301737-review-dynamic-method-kind.md
+++ b/editing-history/202608301737-review-dynamic-method-kind.md
@@ -1,0 +1,15 @@
+# Review: keep JS member kinds outside nominal methods / Review：区分 JS member 与 nominal method
+
+## 中文
+
+- 根据 PR #530 review，将 `W_DYNAMIC_NOMINAL_METHOD_RECEIVER` 严格限制为普通 `MethodKind::Invoke`。
+- `.-field` 与 `.!method` 即使命名碰巧是 `unwrap-or`，也属于 JavaScript property/native operation，不应按 Option/Result method 诊断。
+- 增加 Access/InvokeNative 反例测试，并将文档中的 `option:*` / `result:*` 明确描述为 Dynamic 边界支持的低层 API；类型化代码仍优先使用 method。
+- 目标测试、strict clippy 与格式检查通过。
+
+## English
+
+- Follow PR #530 review by restricting `W_DYNAMIC_NOMINAL_METHOD_RECEIVER` to ordinary `MethodKind::Invoke` calls.
+- `.-field` and `.!method` remain JavaScript property/native operations even when their names happen to be `unwrap-or`; they must not be diagnosed as Option/Result methods.
+- Add Access/InvokeNative negative regressions and describe `option:*` / `result:*` as supported lower-level Dynamic-boundary APIs while retaining method syntax as the typed-code preference.
+- Targeted tests, strict clippy, and formatting checks pass.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -224,6 +224,27 @@ fn option_migration_source_calls_fail_during_preprocessing() {
 }
 
 #[test]
+fn dynamic_option_method_receiver_fails_during_preprocessing() {
+  run_with_large_stack(|| {
+    let entries =
+      load_snippet_entries("let\n    m $ unsafe-coerce ({} (:a 1)) 'Dynamic\n    fallback 0\n  (get m :a) .unwrap-or fallback");
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("Dynamic Option method misuse should report before runtime");
+
+    let warnings = warnings.borrow();
+    let matched = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_DYNAMIC_NOMINAL_METHOD_RECEIVER"))
+      .collect::<Vec<_>>();
+    assert_eq!(matched.len(), 1, "expected one Dynamic Option-method warning, got: {warnings:?}");
+    assert!(matched[0].message().contains("`.unwrap-or`"));
+    assert!(matched[0].message().contains("`option:*` or `result:*`"));
+  });
+}
+
+#[test]
 fn option_fold_callbacks_share_return_type_during_preprocessing() {
   run_with_large_stack(|| {
     let snippets = [

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1718,17 +1718,28 @@ fn preprocess_list_call(
           // For non-struct/trait types (Dynamic, Fn, etc.), silently fall through —
           // `.method` is a normal argument.
         }
-        if warn_dyn_method_enabled()
-          && file_ns != calcit::CORE_NS
+        if file_ns != calcit::CORE_NS
           && resolve_type_value(&head_form, scope_types).is_none_or(|type_info| is_dynamic_annotation(type_info.as_ref()))
         {
-          let message = format!(
-            "[Warn] postfix method `.{method_name}` has a dynamic receiver in {file_ns}/{def_name}; use prefix syntax `(.{method_name} receiver ...)`, assert-traits, or unsafe-coerce at an FFI boundary"
-          );
-          if let Some(loc) = head_form.get_location().or_else(|| first_arg.get_location()) {
-            gen_check_warning_with_location_code(message, "P_DYNAMIC_POSTFIX_METHOD", loc, check_warnings);
-          } else {
-            gen_check_warning_code(message, "P_DYNAMIC_POSTFIX_METHOD", file_ns, check_warnings);
+          let location = head_form.get_location().or_else(|| first_arg.get_location());
+          if let Some((receiver_requirement, helper_hint)) = dynamic_nominal_method_requirement(method_name.as_ref()) {
+            let message = format!(
+              "[Warn] postfix nominal method `.{method_name}` requires a statically known {receiver_requirement} receiver in {file_ns}/{def_name}, but the receiver is Dynamic; narrow it with a schema/assertion before using method syntax, or call {helper_hint} at an intentional Dynamic boundary"
+            );
+            if let Some(loc) = location {
+              gen_check_warning_with_location_code(message, "W_DYNAMIC_NOMINAL_METHOD_RECEIVER", loc, check_warnings);
+            } else {
+              gen_check_warning_code(message, "W_DYNAMIC_NOMINAL_METHOD_RECEIVER", file_ns, check_warnings);
+            }
+          } else if warn_dyn_method_enabled() {
+            let message = format!(
+              "[Warn] postfix method `.{method_name}` has a dynamic receiver in {file_ns}/{def_name}; use prefix syntax `(.{method_name} receiver ...)`, assert-traits, or unsafe-coerce at an FFI boundary"
+            );
+            if let Some(loc) = location {
+              gen_check_warning_with_location_code(message, "P_DYNAMIC_POSTFIX_METHOD", loc, check_warnings);
+            } else {
+              gen_check_warning_code(message, "P_DYNAMIC_POSTFIX_METHOD", file_ns, check_warnings);
+            }
           }
         }
       }
@@ -5535,6 +5546,15 @@ fn is_dynamic_annotation(type_value: &CalcitTypeAnnotation) -> bool {
     || matches!(type_value, CalcitTypeAnnotation::Optional(inner) if is_dynamic_annotation(inner.as_ref()))
 }
 
+fn dynamic_nominal_method_requirement(method_name: &str) -> Option<(&'static str, &'static str)> {
+  match method_name {
+    "some?" | "none?" | "unwrap" | "fold" => Some(("Option", "the matching `option:*` function")),
+    "ok?" | "err?" | "map-err" => Some(("Result", "the matching `result:*` function")),
+    "unwrap-or" | "and-then" | "or-else" => Some(("Option or Result", "the matching `option:*` or `result:*` function")),
+    _ => None,
+  }
+}
+
 /// Rank annotations by how much static information they erase. Root-level
 /// dynamic callable/value types are weaker than an equally dynamic container,
 /// because the latter still preserves useful shape information.
@@ -8659,6 +8679,35 @@ mod tests {
       .collect::<Vec<_>>();
     assert_eq!(matched.len(), 1, "expected one dynamic postfix warning, got: {warnings:?}");
     assert!(matched[0].message().contains("unsafe-coerce"));
+  }
+
+  #[test]
+  fn nominal_container_methods_warn_on_dynamic_receivers_without_opt_in() {
+    let _lock = lock_preprocess_test_state();
+    let _warn_guard = WarnDynMethodGuard::new(false);
+    let expr = Cirru::List(vec![Cirru::leaf("receiver"), Cirru::leaf(".unwrap-or"), Cirru::leaf("0")]);
+    let code = code_to_calcit(&expr, "tests.dynamic-option", "main", vec![]).expect("parse cirru");
+    let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
+    scope_defs.insert(Arc::from("receiver"));
+    let mut scope_types: ScopeTypes = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default();
+
+    preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.dynamic-option", &warnings, &stack)
+      .expect("dynamic Option method should preprocess far enough to report a warning");
+
+    let warnings = warnings.borrow();
+    let matched = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_DYNAMIC_NOMINAL_METHOD_RECEIVER"))
+      .collect::<Vec<_>>();
+    assert_eq!(matched.len(), 1, "expected one Dynamic nominal-method warning, got: {warnings:?}");
+    assert!(matched[0].message().contains("statically known Option or Result receiver"));
+    assert!(matched[0].message().contains("`option:*` or `result:*`"));
+    assert!(
+      warnings.iter().all(|warning| warning.code() != Some("P_DYNAMIC_POSTFIX_METHOD")),
+      "the unconditional diagnostic should not be duplicated by the opt-in policy warning"
+    );
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1722,7 +1722,9 @@ fn preprocess_list_call(
           && resolve_type_value(&head_form, scope_types).is_none_or(|type_info| is_dynamic_annotation(type_info.as_ref()))
         {
           let location = head_form.get_location().or_else(|| first_arg.get_location());
-          if let Some((receiver_requirement, helper_hint)) = dynamic_nominal_method_requirement(method_name.as_ref()) {
+          if matches!(method_kind, calcit::MethodKind::Invoke(_))
+            && let Some((receiver_requirement, helper_hint)) = dynamic_nominal_method_requirement(method_name.as_ref())
+          {
             let message = format!(
               "[Warn] postfix nominal method `.{method_name}` requires a statically known {receiver_requirement} receiver in {file_ns}/{def_name}, but the receiver is Dynamic; narrow it with a schema/assertion before using method syntax, or call {helper_hint} at an intentional Dynamic boundary"
             );
@@ -8708,6 +8710,39 @@ mod tests {
       warnings.iter().all(|warning| warning.code() != Some("P_DYNAMIC_POSTFIX_METHOD")),
       "the unconditional diagnostic should not be duplicated by the opt-in policy warning"
     );
+  }
+
+  #[test]
+  fn native_js_members_do_not_trigger_dynamic_nominal_method_warning() {
+    let _lock = lock_preprocess_test_state();
+    let _warn_guard = WarnDynMethodGuard::new(false);
+
+    for method in [".-unwrap-or", ".!unwrap-or"] {
+      let expr = Cirru::List(vec![Cirru::leaf("receiver"), Cirru::leaf(method), Cirru::leaf("0")]);
+      let code = code_to_calcit(&expr, "tests.dynamic-js-member", "main", vec![]).expect("parse cirru");
+      let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
+      scope_defs.insert(Arc::from("receiver"));
+      let mut scope_types: ScopeTypes = ScopeTypes::new();
+      let warnings = RefCell::new(vec![]);
+
+      preprocess_expr(
+        &code,
+        &scope_defs,
+        &mut scope_types,
+        "tests.dynamic-js-member",
+        &warnings,
+        &CallStackList::default(),
+      )
+      .expect("native JavaScript member token should remain outside nominal method diagnostics");
+
+      assert!(
+        warnings
+          .borrow()
+          .iter()
+          .all(|warning| warning.code() != Some("W_DYNAMIC_NOMINAL_METHOD_RECEIVER")),
+        "{method} must not be treated as an Option/Result method"
+      );
+    }
   }
 
   #[test]


### PR DESCRIPTION
## 中文

修复 #527，阻止 Dynamic 边界上的 Option/Result postfix method 静态放行后在运行时把实际 enum 值当作 operator。

### 改动

- 对 `.unwrap-or`、`.and-then`、`.or-else` 以及 Option/Result 专属 nominal methods 增加无条件预处理诊断 `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`。
- 要求 method receiver 先通过 schema/assertion 收窄；有意保留的 Dynamic 边界可显式调用对应 `option:*` / `result:*` 函数。
- 其他 Dynamic postfix methods 继续使用已有 `--warn-dyn-method` / `analyze dynamic-methods` 策略，避免扩大无关兼容性影响。
- 补充单元测试、完整 snippet 回归及 upgrade/polymorphism 文档。

### 验证

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- 全部 Rust tests：584 library + 267 calcit binary + 24 caps + 20 cr-wasm
- Calcit core：223/223
- `yarn compile`
- `yarn check-all`（native/JS/IR/WASM 与性能回归）
- `yarn check-agent-interface`：17/17
- 原始最小复现现在在预处理阶段报告 `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`
- 显式 `option:unwrap-or` Dynamic 边界与静态 `%some ... .unwrap-or ...` 均正常
- 使用新编译器检查 TopixIM/copyboard 最新 main 与 Cumulo/calcium-workflow 最新 main 均通过

## English

Fix #527 by preventing postfix Option/Result methods at Dynamic boundaries from passing static preprocessing and later evaluating the actual enum value as an operator.

### Changes

- Add the unconditional `W_DYNAMIC_NOMINAL_METHOD_RECEIVER` preprocessing diagnostic for `.unwrap-or`, `.and-then`, `.or-else`, and Option/Result-specific nominal methods.
- Require method receivers to be narrowed through schemas/assertions; intentionally Dynamic boundaries may explicitly call the corresponding `option:*` / `result:*` function.
- Keep other Dynamic postfix methods under the existing `--warn-dyn-method` / `analyze dynamic-methods` policy to avoid unrelated compatibility expansion.
- Add a unit regression, a full snippet regression, and upgrade/polymorphism documentation.

### Verification

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- All Rust tests: 584 library + 267 calcit binary + 24 caps + 20 cr-wasm
- Calcit core: 223/223
- `yarn compile`
- `yarn check-all` (native/JS/IR/WASM and performance regressions)
- `yarn check-agent-interface`: 17/17
- The original reproduction now reports `W_DYNAMIC_NOMINAL_METHOD_RECEIVER` during preprocessing
- Explicit `option:unwrap-or` at a Dynamic boundary and statically typed `%some ... .unwrap-or ...` both remain valid
- The new compiler checks the latest TopixIM/copyboard and Cumulo/calcium-workflow main branches successfully

Closes #527.
