### PR TITLE
收尾近期 FFI review findings / Close recent FFI review findings

### DIFF
--- a/editing-history/202608310946-recent-review-cleanup.md
+++ b/editing-history/202608310946-recent-review-cleanup.md
@@ -1,0 +1,11 @@
+# 收尾近期 FFI review / Close recent FFI review findings
+
+- WIT 生成器按规范区分 `Result<T, Unit>`、`Result<Unit, E>` 与 `Result<Unit, Unit>`，分别输出省略空 payload 的 canonical forms。
+- 在渲染前按 Rust/TypeScript、Calcit/WIT 与 native symbol 各自的规范化规则检查生成标识符冲突，并覆盖跨命名空间同名定义。
+- native FFI base symbol 明确拒绝三个已发布 ABI 的协议后缀，避免运行时再次追加后查找不存在的入口。
+- 功能 PR 不单独修改 manifest 版本；版本仍由合并后的 release 提交统一同步。
+
+- The WIT generator now distinguishes `Result<T, Unit>`, `Result<Unit, E>`, and `Result<Unit, Unit>`, emitting canonical forms with absent payloads omitted.
+- Generated identifiers are checked before rendering under the normalization rules for Rust/TypeScript, Calcit/WIT, and native symbols, including same-name definitions from different namespaces.
+- Native FFI base symbols explicitly reject all three published ABI protocol suffixes, preventing runtime lookup after a second suffix is appended.
+- Feature PRs do not bump manifest versions independently; synchronized versions remain the responsibility of the post-merge release commit.

--- a/editing-history/202608310953-ffi-member-collision-review.md
+++ b/editing-history/202608310953-ffi-member-collision-review.md
@@ -1,0 +1,9 @@
+# 守门 FFI 成员标识符冲突 / Guard FFI member identifier collisions
+
+- 将生成标识符守门扩展到 struct fields 与 enum variants。
+- 分别按 Rust/TypeScript 与 WIT 的名称规范化规则检查字段，并按 Rust 与 TypeScript/WIT 规则检查 enum variants。
+- 新增 `foo-bar` / `foo_bar` 字段与 `retry-now` / `retry_now` variant 回归，确保生成前失败而非输出无法编译的代码。
+
+- Extended generated-identifier guards to struct fields and enum variants.
+- Fields are checked under Rust/TypeScript and WIT normalization, while enum variants are checked under Rust and TypeScript/WIT normalization.
+- Added `foo-bar` / `foo_bar` field and `retry-now` / `retry_now` variant regressions so generation fails before emitting uncompilable code.

--- a/scripts/ffi-bindgen-preview.mjs
+++ b/scripts/ffi-bindgen-preview.mjs
@@ -167,8 +167,17 @@ function witType(type, definitionId, declarations) {
       return `option<${item}>`;
     }
     case "result": {
-      const ok = witType(type.ok, definitionId, declarations) ?? "_";
-      const error = witType(type.error, definitionId, declarations) ?? "_";
+      const ok = witType(type.ok, definitionId, declarations);
+      const error = witType(type.error, definitionId, declarations);
+      if (ok === null && error === null) {
+        return "result";
+      }
+      if (error === null) {
+        return `result<${ok}>`;
+      }
+      if (ok === null) {
+        return `result<_, ${error}>`;
+      }
       return `result<${ok}, ${error}>`;
     }
     case "struct":
@@ -206,6 +215,28 @@ function ensurePreviewBinding(definition) {
       `${definition.id} uses invoke=${lowering.invoke ?? "<missing>"} transport=${lowering.transport ?? "<missing>"}; Phase 0 preview requires sync edn-buffer-v1`,
     );
   }
