### PR TITLE
严格校验 typed FFI lowering 契约 / Validate typed FFI lowering contracts

### DIFF
--- a/docs/installation/ffi-interface-ir.md
+++ b/docs/installation/ffi-interface-ir.md
@@ -59,6 +59,35 @@ Both layers remain visible:
 - `status` and `diagnostic_codes` prevent generators from treating an
   unsupported definition as usable.
 
+## Lowering contract validation
+
+Interface IR v1 callable definitions have one direction: Calcit imports a raw
+binding from the selected host backend. An explicit import/export direction
+field is reserved for a future IR version; consumers must not infer a reverse
+export from v1 metadata.
+
+Native callables are generator-safe only when all three lowering fields are
+present and coherent:
+
+| Invoke                | Transport          | Symbol |
+| --------------------- | ------------------ | ------ |
+| `sync`                | `edn-buffer-v1`    | portable C base identifier |
+| `async`               | `async-task-v1`    | portable C base identifier |
+| `blocking-callback`   | `blocking-host-v1` | portable C base identifier |
+
+The symbol is the unsuffixed logical base such as `read_file`; Calcit derives
+the versioned C entry point. Native targets are omitted or `native`. JS targets
+are omitted, `browser`, or `node`. Unknown backends, invalid targets, missing
+fields, non-portable symbols, unversioned transports, and mismatched
+invoke/transport pairs produce path-specific diagnostics before bindgen.
+
+Interface IR v1 的 callable direction 固定为“Calcit 从 host backend import raw
+binding”；显式双向 direction 字段留给后续 IR 版本。native callable 必须声明
+未带协议后缀的 portable C base symbol，并使用 `sync + edn-buffer-v1`、
+`async + async-task-v1` 或 `blocking-callback + blocking-host-v1` 之一。
+未知 backend/target、缺失字段、非法 symbol、未版本化 transport 与组合错配都会
+在 bindgen 前产生带精确 path 的 diagnostic。
+
 V1 represents `Unit`, `Bool`, `Number`, `String`, `Buffer`, homogeneous
 `List`, and nominal named types (including representable `Option`, `Result`,
 struct, and enum references). `Dynamic`, callbacks, `Map`, `Set`, `Ref`, host
@@ -76,10 +105,11 @@ Map/Set、Ref、host object、可变参数或泛型调用边界给出结构化�
 
 ## Scope of v1
 
-This phase defines an inventory and generator input. It does not yet validate
-every backend-specific arity, transport, ownership, cancellation, or resource
-lifecycle rule, and it does not replace the existing C-safe native protocols.
-Those checks and generated adapters belong to the next bindgen phase.
+This phase defines an inventory and generator input. It validates fixed
+function arity and the published native invocation/transport pairs, but does
+not yet validate callback positions, ownership, cancellation, or resource
+lifecycle fields nested in lowering metadata. Those structured checks and
+generated adapters belong to the next bindgen phase.
 
 ## Phase 0 bindgen preview
 

