### PR TITLE
fix: normalize blocking Unit callback transport / 规范化 blocking Unit callback 传输

### DIFF
--- a/docs/installation/ffi-async-protocol.md
+++ b/docs/installation/ffi-async-protocol.md
@@ -392,6 +392,13 @@ typedef struct {
 } CalcitFfiBlockingHostV1;
 ```
 
+Callback values use Cirru EDN transport. Because Calcit `Unit` is deliberately
+distinct from EDN `nil` and has no EDN representation, the host normalizes a
+blocking callback's `Unit` result to `nil` at this transport boundary. The
+callback remains typed as returning `Unit` inside Calcit; blocking native
+methods should treat callback results as acknowledgements unless their API
+explicitly documents a value-bearing callback.
+
 The function pointer signatures are equivalent to:
 
 ```c

--- a/docs/installation/ffi-bindings.md
+++ b/docs/installation/ffi-bindings.md
@@ -205,6 +205,10 @@ Foreign-thread invocation is rejected.
 Callback results are allocated and tracked by the host and must be returned
 through the blocking host table's `free_buffer`; the method's final output is
 allocated by the module and released through `calcit_ffi_buffer_free`.
+Calcit `Unit` callback results are normalized to EDN `nil` only for this
+transport because Cirru EDN has no Unit value; the typed Calcit callback still
+returns `Unit`.
+
 `finish` may be called explicitly once, otherwise method return finishes the
 task implicitly. Missing protocol or per-method blocking symbols are migration
 errors. See

--- a/editing-history/202608310330-blocking-unit-transport.md
+++ b/editing-history/202608310330-blocking-unit-transport.md
@@ -1,0 +1,13 @@
+# Blocking callback Unit transport / Blocking callback 的 Unit 传输
+
+## 中文
+
+- 修复 blocking C FFI callback 返回 `Unit` 时，host 输出 `&unit` 而 native adapter 按 Cirru EDN 解码失败的契约不一致。
+- 仅在 blocking callback 的返回传输边界把 `Unit` 规范化为 EDN `nil`；Calcit 内部类型仍为 `Unit`，异步 terminal 的显式 `&unit` 协议保持不变。
+- 新增真实 host buffer 回归，验证状态为成功、payload 可由 Cirru EDN 解码且 buffer 仍按一次性所有权释放。
+
+## English
+
+- Fix the blocking C FFI contract mismatch where a callback returning `Unit` produced `&unit`, while the native adapter decoded the result as Cirru EDN.
+- Normalize `Unit` to EDN `nil` only at the blocking callback result transport boundary; the Calcit type remains `Unit`, and the explicit async terminal `&unit` protocol is unchanged.
+- Add a real host-buffer regression covering successful status, Cirru EDN decoding, and exactly-once buffer ownership release.