+}
+
+function ensureUniqueGeneratedIdentifiers(items, target, generatedIdentifier) {
+  const owners = new Map();
+  for (const item of items) {
+    const generated = generatedIdentifier(item);
+    const previous = owners.get(generated);
+    if (previous) {
+      throw new Error(
+        `generated ${target} identifier ${JSON.stringify(generated)} collides between ${previous.id} and ${item.id}`,
+      );
+    }
+    owners.set(generated, item);
+  }
+}
+
+function ensureGeneratedIdentifiers(definitions, declarations) {
+  ensureUniqueGeneratedIdentifiers(definitions, "Rust/TypeScript definition", (definition) => identifier(definition.name));
+  ensureUniqueGeneratedIdentifiers(definitions, "Calcit/WIT definition", (definition) => identifier(definition.name, "-"));
+  ensureUniqueGeneratedIdentifiers(definitions, "Rust native symbol", (definition) => identifier(definition.lowering.symbol));
+  ensureUniqueGeneratedIdentifiers(declarations, "Rust/TypeScript declaration", (declaration) => declarationTypeName(declaration.id));
+  ensureUniqueGeneratedIdentifiers(declarations, "WIT declaration", (declaration) => identifier(declaration.id, "-"));
 }
 
 function renderRustDeclarations(interfaceDocument, declarations) {
@@ -428,6 +459,7 @@ export function generatePreview(document) {
   }
   definitions.forEach(ensurePreviewBinding);
   const declarations = declarationMap(interfaceDocument);
+  ensureGeneratedIdentifiers(definitions, [...declarations.values()]);
   const slug = identifier(interfaceDocument.package, "-");
   return new Map([
     [`${slug}.ffi.rs`, renderRust(interfaceDocument, definitions, declarations)],

--- a/scripts/ffi-bindgen-preview.mjs
+++ b/scripts/ffi-bindgen-preview.mjs
@@ -237,6 +237,22 @@ function ensureGeneratedIdentifiers(definitions, declarations) {
   ensureUniqueGeneratedIdentifiers(definitions, "Rust native symbol", (definition) => identifier(definition.lowering.symbol));
   ensureUniqueGeneratedIdentifiers(declarations, "Rust/TypeScript declaration", (declaration) => declarationTypeName(declaration.id));
   ensureUniqueGeneratedIdentifiers(declarations, "WIT declaration", (declaration) => identifier(declaration.id, "-"));
+  for (const declaration of declarations) {
+    if (declaration.kind === "struct") {
+      const fields = declaration.fields.map((field) => ({ id: `${declaration.id}.${field.name}`, name: field.name }));
+      ensureUniqueGeneratedIdentifiers(fields, `Rust/TypeScript field in ${declaration.id}`, (field) => identifier(field.name));
+      ensureUniqueGeneratedIdentifiers(fields, `WIT field in ${declaration.id}`, (field) => identifier(field.name, "-"));
+    } else if (declaration.kind === "enum") {
+      const variants = declaration.variants.map((variant) => ({
+        id: `${declaration.id}.${variant.name}`,
+        name: variant.name,
+      }));
+      ensureUniqueGeneratedIdentifiers(variants, `Rust variant in ${declaration.id}`, (variant) => pascalIdentifier(variant.name));
+      ensureUniqueGeneratedIdentifiers(variants, `TypeScript/WIT variant in ${declaration.id}`, (variant) =>
+        identifier(variant.name, "-"),
+      );
+    }
+  }
 }
 
 function renderRustDeclarations(interfaceDocument, declarations) {

--- a/scripts/ffi-bindgen-preview.test.mjs
+++ b/scripts/ffi-bindgen-preview.test.mjs
@@ -109,3 +109,27 @@ test("preview rejects generated definition identifiers that collide across names
     /generated Rust\/TypeScript definition identifier "md5" collides between calcit\.std\.hash\/md5 and demo\.hash\/md5/u,
   );
 });
+
+test("preview rejects generated struct-field and enum-variant collisions", async () => {
+  const fixture = await readJson(path.join(fixtureRoot, "composite-interface.json"));
+
+  const structCollision = structuredClone(fixture);
+  structCollision.declarations[0].fields.push(
+    { name: "foo-bar", type: { kind: "string" } },
+    { name: "foo_bar", type: { kind: "string" } },
+  );
+  assert.throws(
+    () => generatePreview(structCollision),
+    /generated Rust\/TypeScript field in demo\.schema\/Person identifier "foo_bar" collides/u,
+  );
+
+  const enumCollision = structuredClone(fixture);
+  enumCollision.declarations[1].variants.push(
+    { name: "retry-now", payload: [] },
+    { name: "retry_now", payload: [] },
+  );
+  assert.throws(
+    () => generatePreview(enumCollision),
+    /generated Rust variant in demo\.schema\/Outcome identifier "RetryNow" collides/u,
+  );
+});

--- a/scripts/ffi-bindgen-preview.test.mjs
+++ b/scripts/ffi-bindgen-preview.test.mjs
@@ -78,3 +78,34 @@ test("generates Struct, Enum, Option, and Result declarations from Interface IR 
   assert.match(wit, /variant demo-schema-outcome/u);
   assert.match(wit, /roundtrip: func\(arg0: demo-schema-person\) -> result<demo-schema-outcome, string>/u);
 });
+
+test("WIT preview uses canonical Result forms when Unit omits payloads", async () => {
+  const fixture = await readJson(path.join(fixtureRoot, "composite-interface.json"));
+
+  const unitError = structuredClone(fixture);
+  unitError.definitions[0].signature.result.error = { kind: "unit" };
+  assert.match(generatePreview(unitError).get("demo-types.wit"), /-> result<demo-schema-outcome>;/u);
+
+  const unitOk = structuredClone(fixture);
+  unitOk.definitions[0].signature.result.ok = { kind: "unit" };
+  assert.match(generatePreview(unitOk).get("demo-types.wit"), /-> result<_, string>;/u);
+
+  const unitBoth = structuredClone(fixture);
+  unitBoth.definitions[0].signature.result.ok = { kind: "unit" };
+  unitBoth.definitions[0].signature.result.error = { kind: "unit" };
+  assert.match(generatePreview(unitBoth).get("demo-types.wit"), /-> result;/u);
+});
+
+test("preview rejects generated definition identifiers that collide across namespaces", async () => {
+  const document = await readJson(path.join(fixtureRoot, "md5-interface.json"));
+  const duplicate = structuredClone(document.definitions[0]);
+  duplicate.id = "demo.hash/md5";
+  duplicate.namespace = "demo.hash";
+  duplicate.lowering.symbol = "demo_md5";
+  document.definitions.push(duplicate);
+
+  assert.throws(
+    () => generatePreview(document),
+    /generated Rust\/TypeScript definition identifier "md5" collides between calcit\.std\.hash\/md5 and demo\.hash\/md5/u,
+  );
+});

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -812,7 +812,11 @@ fn is_portable_c_identifier(value: &str) -> bool {
   let Some(first) = chars.next() else {
     return false;
   };
-  (first == '_' || first.is_ascii_alphabetic()) && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+  (first == '_' || first.is_ascii_alphabetic())
+    && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    && !["_calcit_ffi_v1", "_calcit_ffi_async_v1", "_calcit_ffi_blocking_v1"]
+      .iter()
+      .any(|suffix| value.ends_with(suffix))
 }
 
 fn validate_lowering_contract(definition: &str, lowering: &FfiLoweringIr, diagnostics: &mut Vec<FfiInterfaceDiagnostic>) {
@@ -1570,6 +1574,37 @@ mod tests {
     let codes = diagnostic_codes(&report);
     assert!(codes.contains("E_FFI_IR_SYMBOL_INVALID"));
     assert!(codes.contains("E_FFI_IR_TRANSPORT_MISMATCH"));
+  }
+
+  #[test]
+  fn rejects_protocol_suffixed_native_base_symbols() {
+    let definitions = [
+      ("sync", "edn-buffer-v1", "read_calcit_ffi_v1"),
+      ("async", "async-task-v1", "watch_calcit_ffi_async_v1"),
+      ("blocking-callback", "blocking-host-v1", "read_lines_calcit_ffi_blocking_v1"),
+    ]
+    .into_iter()
+    .map(|(invoke, transport, symbol)| {
+      (
+        invoke,
+        function_entry(
+          vec![],
+          Arc::new(CalcitTypeAnnotation::Unit),
+          Edn::map_from_iter([
+            (Edn::tag("backend"), Edn::tag("native")),
+            (Edn::tag("invoke"), Edn::tag(invoke)),
+            (Edn::tag("symbol"), Edn::str(symbol)),
+            (Edn::tag("transport"), Edn::tag(transport)),
+          ]),
+        ),
+      )
+    })
+    .collect();
+    let report = export_snapshot(&snapshot(definitions), None).expect("inventory protocol-suffixed symbols");
+
+    assert_eq!(report.summary.supported, 0);
+    assert_eq!(report.summary.unsupported, 3);
+    assert!(diagnostic_codes(&report).contains("E_FFI_IR_SYMBOL_INVALID"));
   }
 
   #[test]


### PR DESCRIPTION
## 中文

阶段性收尾近期已合并 FFI PR 中仍有效的 review comments：

- 修正 WIT `Result` 在 Unit payload 下的输出：`Result<T, Unit>`、`Result<Unit, E>`、`Result<Unit, Unit>` 分别生成 `result<T>`、`result<_, E>`、`result`。
- 在渲染前按 Rust/TypeScript、Calcit/WIT 与 native symbol 的目标规范化规则检查标识符冲突，拒绝跨命名空间同名定义产生重复方法或函数。
- 拒绝 native FFI base symbol 预先包含 `_calcit_ffi_v1`、`_calcit_ffi_async_v1` 或 `_calcit_ffi_blocking_v1`，避免运行时追加第二个协议后缀。
- `package.json` 已由后续发布提交同步为 `0.13.71`；本功能修复不另行修改 manifest 版本。

关联 review：#539、#541、#543。

## 验证

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`（855 项 Rust 测试）
- `yarn compile`
- `yarn check-all`（Calcit core 225/225、Agent interface 18/18、JS/IR/WASM 与性能烟测）

## English

This PR closes the still-valid review findings left on recently merged FFI PRs:

- Emit canonical WIT `result` forms for Unit payloads: `result<T>`, `result<_, E>`, and bare `result`.
- Detect generated identifier collisions before rendering under the target normalization rules for Rust/TypeScript, Calcit/WIT, and native symbols, including same-name definitions from different namespaces.
- Reject native FFI base symbols that already contain `_calcit_ffi_v1`, `_calcit_ffi_async_v1`, or `_calcit_ffi_blocking_v1`, preventing a second protocol suffix at runtime.
- `package.json` is already synchronized to `0.13.71` by the subsequent release commit; this feature fix does not independently bump manifest versions.

Related reviews: #539, #541, and #543.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (855 Rust tests)
- `yarn compile`
- `yarn check-all` (Calcit core 225/225, Agent interface 18/18, JS/IR/WASM, and performance smoke checks)
