### PR TITLE
将 typed scalar kernel 降为 Calx 严格程序 | Lower typed scalar kernels to strict Calx programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bisection_key"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +138,7 @@ dependencies = [
  "argh",
  "bisection_key",
  "calcit_native_ffi",
+ "calx_vm",
  "cirru_edn",
  "cirru_parser",
  "colored",
@@ -148,6 +169,18 @@ name = "calcit_native_ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a8cfaff7caed355a63e9df68c57cea5af1d01b1b37734ed812a4a9ed2faeed"
+
+[[package]]
+name = "calx_vm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41617de20ac52661b75b70b13fba720c657032e086c14e70c0ef3b79bc0cdf08"
+dependencies = [
+ "argh",
+ "bincode",
+ "cirru_parser",
+ "regex",
+]
 
 [[package]]
 name = "cc"
@@ -981,6 +1014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1053,12 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0.151"
 cirru_edn = "0.8.0"
 cirru_parser = "=0.2.15"
 bisection_key = "0.0.1"
+calx_vm = "0.3.0"
 calcit_native_ffi = { version = "0.1.2", default-features = false }
 rmp-serde = "1.3.0"
 semver = "1.0.28"

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -1,33 +1,47 @@
-# 实验性 Calx target：eligibility 与整体回退
+# 实验性 Calx target：typed scalar kernel lowering
 
 Calcit 正在验证一个很窄的 typed scalar kernel 子集能否编译到 Calx。这个实验不改变默认 native
 runner、JS codegen 或仓库内部 WASM backend，也不会把任意 Calcit 函数静默发送给另一个运行时。
 
-当前第一阶段只建立编译前的 eligibility boundary：
+当前阶段建立 eligibility boundary，并把通过证明的 closed kernel 降为可执行的 strict Calx program：
 
 ```text
 explicit namespace/definition
   -> macro-expanded, symbol-resolved, typed CompiledProgram snapshot
   -> closed reachable direct-call graph
-       -> eligible graph
        -> structured FallbackReport
+       -> typed lowering plan
+       -> ProgramBuilder -> CalxProgram -> ValidatedProgram
+       -> CalxVM::run_typed
 ```
 
 Rust embedding 可对同一个不可变 snapshot 调用：
 
 ```rust
-use calcit::codegen::calx::analyze_calx_eligibility;
+use calcit::calcit::Calcit;
+use calcit::codegen::calx::{analyze_calx_eligibility, compile_calx_kernel};
 
 let snapshot = calcit::program::clone_compiled_program_snapshot()?;
 match analyze_calx_eligibility(&snapshot, "app.kernel", "range-sum") {
   Ok(graph) => println!("{}", graph.stable_summary()),
   Err(report) => eprintln!("{}", report.stable_summary()),
 }
+
+let kernel = compile_calx_kernel(&snapshot, "app.kernel", "range-sum")?;
+let value = kernel.run(&[Calcit::Number(10.0), Calcit::Number(0.0)])?;
 ```
 
 `analyze_calx_eligibility` 不执行代码，也不产生半个 Calx program。只有入口可达的每个 definition
 都通过时才返回 `CalxEligibleCallGraph`；任意 callee 不合格都会返回覆盖整个 closure 的
 `CalxFallbackReport`。
+
+`compile_calx_kernel` 只在完整 graph eligible 后创建 lowering plan，再统一提交给 `ProgramBuilder` 并转换为
+`ValidatedProgram`。entry 在 Calx 内命名为 `main`，其余 reachable functions 使用确定的 fully-qualified
+name；direct tail call 与 `recur` 降为 `return-call`。
+
+运行边界严格按已证明签名逐项转换：Calcit `Number` 对应 Calx `F64`，Calcit `Bool` 对应 Calx
+`Bool`，void result 对应 Calcit `Unit`。`Nil`、Dynamic 或任意不匹配的 runtime value 会在进入 VM
+之前被拒绝，不会被编码为占位值。
 
 ## 首批接受范围
 
@@ -74,18 +88,22 @@ golden tests，但明确是 experimental report，不是可持久化的 compiler
 - `fibonacci`：if、F64 comparison 与 direct recursion；
 - `affine`：多参数算术和 direct helper call graph。
 
-测试先让这些 definitions 经过 Calcit preprocessing，再从 `CompiledProgram` snapshot 分析；对应
-golden 固定 ABI、entry、函数签名、确定排序与 direct-call edges。另一个 fixture 固定 Dynamic
-callee 导致整个入口 closure fallback 的报告。
+测试先让这些 definitions 经过 Calcit preprocessing，再从 `CompiledProgram` snapshot 分析和 lowering；
+对应 golden 固定 ABI、entry、函数签名、确定排序与 direct-call edges。三个 kernel 都会在 strict Calx
+VM 中实际执行，并与同一源码的 Calcit native runner 做差分比较。另一个 fixture 固定 Dynamic callee
+导致整个入口 closure fallback 的报告，并验证不会进入 lowering。
+
+## 错误与回退边界
+
+- `Eligibility` 是唯一允许 embedding 选择整体回退到 Calcit 的编译结果；
+- `Lowering` 表示 eligibility 与 lowering 对 typed expression 的理解不一致；
+- `Build` / `Validation` 表示生成程序违反 Calx contract；
+- `Instantiate` / `Runtime` 表示 binding 或执行失败。
+
+后四类不是 eligibility fallback，运行失败后也不会自动重跑 Calcit，以免未来 effect import 被执行两次。
 
 ## 尚未实现
 
-本阶段故意不依赖未发布的 `calx_vm` git revision，也不复制 Calx IR。后续阶段会在包含
-`ProgramBuilder` 的稳定 calx_vm crate 可用后，把 eligible graph 和同一份 typed expressions 降为：
-
-```text
-ProgramBuilder -> CalxProgram -> ValidatedProgram -> CalxVM::run_typed
-```
-
-build/validation/binding failure 与 runtime trap 不属于 eligibility fallback，运行失败后也不会自动
-重跑 Calcit，以免 effect import 被执行两次。
+当前 API 仍是 Rust embedding，不是 `calcit` CLI 的正式 backend。首批没有 collection/nominal value、closure、
+typed host capability、cache、profiling/selection policy，也还没有基于 benchmark 的自动 offload。下一阶段应先补
+compile cache 与基准矩阵，再扩展一小组无歧义的 typed host imports；在 effect contract 完成前不扩大到有副作用代码。