--- a/src/bin/injection/mod.rs
+++ b/src/bin/injection/mod.rs
@@ -696,7 +696,7 @@ unsafe fn invoke_native_blocking(
     ),
   );
   match runner::run_fn(&args, info, &task.stack) {
-    Ok(ret) => match encode_async_value(&ret) {
+    Ok(ret) => match encode_blocking_callback_value(&ret) {
       Ok(output) => match store_blocking_host_buffer(&blocking, output, out) {
         Ok(()) => async_status::OK,
         Err(status) => status,
@@ -1042,6 +1042,16 @@ fn encode_async_value(value: &Calcit) -> Result<Vec<u8>, CalcitErr> {
   cirru_edn::format(&value, true)
     .map(String::into_bytes)
     .map_err(|error| CalcitErr::use_str(CalcitErrKind::Unexpected, format!("failed to encode async FFI value: {error}")))
+}
+
+/// Blocking callback results use the Cirru EDN transport expected by native
+/// adapters. Unit has no Cirru EDN representation, so normalize it to `nil` at
+/// this ignored-result boundary while preserving Unit inside Calcit.
+fn encode_blocking_callback_value(value: &Calcit) -> Result<Vec<u8>, CalcitErr> {
+  if matches!(value, Calcit::Unit) {
+    return encode_async_value(&Calcit::Nil);
+  }
+  encode_async_value(value)
 }
 
 fn resolve_async_response_with(
@@ -2552,6 +2562,10 @@ mod async_callback_tests {
   }
 
   fn constant_callback(value: &str) -> Calcit {
+    constant_callback_value(Calcit::Str(Arc::from(value)))
+  }
+
+  fn constant_callback_value(value: Calcit) -> Calcit {
     Calcit::Fn {
       id: Arc::from("blocking-fixture-callback"),
       info: Arc::new(calcit::calcit::CalcitFn {
@@ -2562,7 +2576,7 @@ mod async_callback_tests {
         scope: Arc::new(calcit::calcit::CalcitScope::default()),
         args: Arc::new(calcit::calcit::CalcitFnArgs::Args(vec![])),
         call_shape: calcit::calcit::CalcitFnCallShape::fixed(0),
-        body: vec![Calcit::Str(Arc::from(value))],
+        body: vec![value],
         generics: Arc::new(vec![]),
         where_bounds: Arc::new(vec![]),
         return_type: calcit::calcit::DYNAMIC_TYPE.clone(),
@@ -2647,6 +2661,28 @@ mod async_callback_tests {
     );
     assert!(late_output.ptr.is_null());
     assert!(matches!(runtime.registry.release(handle), Ok(NativeAsyncResource::Task(_))));
+  }
+
+  #[test]
+  fn blocking_unit_callback_uses_edn_nil_transport() {
+    let runtime = test_runtime(4);
+    let (task, blocking) = blocking_test_task_with_callback(constant_callback_value(Calcit::Unit));
+    let handle = runtime
+      .registry
+      .register_with_flags(FfiAsyncHandleKind::OneShot, ASYNC_TASK_FLAG_SERIAL_EVENTS, task)
+      .expect("register blocking task");
+    let payload = b"[]";
+    let mut output = FfiBuffer::empty();
+    assert_eq!(
+      unsafe { invoke_native_blocking(&runtime, handle.raw(), handle.raw(), payload.as_ptr(), payload.len(), &mut output) },
+      async_status::OK
+    );
+    let output_bytes = unsafe { std::slice::from_raw_parts(output.ptr.cast_const(), output.len) };
+    assert_eq!(
+      cirru_edn::parse(std::str::from_utf8(output_bytes).expect("callback UTF-8")).expect("callback EDN"),
+      Edn::Nil
+    );
+    assert_eq!(free_blocking_host_buffer(&blocking, output), Ok(()));
   }
 
   #[test]


### PR DESCRIPTION
## 中文

### 背景

在验证 `calcit.std#48` 的真实逐行 blocking callback 时发现：Calcit callback 返回 `Unit` 会被 host 编码为 `&unit`，而 blocking native adapter 按 Cirru EDN 解码 callback 结果。由于 Cirru EDN 没有 Unit 值，公开 API 因此失败。

### 修改

- 仅在 blocking callback 返回值的传输边界将 `Unit` 规范化为 EDN `nil`。
- 保持 Calcit 内部 `Unit` 类型与 async terminal 的显式 `&unit` 协议不变。
- 增加真实 host-buffer 回归，覆盖状态、EDN 解码和一次性 buffer 释放。
- 补充 blocking C FFI 协议与 binding 文档。

### 验证

- `cargo fmt --check`
- `cargo test`（906 项 Rust 测试）
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-all`（Calcit core 225/225、JS、IR、WASM 与性能回归）
- `yarn check-agent-interface`（17/17）

关联：calcit-lang/calcit.std#48、#501

## English

### Context

Real `calcit.std#48` line-stream validation exposed a blocking callback contract mismatch: a Calcit callback returning `Unit` was encoded as `&unit`, while the blocking native adapter decoded callback results as Cirru EDN. Cirru EDN has no Unit value, so the public API failed.

### Changes

- Normalize `Unit` to EDN `nil` only at the blocking callback result transport boundary.
- Preserve Calcit's internal `Unit` type and the explicit async terminal `&unit` protocol.
- Add a real host-buffer regression covering status, EDN decoding, and exactly-once buffer release.
- Document the behavior in the blocking C FFI protocol and bindings guides.

### Validation

- `cargo fmt --check`
- `cargo test` (906 Rust tests)
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-all` (Calcit core 225/225, JS, IR, WASM, and performance regressions)
- `yarn check-agent-interface` (17/17)

Related: calcit-lang/calcit.std#48, #501
