### PR TITLE
完成 Calx typed import correctness corpus | Complete the Calx typed-import correctness corpus

### DIFF
--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -11,6 +11,7 @@ explicit namespace/definition
   -> closed reachable direct-call graph
        -> structured FallbackReport
        -> typed lowering plan
+       -> explicit signature-matched host capabilities
        -> ProgramBuilder -> CalxProgram -> ValidatedProgram
        -> CalxVM::run_typed
 ```
@@ -31,6 +32,11 @@ let kernel = compile_calx_kernel(&snapshot, "app.kernel", "range-sum")?;
 let value = kernel.run(&[Calcit::Number(10.0), Calcit::Number(0.0)])?;
 ```
 
+需要宿主能力时，embedding 必须显式构造 `CalxHostImports`，以 Calcit definition 为 capability key，
+再调用 `analyze_calx_eligibility_with_imports` / `compile_calx_kernel_with_imports`。普通未知调用不会自动
+变成 import，allowlist 中的 declaration 也必须与 typed snapshot 的 fixed-arity Number/Bool/Unit
+签名完全一致，否则整个 kernel 在 lowering 前结构化回退。
+
 `analyze_calx_eligibility` 不执行代码，也不产生半个 Calx program。只有入口可达的每个 definition
 都通过时才返回 `CalxEligibleCallGraph`；任意 callee 不合格都会返回覆盖整个 closure 的
 `CalxFallbackReport`。
@@ -50,6 +56,7 @@ name；direct tail call 与 `recur` 降为 `return-call`。
 - Number/Bool literal、typed local、单 binding `&let`、有 else 的 `if`；
 - `&+`、一元/二元 `&-`、`&*`、`&/`、`&=`、`&<`、`&>`；
 - fixed-arity direct call 与 tail-position `recur`；
+- 显式 allowlist 的 zero-result / single-result typed host import；
 - 条件必须静态为 Bool，不复用 Calcit 或 Calx 的 numeric truthiness。
 
 首批明确拒绝：
@@ -58,6 +65,17 @@ name；direct tail call 与 `recur` 降为 `return-call`。
 - closure、function value、local/dynamic operator、HOF、rest/optional arity；
 - 无 else 的 `if`、非 tail `recur`、global/ref/atom、collection/nominal value；
 - 未加入 allowlist 的 host/native capability。
+
+## Typed host import contract
+
+`CalxHostImport::void` 绑定 `Result<(), CalxError>`，`CalxHostImport::value` 绑定
+`Result<CalxValue, CalxError>`。参数由 VM 在 callback 前按 F64/Bool 声明检查，single-result callback
+返回的 owned value 也会再次检查。Nil、Dynamic、多个结果和隐式类型转换都不进入该 ABI。
+
+每次 kernel `run` 都创建独立 VM instance，并复用编译期固定的函数指针 binding；参数以 owned Calx
+scalar 进入 VM，callback 只借用本次调用的 slice，single result 由 callback 转移给 VM。embedding
+负责 capability 的外部状态与并发策略。callback 一旦执行，无论成功或 trap 都不会自动回退到 Calcit，
+因此 effect 不会因双执行而重复。
 
 ## Fallback contract
 
@@ -93,6 +111,11 @@ golden tests，但明确是 experimental report，不是可持久化的 compiler
 VM 中实际执行，并与同一源码的 Calcit native runner 做差分比较。另一个 fixture 固定 Dynamic callee
 导致整个入口 closure fallback 的报告，并验证不会进入 lowering。
 
+[`tests/fixtures/calx/typed-imports.cirru`](../../tests/fixtures/calx/typed-imports.cirru)
+覆盖 zero-result observe capability、single-result numeric capability 和 trapping capability。对应
+generated-program golden 固定 import declaration、guest syntax 与 Calcit tree origin；trap golden 固定
+`CALX_HOST_IMPORT` 诊断。签名不一致的显式 capability 在 lowering 前整体 fallback。
+
 ## 错误与回退边界
 
 - `Eligibility` 是唯一允许 embedding 选择整体回退到 Calcit 的编译结果；
@@ -105,5 +128,6 @@ VM 中实际执行，并与同一源码的 Calcit native runner 做差分比较�
 ## 尚未实现
 
 当前 API 仍是 Rust embedding，不是 `calcit` CLI 的正式 backend。首批没有 collection/nominal value、closure、
-typed host capability、cache、profiling/selection policy，也还没有基于 benchmark 的自动 offload。下一阶段应先补
-compile cache 与基准矩阵，再扩展一小组无歧义的 typed host imports；在 effect contract 完成前不扩大到有副作用代码。
+cache、profiling/selection policy，也还没有基于 benchmark 的自动 offload。correctness corpus 已覆盖 scalar
+kernel、zero/single-result typed imports、generated program、trap 与 fallback；下一阶段进入 #39，先建立分阶段
+基准矩阵和 crossover point，再用 profile 证据决定 compile cache、VM reuse 与 selection policy。

