### PR TITLE
feat: 建立 Calx 标量子集准入边界 / establish Calx scalar eligibility boundary

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -49,6 +49,7 @@ calcit js
 - [CLI Options](./run/cli-options.md)
 - [Development Debugging](./run/debugging.md)
 - [Querying definitions](./run/query.md)
+- [Experimental Calx target eligibility](./run/calx-target.md)
 - [Documentation & Libraries](./run/docs-libs.md)
 - [CLI Code Editing](./run/edit-tree.md)
 - [Load Deps](./run/load-deps.md)

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -1,0 +1,91 @@
+# 实验性 Calx target：eligibility 与整体回退
+
+Calcit 正在验证一个很窄的 typed scalar kernel 子集能否编译到 Calx。这个实验不改变默认 native
+runner、JS codegen 或仓库内部 WASM backend，也不会把任意 Calcit 函数静默发送给另一个运行时。
+
+当前第一阶段只建立编译前的 eligibility boundary：
+
+```text
+explicit namespace/definition
+  -> macro-expanded, symbol-resolved, typed CompiledProgram snapshot
+  -> closed reachable direct-call graph
+       -> eligible graph
+       -> structured FallbackReport
+```
+
+Rust embedding 可对同一个不可变 snapshot 调用：
+
+```rust
+use calcit::codegen::calx::analyze_calx_eligibility;
+
+let snapshot = calcit::program::clone_compiled_program_snapshot()?;
+match analyze_calx_eligibility(&snapshot, "app.kernel", "range-sum") {
+  Ok(graph) => println!("{}", graph.stable_summary()),
+  Err(report) => eprintln!("{}", report.stable_summary()),
+}
+```
+
+`analyze_calx_eligibility` 不执行代码，也不产生半个 Calx program。只有入口可达的每个 definition
+都通过时才返回 `CalxEligibleCallGraph`；任意 callee 不合格都会返回覆盖整个 closure 的
+`CalxFallbackReport`。
+
+## 首批接受范围
+
+- function boundary 与 local：`Number`、`Bool`；函数结果额外接受 `Unit`，映射为 void；
+- fixed arity top-level function；
+- Number/Bool literal、typed local、单 binding `&let`、有 else 的 `if`；
+- `&+`、一元/二元 `&-`、`&*`、`&/`、`&=`、`&<`、`&>`；
+- fixed-arity direct call 与 tail-position `recur`；
+- 条件必须静态为 Bool，不复用 Calcit 或 Calx 的 numeric truthiness。
+
+首批明确拒绝：
+
+- `Dynamic`、`Nil`、Optional/JsNullish，以及除 Number/Bool/Unit 之外的 boundary/storage type；
+- closure、function value、local/dynamic operator、HOF、rest/optional arity；
+- 无 else 的 `if`、非 tail `recur`、global/ref/atom、collection/nominal value；
+- 未加入 allowlist 的 host/native capability。
+
+## Fallback contract
+
+fallback 使用 ABI edition `calcit-calx-kernel/1`，并保留 entry、失败 definition、可用的 source tree
+path、call path、稳定 code 与人类可读 message。稳定 code 包括：
+
+- `CALX_SUBSET_DYNAMIC_TYPE`
+- `CALX_SUBSET_NIL_VALUE`
+- `CALX_SUBSET_UNSUPPORTED_TYPE`
+- `CALX_SUBSET_UNSUPPORTED_FORM`
+- `CALX_SUBSET_INDIRECT_CALL`
+- `CALX_SUBSET_ARITY`
+- `CALX_SUBSET_NON_BOOL_CONDITION`
+- `CALX_SUBSET_RECUR_NOT_TAIL`
+- `CALX_SUBSET_HOST_CAPABILITY`
+- `CALX_SUBSET_CALL_CLOSURE`
+- `CALX_SUBSET_ABI_EDITION`
+
+issues 按 code、definition、source path 与 call path 确定排序。`stable_summary()` 用于 repository
+golden tests，但明确是 experimental report，不是可持久化的 compiler ABI。
+
+## Source-backed fixtures
+
+[`tests/fixtures/calx/scalar-kernels.cirru`](../../tests/fixtures/calx/scalar-kernels.cirru)
+包含首批三类真实 Calcit source：
+
+- `range-sum`：Number comparison 与 tail recur；
+- `fibonacci`：if、F64 comparison 与 direct recursion；
+- `affine`：多参数算术和 direct helper call graph。
+
+测试先让这些 definitions 经过 Calcit preprocessing，再从 `CompiledProgram` snapshot 分析；对应
+golden 固定 ABI、entry、函数签名、确定排序与 direct-call edges。另一个 fixture 固定 Dynamic
+callee 导致整个入口 closure fallback 的报告。
+
+## 尚未实现
+
+本阶段故意不依赖未发布的 `calx_vm` git revision，也不复制 Calx IR。后续阶段会在包含
+`ProgramBuilder` 的稳定 calx_vm crate 可用后，把 eligible graph 和同一份 typed expressions 降为：
+
+```text
+ProgramBuilder -> CalxProgram -> ValidatedProgram -> CalxVM::run_typed
+```
+
+build/validation/binding failure 与 runtime trap 不属于 eligibility fallback，运行失败后也不会自动
+重跑 Calcit，以免 effect import 被执行两次。

