### PR TITLE
fix: 从 deps manifest 导出 FFI 项目版本 / export FFI package version from deps manifest

### DIFF
--- a/docs/installation/ffi-interface-ir.md
+++ b/docs/installation/ffi-interface-ir.md
@@ -38,6 +38,9 @@ Definitions and diagnostics are sorted deterministically, and `revision` is a
 digest of the interface plus diagnostics. Unordered EDN maps and sets are
 canonicalized recursively before `logical_schema`, `lowering.raw`, and the
 revision are emitted. Consumers must check `version` before generation.
+`package_version` comes from the adjacent `deps.cirru :version`, which is the
+project's release-version source of truth. Legacy projects without that field
+fall back to the compatibility version retained in the snapshot.
 
 ## Boundary selection
 
@@ -67,6 +70,9 @@ diagnostics. A rejected signature is `null`; there is no Dynamic fallback.
 Map/Set、Ref、host object、可变参数或泛型调用边界给出结构化错误，不会静默
 退化为动态调用。生成器必须先检查 interface `version`、definition `status`
 和顶层 `diagnostics`。
+
+`package_version` 读取相邻 `deps.cirru` 的 `:version`，与当前项目发版流程保持
+同一事实来源；尚未迁移版本字段的旧项目才回退到 snapshot 兼容值。
 
 ## Scope of v1
 

--- a/editing-history/202608310639-ffi-export-package-version.md
+++ b/editing-history/202608310639-ffi-export-package-version.md
@@ -1,0 +1,12 @@
+# FFI export package version / FFI 导出项目版本
+
+- `calcit ffi export` now reads `package_version` from the adjacent
+  `deps.cirru :version`, matching the project release source of truth.
+- Projects without a manifest version retain the legacy snapshot fallback;
+  malformed manifest values fail with a deterministic error.
+- Added focused tests and documented the version-source contract.
+
+- `calcit ffi export` 现在从相邻 `deps.cirru :version` 读取
+  `package_version`，与项目发版的事实来源保持一致。
+- 未声明 manifest 版本的旧项目继续回退到 snapshot；非法值会确定性报错。
+- 增加针对性测试，并记录版本来源契约。

--- a/src/bin/cli_handlers/common.rs
+++ b/src/bin/cli_handlers/common.rs
@@ -70,6 +70,28 @@ pub fn deps_path_for_snapshot(snapshot_path: &str) -> String {
     .to_string()
 }
 
+/// Read the package version owned by the dependency manifest next to a
+/// Snapshot. Project versions moved out of `calcit.cirru`, so read-only tools
+/// must not report the compatibility value still present in older snapshots.
+pub fn package_version_for_snapshot(snapshot_path: &str) -> Result<Option<String>, String> {
+  let deps_path = deps_path_for_snapshot(snapshot_path);
+  if !Path::new(&deps_path).exists() {
+    return Ok(None);
+  }
+
+  let content = fs::read_to_string(&deps_path).map_err(|error| format!("Failed to read {deps_path}: {error}"))?;
+  let data = cirru_edn::parse(&content).map_err(|error| format!("Failed to parse {deps_path}: {error}"))?;
+  let deps = data
+    .view_map()
+    .map_err(|error| format!("Invalid dependency manifest {deps_path}: {error}"))?;
+  match deps.get_or_nil("version") {
+    Edn::Str(version) if version.trim().is_empty() || version.as_ref() == "|" => Ok(None),
+    Edn::Str(version) => Ok(Some(version.to_string())),
+    Edn::Nil => Ok(None),
+    value => Err(format!("Invalid :version in {deps_path}: expected a string, got {value}")),
+  }
+}
+
 /// Refuse to rewrite a Snapshot with a different Calcit release than the one
 /// pinned by the adjacent deps.cirru. Snapshot serialization can evolve between
 /// releases, so a newer global CLI must not silently produce data that the