--- a/editing-history/202608310054-calx-import-golden.md
+++ b/editing-history/202608310054-calx-import-golden.md
@@ -1,0 +1,27 @@
+# Calx typed imports 与 correctness golden
+
+## 中文
+
+本次修改完成 Calcit→Calx correctness prototype 的剩余闭环：显式 typed host imports、固定 generated-program golden 和 runtime trap golden。
+
+- 新增 `CalxHostImport` / `CalxHostImports`。embedding 必须以 Calcit definition 为 capability key 显式提供 binding；未知调用不会自动成为 import。
+- eligibility 同时校验 typed snapshot 中的 fixed-arity Number/Bool/Unit 签名与 host declaration。签名不一致返回 `CALX_SUBSET_HOST_CAPABILITY`，并在 lowering 前整体 fallback。
+- lowering 只为实际可达的 capability 生成 `ProgramBuilder::import_at` 与 `call_import`，并把对应 binding 固定在 compiled kernel 中。未使用的配置不会进入 program。
+- zero-result callback 使用 `Result<(), CalxError>`，single-result callback 使用 `Result<CalxValue, CalxError>`。每次运行创建独立 VM；host callback error 保持为 runtime trap，不自动重跑 Calcit。
+- `stable_program_summary()` 固定 import declaration、guest syntax 与 Calcit tree origin，供 repository golden 使用，不作为序列化 ABI。
+- 新 fixture 覆盖 void observe、value scale、host trap、native/Calx differential result，以及 import signature mismatch fallback。
+
+验证要求包括 focused Calx tests、全部 Rust tests、strict Clippy、`yarn compile`、`yarn check-all` 和 Agent interface suite。
+
+## English
+
+This change completes the remaining correctness loop for the Calcit-to-Calx prototype: explicit typed host imports, a fixed generated-program golden, and a runtime-trap golden.
+
+- Added `CalxHostImport` / `CalxHostImports`. The embedding must explicitly bind a capability using a Calcit definition as the key; unknown calls never become imports automatically.
+- Eligibility verifies that the fixed-arity Number/Bool/Unit signature in the typed snapshot exactly matches the host declaration. A mismatch produces `CALX_SUBSET_HOST_CAPABILITY` and falls back for the whole kernel before lowering.
+- Lowering emits `ProgramBuilder::import_at` and `call_import` only for reachable capabilities, then retains exactly those bindings in the compiled kernel. Unused configuration does not enter the program.
+- Zero-result callbacks use `Result<(), CalxError>` and single-result callbacks use `Result<CalxValue, CalxError>`. Every run creates an independent VM; a host callback error remains a runtime trap and never reruns Calcit automatically.
+- `stable_program_summary()` fixes import declarations, guest syntax, and Calcit tree origins for repository goldens; it is not a serialized ABI.
+- The new fixture covers a void observer, a value-returning scale operation, a host trap, native/Calx differential results, and fallback for an import signature mismatch.
+
+Required verification includes focused Calx tests, the complete Rust suite, strict Clippy, `yarn compile`, `yarn check-all`, and the Agent interface suite.

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -7,14 +7,16 @@
 
 mod lowering;
 
-pub use calx_vm::{CalxBuildError, CalxError, CalxProgramError};
+pub use calx_vm::{Calx as CalxValue, CalxBuildError, CalxError, CalxProgramError};
 pub use lowering::{
   CalxCompiledKernel, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError,
-  CalxLoweringError, compile_calx_kernel,
+  CalxLoweringError, compile_calx_kernel, compile_calx_kernel_with_imports,
 };
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+
+use calx_vm::{CalxHostBinding, CalxType as VmType};
 
 use crate::builtins::syntax::get_raw_args_fn;
 use crate::calcit::{Calcit, CalcitFnArgs, CalcitProc, CalcitSyntax, CalcitTypeAnnotation};
@@ -33,6 +35,13 @@ impl CalxScalarType {
     match self {
       Self::F64 => "F64",
       Self::Bool => "Bool",
+    }
+  }
+
+  const fn vm_type(self) -> VmType {
+    match self {
+      Self::F64 => VmType::F64,
+      Self::Bool => VmType::Bool,
     }
   }
 }
@@ -55,6 +64,78 @@ impl CalxDefinitionRef {
     format!("{}/{}", self.namespace, self.definition)
   }
 }
