### PR TITLE
记录主仓库拆分边界 / document core repository boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@
 - **跨项目验证**：相关语言/生态改动优先在 Calcium Workflow 回归，并逐步用 TopixIM/Timegrass 类真实实时应用验证；Calcit、Respo、Recollect、WebSocket 与 native FFI 模块应保持层次清晰、职责一致。
 - **双语协作记录**：关联 Issue 与 PR 的标题、正文和阶段性进度保持中英双语，便于跨项目追踪同一设计方向。
 
+### 仓库职责与拆分模块追踪
+
+- **主仓库边界**：parser/source model、Snapshot、preprocess/type system、runtime、JS/WASM/Calx backend 语义、`@calcit/procs`、`calcit` CLI/Agent interface 以及权威 RFC/离线文档留在本仓库。短期不规划 LSP，不为假设中的 LSP consumer 拆独立 analysis 仓库。
+- **拆分总索引**：跨仓库职责和迁移顺序由 [calcit#549](https://github.com/calcit-lang/calcit/issues/549) 追踪；bindgen、caps、Calx benchmark 和 native ABI 的具体任务使用总索引中的 child Issues，避免重复立项。
+- **状态必须可发现**：每个拆出或供多个仓库复用的模块，都必须在自己的 README 或 AGENTS.md 说明状态（production / experimental / template / internal）、职责与非职责、上游/下游契约和 source of truth、兼容矩阵、版本与发布策略、迁移/验证命令以及关联 umbrella/child Issues。
+- **模板不冒充产品**：workflow/template 仓库必须明确标记用途及“不随业务功能迭代版本”；实验性 benchmark 也必须明确结果可比性和非生产定位。
+- **迁移完成才删除**：只有目标仓库具备文档、Actions、发布或实验运行入口、兼容验证与跨仓库 smoke 后，才能从主仓库删除原实现；迁移期 README 必须同时说明当前入口与目标状态。
+
 直接使用命令修改 calcit 程序时不需要调用 cargo, 直接按照文档给出的命令行示例执行即可。
 
 在开始任何 `calcit edit` / `calcit tree` 修改前，先把下面这条命令当作**硬前置步骤**执行一遍，而不是可选建议：

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ Current direction:
 - Better CLI editing and validation for CI, docs lookup, module management, and incremental updates
 - Consistent support for real-time web applications: typed WebSocket messages, deterministic state updates, diff/patch synchronization, acknowledgement, and resynchronization
 
+### Repository Boundaries
+
+Calcit keeps language semantics, runtime behavior, backend lowering, the `calcit` CLI/Agent interface, and
+versioned language documentation in this repository. Products with independent dependencies and release
+cadence are maintained separately or tracked for extraction:
+
+| Module | Status and ownership |
+| --- | --- |
+| [`calcit-bindgen`](https://github.com/calcit-lang/calcit-bindgen) | Independent repository; production generator parity and removal of the core preview are tracked in [#544](https://github.com/calcit-lang/calcit/issues/544). |
+| [`calcit-native-ffi`](https://github.com/calcit-lang/calcit-native-ffi) | Independent production shared ABI/helper crate for native modules; canonical ABI ownership is tracked in [calcit-native-ffi#7](https://github.com/calcit-lang/calcit-native-ffi/issues/7). |
+| `caps` | Still shipped from this repository while independent package-manager extraction is tracked in [#546](https://github.com/calcit-lang/calcit/issues/546). |
+| `calcit-calx-bench` | Experimental harness still in this repository; extraction of benchmark policy and reports is tracked in [#547](https://github.com/calcit-lang/calcit/issues/547), while Calx backend semantics remain in core. |
+
+See [#549](https://github.com/calcit-lang/calcit/issues/549) for the bilingual repository-boundary roadmap.
+Calcit has no near-term LSP plan, so analysis and Agent CLI capabilities remain in this repository and release
+unit rather than being split for a hypothetical consumer.
+
 ### Install ![GitHub Release](https://img.shields.io/github/v/release/calcit-lang/calcit)
 
 Build and install with Rust:

--- a/editing-history/2026-08-31-1318-repository-boundary-tracking.md
+++ b/editing-history/2026-08-31-1318-repository-boundary-tracking.md
@@ -1,0 +1,15 @@
+# Repository boundary tracking
+
+## 中文
+
+- 记录 Calcit 主仓库与独立产品的当前边界：语言语义、backend、CLI/Agent 和权威文档留在 core。
+- `calcit-bindgen` 与 `calcit-native-ffi` 已独立；`caps` 和 Calx benchmark harness 进入拆分规划。
+- 短期不规划 LSP，因此不为假设中的 consumer 拆出 analysis 仓库。
+- 固化拆分模块文档规则：README/AGENTS 必须说明状态、职责、source of truth、兼容/发布策略、迁移验证与 Issues。
+
+## English
+
+- Documented the boundary between Calcit core and independently maintained products.
+- Recorded the existing bindgen/native-ffi repositories and the planned caps/Calx benchmark extractions.
+- Explicitly kept analysis and Agent CLI capabilities in core because no near-term LSP is planned.
+- Added a durable README/AGENTS documentation contract for extracted, shared, template, and experimental modules.


### PR DESCRIPTION
## 中文

### 内容

- 在 README 记录 Calcit core、已拆出的 `calcit-bindgen` / `calcit-native-ffi`，以及待拆的 `caps` / Calx benchmark 当前状态；
- 链接 repository-boundary umbrella #549 和各 child Issues；
- 明确短期不规划 LSP，不为假设 consumer 拆 analysis repository；
- 在 AGENTS.md 固化拆分/复用模块的文档规则：状态、职责/非职责、source of truth、兼容与发布策略、迁移验证和追踪链接必须可发现；
- 明确 workflow/template 与 experimental benchmark 的定位标记要求。

### 验证

- `git diff --check`
- 纯文档改动，未运行编译与 runtime tests。

Closes no issue; documents and indexes #544, #546, #547, #549 and calcit-native-ffi#7.

## English

### Changes

- document current ownership for Calcit core, extracted bindgen/native-ffi repositories, and planned caps/Calx benchmark extractions;
- link the repository-boundary umbrella and child Issues;
- explicitly keep analysis and Agent CLI capabilities in core because no near-term LSP is planned;
- require extracted/shared modules to document status, responsibilities, source of truth, compatibility/release policy, migration validation, and tracking links;
- require explicit template and experimental-harness status.

### Validation

- `git diff --check`
- Documentation-only change; compiler/runtime tests were not run.