--- a/editing-history/202608302229-calx-program-lowering.md
+++ b/editing-history/202608302229-calx-program-lowering.md
@@ -1,0 +1,21 @@
+# Calx strict program lowering / Calx 严格程序 lowering
+
+## 中文
+
+- 在完整 eligibility graph 通过后，从同一份 typed `CompiledProgram` expression 先建立内部 lowering plan，再通过稳定版 `calx_vm 0.3.0` 的 `ProgramBuilder -> CalxProgram -> ValidatedProgram` 生成可执行程序；entry 映射为 `main`，其余 reachable function 使用确定的 fully-qualified name。
+- 首批 lowering 覆盖 `Number`/`Bool`/`Unit`、typed parameter/local、单 binding `&let`、sequence/drop、完整 `if`、数值运算与比较、direct call、direct tail call 与 `recur`。每条生成 syntax 携带可追踪到 Calcit definition/tree path 的 synthetic source origin。
+- 严格运行边界只做 `Calcit::Number <-> Calx::F64`、`Calcit::Bool <-> Calx::Bool`、void result -> `Calcit::Unit` 的精确转换。Nil、Dynamic 或其他 runtime value 在实例化 VM 前拒绝，不产生占位值。
+- 只有 `Eligibility` 允许 embedding 选择 whole-kernel fallback；`Lowering`、`Build`、`Validation`、`Instantiate` 与 runtime trap 保持独立，执行失败后不会自动重跑 Calcit，避免未来 effect import 双执行。
+- source-backed fixtures 实际执行 range sum、Fibonacci 与带 typed local/helper tail call 的 affine kernel，并与 native Calcit runner 做差分；Dynamic callee 继续验证整条 closure 在 lowering 前回退。
+- 新依赖树复用了已有 `argh`、`cirru_parser`、`regex`，额外引入 `bincode` 及其 derive 构建依赖；同工具链 release LTO 产物从 main 基线 9,392,160 bytes 增至 9,392,368 bytes（+208 bytes），默认执行路径没有 Calx 初始化。
+- 验证通过：`cargo fmt`、`cargo clippy --all-targets --all-features -- -D warnings`、`cargo test`、`yarn compile`、`yarn check-all`、`yarn check-agent-interface`（17/17），并完成 release binary size 对比。
+
+## English
+
+- After the complete eligibility graph succeeds, build an internal lowering plan from the same typed `CompiledProgram` expressions, then produce an executable program through stable `calx_vm 0.3.0` and `ProgramBuilder -> CalxProgram -> ValidatedProgram`. The entry maps to `main`; other reachable functions use deterministic fully-qualified names.
+- The initial lowering covers `Number`/`Bool`/`Unit`, typed parameters and locals, one-binding `&let`, sequence/drop, complete `if`, numeric operations and comparisons, direct calls, direct tail calls, and `recur`. Every generated syntax item carries a synthetic source origin traceable to a Calcit definition/tree path.
+- The strict runtime boundary performs only exact `Calcit::Number <-> Calx::F64`, `Calcit::Bool <-> Calx::Bool`, and void result -> `Calcit::Unit` conversions. Nil, Dynamic, and other runtime values are rejected before VM instantiation; no placeholder value is emitted.
+- Only `Eligibility` lets an embedding select whole-kernel fallback. `Lowering`, `Build`, `Validation`, `Instantiate`, and runtime traps remain distinct, and execution failures never automatically rerun Calcit, preventing future effect imports from executing twice.
+- Source-backed fixtures execute range sum, Fibonacci, and an affine kernel with a typed local/helper tail call, then compare them differentially with the native Calcit runner. A Dynamic callee still proves whole-closure fallback happens before lowering.
+- The dependency tree reuses the existing `argh`, `cirru_parser`, and `regex` crates, adding `bincode` and its derive-time dependencies. With the same release LTO toolchain, the binary grows from a main baseline of 9,392,160 bytes to 9,392,368 bytes (+208 bytes), with no Calx initialization on the default execution path.
+- Verification passes `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, `yarn compile`, `yarn check-all`, and `yarn check-agent-interface` (17/17), plus a release binary-size comparison.

--- a/editing-history/202608310011-calx-lowering-review.md
+++ b/editing-history/202608310011-calx-lowering-review.md
@@ -1,0 +1,17 @@
+# Calx lowering review hardening / Calx lowering 审阅加固
+
+## 中文
+
+- 处理 PR #532 review：生成阶段不再用 map 下标直接访问 `LocalId`。typed local 若没有对应的 emitted Calx local，会返回带 definition 与 source tree path 的 `CalxKernelCompileError::Lowering`，不再存在异常 snapshot 触发 panic 的路径。
+- 由于 `BodyBuilder` 的 structured-control closure 只接受 `CalxBuildError`，emission context 记录首个 lowering invariant failure，并在 function 加入 `ProgramBuilder` 之前返回；不会生成或验证部分 program。
+- 增加异常 lowering plan 的回归测试，固定 missing local index 的结构化错误行为。
+- 从 `calcit::codegen::calx` re-export 公共错误枚举 payload 使用的 `CalxBuildError`、`CalxProgramError` 与 `CalxError`，下游无需声明匹配版本的直接依赖即可匹配错误。
+- 验证通过：`cargo fmt`、590 个 library tests 与全部 binary/doc tests、`cargo clippy --all-targets --all-features -- -D warnings`、`yarn compile`、`yarn check-all`、`yarn check-agent-interface`（17/17）。
+
+## English
+
+- Address PR #532 review feedback by removing direct map indexing for `LocalId` during emission. If a typed local has no emitted Calx local, lowering now returns `CalxKernelCompileError::Lowering` with its definition and source tree path instead of allowing a malformed snapshot to panic.
+- Because `BodyBuilder` structured-control closures accept only `CalxBuildError`, the emission context records the first lowering invariant failure and returns it before adding the function to `ProgramBuilder`; no partial program is built or validated.
+- Add a regression test for the structured missing-local error from a malformed lowering plan.
+- Re-export `CalxBuildError`, `CalxProgramError`, and `CalxError` from `calcit::codegen::calx`, matching the payload types exposed by the public error enums so downstream users do not need a version-matched direct dependency merely to pattern-match errors.
+- Verification passes `cargo fmt`, 590 library tests plus all binary/doc tests, `cargo clippy --all-targets --all-features -- -D warnings`, `yarn compile`, `yarn check-all`, and `yarn check-agent-interface` (17/17).

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -1,8 +1,16 @@
-//! Eligibility analysis for the experimental Calcit-to-Calx scalar subset.
+//! Eligibility analysis and lowering for the experimental Calcit-to-Calx scalar subset.
 //!
 //! This module consumes an immutable [`CompiledProgram`](crate::program::CompiledProgram)
-//! snapshot. It does not depend on `calx_vm` and does not emit a partial program:
-//! callers receive either a closed eligible call graph or one stable fallback report.
+//! snapshot. It never emits a partial program: callers receive either a closed eligible
+//! call graph, or one stable fallback report. Eligible graphs can then be lowered through
+//! `calx_vm::ProgramBuilder` and strict validation without admitting Nil or Dynamic values.
+
+mod lowering;
+
+pub use lowering::{
+  CalxCompiledKernel, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError,
+  CalxLoweringError, compile_calx_kernel,
+};
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -7,6 +7,7 @@
 
 mod lowering;
 
+pub use calx_vm::{CalxBuildError, CalxError, CalxProgramError};
 pub use lowering::{
   CalxCompiledKernel, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError,
   CalxLoweringError, compile_calx_kernel,

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -1,0 +1,838 @@
+//! Typed lowering from a proven Calx-eligible Calcit call graph.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
+use std::sync::Arc;
+
+use calx_vm::{
+  BodyBuilder, Calx as VmValue, CalxBuildError, CalxError, CalxHostBindings, CalxProgramError, CalxRunResult, CalxSyntax as VmSyntax,
+  CalxType as VmType, CalxVM, FunctionBuilder, LocalId, ProgramBuilder, SourceSpan, ValidatedProgram,
+};
+
+use crate::calcit::{Calcit, CalcitFnArgs, CalcitLocal, CalcitProc, CalcitSyntax, brief_type_of_value};
+use crate::program::CompiledProgram;
+
+use super::{
+  CalxDefinitionRef, CalxEligibleCallGraph, CalxFallbackReport, CalxScalarType, analyze_calx_eligibility, extract_fn_parts,
+  lookup_compiled_def, source_path,
+};
+
+impl CalxScalarType {
+  const fn vm_type(self) -> VmType {
+    match self {
+      Self::F64 => VmType::F64,
+      Self::Bool => VmType::Bool,
+    }
+  }
+}
+
+/// A mismatch discovered while converting a graph that already passed the
+/// eligibility proof. This is a compiler integration error, not a fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxLoweringError {
+  pub function: CalxDefinitionRef,
+  pub source_path: Option<Vec<u16>>,
+  pub message: String,
+}
+
+impl fmt::Display for CalxLoweringError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "failed to lower `{}`: {}", self.function.qualified(), self.message)
+  }
+}
+
+impl Error for CalxLoweringError {}
+
+/// Compile-time phases remain distinct so only eligibility failures may be
+/// treated as a deliberate whole-kernel fallback by an embedding.
+#[derive(Debug)]
+pub enum CalxKernelCompileError {
+  Eligibility(CalxFallbackReport),
+  Lowering(CalxLoweringError),
+  Build(CalxBuildError),
+  Validation(CalxProgramError),
+}
+
+impl fmt::Display for CalxKernelCompileError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Eligibility(report) => write!(
+        f,
+        "Calx eligibility rejected `{}` with {} issue(s)",
+        report.entry.qualified(),
+        report.issues.len()
+      ),
+      Self::Lowering(error) => error.fmt(f),
+      Self::Build(error) => write!(f, "Calx program build failed: {error}"),
+      Self::Validation(error) => write!(f, "Calx program validation failed: {error}"),
+    }
+  }
+}
+
+impl Error for CalxKernelCompileError {
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    match self {
+      Self::Eligibility(_) => None,
+      Self::Lowering(error) => Some(error),
+      Self::Build(error) => Some(error),
+      Self::Validation(error) => Some(error),
+    }
+  }
+}
+
+impl From<CalxLoweringError> for CalxKernelCompileError {
+  fn from(error: CalxLoweringError) -> Self {
+    Self::Lowering(error)
+  }
+}
+
+impl From<CalxBuildError> for CalxKernelCompileError {
+  fn from(error: CalxBuildError) -> Self {
+    Self::Build(error)
+  }
+}
+
+impl From<CalxProgramError> for CalxKernelCompileError {
+  fn from(error: CalxProgramError) -> Self {
+    Self::Validation(error)
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalxKernelBoundaryErrorKind {
+  Arity,
+  ArgumentType,
+  ResultType,
+}
+
+/// Failure at the strict Calcit/Calx value boundary. No conversion to Nil or
+/// Dynamic is attempted when a value does not match the proven signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxKernelBoundaryError {
+  pub kind: CalxKernelBoundaryErrorKind,
+  pub message: String,
+}
+
+impl fmt::Display for CalxKernelBoundaryError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.write_str(&self.message)
+  }
+}
+
+impl Error for CalxKernelBoundaryError {}
+
+#[derive(Debug)]
+pub enum CalxKernelRunError {
+  Boundary(CalxKernelBoundaryError),
+  Instantiate(CalxProgramError),
+  Runtime(CalxError),
+}
+
+impl fmt::Display for CalxKernelRunError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Boundary(error) => write!(f, "Calx kernel boundary rejected a value: {error}"),
+      Self::Instantiate(error) => write!(f, "Calx kernel instantiation failed: {error}"),
+      Self::Runtime(error) => write!(f, "Calx kernel trapped: {error}"),
+    }
+  }
+}
+
+impl Error for CalxKernelRunError {
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    match self {
+      Self::Boundary(error) => Some(error),
+      Self::Instantiate(error) => Some(error),
+      // calx_vm 0.3 keeps CalxError as a diagnostic value rather than a
+      // std::error::Error implementation.
+      Self::Runtime(_) => None,
+    }
+  }
+}
+
+/// An immutable strict Calx program plus its proven Calcit kernel boundary.
+#[derive(Debug, Clone)]
+pub struct CalxCompiledKernel {
+  graph: CalxEligibleCallGraph,
+  params: Vec<CalxScalarType>,
+  result: Option<CalxScalarType>,
+  program: ValidatedProgram,
+}
+
+impl CalxCompiledKernel {
+  pub fn graph(&self) -> &CalxEligibleCallGraph {
+    &self.graph
+  }
+
+  pub fn params(&self) -> &[CalxScalarType] {
+    &self.params
+  }
+
+  pub fn result(&self) -> Option<CalxScalarType> {
+    self.result
+  }
+
+  pub fn validated_program(&self) -> &ValidatedProgram {
+    &self.program
+  }
+
+  pub fn instantiate(&self) -> Result<CalxVM, CalxKernelRunError> {
+    CalxVM::from_validated_program(self.program.clone(), CalxHostBindings::new()).map_err(CalxKernelRunError::Instantiate)
+  }
+
+  pub fn run(&self, args: &[Calcit]) -> Result<Calcit, CalxKernelRunError> {
+    if args.len() != self.params.len() {
+      return Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+        kind: CalxKernelBoundaryErrorKind::Arity,
+        message: format!("expected {} arguments, found {}", self.params.len(), args.len()),
+      }));
+    }
+    let mut vm_args = Vec::with_capacity(args.len());
+    for (index, (value, expected)) in args.iter().zip(&self.params).enumerate() {
+      let converted = match (expected, value) {
+        (CalxScalarType::F64, Calcit::Number(value)) => VmValue::F64(*value),
+        (CalxScalarType::Bool, Calcit::Bool(value)) => VmValue::Bool(*value),
+        _ => {
+          return Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+            kind: CalxKernelBoundaryErrorKind::ArgumentType,
+            message: format!(
+              "argument {index} expected {}, found {}",
+              expected.as_str(),
+              brief_type_of_value(value)
+            ),
+          }));
+        }
+      };
+      vm_args.push(converted);
+    }
+
+    let mut vm = self.instantiate()?;
+    let output = vm.run_typed(vm_args).map_err(CalxKernelRunError::Runtime)?;
+    match (self.result, output) {
+      (None, CalxRunResult::Void) => Ok(Calcit::Unit),
+      (Some(CalxScalarType::F64), CalxRunResult::Value(VmValue::F64(value))) => Ok(Calcit::Number(value)),
+      (Some(CalxScalarType::Bool), CalxRunResult::Value(VmValue::Bool(value))) => Ok(Calcit::Bool(value)),
+      (expected, actual) => Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+        kind: CalxKernelBoundaryErrorKind::ResultType,
+        message: format!("validated result contract {expected:?} produced {actual:?}"),
+      })),
+    }
+  }
+}
+
+/// Prove, lower, build, and validate one closed scalar kernel call graph.
+///
+/// Only [`CalxKernelCompileError::Eligibility`] is a supported signal for
+/// whole-kernel fallback. Later failures indicate a compiler/VM integration
+/// problem and must not cause an automatic retry in the Calcit runtime.
+pub fn compile_calx_kernel(
+  program: &CompiledProgram,
+  namespace: impl Into<Arc<str>>,
+  definition: impl Into<Arc<str>>,
+) -> Result<CalxCompiledKernel, CalxKernelCompileError> {
+  let graph = analyze_calx_eligibility(program, namespace, definition).map_err(CalxKernelCompileError::Eligibility)?;
+  let entry_signature = graph
+    .functions
+    .iter()
+    .find(|function| function.definition == graph.entry)
+    .ok_or_else(|| CalxLoweringError {
+      function: graph.entry.clone(),
+      source_path: None,
+      message: "eligible graph does not contain its entry function".to_owned(),
+    })?;
+  let params = entry_signature.params.clone();
+  let result = entry_signature.result;
+  let names = function_names(&graph);
+  let signatures = graph
+    .functions
+    .iter()
+    .map(|function| (function.definition.clone(), (function.params.clone(), function.result)))
+    .collect::<BTreeMap<_, _>>();
+
+  let mut plans = Vec::with_capacity(graph.functions.len());
+  for function in &graph.functions {
+    plans.push(plan_function(
+      program,
+      function.definition.clone(),
+      &function.params,
+      function.result,
+      &names,
+      &signatures,
+    )?);
+  }
+
+  let mut builder = ProgramBuilder::new();
+  for plan in &plans {
+    builder.function(emit_function(plan)?)?;
+  }
+  let program = builder.build()?;
+  let program = ValidatedProgram::try_from_program(program)?;
+  Ok(CalxCompiledKernel {
+    graph,
+    params,
+    result,
+    program,
+  })
+}
+
+fn function_names(graph: &CalxEligibleCallGraph) -> BTreeMap<CalxDefinitionRef, String> {
+  graph
+    .functions
+    .iter()
+    .map(|function| {
+      let name = if function.definition == graph.entry {
+        "main".to_owned()
+      } else {
+        function.definition.qualified()
+      };
+      (function.definition.clone(), name)
+    })
+    .collect()
+}
+
+#[derive(Debug, Clone)]
+struct PlannedLocal {
+  name: Arc<str>,
+  value_type: CalxScalarType,
+  source_path: Option<Vec<u16>>,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedFunction {
+  definition: CalxDefinitionRef,
+  vm_name: String,
+  params: Vec<(u16, PlannedLocal)>,
+  locals: BTreeMap<u16, PlannedLocal>,
+  result: Option<CalxScalarType>,
+  body: PlannedExpression,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedExpression {
+  result: Option<CalxScalarType>,
+  source_path: Option<Vec<u16>>,
+  kind: PlannedExpressionKind,
+}
+
+#[derive(Debug, Clone)]
+enum PlannedExpressionKind {
+  Number(f64),
+  Bool(bool),
+  Unit,
+  Local(u16),
+  Sequence(Vec<PlannedExpression>),
+  Let {
+    local: u16,
+    value: Box<PlannedExpression>,
+    body: Box<PlannedExpression>,
+  },
+  If {
+    condition: Box<PlannedExpression>,
+    then_branch: Box<PlannedExpression>,
+    else_branch: Box<PlannedExpression>,
+  },
+  Operation {
+    operation: PlannedOperation,
+    args: Vec<PlannedExpression>,
+  },
+  Call {
+    function: String,
+    args: Vec<PlannedExpression>,
+    tail: bool,
+  },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PlannedOperation {
+  Add,
+  Subtract,
+  Multiply,
+  Divide,
+  Negate,
+  Equal,
+  LessThan,
+  GreaterThan,
+}
+
+struct PlanningContext<'a> {
+  function: &'a CalxDefinitionRef,
+  function_result: Option<CalxScalarType>,
+  names: &'a BTreeMap<CalxDefinitionRef, String>,
+  signatures: &'a BTreeMap<CalxDefinitionRef, (Vec<CalxScalarType>, Option<CalxScalarType>)>,
+  locals: BTreeMap<u16, PlannedLocal>,
+}
+
+fn plan_function(
+  program: &CompiledProgram,
+  definition: CalxDefinitionRef,
+  param_types: &[CalxScalarType],
+  result: Option<CalxScalarType>,
+  names: &BTreeMap<CalxDefinitionRef, String>,
+  signatures: &BTreeMap<CalxDefinitionRef, (Vec<CalxScalarType>, Option<CalxScalarType>)>,
+) -> Result<PlannedFunction, CalxLoweringError> {
+  let compiled =
+    lookup_compiled_def(program, &definition).ok_or_else(|| lower_error(&definition, None, "compiled definition disappeared"))?;
+  let (args, body) = extract_fn_parts(compiled, &definition, std::slice::from_ref(&definition), &mut vec![]).ok_or_else(|| {
+    lower_error(
+      &definition,
+      source_path(&compiled.preprocessed_code),
+      "eligible function shape could not be recovered",
+    )
+  })?;
+  let CalcitFnArgs::Args(arg_ids) = args else {
+    return Err(lower_error(
+      &definition,
+      source_path(&compiled.preprocessed_code),
+      "eligible function has marked arguments",
+    ));
+  };
+  if arg_ids.len() != param_types.len() {
+    return Err(lower_error(
+      &definition,
+      source_path(&compiled.preprocessed_code),
+      format!("parameter count changed from {} to {}", param_types.len(), arg_ids.len()),
+    ));
+  }
+
+  let params = arg_ids
+    .iter()
+    .zip(param_types)
+    .map(|(idx, value_type)| {
+      (
+        *idx,
+        PlannedLocal {
+          name: Arc::from(CalcitLocal::read_name(*idx)),
+          value_type: *value_type,
+          source_path: source_path(&compiled.preprocessed_code),
+        },
+      )
+    })
+    .collect::<Vec<_>>();
+  let mut context = PlanningContext {
+    function: &definition,
+    function_result: result,
+    names,
+    signatures,
+    locals: BTreeMap::new(),
+  };
+  let body = plan_sequence(&body, true, &mut context)?;
+  if body.result != result {
+    return Err(lower_error(
+      &definition,
+      body.source_path.clone(),
+      format!("planned result {:?} differs from eligible result {result:?}", body.result),
+    ));
+  }
+  let vm_name = names
+    .get(&definition)
+    .cloned()
+    .ok_or_else(|| lower_error(&definition, None, "eligible function has no Calx name"))?;
+  Ok(PlannedFunction {
+    definition: definition.clone(),
+    vm_name,
+    params,
+    locals: context.locals,
+    result,
+    body,
+  })
+}
+
+fn plan_sequence(
+  expressions: &[Calcit],
+  tail: bool,
+  context: &mut PlanningContext<'_>,
+) -> Result<PlannedExpression, CalxLoweringError> {
+  let Some(last) = expressions.last() else {
+    return Err(lower_error(context.function, None, "eligible sequence is empty"));
+  };
+  if expressions.len() == 1 {
+    return plan_expression(last, tail, context);
+  }
+  let mut planned = Vec::with_capacity(expressions.len());
+  for (index, expression) in expressions.iter().enumerate() {
+    planned.push(plan_expression(expression, tail && index + 1 == expressions.len(), context)?);
+  }
+  let result = planned.last().and_then(|expression| expression.result);
+  Ok(PlannedExpression {
+    result,
+    source_path: expressions.iter().find_map(source_path),
+    kind: PlannedExpressionKind::Sequence(planned),
+  })
+}
+
+fn plan_expression(expression: &Calcit, tail: bool, context: &mut PlanningContext<'_>) -> Result<PlannedExpression, CalxLoweringError> {
+  let path = source_path(expression);
+  match expression {
+    Calcit::Number(value) => Ok(planned(Some(CalxScalarType::F64), path, PlannedExpressionKind::Number(*value))),
+    Calcit::Bool(value) => Ok(planned(Some(CalxScalarType::Bool), path, PlannedExpressionKind::Bool(*value))),
+    Calcit::Unit => Ok(planned(None, path, PlannedExpressionKind::Unit)),
+    Calcit::Local(local) => Ok(planned(
+      scalar_local_type(local, context.function)?,
+      path,
+      PlannedExpressionKind::Local(local.idx),
+    )),
+    Calcit::List(items) if !items.is_empty() => plan_call(items, tail, context),
+    other => Err(lower_error(
+      context.function,
+      path,
+      format!("eligibility admitted unsupported expression `{other}`"),
+    )),
+  }
+}
+
+fn plan_call(
+  items: &crate::calcit::CalcitList,
+  tail: bool,
+  context: &mut PlanningContext<'_>,
+) -> Result<PlannedExpression, CalxLoweringError> {
+  let operator = &items[0];
+  let args = items.drop_left().to_vec();
+  match operator {
+    Calcit::Syntax(CalcitSyntax::If, _) => plan_if(&args, tail, context),
+    Calcit::Syntax(CalcitSyntax::CoreLet, _) => plan_let(&args, tail, context),
+    Calcit::Syntax(CalcitSyntax::AssertType, _) => args
+      .first()
+      .ok_or_else(|| lower_error(context.function, source_path(operator), "eligible assert-type has no value"))
+      .and_then(|value| plan_expression(value, tail, context)),
+    Calcit::Syntax(CalcitSyntax::HintFn, _) => Ok(planned(None, source_path(operator), PlannedExpressionKind::Unit)),
+    Calcit::Proc(proc) => plan_proc(*proc, &args, tail, context),
+    Calcit::Import(import) if import.ns.as_ref() == "calcit.core" && import.def.as_ref() == "do" => plan_sequence(&args, tail, context),
+    Calcit::Import(import) => plan_direct_call(CalxDefinitionRef::new(import.ns.clone(), import.def.clone()), &args, tail, context),
+    Calcit::Fn { info, .. } if info.def_ref.is_some() => {
+      let def_ref = info.def_ref.as_ref().ok_or_else(|| {
+        lower_error(
+          context.function,
+          source_path(operator),
+          "eligible direct function lost its definition reference",
+        )
+      })?;
+      plan_direct_call(
+        CalxDefinitionRef::new(def_ref.def_ns.clone(), def_ref.def_name.clone()),
+        &args,
+        tail,
+        context,
+      )
+    }
+    other => Err(lower_error(
+      context.function,
+      source_path(other),
+      format!("eligibility admitted unsupported operator `{other}`"),
+    )),
+  }
+}
+
+fn plan_if(args: &[Calcit], tail: bool, context: &mut PlanningContext<'_>) -> Result<PlannedExpression, CalxLoweringError> {
+  if args.len() != 3 {
+    return Err(lower_error(
+      context.function,
+      args.first().and_then(source_path),
+      "eligible if is not ternary",
+    ));
+  }
+  let condition = plan_expression(&args[0], false, context)?;
+  let then_branch = plan_expression(&args[1], tail, context)?;
+  let else_branch = plan_expression(&args[2], tail, context)?;
+  if condition.result != Some(CalxScalarType::Bool) || then_branch.result != else_branch.result {
+    return Err(lower_error(
+      context.function,
+      source_path(&args[0]),
+      "eligible if lost its Bool condition or equal branch types",
+    ));
+  }
+  let result = then_branch.result;
+  Ok(planned(
+    result,
+    source_path(&args[0]),
+    PlannedExpressionKind::If {
+      condition: Box::new(condition),
+      then_branch: Box::new(then_branch),
+      else_branch: Box::new(else_branch),
+    },
+  ))
+}
+
+fn plan_let(args: &[Calcit], tail: bool, context: &mut PlanningContext<'_>) -> Result<PlannedExpression, CalxLoweringError> {
+  let Some((binding, body)) = args.split_first() else {
+    return Err(lower_error(context.function, None, "eligible &let has no binding"));
+  };
+  match binding {
+    Calcit::Nil | Calcit::Unit => plan_sequence(body, tail, context),
+    Calcit::List(pair) if pair.is_empty() => plan_sequence(body, tail, context),
+    Calcit::List(pair) if pair.len() == 2 => {
+      let Calcit::Local(local) = &pair[0] else {
+        return Err(lower_error(
+          context.function,
+          source_path(&pair[0]),
+          "eligible &let name is not a local",
+        ));
+      };
+      let value_type = scalar_local_type(local, context.function)?;
+      let value = plan_expression(&pair[1], false, context)?;
+      if value.result != value_type {
+        return Err(lower_error(
+          context.function,
+          source_path(&pair[1]),
+          "eligible &let value changed type before lowering",
+        ));
+      }
+      let local_plan = PlannedLocal {
+        name: local.sym.clone(),
+        value_type: value_type.ok_or_else(|| lower_error(context.function, source_path(&pair[0]), "&let local cannot be void"))?,
+        source_path: local.location.as_ref().map(|path| path.as_ref().clone()),
+      };
+      if let Some(previous) = context.locals.insert(local.idx, local_plan.clone())
+        && (previous.name != local_plan.name || previous.value_type != local_plan.value_type)
+      {
+        return Err(lower_error(
+          context.function,
+          source_path(&pair[0]),
+          format!("local index {} was reused with an incompatible declaration", local.idx),
+        ));
+      }
+      let body = plan_sequence(body, tail, context)?;
+      let result = body.result;
+      Ok(planned(
+        result,
+        source_path(binding),
+        PlannedExpressionKind::Let {
+          local: local.idx,
+          value: Box::new(value),
+          body: Box::new(body),
+        },
+      ))
+    }
+    other => Err(lower_error(
+      context.function,
+      source_path(other),
+      "eligible &let binding has an unsupported shape",
+    )),
+  }
+}
+
+fn plan_proc(
+  proc: CalcitProc,
+  args: &[Calcit],
+  tail: bool,
+  context: &mut PlanningContext<'_>,
+) -> Result<PlannedExpression, CalxLoweringError> {
+  let (operation, result) = match proc {
+    CalcitProc::NativeAdd => (Some(PlannedOperation::Add), Some(CalxScalarType::F64)),
+    CalcitProc::NativeMinus if args.len() == 1 => (Some(PlannedOperation::Negate), Some(CalxScalarType::F64)),
+    CalcitProc::NativeMinus => (Some(PlannedOperation::Subtract), Some(CalxScalarType::F64)),
+    CalcitProc::NativeMultiply => (Some(PlannedOperation::Multiply), Some(CalxScalarType::F64)),
+    CalcitProc::NativeDivide => (Some(PlannedOperation::Divide), Some(CalxScalarType::F64)),
+    CalcitProc::NativeEquals => (Some(PlannedOperation::Equal), Some(CalxScalarType::Bool)),
+    CalcitProc::NativeLessThan => (Some(PlannedOperation::LessThan), Some(CalxScalarType::Bool)),
+    CalcitProc::NativeGreaterThan => (Some(PlannedOperation::GreaterThan), Some(CalxScalarType::Bool)),
+    CalcitProc::Recur => {
+      let name = context
+        .names
+        .get(context.function)
+        .cloned()
+        .ok_or_else(|| lower_error(context.function, None, "recursive function has no Calx name"))?;
+      let args = plan_args(args, context)?;
+      return Ok(planned(
+        context.function_result,
+        args.first().and_then(|value| value.source_path.clone()),
+        PlannedExpressionKind::Call {
+          function: name,
+          args,
+          tail,
+        },
+      ));
+    }
+    _ => {
+      return Err(lower_error(
+        context.function,
+        args.first().and_then(source_path),
+        format!("eligibility admitted unsupported proc `{proc}`"),
+      ));
+    }
+  };
+  let args = plan_args(args, context)?;
+  Ok(planned(
+    result,
+    args.first().and_then(|value| value.source_path.clone()),
+    PlannedExpressionKind::Operation {
+      operation: operation.ok_or_else(|| lower_error(context.function, None, "operation plan is missing"))?,
+      args,
+    },
+  ))
+}
+
+fn plan_direct_call(
+  target: CalxDefinitionRef,
+  args: &[Calcit],
+  tail: bool,
+  context: &mut PlanningContext<'_>,
+) -> Result<PlannedExpression, CalxLoweringError> {
+  let (_, result) = context.signatures.get(&target).ok_or_else(|| {
+    lower_error(
+      context.function,
+      args.first().and_then(source_path),
+      format!("callee `{}` is outside the graph", target.qualified()),
+    )
+  })?;
+  let function = context.names.get(&target).cloned().ok_or_else(|| {
+    lower_error(
+      context.function,
+      args.first().and_then(source_path),
+      format!("callee `{}` has no Calx name", target.qualified()),
+    )
+  })?;
+  let args = plan_args(args, context)?;
+  Ok(planned(
+    *result,
+    args.first().and_then(|value| value.source_path.clone()),
+    PlannedExpressionKind::Call { function, args, tail },
+  ))
+}
+
+fn plan_args(args: &[Calcit], context: &mut PlanningContext<'_>) -> Result<Vec<PlannedExpression>, CalxLoweringError> {
+  args.iter().map(|argument| plan_expression(argument, false, context)).collect()
+}
+
+fn scalar_local_type(local: &CalcitLocal, function: &CalxDefinitionRef) -> Result<Option<CalxScalarType>, CalxLoweringError> {
+  match local.type_info.as_ref() {
+    crate::calcit::CalcitTypeAnnotation::Number => Ok(Some(CalxScalarType::F64)),
+    crate::calcit::CalcitTypeAnnotation::Bool => Ok(Some(CalxScalarType::Bool)),
+    other => Err(lower_error(
+      function,
+      local.location.as_ref().map(|path| path.as_ref().clone()),
+      format!("eligible local `{}` has non-scalar type `{other}`", local.sym),
+    )),
+  }
+}
+
+fn planned(result: Option<CalxScalarType>, source_path: Option<Vec<u16>>, kind: PlannedExpressionKind) -> PlannedExpression {
+  PlannedExpression { result, source_path, kind }
+}
+
+fn lower_error(function: &CalxDefinitionRef, source_path: Option<Vec<u16>>, message: impl Into<String>) -> CalxLoweringError {
+  CalxLoweringError {
+    function: function.clone(),
+    source_path,
+    message: message.into(),
+  }
+}
+
+fn emit_function(plan: &PlannedFunction) -> Result<FunctionBuilder, CalxBuildError> {
+  let source = source_origin(&plan.definition, None);
+  let results = plan.result.into_iter().map(CalxScalarType::vm_type).collect();
+  let mut builder = FunctionBuilder::synthetic(plan.vm_name.clone(), results, source)?;
+  let mut local_ids = BTreeMap::new();
+  for (idx, local) in &plan.params {
+    let id = builder.parameter(local.name.as_ref(), local.value_type.vm_type())?;
+    local_ids.insert(*idx, id);
+  }
+  for (idx, local) in &plan.locals {
+    if local_ids.contains_key(idx) {
+      continue;
+    }
+    let span = Some(SourceSpan::synthetic(source_origin(&plan.definition, local.source_path.as_deref())));
+    let id = builder.local_at(local.name.as_ref(), local.value_type.vm_type(), span)?;
+    local_ids.insert(*idx, id);
+  }
+  emit_expression(&plan.body, builder.body(), &plan.definition, &local_ids)?;
+  Ok(builder)
+}
+
+fn emit_expression(
+  expression: &PlannedExpression,
+  body: &mut BodyBuilder,
+  function: &CalxDefinitionRef,
+  locals: &BTreeMap<u16, LocalId>,
+) -> Result<(), CalxBuildError> {
+  body.set_default_span(Some(SourceSpan::synthetic(source_origin(
+    function,
+    expression.source_path.as_deref(),
+  ))));
+  match &expression.kind {
+    PlannedExpressionKind::Number(value) => {
+      body.constant(VmValue::F64(*value))?;
+    }
+    PlannedExpressionKind::Bool(value) => {
+      body.constant(VmValue::Bool(*value))?;
+    }
+    PlannedExpressionKind::Unit => {}
+    PlannedExpressionKind::Local(idx) => {
+      body.local_get(&locals[idx])?;
+    }
+    PlannedExpressionKind::Sequence(expressions) => emit_sequence(expressions, body, function, locals)?,
+    PlannedExpressionKind::Let {
+      local,
+      value,
+      body: let_body,
+    } => {
+      emit_expression(value, body, function, locals)?;
+      body.local_set(&locals[local])?;
+      emit_expression(let_body, body, function, locals)?;
+    }
+    PlannedExpressionKind::If {
+      condition,
+      then_branch,
+      else_branch,
+    } => {
+      emit_expression(condition, body, function, locals)?;
+      let results = expression.result.into_iter().map(CalxScalarType::vm_type).collect();
+      body.if_else(
+        results,
+        |then_body| emit_expression(then_branch, then_body, function, locals),
+        |else_body| emit_expression(else_branch, else_body, function, locals),
+      )?;
+    }
+    PlannedExpressionKind::Operation { operation, args } => {
+      for argument in args {
+        emit_expression(argument, body, function, locals)?;
+      }
+      match operation {
+        PlannedOperation::Add => body.emit(VmSyntax::Add)?,
+        PlannedOperation::Subtract => body.emit(VmSyntax::Neg)?.emit(VmSyntax::Add)?,
+        PlannedOperation::Multiply => body.emit(VmSyntax::Mul)?,
+        PlannedOperation::Divide => body.emit(VmSyntax::Div)?,
+        PlannedOperation::Negate => body.emit(VmSyntax::Neg)?,
+        PlannedOperation::Equal => body.emit(VmSyntax::F64Eq)?,
+        PlannedOperation::LessThan => body.emit(VmSyntax::F64Lt)?,
+        PlannedOperation::GreaterThan => body.emit(VmSyntax::F64Gt)?,
+      };
+    }
+    PlannedExpressionKind::Call {
+      function: callee,
+      args,
+      tail,
+    } => {
+      for argument in args {
+        emit_expression(argument, body, function, locals)?;
+      }
+      if *tail {
+        body.return_call(callee.as_str())?;
+      } else {
+        body.call(callee.as_str())?;
+      }
+    }
+  }
+  Ok(())
+}
+
+fn emit_sequence(
+  expressions: &[PlannedExpression],
+  body: &mut BodyBuilder,
+  function: &CalxDefinitionRef,
+  locals: &BTreeMap<u16, LocalId>,
+) -> Result<(), CalxBuildError> {
+  for (index, expression) in expressions.iter().enumerate() {
+    emit_expression(expression, body, function, locals)?;
+    if index + 1 != expressions.len() && expression.result.is_some() {
+      body.emit(VmSyntax::Drop)?;
+    }
+  }
+  Ok(())
+}
+
+fn source_origin(function: &CalxDefinitionRef, path: Option<&[u16]>) -> String {
+  let path = path
+    .map(|parts| parts.iter().map(u16::to_string).collect::<Vec<_>>().join("."))
+    .unwrap_or_else(|| "-".to_owned());
+  format!("calcit:{}@{path}", function.qualified())
+}

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -1,5 +1,6 @@
 //! Typed lowering from a proven Calx-eligible Calcit call graph.
 
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
@@ -717,7 +718,7 @@ fn lower_error(function: &CalxDefinitionRef, source_path: Option<Vec<u16>>, mess
   }
 }
 
-fn emit_function(plan: &PlannedFunction) -> Result<FunctionBuilder, CalxBuildError> {
+fn emit_function(plan: &PlannedFunction) -> Result<FunctionBuilder, CalxKernelCompileError> {
   let source = source_origin(&plan.definition, None);
   let results = plan.result.into_iter().map(CalxScalarType::vm_type).collect();
   let mut builder = FunctionBuilder::synthetic(plan.vm_name.clone(), results, source)?;
@@ -734,18 +735,44 @@ fn emit_function(plan: &PlannedFunction) -> Result<FunctionBuilder, CalxBuildErr
     let id = builder.local_at(local.name.as_ref(), local.value_type.vm_type(), span)?;
     local_ids.insert(*idx, id);
   }
-  emit_expression(&plan.body, builder.body(), &plan.definition, &local_ids)?;
+  let context = EmissionContext {
+    function: &plan.definition,
+    locals: &local_ids,
+    lowering_error: RefCell::new(None),
+  };
+  emit_expression(&plan.body, builder.body(), &context)?;
+  if let Some(error) = context.lowering_error.into_inner() {
+    return Err(CalxKernelCompileError::Lowering(error));
+  }
   Ok(builder)
+}
+
+struct EmissionContext<'a> {
+  function: &'a CalxDefinitionRef,
+  locals: &'a BTreeMap<u16, LocalId>,
+  lowering_error: RefCell<Option<CalxLoweringError>>,
+}
+
+impl EmissionContext<'_> {
+  fn record_missing_local(&self, idx: u16, source_path: Option<Vec<u16>>) {
+    let mut error = self.lowering_error.borrow_mut();
+    if error.is_none() {
+      *error = Some(lower_error(
+        self.function,
+        source_path,
+        format!("typed local index {idx} has no emitted Calx LocalId"),
+      ));
+    }
+  }
 }
 
 fn emit_expression(
   expression: &PlannedExpression,
   body: &mut BodyBuilder,
-  function: &CalxDefinitionRef,
-  locals: &BTreeMap<u16, LocalId>,
+  context: &EmissionContext<'_>,
 ) -> Result<(), CalxBuildError> {
   body.set_default_span(Some(SourceSpan::synthetic(source_origin(
-    function,
+    context.function,
     expression.source_path.as_deref(),
   ))));
   match &expression.kind {
@@ -757,34 +784,42 @@ fn emit_expression(
     }
     PlannedExpressionKind::Unit => {}
     PlannedExpressionKind::Local(idx) => {
-      body.local_get(&locals[idx])?;
+      if let Some(local) = context.locals.get(idx) {
+        body.local_get(local)?;
+      } else {
+        context.record_missing_local(*idx, expression.source_path.clone());
+      }
     }
-    PlannedExpressionKind::Sequence(expressions) => emit_sequence(expressions, body, function, locals)?,
+    PlannedExpressionKind::Sequence(expressions) => emit_sequence(expressions, body, context)?,
     PlannedExpressionKind::Let {
       local,
       value,
       body: let_body,
     } => {
-      emit_expression(value, body, function, locals)?;
-      body.local_set(&locals[local])?;
-      emit_expression(let_body, body, function, locals)?;
+      emit_expression(value, body, context)?;
+      if let Some(local_id) = context.locals.get(local) {
+        body.local_set(local_id)?;
+      } else {
+        context.record_missing_local(*local, expression.source_path.clone());
+      }
+      emit_expression(let_body, body, context)?;
     }
     PlannedExpressionKind::If {
       condition,
       then_branch,
       else_branch,
     } => {
-      emit_expression(condition, body, function, locals)?;
+      emit_expression(condition, body, context)?;
       let results = expression.result.into_iter().map(CalxScalarType::vm_type).collect();
       body.if_else(
         results,
-        |then_body| emit_expression(then_branch, then_body, function, locals),
-        |else_body| emit_expression(else_branch, else_body, function, locals),
+        |then_body| emit_expression(then_branch, then_body, context),
+        |else_body| emit_expression(else_branch, else_body, context),
       )?;
     }
     PlannedExpressionKind::Operation { operation, args } => {
       for argument in args {
-        emit_expression(argument, body, function, locals)?;
+        emit_expression(argument, body, context)?;
       }
       match operation {
         PlannedOperation::Add => body.emit(VmSyntax::Add)?,
@@ -803,7 +838,7 @@ fn emit_expression(
       tail,
     } => {
       for argument in args {
-        emit_expression(argument, body, function, locals)?;
+        emit_expression(argument, body, context)?;
       }
       if *tail {
         body.return_call(callee.as_str())?;
@@ -818,11 +853,10 @@ fn emit_expression(
 fn emit_sequence(
   expressions: &[PlannedExpression],
   body: &mut BodyBuilder,
-  function: &CalxDefinitionRef,
-  locals: &BTreeMap<u16, LocalId>,
+  context: &EmissionContext<'_>,
 ) -> Result<(), CalxBuildError> {
   for (index, expression) in expressions.iter().enumerate() {
-    emit_expression(expression, body, function, locals)?;
+    emit_expression(expression, body, context)?;
     if index + 1 != expressions.len() && expression.result.is_some() {
       body.emit(VmSyntax::Drop)?;
     }
@@ -835,4 +869,30 @@ fn source_origin(function: &CalxDefinitionRef, path: Option<&[u16]>) -> String {
     .map(|parts| parts.iter().map(u16::to_string).collect::<Vec<_>>().join("."))
     .unwrap_or_else(|| "-".to_owned());
   format!("calcit:{}@{path}", function.qualified())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn missing_planned_local_returns_lowering_error() {
+    let definition = CalxDefinitionRef::new("tests.calx", "missing-local");
+    let plan = PlannedFunction {
+      definition: definition.clone(),
+      vm_name: "main".to_owned(),
+      params: vec![],
+      locals: BTreeMap::new(),
+      result: Some(CalxScalarType::F64),
+      body: planned(Some(CalxScalarType::F64), Some(vec![3, 1]), PlannedExpressionKind::Local(42)),
+    };
+
+    let error = emit_function(&plan).expect_err("an unplanned typed local must not panic");
+    let CalxKernelCompileError::Lowering(error) = error else {
+      panic!("expected a lowering error, got {error}");
+    };
+    assert_eq!(error.function, definition);
+    assert_eq!(error.source_path, Some(vec![3, 1]));
+    assert!(error.message.contains("local index 42"));
+  }
 }

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -2,7 +2,10 @@ use super::*;
 use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
 use crate::calcit::{CalcitFnTypeAnnotation, CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo, SchemaKind};
 use crate::call_stack::CallStackList;
-use crate::codegen::calx::{CalxDefinitionRef, CalxFallbackCode, CalxScalarType, analyze_calx_eligibility};
+use crate::codegen::calx::{
+  CalxDefinitionRef, CalxFallbackCode, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError, CalxScalarType,
+  analyze_calx_eligibility, compile_calx_kernel,
+};
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
 use cirru_edn::EdnTag;
@@ -258,11 +261,7 @@ fn compile_calx_test_entry(namespace: &str, definition: &str) {
   );
 }
 
-#[test]
-fn calx_eligibility_accepts_three_real_preprocessed_scalar_kernels() {
-  let _guard = lock_program_test_state();
-  reset_program_test_state();
-  let namespace = "tests.calx-kernels";
+fn install_calx_scalar_kernel_fixture(namespace: &str) {
   let number = || CalcitTypeAnnotation::Number;
   let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/scalar-kernels.cirru"));
   install_calx_test_defs(
@@ -293,6 +292,14 @@ fn calx_eligibility_accepts_three_real_preprocessed_scalar_kernels() {
   for definition in ["range-sum", "fibonacci", "affine"] {
     compile_calx_test_entry(namespace, definition);
   }
+}
+
+#[test]
+fn calx_eligibility_accepts_three_real_preprocessed_scalar_kernels() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-kernels";
+  install_calx_scalar_kernel_fixture(namespace);
   let snapshot = clone_compiled_program_snapshot().expect("clone typed preprocessed Calx fixtures");
 
   let range = analyze_calx_eligibility(&snapshot, namespace, "range-sum").expect("range-sum should be eligible");
@@ -323,6 +330,49 @@ fn calx_eligibility_accepts_three_real_preprocessed_scalar_kernels() {
     affine.stable_summary()
   );
   assert_eq!(summary, include_str!("../../tests/fixtures/calx/scalar-kernels.golden.txt"));
+}
+
+#[test]
+fn calx_lowering_executes_three_source_kernels_like_native_calcit() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-kernels";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed preprocessed Calx fixtures");
+
+  let cases = [
+    ("range-sum", vec![Calcit::Number(10.0), Calcit::Number(0.0)]),
+    ("fibonacci", vec![Calcit::Number(10.0)]),
+    ("affine", vec![Calcit::Number(3.0), Calcit::Number(4.0), Calcit::Number(5.0)]),
+  ];
+  for (definition, args) in cases {
+    let kernel = compile_calx_kernel(&snapshot, namespace, definition)
+      .unwrap_or_else(|error| panic!("compile Calx kernel {namespace}/{definition}: {error}"));
+    assert_eq!(kernel.validated_program().functions()[0].name.as_ref(), "main");
+    assert!(
+      kernel
+        .validated_program()
+        .functions()
+        .iter()
+        .all(|function| !function.instrs.is_empty())
+    );
+
+    let calx_result = kernel
+      .run(&args)
+      .unwrap_or_else(|error| panic!("run Calx kernel {namespace}/{definition}: {error}"));
+    let native_result = run_program_with_docs(Arc::from(namespace), Arc::from(definition), &args)
+      .unwrap_or_else(|error| panic!("run native Calcit kernel {namespace}/{definition}: {error}"));
+    assert_eq!(calx_result, native_result, "Calx/native mismatch for {definition}");
+  }
+
+  let range = compile_calx_kernel(&snapshot, namespace, "range-sum").expect("compile range-sum boundary fixture");
+  let error = range
+    .run(&[Calcit::Nil, Calcit::Number(0.0)])
+    .expect_err("Nil must not cross the strict Calx boundary");
+  assert!(matches!(
+    error,
+    CalxKernelRunError::Boundary(ref boundary) if boundary.kind == CalxKernelBoundaryErrorKind::ArgumentType
+  ));
 }
 
 #[test]
@@ -363,6 +413,10 @@ fn calx_eligibility_falls_back_for_the_whole_reachable_closure() {
     .expect("Dynamic fallback detail");
   assert_eq!(dynamic.call_path.len(), 2);
   assert_eq!(dynamic.call_path[1], CalxDefinitionRef::new(namespace, "dynamic-helper"));
+  assert!(matches!(
+    compile_calx_kernel(&snapshot, namespace, "entry"),
+    Err(CalxKernelCompileError::Eligibility(_))
+  ));
 }
 
 fn compiled_def_for_test(def_id: DefId, deps: Vec<DefId>) -> CompiledDef {

--- a/tests/fixtures/calx/scalar-kernels.cirru
+++ b/tests/fixtures/calx/scalar-kernels.cirru
@@ -11,7 +11,9 @@ defn fibonacci (n)
       fibonacci $ &- n 2
 
 defn affine-helper (x scale offset)
-  &+ (&* x scale) offset
+  &let
+    scaled $ &* x scale
+    &+ scaled offset
 
 defn affine (x scale offset)
   affine-helper x scale offset


### PR DESCRIPTION
## 中文

### 目标

把上一阶段已经通过 eligibility 的 typed scalar kernel，从只读分析推进到真实、可验证、可执行的 Calx 程序。关联规划：https://github.com/calcit-lang/calx-vm/issues/38

### 改动

- 依赖稳定版 `calx_vm 0.3.0`，从同一份 typed `CompiledProgram` expression 建立内部 lowering plan。
- 通过 `ProgramBuilder -> CalxProgram -> ValidatedProgram` 生成 strict program；入口映射为 `main`，其余 reachable functions 使用确定的 fully-qualified name。
- lowering 覆盖 `Number`、`Bool`、`Unit`、typed parameter/local、单 binding `&let`、sequence/drop、完整 `if`、数值运算与比较、direct call、direct tail call 和 `recur`。
- 生成 syntax 携带 Calcit definition/tree path 对应的 synthetic source origin。
- 增加 `CalxCompiledKernel` typed boundary：只允许 `Number <-> F64`、`Bool <-> Bool`、void -> `Unit`；Nil、Dynamic 与其他不匹配值在进入 VM 前拒绝。
- 明确区分 `Eligibility`、`Lowering`、`Build`、`Validation`、`Instantiate` 与 runtime trap。只有 eligibility failure 可由 embedding 选择 whole-kernel fallback，执行失败不会自动重跑 Calcit。
- 更新 Calx target 文档与 editing history。

### 验证

- 三个真实 Cirru source fixture 均经过正常 preprocessing：range sum、Fibonacci、带 typed local 和 helper tail call 的 affine。
- 三个 kernel 在 strict Calx VM 中实际执行，并与 native Calcit runner 做差分比较。
- Dynamic reachable callee 仍在 lowering 前触发 whole-closure fallback；Nil runtime argument 在 VM 前被拒绝。
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`（17/17）
- release LTO 二进制：main 基线 9,392,160 bytes，当前 9,392,368 bytes，增加 208 bytes。