+
+/// One explicitly approved scalar host capability for a Calx kernel.
+///
+/// The Calcit definition is supplied as the key in [`CalxHostImports`]. Its
+/// typed snapshot signature must exactly match this declaration before the
+/// function body may be replaced by the host callback.
+#[derive(Debug, Clone)]
+pub struct CalxHostImport {
+  name: Arc<str>,
+  params: Vec<CalxScalarType>,
+  result: Option<CalxScalarType>,
+  binding: CalxHostBinding,
+}
+
+impl CalxHostImport {
+  /// Declares a zero-result import backed by `Result<(), CalxError>`.
+  pub fn void(
+    name: impl Into<Arc<str>>,
+    params: Vec<CalxScalarType>,
+    callback: fn(&[CalxValue]) -> Result<(), CalxError>,
+  ) -> Result<Self, CalxProgramError> {
+    let binding = CalxHostBinding::void(params.iter().copied().map(CalxScalarType::vm_type).collect(), callback)?;
+    Ok(Self {
+      name: name.into(),
+      params,
+      result: None,
+      binding,
+    })
+  }
+
+  /// Declares a single-result import backed by `Result<CalxValue, CalxError>`.
+  pub fn value(
+    name: impl Into<Arc<str>>,
+    params: Vec<CalxScalarType>,
+    result: CalxScalarType,
+    callback: fn(&[CalxValue]) -> Result<CalxValue, CalxError>,
+  ) -> Result<Self, CalxProgramError> {
+    let binding = CalxHostBinding::value(
+      params.iter().copied().map(CalxScalarType::vm_type).collect(),
+      result.vm_type(),
+      callback,
+    )?;
+    Ok(Self {
+      name: name.into(),
+      params,
+      result: Some(result),
+      binding,
+    })
+  }
+
+  /// Calx import declaration name used in the generated program.
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  /// Concrete non-nil, non-Dynamic scalar parameter contract.
+  pub fn params(&self) -> &[CalxScalarType] {
+    &self.params
+  }
+
+  /// Zero-result imports return `None`; single-result imports return one scalar type.
+  pub fn result(&self) -> Option<CalxScalarType> {
+    self.result
+  }
+
+  fn binding(&self) -> &CalxHostBinding {
+    &self.binding
+  }
+}
+
+/// Explicit Calcit-definition to Calx-host-capability mapping.
+pub type CalxHostImports = BTreeMap<CalxDefinitionRef, CalxHostImport>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CalxFallbackCode {
@@ -143,6 +224,7 @@ pub struct CalxEligibleFunction {
   pub params: Vec<CalxScalarType>,
   pub result: Option<CalxScalarType>,
   pub direct_calls: Vec<CalxDefinitionRef>,
+  pub host_imports: Vec<CalxDefinitionRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,6 +246,9 @@ impl CalxEligibleCallGraph {
       for callee in &function.direct_calls {
         output.push_str(&format!("  call {}\n", callee.qualified()));
       }
+      for import in &function.host_imports {
+        output.push_str(&format!("  import {}\n", import.qualified()));
+      }
     }
     output
   }
@@ -179,13 +264,24 @@ pub fn analyze_calx_eligibility(
   namespace: impl Into<Arc<str>>,
   definition: impl Into<Arc<str>>,
 ) -> Result<CalxEligibleCallGraph, CalxFallbackReport> {
+  analyze_calx_eligibility_with_imports(program, namespace, definition, &CalxHostImports::new())
+}
+
+/// Proves eligibility while replacing only explicitly declared, signature-
+/// matched Calcit definitions with strict typed host imports.
+pub fn analyze_calx_eligibility_with_imports(
+  program: &CompiledProgram,
+  namespace: impl Into<Arc<str>>,
+  definition: impl Into<Arc<str>>,
+  imports: &CalxHostImports,
+) -> Result<CalxEligibleCallGraph, CalxFallbackReport> {
   let entry = CalxDefinitionRef::new(namespace, definition);
-  let mut analyzer = EligibilityAnalyzer::new(program, entry.clone());
+  let mut analyzer = EligibilityAnalyzer::new(program, entry.clone(), imports);
   analyzer.visit(entry.clone(), vec![entry.clone()]);
   analyzer.finish()
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct FunctionSignature {
   params: Vec<CalxScalarType>,
   result: Option<CalxScalarType>,
@@ -193,6 +289,7 @@ struct FunctionSignature {
 
 struct EligibilityAnalyzer<'a> {
   program: &'a CompiledProgram,
+  imports: &'a CalxHostImports,
   entry: CalxDefinitionRef,
   visited: BTreeSet<CalxDefinitionRef>,
   functions: BTreeMap<CalxDefinitionRef, CalxEligibleFunction>,
@@ -200,9 +297,10 @@ struct EligibilityAnalyzer<'a> {
 }
 
 impl<'a> EligibilityAnalyzer<'a> {
-  fn new(program: &'a CompiledProgram, entry: CalxDefinitionRef) -> Self {
+  fn new(program: &'a CompiledProgram, entry: CalxDefinitionRef, imports: &'a CalxHostImports) -> Self {
     Self {
       program,
+      imports,
       entry,
       visited: BTreeSet::new(),
       functions: BTreeMap::new(),
@@ -241,6 +339,7 @@ impl<'a> EligibilityAnalyzer<'a> {
     let signature = analyze_signature(compiled, &target, &call_path, &mut self.issues);
     let parts = extract_fn_parts(compiled, &target, &call_path, &mut self.issues);
     let mut direct_calls = BTreeSet::new();
+    let mut host_imports = BTreeSet::new();
     let mut body_result = None;
     if let Some((args, body)) = parts {
       if let Some(signature) = &signature
@@ -274,6 +373,8 @@ impl<'a> EligibilityAnalyzer<'a> {
         signature: signature.as_ref(),
         call_path: &call_path,
         direct_calls: &mut direct_calls,
+        host_imports: &mut host_imports,
+        imports: self.imports,
         issues: &mut self.issues,
       };
       body_result = analyze_sequence(&body, true, &mut context);
@@ -302,6 +403,7 @@ impl<'a> EligibilityAnalyzer<'a> {
           params: signature.params,
           result: signature.result,
           direct_calls: direct_calls.iter().cloned().collect(),
+          host_imports: host_imports.iter().cloned().collect(),
         },
       );
     }
@@ -522,6 +624,8 @@ struct ExpressionContext<'a> {
   signature: Option<&'a FunctionSignature>,
   call_path: &'a [CalxDefinitionRef],
   direct_calls: &'a mut BTreeSet<CalxDefinitionRef>,
+  host_imports: &'a mut BTreeSet<CalxDefinitionRef>,
+  imports: &'a CalxHostImports,
   issues: &'a mut Vec<CalxFallbackIssue>,
 }
 
@@ -813,6 +917,9 @@ fn analyze_direct_call(
   args: &[Calcit],
   context: &mut ExpressionContext<'_>,
 ) -> Option<Option<CalxScalarType>> {
+  if let Some(import) = context.imports.get(&target) {
+    return analyze_host_import_call(target, import, args, context);
+  }
   let Some(compiled) = lookup_compiled_def(context.program, &target) else {
     analyze_unknown_args(args, context);
     issue(
@@ -862,6 +969,78 @@ fn analyze_direct_call(
     }
   }
   valid.then_some(signature.result)
+}
+
+fn analyze_host_import_call(
+  target: CalxDefinitionRef,
+  import: &CalxHostImport,
+  args: &[Calcit],
+  context: &mut ExpressionContext<'_>,
+) -> Option<Option<CalxScalarType>> {
+  let Some(compiled) = lookup_compiled_def(context.program, &target) else {
+    analyze_unknown_args(args, context);
+    issue(
+      context,
+      CalxFallbackCode::HostCapability,
+      args.first().and_then(source_path),
+      format!("approved host import `{}` is missing from the typed snapshot", target.qualified()),
+    );
+    return None;
+  };
+  if compiled.kind != CompiledDefKind::Fn {
+    analyze_unknown_args(args, context);
+    issue(
+      context,
+      CalxFallbackCode::HostCapability,
+      source_path(&compiled.preprocessed_code),
+      format!("approved host import `{}` is not a top-level function", target.qualified()),
+    );
+    return None;
+  }
+  let declared = analyze_signature(compiled, &target, context.call_path, context.issues)?;
+  if declared.params != import.params || declared.result != import.result {
+    analyze_unknown_args(args, context);
+    issue(
+      context,
+      CalxFallbackCode::HostCapability,
+      source_path(&compiled.preprocessed_code),
+      format!(
+        "approved host import `{}` declares ({:?})->{:?}, but typed snapshot requires ({:?})->{:?}",
+        target.qualified(),
+        import.params,
+        import.result,
+        declared.params,
+        declared.result
+      ),
+    );
+    return None;
+  }
+  if args.len() != import.params.len() {
+    issue(
+      context,
+      CalxFallbackCode::Arity,
+      args.first().and_then(source_path),
+      format!(
+        "host import `{}` expects {} arguments, found {}",
+        target.qualified(),
+        import.params.len(),
+        args.len()
+      ),
+    );
+    return None;
+  }
+  let mut valid = true;
+  for (argument, expected) in args.iter().zip(&import.params) {
+    if analyze_expression(argument, false, context) != Some(Some(*expected)) {
+      valid = false;
+    }
+  }
+  if valid {
+    context.host_imports.insert(target);
+    Some(import.result)
+  } else {
+    None
+  }
 }
 
 fn analyze_unknown_args(args: &[Calcit], context: &mut ExpressionContext<'_>) {

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -1,32 +1,23 @@
 //! Typed lowering from a proven Calx-eligible Calcit call graph.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 use std::sync::Arc;
 
 use calx_vm::{
   BodyBuilder, Calx as VmValue, CalxBuildError, CalxError, CalxHostBindings, CalxProgramError, CalxRunResult, CalxSyntax as VmSyntax,
-  CalxType as VmType, CalxVM, FunctionBuilder, LocalId, ProgramBuilder, SourceSpan, ValidatedProgram,
+  CalxVM, FunctionBuilder, ImportId, LocalId, ProgramBuilder, SourceSpan, ValidatedProgram,
 };
 
 use crate::calcit::{Calcit, CalcitFnArgs, CalcitLocal, CalcitProc, CalcitSyntax, brief_type_of_value};
 use crate::program::CompiledProgram;
 
 use super::{
-  CalxDefinitionRef, CalxEligibleCallGraph, CalxFallbackReport, CalxScalarType, analyze_calx_eligibility, extract_fn_parts,
-  lookup_compiled_def, source_path,
+  CalxDefinitionRef, CalxEligibleCallGraph, CalxFallbackReport, CalxHostImports, CalxScalarType, analyze_calx_eligibility_with_imports,
+  extract_fn_parts, lookup_compiled_def, source_path,
 };
-
-impl CalxScalarType {
-  const fn vm_type(self) -> VmType {
-    match self {
-      Self::F64 => VmType::F64,
-      Self::Bool => VmType::Bool,
-    }
-  }
-}
 
 /// A mismatch discovered while converting a graph that already passed the
 /// eligibility proof. This is a compiler integration error, not a fallback.
@@ -159,6 +150,7 @@ pub struct CalxCompiledKernel {
   params: Vec<CalxScalarType>,
   result: Option<CalxScalarType>,
   program: ValidatedProgram,
+  host_bindings: CalxHostBindings,
 }
 
 impl CalxCompiledKernel {
@@ -178,8 +170,45 @@ impl CalxCompiledKernel {
     &self.program
   }
 
+  /// Deterministic generated-program report for repository golden fixtures.
+  /// This is diagnostic text, not a serialized Calx program ABI.
+  pub fn stable_program_summary(&self) -> String {
+    let mut output = format!("abi {}\nentry {}\n", self.graph.abi_edition, self.graph.entry.qualified());
+    for import in self.program.imports() {
+      let params = import.params.iter().map(ToString::to_string).collect::<Vec<_>>().join(",");
+      let result = import.result.map(|value| value.to_string()).unwrap_or_else(|| "Void".to_owned());
+      output.push_str(&format!("import {} ({params})->{result}\n", import.name));
+    }
+    for function in self.program.functions() {
+      let params = function
+        .params_types
+        .iter()
+        .map(|value| format!("{value:?}"))
+        .collect::<Vec<_>>()
+        .join(",");
+      let result = function
+        .ret_types
+        .iter()
+        .map(|value| format!("{value:?}"))
+        .collect::<Vec<_>>()
+        .join(",");
+      let result = if result.is_empty() { "Void" } else { result.as_str() };
+      output.push_str(&format!("function {} ({params})->{result}\n", function.name));
+      for (index, syntax) in function.syntax.iter().enumerate() {
+        let origin = function
+          .source_spans
+          .get(index)
+          .and_then(Option::as_ref)
+          .map(|span| span.source.as_ref())
+          .unwrap_or("-");
+        output.push_str(&format!("  {index:03} {syntax:?} @ {origin}\n"));
+      }
+    }
+    output
+  }
+
   pub fn instantiate(&self) -> Result<CalxVM, CalxKernelRunError> {
-    CalxVM::from_validated_program(self.program.clone(), CalxHostBindings::new()).map_err(CalxKernelRunError::Instantiate)
+    CalxVM::from_validated_program(self.program.clone(), self.host_bindings.clone()).map_err(CalxKernelRunError::Instantiate)
   }
 
   pub fn run(&self, args: &[Calcit]) -> Result<Calcit, CalxKernelRunError> {
@@ -232,7 +261,18 @@ pub fn compile_calx_kernel(
   namespace: impl Into<Arc<str>>,
   definition: impl Into<Arc<str>>,
 ) -> Result<CalxCompiledKernel, CalxKernelCompileError> {
-  let graph = analyze_calx_eligibility(program, namespace, definition).map_err(CalxKernelCompileError::Eligibility)?;
+  compile_calx_kernel_with_imports(program, namespace, definition, &CalxHostImports::new())
+}
+
+/// Compiles a kernel with an explicit set of typed scalar host capabilities.
+pub fn compile_calx_kernel_with_imports(
+  program: &CompiledProgram,
+  namespace: impl Into<Arc<str>>,
+  definition: impl Into<Arc<str>>,
+  imports: &CalxHostImports,
+) -> Result<CalxCompiledKernel, CalxKernelCompileError> {
+  let graph =
+    analyze_calx_eligibility_with_imports(program, namespace, definition, imports).map_err(CalxKernelCompileError::Eligibility)?;
   let entry_signature = graph
     .functions
     .iter()
@@ -260,12 +300,37 @@ pub fn compile_calx_kernel(
       function.result,
       &names,
       &signatures,
+      imports,
     )?);
   }
 
   let mut builder = ProgramBuilder::new();
+  let used_imports = graph
+    .functions
+    .iter()
+    .flat_map(|function| function.host_imports.iter().cloned())
+    .collect::<BTreeSet<_>>();
+  let mut import_ids = BTreeMap::new();
+  let mut host_bindings = CalxHostBindings::new();
+  for target in used_imports {
+    let import = imports.get(&target).ok_or_else(|| {
+      CalxKernelCompileError::Lowering(lower_error(
+        &target,
+        None,
+        "eligible host import has no compile-time capability binding",
+      ))
+    })?;
+    let id = builder.import_at(
+      import.name(),
+      import.params().iter().copied().map(CalxScalarType::vm_type).collect(),
+      import.result().map(CalxScalarType::vm_type),
+      Some(SourceSpan::synthetic(source_origin(&target, None))),
+    )?;
+    import_ids.insert(target, id);
+    host_bindings.insert(import.name().into(), import.binding().clone());
+  }
   for plan in &plans {
-    builder.function(emit_function(plan)?)?;
+    builder.function(emit_function(plan, &import_ids)?)?;
   }
   let program = builder.build()?;
   let program = ValidatedProgram::try_from_program(program)?;
@@ -274,6 +339,7 @@ pub fn compile_calx_kernel(
     params,
     result,
     program,
+    host_bindings,
   })
 }
 
@@ -342,6 +408,10 @@ enum PlannedExpressionKind {
     args: Vec<PlannedExpression>,
     tail: bool,
   },
+  ImportCall {
+    target: CalxDefinitionRef,
+    args: Vec<PlannedExpression>,
+  },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -361,6 +431,7 @@ struct PlanningContext<'a> {
   function_result: Option<CalxScalarType>,
   names: &'a BTreeMap<CalxDefinitionRef, String>,
   signatures: &'a BTreeMap<CalxDefinitionRef, (Vec<CalxScalarType>, Option<CalxScalarType>)>,
+  imports: &'a CalxHostImports,
   locals: BTreeMap<u16, PlannedLocal>,
 }
 
@@ -371,6 +442,7 @@ fn plan_function(
   result: Option<CalxScalarType>,
   names: &BTreeMap<CalxDefinitionRef, String>,
   signatures: &BTreeMap<CalxDefinitionRef, (Vec<CalxScalarType>, Option<CalxScalarType>)>,
+  imports: &CalxHostImports,
 ) -> Result<PlannedFunction, CalxLoweringError> {
   let compiled =
     lookup_compiled_def(program, &definition).ok_or_else(|| lower_error(&definition, None, "compiled definition disappeared"))?;
@@ -415,6 +487,7 @@ fn plan_function(
     function_result: result,
     names,
     signatures,
+    imports,
     locals: BTreeMap::new(),
   };
   let body = plan_sequence(&body, true, &mut context)?;
@@ -668,6 +741,15 @@ fn plan_direct_call(
   tail: bool,
   context: &mut PlanningContext<'_>,
 ) -> Result<PlannedExpression, CalxLoweringError> {
+  if let Some(import) = context.imports.get(&target) {
+    let result = import.result();
+    let args = plan_args(args, context)?;
+    return Ok(planned(
+      result,
+      args.first().and_then(|value| value.source_path.clone()),
+      PlannedExpressionKind::ImportCall { target, args },
+    ));
+  }
   let (_, result) = context.signatures.get(&target).ok_or_else(|| {
     lower_error(
       context.function,
@@ -718,7 +800,10 @@ fn lower_error(function: &CalxDefinitionRef, source_path: Option<Vec<u16>>, mess
   }
 }
 
-fn emit_function(plan: &PlannedFunction) -> Result<FunctionBuilder, CalxKernelCompileError> {
+fn emit_function(
+  plan: &PlannedFunction,
+  imports: &BTreeMap<CalxDefinitionRef, ImportId>,
+) -> Result<FunctionBuilder, CalxKernelCompileError> {
   let source = source_origin(&plan.definition, None);
   let results = plan.result.into_iter().map(CalxScalarType::vm_type).collect();
   let mut builder = FunctionBuilder::synthetic(plan.vm_name.clone(), results, source)?;
@@ -738,6 +823,7 @@ fn emit_function(plan: &PlannedFunction) -> Result<FunctionBuilder, CalxKernelCo
   let context = EmissionContext {
     function: &plan.definition,
     locals: &local_ids,
+    imports,
     lowering_error: RefCell::new(None),
   };
   emit_expression(&plan.body, builder.body(), &context)?;
@@ -750,6 +836,7 @@ fn emit_function(plan: &PlannedFunction) -> Result<FunctionBuilder, CalxKernelCo
 struct EmissionContext<'a> {
   function: &'a CalxDefinitionRef,
   locals: &'a BTreeMap<u16, LocalId>,
+  imports: &'a BTreeMap<CalxDefinitionRef, ImportId>,
   lowering_error: RefCell<Option<CalxLoweringError>>,
 }
 
@@ -846,6 +933,23 @@ fn emit_expression(
         body.call(callee.as_str())?;
       }
     }
+    PlannedExpressionKind::ImportCall { target, args } => {
+      for argument in args {
+        emit_expression(argument, body, context)?;
+      }
+      if let Some(import) = context.imports.get(target) {
+        body.call_import(import)?;
+      } else {
+        let mut error = context.lowering_error.borrow_mut();
+        if error.is_none() {
+          *error = Some(lower_error(
+            context.function,
+            expression.source_path.clone(),
+            format!("host import `{}` has no emitted Calx ImportId", target.qualified()),
+          ));
+        }
+      }
+    }
   }
   Ok(())
 }
@@ -887,7 +991,7 @@ mod tests {
       body: planned(Some(CalxScalarType::F64), Some(vec![3, 1]), PlannedExpressionKind::Local(42)),
     };
 
-    let error = emit_function(&plan).expect_err("an unplanned typed local must not panic");
+    let error = emit_function(&plan, &BTreeMap::new()).expect_err("an unplanned typed local must not panic");
     let CalxKernelCompileError::Lowering(error) = error else {
       panic!("expected a lowering error, got {error}");
     };

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -3,16 +3,19 @@ use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
 use crate::calcit::{CalcitFnTypeAnnotation, CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo, SchemaKind};
 use crate::call_stack::CallStackList;
 use crate::codegen::calx::{
-  CalxDefinitionRef, CalxFallbackCode, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError, CalxScalarType,
-  analyze_calx_eligibility, compile_calx_kernel,
+  CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport, CalxHostImports, CalxKernelBoundaryErrorKind, CalxKernelCompileError,
+  CalxKernelRunError, CalxScalarType, CalxValue, analyze_calx_eligibility, analyze_calx_eligibility_with_imports, compile_calx_kernel,
+  compile_calx_kernel_with_imports,
 };
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
 use cirru_edn::EdnTag;
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex};
 
 static PROGRAM_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static CALX_VOID_IMPORT_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 fn cirru_leaf(value: &str) -> Cirru {
   Cirru::Leaf(value.into())
@@ -372,6 +375,168 @@ fn calx_lowering_executes_three_source_kernels_like_native_calcit() {
   assert!(matches!(
     error,
     CalxKernelRunError::Boundary(ref boundary) if boundary.kind == CalxKernelBoundaryErrorKind::ArgumentType
+  ));
+}
+
+fn install_calx_typed_import_fixture(namespace: &str) {
+  let number = || CalcitTypeAnnotation::Number;
+  let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/typed-imports.cirru"));
+  install_calx_test_defs(
+    namespace,
+    vec![
+      (
+        "host-scale",
+        source_defs.remove("host-scale").expect("host-scale source"),
+        calx_test_fn_schema(vec![number()], number()),
+      ),
+      (
+        "host-observe",
+        source_defs.remove("host-observe").expect("host-observe source"),
+        calx_test_fn_schema(vec![number()], CalcitTypeAnnotation::Unit),
+      ),
+      (
+        "host-trap",
+        source_defs.remove("host-trap").expect("host-trap source"),
+        calx_test_fn_schema(vec![number()], number()),
+      ),
+      (
+        "imported-pipeline",
+        source_defs.remove("imported-pipeline").expect("imported-pipeline source"),
+        calx_test_fn_schema(vec![number()], number()),
+      ),
+      (
+        "imported-trap",
+        source_defs.remove("imported-trap").expect("imported-trap source"),
+        calx_test_fn_schema(vec![number()], number()),
+      ),
+    ],
+  );
+  for definition in ["imported-pipeline", "imported-trap"] {
+    compile_calx_test_entry(namespace, definition);
+  }
+}
+
+fn calx_test_scale(args: &[CalxValue]) -> Result<CalxValue, CalxError> {
+  let [CalxValue::F64(value)] = args else {
+    return Err(CalxError::new_raw("fixture scale expected one F64".to_owned()));
+  };
+  Ok(CalxValue::F64(value * 2.0))
+}
+
+fn calx_test_observe(args: &[CalxValue]) -> Result<(), CalxError> {
+  let [CalxValue::F64(_)] = args else {
+    return Err(CalxError::new_raw("fixture observe expected one F64".to_owned()));
+  };
+  CALX_VOID_IMPORT_CALLS.fetch_add(1, Ordering::SeqCst);
+  Ok(())
+}
+
+fn calx_test_trap(_args: &[CalxValue]) -> Result<CalxValue, CalxError> {
+  Err(CalxError::new_raw("fixture host trap".to_owned()))
+}
+
+fn calx_test_host_imports(namespace: &str) -> CalxHostImports {
+  let mut imports = CalxHostImports::new();
+  imports.insert(
+    CalxDefinitionRef::new(namespace, "host-scale"),
+    CalxHostImport::value("fixture.scale", vec![CalxScalarType::F64], CalxScalarType::F64, calx_test_scale)
+      .expect("valid value host import"),
+  );
+  imports.insert(
+    CalxDefinitionRef::new(namespace, "host-observe"),
+    CalxHostImport::void("fixture.observe", vec![CalxScalarType::F64], calx_test_observe).expect("valid void host import"),
+  );
+  imports.insert(
+    CalxDefinitionRef::new(namespace, "host-trap"),
+    CalxHostImport::value("fixture.trap", vec![CalxScalarType::F64], CalxScalarType::F64, calx_test_trap)
+      .expect("valid trapping host import"),
+  );
+  imports
+}
+
+#[test]
+fn calx_typed_imports_cover_void_value_and_generated_program_golden() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-imports";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed import fixtures");
+  let imports = calx_test_host_imports(namespace);
+
+  let graph = analyze_calx_eligibility_with_imports(&snapshot, namespace, "imported-pipeline", &imports)
+    .expect("explicit typed imports should be eligible");
+  assert_eq!(graph.functions.len(), 1, "approved imports must not expand the guest call graph");
+  assert_eq!(
+    graph.functions[0].host_imports,
+    vec![
+      CalxDefinitionRef::new(namespace, "host-observe"),
+      CalxDefinitionRef::new(namespace, "host-scale"),
+    ]
+  );
+
+  let kernel =
+    compile_calx_kernel_with_imports(&snapshot, namespace, "imported-pipeline", &imports).expect("compile typed import fixture");
+  assert_eq!(
+    kernel.stable_program_summary(),
+    include_str!("../../tests/fixtures/calx/generated-program.golden.txt")
+  );
+  assert_eq!(kernel.validated_program().imports().len(), 2);
+  assert!(kernel.validated_program().imports().iter().any(|import| import.result.is_none()));
+  assert!(kernel.validated_program().imports().iter().any(|import| import.result.is_some()));
+
+  CALX_VOID_IMPORT_CALLS.store(0, Ordering::SeqCst);
+  let args = [Calcit::Number(3.0)];
+  let calx_result = kernel.run(&args).expect("run typed import fixture");
+  let native_result =
+    run_program_with_docs(Arc::from(namespace), Arc::from("imported-pipeline"), &args).expect("run native typed import fixture");
+  assert_eq!(calx_result, native_result);
+  assert_eq!(calx_result, Calcit::Number(7.0));
+  assert_eq!(CALX_VOID_IMPORT_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn calx_typed_import_trap_is_stable_and_never_becomes_fallback() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-imports";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed import trap fixture");
+  let imports = calx_test_host_imports(namespace);
+  let kernel =
+    compile_calx_kernel_with_imports(&snapshot, namespace, "imported-trap", &imports).expect("compile trapping typed import fixture");
+
+  let error = kernel
+    .run(&[Calcit::Number(2.0)])
+    .expect_err("host callback failure must remain a Calx runtime trap");
+  let summary = format!("{error}\n");
+  assert_eq!(summary, include_str!("../../tests/fixtures/calx/trap.golden.txt"));
+  let CalxKernelRunError::Runtime(runtime) = error else {
+    panic!("host callback failure must not become boundary/fallback: {error}");
+  };
+  assert_eq!(runtime.message, "fixture host trap");
+  assert!(runtime.snapshot.is_none(), "host errors must not invent VM state");
+}
+
+#[test]
+fn calx_typed_import_signature_mismatch_falls_back_before_lowering() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-imports";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed import mismatch fixture");
+  let mut imports = calx_test_host_imports(namespace);
+  imports.insert(
+    CalxDefinitionRef::new(namespace, "host-scale"),
+    CalxHostImport::value("fixture.scale", vec![CalxScalarType::Bool], CalxScalarType::F64, calx_test_scale)
+      .expect("construct deliberately mismatched import"),
+  );
+
+  let report = analyze_calx_eligibility_with_imports(&snapshot, namespace, "imported-pipeline", &imports)
+    .expect_err("typed import signature mismatch must reject the whole kernel");
+  assert!(report.issues.iter().any(|issue| issue.code == CalxFallbackCode::HostCapability));
+  assert!(matches!(
+    compile_calx_kernel_with_imports(&snapshot, namespace, "imported-pipeline", &imports),
+    Err(CalxKernelCompileError::Eligibility(_))
   ));
 }
 

--- a/tests/fixtures/calx/generated-program.golden.txt
+++ b/tests/fixtures/calx/generated-program.golden.txt
@@ -1,0 +1,13 @@
+abi calcit-calx-kernel/1
+entry tests.calx-imports/imported-pipeline
+import fixture.observe (F64)->Void
+import fixture.scale (F64)->F64
+function main (F64)->F64
+  000 LocalGet(0) @ calcit:tests.calx-imports/imported-pipeline@3.1.1.1.1
+  001 CallImport("fixture.scale") @ calcit:tests.calx-imports/imported-pipeline@3.1.1.1.1
+  002 LocalSet(1) @ calcit:tests.calx-imports/imported-pipeline@3.1.1.1.1
+  003 LocalGet(1) @ calcit:tests.calx-imports/imported-pipeline@3.2.1
+  004 CallImport("fixture.observe") @ calcit:tests.calx-imports/imported-pipeline@3.2.1
+  005 LocalGet(1) @ calcit:tests.calx-imports/imported-pipeline@3.3.1
+  006 Const(F64(1.0)) @ calcit:tests.calx-imports/imported-pipeline@-
+  007 Add @ calcit:tests.calx-imports/imported-pipeline@-

--- a/tests/fixtures/calx/trap.golden.txt
+++ b/tests/fixtures/calx/trap.golden.txt
@@ -1,0 +1,1 @@
+Calx kernel trapped: error[CALX_HOST_IMPORT] host: fixture host trap

--- a/tests/fixtures/calx/typed-imports.cirru
+++ b/tests/fixtures/calx/typed-imports.cirru
@@ -1,0 +1,17 @@
+defn host-scale (x)
+  &* x 2
+
+defn host-observe (x)
+  , &unit
+
+defn host-trap (x)
+  , x
+
+defn imported-pipeline (x)
+  &let
+    scaled $ assert-type (host-scale x) 'Number
+    host-observe scaled
+    &+ scaled 1
+
+defn imported-trap (x)
+  host-trap x


### PR DESCRIPTION
## 中文

### 背景与目标

PR #531 建立了 typed scalar eligibility，PR #532 已把合格的 closed kernel 降为 strict Calx program 并完成三个真实源码 kernel 的差分执行。本 PR 完成 calx-vm #38 剩余的 correctness 验收：zero-result / single-result typed imports、固定 generated-program golden 与 runtime trap golden。

### 主要变更

- 新增 `CalxHostImport`、`CalxHostImports`、`analyze_calx_eligibility_with_imports` 与 `compile_calx_kernel_with_imports`。
- embedding 必须以 Calcit definition 为 capability key 显式提供 binding；未知调用不会自动转换为 host import。
- eligibility 要求 host declaration 与 typed snapshot 中的 fixed-arity Number/Bool/Unit 签名完全一致。签名不一致产生 `CALX_SUBSET_HOST_CAPABILITY`，并在 lowering 前整体 fallback。
- lowering 只声明实际可达的 imports，使用 `ProgramBuilder::import_at` / `call_import`，并只把对应 bindings 固定到 compiled kernel。未使用配置不会进入 strict program。
- zero-result callback 使用 `Result<(), CalxError>`；single-result callback 使用 `Result<CalxValue, CalxError>`。Nil、Dynamic、多个结果和隐式转换都不进入 ABI。
- host callback error 保持为 `CALX_HOST_IMPORT` runtime trap，不会自动重跑 Calcit，避免 effect 双执行。
- 新增 `stable_program_summary()`，固定 import declarations、guest syntax 和 Calcit tree origins，作为 repository golden，不作为序列化 ABI。
- 更新 Calx target 文档，说明 capability、ownership、每次运行生命周期、错误分层和下一阶段 #39 benchmark 边界。

### Fixtures 与验证

新的真实 Cirru fixture 覆盖：

- single-result numeric import；
- zero-result observe import，并验证恰好调用一次；
- Calx/native differential result；
- trapping host import 与稳定 trap golden；
- import signature mismatch 的 whole-kernel fallback；
- 固定 generated Calx program、import 顺序、syntax 和 source origins。

已在最新 `main` / Calcit 0.13.67 基线上通过：

- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`（17/17）

---

## English

### Context and goal

PR #531 established typed scalar eligibility. PR #532 lowered eligible closed kernels into strict Calx programs and differentially executed three real source kernels. This PR completes the remaining correctness acceptance work in calx-vm #38: zero-result and single-result typed imports, a fixed generated-program golden, and a runtime-trap golden.

### Main changes

- Add `CalxHostImport`, `CalxHostImports`, `analyze_calx_eligibility_with_imports`, and `compile_calx_kernel_with_imports`.
- The embedding must explicitly provide a binding keyed by a Calcit definition. Unknown calls never become host imports automatically.
- Eligibility requires the host declaration to exactly match the fixed-arity Number/Bool/Unit signature in the typed snapshot. A mismatch produces `CALX_SUBSET_HOST_CAPABILITY` and falls back for the whole kernel before lowering.
- Lowering declares only reachable imports through `ProgramBuilder::import_at` and `call_import`, and retains only their bindings in the compiled kernel. Unused configuration never enters the strict program.
- Zero-result callbacks use `Result<(), CalxError>`. Single-result callbacks use `Result<CalxValue, CalxError>`. Nil, Dynamic, multiple results, and implicit conversions remain outside the ABI.
- A host callback error remains a `CALX_HOST_IMPORT` runtime trap and never reruns Calcit automatically, preventing duplicated effects.
- Add `stable_program_summary()` to fix import declarations, guest syntax, and Calcit tree origins as a repository golden rather than a serialized ABI.
- Update the Calx target documentation with capability, ownership, per-run lifecycle, error-stage, and next-phase #39 benchmark boundaries.

### Fixtures and verification

The new real Cirru fixture covers:

- a single-result numeric import;
- a zero-result observe import invoked exactly once;
- a Calx/native differential result;
- a trapping host import and stable trap golden;
- whole-kernel fallback for an import signature mismatch;
- a fixed generated Calx program, import order, syntax, and source origins.

Validated on the latest `main` and Calcit 0.13.67 baseline with:

- `cargo fmt -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` (17/17)

Closes calcit-lang/calx-vm#38