--- a/docs/installation/ffi-upgrade-guide.md
+++ b/docs/installation/ffi-upgrade-guide.md
@@ -27,6 +27,31 @@ bytes 交换业务数据，不再要求使用同一个 rustc 或同一个 `cirru
 crate build。`calcit_ffi_build_id`、`abi_version`、`edn_version` 和 Rust-layout
 business methods 均已退役。
 
+每个 native raw binding 的 `:ffi` metadata 也必须完整声明 lowering contract：
+
+```cirru.no-check
+:ffi $ {}
+  :backend :native
+  :invoke :sync
+  :kind :dylib-method
+  :symbol |read_file
+  :transport :edn-buffer-v1
+```
+
+同步、异步与 blocking callback 分别使用 `sync + edn-buffer-v1`、
+`async + async-task-v1`、`blocking-callback + blocking-host-v1`。`symbol` 使用
+不带 `_calcit_ffi_*_v1` 后缀的 C identifier；host 会根据 transport 解析版本化
+entry point。可先运行 `calcit calcit.cirru ffi export --json`，在构建 dylib 前
+发现缺失字段、非法 symbol 与协议错配。
+
+Every native raw binding must also declare a complete `:ffi` lowering
+contract. Sync, async, and blocking callbacks use `sync + edn-buffer-v1`,
+`async + async-task-v1`, and `blocking-callback + blocking-host-v1`
+respectively. The symbol is an unsuffixed portable C identifier; the host
+derives the versioned entry point. Run `calcit calcit.cirru ffi export --json`
+to catch missing fields, invalid symbols, and protocol mismatches before
+building the dylib.
+
 Rust 模块应依赖已发布的 `calcit_native_ffi`，复用版本化 descriptor、buffer
 ownership、Cirru EDN transport、async backpressure 和 blocking adapter。模块
 仓库继续负责业务参数与逻辑、thread、connection/task registry、cancel state、

--- a/editing-history/202608310734-ffi-lowering-validation.md
+++ b/editing-history/202608310734-ffi-lowering-validation.md
@@ -1,0 +1,18 @@
+# Strict FFI lowering validation / 严格 FFI lowering 校验
+
+- Validate native base symbols, invocation modes, versioned transports, and
+  published invoke/transport pairs while exporting Interface IR v1.
+- Reject unknown backends and incompatible native/JS targets with stable,
+  path-specific diagnostics before generation.
+- Keep IR v1 schema stable and document its direction invariant: Calcit
+  imports callable bindings from the selected host backend.
+- Preserve the Phase 0 std/regex/wss export counts while making legacy
+  incomplete metadata explicitly unsupported.
+
+- 在 Interface IR v1 导出阶段校验 native base symbol、invoke、版本化 transport
+  及已发布的 invoke/transport 组合。
+- 对未知 backend 与不兼容 native/JS target 输出稳定、精确 path 的诊断。
+- 保持 IR v1 schema 不变，并明确其 direction 不变量：Calcit 从选定 host
+  backend import callable binding。
+- 保持 Phase 0 std/regex/wss 导出数量，同时让旧的不完整 metadata 明确变为
+  unsupported。

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -343,6 +343,141 @@ fn scalar_metadata(metadata: &Edn, key: &str, definition: &str, diagnostics: &mu
   }
 }
 
+fn is_portable_c_identifier(value: &str) -> bool {
+  let mut chars = value.chars();
+  let Some(first) = chars.next() else {
+    return false;
+  };
+  (first == '_' || first.is_ascii_alphabetic()) && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn validate_lowering_contract(definition: &str, lowering: &FfiLoweringIr, diagnostics: &mut Vec<FfiInterfaceDiagnostic>) {
+  match lowering.backend.as_deref() {
+    None => {}
+    Some("native") => {
+      if let Some(target) = lowering.target.as_deref()
+        && target != "native"
+      {
+        diagnostics.push(diagnostic(
+          definition,
+          "lowering.target",
+          "E_FFI_IR_TARGET_INVALID",
+          format!("Native FFI lowering cannot target `{target}`."),
+          "Omit `:target` for the current native host or use `:target :native`; browser/node targets belong to the JS backend.",
+        ));
+      }
+
+      match lowering.symbol.as_deref() {
+        None => diagnostics.push(diagnostic(
+          definition,
+          "lowering.symbol",
+          "E_FFI_IR_SYMBOL_REQUIRED",
+          "Native FFI lowering does not declare a base symbol.",
+          "Declare a portable C identifier such as `:symbol |read_file`; Calcit derives the versioned protocol suffix.",
+        )),
+        Some(symbol) if !is_portable_c_identifier(symbol) => diagnostics.push(diagnostic(
+          definition,
+          "lowering.symbol",
+          "E_FFI_IR_SYMBOL_INVALID",
+          format!("Native FFI base symbol `{symbol}` is not a portable C identifier."),
+          "Use ASCII letters, digits, and underscores, beginning with a letter or underscore; do not include a protocol suffix.",
+        )),
+        Some(_) => {}
+      }
+
+      let invoke_known = match lowering.invoke.as_deref() {
+        None => {
+          diagnostics.push(diagnostic(
+            definition,
+            "lowering.invoke",
+            "E_FFI_IR_INVOKE_REQUIRED",
+            "Native FFI lowering does not declare an invocation mode.",
+            "Declare `:invoke :sync`, `:invoke :async`, or `:invoke :blocking-callback`.",
+          ));
+          false
+        }
+        Some("sync" | "async" | "blocking-callback") => true,
+        Some(invoke) => {
+          diagnostics.push(diagnostic(
+            definition,
+            "lowering.invoke",
+            "E_FFI_IR_INVOKE_UNKNOWN",
+            format!("Native FFI invocation mode `{invoke}` is not supported."),
+            "Use one of the published native invocation modes: sync, async, or blocking-callback.",
+          ));
+          false
+        }
+      };
+
+      let transport_known = match lowering.transport.as_deref() {
+        None => {
+          diagnostics.push(diagnostic(
+            definition,
+            "lowering.transport",
+            "E_FFI_IR_TRANSPORT_REQUIRED",
+            "Native FFI lowering does not declare a transport.",
+            "Declare `:transport :edn-buffer-v1`, `:transport :async-task-v1`, or `:transport :blocking-host-v1`.",
+          ));
+          false
+        }
+        Some("edn-buffer-v1" | "async-task-v1" | "blocking-host-v1") => true,
+        Some(transport) => {
+          diagnostics.push(diagnostic(
+            definition,
+            "lowering.transport",
+            "E_FFI_IR_TRANSPORT_UNKNOWN",
+            format!("Native FFI transport `{transport}` is not supported."),
+            "Use one of the published versioned native transports instead of an unversioned or Rust-layout ABI.",
+          ));
+          false
+        }
+      };
+
+      if invoke_known && transport_known {
+        let pair = (lowering.invoke.as_deref(), lowering.transport.as_deref());
+        if !matches!(
+          pair,
+          (Some("sync"), Some("edn-buffer-v1"))
+            | (Some("async"), Some("async-task-v1"))
+            | (Some("blocking-callback"), Some("blocking-host-v1"))
+        ) {
+          diagnostics.push(diagnostic(
+            definition,
+            "lowering.transport",
+            "E_FFI_IR_TRANSPORT_MISMATCH",
+            format!(
+              "Native FFI invocation mode `{}` is incompatible with transport `{}`.",
+              lowering.invoke.as_deref().expect("known invocation mode"),
+              lowering.transport.as_deref().expect("known transport")
+            ),
+            "Use sync + edn-buffer-v1, async + async-task-v1, or blocking-callback + blocking-host-v1.",
+          ));
+        }
+      }
+    }
+    Some("js") => {
+      if let Some(target) = lowering.target.as_deref()
+        && !matches!(target, "browser" | "node")
+      {
+        diagnostics.push(diagnostic(
+          definition,
+          "lowering.target",
+          "E_FFI_IR_TARGET_INVALID",
+          format!("JS FFI target `{target}` is not supported."),
+          "Use `:target :browser`, `:target :node`, or omit the target for a shared JS boundary.",
+        ));
+      }
+    }
+    Some(backend) => diagnostics.push(diagnostic(
+      definition,
+      "lowering.backend",
+      "E_FFI_IR_BACKEND_UNKNOWN",
+      format!("FFI backend `{backend}` is not part of Interface IR v{FFI_INTERFACE_IR_VERSION}."),
+      "Use the native or JS backend, or keep the boundary behind a handwritten adapter until that backend has a versioned contract.",
+    )),
+  }
+}
+
 fn convert_lowering(metadata: &Edn, definition: &str) -> Result<(FfiLoweringIr, Vec<FfiInterfaceDiagnostic>), String> {
   let mut diagnostics = Vec::new();
   if !matches!(metadata, Edn::Struct(_) | Edn::Map(_)) {
@@ -364,18 +499,17 @@ fn convert_lowering(metadata: &Edn, definition: &str) -> Result<(FfiLoweringIr, 
       "Declare `:backend :native`, `:backend :js`, or another explicit backend before generation.",
     ));
   }
-  Ok((
-    FfiLoweringIr {
-      backend,
-      target: scalar_metadata(metadata, "target", definition, &mut diagnostics),
-      kind: scalar_metadata(metadata, "kind", definition, &mut diagnostics),
-      symbol: scalar_metadata(metadata, "symbol", definition, &mut diagnostics),
-      invoke: scalar_metadata(metadata, "invoke", definition, &mut diagnostics),
-      transport: scalar_metadata(metadata, "transport", definition, &mut diagnostics),
-      raw: canonical_edn_display(metadata),
-    },
-    diagnostics,
-  ))
+  let lowering = FfiLoweringIr {
+    backend,
+    target: scalar_metadata(metadata, "target", definition, &mut diagnostics),
+    kind: scalar_metadata(metadata, "kind", definition, &mut diagnostics),
+    symbol: scalar_metadata(metadata, "symbol", definition, &mut diagnostics),
+    invoke: scalar_metadata(metadata, "invoke", definition, &mut diagnostics),
+    transport: scalar_metadata(metadata, "transport", definition, &mut diagnostics),
+    raw: canonical_edn_display(metadata),
+  };
+  validate_lowering_contract(definition, &lowering, &mut diagnostics);
+  Ok((lowering, diagnostics))
 }
 
 pub fn export_snapshot(snapshot: &Snapshot, namespace: Option<&str>) -> Result<FfiExportReport, String> {
@@ -545,7 +679,13 @@ mod tests {
   }
 
   fn native_metadata(symbol: &str) -> Edn {
-    Edn::map_from_iter([(Edn::tag("backend"), Edn::tag("native")), (Edn::tag("symbol"), Edn::str(symbol))])
+    Edn::map_from_iter([
+      (Edn::tag("backend"), Edn::tag("native")),
+      (Edn::tag("invoke"), Edn::tag("sync")),
+      (Edn::tag("kind"), Edn::tag("dylib-method")),
+      (Edn::tag("symbol"), Edn::str(symbol)),
+      (Edn::tag("transport"), Edn::tag("edn-buffer-v1")),
+    ])
   }
 
   fn diagnostic_codes(report: &FfiExportReport) -> HashSet<&str> {
@@ -657,6 +797,157 @@ mod tests {
     assert_eq!(report.summary.unsupported, 1);
     assert!(codes.contains("E_FFI_IR_METADATA_SHAPE"));
     assert!(codes.contains("E_FFI_IR_BACKEND_REQUIRED"));
+  }
+
+  #[test]
+  fn rejects_incomplete_native_lowering_before_generation() {
+    let report = export_snapshot(
+      &snapshot(vec![(
+        "incomplete",
+        function_entry(
+          vec![Arc::new(CalcitTypeAnnotation::String)],
+          Arc::new(CalcitTypeAnnotation::String),
+          Edn::map_from_iter([(Edn::tag("backend"), Edn::tag("native"))]),
+        ),
+      )]),
+      None,
+    )
+    .expect("inventory incomplete native metadata");
+
+    let codes = diagnostic_codes(&report);
+    assert_eq!(report.summary.unsupported, 1);
+    assert!(codes.contains("E_FFI_IR_SYMBOL_REQUIRED"));
+    assert!(codes.contains("E_FFI_IR_INVOKE_REQUIRED"));
+    assert!(codes.contains("E_FFI_IR_TRANSPORT_REQUIRED"));
+    assert_eq!(
+      report.diagnostics.iter().map(|item| item.path.as_str()).collect::<Vec<_>>(),
+      ["lowering.symbol", "lowering.invoke", "lowering.transport"]
+    );
+  }
+
+  #[test]
+  fn rejects_invalid_native_symbol_and_protocol_pair() {
+    let metadata = Edn::map_from_iter([
+      (Edn::tag("backend"), Edn::tag("native")),
+      (Edn::tag("invoke"), Edn::tag("async")),
+      (Edn::tag("symbol"), Edn::str("not-portable!")),
+      (Edn::tag("transport"), Edn::tag("edn-buffer-v1")),
+    ]);
+    let report = export_snapshot(
+      &snapshot(vec![(
+        "invalid",
+        function_entry(
+          vec![Arc::new(CalcitTypeAnnotation::String)],
+          Arc::new(CalcitTypeAnnotation::String),
+          metadata,
+        ),
+      )]),
+      None,
+    )
+    .expect("inventory invalid native metadata");
+
+    let codes = diagnostic_codes(&report);
+    assert!(codes.contains("E_FFI_IR_SYMBOL_INVALID"));
+    assert!(codes.contains("E_FFI_IR_TRANSPORT_MISMATCH"));
+  }
+
+  #[test]
+  fn accepts_each_published_native_protocol_pair() {
+    let definitions = [
+      ("sync", "edn-buffer-v1"),
+      ("async", "async-task-v1"),
+      ("blocking-callback", "blocking-host-v1"),
+    ]
+    .into_iter()
+    .map(|(invoke, transport)| {
+      (
+        invoke,
+        function_entry(
+          vec![],
+          Arc::new(CalcitTypeAnnotation::Unit),
+          Edn::map_from_iter([
+            (Edn::tag("backend"), Edn::tag("native")),
+            (Edn::tag("invoke"), Edn::tag(invoke)),
+            (Edn::tag("symbol"), Edn::str(invoke.replace('-', "_"))),
+            (Edn::tag("transport"), Edn::tag(transport)),
+          ]),
+        ),
+      )
+    })
+    .collect();
+    let report = export_snapshot(&snapshot(definitions), None).expect("export published native protocol pairs");
+
+    assert_eq!(report.summary.supported, 3);
+    assert_eq!(report.summary.unsupported, 0);
+    assert!(report.diagnostics.is_empty());
+  }
+
+  #[test]
+  fn rejects_unknown_lowering_values_and_backend_targets() {
+    let definitions = vec![
+      (
+        "native-target",
+        function_entry(
+          vec![],
+          Arc::new(CalcitTypeAnnotation::Unit),
+          Edn::map_from_iter([
+            (Edn::tag("backend"), Edn::tag("native")),
+            (Edn::tag("invoke"), Edn::tag("future")),
+            (Edn::tag("symbol"), Edn::str("native_target")),
+            (Edn::tag("target"), Edn::tag("browser")),
+            (Edn::tag("transport"), Edn::tag("rust-abi")),
+          ]),
+        ),
+      ),
+      (
+        "js-target",
+        function_entry(
+          vec![],
+          Arc::new(CalcitTypeAnnotation::Unit),
+          Edn::map_from_iter([(Edn::tag("backend"), Edn::tag("js")), (Edn::tag("target"), Edn::tag("worker"))]),
+        ),
+      ),
+      (
+        "unknown-backend",
+        function_entry(
+          vec![],
+          Arc::new(CalcitTypeAnnotation::Unit),
+          Edn::map_from_iter([(Edn::tag("backend"), Edn::tag("python"))]),
+        ),
+      ),
+    ];
+    let report = export_snapshot(&snapshot(definitions), None).expect("inventory unknown lowering values");
+
+    let codes = diagnostic_codes(&report);
+    assert_eq!(report.summary.unsupported, 3);
+    assert!(codes.contains("E_FFI_IR_TARGET_INVALID"));
+    assert!(codes.contains("E_FFI_IR_INVOKE_UNKNOWN"));
+    assert!(codes.contains("E_FFI_IR_TRANSPORT_UNKNOWN"));
+    assert!(codes.contains("E_FFI_IR_BACKEND_UNKNOWN"));
+  }
+
+  #[test]
+  fn invalid_lowering_diagnostics_and_revision_are_repeatable() {
+    let metadata = || {
+      Edn::map_from_iter([
+        (Edn::tag("transport"), Edn::tag("edn-buffer-v1")),
+        (Edn::tag("backend"), Edn::tag("native")),
+        (Edn::tag("symbol"), Edn::str("not-portable!")),
+        (Edn::tag("invoke"), Edn::tag("async")),
+      ])
+    };
+    let make_report = || {
+      export_snapshot(
+        &snapshot(vec![(
+          "invalid",
+          function_entry(vec![], Arc::new(CalcitTypeAnnotation::Unit), metadata()),
+        )]),
+        None,
+      )
+      .expect("export repeatable invalid lowering")
+    };
+
+    assert_eq!(make_report(), make_report());
   }
 
   #[test]


### PR DESCRIPTION
## 中文

这是 #540 / #514 Phase 1 的第一段：Interface IR 不再只检查逻辑类型，还会在 bindgen 前验证 native lowering contract。

### 改动

- native callable 必须声明 portable C base symbol、invoke 与 transport；
- 接受已发布组合：`sync + edn-buffer-v1`、`async + async-task-v1`、`blocking-callback + blocking-host-v1`；
- 对缺失字段、非法 symbol、未知 backend/invoke/transport、错误 native/JS target 与协议错配输出稳定、精确 path 的 diagnostics；
- 保持 Interface IR v1 schema 不变，并明确 v1 callable direction 是 Calcit 从 host backend import；显式双向 direction 留给未来 IR 版本；
- 在升级文档补充完整 `:ffi` metadata 模板与迁移命令。

### 真实模块回归

- calcit.std 0.2.29：`md5` 1/1 supported；
- calcit-regex 0.0.18：保持 1 supported / 3 explicit type diagnostics；
- calcit-wss 0.2.26：保持 2 supported / 2 explicit type diagnostics；
- 旧 calcit-json metadata：新增明确的 `E_FFI_IR_INVOKE_REQUIRED` / `E_FFI_IR_TRANSPORT_REQUIRED`，不会被误认为 generator-safe。

### 验证

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`（924 tests）
- `yarn check-all`（core 225/225，JS/IR/WASM，agent interface 18/18）
- `bash scripts/check-docs-md.sh`（63 files，327 blocks）
- FFI bindgen preview golden tests 3/3