## English

### Goal

Advance the previously eligible typed scalar kernel subset from read-only analysis to real, validated, executable Calx programs. Related roadmap: https://github.com/calcit-lang/calx-vm/issues/38

### Changes

- Depend on stable `calx_vm 0.3.0` and build an internal lowering plan from the same typed `CompiledProgram` expressions.
- Produce strict programs through `ProgramBuilder -> CalxProgram -> ValidatedProgram`; map the entry to `main` and use deterministic fully-qualified names for other reachable functions.
- Lower `Number`, `Bool`, `Unit`, typed parameters/locals, one-binding `&let`, sequence/drop, complete `if`, numeric operations and comparisons, direct calls, direct tail calls, and `recur`.
- Attach synthetic source origins derived from Calcit definition/tree paths to generated syntax.
- Add a `CalxCompiledKernel` typed boundary that only permits `Number <-> F64`, `Bool <-> Bool`, and void -> `Unit`; reject Nil, Dynamic, and all mismatched values before VM entry.
- Keep `Eligibility`, `Lowering`, `Build`, `Validation`, `Instantiate`, and runtime traps distinct. Only eligibility failure permits embedding-selected whole-kernel fallback; an execution failure never reruns Calcit automatically.
- Update the Calx target documentation and editing history.

### Verification

- Drive three real Cirru source fixtures through normal preprocessing: range sum, Fibonacci, and affine with a typed local plus helper tail call.
- Execute all three kernels in the strict Calx VM and compare their results differentially with the native Calcit runner.
- Confirm that a reachable Dynamic callee still triggers whole-closure fallback before lowering and that a Nil runtime argument is rejected before VM entry.
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (17/17)
- Release LTO binary: 9,392,160-byte main baseline versus 9,392,368 bytes on this branch, a 208-byte increase.
