### PR TITLE
统一 String 字符数与 UTF-8 字节数语义 / distinguish character and UTF-8 byte counts

### DIFF
--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -6,9 +6,9 @@
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-wasm.helper $ %{} 'FileEntry
+    'test-wasm.helper $ %{} 'FileEntry
       :defs $ {}
-        |add-and-double $ %{} 'CodeEntry (:doc "|Helper: add two numbers and double")
+        'add-and-double $ %{} 'CodeEntry (:doc "|Helper: add two numbers and double")
           :code $ quote
             defn add-and-double (a b)
               &* (&+ a b) 2
@@ -16,18 +16,18 @@
           :schema $ :: 'Dynamic
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns test-wasm.helper)
-    |test-wasm.main $ %{} 'FileEntry
+    'test-wasm.main $ %{} 'FileEntry
       :defs $ {}
-        |Point $ %{} 'CodeEntry (:doc "|Struct definition (via legacy defrecord) for WASM test")
+        'Point $ %{} 'CodeEntry (:doc "|Struct definition (via legacy defrecord) for WASM test")
           :code $ quote (defrecord Point :x :y)
           :examples $ []
           :schema $ :: 'Dynamic
-        |add-two $ %{} 'CodeEntry (:doc "|Simple addition")
+        'add-two $ %{} 'CodeEntry (:doc "|Simple addition")
           :code $ quote
             defn add-two (a b) (&+ a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |collatz-steps $ %{} 'CodeEntry (:doc "|Collatz conjecture step counter")
+        'collatz-steps $ %{} 'CodeEntry (:doc "|Collatz conjecture step counter")
           :code $ quote
             defn collatz-steps (n)
               if (&< n 2) 0 $ if
@@ -37,24 +37,24 @@
                   &+ (&* 3 n) 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |collect-rest $ %{} 'CodeEntry (:doc "|returns rest list unchanged")
+        'collect-rest $ %{} 'CodeEntry (:doc "|returns rest list unchanged")
           :code $ quote
             defn collect-rest (a & xs) xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |compare-wasm-ascending $ %{} 'CodeEntry (:doc |)
+        'compare-wasm-ascending $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn compare-wasm-ascending (a b) (&- a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |factorial $ %{} 'CodeEntry (:doc "|Factorial — recursive")
+        'factorial $ %{} 'CodeEntry (:doc "|Factorial — recursive")
           :code $ quote
             defn factorial (n)
               if (&< n 2) 1 $ &* n
                 factorial $ &- n 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |fibo $ %{} 'CodeEntry (:doc "|Fibonacci — recursive")
+        'fibo $ %{} 'CodeEntry (:doc "|Fibonacci — recursive")
           :code $ quote
             defn fibo (n)
               if (&< n 2) 1 $ &+
@@ -62,54 +62,54 @@
                 fibo $ &- n 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |gcd $ %{} 'CodeEntry (:doc "|Greatest common divisor")
+        'gcd $ %{} 'CodeEntry (:doc "|Greatest common divisor")
           :code $ quote
             defn gcd (a b)
               if (&= b 0) a $ recur b (&number:rem a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |host-string-upcase $ %{} 'CodeEntry (:doc |)
+        'host-string-upcase $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defwasm-import host-string-upcase (text) |host |string-upcase
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'String)
               :args $ [] 'String
-        |main! $ %{} 'CodeEntry (:doc |)
+        'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () $ println (fibo 10)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} 'CodeEntry (:doc |)
+        'reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! $
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
-        |sum-range $ %{} 'CodeEntry (:doc "|Sum 1..n via helper")
+        'sum-range $ %{} 'CodeEntry (:doc "|Sum 1..n via helper")
           :code $ quote
             defn sum-range (n) (sum-range-step 0 1 n)
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-range-step $ %{} 'CodeEntry (:doc "|Sum step helper: sum-range-step(acc, i, n)")
+        'sum-range-step $ %{} 'CodeEntry (:doc "|Sum step helper: sum-range-step(acc, i, n)")
           :code $ quote
             defn sum-range-step (acc i n)
               if (&> i n) acc $ recur (&+ acc i) (&+ i 1) n
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-rest $ %{} 'CodeEntry (:doc "|variadic sum: a + b + rest...")
+        'sum-rest $ %{} 'CodeEntry (:doc "|variadic sum: a + b + rest...")
           :code $ quote
             defn sum-rest (a b & xs)
               sum-rest-list (&+ a b) xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-rest-forward $ %{} 'CodeEntry (:doc "|forwards a rest list via &call-spread")
+        'sum-rest-forward $ %{} 'CodeEntry (:doc "|forwards a rest list via &call-spread")
           :code $ quote
             defn sum-rest-forward (a b & xs) (sum-rest a b & xs)
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-rest-list $ %{} 'CodeEntry (:doc "|helper: sums a list via recur")
+        'sum-rest-list $ %{} 'CodeEntry (:doc "|helper: sums a list via recur")
           :code $ quote
             defn sum-rest-list (acc xs)
               if (&list:empty? xs) acc $ recur
@@ -117,42 +117,42 @@
                 &list:rest xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-abs $ %{} 'CodeEntry (:doc "|abs from calcit.core")
+        'test-abs $ %{} 'CodeEntry (:doc "|abs from calcit.core")
           :code $ quote
             defn test-abs (x) (abs x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-and $ %{} 'CodeEntry (:doc "|Bitwise AND")
+        'test-bit-and $ %{} 'CodeEntry (:doc "|Bitwise AND")
           :code $ quote
             defn test-bit-and (a b) (bit-and a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-not $ %{} 'CodeEntry (:doc "|Bitwise NOT")
+        'test-bit-not $ %{} 'CodeEntry (:doc "|Bitwise NOT")
           :code $ quote
             defn test-bit-not (a) (bit-not a)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-or $ %{} 'CodeEntry (:doc "|Bitwise OR")
+        'test-bit-or $ %{} 'CodeEntry (:doc "|Bitwise OR")
           :code $ quote
             defn test-bit-or (a b) (bit-or a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-shl $ %{} 'CodeEntry (:doc "|Bitwise shift left")
+        'test-bit-shl $ %{} 'CodeEntry (:doc "|Bitwise shift left")
           :code $ quote
             defn test-bit-shl (a b) (bit-shl a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-shr $ %{} 'CodeEntry (:doc "|Bitwise shift right")
+        'test-bit-shr $ %{} 'CodeEntry (:doc "|Bitwise shift right")
           :code $ quote
             defn test-bit-shr (a b) (bit-shr a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-bit-xor $ %{} 'CodeEntry (:doc "|Bitwise XOR")
+        'test-bit-xor $ %{} 'CodeEntry (:doc "|Bitwise XOR")
           :code $ quote
             defn test-bit-xor (a b) (bit-xor a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-doseq $ %{} 'CodeEntry (:doc "||buf-list: use doseq to push 4 items, count=4")
+        'test-buf-list-doseq $ %{} 'CodeEntry (:doc "||buf-list: use doseq to push 4 items, count=4")
           :code $ quote
             defn test-buf-list-doseq () $ let
                 buf $ &buf-list:new
@@ -162,7 +162,7 @@
               &buf-list:count buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-each $ %{} 'CodeEntry (:doc "||buf-list: use each to push 3 items, count=3")
+        'test-buf-list-each $ %{} 'CodeEntry (:doc "||buf-list: use each to push 3 items, count=3")
           :code $ quote
             defn test-buf-list-each () $ let
                 buf $ &buf-list:new
@@ -171,7 +171,7 @@
               &buf-list:count buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-filter $ %{} 'CodeEntry (:doc "||buf-list: concat [1..5], filter even from to-list, count=2")
+        'test-buf-list-filter $ %{} 'CodeEntry (:doc "||buf-list: concat [1..5], filter even from to-list, count=2")
           :code $ quote
             defn test-buf-list-filter () $ let
                 buf $ &buf-list:new
@@ -181,7 +181,7 @@
                   &= (&number:rem x 2) 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-map $ %{} 'CodeEntry (:doc "||buf-list: concat 3 items, map to-list, count=3")
+        'test-buf-list-map $ %{} 'CodeEntry (:doc "||buf-list: concat 3 items, map to-list, count=3")
           :code $ quote
             defn test-buf-list-map () $ let
                 buf $ &buf-list:new
@@ -190,7 +190,7 @@
                 fn (x) (&* x 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-push $ %{} 'CodeEntry (:doc "||buf-list push 3 items, count=3")
+        'test-buf-list-push $ %{} 'CodeEntry (:doc "||buf-list push 3 items, count=3")
           :code $ quote
             defn test-buf-list-push () $ let
                 buf $ &buf-list:new
@@ -200,7 +200,7 @@
               &buf-list:count buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-buf-list-to-list $ %{} 'CodeEntry (:doc "||buf-list concat [1,2,3] then to-list, count=3")
+        'test-buf-list-to-list $ %{} 'CodeEntry (:doc "||buf-list concat [1,2,3] then to-list, count=3")
           :code $ quote
             defn test-buf-list-to-list () $ let
                 buf $ &buf-list:new
@@ -209,64 +209,64 @@
               &list:count $ &buf-list:to-list buf
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-call-spread-rest $ %{} 'CodeEntry (:doc "|rest list forwarding via &call-spread")
+        'test-call-spread-rest $ %{} 'CodeEntry (:doc "|rest list forwarding via &call-spread")
           :code $ quote
             defn test-call-spread-rest () $ sum-rest-forward 1 2 3 4 5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-ceil $ %{} 'CodeEntry (:doc "|ceil function")
+        'test-ceil $ %{} 'CodeEntry (:doc "|ceil function")
           :code $ quote
             defn test-ceil (x) (ceil x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-compare $ %{} 'CodeEntry (:doc "|comparison chain")
+        'test-compare $ %{} 'CodeEntry (:doc "|comparison chain")
           :code $ quote
             defn test-compare (a b)
               if (&< a b) -1 $ if (&> a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-cos $ %{} 'CodeEntry (:doc "|cos via host import")
+        'test-cos $ %{} 'CodeEntry (:doc "|cos via host import")
           :code $ quote
             defn test-cos (x) (cos x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-cross-ns $ %{} 'CodeEntry (:doc "|Cross-namespace function call")
+        'test-cross-ns $ %{} 'CodeEntry (:doc "|Cross-namespace function call")
           :code $ quote
             defn test-cross-ns (a b) (helper/add-and-double a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-display-by-bin $ %{} 'CodeEntry (:doc "|17 in binary = 0b10001, length 7")
+        'test-display-by-bin $ %{} 'CodeEntry (:doc "|17 in binary = 0b10001, length 7")
           :code $ quote
             defn test-display-by-bin () $ &str:count (&number:display-by 17 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-display-by-hex $ %{} 'CodeEntry (:doc "|17 in hex = 0x11, length 4")
+        'test-display-by-hex $ %{} 'CodeEntry (:doc "|17 in hex = 0x11, length 4")
           :code $ quote
             defn test-display-by-hex () $ &str:count (&number:display-by 17 16)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-enum-assoc $ %{} 'CodeEntry (:doc "|Enum assoc updates payload by index")
+        'test-enum-assoc $ %{} 'CodeEntry (:doc "|Enum assoc updates payload by index")
           :code $ quote
             defn test-enum-assoc () $ &let
               t $ &enum:assoc (:: :pair 10 20) 1 9
               &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-enum-count $ %{} 'CodeEntry (:doc "|Enum count returns payload count")
+        'test-enum-count $ %{} 'CodeEntry (:doc "|Enum count returns payload count")
           :code $ quote
             defn test-enum-count () $ &let
               t $ :: :pair 10 20
               &enum:count t
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-enum-sum $ %{} 'CodeEntry (:doc "|Enum create + nth access: idx 1 and 2 are payloads")
+        'test-enum-sum $ %{} 'CodeEntry (:doc "|Enum create + nth access: idx 1 and 2 are payloads")
           :code $ quote
             defn test-enum-sum () $ &let
               t $ :: :pair 10 20
               &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-found $ %{} 'CodeEntry (:doc |)
+        'test-find-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-found () $ option:unwrap-or
               find ([] 1 2 3)
@@ -274,7 +274,7 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-index-found $ %{} 'CodeEntry (:doc |)
+        'test-find-index-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-index-found () $ option:unwrap-or
               find-index ([] 1 2 3)
@@ -282,7 +282,7 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-index-not-found $ %{} 'CodeEntry (:doc |)
+        'test-find-index-not-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-index-not-found () $ option:unwrap-or
               find-index ([] 1 2 3)
@@ -290,7 +290,7 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-find-not-found $ %{} 'CodeEntry (:doc |)
+        'test-find-not-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-not-found () $ option:unwrap-or
               find ([] 1 2 3)
@@ -298,25 +298,25 @@
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-floor $ %{} 'CodeEntry (:doc "|floor function")
+        'test-floor $ %{} 'CodeEntry (:doc "|floor function")
           :code $ quote
             defn test-floor (x) (floor x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-gte $ %{} 'CodeEntry (:doc |greater-than-or-equal)
+        'test-gte $ %{} 'CodeEntry (:doc |greater-than-or-equal)
           :code $ quote
             defn test-gte (a b)
               if (&> a b) 1 $ if (&= a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-hash-number $ %{} 'CodeEntry (:doc "|hash on number returns stable non-zero value")
+        'test-hash-number $ %{} 'CodeEntry (:doc "|hash on number returns stable non-zero value")
           :code $ quote
             defn test-hash-number () $ if
               &> (&hash 42) 0
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-let-chain $ %{} 'CodeEntry (:doc "|chained let bindings")
+        'test-let-chain $ %{} 'CodeEntry (:doc "|chained let bindings")
           :code $ quote
             defn test-let-chain (x)
               &let
@@ -326,54 +326,54 @@
                   &* b 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-append $ %{} 'CodeEntry (:doc "|append returns correct count and last elem")
+        'test-list-append $ %{} 'CodeEntry (:doc "|append returns correct count and last elem")
           :code $ quote
             defn test-list-append () $ &let
               xs $ append ([] 10 20) 30
               &+ (&list:count xs) (&list:nth xs 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-assoc $ %{} 'CodeEntry (:doc "|assoc replaces element")
+        'test-list-assoc $ %{} 'CodeEntry (:doc "|assoc replaces element")
           :code $ quote
             defn test-list-assoc () $ &list:nth
               &list:assoc ([] 10 20 30) 1 99
               , 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-assoc-after $ %{} 'CodeEntry (:doc "|assoc-after inserts element after index")
+        'test-list-assoc-after $ %{} 'CodeEntry (:doc "|assoc-after inserts element after index")
           :code $ quote
             defn test-list-assoc-after () $ &let
               xs $ &list:assoc-after ([] 10 20 30) 0 99
               &+ (&list:count xs) (&list:nth xs 1)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-assoc-before $ %{} 'CodeEntry (:doc "|assoc-before inserts element before index")
+        'test-list-assoc-before $ %{} 'CodeEntry (:doc "|assoc-before inserts element before index")
           :code $ quote
             defn test-list-assoc-before () $ &let
               xs $ &list:assoc-before ([] 10 20 30) 1 99
               &+ (&list:count xs) (&list:nth xs 1)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-butlast $ %{} 'CodeEntry (:doc "|butlast drops last element")
+        'test-list-butlast $ %{} 'CodeEntry (:doc "|butlast drops last element")
           :code $ quote
             defn test-list-butlast () $ &list:count
               butlast $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-butlast-empty $ %{} 'CodeEntry (:doc |)
+        'test-list-butlast-empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-butlast-empty () $ &list:count
               butlast $ []
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-concat $ %{} 'CodeEntry (:doc "|concat two lists")
+        'test-list-concat $ %{} 'CodeEntry (:doc "|concat two lists")
           :code $ quote
             defn test-list-concat () $ &let
               xs $ &list:concat ([] 10 20) ([] 30 40)
               &+ (&list:count xs) (&list:nth xs 3)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-contains $ %{} 'CodeEntry (:doc "|contains checks index bounds")
+        'test-list-contains $ %{} 'CodeEntry (:doc "|contains checks index bounds")
           :code $ quote
             defn test-list-contains () $ &let
               xs $ [] 10 20 30
@@ -382,7 +382,7 @@
                 if (&list:contains? xs 5) 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on list")
+        'test-list-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on list")
           :code $ quote
             defn test-list-contains-method () $ &+
               if
@@ -393,57 +393,57 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-count $ %{} 'CodeEntry (:doc "|list count")
+        'test-list-count $ %{} 'CodeEntry (:doc "|list count")
           :code $ quote
             defn test-list-count () $ &list:count ([] 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-dissoc $ %{} 'CodeEntry (:doc "|dissoc removes element")
+        'test-list-dissoc $ %{} 'CodeEntry (:doc "|dissoc removes element")
           :code $ quote
             defn test-list-dissoc () $ &let
               xs $ &list:dissoc ([] 10 20 30) 1
               &+ (&list:count xs) (&list:nth xs 1)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty-false $ %{} 'CodeEntry (:doc "|non-empty list not empty")
+        'test-list-empty-false $ %{} 'CodeEntry (:doc "|non-empty list not empty")
           :code $ quote
             defn test-list-empty-false () $ if
               &list:empty? $ [] 1
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty list")
+        'test-list-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty list")
           :code $ quote
             defn test-list-empty-method () $ count
               .empty $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty-true $ %{} 'CodeEntry (:doc "|empty list is empty")
+        'test-list-empty-true $ %{} 'CodeEntry (:doc "|empty list is empty")
           :code $ quote
             defn test-list-empty-true () $ if
               &list:empty? $ []
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-empty?-method $ %{} 'CodeEntry (:doc "|.empty? uses generic method dispatch")
+        'test-list-empty?-method $ %{} 'CodeEntry (:doc "|.empty? uses generic method dispatch")
           :code $ quote
             defn test-list-empty?-method () $ if
               .empty? $ []
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-first $ %{} 'CodeEntry (:doc "|list first element")
+        'test-list-first $ %{} 'CodeEntry (:doc "|list first element")
           :code $ quote
             defn test-list-first () $ &list:first ([] 42 99)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-first-generic $ %{} 'CodeEntry (:doc "|generic first() on list via invoke")
+        'test-list-first-generic $ %{} 'CodeEntry (:doc "|generic first() on list via invoke")
           :code $ quote
             defn test-list-first-generic () $ option:unwrap
               first $ [] 42 99
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-includes $ %{} 'CodeEntry (:doc "|includes checks value presence")
+        'test-list-includes $ %{} 'CodeEntry (:doc "|includes checks value presence")
           :code $ quote
             defn test-list-includes () $ &+
               if
@@ -454,7 +454,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on list")
+        'test-list-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on list")
           :code $ quote
             defn test-list-includes-method () $ &+
               if
@@ -465,78 +465,78 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-max-empty $ %{} 'CodeEntry (:doc |)
+        'test-list-max-empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-max-empty () $ option:unwrap-or
               .max $ []
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-max-method $ %{} 'CodeEntry (:doc "|.max dispatches on list")
+        'test-list-max-method $ %{} 'CodeEntry (:doc "|.max dispatches on list")
           :code $ quote
             defn test-list-max-method () $ option:unwrap-or
               .max $ [] 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-min-method $ %{} 'CodeEntry (:doc "|.min dispatches on list")
+        'test-list-min-method $ %{} 'CodeEntry (:doc "|.min dispatches on list")
           :code $ quote
             defn test-list-min-method () $ option:unwrap-or
               .min $ [] 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-nth $ %{} 'CodeEntry (:doc "|list nth element")
+        'test-list-nth $ %{} 'CodeEntry (:doc "|list nth element")
           :code $ quote
             defn test-list-nth (i)
               &list:nth ([] 10 20 30 40) i
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-prepend $ %{} 'CodeEntry (:doc "|prepend returns correct first elem")
+        'test-list-prepend $ %{} 'CodeEntry (:doc "|prepend returns correct first elem")
           :code $ quote
             defn test-list-prepend () $ &list:first
               prepend ([] 10 20) 5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-count $ %{} 'CodeEntry (:doc "|count of rest")
+        'test-list-rest-count $ %{} 'CodeEntry (:doc "|count of rest")
           :code $ quote
             defn test-list-rest-count () $ &list:count
               &list:rest $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-empty $ %{} 'CodeEntry (:doc |)
+        'test-list-rest-empty $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-rest-empty () $ &list:count
               &list:rest $ []
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-first $ %{} 'CodeEntry (:doc "|first of rest")
+        'test-list-rest-first $ %{} 'CodeEntry (:doc "|first of rest")
           :code $ quote
             defn test-list-rest-first () $ &list:first
               &list:rest $ [] 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-rest-generic-first $ %{} 'CodeEntry (:doc "|generic rest() on list via invoke")
+        'test-list-rest-generic-first $ %{} 'CodeEntry (:doc "|generic rest() on list via invoke")
           :code $ quote
             defn test-list-rest-generic-first () $ option:unwrap
               first $ rest ([] 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-reverse $ %{} 'CodeEntry (:doc "|reverse a list")
+        'test-list-reverse $ %{} 'CodeEntry (:doc "|reverse a list")
           :code $ quote
             defn test-list-reverse () $ &let
               xs $ &list:reverse ([] 10 20 30)
               &+ (&list:first xs) (&list:nth xs 2)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-slice $ %{} 'CodeEntry (:doc "|slice with start and end")
+        'test-list-slice $ %{} 'CodeEntry (:doc "|slice with start and end")
           :code $ quote
             defn test-list-slice () $ &let
               xs $ &list:slice ([] 10 20 30 40 50) 1 4
               &+ (&list:count xs) (&list:first xs)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-sort-ascending $ %{} 'CodeEntry (:doc |)
+        'test-list-sort-ascending $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-sort-ascending () $ &let
               ys $ sort ([] 4 1 3 2) &-
@@ -545,7 +545,7 @@
                 &list:last ys
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-sort-descending $ %{} 'CodeEntry (:doc |)
+        'test-list-sort-descending $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-sort-descending () $ &let
               ys $ &list:sort ([] 4 1 3 2)
@@ -555,7 +555,7 @@
                 &list:last ys
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-sort-dynamic-callee $ %{} 'CodeEntry (:doc |)
+        'test-list-sort-dynamic-callee $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-sort-dynamic-callee () $ &let (comparator compare-wasm-ascending)
               &let
@@ -565,7 +565,7 @@
                   &list:last ys
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-sort-input-immutable $ %{} 'CodeEntry (:doc |)
+        'test-list-sort-input-immutable $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-sort-input-immutable () $ &let
               xs $ [] 4 1 3 2
@@ -577,7 +577,7 @@
                   &list:first ys
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-sort-stable $ %{} 'CodeEntry (:doc |)
+        'test-list-sort-stable $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-sort-stable () $ &let
               xs $ [] ([] 2 20) ([] 1 10) ([] 2 21) ([] 1 11)
@@ -592,46 +592,46 @@
                   &list:nth (&list:nth ys 3) 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-to-set $ %{} 'CodeEntry (:doc "|list to set deduplicates elements")
+        'test-list-to-set $ %{} 'CodeEntry (:doc "|list to set deduplicates elements")
           :code $ quote
             defn test-list-to-set () $ &let
               s $ &list:to-set ([] 10 20 30 20 10)
               &set:count s
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list?-false $ %{} 'CodeEntry (:doc "|list? on number returns false (0)")
+        'test-list?-false $ %{} 'CodeEntry (:doc "|list? on number returns false (0)")
           :code $ quote
             defn test-list?-false () $ if (list? 42) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list?-true $ %{} 'CodeEntry (:doc "|list? on a list returns true (1)")
+        'test-list?-true $ %{} 'CodeEntry (:doc "|list? on a list returns true (1)")
           :code $ quote
             defn test-list?-true () $ if
               list? $ [] 1 2
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-lte $ %{} 'CodeEntry (:doc |less-than-or-equal)
+        'test-lte $ %{} 'CodeEntry (:doc |less-than-or-equal)
           :code $ quote
             defn test-lte (a b)
               if (&< a b) 1 $ if (&= a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-assoc-new $ %{} 'CodeEntry (:doc "|assoc adds new key")
+        'test-map-assoc-new $ %{} 'CodeEntry (:doc "|assoc adds new key")
           :code $ quote
             defn test-map-assoc-new () $ &let
               m $ &map:assoc (&{} :a 1) :b 2
               &+ (&map:count m) (&map:get m :b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-assoc-update $ %{} 'CodeEntry (:doc "|assoc updates existing key")
+        'test-map-assoc-update $ %{} 'CodeEntry (:doc "|assoc updates existing key")
           :code $ quote
             defn test-map-assoc-update () $ &map:get
               &map:assoc (&{} :a 1 :b 2) :b 99
               , :b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-bucket-update $ %{} 'CodeEntry (:doc "|update on collided numeric keys keeps lookup correct")
+        'test-map-bucket-update $ %{} 'CodeEntry (:doc "|update on collided numeric keys keeps lookup correct")
           :code $ quote
             defn test-map-bucket-update (a b)
               &let
@@ -639,13 +639,13 @@
                 &+ (&map:get m a) (&map:get m b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-common-keys $ %{} 'CodeEntry (:doc "|common-keys: keys in both a and b")
+        'test-map-common-keys $ %{} 'CodeEntry (:doc "|common-keys: keys in both a and b")
           :code $ quote
             defn test-map-common-keys () $ &set:count
               &map:common-keys (&{} :a 1 :b 2 :c 3) (&{} :b 10 :c 20 :d 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-contains $ %{} 'CodeEntry (:doc "|contains checks key presence")
+        'test-map-contains $ %{} 'CodeEntry (:doc "|contains checks key presence")
           :code $ quote
             defn test-map-contains () $ &+
               if
@@ -656,7 +656,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on map")
+        'test-map-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on map")
           :code $ quote
             defn test-map-contains-method () $ &+
               if
@@ -667,56 +667,56 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-count $ %{} 'CodeEntry (:doc "|map count")
+        'test-map-count $ %{} 'CodeEntry (:doc "|map count")
           :code $ quote
             defn test-map-count () $ &map:count (&{} :a 1 :b 2 :c 3)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-diff-keys $ %{} 'CodeEntry (:doc "|diff-keys: keys in a not in b")
+        'test-map-diff-keys $ %{} 'CodeEntry (:doc "|diff-keys: keys in a not in b")
           :code $ quote
             defn test-map-diff-keys () $ &set:count
               &map:diff-keys (&{} :a 1 :b 2 :c 3) (&{} :b 10)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-diff-new $ %{} 'CodeEntry (:doc "|diff-new: entries in b not in a")
+        'test-map-diff-new $ %{} 'CodeEntry (:doc "|diff-new: entries in b not in a")
           :code $ quote
             defn test-map-diff-new () $ &map:count
               &map:diff-new (&{} :a 1 :b 2) (&{} :b 3 :c 4 :d 5)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-dissoc $ %{} 'CodeEntry (:doc "|dissoc removes key")
+        'test-map-dissoc $ %{} 'CodeEntry (:doc "|dissoc removes key")
           :code $ quote
             defn test-map-dissoc () $ &let
               m $ &map:dissoc (&{} :a 1 :b 2 :c 3) :b
               &+ (&map:count m) (&map:get m :c)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-empty-false $ %{} 'CodeEntry (:doc "|non-empty map not empty")
+        'test-map-empty-false $ %{} 'CodeEntry (:doc "|non-empty map not empty")
           :code $ quote
             defn test-map-empty-false () $ if
               &map:empty? $ &{} :a 1
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty map")
+        'test-map-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty map")
           :code $ quote
             defn test-map-empty-method () $ count
               .empty $ &{} :a 1 :b 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-empty-true $ %{} 'CodeEntry (:doc "|empty map is empty")
+        'test-map-empty-true $ %{} 'CodeEntry (:doc "|empty map is empty")
           :code $ quote
             defn test-map-empty-true () $ if
               &map:empty? $ &{}
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-get $ %{} 'CodeEntry (:doc "|map get by key")
+        'test-map-get $ %{} 'CodeEntry (:doc "|map get by key")
           :code $ quote
             defn test-map-get () $ &map:get (&{} :a 10 :b 20 :c 30) :b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-hash-index1 $ %{} 'CodeEntry (:doc "|second 5 bits of number hash")
+        'test-map-hash-index1 $ %{} 'CodeEntry (:doc "|second 5 bits of number hash")
           :code $ quote
             defn test-map-hash-index1 (n)
               bit-and
@@ -724,12 +724,12 @@
                 , 31
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-hash-value $ %{} 'CodeEntry (:doc "|raw hash for numeric key")
+        'test-map-hash-value $ %{} 'CodeEntry (:doc "|raw hash for numeric key")
           :code $ quote
             defn test-map-hash-value (n) (&hash n)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-includes $ %{} 'CodeEntry (:doc "|map includes checks value")
+        'test-map-includes $ %{} 'CodeEntry (:doc "|map includes checks value")
           :code $ quote
             defn test-map-includes () $ &+
               if
@@ -740,7 +740,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on map")
+        'test-map-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on map")
           :code $ quote
             defn test-map-includes-method () $ &+
               if
@@ -751,20 +751,20 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-merge $ %{} 'CodeEntry (:doc "|merge two maps, b overrides a")
+        'test-map-merge $ %{} 'CodeEntry (:doc "|merge two maps, b overrides a")
           :code $ quote
             defn test-map-merge () $ &map:count
               &merge (&{} :a 1 :b 2) (&{} :b 3 :c 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-merge-value $ %{} 'CodeEntry (:doc "|merge override check via get")
+        'test-map-merge-value $ %{} 'CodeEntry (:doc "|merge override check via get")
           :code $ quote
             defn test-map-merge-value () $ &map:get
               &merge (&{} :a 1 :b 2) (&{} :b 99)
               , :b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-two-keys-sum $ %{} 'CodeEntry (:doc "|sum lookups for two numeric keys")
+        'test-map-two-keys-sum $ %{} 'CodeEntry (:doc "|sum lookups for two numeric keys")
           :code $ quote
             defn test-map-two-keys-sum (a b)
               &let
@@ -772,14 +772,14 @@
                 &+ (&map:get m a) (&map:get m b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map?-true $ %{} 'CodeEntry (:doc "|map? on map returns true (1)")
+        'test-map?-true $ %{} 'CodeEntry (:doc "|map? on map returns true (1)")
           :code $ quote
             defn test-map?-true () $ if
               map? $ &{} :a 1
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match-sub $ %{} 'CodeEntry (:doc "|Match on second variant")
+        'test-match-sub $ %{} 'CodeEntry (:doc "|Match on second variant")
           :code $ quote
             defn test-match-sub (x y)
               &let
@@ -790,7 +790,7 @@
                   _ 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match-tag $ %{} 'CodeEntry (:doc "|Match on enum tag")
+        'test-match-tag $ %{} 'CodeEntry (:doc "|Match on enum tag")
           :code $ quote
             defn test-match-tag (x y)
               &let
@@ -801,7 +801,7 @@
                   _ 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match-wildcard $ %{} 'CodeEntry (:doc "|Match falls to wildcard")
+        'test-match-wildcard $ %{} 'CodeEntry (:doc "|Match falls to wildcard")
           :code $ quote
             defn test-match-wildcard () $ &let
               t $ :: :unknown 99
@@ -810,101 +810,101 @@
                 _ -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-max $ %{} 'CodeEntry (:doc "|max of two numbers")
+        'test-max $ %{} 'CodeEntry (:doc "|max of two numbers")
           :code $ quote
             defn test-max (a b)
               if (&> a b) a b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-min $ %{} 'CodeEntry (:doc "|min of two numbers")
+        'test-min $ %{} 'CodeEntry (:doc "|min of two numbers")
           :code $ quote
             defn test-min (a b)
               if (&< a b) a b
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-negate $ %{} 'CodeEntry (:doc "|negate from calcit.core")
+        'test-negate $ %{} 'CodeEntry (:doc "|negate from calcit.core")
           :code $ quote
             defn test-negate (x) (negate x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-not $ %{} 'CodeEntry (:doc "|not operation")
+        'test-not $ %{} 'CodeEntry (:doc "|not operation")
           :code $ quote
             defn test-not (x) (not x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-number-compare-method $ %{} 'CodeEntry (:doc |)
+        'test-number-compare-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-number-compare-method () $ .compare 1 2
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-number?-true $ %{} 'CodeEntry (:doc "|number? on number returns true (1)")
+        'test-number?-true $ %{} 'CodeEntry (:doc "|number? on number returns true (1)")
           :code $ quote
             defn test-number?-true () $ if (number? 42) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-option-unwrap-or $ %{} 'CodeEntry (:doc |)
+        'test-option-unwrap-or $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-option-unwrap-or () $ option:unwrap-or (%none) 7
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-pow $ %{} 'CodeEntry (:doc "|pow via host import")
+        'test-pow $ %{} 'CodeEntry (:doc "|pow via host import")
           :code $ quote
             defn test-pow (base exp) (pow base exp)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-println $ %{} 'CodeEntry (:doc |)
+        'test-println $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-println () do (println 42) 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-range $ %{} 'CodeEntry (:doc "|range creates list of numbers")
+        'test-range $ %{} 'CodeEntry (:doc "|range creates list of numbers")
           :code $ quote
             defn test-range () $ &list:count (range 5)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-range-sum $ %{} 'CodeEntry (:doc "|range 5 first+last: 0+4=4")
+        'test-range-sum $ %{} 'CodeEntry (:doc "|range 5 first+last: 0+4=4")
           :code $ quote
             defn test-range-sum () $ &let
               xs $ range 5
               &+ (&list:nth xs 0) (&list:nth xs 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-range-two-args $ %{} 'CodeEntry (:doc "|range 2 5 creates 3 elements")
+        'test-range-two-args $ %{} 'CodeEntry (:doc "|range 2 5 creates 3 elements")
           :code $ quote
             defn test-range-two-args () $ &list:count (range 2 5)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rem $ %{} 'CodeEntry (:doc |remainder)
+        'test-rem $ %{} 'CodeEntry (:doc |remainder)
           :code $ quote
             defn test-rem (a b) (&number:rem a b)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rest-count $ %{} 'CodeEntry (:doc "|rest args count: 3 extras")
+        'test-rest-count $ %{} 'CodeEntry (:doc "|rest args count: 3 extras")
           :code $ quote
             defn test-rest-count () $ &list:count (collect-rest 1 2 3 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rest-empty $ %{} 'CodeEntry (:doc "|rest args with no extras: 10+20 = 30")
+        'test-rest-empty $ %{} 'CodeEntry (:doc "|rest args with no extras: 10+20 = 30")
           :code $ quote
             defn test-rest-empty () $ sum-rest 10 20
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-rest-sum $ %{} 'CodeEntry (:doc "|rest args: 1+2+3+4+5 = 15")
+        'test-rest-sum $ %{} 'CodeEntry (:doc "|rest args: 1+2+3+4+5 = 15")
           :code $ quote
             defn test-rest-sum () $ sum-rest 1 2 3 4 5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-result-unwrap-or $ %{} 'CodeEntry (:doc |)
+        'test-result-unwrap-or $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-result-unwrap-or () $ result:unwrap-or (%err 3) 7
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-round $ %{} 'CodeEntry (:doc "|round function")
+        'test-round $ %{} 'CodeEntry (:doc "|round function")
           :code $ quote
             defn test-round (x) (round x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on set")
+        'test-set-contains-method $ %{} 'CodeEntry (:doc "|.contains? dispatches on set")
           :code $ quote
             defn test-set-contains-method () $ &+
               if
@@ -915,24 +915,24 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-count $ %{} 'CodeEntry (:doc "|set count")
+        'test-set-count $ %{} 'CodeEntry (:doc "|set count")
           :code $ quote
             defn test-set-count () $ &set:count (#{} 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-difference $ %{} 'CodeEntry (:doc "|difference removes elements in second set")
+        'test-set-difference $ %{} 'CodeEntry (:doc "|difference removes elements in second set")
           :code $ quote
             defn test-set-difference () $ &set:count
               &difference (#{} 10 20 30 40) (#{} 20 40)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-difference-empty $ %{} 'CodeEntry (:doc "|difference with disjoint sets keeps all")
+        'test-set-difference-empty $ %{} 'CodeEntry (:doc "|difference with disjoint sets keeps all")
           :code $ quote
             defn test-set-difference-empty () $ &set:count
               &difference (#{} 10 20) (#{} 30 40)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-empty $ %{} 'CodeEntry (:doc "|empty set")
+        'test-set-empty $ %{} 'CodeEntry (:doc "|empty set")
           :code $ quote
             defn test-set-empty () $ &+
               if
@@ -943,25 +943,25 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty set")
+        'test-set-empty-method $ %{} 'CodeEntry (:doc "|.empty returns an empty set")
           :code $ quote
             defn test-set-empty-method () $ count
               .empty $ #{} 10 20 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-exclude $ %{} 'CodeEntry (:doc "|exclude removes element")
+        'test-set-exclude $ %{} 'CodeEntry (:doc "|exclude removes element")
           :code $ quote
             defn test-set-exclude () $ &set:count
               &exclude (#{} 10 20 30) 20
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-include $ %{} 'CodeEntry (:doc "|include adds element")
+        'test-set-include $ %{} 'CodeEntry (:doc "|include adds element")
           :code $ quote
             defn test-set-include () $ &set:count
               &include (#{} 10 20) 30
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-includes $ %{} 'CodeEntry (:doc "|set includes value")
+        'test-set-includes $ %{} 'CodeEntry (:doc "|set includes value")
           :code $ quote
             defn test-set-includes () $ &+
               if
@@ -972,7 +972,7 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on set")
+        'test-set-includes-method $ %{} 'CodeEntry (:doc "|.includes? dispatches on set")
           :code $ quote
             defn test-set-includes-method () $ &+
               if
@@ -983,152 +983,166 @@
                 , 10 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-max-method $ %{} 'CodeEntry (:doc "|.max dispatches on set")
+        'test-set-max-method $ %{} 'CodeEntry (:doc "|.max dispatches on set")
           :code $ quote
             defn test-set-max-method () $ option:unwrap-or
               .max $ #{} 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-min-method $ %{} 'CodeEntry (:doc "|.min dispatches on set")
+        'test-set-min-method $ %{} 'CodeEntry (:doc "|.min dispatches on set")
           :code $ quote
             defn test-set-min-method () $ option:unwrap-or
               .min $ #{} 10 20 30 15
               , -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-union $ %{} 'CodeEntry (:doc "|union merges two sets")
+        'test-set-union $ %{} 'CodeEntry (:doc "|union merges two sets")
           :code $ quote
             defn test-set-union () $ &set:count
               &union (#{} 10 20) (#{} 20 30 40)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-union-same $ %{} 'CodeEntry (:doc "|union of identical sets")
+        'test-set-union-same $ %{} 'CodeEntry (:doc "|union of identical sets")
           :code $ quote
             defn test-set-union-same () $ &set:count
               &union (#{} 10 20 30) (#{} 10 20 30)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-sin $ %{} 'CodeEntry (:doc "|sin via host import")
+        'test-sin $ %{} 'CodeEntry (:doc "|sin via host import")
           :code $ quote
             defn test-sin (x) (sin x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-sqrt $ %{} 'CodeEntry (:doc "|sqrt function")
+        'test-sqrt $ %{} 'CodeEntry (:doc "|sqrt function")
           :code $ quote
             defn test-sqrt (x) (sqrt x)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-compare-eq $ %{} 'CodeEntry (:doc "|compare equal strings = 0")
+        'test-str-character-count $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-str-character-count () $ &str:count "|A😀"
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+        'test-str-compare-eq $ %{} 'CodeEntry (:doc "|compare equal strings = 0")
           :code $ quote
             defn test-str-compare-eq () $ &str:compare |abc |abc
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-compare-gt $ %{} 'CodeEntry (:doc "|compare abd > abc = 1")
+        'test-str-compare-gt $ %{} 'CodeEntry (:doc "|compare abd > abc = 1")
           :code $ quote
             defn test-str-compare-gt () $ &str:compare |abd |abc
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-compare-lt $ %{} 'CodeEntry (:doc "|compare abc < abd = -1")
+        'test-str-compare-lt $ %{} 'CodeEntry (:doc "|compare abc < abd = -1")
           :code $ quote
             defn test-str-compare-lt () $ &str:compare |abc |abd
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-concat $ %{} 'CodeEntry (:doc "|concat two strings and return byte count")
+        'test-str-concat $ %{} 'CodeEntry (:doc "|concat two strings and return byte count")
           :code $ quote
             defn test-str-concat () $ &str:count (&str:concat |foo |bar)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-contains-false $ %{} 'CodeEntry (:doc |)
+        'test-str-contains-false $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-contains-false () $ &str:contains? |hello 10
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-contains-true $ %{} 'CodeEntry (:doc |)
+        'test-str-contains-true $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-contains-true () $ &str:contains? |hello 1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-count $ %{} 'CodeEntry (:doc "|string byte length")
+        'test-str-count $ %{} 'CodeEntry (:doc "|string byte length")
           :code $ quote
             defn test-str-count () $ &str:count |hello
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-empty-false $ %{} 'CodeEntry (:doc "|non-empty string has non-zero count")
+        'test-str-empty-false $ %{} 'CodeEntry (:doc "|non-empty string has non-zero count")
           :code $ quote
             defn test-str-empty-false () $ &= (&str:count |hi) 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-empty-true $ %{} 'CodeEntry (:doc "|rest of 1-char string has 0 bytes")
+        'test-str-empty-true $ %{} 'CodeEntry (:doc "|rest of 1-char string has 0 bytes")
           :code $ quote
             defn test-str-empty-true () $ &=
               &str:count $ &str:rest |a
               , 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-escape $ %{} 'CodeEntry (:doc "|escape special chars")
+        'test-str-escape $ %{} 'CodeEntry (:doc "|escape special chars")
           :code $ quote
             defn test-str-escape () $ &str:count (&str:escape |hello)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-find-index-found $ %{} 'CodeEntry (:doc |)
+        'test-str-find-index-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-find-index-found () $ option:unwrap-or (.find-index |hello |ell) -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-find-index-not-found $ %{} 'CodeEntry (:doc |)
+        'test-str-find-index-not-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-find-index-not-found () $ option:unwrap-or (.find-index |hello |xyz) -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-first $ %{} 'CodeEntry (:doc "|first byte of hello = 104 (h)")
+        'test-str-first $ %{} 'CodeEntry (:doc "|first byte of hello = 104 (h)")
           :code $ quote
             defn test-str-first () $ &str:first |hello
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-includes-false $ %{} 'CodeEntry (:doc |)
+        'test-str-includes-false $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-includes-false () $ &str:includes? |hello |xyz
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-includes-true $ %{} 'CodeEntry (:doc |)
+        'test-str-includes-true $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-includes-true () $ &str:includes? |hello |ell
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-nth $ %{} 'CodeEntry (:doc "|nth character at index 1 of hello is e")
+        'test-str-nth $ %{} 'CodeEntry (:doc "|nth character at index 1 of hello is e")
           :code $ quote
             defn test-str-nth () $ if
               = (&str:nth |hello 1) |e
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-pad-left $ %{} 'CodeEntry (:doc |)
+        'test-str-pad-left $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-pad-left () $ &str:count (&str:pad-left |hi 5 |-)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-pad-right $ %{} 'CodeEntry (:doc |)
+        'test-str-pad-right $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-pad-right () $ &str:count (&str:pad-right |hi 5 |-)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-rest $ %{} 'CodeEntry (:doc "|rest of hello has 4 bytes")
+        'test-str-rest $ %{} 'CodeEntry (:doc "|rest of hello has 4 bytes")
           :code $ quote
             defn test-str-rest () $ &str:count (&str:rest |hello)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-str-slice $ %{} 'CodeEntry (:doc "|slice bytes 1..4 from abcde = 3 bytes (bcd)")
+        'test-str-slice $ %{} 'CodeEntry (:doc "|slice bytes 1..4 from abcde = 3 bytes (bcd)")
           :code $ quote
             defn test-str-slice () $ &str:count (&str:slice |abcde 1 4)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-string-compare-method $ %{} 'CodeEntry (:doc |)
+        'test-str-utf8-byte-count $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-str-utf8-byte-count () $ &str:utf8-byte-count "|A😀"
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+        'test-string-compare-method $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-string-compare-method () $ .compare |abc |abd
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-eq $ %{} 'CodeEntry (:doc "|struct definition equals source struct")
+        'test-struct-eq $ %{} 'CodeEntry (:doc "|struct definition equals source struct")
           :code $ quote
             defn test-struct-eq () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -1137,7 +1151,7 @@
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-field-tag $ %{} 'CodeEntry (:doc "|struct field-tag resolves by index")
+        'test-struct-field-tag $ %{} 'CodeEntry (:doc "|struct field-tag resolves by index")
           :code $ quote
             defn test-struct-field-tag () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -1146,7 +1160,7 @@
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-get-name $ %{} 'CodeEntry (:doc "|struct get-name returns struct tag")
+        'test-struct-get-name $ %{} 'CodeEntry (:doc "|struct get-name returns struct tag")
           :code $ quote
             defn test-struct-get-name () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -1155,7 +1169,7 @@
                 , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-matches-true $ %{} 'CodeEntry (:doc "|struct:matches? returns true for same type")
+        'test-struct-matches-true $ %{} 'CodeEntry (:doc "|struct:matches? returns true for same type")
           :code $ quote
             defn test-struct-matches-true () $ &let
               a $ %{} Point (:x 1) (:y 2)
@@ -1164,7 +1178,7 @@
                 if (&struct:matches? a b) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-sum $ %{} 'CodeEntry (:doc "|Struct create + field access")
+        'test-struct-sum $ %{} 'CodeEntry (:doc "|Struct create + field access")
           :code $ quote
             defn test-struct-sum (x y)
               &let
@@ -1172,7 +1186,7 @@
                 &+ (&struct:nth p 0 :x) (&struct:nth p 1 :y)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-to-map $ %{} 'CodeEntry (:doc "|struct to-map exposes field values by tag")
+        'test-struct-to-map $ %{} 'CodeEntry (:doc "|struct to-map exposes field values by tag")
           :code $ quote
             defn test-struct-to-map () $ &let
               point $ %{} Point (:x 1) (:y 2)
@@ -1181,17 +1195,17 @@
                 &+ (&map:get m :x) (&map:get m :y)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tag-eq $ %{} 'CodeEntry (:doc "|Tag equality — same tags")
+        'test-tag-eq $ %{} 'CodeEntry (:doc "|Tag equality — same tags")
           :code $ quote
             defn test-tag-eq () $ if (&= :ok :ok) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-tag-neq $ %{} 'CodeEntry (:doc "|Tag inequality — different tags")
+        'test-tag-neq $ %{} 'CodeEntry (:doc "|Tag inequality — different tags")
           :code $ quote
             defn test-tag-neq () $ if (&= :ok :err) 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-to-pairs $ %{} 'CodeEntry (:doc "|to-pairs count")
+        'test-to-pairs $ %{} 'CodeEntry (:doc "|to-pairs count")
           :code $ quote
             defn test-to-pairs () $ &let
               ps $ to-pairs (&{} :a 1 :b 2)
@@ -1199,7 +1213,7 @@
                 &list:count $ &list:first ps
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-enum $ %{} 'CodeEntry (:doc "|type-of enum == :enum tag")
+        'test-type-of-enum $ %{} 'CodeEntry (:doc "|type-of enum == :enum tag")
           :code $ quote
             defn test-type-of-enum () $ if
               &=
@@ -1208,7 +1222,7 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-list $ %{} 'CodeEntry (:doc "|type-of list == :list tag")
+        'test-type-of-list $ %{} 'CodeEntry (:doc "|type-of list == :list tag")
           :code $ quote
             defn test-type-of-list () $ if
               &=
@@ -1217,7 +1231,7 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-map $ %{} 'CodeEntry (:doc "|type-of map == :map tag")
+        'test-type-of-map $ %{} 'CodeEntry (:doc "|type-of map == :map tag")
           :code $ quote
             defn test-type-of-map () $ if
               &=
@@ -1226,14 +1240,14 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-number $ %{} 'CodeEntry (:doc "|type-of number == :number tag")
+        'test-type-of-number $ %{} 'CodeEntry (:doc "|type-of number == :number tag")
           :code $ quote
             defn test-type-of-number () $ if
               &= (type-of 42) :number
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-of-set $ %{} 'CodeEntry (:doc "|type-of set == :set tag")
+        'test-type-of-set $ %{} 'CodeEntry (:doc "|type-of set == :set tag")
           :code $ quote
             defn test-type-of-set () $ if
               &=
@@ -1242,14 +1256,14 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
-        |wasm-ffi-add $ %{} 'CodeEntry (:doc |)
+        'wasm-ffi-add $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defwasm-export wasm-ffi-add (a b) (&+ a b)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'Number 'Number
-        |wasm-ffi-upcase $ %{} 'CodeEntry (:doc |)
+        'wasm-ffi-upcase $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defwasm-export wasm-ffi-upcase (text) (host-string-upcase text)
           :examples $ []

--- a/docs/data/string.md
+++ b/docs/data/string.md
@@ -14,6 +14,17 @@ The way strings are represented in Calcit is a bit unique. Strings are distingui
 
 This somewhat unusual design exists because the structural editor naturally wraps strings in double quotes. When writing with indentation-based syntax, the outermost double quotes can be omitted for convenience.
 
+### Character count and wire size
+
+String `.count` returns the number of Unicode scalar values consistently on the native, JavaScript, and WASM backends. Use `.utf8-byte-count` when a protocol, queue, file, or metric needs the encoded UTF-8 byte length:
+
+```cirru
+assert= 2 $ "|A😀".count
+assert= 5 $ "|A😀".utf8-byte-count
+```
+
+Keep these operations distinct: character count describes Calcit text indexing semantics, while UTF-8 byte count describes storage and wire budgets. The latter is O(1) on the native and WASM representations and uses one allocation-free linear pass in generated JavaScript.
+
 ### Tag
 
 Calcit also provides the Tag type, written with a leading `:` such as `:demo`. Tags are interned immutable identifiers with consistent Calcit semantics across the Rust interpreter and JavaScript output. They are commonly used for struct fields, enum variants, map keys, and protocol labels; ordinary user-facing text should remain a String.

--- a/editing-history/202608310033-utf8-byte-count.md
+++ b/editing-history/202608310033-utf8-byte-count.md
@@ -1,0 +1,16 @@
+# Distinguish text length from UTF-8 wire size / 区分文本长度与 UTF-8 线协议大小
+
+## Summary / 概要
+
+- Added the String receiver method `.utf8-byte-count` backed by the internal `&str:utf8-byte-count` primitive. Native and WASM read the stored UTF-8 length in O(1); generated JavaScript performs one allocation-free pass.
+- 增加 String receiver method `.utf8-byte-count`，底层为 `&str:utf8-byte-count` primitive。Native/WASM O(1) 读取已存 UTF-8 长度，生成的 JavaScript 做一次无分配扫描。
+- Corrected `.count` / `&str:count` to mean Unicode scalar count consistently. JavaScript no longer exposes UTF-16 code-unit length, and WASM no longer exposes UTF-8 byte length under the character-count API.
+- 统一 `.count` / `&str:count` 为 Unicode scalar 数量；JavaScript 不再返回 UTF-16 code unit 数量，WASM 也不再把 UTF-8 bytes 冒充字符数。
+- Added native core, JavaScript runtime, and WASM regressions for ASCII, 2/3/4-byte UTF-8 scalars and astral Unicode values.
+- 增加 native core、JavaScript runtime 与 WASM 回归，覆盖 ASCII、2/3/4-byte UTF-8 scalar 与 astral Unicode。
+
+## Realtime motivation / 实时应用动机
+
+Calcium Workflow previously measured patch wire bytes with an interpreted per-character fold. A 384 KiB fault-injection payload blocked the server callback for more than 20 seconds before transport backpressure could be observed. The new method gives application metrics an explicit, cross-backend wire-size operation without allocating an encoded copy or conflating it with text indexing.
+
+Calcium Workflow 原先通过解释执行的逐字符 fold 统计 patch wire bytes。384 KiB 故障注入 payload 会阻塞 server callback 超过 20 秒，甚至来不及进入 transport backpressure。新 method 为应用指标提供显式、跨 backend 的 wire-size 操作，不分配 encoded copy，也不再与文本索引语义混淆。

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -49,6 +49,11 @@ try {
     "string replacement must treat patterns and replacement text literally"
   );
   assert.equal(runtimeA._$n_str_$o_replace("ab", "", "-"), "-a-b-", "empty string patterns should replace each boundary");
+  assert.equal(runtimeA._$n_str_$o_utf8_byte_count("abc"), 3, "ASCII byte length must match code-unit length");
+  assert.equal(runtimeA._$n_str_$o_utf8_byte_count("é"), 2, "two-byte UTF-8 scalars must be counted exactly");
+  assert.equal(runtimeA._$n_str_$o_utf8_byte_count("中"), 3, "three-byte UTF-8 scalars must be counted exactly");
+  assert.equal(runtimeA._$n_str_$o_utf8_byte_count("😀"), 4, "surrogate pairs must count as one four-byte UTF-8 scalar");
+  assert.equal(runtimeA._$n_str_$o_count("A😀"), 2, "string count must use Unicode scalars rather than UTF-16 code units");
 
   const todoName = runtimeA.newTag("TodoState");
   const todoField = runtimeA.newTag("draft");

--- a/scripts/test-wasm.mjs
+++ b/scripts/test-wasm.mjs
@@ -502,6 +502,8 @@ check("test-buf-list-filter()", 2, e["test-buf-list-filter"]);
 
 // --- String operation tests ---
 check("test-str-count()", 5, e["test-str-count"]);
+check("test-str-character-count()", 2, e["test-str-character-count"]);
+check("test-str-utf8-byte-count()", 5, e["test-str-utf8-byte-count"]);
 check("test-str-empty-true()", 1, e["test-str-empty-true"]); // count("") == 0
 check("test-str-empty-false()", 0, e["test-str-empty-false"]); // count("hi") == 0 is false
 check("test-str-concat()", 6, e["test-str-concat"]);

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -481,6 +481,7 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     NativeStrReplace => strings::replace(args),
     NativeStrEscape => strings::escape(args),
     NativeStrCount => strings::count(args),
+    NativeStrUtf8ByteCount => strings::utf8_byte_count(args),
     NativeStrEmpty => strings::empty_ques(args),
     NativeStrContains => strings::contains_ques(args),
     NativeStrIncludes => strings::includes_ques(args),

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -346,6 +346,17 @@ pub fn count(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
+pub fn utf8_byte_count(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  match xs.first() {
+    Some(Calcit::Str(s)) => Ok(Calcit::Number(s.len() as f64)),
+    Some(a) => CalcitErr::err_str(
+      CalcitErrKind::Type,
+      format!("&str:utf8-byte-count expected a string, but received: {a}"),
+    ),
+    None => CalcitErr::err_str(CalcitErrKind::Arity, "&str:utf8-byte-count expected 1 argument, but received none"),
+  }
+}
+
 pub fn empty_ques(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   match xs.first() {
     Some(Calcit::Str(s)) => Ok(Calcit::Bool(s.is_empty())),

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -270,6 +270,8 @@ pub enum CalcitProc {
   NativeStrEscape,
   #[strum(serialize = "&str:count")]
   NativeStrCount,
+  #[strum(serialize = "&str:utf8-byte-count")]
+  NativeStrUtf8ByteCount,
   #[strum(serialize = "&str:empty?")]
   NativeStrEmpty,
   #[strum(serialize = "&str:contains?")]
@@ -869,6 +871,10 @@ impl CalcitProc {
         arg_types: vec![some_tag("string")],
       }),
       NativeStrCount => Some(ProcTypeSignature {
+        return_type: some_tag("number"),
+        arg_types: vec![some_tag("string")],
+      }),
+      NativeStrUtf8ByteCount => Some(ProcTypeSignature {
         return_type: some_tag("number"),
         arg_types: vec![some_tag("string")],
       }),

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -436,7 +436,7 @@
           :tags $ #{} :internal
         '&core-string-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare) (:: :parse-cirru try-parse-cirru) (:: :parse-cirru-list try-parse-cirru-list) (:: :parse-cirru-edn try-parse-cirru-edn) (:: :parse-json try-parse-json)
+            def &core-string-methods $ &impl::new :&core-string-methods (:: :blank? blank?) (:: :count &str:count) (:: :utf8-byte-count &str:utf8-byte-count) (:: :empty &str:empty) (:: :ends-with? ends-with?) (:: :get get) (:: :parse-float parse-float) (:: :replace &str:replace) (:: :split split) (:: :split-lines split-lines) (:: :starts-with? starts-with?) (:: :strip-prefix strip-prefix) (:: :strip-suffix strip-suffix) (:: :slice &str:slice) (:: :trim trim) (:: :empty? &str:empty?) (:: :contains? &str:contains?) (:: :includes? &str:includes?) (:: :nth nth) (:: :first first) (:: :rest &str:rest) (:: :pad-left &str:pad-left) (:: :pad-right &str:pad-right) (:: :find-index str-find-index) (:: :get-char-code get-char-code) (:: :escape &str:escape) (:: :mappend &str:concat) (:: :compare &str:compare) (:: :parse-cirru try-parse-cirru) (:: :parse-cirru-list try-parse-cirru-list) (:: :parse-cirru-edn try-parse-cirru-edn) (:: :parse-json try-parse-json)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -2162,6 +2162,7 @@
                 do
                   assert= 3 $ &str:count |abc
                   assert= 2 $ &str:count "|中文"
+                  assert= 1 $ &str:count "|😀"
               :tags $ #{} :core :unit
         '&str:empty $ %{} 'CodeEntry (:doc "|internal helper for string :empty method entry")
           :code $ quote
@@ -2327,6 +2328,26 @@
                 do
                   assert= |bc $ &str:slice |abcd 1 3
                   assert= "|文字" $ &str:slice "|中文字符串" 1 3
+              :tags $ #{} :core :unit
+        '&str:utf8-byte-count $ %{} 'CodeEntry (:doc "|Return the UTF-8 wire byte length of a String in O(1) on native/WASM and one linear pass on JavaScript. Prefer receiver method .utf8-byte-count in application code.")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'String
+          :tags $ #{} :builtin :internal
+          :tests $ []
+            %{} 'TestEntry (:name |counts-utf8-wire-bytes)
+              :code $ quote
+                do
+                  assert= 3 $ &str:utf8-byte-count |abc
+                  assert= 2 $ &str:utf8-byte-count "|é"
+                  assert= 3 $ &str:utf8-byte-count "|中"
+                  assert= 4 $ &str:utf8-byte-count "|😀"
+              :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |receiver-method-counts-wire-bytes)
+              :code $ quote
+                assert= 5 $ "|A😀" .utf8-byte-count
               :tags $ #{} :core :unit
         '&struct-def:impl-traits $ %{} 'CodeEntry (:doc "|Attach implementations to a StructDef.")
           :code $ quote &runtime-implementation

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -2061,6 +2061,7 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
 
     // ------- String operations -------
     CalcitProc::NativeStrCount => emit_str_count(ctx, args),
+    CalcitProc::NativeStrUtf8ByteCount => emit_str_utf8_byte_count(ctx, args),
     CalcitProc::NativeStrEmpty => emit_str_empty(ctx, args),
     CalcitProc::NativeStrConcat => emit_str_concat(ctx, args),
     CalcitProc::NativeStrNth => emit_str_nth(ctx, args),

--- a/src/codegen/emit_wasm/strings.rs
+++ b/src/codegen/emit_wasm/strings.rs
@@ -43,12 +43,64 @@ pub(super) fn emit_str_alloc(ctx: &mut WasmGenCtx, len_i32: u32) -> (u32, u32) {
   (ptr, content_base)
 }
 
-/// `count` on a string — returns byte length as f64.
+/// `count` on a string — returns Unicode scalar count as f64.
 pub(super) fn emit_str_count(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
   expect_arity(1, args, "&str:count")?;
   emit_expr(ctx, &args[0])?;
   ctx.emit(Instruction::I32TruncF64U);
-  ctx.emit(Instruction::F64Load(mem_arg_f64(0))); // byte_len at logical_ptr+0
+  let ptr = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalSet(ptr));
+
+  let byte_len = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalGet(ptr));
+  ctx.emit(Instruction::F64Load(mem_arg_f64(0)));
+  ctx.emit(Instruction::I32TruncF64U);
+  ctx.emit(Instruction::LocalSet(byte_len));
+
+  let index = ctx.alloc_i32(0);
+  let count = ctx.alloc_i32(0);
+  ctx.emit(Instruction::Block(BlockType::Empty));
+  ctx.emit(Instruction::Loop(BlockType::Empty));
+  ctx.emit(Instruction::LocalGet(index));
+  ctx.emit(Instruction::LocalGet(byte_len));
+  ctx.emit(Instruction::I32GeU);
+  ctx.emit(Instruction::BrIf(1));
+
+  ctx.emit(Instruction::LocalGet(ptr));
+  ctx.emit(Instruction::I32Const(8));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalGet(index));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  ctx.emit(Instruction::I32Const(0xc0));
+  ctx.emit(Instruction::I32And);
+  ctx.emit(Instruction::I32Const(0x80));
+  ctx.emit(Instruction::I32Ne);
+  ctx.emit(Instruction::If(BlockType::Empty));
+  ctx.emit(Instruction::LocalGet(count));
+  ctx.emit(Instruction::I32Const(1));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalSet(count));
+  ctx.emit(Instruction::End);
+
+  ctx.emit(Instruction::LocalGet(index));
+  ctx.emit(Instruction::I32Const(1));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalSet(index));
+  ctx.emit(Instruction::Br(0));
+  ctx.emit(Instruction::End);
+  ctx.emit(Instruction::End);
+  ctx.emit(Instruction::LocalGet(count));
+  ctx.emit(Instruction::F64ConvertI32U);
+  Ok(())
+}
+
+/// UTF-8 byte count is stored directly in the string header.
+pub(super) fn emit_str_utf8_byte_count(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  expect_arity(1, args, "&str:utf8-byte-count")?;
+  emit_expr(ctx, &args[0])?;
+  ctx.emit(Instruction::I32TruncF64U);
+  ctx.emit(Instruction::F64Load(mem_arg_f64(0)));
   Ok(())
 }
 

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -371,9 +371,37 @@ export function _$n_list_$o_count(x: CalcitValue): number {
   throw new Error(`expected a list ${x}`);
 }
 export function _$n_str_$o_count(x: CalcitValue): number {
-  if (typeof x === "string") return x.length;
+  if (typeof x === "string") {
+    let count = 0;
+    for (const _scalar of x) count += 1;
+    return count;
+  }
 
   throw new Error(`expected a string ${x}`);
+}
+export function _$n_str_$o_utf8_byte_count(x: CalcitValue): number {
+  if (typeof x !== "string") throw new Error(`&str:utf8-byte-count expected a string ${x}`);
+
+  let bytes = 0;
+  for (let i = 0; i < x.length; i += 1) {
+    const code = x.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < x.length) {
+      const next = x.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i += 1;
+      } else {
+        bytes += 3;
+      }
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
 }
 export function _$n_map_$o_count(x: CalcitValue): number {
   if (x instanceof CalcitMap || x instanceof CalcitSliceMap) return x.len();


### PR DESCRIPTION
## 中文

关联 calcit-lang/calcit#501、Cumulo/calcium-workflow#33。

### 背景

Calcium 的真实 slow-reader 故障注入使用 384 KiB patch 时，应用层 `utf8-byte-count` 逐字符 fold 阻塞 server callback 超过 20 秒，尚未进入 transport backpressure 就已失去响应。同时发现现有 `String.count` 在三个 backend 的含义不一致：native 返回 Unicode scalar 数量，JavaScript 返回 UTF-16 code unit 数量，WASM 返回 UTF-8 byte 数量。

### 改动

- 增加 String receiver method `.utf8-byte-count`，底层 primitive 为 `&str:utf8-byte-count`。
- Native/WASM 直接读取已存 UTF-8 长度，O(1)；JavaScript 使用无分配单遍扫描。
- 统一 `.count` / `&str:count` 为 Unicode scalar 数量：修复 JavaScript astral character 与 WASM 多字节字符语义。
- 增加 native core、JS runtime、WASM 回归，覆盖 ASCII、2/3/4-byte UTF-8 scalar 与 emoji。
- 补充 String 文档，明确文本索引长度与 wire/storage byte budget 的边界。
- `calcit/test-wasm.cirru` 随当前 formatter 把 definition/ns keys 从兼容 string 表示转成 symbol 表示；loader 继续兼容旧 string snapshot。

### 验证

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn check-all`
- Calcit core unit tests：225/225
- Agent interface：17/17
- JS runtime identity、native Unicode、WASM Unicode/byte-count checks 全绿
- `calcit docs check-md docs/data/string.md`

## English

Related to calcit-lang/calcit#501 and Cumulo/calcium-workflow#33.

### Background

A real Calcium slow-reader fault injection with a 384 KiB patch spent more than 20 seconds in the application-level interpreted `utf8-byte-count` fold, blocking the server callback before transport backpressure could even be exercised. The investigation also found that `String.count` had three backend meanings: Unicode scalar count on native, UTF-16 code-unit count on JavaScript, and UTF-8 byte count on WASM.

### Changes

- Add String receiver method `.utf8-byte-count`, backed by `&str:utf8-byte-count`.
- Native/WASM read the stored UTF-8 length in O(1); JavaScript uses one allocation-free pass.
- Define `.count` / `&str:count` consistently as Unicode scalar count, fixing astral characters on JavaScript and multibyte text on WASM.
- Add native core, JS runtime, and WASM regressions for ASCII, 2/3/4-byte UTF-8 scalars, and emoji.
- Document the boundary between text-index length and wire/storage byte budgets.
- Let the current formatter migrate `calcit/test-wasm.cirru` definition/namespace keys from the compatible string representation to symbols; the loader remains backward compatible with old string snapshots.

### Validation

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn check-all`
- Calcit core unit tests: 225/225
- Agent interface: 17/17
- JS runtime identity, native Unicode, and WASM Unicode/byte-count checks pass
- `calcit docs check-md docs/data/string.md`