## English

This is the first Phase 1 slice for #540 / #514. Interface IR now validates the native lowering contract before bindgen instead of checking only the logical type.

### Changes

- Require a portable C base symbol, invocation mode, and transport for native callables.
- Accept the published pairs: `sync + edn-buffer-v1`, `async + async-task-v1`, and `blocking-callback + blocking-host-v1`.
- Emit stable, path-specific diagnostics for missing fields, invalid symbols, unknown backend/invocation/transport values, invalid native/JS targets, and protocol mismatches.
- Keep the Interface IR v1 schema unchanged and document its callable direction as a Calcit import from the host backend; explicit bidirectional direction belongs to a future IR version.
- Add a complete `:ffi` metadata template and migration command to the upgrade guide.

### Real-module regression

- calcit.std 0.2.29: `md5` remains 1/1 supported.
- calcit-regex 0.0.18: remains 1 supported / 3 explicit type diagnostics.
- calcit-wss 0.2.26: remains 2 supported / 2 explicit type diagnostics.
- Legacy calcit-json metadata now receives explicit `E_FFI_IR_INVOKE_REQUIRED` / `E_FFI_IR_TRANSPORT_REQUIRED` instead of being treated as generator-safe.

### Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (924 tests)
- `yarn check-all` (core 225/225, JS/IR/WASM, agent interface 18/18)
- `bash scripts/check-docs-md.sh` (63 files, 327 blocks)
- FFI bindgen preview golden tests 3/3

Closes #540
Refs #514