@@ -430,7 +452,7 @@ pub fn parse_input_to_cirru(raw: &str) -> Result<Cirru, String> {
 mod tests {
   use super::{
     GlobalTempPathKind, format_path, format_path_with_separator, global_temp_path_guidance, guard_snapshot_mutation_toolchain,
-    parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes, resolve_definition_lookup, shell_quote,
+    package_version_for_snapshot, parse_input_to_cirru, parse_path, parse_quoted_cirru_nodes, resolve_definition_lookup, shell_quote,
   };
   use cirru_parser::Cirru;
   use std::fs;
@@ -576,6 +598,33 @@ mod tests {
       guard_snapshot_mutation_toolchain(snapshot.to_str().unwrap()).unwrap();
       fs::remove_dir_all(dir).unwrap();
     }
+  }
+
+  #[test]
+  fn package_version_comes_from_dependency_manifest() {
+    let (dir, snapshot) = mutation_guard_fixture(Some("{} (:version |1.2.3) (:calcit-version |0.13.69)\n"));
+    assert_eq!(
+      package_version_for_snapshot(snapshot.to_str().unwrap()).unwrap(),
+      Some("1.2.3".to_owned())
+    );
+    fs::remove_dir_all(dir).unwrap();
+  }
+
+  #[test]
+  fn package_version_allows_legacy_or_unversioned_projects() {
+    for deps in [Some("{} (:dependencies $ {})\n"), None] {
+      let (dir, snapshot) = mutation_guard_fixture(deps);
+      assert_eq!(package_version_for_snapshot(snapshot.to_str().unwrap()).unwrap(), None);
+      fs::remove_dir_all(dir).unwrap();
+    }
+  }
+
+  #[test]
+  fn package_version_rejects_invalid_manifest_values() {
+    let (dir, snapshot) = mutation_guard_fixture(Some("{} (:version 1)\n"));
+    let error = package_version_for_snapshot(snapshot.to_str().unwrap()).unwrap_err();
+    assert!(error.contains("Invalid :version"), "error: {error}");
+    fs::remove_dir_all(dir).unwrap();
   }
 
   #[test]

--- a/src/bin/cli_handlers/ffi.rs
+++ b/src/bin/cli_handlers/ffi.rs
@@ -1,12 +1,16 @@
 use calcit::cli_args::{FfiCommand, FfiSubcommand};
 use calcit::ffi_interface_ir::{FFI_INTERFACE_IR_SCHEMA_ID, export_snapshot, format_human_report};
 
+use super::common::package_version_for_snapshot;
 use super::query::load_main_snapshot;
 
 pub fn handle_ffi_command(command: &FfiCommand, input_path: &str) -> Result<(), String> {
   match &command.subcommand {
     FfiSubcommand::Export(options) => {
-      let snapshot = load_main_snapshot(input_path)?;
+      let mut snapshot = load_main_snapshot(input_path)?;
+      if let Some(version) = package_version_for_snapshot(input_path)? {
+        snapshot.version = version;
+      }
       let report = export_snapshot(&snapshot, options.ns.as_deref())?;
       if options.json {
         let envelope = serde_json::json!({


### PR DESCRIPTION
## 中文

### 背景

`calcit ffi export` 的 `package_version` 仍读取 `calcit.cirru` 中仅为兼容保留的版本，因此真实模块会错误导出 `0.0.0`。项目版本已经迁移到相邻的 `deps.cirru :version`，错误版本会污染生成物 revision、兼容性 diff 与发布审查。

### 修改

- 从与所选 snapshot 相邻的 `deps.cirru :version` 读取 FFI Interface IR 的 `package_version`；
- 对未声明 manifest 版本的旧项目保留 snapshot fallback；
- 对非法 `:version` 类型给出确定性错误；
- 补充单元测试与 Interface IR 文档；
- 用真实 `calcit-lang/calcit-regex` 验证，版本从错误的 `0.0.0` 修正为 `0.0.17`。

### 验证

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`（919 项）
- `yarn check-all`（Calcit core 225/225、JS/IR/WASM、agent interface 18/18、性能门禁）
- 真实 regex `calcit ffi export --json`

## English

### Context

`calcit ffi export` still sourced `package_version` from the compatibility value retained in `calcit.cirru`, so real modules exported the incorrect `0.0.0`. Project release versions now live in adjacent `deps.cirru :version`; the wrong value contaminates generated revisions, compatibility diffs, and release review.

### Changes

- source Interface IR `package_version` from adjacent `deps.cirru :version`;
- preserve the snapshot fallback for legacy projects without a manifest version;
- reject malformed `:version` values deterministically;
- add focused tests and document the contract;
- verify against real `calcit-lang/calcit-regex`, correcting `0.0.0` to `0.0.17`.

### Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (919 tests)
- `yarn check-all` (Calcit core 225/225, JS/IR/WASM, agent interface 18/18, performance gates)
- real regex `calcit ffi export --json`

Refs #514