--- a/editing-history/202608302117-calx-scalar-eligibility.md
+++ b/editing-history/202608302117-calx-scalar-eligibility.md
@@ -1,0 +1,19 @@
+# Calx scalar eligibility boundary / Calx 标量子集准入边界
+
+## 中文
+
+- 为 Calx 编译目标建立第一段只读边界：直接消费真实的 typed `CompiledProgram` snapshot，不从源码文本重新推断，也不在分析失败时产生半成品 Calx program。
+- 首批只接受固定参数的 `Number`/`Bool` 标量函数、`Unit` 结果、局部变量、完整 `if`、数值运算与比较、直接调用及尾位置 `recur`；`Dynamic`、Nil/absence、间接调用和未批准 host capability 都产生稳定的结构化 fallback code。
+- eligibility 按入口的完整可达 direct-call closure 判断。任一 callee 不合格时，整个入口回退，并保留 definition、source tree path 与 call path；函数和 issue 使用确定排序，便于 golden 与跨仓库追踪。
+- fixtures 从 Cirru source 进入正常 preprocessing，再分析不可变 snapshot；覆盖 range sum、Fibonacci、affine helper graph，以及 Dynamic callee 触发的 closure fallback。
+- 当前不依赖尚未发布 `ProgramBuilder` 的 `calx_vm` git revision。等对应稳定 crate 发布后，再从同一 typed expression 降低到 `ProgramBuilder -> CalxProgram -> ValidatedProgram`。
+- 验证通过：`cargo fmt --check`、strict all-target/all-feature Clippy、全部 Rust tests、`yarn compile`、Agent interface 17/17、`yarn check-all`（含 native/JS/WASM 与性能回归）。
+
+## English
+
+- Establish the first read-only boundary for the Calx compilation target: consume the real typed `CompiledProgram` snapshot directly, without re-inferring from source text or emitting a partial Calx program on failure.
+- Initially accept only fixed-arity `Number`/`Bool` scalar functions, `Unit` results, locals, complete `if`, numeric operations and comparisons, direct calls, and tail-position `recur`. `Dynamic`, Nil/absence, indirect calls, and unapproved host capabilities produce stable structured fallback codes.
+- Decide eligibility across the entry's complete reachable direct-call closure. One ineligible callee falls back the whole entry while preserving the definition, source tree path, and call path; deterministic function and issue ordering supports golden tests and cross-repository tracking.
+- Drive fixtures from Cirru source through normal preprocessing before analyzing an immutable snapshot. Coverage includes range sum, Fibonacci, an affine helper graph, and closure fallback caused by a Dynamic callee.
+- Do not depend on an unpublished `calx_vm` Git revision containing `ProgramBuilder`. Once the matching stable crate is published, lower the same typed expressions through `ProgramBuilder -> CalxProgram -> ValidatedProgram`.
+- Verification passes `cargo fmt --check`, strict all-target/all-feature Clippy, all Rust tests, `yarn compile`, Agent interface 17/17, and `yarn check-all` including native/JS/WASM and performance regressions.

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
+pub mod calx;
 pub mod emit_js;
 pub mod emit_wasm;
 pub mod gen_ir;

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -1,0 +1,1009 @@
+//! Eligibility analysis for the experimental Calcit-to-Calx scalar subset.
+//!
+//! This module consumes an immutable [`CompiledProgram`](crate::program::CompiledProgram)
+//! snapshot. It does not depend on `calx_vm` and does not emit a partial program:
+//! callers receive either a closed eligible call graph or one stable fallback report.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use crate::builtins::syntax::get_raw_args_fn;
+use crate::calcit::{Calcit, CalcitFnArgs, CalcitProc, CalcitSyntax, CalcitTypeAnnotation};
+use crate::program::{CompiledDef, CompiledDefKind, CompiledProgram};
+
+pub const CALX_KERNEL_ABI_EDITION: &str = "calcit-calx-kernel/1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalxScalarType {
+  F64,
+  Bool,
+}
+
+impl CalxScalarType {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::F64 => "F64",
+      Self::Bool => "Bool",
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CalxDefinitionRef {
+  pub namespace: Arc<str>,
+  pub definition: Arc<str>,
+}
+
+impl CalxDefinitionRef {
+  pub fn new(namespace: impl Into<Arc<str>>, definition: impl Into<Arc<str>>) -> Self {
+    Self {
+      namespace: namespace.into(),
+      definition: definition.into(),
+    }
+  }
+
+  pub fn qualified(&self) -> String {
+    format!("{}/{}", self.namespace, self.definition)
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalxFallbackCode {
+  DynamicType,
+  NilValue,
+  UnsupportedType,
+  UnsupportedForm,
+  IndirectCall,
+  Arity,
+  NonBoolCondition,
+  RecurNotTail,
+  HostCapability,
+  CallClosure,
+  AbiEdition,
+}
+
+impl CalxFallbackCode {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::DynamicType => "CALX_SUBSET_DYNAMIC_TYPE",
+      Self::NilValue => "CALX_SUBSET_NIL_VALUE",
+      Self::UnsupportedType => "CALX_SUBSET_UNSUPPORTED_TYPE",
+      Self::UnsupportedForm => "CALX_SUBSET_UNSUPPORTED_FORM",
+      Self::IndirectCall => "CALX_SUBSET_INDIRECT_CALL",
+      Self::Arity => "CALX_SUBSET_ARITY",
+      Self::NonBoolCondition => "CALX_SUBSET_NON_BOOL_CONDITION",
+      Self::RecurNotTail => "CALX_SUBSET_RECUR_NOT_TAIL",
+      Self::HostCapability => "CALX_SUBSET_HOST_CAPABILITY",
+      Self::CallClosure => "CALX_SUBSET_CALL_CLOSURE",
+      Self::AbiEdition => "CALX_SUBSET_ABI_EDITION",
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CalxFallbackIssue {
+  pub code: CalxFallbackCode,
+  pub namespace: Arc<str>,
+  pub definition: Arc<str>,
+  pub source_path: Option<Vec<u16>>,
+  pub call_path: Vec<CalxDefinitionRef>,
+  pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxFallbackReport {
+  pub abi_edition: Arc<str>,
+  pub entry: CalxDefinitionRef,
+  pub issues: Vec<CalxFallbackIssue>,
+}
+
+impl CalxFallbackReport {
+  /// Deterministic text used by source-backed golden fixtures. This is an
+  /// experimental report format, not a serialized compiler ABI.
+  pub fn stable_summary(&self) -> String {
+    let mut output = format!("abi {}\nentry {}\n", self.abi_edition, self.entry.qualified());
+    for issue in &self.issues {
+      let path = issue
+        .source_path
+        .as_ref()
+        .map(|parts| parts.iter().map(u16::to_string).collect::<Vec<_>>().join("."))
+        .unwrap_or_else(|| "-".to_owned());
+      let call_path = issue
+        .call_path
+        .iter()
+        .map(CalxDefinitionRef::qualified)
+        .collect::<Vec<_>>()
+        .join(" -> ");
+      output.push_str(&format!(
+        "issue {} {}/{} source={} call={} message={}\n",
+        issue.code.as_str(),
+        issue.namespace,
+        issue.definition,
+        path,
+        call_path,
+        issue.message
+      ));
+    }
+    output
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxEligibleFunction {
+  pub definition: CalxDefinitionRef,
+  pub params: Vec<CalxScalarType>,
+  pub result: Option<CalxScalarType>,
+  pub direct_calls: Vec<CalxDefinitionRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxEligibleCallGraph {
+  pub abi_edition: Arc<str>,
+  pub entry: CalxDefinitionRef,
+  pub functions: Vec<CalxEligibleFunction>,
+}
+
+impl CalxEligibleCallGraph {
+  /// Deterministic text used by source-backed golden fixtures. This is an
+  /// experimental report format, not a serialized compiler ABI.
+  pub fn stable_summary(&self) -> String {
+    let mut output = format!("abi {}\nentry {}\n", self.abi_edition, self.entry.qualified());
+    for function in &self.functions {
+      let params = function.params.iter().map(|value| value.as_str()).collect::<Vec<_>>().join(",");
+      let result = function.result.map(CalxScalarType::as_str).unwrap_or("Void");
+      output.push_str(&format!("function {} ({params})->{result}\n", function.definition.qualified()));
+      for callee in &function.direct_calls {
+        output.push_str(&format!("  call {}\n", callee.qualified()));
+      }
+    }
+    output
+  }
+}
+
+/// Proves that one explicit entry and its reachable direct-call closure belong
+/// to the first Calx scalar subset.
+///
+/// Any issue returns a sorted [`CalxFallbackReport`]. The eligible graph is
+/// published only when every reachable definition succeeds.
+pub fn analyze_calx_eligibility(
+  program: &CompiledProgram,
+  namespace: impl Into<Arc<str>>,
+  definition: impl Into<Arc<str>>,
+) -> Result<CalxEligibleCallGraph, CalxFallbackReport> {
+  let entry = CalxDefinitionRef::new(namespace, definition);
+  let mut analyzer = EligibilityAnalyzer::new(program, entry.clone());
+  analyzer.visit(entry.clone(), vec![entry.clone()]);
+  analyzer.finish()
+}
+
+#[derive(Debug, Clone)]
+struct FunctionSignature {
+  params: Vec<CalxScalarType>,
+  result: Option<CalxScalarType>,
+}
+
+struct EligibilityAnalyzer<'a> {
+  program: &'a CompiledProgram,
+  entry: CalxDefinitionRef,
+  visited: BTreeSet<CalxDefinitionRef>,
+  functions: BTreeMap<CalxDefinitionRef, CalxEligibleFunction>,
+  issues: Vec<CalxFallbackIssue>,
+}
+
+impl<'a> EligibilityAnalyzer<'a> {
+  fn new(program: &'a CompiledProgram, entry: CalxDefinitionRef) -> Self {
+    Self {
+      program,
+      entry,
+      visited: BTreeSet::new(),
+      functions: BTreeMap::new(),
+      issues: vec![],
+    }
+  }
+
+  fn visit(&mut self, target: CalxDefinitionRef, call_path: Vec<CalxDefinitionRef>) {
+    if !self.visited.insert(target.clone()) {
+      return;
+    }
+    let Some(compiled) = lookup_compiled_def(self.program, &target) else {
+      self.push_issue(
+        CalxFallbackCode::UnsupportedForm,
+        &target,
+        None,
+        &call_path,
+        format!(
+          "reachable definition `{}` is missing from the compiled snapshot",
+          target.qualified()
+        ),
+      );
+      return;
+    };
+    if compiled.kind != CompiledDefKind::Fn {
+      self.push_issue(
+        CalxFallbackCode::IndirectCall,
+        &target,
+        source_path(&compiled.preprocessed_code),
+        &call_path,
+        format!("reachable definition `{}` is not a top-level function", target.qualified()),
+      );
+      return;
+    }
+
+    let signature = analyze_signature(compiled, &target, &call_path, &mut self.issues);
+    let parts = extract_fn_parts(compiled, &target, &call_path, &mut self.issues);
+    let mut direct_calls = BTreeSet::new();
+    let mut body_result = None;
+    if let Some((args, body)) = parts {
+      if let Some(signature) = &signature
+        && args.param_len() != signature.params.len()
+      {
+        self.push_issue(
+          CalxFallbackCode::Arity,
+          &target,
+          source_path(&compiled.preprocessed_code),
+          &call_path,
+          format!(
+            "function `{}` has {} preprocessed parameters but {} typed parameters",
+            target.qualified(),
+            args.param_len(),
+            signature.params.len()
+          ),
+        );
+      }
+      if matches!(args, CalcitFnArgs::MarkedArgs(_)) {
+        self.push_issue(
+          CalxFallbackCode::Arity,
+          &target,
+          source_path(&compiled.preprocessed_code),
+          &call_path,
+          format!("function `{}` uses optional/rest argument markers", target.qualified()),
+        );
+      }
+      let mut context = ExpressionContext {
+        program: self.program,
+        function: &target,
+        signature: signature.as_ref(),
+        call_path: &call_path,
+        direct_calls: &mut direct_calls,
+        issues: &mut self.issues,
+      };
+      body_result = analyze_sequence(&body, true, &mut context);
+    }
+    if let (Some(signature), Some(actual_result)) = (&signature, body_result)
+      && actual_result != signature.result
+    {
+      self.push_issue(
+        CalxFallbackCode::UnsupportedType,
+        &target,
+        source_path(&compiled.preprocessed_code),
+        &call_path,
+        format!(
+          "function `{}` body result {actual_result:?} does not match declared result {:?}",
+          target.qualified(),
+          signature.result
+        ),
+      );
+    }
+
+    if let Some(signature) = signature {
+      self.functions.insert(
+        target.clone(),
+        CalxEligibleFunction {
+          definition: target.clone(),
+          params: signature.params,
+          result: signature.result,
+          direct_calls: direct_calls.iter().cloned().collect(),
+        },
+      );
+    }
+
+    for callee in direct_calls {
+      let mut callee_path = call_path.clone();
+      callee_path.push(callee.clone());
+      self.visit(callee, callee_path);
+    }
+  }
+
+  fn push_issue(
+    &mut self,
+    code: CalxFallbackCode,
+    target: &CalxDefinitionRef,
+    source_path: Option<Vec<u16>>,
+    call_path: &[CalxDefinitionRef],
+    message: String,
+  ) {
+    self.issues.push(CalxFallbackIssue {
+      code,
+      namespace: target.namespace.clone(),
+      definition: target.definition.clone(),
+      source_path,
+      call_path: call_path.to_vec(),
+      message,
+    });
+  }
+
+  fn finish(mut self) -> Result<CalxEligibleCallGraph, CalxFallbackReport> {
+    if self.issues.iter().any(|issue| {
+      issue.namespace.as_ref() != self.entry.namespace.as_ref() || issue.definition.as_ref() != self.entry.definition.as_ref()
+    }) {
+      self.issues.push(CalxFallbackIssue {
+        code: CalxFallbackCode::CallClosure,
+        namespace: self.entry.namespace.clone(),
+        definition: self.entry.definition.clone(),
+        source_path: None,
+        call_path: vec![self.entry.clone()],
+        message: format!("entry `{}` has an ineligible reachable call closure", self.entry.qualified()),
+      });
+    }
+    self.issues.sort();
+    self.issues.dedup();
+    if self.issues.is_empty() {
+      Ok(CalxEligibleCallGraph {
+        abi_edition: Arc::from(CALX_KERNEL_ABI_EDITION),
+        entry: self.entry,
+        functions: self.functions.into_values().collect(),
+      })
+    } else {
+      Err(CalxFallbackReport {
+        abi_edition: Arc::from(CALX_KERNEL_ABI_EDITION),
+        entry: self.entry,
+        issues: self.issues,
+      })
+    }
+  }
+}
+
+fn lookup_compiled_def<'a>(program: &'a CompiledProgram, target: &CalxDefinitionRef) -> Option<&'a CompiledDef> {
+  program.get(target.namespace.as_ref())?.get(target.definition.as_ref())
+}
+
+fn analyze_signature(
+  compiled: &CompiledDef,
+  target: &CalxDefinitionRef,
+  call_path: &[CalxDefinitionRef],
+  issues: &mut Vec<CalxFallbackIssue>,
+) -> Option<FunctionSignature> {
+  let CalcitTypeAnnotation::Fn(signature) = compiled.schema.as_ref() else {
+    let code = if matches!(compiled.schema.as_ref(), CalcitTypeAnnotation::Dynamic) {
+      CalxFallbackCode::DynamicType
+    } else {
+      CalxFallbackCode::UnsupportedType
+    };
+    push_expression_issue(
+      issues,
+      code,
+      target,
+      source_path(&compiled.preprocessed_code),
+      call_path,
+      format!("function `{}` has non-function schema `{}`", target.qualified(), compiled.schema),
+    );
+    return None;
+  };
+  if !signature.generics.is_empty() || !signature.where_bounds.is_empty() {
+    push_expression_issue(
+      issues,
+      CalxFallbackCode::UnsupportedType,
+      target,
+      source_path(&compiled.preprocessed_code),
+      call_path,
+      format!("function `{}` has unresolved generics or trait bounds", target.qualified()),
+    );
+  }
+  if signature.rest_type.is_some() {
+    push_expression_issue(
+      issues,
+      CalxFallbackCode::Arity,
+      target,
+      source_path(&compiled.preprocessed_code),
+      call_path,
+      format!("function `{}` declares a rest parameter", target.qualified()),
+    );
+  }
+
+  let mut params = vec![];
+  for (index, value_type) in signature.arg_types.iter().enumerate() {
+    if let Some(value_type) = map_slot_type(
+      value_type,
+      &format!("parameter {index}"),
+      target,
+      source_path(&compiled.preprocessed_code),
+      call_path,
+      issues,
+    ) {
+      params.push(value_type);
+    }
+  }
+  let result = map_result_type(
+    &signature.return_type,
+    "function result",
+    target,
+    source_path(&compiled.preprocessed_code),
+    call_path,
+    issues,
+  );
+  if params.len() == signature.arg_types.len() && result.is_some() {
+    Some(FunctionSignature {
+      params,
+      result: result.flatten(),
+    })
+  } else {
+    None
+  }
+}
+
+fn signature_without_issues(compiled: &CompiledDef) -> Option<FunctionSignature> {
+  let CalcitTypeAnnotation::Fn(signature) = compiled.schema.as_ref() else {
+    return None;
+  };
+  if !signature.generics.is_empty() || !signature.where_bounds.is_empty() || signature.rest_type.is_some() {
+    return None;
+  }
+  let params: Option<Vec<_>> = signature.arg_types.iter().map(|value| map_slot_type_quiet(value)).collect();
+  Some(FunctionSignature {
+    params: params?,
+    result: map_result_type_quiet(&signature.return_type)?,
+  })
+}
+
+fn extract_fn_parts(
+  compiled: &CompiledDef,
+  target: &CalxDefinitionRef,
+  call_path: &[CalxDefinitionRef],
+  issues: &mut Vec<CalxFallbackIssue>,
+) -> Option<(CalcitFnArgs, Vec<Calcit>)> {
+  let Calcit::List(items) = &compiled.preprocessed_code else {
+    push_expression_issue(
+      issues,
+      CalxFallbackCode::UnsupportedForm,
+      target,
+      source_path(&compiled.preprocessed_code),
+      call_path,
+      format!("function `{}` is not a preprocessed defn form", target.qualified()),
+    );
+    return None;
+  };
+  let Some(Calcit::Syntax(CalcitSyntax::Defn, _)) = items.first() else {
+    push_expression_issue(
+      issues,
+      CalxFallbackCode::UnsupportedForm,
+      target,
+      source_path(&compiled.preprocessed_code),
+      call_path,
+      format!("function `{}` is not a standard defn", target.qualified()),
+    );
+    return None;
+  };
+  let Some(Calcit::List(args)) = items.get(2) else {
+    push_expression_issue(
+      issues,
+      CalxFallbackCode::Arity,
+      target,
+      source_path(&compiled.preprocessed_code),
+      call_path,
+      format!("function `{}` has no parameter list", target.qualified()),
+    );
+    return None;
+  };
+  let args = match get_raw_args_fn(args) {
+    Ok(args) => args,
+    Err(message) => {
+      push_expression_issue(
+        issues,
+        CalxFallbackCode::Arity,
+        target,
+        source_path(&compiled.preprocessed_code),
+        call_path,
+        format!("function `{}` has invalid parameters: {message}", target.qualified()),
+      );
+      return None;
+    }
+  };
+  let body = items
+    .iter()
+    .skip(3)
+    .filter(|item| CalcitTypeAnnotation::extract_fn_annotation_from_hint_form(item).is_none())
+    .cloned()
+    .collect();
+  Some((args, body))
+}
+
+struct ExpressionContext<'a> {
+  program: &'a CompiledProgram,
+  function: &'a CalxDefinitionRef,
+  signature: Option<&'a FunctionSignature>,
+  call_path: &'a [CalxDefinitionRef],
+  direct_calls: &'a mut BTreeSet<CalxDefinitionRef>,
+  issues: &'a mut Vec<CalxFallbackIssue>,
+}
+
+fn analyze_sequence(expressions: &[Calcit], tail: bool, context: &mut ExpressionContext<'_>) -> Option<Option<CalxScalarType>> {
+  if expressions.is_empty() {
+    issue(
+      context,
+      CalxFallbackCode::NilValue,
+      None,
+      "an empty function/branch body would produce Nil".to_owned(),
+    );
+    return None;
+  }
+  let mut result = None;
+  for (index, expression) in expressions.iter().enumerate() {
+    result = analyze_expression(expression, tail && index + 1 == expressions.len(), context);
+  }
+  result
+}
+
+fn analyze_expression(expression: &Calcit, tail: bool, context: &mut ExpressionContext<'_>) -> Option<Option<CalxScalarType>> {
+  match expression {
+    Calcit::Number(_) => Some(Some(CalxScalarType::F64)),
+    Calcit::Bool(_) => Some(Some(CalxScalarType::Bool)),
+    Calcit::Unit => Some(None),
+    Calcit::Nil => {
+      issue(
+        context,
+        CalxFallbackCode::NilValue,
+        source_path(expression),
+        "Nil is not part of the Calx scalar subset".to_owned(),
+      );
+      None
+    }
+    Calcit::Local(local) => map_slot_type(
+      &local.type_info,
+      &format!("local `{}`", local.sym),
+      context.function,
+      local.location.as_ref().map(|path| path.as_ref().clone()),
+      context.call_path,
+      context.issues,
+    )
+    .map(Some),
+    Calcit::List(items) if !items.is_empty() => analyze_call(items, tail, context),
+    Calcit::Import(_) | Calcit::Fn { .. } | Calcit::Proc(_) | Calcit::Method(_, _) | Calcit::Symbol { .. } => {
+      issue(
+        context,
+        CalxFallbackCode::IndirectCall,
+        source_path(expression),
+        format!("function/operator value `{expression}` is not a direct fixed-arity call"),
+      );
+      None
+    }
+    other => {
+      issue(
+        context,
+        CalxFallbackCode::UnsupportedForm,
+        source_path(other),
+        format!("unsupported Calx scalar expression `{other}`"),
+      );
+      None
+    }
+  }
+}
+
+fn analyze_call(items: &crate::calcit::CalcitList, tail: bool, context: &mut ExpressionContext<'_>) -> Option<Option<CalxScalarType>> {
+  let operator = &items[0];
+  let args = items.drop_left().to_vec();
+  match operator {
+    Calcit::Syntax(CalcitSyntax::If, _) => analyze_if(&args, tail, context),
+    Calcit::Syntax(CalcitSyntax::CoreLet, _) => analyze_let(&args, tail, context),
+    Calcit::Syntax(CalcitSyntax::AssertType, _) => {
+      if let Some(value) = args.first() {
+        analyze_expression(value, tail, context)
+      } else {
+        issue(
+          context,
+          CalxFallbackCode::UnsupportedForm,
+          source_path(operator),
+          "assert-type has no value expression".to_owned(),
+        );
+        None
+      }
+    }
+    Calcit::Syntax(CalcitSyntax::HintFn, _) => Some(None),
+    Calcit::Syntax(syntax, _) => {
+      issue(
+        context,
+        CalxFallbackCode::UnsupportedForm,
+        source_path(operator),
+        format!("syntax `{syntax}` is outside the Calx scalar subset"),
+      );
+      None
+    }
+    Calcit::Proc(proc) => analyze_proc(*proc, &args, tail, context),
+    Calcit::Import(import) if import.ns.as_ref() == "calcit.core" && import.def.as_ref() == "do" => {
+      analyze_sequence(&args, tail, context)
+    }
+    Calcit::Import(import) => analyze_direct_call(CalxDefinitionRef::new(import.ns.clone(), import.def.clone()), &args, context),
+    Calcit::Fn { info, .. } if info.def_ref.is_some() => {
+      let def_ref = info.def_ref.as_ref().expect("checked function definition reference");
+      analyze_direct_call(
+        CalxDefinitionRef::new(def_ref.def_ns.clone(), def_ref.def_name.clone()),
+        &args,
+        context,
+      )
+    }
+    Calcit::Local(_) | Calcit::Fn { .. } | Calcit::Symbol { .. } => {
+      analyze_unknown_args(&args, context);
+      issue(
+        context,
+        CalxFallbackCode::IndirectCall,
+        source_path(operator),
+        format!("dynamic operator `{operator}` is not supported"),
+      );
+      None
+    }
+    other => {
+      analyze_unknown_args(&args, context);
+      issue(
+        context,
+        CalxFallbackCode::UnsupportedForm,
+        source_path(other),
+        format!("unsupported call operator `{other}`"),
+      );
+      None
+    }
+  }
+}
+
+fn analyze_if(args: &[Calcit], tail: bool, context: &mut ExpressionContext<'_>) -> Option<Option<CalxScalarType>> {
+  if args.len() != 3 {
+    issue(
+      context,
+      CalxFallbackCode::NilValue,
+      args.first().and_then(source_path),
+      format!("Calx scalar if requires condition, then, and else; found {} arguments", args.len()),
+    );
+    return None;
+  }
+  let condition = analyze_expression(&args[0], false, context);
+  if condition != Some(Some(CalxScalarType::Bool)) {
+    issue(
+      context,
+      CalxFallbackCode::NonBoolCondition,
+      source_path(&args[0]),
+      "Calx scalar conditions must be statically Bool".to_owned(),
+    );
+  }
+  let then_type = analyze_expression(&args[1], tail, context);
+  let else_type = analyze_expression(&args[2], tail, context);
+  if then_type.is_some() && else_type.is_some() && then_type != else_type {
+    issue(
+      context,
+      CalxFallbackCode::UnsupportedType,
+      source_path(&args[1]),
+      "if branches must have the same scalar/void result".to_owned(),
+    );
+    None
+  } else {
+    then_type.or(else_type)
+  }
+}
+
+fn analyze_let(args: &[Calcit], tail: bool, context: &mut ExpressionContext<'_>) -> Option<Option<CalxScalarType>> {
+  let Some((binding, body)) = args.split_first() else {
+    issue(
+      context,
+      CalxFallbackCode::UnsupportedForm,
+      None,
+      "&let requires a binding and body".to_owned(),
+    );
+    return None;
+  };
+  match binding {
+    Calcit::Nil | Calcit::Unit => {}
+    Calcit::List(pair) if pair.len() == 2 => {
+      let declared = match &pair[0] {
+        Calcit::Local(local) => map_slot_type(
+          &local.type_info,
+          &format!("local `{}`", local.sym),
+          context.function,
+          local.location.as_ref().map(|path| path.as_ref().clone()),
+          context.call_path,
+          context.issues,
+        )
+        .map(Some),
+        other => {
+          issue(
+            context,
+            CalxFallbackCode::UnsupportedForm,
+            source_path(other),
+            format!("&let binding name `{other}` is not a resolved local"),
+          );
+          None
+        }
+      };
+      let value = analyze_expression(&pair[1], false, context);
+      if declared.is_some() && value.is_some() && declared != value {
+        issue(
+          context,
+          CalxFallbackCode::UnsupportedType,
+          source_path(&pair[1]),
+          "&let binding value does not match its concrete local type".to_owned(),
+        );
+      }
+    }
+    other => {
+      issue(
+        context,
+        CalxFallbackCode::UnsupportedForm,
+        source_path(other),
+        "&let requires exactly one resolved local binding".to_owned(),
+      );
+    }
+  }
+  analyze_sequence(body, tail, context)
+}
+
+fn analyze_proc(proc: CalcitProc, args: &[Calcit], tail: bool, context: &mut ExpressionContext<'_>) -> Option<Option<CalxScalarType>> {
+  match proc {
+    CalcitProc::NativeAdd | CalcitProc::NativeMultiply | CalcitProc::NativeDivide => {
+      analyze_typed_args(proc, args, &[CalxScalarType::F64, CalxScalarType::F64], context)?;
+      Some(Some(CalxScalarType::F64))
+    }
+    CalcitProc::NativeMinus if args.len() == 1 => {
+      analyze_typed_args(proc, args, &[CalxScalarType::F64], context)?;
+      Some(Some(CalxScalarType::F64))
+    }
+    CalcitProc::NativeMinus => {
+      analyze_typed_args(proc, args, &[CalxScalarType::F64, CalxScalarType::F64], context)?;
+      Some(Some(CalxScalarType::F64))
+    }
+    CalcitProc::NativeLessThan | CalcitProc::NativeGreaterThan | CalcitProc::NativeEquals => {
+      analyze_typed_args(proc, args, &[CalxScalarType::F64, CalxScalarType::F64], context)?;
+      Some(Some(CalxScalarType::Bool))
+    }
+    CalcitProc::Recur => {
+      if !tail {
+        issue(
+          context,
+          CalxFallbackCode::RecurNotTail,
+          args.first().and_then(source_path),
+          "recur is only eligible in tail position".to_owned(),
+        );
+      }
+      let signature = context.signature?;
+      analyze_typed_args(proc, args, &signature.params, context)?;
+      Some(signature.result)
+    }
+    other => {
+      issue(
+        context,
+        CalxFallbackCode::UnsupportedForm,
+        args.first().and_then(source_path),
+        format!("native proc `{other}` is outside the Calx scalar subset"),
+      );
+      None
+    }
+  }
+}
+
+fn analyze_typed_args(
+  operator: CalcitProc,
+  args: &[Calcit],
+  expected: &[CalxScalarType],
+  context: &mut ExpressionContext<'_>,
+) -> Option<()> {
+  if args.len() != expected.len() {
+    issue(
+      context,
+      CalxFallbackCode::Arity,
+      args.first().and_then(source_path),
+      format!("`{operator}` expects {} arguments, found {}", expected.len(), args.len()),
+    );
+    return None;
+  }
+  let mut valid = true;
+  for (argument, expected) in args.iter().zip(expected) {
+    if analyze_expression(argument, false, context) != Some(Some(*expected)) {
+      valid = false;
+    }
+  }
+  valid.then_some(())
+}
+
+fn analyze_direct_call(
+  target: CalxDefinitionRef,
+  args: &[Calcit],
+  context: &mut ExpressionContext<'_>,
+) -> Option<Option<CalxScalarType>> {
+  let Some(compiled) = lookup_compiled_def(context.program, &target) else {
+    analyze_unknown_args(args, context);
+    issue(
+      context,
+      CalxFallbackCode::HostCapability,
+      args.first().and_then(source_path),
+      format!(
+        "call target `{}` is not a declared compiled function or approved host capability",
+        target.qualified()
+      ),
+    );
+    return None;
+  };
+  if compiled.kind != CompiledDefKind::Fn {
+    analyze_unknown_args(args, context);
+    issue(
+      context,
+      CalxFallbackCode::IndirectCall,
+      args.first().and_then(source_path),
+      format!("call target `{}` is not a top-level function", target.qualified()),
+    );
+    return None;
+  }
+  context.direct_calls.insert(target.clone());
+  let Some(signature) = signature_without_issues(compiled) else {
+    analyze_unknown_args(args, context);
+    return None;
+  };
+  if args.len() != signature.params.len() {
+    issue(
+      context,
+      CalxFallbackCode::Arity,
+      args.first().and_then(source_path),
+      format!(
+        "call target `{}` expects {} arguments, found {}",
+        target.qualified(),
+        signature.params.len(),
+        args.len()
+      ),
+    );
+    return None;
+  }
+  let mut valid = true;
+  for (argument, expected) in args.iter().zip(&signature.params) {
+    if analyze_expression(argument, false, context) != Some(Some(*expected)) {
+      valid = false;
+    }
+  }
+  valid.then_some(signature.result)
+}
+
+fn analyze_unknown_args(args: &[Calcit], context: &mut ExpressionContext<'_>) {
+  for argument in args {
+    analyze_expression(argument, false, context);
+  }
+}
+
+fn map_slot_type(
+  annotation: &CalcitTypeAnnotation,
+  boundary: &str,
+  target: &CalxDefinitionRef,
+  source_path: Option<Vec<u16>>,
+  call_path: &[CalxDefinitionRef],
+  issues: &mut Vec<CalxFallbackIssue>,
+) -> Option<CalxScalarType> {
+  match annotation {
+    CalcitTypeAnnotation::Number => Some(CalxScalarType::F64),
+    CalcitTypeAnnotation::Bool => Some(CalxScalarType::Bool),
+    CalcitTypeAnnotation::Dynamic => {
+      push_expression_issue(
+        issues,
+        CalxFallbackCode::DynamicType,
+        target,
+        source_path,
+        call_path,
+        format!("{boundary} remains Dynamic"),
+      );
+      None
+    }
+    CalcitTypeAnnotation::Nil | CalcitTypeAnnotation::Optional(_) | CalcitTypeAnnotation::JsNullish(_) => {
+      push_expression_issue(
+        issues,
+        CalxFallbackCode::NilValue,
+        target,
+        source_path,
+        call_path,
+        format!("{boundary} can contain Nil/absence"),
+      );
+      None
+    }
+    other => {
+      push_expression_issue(
+        issues,
+        CalxFallbackCode::UnsupportedType,
+        target,
+        source_path,
+        call_path,
+        format!("{boundary} type `{other}` is outside the Calx scalar subset"),
+      );
+      None
+    }
+  }
+}
+
+fn map_result_type(
+  annotation: &CalcitTypeAnnotation,
+  boundary: &str,
+  target: &CalxDefinitionRef,
+  source_path: Option<Vec<u16>>,
+  call_path: &[CalxDefinitionRef],
+  issues: &mut Vec<CalxFallbackIssue>,
+) -> Option<Option<CalxScalarType>> {
+  if matches!(annotation, CalcitTypeAnnotation::Unit) {
+    Some(None)
+  } else {
+    map_slot_type(annotation, boundary, target, source_path, call_path, issues).map(Some)
+  }
+}
+
+fn map_slot_type_quiet(annotation: &CalcitTypeAnnotation) -> Option<CalxScalarType> {
+  match annotation {
+    CalcitTypeAnnotation::Number => Some(CalxScalarType::F64),
+    CalcitTypeAnnotation::Bool => Some(CalxScalarType::Bool),
+    _ => None,
+  }
+}
+
+fn map_result_type_quiet(annotation: &CalcitTypeAnnotation) -> Option<Option<CalxScalarType>> {
+  if matches!(annotation, CalcitTypeAnnotation::Unit) {
+    Some(None)
+  } else {
+    map_slot_type_quiet(annotation).map(Some)
+  }
+}
+
+fn issue(context: &mut ExpressionContext<'_>, code: CalxFallbackCode, source_path: Option<Vec<u16>>, message: String) {
+  push_expression_issue(context.issues, code, context.function, source_path, context.call_path, message);
+}
+
+fn push_expression_issue(
+  issues: &mut Vec<CalxFallbackIssue>,
+  code: CalxFallbackCode,
+  target: &CalxDefinitionRef,
+  source_path: Option<Vec<u16>>,
+  call_path: &[CalxDefinitionRef],
+  message: String,
+) {
+  issues.push(CalxFallbackIssue {
+    code,
+    namespace: target.namespace.clone(),
+    definition: target.definition.clone(),
+    source_path,
+    call_path: call_path.to_vec(),
+    message,
+  });
+}
+
+fn source_path(expression: &Calcit) -> Option<Vec<u16>> {
+  match expression {
+    Calcit::Local(local) => local.location.as_ref().map(|path| path.as_ref().clone()),
+    Calcit::Symbol { location, .. } => location.as_ref().map(|path| path.as_ref().clone()),
+    Calcit::List(items) => items.iter().find_map(source_path),
+    _ => None,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn fallback_codes_keep_the_v1_abi_names() {
+    assert_eq!(
+      [
+        CalxFallbackCode::DynamicType,
+        CalxFallbackCode::NilValue,
+        CalxFallbackCode::UnsupportedType,
+        CalxFallbackCode::UnsupportedForm,
+        CalxFallbackCode::IndirectCall,
+        CalxFallbackCode::Arity,
+        CalxFallbackCode::NonBoolCondition,
+        CalxFallbackCode::RecurNotTail,
+        CalxFallbackCode::HostCapability,
+        CalxFallbackCode::CallClosure,
+        CalxFallbackCode::AbiEdition,
+      ]
+      .map(CalxFallbackCode::as_str),
+      [
+        "CALX_SUBSET_DYNAMIC_TYPE",
+        "CALX_SUBSET_NIL_VALUE",
+        "CALX_SUBSET_UNSUPPORTED_TYPE",
+        "CALX_SUBSET_UNSUPPORTED_FORM",
+        "CALX_SUBSET_INDIRECT_CALL",
+        "CALX_SUBSET_ARITY",
+        "CALX_SUBSET_NON_BOOL_CONDITION",
+        "CALX_SUBSET_RECUR_NOT_TAIL",
+        "CALX_SUBSET_HOST_CAPABILITY",
+        "CALX_SUBSET_CALL_CLOSURE",
+        "CALX_SUBSET_ABI_EDITION",
+      ]
+    );
+  }
+}

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -1,10 +1,12 @@
 use super::*;
 use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
-use crate::calcit::{CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo};
+use crate::calcit::{CalcitFnTypeAnnotation, CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo, SchemaKind};
 use crate::call_stack::CallStackList;
+use crate::codegen::calx::{CalxDefinitionRef, CalxFallbackCode, CalxScalarType, analyze_calx_eligibility};
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
 use cirru_edn::EdnTag;
+use std::collections::HashSet;
 use std::sync::{LazyLock, Mutex};
 
 static PROGRAM_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -190,6 +192,177 @@ fn reset_program_test_state() {
   PROGRAM_COMPILED_DATA_STATE.write().expect("reset compiled data").clear();
   PROGRAM_CODE_DATA.write().expect("reset program code").clear();
   *PROGRAM_DEF_ID_INDEX.write().expect("reset def id index") = ProgramDefIdIndex::default();
+}
+
+fn calx_test_fn_schema(arg_types: Vec<CalcitTypeAnnotation>, return_type: CalcitTypeAnnotation) -> Arc<CalcitTypeAnnotation> {
+  Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+    generics: Arc::new(vec![]),
+    where_bounds: Arc::new(vec![]),
+    arg_types: arg_types.into_iter().map(Arc::new).collect(),
+    return_type: Arc::new(return_type),
+    fn_kind: SchemaKind::Fn,
+    rest_type: None,
+    features: Arc::new(HashSet::new()),
+  })))
+}
+
+fn calx_test_defs_from_source(namespace: &str, source: &str) -> HashMap<String, Calcit> {
+  cirru_parser::parse(source)
+    .expect("parse Calx source fixture")
+    .into_iter()
+    .map(|node| {
+      let Cirru::List(items) = &node else {
+        panic!("Calx fixture definition must be a list: {node}");
+      };
+      let Some(Cirru::Leaf(definition)) = items.get(1) else {
+        panic!("Calx fixture definition must have a name: {node}");
+      };
+      let code = code_to_calcit(&node, namespace, definition, vec![]).expect("convert Calx fixture source");
+      (definition.to_string(), code)
+    })
+    .collect()
+}
+
+fn install_calx_test_defs(namespace: &str, defs: Vec<(&str, Calcit, Arc<CalcitTypeAnnotation>)>) {
+  let mut entries = HashMap::new();
+  for (definition, code, schema) in defs {
+    let _ = ensure_def_id(namespace, definition);
+    entries.insert(
+      Arc::from(definition),
+      ProgramDefEntry {
+        code,
+        schema,
+        doc: Arc::from(""),
+        examples: vec![],
+        ffi: None,
+      },
+    );
+  }
+  PROGRAM_CODE_DATA.write().expect("install Calx eligibility fixtures").insert(
+    Arc::from(namespace),
+    ProgramFileData {
+      import_map: HashMap::new(),
+      defs: entries,
+    },
+  );
+}
+
+fn compile_calx_test_entry(namespace: &str, definition: &str) {
+  let warnings = RefCell::new(vec![]);
+  crate::runner::preprocess::ensure_ns_def_compiled(namespace, definition, &warnings, &CallStackList::default())
+    .unwrap_or_else(|error| panic!("preprocess Calx fixture {namespace}/{definition}: {error}"));
+  assert!(
+    warnings.borrow().is_empty(),
+    "unexpected fixture warnings: {:#?}",
+    warnings.borrow()
+  );
+}
+
+#[test]
+fn calx_eligibility_accepts_three_real_preprocessed_scalar_kernels() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-kernels";
+  let number = || CalcitTypeAnnotation::Number;
+  let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/scalar-kernels.cirru"));
+  install_calx_test_defs(
+    namespace,
+    vec![
+      (
+        "range-sum",
+        source_defs.remove("range-sum").expect("range-sum source"),
+        calx_test_fn_schema(vec![number(), number()], number()),
+      ),
+      (
+        "fibonacci",
+        source_defs.remove("fibonacci").expect("fibonacci source"),
+        calx_test_fn_schema(vec![number()], number()),
+      ),
+      (
+        "affine-helper",
+        source_defs.remove("affine-helper").expect("affine-helper source"),
+        calx_test_fn_schema(vec![number(), number(), number()], number()),
+      ),
+      (
+        "affine",
+        source_defs.remove("affine").expect("affine source"),
+        calx_test_fn_schema(vec![number(), number(), number()], number()),
+      ),
+    ],
+  );
+  for definition in ["range-sum", "fibonacci", "affine"] {
+    compile_calx_test_entry(namespace, definition);
+  }
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed preprocessed Calx fixtures");
+
+  let range = analyze_calx_eligibility(&snapshot, namespace, "range-sum").expect("range-sum should be eligible");
+  assert_eq!(range.functions.len(), 1);
+  assert_eq!(range.functions[0].params, vec![CalxScalarType::F64, CalxScalarType::F64]);
+  assert_eq!(range.functions[0].result, Some(CalxScalarType::F64));
+
+  let fibonacci = analyze_calx_eligibility(&snapshot, namespace, "fibonacci").expect("fibonacci should be eligible");
+  assert_eq!(fibonacci.functions.len(), 1);
+  assert_eq!(
+    fibonacci.functions[0].direct_calls,
+    vec![CalxDefinitionRef::new(namespace, "fibonacci")]
+  );
+
+  let affine = analyze_calx_eligibility(&snapshot, namespace, "affine").expect("affine should be eligible");
+  assert_eq!(
+    affine
+      .functions
+      .iter()
+      .map(|function| function.definition.definition.as_ref())
+      .collect::<Vec<_>>(),
+    vec!["affine", "affine-helper"]
+  );
+  let summary = format!(
+    "## range-sum\n{}## fibonacci\n{}## affine\n{}",
+    range.stable_summary(),
+    fibonacci.stable_summary(),
+    affine.stable_summary()
+  );
+  assert_eq!(summary, include_str!("../../tests/fixtures/calx/scalar-kernels.golden.txt"));
+}
+
+#[test]
+fn calx_eligibility_falls_back_for_the_whole_reachable_closure() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-fallback";
+  let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/fallback.cirru"));
+  install_calx_test_defs(
+    namespace,
+    vec![
+      (
+        "dynamic-helper",
+        source_defs.remove("dynamic-helper").expect("dynamic-helper source"),
+        DYNAMIC_TYPE.clone(),
+      ),
+      (
+        "entry",
+        source_defs.remove("entry").expect("entry source"),
+        calx_test_fn_schema(vec![CalcitTypeAnnotation::Number], CalcitTypeAnnotation::Number),
+      ),
+    ],
+  );
+  compile_calx_test_entry(namespace, "entry");
+  let snapshot = clone_compiled_program_snapshot().expect("clone fallback fixture");
+
+  let report = analyze_calx_eligibility(&snapshot, namespace, "entry").expect_err("reachable Dynamic callee must reject closure");
+  assert_eq!(
+    report.stable_summary(),
+    include_str!("../../tests/fixtures/calx/fallback.golden.txt")
+  );
+  assert!(report.issues.iter().any(|issue| issue.code == CalxFallbackCode::DynamicType));
+  assert!(report.issues.iter().any(|issue| issue.code == CalxFallbackCode::CallClosure));
+  let dynamic = report
+    .issues
+    .iter()
+    .find(|issue| issue.code == CalxFallbackCode::DynamicType)
+    .expect("Dynamic fallback detail");
+  assert_eq!(dynamic.call_path.len(), 2);
+  assert_eq!(dynamic.call_path[1], CalxDefinitionRef::new(namespace, "dynamic-helper"));
 }
 
 fn compiled_def_for_test(def_id: DefId, deps: Vec<DefId>) -> CompiledDef {

--- a/tests/fixtures/calx/fallback.cirru
+++ b/tests/fixtures/calx/fallback.cirru
@@ -1,0 +1,5 @@
+defn dynamic-helper (x)
+  , x
+
+defn entry (x)
+  dynamic-helper x

--- a/tests/fixtures/calx/fallback.golden.txt
+++ b/tests/fixtures/calx/fallback.golden.txt
@@ -1,0 +1,5 @@
+abi calcit-calx-kernel/1
+entry tests.calx-fallback/entry
+issue CALX_SUBSET_DYNAMIC_TYPE tests.calx-fallback/dynamic-helper source=1 call=tests.calx-fallback/entry -> tests.calx-fallback/dynamic-helper message=function `tests.calx-fallback/dynamic-helper` has non-function schema `dynamic`
+issue CALX_SUBSET_DYNAMIC_TYPE tests.calx-fallback/dynamic-helper source=3 call=tests.calx-fallback/entry -> tests.calx-fallback/dynamic-helper message=local `x` remains Dynamic
+issue CALX_SUBSET_CALL_CLOSURE tests.calx-fallback/entry source=- call=tests.calx-fallback/entry message=entry `tests.calx-fallback/entry` has an ineligible reachable call closure

--- a/tests/fixtures/calx/scalar-kernels.cirru
+++ b/tests/fixtures/calx/scalar-kernels.cirru
@@ -1,0 +1,17 @@
+defn range-sum (n acc)
+  if (&< n 1)
+    , acc
+    recur (&- n 1) (&+ acc n)
+
+defn fibonacci (n)
+  if (&< n 2)
+    , n
+    &+
+      fibonacci $ &- n 1
+      fibonacci $ &- n 2
+
+defn affine-helper (x scale offset)
+  &+ (&* x scale) offset
+
+defn affine (x scale offset)
+  affine-helper x scale offset

--- a/tests/fixtures/calx/scalar-kernels.golden.txt
+++ b/tests/fixtures/calx/scalar-kernels.golden.txt
@@ -1,0 +1,15 @@
+## range-sum
+abi calcit-calx-kernel/1
+entry tests.calx-kernels/range-sum
+function tests.calx-kernels/range-sum (F64,F64)->F64
+## fibonacci
+abi calcit-calx-kernel/1
+entry tests.calx-kernels/fibonacci
+function tests.calx-kernels/fibonacci (F64)->F64
+  call tests.calx-kernels/fibonacci
+## affine
+abi calcit-calx-kernel/1
+entry tests.calx-kernels/affine
+function tests.calx-kernels/affine (F64,F64,F64)->F64
+  call tests.calx-kernels/affine-helper
+function tests.calx-kernels/affine-helper (F64,F64,F64)->F64


### PR DESCRIPTION
## 中文

### 背景

这是 [calcit-lang/calx-vm#38](https://github.com/calcit-lang/calx-vm/issues/38) 的第一段 Calcit frontend 工作。目标是在真正生成 Calx program 前，先用 Calcit 已完成 macro expansion、symbol resolution 与类型预处理的 `CompiledProgram` 建立严格的 scalar kernel 准入边界。

### 改动

- 新增 `codegen::calx::analyze_calx_eligibility`，从不可变 `CompiledProgram` snapshot 分析显式入口及其完整 direct-call closure。
- 首批接受固定参数的 `Number`/`Bool`、`Unit` 结果、local、完整 `if`、数值运算/比较、直接调用和尾位置 `recur`。
- 明确拒绝 `Dynamic`、Nil/absence、unsupported storage/boundary types、间接调用、非尾递归和未批准的 host capability。
- 任一可达 callee 不合格时整体回退；报告携带稳定 code、definition、可用的 source tree path 与 call path，并使用确定排序。
- 新增从真实 Cirru source 经正常 preprocessing 产生 snapshot 的 fixtures，覆盖 range sum、Fibonacci、affine helper graph，以及 Dynamic callee 导致的 closure fallback。
- 增加实验边界文档与稳定 golden summaries。

### 边界

本 PR 不生成或执行 Calx program，也不依赖未发布的 `calx_vm` Git revision。等包含 `ProgramBuilder` 的稳定 crate 发布后，下一段再把同一份 typed expressions 降低为 `ProgramBuilder -> CalxProgram -> ValidatedProgram`。

### 验证

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`（17/17）
- `yarn check-all`（包括 native、JS、WASM 与性能回归）

关联：https://github.com/calcit-lang/calx-vm/issues/38

## English

### Background

This is the first Calcit frontend slice for [calcit-lang/calx-vm#38](https://github.com/calcit-lang/calx-vm/issues/38). Before emitting a Calx program, it establishes a strict scalar-kernel eligibility boundary over Calcit's real `CompiledProgram`, after macro expansion, symbol resolution, and type preprocessing.

### Changes

- Add `codegen::calx::analyze_calx_eligibility` to analyze an explicit entry and its complete direct-call closure from an immutable `CompiledProgram` snapshot.
- Initially accept fixed-arity `Number`/`Bool` functions, `Unit` results, locals, complete `if`, numeric operations/comparisons, direct calls, and tail-position `recur`.
- Explicitly reject `Dynamic`, Nil/absence, unsupported storage or boundary types, indirect calls, non-tail recursion, and unapproved host capabilities.
- Fall back the whole entry when any reachable callee is ineligible. Reports retain stable codes, definitions, available source-tree paths, and call paths with deterministic ordering.
- Add fixtures that start from real Cirru source, pass through normal preprocessing, and then analyze the snapshot. They cover range sum, Fibonacci, an affine helper graph, and closure fallback caused by a Dynamic callee.
- Document the experimental boundary and add stable golden summaries.

### Scope

This PR neither emits nor executes a Calx program, and it does not depend on an unpublished `calx_vm` Git revision. Once a stable crate containing `ProgramBuilder` is published, the next slice can lower the same typed expressions through `ProgramBuilder -> CalxProgram -> ValidatedProgram`.

### Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (17/17)
- `yarn check-all`, including native, JS, WASM, and performance regressions

Related: https://github.com/calcit-lang/calx-vm/issues/38
