### PR TITLE
建立公平 cached Calcit→Calx 基线 / Add a fair cached Calcit-to-Calx baseline

### DIFF
--- a/benchmarks/calx/20260831-macos-arm64.json
+++ b/benchmarks/calx/20260831-macos-arm64.json
@@ -1,6 +1,6 @@
 {
-  "schema": "calcit-calx-benchmark-suite/1",
-  "generatedAt": "2026-08-30T17:37:17.183Z",
+  "schema": "calcit-calx-benchmark-suite/2",
+  "generatedAt": "2026-08-31T05:30:05.586Z",
   "scope": {
     "workload": "scalar-only",
     "typedBufferStatus": "not-measured-no-typed-buffer-abi",
@@ -16,7 +16,7 @@
     "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)\nbinary: rustc\ncommit-hash: 8bab26f4f68e0e26f0bb7960be334d5b520ea452\ncommit-date: 2026-07-14\nhost: aarch64-apple-darwin\nrelease: 1.97.1\nLLVM version: 22.1.6",
     "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
     "node": "v24.4.1",
-    "gitCommit": "a1708055af6a0ab6ba04cda8cada3bc3d4720dae",
+    "gitCommit": "88bb5a2250ba65b0e35c4d1809e6d49a14c61623",
     "gitDirty": false
   },
   "methodology": {
@@ -24,6 +24,8 @@
     "samples": 7,
     "vmWarmup": 20,
     "hotIterations": 100,
+    "hotWarmupMeaning": "applied equally to the cached Calcit callable and reused Calx VM",
+    "cachedNativeMeaning": "resolved callable reused; scope setup, argument binding, and runner execution remain timed",
     "noiseStatistic": "median-and-median-absolute-deviation",
     "processWallMeaning": "Node spawn wall time including process startup and all measured phases",
     "regressionPolicy": "informational-no-absolute-ci-threshold"
@@ -86,55 +88,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 6316250,
-              "fixtureInstallNs": 441000,
-              "calcitFrontendNs": 619417,
-              "snapshotCloneNs": 1875,
-              "eligibilityNs": 50292,
-              "planningNs": 35667,
-              "programConstructionNs": 63708,
-              "validationLoweringNs": 19625,
-              "calxCompileTotalNs": 178417,
-              "nativeCallNs": 83959,
-              "boundaryArgumentsNs": 2875,
-              "vmSetupNs": 4250,
-              "pureExecutionNs": 18959,
-              "boundaryResultNs": 167,
-              "calxOneShotNs": 26583,
-              "hotExecutionPerCallNs": 11656
+              "processWallNs": 10377792,
+              "fixtureInstallNs": 411084,
+              "calcitFrontendNs": 606333,
+              "snapshotCloneNs": 1958,
+              "eligibilityNs": 56125,
+              "planningNs": 43209,
+              "programConstructionNs": 71958,
+              "validationLoweringNs": 18792,
+              "calxCompileTotalNs": 193833,
+              "nativeCallNs": 80583,
+              "cachedNativeResolutionNs": 1875,
+              "cachedNativeExecutionTotalNs": 3366083,
+              "cachedNativeExecutionPerCallNs": 33660,
+              "boundaryArgumentsNs": 3333,
+              "vmSetupNs": 4583,
+              "pureExecutionNs": 16625,
+              "boundaryResultNs": 125,
+              "calxOneShotNs": 26333,
+              "hotExecutionTotalNs": 994792,
+              "hotExecutionPerCallNs": 9947
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 330667,
-              "fixtureInstallNs": 29250,
-              "calcitFrontendNs": 55167,
-              "snapshotCloneNs": 83,
-              "eligibilityNs": 7208,
-              "planningNs": 2792,
-              "programConstructionNs": 7458,
-              "validationLoweringNs": 1958,
-              "calxCompileTotalNs": 19583,
-              "nativeCallNs": 6375,
-              "boundaryArgumentsNs": 333,
-              "vmSetupNs": 375,
-              "pureExecutionNs": 1917,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 2792,
-              "hotExecutionPerCallNs": 1104
+              "processWallNs": 480042,
+              "fixtureInstallNs": 33875,
+              "calcitFrontendNs": 30583,
+              "snapshotCloneNs": 250,
+              "eligibilityNs": 2084,
+              "planningNs": 5374,
+              "programConstructionNs": 6042,
+              "validationLoweringNs": 2875,
+              "calxCompileTotalNs": 20875,
+              "nativeCallNs": 8583,
+              "cachedNativeResolutionNs": 83,
+              "cachedNativeExecutionTotalNs": 238916,
+              "cachedNativeExecutionPerCallNs": 2389,
+              "boundaryArgumentsNs": 2000,
+              "vmSetupNs": 1000,
+              "pureExecutionNs": 1833,
+              "boundaryResultNs": 41,
+              "calxOneShotNs": 333,
+              "hotExecutionTotalNs": 113792,
+              "hotExecutionPerCallNs": 1137
             },
             "derived": {
-              "nativeEndToEndNs": 1144376,
-              "calxEndToEndNs": 1267292,
-              "hotVsNativeRatio": 0.13882966686120607,
-              "oneShotEndToEndRatio": 1.1074087537662447
+              "lookupNativeEndToEndNs": 1098000,
+              "calxEndToEndNs": 1239541,
+              "calxHotVsLookupNativeRatio": 0.12343794596875271,
+              "calxHotVsCachedNativeRatio": 0.29551396316102196,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.128908014571949
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 7369666,
+              "processWallNs": 12137792,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -145,265 +156,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 615875,
-                "calcitFrontendNs": 802458,
-                "snapshotCloneNs": 1959,
+                "fixtureInstallNs": 377209,
+                "calcitFrontendNs": 576667,
+                "snapshotCloneNs": 1958,
                 "compile": {
-                  "eligibilityNs": 57500,
-                  "planningNs": 40500,
-                  "programConstructionNs": 74875,
-                  "validationLoweringNs": 19625,
-                  "totalNs": 198000
+                  "eligibilityNs": 47708,
+                  "planningNs": 39500,
+                  "programConstructionNs": 71958,
+                  "validationLoweringNs": 18708,
+                  "totalNs": 183250
                 },
                 "runtime": {
-                  "nativeCallNs": 102083,
-                  "boundaryArgumentsNs": 3125,
-                  "vmSetupNs": 4750,
-                  "pureExecutionNs": 21917,
-                  "boundaryResultNs": 209,
-                  "calxOneShotNs": 30500,
-                  "hotExecutionTotalNs": 1438750,
-                  "hotExecutionPerCallNs": 14387
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 6646917,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 549583,
-                "calcitFrontendNs": 757792,
-                "snapshotCloneNs": 1917,
-                "compile": {
-                  "eligibilityNs": 58292,
-                  "planningNs": 41167,
-                  "programConstructionNs": 74500,
-                  "validationLoweringNs": 19792,
-                  "totalNs": 199417
-                },
-                "runtime": {
-                  "nativeCallNs": 103584,
-                  "boundaryArgumentsNs": 3250,
-                  "vmSetupNs": 4625,
-                  "pureExecutionNs": 22833,
-                  "boundaryResultNs": 166,
-                  "calxOneShotNs": 31375,
-                  "hotExecutionTotalNs": 1276084,
-                  "hotExecutionPerCallNs": 12760
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 6063417,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 411750,
-                "calcitFrontendNs": 561750,
-                "snapshotCloneNs": 1416,
-                "compile": {
-                  "eligibilityNs": 42333,
-                  "planningNs": 32875,
-                  "programConstructionNs": 56250,
-                  "validationLoweringNs": 15083,
-                  "totalNs": 151083
-                },
-                "runtime": {
-                  "nativeCallNs": 77584,
-                  "boundaryArgumentsNs": 2375,
-                  "vmSetupNs": 3500,
-                  "pureExecutionNs": 16709,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 23125,
-                  "hotExecutionTotalNs": 1289583,
-                  "hotExecutionPerCallNs": 12895
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 6021958,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 441000,
-                "calcitFrontendNs": 619417,
-                "snapshotCloneNs": 1875,
-                "compile": {
-                  "eligibilityNs": 50250,
-                  "planningNs": 35667,
-                  "programConstructionNs": 63708,
-                  "validationLoweringNs": 24000,
-                  "totalNs": 178417
-                },
-                "runtime": {
-                  "nativeCallNs": 83959,
-                  "boundaryArgumentsNs": 2542,
-                  "vmSetupNs": 4208,
-                  "pureExecutionNs": 18959,
-                  "boundaryResultNs": 209,
-                  "calxOneShotNs": 26583,
-                  "hotExecutionTotalNs": 1165625,
-                  "hotExecutionPerCallNs": 11656
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 6681584,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 466750,
-                "calcitFrontendNs": 669917,
-                "snapshotCloneNs": 2791,
-                "compile": {
-                  "eligibilityNs": 61500,
-                  "planningNs": 40000,
-                  "programConstructionNs": 78166,
-                  "validationLoweringNs": 21750,
-                  "totalNs": 207750
-                },
-                "runtime": {
-                  "nativeCallNs": 85625,
-                  "boundaryArgumentsNs": 3083,
-                  "vmSetupNs": 5625,
-                  "pureExecutionNs": 19833,
-                  "boundaryResultNs": 375,
-                  "calxOneShotNs": 29375,
-                  "hotExecutionTotalNs": 1075709,
-                  "hotExecutionPerCallNs": 10757
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 6316250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 429458,
-                "calcitFrontendNs": 609041,
-                "snapshotCloneNs": 1875,
-                "compile": {
-                  "eligibilityNs": 50292,
-                  "planningNs": 34833,
-                  "programConstructionNs": 63250,
-                  "validationLoweringNs": 17875,
-                  "totalNs": 171000
-                },
-                "runtime": {
-                  "nativeCallNs": 79792,
-                  "boundaryArgumentsNs": 2875,
-                  "vmSetupNs": 4250,
-                  "pureExecutionNs": 17791,
+                  "nativeCallNs": 73083,
+                  "cachedNativeResolutionNs": 1875,
+                  "cachedNativeExecutionTotalNs": 4722250,
+                  "cachedNativeExecutionPerCallNs": 47222,
+                  "boundaryArgumentsNs": 9417,
+                  "vmSetupNs": 5583,
+                  "pureExecutionNs": 20500,
                   "boundaryResultNs": 167,
-                  "calxOneShotNs": 25583,
-                  "hotExecutionTotalNs": 1069167,
-                  "hotExecutionPerCallNs": 10691
+                  "calxOneShotNs": 36209,
+                  "hotExecutionTotalNs": 1181292,
+                  "hotExecutionPerCallNs": 11812
                 },
                 "program": {
                   "functions": 1,
@@ -418,11 +192,11 @@
               }
             },
             {
-              "processWallNs": 5955291,
+              "processWallNs": 11753625,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -433,25 +207,283 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 385667,
-                "calcitFrontendNs": 564250,
-                "snapshotCloneNs": 1792,
+                "fixtureInstallNs": 467125,
+                "calcitFrontendNs": 715375,
+                "snapshotCloneNs": 2167,
                 "compile": {
-                  "eligibilityNs": 46084,
-                  "planningNs": 34500,
-                  "programConstructionNs": 61333,
-                  "validationLoweringNs": 17667,
-                  "totalNs": 165042
+                  "eligibilityNs": 57209,
+                  "planningNs": 49417,
+                  "programConstructionNs": 78000,
+                  "validationLoweringNs": 20625,
+                  "totalNs": 212166
                 },
                 "runtime": {
-                  "nativeCallNs": 76833,
-                  "boundaryArgumentsNs": 2541,
+                  "nativeCallNs": 90666,
+                  "cachedNativeResolutionNs": 2417,
+                  "cachedNativeExecutionTotalNs": 4064208,
+                  "cachedNativeExecutionPerCallNs": 40642,
+                  "boundaryArgumentsNs": 3333,
                   "vmSetupNs": 4000,
-                  "pureExecutionNs": 17042,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 24250,
-                  "hotExecutionTotalNs": 991000,
-                  "hotExecutionPerCallNs": 9910
+                  "pureExecutionNs": 18458,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 26333,
+                  "hotExecutionTotalNs": 1185541,
+                  "hotExecutionPerCallNs": 11855
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 10765083,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 411084,
+                "calcitFrontendNs": 606333,
+                "snapshotCloneNs": 1875,
+                "compile": {
+                  "eligibilityNs": 56125,
+                  "planningNs": 43209,
+                  "programConstructionNs": 67000,
+                  "validationLoweringNs": 21667,
+                  "totalNs": 193833
+                },
+                "runtime": {
+                  "nativeCallNs": 80583,
+                  "cachedNativeResolutionNs": 1958,
+                  "cachedNativeExecutionTotalNs": 3661625,
+                  "cachedNativeExecutionPerCallNs": 36616,
+                  "boundaryArgumentsNs": 1333,
+                  "vmSetupNs": 6458,
+                  "pureExecutionNs": 17709,
+                  "boundaryResultNs": 84,
+                  "calxOneShotNs": 26000,
+                  "hotExecutionTotalNs": 1067292,
+                  "hotExecutionPerCallNs": 10672
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 10377792,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 381000,
+                "calcitFrontendNs": 514209,
+                "snapshotCloneNs": 1500,
+                "compile": {
+                  "eligibilityNs": 35917,
+                  "planningNs": 31958,
+                  "programConstructionNs": 52708,
+                  "validationLoweringNs": 14208,
+                  "totalNs": 138375
+                },
+                "runtime": {
+                  "nativeCallNs": 72000,
+                  "cachedNativeResolutionNs": 1792,
+                  "cachedNativeExecutionTotalNs": 3366083,
+                  "cachedNativeExecutionPerCallNs": 33660,
+                  "boundaryArgumentsNs": 2083,
+                  "vmSetupNs": 3375,
+                  "pureExecutionNs": 15625,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 24416,
+                  "hotExecutionTotalNs": 994792,
+                  "hotExecutionPerCallNs": 9947
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 9536833,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 375250,
+                "calcitFrontendNs": 513084,
+                "snapshotCloneNs": 1250,
+                "compile": {
+                  "eligibilityNs": 35417,
+                  "planningNs": 30916,
+                  "programConstructionNs": 51292,
+                  "validationLoweringNs": 11250,
+                  "totalNs": 132250
+                },
+                "runtime": {
+                  "nativeCallNs": 68416,
+                  "cachedNativeResolutionNs": 1625,
+                  "cachedNativeExecutionTotalNs": 3244291,
+                  "cachedNativeExecutionPerCallNs": 32442,
+                  "boundaryArgumentsNs": 2375,
+                  "vmSetupNs": 6625,
+                  "pureExecutionNs": 16625,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 26333,
+                  "hotExecutionTotalNs": 970292,
+                  "hotExecutionPerCallNs": 9702
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 9897750,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 420958,
+                "calcitFrontendNs": 626667,
+                "snapshotCloneNs": 2292,
+                "compile": {
+                  "eligibilityNs": 57208,
+                  "planningNs": 48583,
+                  "programConstructionNs": 76792,
+                  "validationLoweringNs": 23959,
+                  "totalNs": 214708
+                },
+                "runtime": {
+                  "nativeCallNs": 83709,
+                  "cachedNativeResolutionNs": 5250,
+                  "cachedNativeExecutionTotalNs": 3168041,
+                  "cachedNativeExecutionPerCallNs": 31680,
+                  "boundaryArgumentsNs": 7792,
+                  "vmSetupNs": 4542,
+                  "pureExecutionNs": 14375,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 27209,
+                  "hotExecutionTotalNs": 881000,
+                  "hotExecutionPerCallNs": 8810
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 10277875,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 481625,
+                "calcitFrontendNs": 636916,
+                "snapshotCloneNs": 2208,
+                "compile": {
+                  "eligibilityNs": 58209,
+                  "planningNs": 47833,
+                  "programConstructionNs": 98417,
+                  "validationLoweringNs": 18792,
+                  "totalNs": 229416
+                },
+                "runtime": {
+                  "nativeCallNs": 92708,
+                  "cachedNativeResolutionNs": 1875,
+                  "cachedNativeExecutionTotalNs": 3127167,
+                  "cachedNativeExecutionPerCallNs": 31271,
+                  "boundaryArgumentsNs": 6833,
+                  "vmSetupNs": 4583,
+                  "pureExecutionNs": 14292,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 26167,
+                  "hotExecutionTotalNs": 874709,
+                  "hotExecutionPerCallNs": 8747
                 },
                 "program": {
                   "functions": 1,
@@ -481,55 +513,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 14991916,
-              "fixtureInstallNs": 376291,
-              "calcitFrontendNs": 564875,
-              "snapshotCloneNs": 1958,
-              "eligibilityNs": 46792,
-              "planningNs": 34667,
-              "programConstructionNs": 62083,
-              "validationLoweringNs": 18000,
-              "calxCompileTotalNs": 166625,
-              "nativeCallNs": 344166,
-              "boundaryArgumentsNs": 2500,
-              "vmSetupNs": 4250,
-              "pureExecutionNs": 96416,
+              "processWallNs": 52202333,
+              "fixtureInstallNs": 395834,
+              "calcitFrontendNs": 559333,
+              "snapshotCloneNs": 1875,
+              "eligibilityNs": 49000,
+              "planningNs": 41042,
+              "programConstructionNs": 68958,
+              "validationLoweringNs": 18375,
+              "calxCompileTotalNs": 181208,
+              "nativeCallNs": 342125,
+              "cachedNativeResolutionNs": 1792,
+              "cachedNativeExecutionTotalNs": 29879834,
+              "cachedNativeExecutionPerCallNs": 298798,
+              "boundaryArgumentsNs": 8625,
+              "vmSetupNs": 13791,
+              "pureExecutionNs": 98208,
               "boundaryResultNs": 167,
-              "calxOneShotNs": 105000,
-              "hotExecutionPerCallNs": 84597
+              "calxOneShotNs": 123500,
+              "hotExecutionTotalNs": 8311709,
+              "hotExecutionPerCallNs": 83117
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 214126,
-              "fixtureInstallNs": 6500,
-              "calcitFrontendNs": 30583,
-              "snapshotCloneNs": 166,
-              "eligibilityNs": 3874,
-              "planningNs": 2417,
-              "programConstructionNs": 3833,
-              "validationLoweringNs": 1500,
-              "calxCompileTotalNs": 11125,
-              "nativeCallNs": 9458,
-              "boundaryArgumentsNs": 167,
-              "vmSetupNs": 458,
-              "pureExecutionNs": 1334,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 2417,
-              "hotExecutionPerCallNs": 323
+              "processWallNs": 478749,
+              "fixtureInstallNs": 23875,
+              "calcitFrontendNs": 35124,
+              "snapshotCloneNs": 458,
+              "eligibilityNs": 2667,
+              "planningNs": 4624,
+              "programConstructionNs": 4709,
+              "validationLoweringNs": 2666,
+              "calxCompileTotalNs": 10459,
+              "nativeCallNs": 6375,
+              "cachedNativeResolutionNs": 209,
+              "cachedNativeExecutionTotalNs": 87209,
+              "cachedNativeExecutionPerCallNs": 872,
+              "boundaryArgumentsNs": 3375,
+              "vmSetupNs": 3624,
+              "pureExecutionNs": 4459,
+              "boundaryResultNs": 83,
+              "calxOneShotNs": 8208,
+              "hotExecutionTotalNs": 113417,
+              "hotExecutionPerCallNs": 1135
             },
             "derived": {
-              "nativeEndToEndNs": 1285332,
-              "calxEndToEndNs": 1214749,
-              "hotVsNativeRatio": 0.24580289743902653,
-              "oneShotEndToEndRatio": 0.9450857832840076
+              "lookupNativeEndToEndNs": 1297292,
+              "calxEndToEndNs": 1261750,
+              "calxHotVsLookupNativeRatio": 0.24294336865180854,
+              "calxHotVsCachedNativeRatio": 0.27817120596523404,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.9726029297952966
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 15170583,
+              "processWallNs": 51257125,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -540,73 +581,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 382375,
-                "calcitFrontendNs": 573084,
-                "snapshotCloneNs": 2250,
+                "fixtureInstallNs": 451084,
+                "calcitFrontendNs": 497500,
+                "snapshotCloneNs": 1333,
                 "compile": {
-                  "eligibilityNs": 57000,
-                  "planningNs": 39625,
-                  "programConstructionNs": 71834,
-                  "validationLoweringNs": 21500,
-                  "totalNs": 196791
+                  "eligibilityNs": 33333,
+                  "planningNs": 29833,
+                  "programConstructionNs": 46583,
+                  "validationLoweringNs": 10667,
+                  "totalNs": 123708
                 },
                 "runtime": {
-                  "nativeCallNs": 364208,
-                  "boundaryArgumentsNs": 2583,
-                  "vmSetupNs": 4708,
-                  "pureExecutionNs": 97042,
-                  "boundaryResultNs": 208,
-                  "calxOneShotNs": 105125,
-                  "hotExecutionTotalNs": 8492000,
-                  "hotExecutionPerCallNs": 84920
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 15206042,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 376291,
-                "calcitFrontendNs": 569125,
-                "snapshotCloneNs": 2125,
-                "compile": {
-                  "eligibilityNs": 50666,
-                  "planningNs": 36791,
-                  "programConstructionNs": 65208,
-                  "validationLoweringNs": 19500,
-                  "totalNs": 177750
-                },
-                "runtime": {
-                  "nativeCallNs": 336459,
-                  "boundaryArgumentsNs": 2500,
-                  "vmSetupNs": 4958,
-                  "pureExecutionNs": 96416,
+                  "nativeCallNs": 326375,
+                  "cachedNativeResolutionNs": 1583,
+                  "cachedNativeExecutionTotalNs": 29551000,
+                  "cachedNativeExecutionPerCallNs": 295510,
+                  "boundaryArgumentsNs": 5250,
+                  "vmSetupNs": 10167,
+                  "pureExecutionNs": 93625,
                   "boundaryResultNs": 125,
-                  "calxOneShotNs": 104542,
-                  "hotExecutionTotalNs": 8622666,
-                  "hotExecutionPerCallNs": 86226
+                  "calxOneShotNs": 109833,
+                  "hotExecutionTotalNs": 8198292,
+                  "hotExecutionPerCallNs": 81982
                 },
                 "program": {
                   "functions": 1,
@@ -621,11 +617,11 @@
               }
             },
             {
-              "processWallNs": 15064042,
+              "processWallNs": 52607542,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -636,73 +632,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 381542,
-                "calcitFrontendNs": 597625,
-                "snapshotCloneNs": 1959,
+                "fixtureInstallNs": 384000,
+                "calcitFrontendNs": 570583,
+                "snapshotCloneNs": 2333,
                 "compile": {
-                  "eligibilityNs": 52792,
-                  "planningNs": 39292,
-                  "programConstructionNs": 77750,
-                  "validationLoweringNs": 21375,
-                  "totalNs": 197709
+                  "eligibilityNs": 51167,
+                  "planningNs": 41375,
+                  "programConstructionNs": 68958,
+                  "validationLoweringNs": 18458,
+                  "totalNs": 186542
                 },
                 "runtime": {
-                  "nativeCallNs": 359667,
-                  "boundaryArgumentsNs": 4042,
-                  "vmSetupNs": 5584,
-                  "pureExecutionNs": 99917,
-                  "boundaryResultNs": 208,
-                  "calxOneShotNs": 110375,
-                  "hotExecutionTotalNs": 8446958,
-                  "hotExecutionPerCallNs": 84469
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 14991916,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 382791,
-                "calcitFrontendNs": 564875,
-                "snapshotCloneNs": 1958,
-                "compile": {
-                  "eligibilityNs": 46792,
-                  "planningNs": 34667,
-                  "programConstructionNs": 62083,
-                  "validationLoweringNs": 18000,
-                  "totalNs": 166625
-                },
-                "runtime": {
-                  "nativeCallNs": 344166,
-                  "boundaryArgumentsNs": 2333,
-                  "vmSetupNs": 4166,
-                  "pureExecutionNs": 97750,
+                  "nativeCallNs": 342125,
+                  "cachedNativeResolutionNs": 1791,
+                  "cachedNativeExecutionTotalNs": 30254208,
+                  "cachedNativeExecutionPerCallNs": 302542,
+                  "boundaryArgumentsNs": 5167,
+                  "vmSetupNs": 17542,
+                  "pureExecutionNs": 99792,
                   "boundaryResultNs": 250,
-                  "calxOneShotNs": 105000,
-                  "hotExecutionTotalNs": 8523916,
-                  "hotExecutionPerCallNs": 85239
+                  "calxOneShotNs": 123750,
+                  "hotExecutionTotalNs": 8311709,
+                  "hotExecutionPerCallNs": 83117
                 },
                 "program": {
                   "functions": 1,
@@ -717,11 +668,11 @@
               }
             },
             {
-              "processWallNs": 14717292,
+              "processWallNs": 52687916,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -732,25 +683,130 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 356625,
-                "calcitFrontendNs": 534292,
-                "snapshotCloneNs": 1792,
+                "fixtureInstallNs": 446000,
+                "calcitFrontendNs": 623417,
+                "snapshotCloneNs": 2333,
                 "compile": {
-                  "eligibilityNs": 45000,
-                  "planningNs": 32167,
-                  "programConstructionNs": 59250,
-                  "validationLoweringNs": 17875,
-                  "totalNs": 159375
+                  "eligibilityNs": 63667,
+                  "planningNs": 48208,
+                  "programConstructionNs": 125917,
+                  "validationLoweringNs": 41458,
+                  "totalNs": 287750
+                },
+                "runtime": {
+                  "nativeCallNs": 384500,
+                  "cachedNativeResolutionNs": 2084,
+                  "cachedNativeExecutionTotalNs": 29906417,
+                  "cachedNativeExecutionPerCallNs": 299064,
+                  "boundaryArgumentsNs": 10958,
+                  "vmSetupNs": 16875,
+                  "pureExecutionNs": 102667,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 131708,
+                  "hotExecutionTotalNs": 8226708,
+                  "hotExecutionPerCallNs": 82267
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 51723584,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 371959,
+                "calcitFrontendNs": 555333,
+                "snapshotCloneNs": 1875,
+                "compile": {
+                  "eligibilityNs": 47542,
+                  "planningNs": 41042,
+                  "programConstructionNs": 68958,
+                  "validationLoweringNs": 16625,
+                  "totalNs": 180250
+                },
+                "runtime": {
+                  "nativeCallNs": 348292,
+                  "cachedNativeResolutionNs": 2125,
+                  "cachedNativeExecutionTotalNs": 29879834,
+                  "cachedNativeExecutionPerCallNs": 298798,
+                  "boundaryArgumentsNs": 3750,
+                  "vmSetupNs": 4417,
+                  "pureExecutionNs": 91583,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 100333,
+                  "hotExecutionTotalNs": 8257709,
+                  "hotExecutionPerCallNs": 82577
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 52202333,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 359542,
+                "calcitFrontendNs": 524209,
+                "snapshotCloneNs": 1167,
+                "compile": {
+                  "eligibilityNs": 38917,
+                  "planningNs": 29375,
+                  "programConstructionNs": 54125,
+                  "validationLoweringNs": 22250,
+                  "totalNs": 147875
                 },
                 "runtime": {
                   "nativeCallNs": 345000,
-                  "boundaryArgumentsNs": 9292,
-                  "vmSetupNs": 4209,
-                  "pureExecutionNs": 93792,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 108042,
-                  "hotExecutionTotalNs": 8459708,
-                  "hotExecutionPerCallNs": 84597
+                  "cachedNativeResolutionNs": 1500,
+                  "cachedNativeExecutionTotalNs": 30167208,
+                  "cachedNativeExecutionPerCallNs": 301672,
+                  "boundaryArgumentsNs": 9583,
+                  "vmSetupNs": 5125,
+                  "pureExecutionNs": 91833,
+                  "boundaryResultNs": 542,
+                  "calxOneShotNs": 107583,
+                  "hotExecutionTotalNs": 8497083,
+                  "hotExecutionPerCallNs": 84970
                 },
                 "program": {
                   "functions": 1,
@@ -765,11 +821,11 @@
               }
             },
             {
-              "processWallNs": 14766208,
+              "processWallNs": 52947833,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -780,25 +836,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 361708,
-                "calcitFrontendNs": 533250,
-                "snapshotCloneNs": 1833,
+                "fixtureInstallNs": 405375,
+                "calcitFrontendNs": 595667,
+                "snapshotCloneNs": 1709,
                 "compile": {
-                  "eligibilityNs": 43417,
-                  "planningNs": 33208,
-                  "programConstructionNs": 58250,
-                  "validationLoweringNs": 17083,
-                  "totalNs": 156792
+                  "eligibilityNs": 51667,
+                  "planningNs": 45666,
+                  "programConstructionNs": 73667,
+                  "validationLoweringNs": 15709,
+                  "totalNs": 191667
                 },
                 "runtime": {
-                  "nativeCallNs": 334708,
-                  "boundaryArgumentsNs": 2417,
-                  "vmSetupNs": 4250,
-                  "pureExecutionNs": 95333,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 102583,
-                  "hotExecutionTotalNs": 8443291,
-                  "hotExecutionPerCallNs": 84432
+                  "nativeCallNs": 335375,
+                  "cachedNativeResolutionNs": 1792,
+                  "cachedNativeExecutionTotalNs": 29792625,
+                  "cachedNativeExecutionPerCallNs": 297926,
+                  "boundaryArgumentsNs": 12625,
+                  "vmSetupNs": 13791,
+                  "pureExecutionNs": 99250,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 126834,
+                  "hotExecutionTotalNs": 8827917,
+                  "hotExecutionPerCallNs": 88279
                 },
                 "program": {
                   "functions": 1,
@@ -813,11 +872,11 @@
               }
             },
             {
-              "processWallNs": 14518458,
+              "processWallNs": 51757000,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -828,25 +887,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 355958,
-                "calcitFrontendNs": 505375,
-                "snapshotCloneNs": 1541,
+                "fixtureInstallNs": 395834,
+                "calcitFrontendNs": 559333,
+                "snapshotCloneNs": 2125,
                 "compile": {
-                  "eligibilityNs": 40542,
-                  "planningNs": 32250,
-                  "programConstructionNs": 52959,
-                  "validationLoweringNs": 15334,
-                  "totalNs": 146084
+                  "eligibilityNs": 49000,
+                  "planningNs": 40291,
+                  "programConstructionNs": 67125,
+                  "validationLoweringNs": 18375,
+                  "totalNs": 181208
                 },
                 "runtime": {
-                  "nativeCallNs": 324000,
-                  "boundaryArgumentsNs": 2250,
-                  "vmSetupNs": 3750,
-                  "pureExecutionNs": 91583,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 98084,
-                  "hotExecutionTotalNs": 8342708,
-                  "hotExecutionPerCallNs": 83427
+                  "nativeCallNs": 335750,
+                  "cachedNativeResolutionNs": 1959,
+                  "cachedNativeExecutionTotalNs": 29825125,
+                  "cachedNativeExecutionPerCallNs": 298251,
+                  "boundaryArgumentsNs": 8625,
+                  "vmSetupNs": 15417,
+                  "pureExecutionNs": 98208,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 123500,
+                  "hotExecutionTotalNs": 8451417,
+                  "hotExecutionPerCallNs": 84514
                 },
                 "program": {
                   "functions": 1,
@@ -876,55 +938,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 105994750,
-              "fixtureInstallNs": 368500,
-              "calcitFrontendNs": 553666,
-              "snapshotCloneNs": 1584,
-              "eligibilityNs": 44625,
-              "planningNs": 31958,
-              "programConstructionNs": 59917,
-              "validationLoweringNs": 18292,
-              "calxCompileTotalNs": 160500,
-              "nativeCallNs": 2878208,
-              "boundaryArgumentsNs": 2667,
-              "vmSetupNs": 3500,
-              "pureExecutionNs": 829625,
-              "boundaryResultNs": 84,
-              "calxOneShotNs": 838750,
-              "hotExecutionPerCallNs": 814175
+              "processWallNs": 467831334,
+              "fixtureInstallNs": 391542,
+              "calcitFrontendNs": 568375,
+              "snapshotCloneNs": 1917,
+              "eligibilityNs": 51833,
+              "planningNs": 42375,
+              "programConstructionNs": 70084,
+              "validationLoweringNs": 19875,
+              "calxCompileTotalNs": 189000,
+              "nativeCallNs": 2991542,
+              "cachedNativeResolutionNs": 2250,
+              "cachedNativeExecutionTotalNs": 296227375,
+              "cachedNativeExecutionPerCallNs": 2962273,
+              "boundaryArgumentsNs": 11083,
+              "vmSetupNs": 17875,
+              "pureExecutionNs": 862167,
+              "boundaryResultNs": 375,
+              "calxOneShotNs": 890959,
+              "hotExecutionTotalNs": 83789875,
+              "hotExecutionPerCallNs": 837898
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 110000,
-              "fixtureInstallNs": 5834,
-              "calcitFrontendNs": 10625,
-              "snapshotCloneNs": 209,
-              "eligibilityNs": 5417,
-              "planningNs": 2417,
-              "programConstructionNs": 2458,
-              "validationLoweringNs": 2167,
-              "calxCompileTotalNs": 12125,
-              "nativeCallNs": 11874,
-              "boundaryArgumentsNs": 167,
-              "vmSetupNs": 333,
-              "pureExecutionNs": 2584,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 1917,
-              "hotExecutionPerCallNs": 2376
+              "processWallNs": 2395667,
+              "fixtureInstallNs": 24042,
+              "calcitFrontendNs": 11000,
+              "snapshotCloneNs": 83,
+              "eligibilityNs": 3833,
+              "planningNs": 2958,
+              "programConstructionNs": 3708,
+              "validationLoweringNs": 1708,
+              "calxCompileTotalNs": 10375,
+              "nativeCallNs": 30333,
+              "cachedNativeResolutionNs": 125,
+              "cachedNativeExecutionTotalNs": 1884333,
+              "cachedNativeExecutionPerCallNs": 18843,
+              "boundaryArgumentsNs": 2542,
+              "vmSetupNs": 1708,
+              "pureExecutionNs": 27042,
+              "boundaryResultNs": 42,
+              "calxOneShotNs": 23584,
+              "hotExecutionTotalNs": 154208,
+              "hotExecutionPerCallNs": 1542
             },
             "derived": {
-              "nativeEndToEndNs": 3800374,
-              "calxEndToEndNs": 1923000,
-              "hotVsNativeRatio": 0.2828756643022325,
-              "oneShotEndToEndRatio": 0.5060028302477598
+              "lookupNativeEndToEndNs": 3951459,
+              "calxEndToEndNs": 2041793,
+              "calxHotVsLookupNativeRatio": 0.280088997580512,
+              "calxHotVsCachedNativeRatio": 0.2828564416581456,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.5167187613486562
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 105945083,
+              "processWallNs": 466299833,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -935,25 +1006,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 368500,
-                "calcitFrontendNs": 559041,
-                "snapshotCloneNs": 2042,
+                "fixtureInstallNs": 367500,
+                "calcitFrontendNs": 568375,
+                "snapshotCloneNs": 1667,
                 "compile": {
-                  "eligibilityNs": 49500,
-                  "planningNs": 34375,
-                  "programConstructionNs": 63000,
-                  "validationLoweringNs": 19833,
-                  "totalNs": 173083
+                  "eligibilityNs": 47750,
+                  "planningNs": 42375,
+                  "programConstructionNs": 70084,
+                  "validationLoweringNs": 22584,
+                  "totalNs": 189000
                 },
                 "runtime": {
-                  "nativeCallNs": 2955208,
-                  "boundaryArgumentsNs": 2667,
-                  "vmSetupNs": 6917,
-                  "pureExecutionNs": 834875,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 844875,
-                  "hotExecutionTotalNs": 81092833,
-                  "hotExecutionPerCallNs": 810928
+                  "nativeCallNs": 2979625,
+                  "cachedNativeResolutionNs": 2250,
+                  "cachedNativeExecutionTotalNs": 293929167,
+                  "cachedNativeExecutionPerCallNs": 2939291,
+                  "boundaryArgumentsNs": 14292,
+                  "vmSetupNs": 19959,
+                  "pureExecutionNs": 891292,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 926875,
+                  "hotExecutionTotalNs": 83538167,
+                  "hotExecutionPerCallNs": 835381
                 },
                 "program": {
                   "functions": 1,
@@ -968,11 +1042,11 @@
               }
             },
             {
-              "processWallNs": 106101542,
+              "processWallNs": 467831334,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -983,25 +1057,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 374334,
-                "calcitFrontendNs": 564291,
-                "snapshotCloneNs": 1584,
+                "fixtureInstallNs": 382250,
+                "calcitFrontendNs": 557375,
+                "snapshotCloneNs": 1917,
                 "compile": {
-                  "eligibilityNs": 44625,
-                  "planningNs": 31958,
-                  "programConstructionNs": 60625,
-                  "validationLoweringNs": 18292,
-                  "totalNs": 160500
+                  "eligibilityNs": 47834,
+                  "planningNs": 42042,
+                  "programConstructionNs": 70083,
+                  "validationLoweringNs": 17708,
+                  "totalNs": 183708
                 },
                 "runtime": {
-                  "nativeCallNs": 2951083,
-                  "boundaryArgumentsNs": 2666,
-                  "vmSetupNs": 4458,
-                  "pureExecutionNs": 839500,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 847166,
-                  "hotExecutionTotalNs": 81495125,
-                  "hotExecutionPerCallNs": 814951
+                  "nativeCallNs": 2961209,
+                  "cachedNativeResolutionNs": 2375,
+                  "cachedNativeExecutionTotalNs": 296227375,
+                  "cachedNativeExecutionPerCallNs": 2962273,
+                  "boundaryArgumentsNs": 11083,
+                  "vmSetupNs": 16791,
+                  "pureExecutionNs": 920417,
+                  "boundaryResultNs": 375,
+                  "calxOneShotNs": 949958,
+                  "hotExecutionTotalNs": 83789875,
+                  "hotExecutionPerCallNs": 837898
                 },
                 "program": {
                   "functions": 1,
@@ -1016,11 +1093,11 @@
               }
             },
             {
-              "processWallNs": 106104750,
+              "processWallNs": 465435667,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1031,25 +1108,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 369708,
-                "calcitFrontendNs": 553666,
-                "snapshotCloneNs": 1791,
+                "fixtureInstallNs": 443750,
+                "calcitFrontendNs": 590916,
+                "snapshotCloneNs": 1917,
                 "compile": {
-                  "eligibilityNs": 46375,
-                  "planningNs": 37375,
-                  "programConstructionNs": 62375,
-                  "validationLoweringNs": 21042,
-                  "totalNs": 172625
+                  "eligibilityNs": 55666,
+                  "planningNs": 46792,
+                  "programConstructionNs": 73792,
+                  "validationLoweringNs": 20500,
+                  "totalNs": 202625
                 },
                 "runtime": {
-                  "nativeCallNs": 2867834,
-                  "boundaryArgumentsNs": 2750,
-                  "vmSetupNs": 4250,
-                  "pureExecutionNs": 829625,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 837167,
-                  "hotExecutionTotalNs": 81417500,
-                  "hotExecutionPerCallNs": 814175
+                  "nativeCallNs": 2945584,
+                  "cachedNativeResolutionNs": 1916,
+                  "cachedNativeExecutionTotalNs": 294343042,
+                  "cachedNativeExecutionPerCallNs": 2943430,
+                  "boundaryArgumentsNs": 8541,
+                  "vmSetupNs": 17209,
+                  "pureExecutionNs": 838958,
+                  "boundaryResultNs": 375,
+                  "calxOneShotNs": 867375,
+                  "hotExecutionTotalNs": 83494875,
+                  "hotExecutionPerCallNs": 834948
                 },
                 "program": {
                   "functions": 1,
@@ -1064,11 +1144,11 @@
               }
             },
             {
-              "processWallNs": 106547834,
+              "processWallNs": 483421417,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1079,25 +1159,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 389208,
-                "calcitFrontendNs": 558750,
-                "snapshotCloneNs": 1625,
+                "fixtureInstallNs": 460875,
+                "calcitFrontendNs": 602625,
+                "snapshotCloneNs": 2167,
                 "compile": {
-                  "eligibilityNs": 50500,
-                  "planningNs": 32250,
-                  "programConstructionNs": 57542,
-                  "validationLoweringNs": 19083,
-                  "totalNs": 164000
+                  "eligibilityNs": 54250,
+                  "planningNs": 71416,
+                  "programConstructionNs": 75375,
+                  "validationLoweringNs": 19875,
+                  "totalNs": 226958
                 },
                 "runtime": {
-                  "nativeCallNs": 2885458,
-                  "boundaryArgumentsNs": 7708,
-                  "vmSetupNs": 3375,
-                  "pureExecutionNs": 828667,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 840250,
-                  "hotExecutionTotalNs": 81699292,
-                  "hotExecutionPerCallNs": 816992
+                  "nativeCallNs": 3168958,
+                  "cachedNativeResolutionNs": 6167,
+                  "cachedNativeExecutionTotalNs": 303604625,
+                  "cachedNativeExecutionPerCallNs": 3036046,
+                  "boundaryArgumentsNs": 17500,
+                  "vmSetupNs": 16167,
+                  "pureExecutionNs": 846291,
+                  "boundaryResultNs": 375,
+                  "calxOneShotNs": 881375,
+                  "hotExecutionTotalNs": 83796458,
+                  "hotExecutionPerCallNs": 837964
                 },
                 "program": {
                   "functions": 1,
@@ -1112,11 +1195,11 @@
               }
             },
             {
-              "processWallNs": 105994750,
+              "processWallNs": 471656792,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1127,25 +1210,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 367542,
-                "calcitFrontendNs": 513916,
-                "snapshotCloneNs": 1375,
+                "fixtureInstallNs": 420334,
+                "calcitFrontendNs": 604167,
+                "snapshotCloneNs": 2000,
                 "compile": {
-                  "eligibilityNs": 39208,
-                  "planningNs": 31291,
-                  "programConstructionNs": 59917,
-                  "validationLoweringNs": 16125,
-                  "totalNs": 150583
+                  "eligibilityNs": 56834,
+                  "planningNs": 52167,
+                  "programConstructionNs": 81666,
+                  "validationLoweringNs": 21167,
+                  "totalNs": 217709
                 },
                 "runtime": {
-                  "nativeCallNs": 2878208,
-                  "boundaryArgumentsNs": 2500,
-                  "vmSetupNs": 3500,
-                  "pureExecutionNs": 832209,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 838750,
-                  "hotExecutionTotalNs": 81422541,
-                  "hotExecutionPerCallNs": 814225
+                  "nativeCallNs": 3166750,
+                  "cachedNativeResolutionNs": 6625,
+                  "cachedNativeExecutionTotalNs": 298104208,
+                  "cachedNativeExecutionPerCallNs": 2981042,
+                  "boundaryArgumentsNs": 5167,
+                  "vmSetupNs": 22042,
+                  "pureExecutionNs": 862167,
+                  "boundaryResultNs": 417,
+                  "calxOneShotNs": 890959,
+                  "hotExecutionTotalNs": 83944083,
+                  "hotExecutionPerCallNs": 839440
                 },
                 "program": {
                   "functions": 1,
@@ -1160,11 +1246,11 @@
               }
             },
             {
-              "processWallNs": 105370209,
+              "processWallNs": 465852042,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1175,25 +1261,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 358042,
-                "calcitFrontendNs": 494708,
-                "snapshotCloneNs": 1250,
+                "fixtureInstallNs": 383458,
+                "calcitFrontendNs": 563625,
+                "snapshotCloneNs": 1917,
                 "compile": {
-                  "eligibilityNs": 37875,
-                  "planningNs": 28916,
-                  "programConstructionNs": 52125,
-                  "validationLoweringNs": 13041,
-                  "totalNs": 136583
+                  "eligibilityNs": 49041,
+                  "planningNs": 40750,
+                  "programConstructionNs": 66875,
+                  "validationLoweringNs": 17416,
+                  "totalNs": 179917
                 },
                 "runtime": {
-                  "nativeCallNs": 2855708,
-                  "boundaryArgumentsNs": 2041,
-                  "vmSetupNs": 3167,
-                  "pureExecutionNs": 824791,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 830541,
-                  "hotExecutionTotalNs": 81179916,
-                  "hotExecutionPerCallNs": 811799
+                  "nativeCallNs": 3019250,
+                  "cachedNativeResolutionNs": 2125,
+                  "cachedNativeExecutionTotalNs": 294596125,
+                  "cachedNativeExecutionPerCallNs": 2945961,
+                  "boundaryArgumentsNs": 9917,
+                  "vmSetupNs": 23000,
+                  "pureExecutionNs": 835125,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 869125,
+                  "hotExecutionTotalNs": 83636292,
+                  "hotExecutionPerCallNs": 836362
                 },
                 "program": {
                   "functions": 1,
@@ -1208,11 +1297,11 @@
               }
             },
             {
-              "processWallNs": 105237083,
+              "processWallNs": 484198333,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1223,25 +1312,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 339458,
-                "calcitFrontendNs": 491917,
-                "snapshotCloneNs": 1125,
+                "fixtureInstallNs": 391542,
+                "calcitFrontendNs": 560875,
+                "snapshotCloneNs": 1834,
                 "compile": {
-                  "eligibilityNs": 38209,
-                  "planningNs": 26292,
-                  "programConstructionNs": 51541,
-                  "validationLoweringNs": 13542,
-                  "totalNs": 133375
+                  "eligibilityNs": 51833,
+                  "planningNs": 39417,
+                  "programConstructionNs": 63416,
+                  "validationLoweringNs": 18167,
+                  "totalNs": 178625
                 },
                 "runtime": {
-                  "nativeCallNs": 2866334,
-                  "boundaryArgumentsNs": 5125,
-                  "vmSetupNs": 3167,
-                  "pureExecutionNs": 828083,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 836833,
-                  "hotExecutionTotalNs": 81140500,
-                  "hotExecutionPerCallNs": 811405
+                  "nativeCallNs": 2991542,
+                  "cachedNativeResolutionNs": 2167,
+                  "cachedNativeExecutionTotalNs": 300512083,
+                  "cachedNativeExecutionPerCallNs": 3005120,
+                  "boundaryArgumentsNs": 11166,
+                  "vmSetupNs": 17875,
+                  "pureExecutionNs": 1445542,
+                  "boundaryResultNs": 542,
+                  "calxOneShotNs": 1476541,
+                  "hotExecutionTotalNs": 86352917,
+                  "hotExecutionPerCallNs": 863529
                 },
                 "program": {
                   "functions": 1,
@@ -1271,55 +1363,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 5323208,
-              "fixtureInstallNs": 338875,
-              "calcitFrontendNs": 502500,
-              "snapshotCloneNs": 1334,
-              "eligibilityNs": 40625,
-              "planningNs": 29000,
-              "programConstructionNs": 46500,
-              "validationLoweringNs": 13375,
-              "calxCompileTotalNs": 134917,
-              "nativeCallNs": 96959,
-              "boundaryArgumentsNs": 2125,
-              "vmSetupNs": 3042,
-              "pureExecutionNs": 16875,
-              "boundaryResultNs": 125,
-              "calxOneShotNs": 22667,
-              "hotExecutionPerCallNs": 11290
+              "processWallNs": 15167250,
+              "fixtureInstallNs": 441250,
+              "calcitFrontendNs": 666750,
+              "snapshotCloneNs": 2459,
+              "eligibilityNs": 63250,
+              "planningNs": 44667,
+              "programConstructionNs": 78875,
+              "validationLoweringNs": 21375,
+              "calxCompileTotalNs": 211708,
+              "nativeCallNs": 113709,
+              "cachedNativeResolutionNs": 1375,
+              "cachedNativeExecutionTotalNs": 6277292,
+              "cachedNativeExecutionPerCallNs": 62772,
+              "boundaryArgumentsNs": 4583,
+              "vmSetupNs": 17084,
+              "pureExecutionNs": 27500,
+              "boundaryResultNs": 250,
+              "calxOneShotNs": 50333,
+              "hotExecutionTotalNs": 1171041,
+              "hotExecutionPerCallNs": 11710
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 73374,
-              "fixtureInstallNs": 5209,
-              "calcitFrontendNs": 1500,
-              "snapshotCloneNs": 84,
-              "eligibilityNs": 83,
-              "planningNs": 333,
-              "programConstructionNs": 750,
-              "validationLoweringNs": 250,
-              "calxCompileTotalNs": 2333,
-              "nativeCallNs": 709,
-              "boundaryArgumentsNs": 125,
-              "vmSetupNs": 83,
-              "pureExecutionNs": 625,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 875,
-              "hotExecutionPerCallNs": 71
+              "processWallNs": 502458,
+              "fixtureInstallNs": 35875,
+              "calcitFrontendNs": 63625,
+              "snapshotCloneNs": 209,
+              "eligibilityNs": 5667,
+              "planningNs": 2959,
+              "programConstructionNs": 8208,
+              "validationLoweringNs": 2417,
+              "calxCompileTotalNs": 18125,
+              "nativeCallNs": 10709,
+              "cachedNativeResolutionNs": 125,
+              "cachedNativeExecutionTotalNs": 278208,
+              "cachedNativeExecutionPerCallNs": 2782,
+              "boundaryArgumentsNs": 875,
+              "vmSetupNs": 333,
+              "pureExecutionNs": 2209,
+              "boundaryResultNs": 83,
+              "calxOneShotNs": 2374,
+              "hotExecutionTotalNs": 25124,
+              "hotExecutionPerCallNs": 251
             },
             "derived": {
-              "nativeEndToEndNs": 938334,
-              "calxEndToEndNs": 1000293,
-              "hotVsNativeRatio": 0.11644096989449149,
-              "oneShotEndToEndRatio": 1.06603085894788
+              "lookupNativeEndToEndNs": 1221709,
+              "calxEndToEndNs": 1372500,
+              "calxHotVsLookupNativeRatio": 0.10298217379451055,
+              "calxHotVsCachedNativeRatio": 0.18654814248391002,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1234262823634762
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 5289000,
+              "processWallNs": 14664792,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1330,25 +1431,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 336334,
-                "calcitFrontendNs": 502250,
-                "snapshotCloneNs": 3875,
+                "fixtureInstallNs": 422416,
+                "calcitFrontendNs": 629292,
+                "snapshotCloneNs": 2042,
                 "compile": {
-                  "eligibilityNs": 40625,
-                  "planningNs": 31208,
-                  "programConstructionNs": 45708,
-                  "validationLoweringNs": 15875,
-                  "totalNs": 137250
+                  "eligibilityNs": 54333,
+                  "planningNs": 46708,
+                  "programConstructionNs": 78458,
+                  "validationLoweringNs": 16416,
+                  "totalNs": 200709
                 },
                 "runtime": {
-                  "nativeCallNs": 96250,
-                  "boundaryArgumentsNs": 2458,
-                  "vmSetupNs": 2875,
-                  "pureExecutionNs": 16875,
+                  "nativeCallNs": 105875,
+                  "cachedNativeResolutionNs": 1208,
+                  "cachedNativeExecutionTotalNs": 6488167,
+                  "cachedNativeExecutionPerCallNs": 64881,
+                  "boundaryArgumentsNs": 4667,
+                  "vmSetupNs": 23292,
+                  "pureExecutionNs": 40375,
                   "boundaryResultNs": 83,
-                  "calxOneShotNs": 22667,
-                  "hotExecutionTotalNs": 1130166,
-                  "hotExecutionPerCallNs": 11301
+                  "calxOneShotNs": 69417,
+                  "hotExecutionTotalNs": 1156167,
+                  "hotExecutionPerCallNs": 11561
                 },
                 "program": {
                   "functions": 1,
@@ -1363,11 +1467,11 @@
               }
             },
             {
-              "processWallNs": 5212834,
+              "processWallNs": 14320708,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1378,25 +1482,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 333666,
-                "calcitFrontendNs": 501000,
-                "snapshotCloneNs": 1250,
+                "fixtureInstallNs": 385334,
+                "calcitFrontendNs": 598459,
+                "snapshotCloneNs": 2250,
                 "compile": {
-                  "eligibilityNs": 40625,
-                  "planningNs": 28667,
-                  "programConstructionNs": 46500,
-                  "validationLoweringNs": 13125,
-                  "totalNs": 132833
+                  "eligibilityNs": 59000,
+                  "planningNs": 40666,
+                  "programConstructionNs": 69042,
+                  "validationLoweringNs": 18958,
+                  "totalNs": 193583
                 },
                 "runtime": {
-                  "nativeCallNs": 99334,
-                  "boundaryArgumentsNs": 2125,
-                  "vmSetupNs": 2959,
-                  "pureExecutionNs": 16250,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 21792,
-                  "hotExecutionTotalNs": 1116250,
-                  "hotExecutionPerCallNs": 11162
+                  "nativeCallNs": 103000,
+                  "cachedNativeResolutionNs": 1375,
+                  "cachedNativeExecutionTotalNs": 6277292,
+                  "cachedNativeExecutionPerCallNs": 62772,
+                  "boundaryArgumentsNs": 5292,
+                  "vmSetupNs": 17333,
+                  "pureExecutionNs": 27584,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 51334,
+                  "hotExecutionTotalNs": 1142791,
+                  "hotExecutionPerCallNs": 11427
                 },
                 "program": {
                   "functions": 1,
@@ -1411,11 +1518,11 @@
               }
             },
             {
-              "processWallNs": 5249834,
+              "processWallNs": 15256875,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1426,25 +1533,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 346583,
-                "calcitFrontendNs": 504750,
-                "snapshotCloneNs": 3334,
+                "fixtureInstallNs": 441250,
+                "calcitFrontendNs": 666750,
+                "snapshotCloneNs": 2459,
                 "compile": {
-                  "eligibilityNs": 40708,
-                  "planningNs": 28875,
-                  "programConstructionNs": 46250,
-                  "validationLoweringNs": 12542,
-                  "totalNs": 132041
+                  "eligibilityNs": 68917,
+                  "planningNs": 44917,
+                  "programConstructionNs": 92959,
+                  "validationLoweringNs": 35125,
+                  "totalNs": 249750
                 },
                 "runtime": {
-                  "nativeCallNs": 95958,
-                  "boundaryArgumentsNs": 2083,
-                  "vmSetupNs": 3042,
-                  "pureExecutionNs": 18042,
-                  "boundaryResultNs": 2709,
-                  "calxOneShotNs": 26125,
-                  "hotExecutionTotalNs": 1147709,
-                  "hotExecutionPerCallNs": 11477
+                  "nativeCallNs": 113709,
+                  "cachedNativeResolutionNs": 1333,
+                  "cachedNativeExecutionTotalNs": 6013917,
+                  "cachedNativeExecutionPerCallNs": 60139,
+                  "boundaryArgumentsNs": 3708,
+                  "vmSetupNs": 17417,
+                  "pureExecutionNs": 25291,
+                  "boundaryResultNs": 375,
+                  "calxOneShotNs": 47959,
+                  "hotExecutionTotalNs": 1248500,
+                  "hotExecutionPerCallNs": 12485
                 },
                 "program": {
                   "functions": 1,
@@ -1459,11 +1569,11 @@
               }
             },
             {
-              "processWallNs": 5402625,
+              "processWallNs": 18025583,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1474,25 +1584,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 344792,
-                "calcitFrontendNs": 502500,
-                "snapshotCloneNs": 1417,
+                "fixtureInstallNs": 601292,
+                "calcitFrontendNs": 1263916,
+                "snapshotCloneNs": 2875,
                 "compile": {
-                  "eligibilityNs": 41667,
-                  "planningNs": 30125,
-                  "programConstructionNs": 48375,
-                  "validationLoweringNs": 13458,
-                  "totalNs": 140208
+                  "eligibilityNs": 76084,
+                  "planningNs": 44667,
+                  "programConstructionNs": 112208,
+                  "validationLoweringNs": 27167,
+                  "totalNs": 271125
                 },
                 "runtime": {
-                  "nativeCallNs": 97958,
-                  "boundaryArgumentsNs": 4541,
-                  "vmSetupNs": 3167,
-                  "pureExecutionNs": 17041,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 25417,
-                  "hotExecutionTotalNs": 1129084,
-                  "hotExecutionPerCallNs": 11290
+                  "nativeCallNs": 137541,
+                  "cachedNativeResolutionNs": 1500,
+                  "cachedNativeExecutionTotalNs": 8545375,
+                  "cachedNativeExecutionPerCallNs": 85453,
+                  "boundaryArgumentsNs": 5667,
+                  "vmSetupNs": 17084,
+                  "pureExecutionNs": 27958,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 51959,
+                  "hotExecutionTotalNs": 1186666,
+                  "hotExecutionPerCallNs": 11866
                 },
                 "program": {
                   "functions": 1,
@@ -1507,11 +1620,11 @@
               }
             },
             {
-              "processWallNs": 5413125,
+              "processWallNs": 14780792,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1522,25 +1635,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 345000,
-                "calcitFrontendNs": 514333,
-                "snapshotCloneNs": 1334,
+                "fixtureInstallNs": 502709,
+                "calcitFrontendNs": 635458,
+                "snapshotCloneNs": 2334,
                 "compile": {
-                  "eligibilityNs": 40583,
-                  "planningNs": 29000,
-                  "programConstructionNs": 47584,
-                  "validationLoweringNs": 13417,
-                  "totalNs": 134541
+                  "eligibilityNs": 60500,
+                  "planningNs": 41541,
+                  "programConstructionNs": 78875,
+                  "validationLoweringNs": 21375,
+                  "totalNs": 211708
                 },
                 "runtime": {
-                  "nativeCallNs": 97000,
-                  "boundaryArgumentsNs": 2000,
-                  "vmSetupNs": 3125,
-                  "pureExecutionNs": 16250,
-                  "boundaryResultNs": 166,
-                  "calxOneShotNs": 21875,
-                  "hotExecutionTotalNs": 1128542,
-                  "hotExecutionPerCallNs": 11285
+                  "nativeCallNs": 108792,
+                  "cachedNativeResolutionNs": 1334,
+                  "cachedNativeExecutionTotalNs": 5937458,
+                  "cachedNativeExecutionPerCallNs": 59374,
+                  "boundaryArgumentsNs": 1916,
+                  "vmSetupNs": 7583,
+                  "pureExecutionNs": 25167,
+                  "boundaryResultNs": 209,
+                  "calxOneShotNs": 35333,
+                  "hotExecutionTotalNs": 1212208,
+                  "hotExecutionPerCallNs": 12122
                 },
                 "program": {
                   "functions": 1,
@@ -1555,11 +1671,11 @@
               }
             },
             {
-              "processWallNs": 5356833,
+              "processWallNs": 16178125,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1570,25 +1686,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 337625,
-                "calcitFrontendNs": 502500,
-                "snapshotCloneNs": 1292,
+                "fixtureInstallNs": 405375,
+                "calcitFrontendNs": 1029625,
+                "snapshotCloneNs": 5458,
                 "compile": {
-                  "eligibilityNs": 40292,
-                  "planningNs": 33875,
-                  "programConstructionNs": 47250,
-                  "validationLoweringNs": 13125,
-                  "totalNs": 138333
+                  "eligibilityNs": 134250,
+                  "planningNs": 54291,
+                  "programConstructionNs": 87083,
+                  "validationLoweringNs": 22667,
+                  "totalNs": 305584
                 },
                 "runtime": {
-                  "nativeCallNs": 96459,
+                  "nativeCallNs": 131708,
+                  "cachedNativeResolutionNs": 1542,
+                  "cachedNativeExecutionTotalNs": 6974959,
+                  "cachedNativeExecutionPerCallNs": 69749,
                   "boundaryArgumentsNs": 4583,
-                  "vmSetupNs": 2959,
-                  "pureExecutionNs": 16167,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 24083,
-                  "hotExecutionTotalNs": 1147916,
-                  "hotExecutionPerCallNs": 11479
+                  "vmSetupNs": 17000,
+                  "pureExecutionNs": 27500,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 50333,
+                  "hotExecutionTotalNs": 1171041,
+                  "hotExecutionPerCallNs": 11710
                 },
                 "program": {
                   "functions": 1,
@@ -1603,11 +1722,11 @@
               }
             },
             {
-              "processWallNs": 5323208,
+              "processWallNs": 15167250,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1618,25 +1737,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 338875,
-                "calcitFrontendNs": 510292,
-                "snapshotCloneNs": 1250,
+                "fixtureInstallNs": 451792,
+                "calcitFrontendNs": 730375,
+                "snapshotCloneNs": 2625,
                 "compile": {
-                  "eligibilityNs": 42542,
-                  "planningNs": 28958,
-                  "programConstructionNs": 46166,
-                  "validationLoweringNs": 13375,
-                  "totalNs": 134917
+                  "eligibilityNs": 63250,
+                  "planningNs": 41708,
+                  "programConstructionNs": 75833,
+                  "validationLoweringNs": 19625,
+                  "totalNs": 206375
                 },
                 "runtime": {
-                  "nativeCallNs": 96959,
-                  "boundaryArgumentsNs": 2042,
-                  "vmSetupNs": 3042,
-                  "pureExecutionNs": 16959,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 22458,
-                  "hotExecutionTotalNs": 1121917,
-                  "hotExecutionPerCallNs": 11219
+                  "nativeCallNs": 124542,
+                  "cachedNativeResolutionNs": 19958,
+                  "cachedNativeExecutionTotalNs": 5999084,
+                  "cachedNativeExecutionPerCallNs": 59990,
+                  "boundaryArgumentsNs": 3625,
+                  "vmSetupNs": 11000,
+                  "pureExecutionNs": 23708,
+                  "boundaryResultNs": 416,
+                  "calxOneShotNs": 39583,
+                  "hotExecutionTotalNs": 1145917,
+                  "hotExecutionPerCallNs": 11459
                 },
                 "program": {
                   "functions": 1,
@@ -1666,55 +1788,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 20826417,
-              "fixtureInstallNs": 336542,
-              "calcitFrontendNs": 500459,
-              "snapshotCloneNs": 1333,
-              "eligibilityNs": 41750,
-              "planningNs": 29250,
-              "programConstructionNs": 48709,
-              "validationLoweringNs": 13250,
-              "calxCompileTotalNs": 137083,
-              "nativeCallNs": 763416,
-              "boundaryArgumentsNs": 2208,
-              "vmSetupNs": 3125,
-              "pureExecutionNs": 143375,
-              "boundaryResultNs": 167,
-              "calxOneShotNs": 150083,
-              "hotExecutionPerCallNs": 134030
+              "processWallNs": 114561458,
+              "fixtureInstallNs": 405750,
+              "calcitFrontendNs": 627709,
+              "snapshotCloneNs": 2333,
+              "eligibilityNs": 63750,
+              "planningNs": 42000,
+              "programConstructionNs": 72625,
+              "validationLoweringNs": 19583,
+              "calxCompileTotalNs": 204125,
+              "nativeCallNs": 790709,
+              "cachedNativeResolutionNs": 1333,
+              "cachedNativeExecutionTotalNs": 75425833,
+              "cachedNativeExecutionPerCallNs": 754258,
+              "boundaryArgumentsNs": 4792,
+              "vmSetupNs": 20500,
+              "pureExecutionNs": 164666,
+              "boundaryResultNs": 209,
+              "calxOneShotNs": 191875,
+              "hotExecutionTotalNs": 14268875,
+              "hotExecutionPerCallNs": 142688
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 42542,
-              "fixtureInstallNs": 3084,
-              "calcitFrontendNs": 3042,
-              "snapshotCloneNs": 84,
-              "eligibilityNs": 1584,
-              "planningNs": 167,
-              "programConstructionNs": 1668,
-              "validationLoweringNs": 125,
-              "calxCompileTotalNs": 2917,
-              "nativeCallNs": 1876,
+              "processWallNs": 1771958,
+              "fixtureInstallNs": 17334,
+              "calcitFrontendNs": 17126,
+              "snapshotCloneNs": 126,
+              "eligibilityNs": 3459,
+              "planningNs": 250,
+              "programConstructionNs": 1042,
+              "validationLoweringNs": 416,
+              "calxCompileTotalNs": 3125,
+              "nativeCallNs": 7750,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 1795833,
+              "cachedNativeExecutionPerCallNs": 17958,
               "boundaryArgumentsNs": 42,
-              "vmSetupNs": 125,
-              "pureExecutionNs": 1167,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 417,
-              "hotExecutionPerCallNs": 183
+              "vmSetupNs": 1667,
+              "pureExecutionNs": 3082,
+              "boundaryResultNs": 41,
+              "calxOneShotNs": 5583,
+              "hotExecutionTotalNs": 194959,
+              "hotExecutionPerCallNs": 1950
             },
             "derived": {
-              "nativeEndToEndNs": 1600417,
-              "calxEndToEndNs": 1125500,
-              "hotVsNativeRatio": 0.17556613956217842,
-              "oneShotEndToEndRatio": 0.7032542143703797
+              "lookupNativeEndToEndNs": 1824168,
+              "calxEndToEndNs": 1431792,
+              "calxHotVsLookupNativeRatio": 0.18045576817767345,
+              "calxHotVsCachedNativeRatio": 0.1891766477783464,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.7849013906613864
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 20826417,
+              "processWallNs": 113611584,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1725,25 +1856,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 336208,
-                "calcitFrontendNs": 497958,
-                "snapshotCloneNs": 1292,
+                "fixtureInstallNs": 395583,
+                "calcitFrontendNs": 631041,
+                "snapshotCloneNs": 2125,
                 "compile": {
-                  "eligibilityNs": 39875,
-                  "planningNs": 28625,
-                  "programConstructionNs": 48709,
-                  "validationLoweringNs": 13125,
-                  "totalNs": 134166
+                  "eligibilityNs": 67833,
+                  "planningNs": 42167,
+                  "programConstructionNs": 73667,
+                  "validationLoweringNs": 19583,
+                  "totalNs": 208959
                 },
                 "runtime": {
-                  "nativeCallNs": 763250,
-                  "boundaryArgumentsNs": 2208,
-                  "vmSetupNs": 3000,
-                  "pureExecutionNs": 142208,
-                  "boundaryResultNs": 2625,
-                  "calxOneShotNs": 150459,
-                  "hotExecutionTotalNs": 13449708,
-                  "hotExecutionPerCallNs": 134497
+                  "nativeCallNs": 785500,
+                  "cachedNativeResolutionNs": 1333,
+                  "cachedNativeExecutionTotalNs": 74191125,
+                  "cachedNativeExecutionPerCallNs": 741911,
+                  "boundaryArgumentsNs": 4791,
+                  "vmSetupNs": 18833,
+                  "pureExecutionNs": 155459,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 180333,
+                  "hotExecutionTotalNs": 13932083,
+                  "hotExecutionPerCallNs": 139320
                 },
                 "program": {
                   "functions": 1,
@@ -1758,11 +1892,11 @@
               }
             },
             {
-              "processWallNs": 20913083,
+              "processWallNs": 114561458,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1773,169 +1907,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 339750,
-                "calcitFrontendNs": 501083,
-                "snapshotCloneNs": 1250,
+                "fixtureInstallNs": 423084,
+                "calcitFrontendNs": 751667,
+                "snapshotCloneNs": 2459,
                 "compile": {
-                  "eligibilityNs": 42458,
-                  "planningNs": 31875,
-                  "programConstructionNs": 51166,
-                  "validationLoweringNs": 13250,
-                  "totalNs": 142666
+                  "eligibilityNs": 73459,
+                  "planningNs": 41750,
+                  "programConstructionNs": 71750,
+                  "validationLoweringNs": 19167,
+                  "totalNs": 212333
                 },
                 "runtime": {
-                  "nativeCallNs": 765292,
-                  "boundaryArgumentsNs": 2208,
-                  "vmSetupNs": 3458,
-                  "pureExecutionNs": 143959,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 150167,
-                  "hotExecutionTotalNs": 13384709,
-                  "hotExecutionPerCallNs": 133847
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 20798000,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 333458,
-                "calcitFrontendNs": 510334,
-                "snapshotCloneNs": 1333,
-                "compile": {
-                  "eligibilityNs": 43750,
-                  "planningNs": 29250,
-                  "programConstructionNs": 47125,
-                  "validationLoweringNs": 13208,
-                  "totalNs": 137083
-                },
-                "runtime": {
-                  "nativeCallNs": 763416,
-                  "boundaryArgumentsNs": 2166,
-                  "vmSetupNs": 3250,
-                  "pureExecutionNs": 139667,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 145500,
-                  "hotExecutionTotalNs": 13350042,
-                  "hotExecutionPerCallNs": 133500
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 20783875,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 328292,
-                "calcitFrontendNs": 500459,
-                "snapshotCloneNs": 1417,
-                "compile": {
-                  "eligibilityNs": 40958,
-                  "planningNs": 29417,
-                  "programConstructionNs": 48125,
-                  "validationLoweringNs": 13708,
-                  "totalNs": 135959
-                },
-                "runtime": {
-                  "nativeCallNs": 771875,
-                  "boundaryArgumentsNs": 2250,
-                  "vmSetupNs": 2958,
-                  "pureExecutionNs": 141917,
-                  "boundaryResultNs": 2625,
-                  "calxOneShotNs": 150083,
-                  "hotExecutionTotalNs": 13406791,
-                  "hotExecutionPerCallNs": 134067
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 20909958,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 336542,
-                "calcitFrontendNs": 497417,
-                "snapshotCloneNs": 1458,
-                "compile": {
-                  "eligibilityNs": 41750,
-                  "planningNs": 29250,
-                  "programConstructionNs": 50500,
-                  "validationLoweringNs": 13084,
-                  "totalNs": 138375
-                },
-                "runtime": {
-                  "nativeCallNs": 758375,
-                  "boundaryArgumentsNs": 2167,
-                  "vmSetupNs": 3042,
-                  "pureExecutionNs": 147625,
+                  "nativeCallNs": 978375,
+                  "cachedNativeResolutionNs": 6167,
+                  "cachedNativeExecutionTotalNs": 75425833,
+                  "cachedNativeExecutionPerCallNs": 754258,
+                  "boundaryArgumentsNs": 5458,
+                  "vmSetupNs": 20500,
+                  "pureExecutionNs": 164666,
                   "boundaryResultNs": 208,
-                  "calxOneShotNs": 153375,
-                  "hotExecutionTotalNs": 13486833,
-                  "hotExecutionPerCallNs": 134868
+                  "calxOneShotNs": 191875,
+                  "hotExecutionTotalNs": 14268875,
+                  "hotExecutionPerCallNs": 142688
                 },
                 "program": {
                   "functions": 1,
@@ -1950,11 +1943,11 @@
               }
             },
             {
-              "processWallNs": 20788333,
+              "processWallNs": 113626958,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -1965,25 +1958,130 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 337541,
-                "calcitFrontendNs": 491500,
-                "snapshotCloneNs": 1208,
+                "fixtureInstallNs": 376375,
+                "calcitFrontendNs": 623917,
+                "snapshotCloneNs": 2250,
                 "compile": {
-                  "eligibilityNs": 40166,
-                  "planningNs": 29084,
-                  "programConstructionNs": 47041,
-                  "validationLoweringNs": 13292,
-                  "totalNs": 133459
+                  "eligibilityNs": 59959,
+                  "planningNs": 42000,
+                  "programConstructionNs": 75792,
+                  "validationLoweringNs": 20166,
+                  "totalNs": 204125
                 },
                 "runtime": {
-                  "nativeCallNs": 764834,
-                  "boundaryArgumentsNs": 2083,
-                  "vmSetupNs": 3125,
-                  "pureExecutionNs": 143542,
+                  "nativeCallNs": 786125,
+                  "cachedNativeResolutionNs": 1250,
+                  "cachedNativeExecutionTotalNs": 74768250,
+                  "cachedNativeExecutionPerCallNs": 747682,
+                  "boundaryArgumentsNs": 4750,
+                  "vmSetupNs": 34875,
+                  "pureExecutionNs": 165708,
+                  "boundaryResultNs": 292,
+                  "calxOneShotNs": 206625,
+                  "hotExecutionTotalNs": 14079917,
+                  "hotExecutionPerCallNs": 140799
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 112789500,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 375792,
+                "calcitFrontendNs": 596750,
+                "snapshotCloneNs": 2333,
+                "compile": {
+                  "eligibilityNs": 60583,
+                  "planningNs": 41458,
+                  "programConstructionNs": 71833,
+                  "validationLoweringNs": 20959,
+                  "totalNs": 201000
+                },
+                "runtime": {
+                  "nativeCallNs": 790709,
+                  "cachedNativeResolutionNs": 1292,
+                  "cachedNativeExecutionTotalNs": 73630000,
+                  "cachedNativeExecutionPerCallNs": 736300,
+                  "boundaryArgumentsNs": 4792,
+                  "vmSetupNs": 19541,
+                  "pureExecutionNs": 161584,
+                  "boundaryResultNs": 209,
+                  "calxOneShotNs": 187125,
+                  "hotExecutionTotalNs": 14779750,
+                  "hotExecutionPerCallNs": 147797
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 130984833,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 453417,
+                "calcitFrontendNs": 651125,
+                "snapshotCloneNs": 2166,
+                "compile": {
+                  "eligibilityNs": 60291,
+                  "planningNs": 44083,
+                  "programConstructionNs": 72625,
+                  "validationLoweringNs": 19417,
+                  "totalNs": 202792
+                },
+                "runtime": {
+                  "nativeCallNs": 782959,
+                  "cachedNativeResolutionNs": 1292,
+                  "cachedNativeExecutionTotalNs": 88802000,
+                  "cachedNativeExecutionPerCallNs": 888020,
+                  "boundaryArgumentsNs": 5208,
+                  "vmSetupNs": 22625,
+                  "pureExecutionNs": 165875,
                   "boundaryResultNs": 125,
-                  "calxOneShotNs": 149167,
-                  "hotExecutionTotalNs": 13403000,
-                  "hotExecutionPerCallNs": 134030
+                  "calxOneShotNs": 194833,
+                  "hotExecutionTotalNs": 14463834,
+                  "hotExecutionPerCallNs": 144638
                 },
                 "program": {
                   "functions": 1,
@@ -1998,11 +2096,11 @@
               }
             },
             {
-              "processWallNs": 21427750,
+              "processWallNs": 121455417,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -2013,25 +2111,79 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 352375,
-                "calcitFrontendNs": 530125,
-                "snapshotCloneNs": 1500,
+                "fixtureInstallNs": 405750,
+                "calcitFrontendNs": 627709,
+                "snapshotCloneNs": 2834,
                 "compile": {
-                  "eligibilityNs": 48542,
-                  "planningNs": 31875,
-                  "programConstructionNs": 59208,
-                  "validationLoweringNs": 14542,
-                  "totalNs": 160459
+                  "eligibilityNs": 65375,
+                  "planningNs": 42083,
+                  "programConstructionNs": 78333,
+                  "validationLoweringNs": 20792,
+                  "totalNs": 213000
                 },
                 "runtime": {
-                  "nativeCallNs": 761500,
-                  "boundaryArgumentsNs": 2333,
-                  "vmSetupNs": 3375,
-                  "pureExecutionNs": 143375,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 149666,
-                  "hotExecutionTotalNs": 13390125,
-                  "hotExecutionPerCallNs": 133901
+                  "nativeCallNs": 799709,
+                  "cachedNativeResolutionNs": 1375,
+                  "cachedNativeExecutionTotalNs": 80708208,
+                  "cachedNativeExecutionPerCallNs": 807082,
+                  "boundaryArgumentsNs": 4708,
+                  "vmSetupNs": 19750,
+                  "pureExecutionNs": 155833,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 181458,
+                  "hotExecutionTotalNs": 14443125,
+                  "hotExecutionPerCallNs": 144431
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 118111792,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 406459,
+                "calcitFrontendNs": 610583,
+                "snapshotCloneNs": 2333,
+                "compile": {
+                  "eligibilityNs": 63750,
+                  "planningNs": 41625,
+                  "programConstructionNs": 70500,
+                  "validationLoweringNs": 19333,
+                  "totalNs": 201708
+                },
+                "runtime": {
+                  "nativeCallNs": 935375,
+                  "cachedNativeResolutionNs": 4417,
+                  "cachedNativeExecutionTotalNs": 78235000,
+                  "cachedNativeExecutionPerCallNs": 782350,
+                  "boundaryArgumentsNs": 4833,
+                  "vmSetupNs": 22167,
+                  "pureExecutionNs": 169209,
+                  "boundaryResultNs": 209,
+                  "calxOneShotNs": 197458,
+                  "hotExecutionTotalNs": 14007541,
+                  "hotExecutionPerCallNs": 140075
                 },
                 "program": {
                   "functions": 1,
@@ -2061,55 +2213,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 2127819083,
-              "fixtureInstallNs": 392708,
-              "calcitFrontendNs": 618583,
-              "snapshotCloneNs": 2333,
-              "eligibilityNs": 60750,
-              "planningNs": 39584,
-              "programConstructionNs": 67292,
-              "validationLoweringNs": 21500,
-              "calxCompileTotalNs": 196208,
-              "nativeCallNs": 87657667,
-              "boundaryArgumentsNs": 4667,
-              "vmSetupNs": 7750,
-              "pureExecutionNs": 16833209,
-              "boundaryResultNs": 125,
-              "calxOneShotNs": 16845208,
-              "hotExecutionPerCallNs": 16802192
+              "processWallNs": 13528825125,
+              "fixtureInstallNs": 424917,
+              "calcitFrontendNs": 656292,
+              "snapshotCloneNs": 2250,
+              "eligibilityNs": 69167,
+              "planningNs": 42875,
+              "programConstructionNs": 76875,
+              "validationLoweringNs": 20208,
+              "calxCompileTotalNs": 221666,
+              "nativeCallNs": 91734916,
+              "cachedNativeResolutionNs": 4875,
+              "cachedNativeExecutionTotalNs": 9351125791,
+              "cachedNativeExecutionPerCallNs": 93511257,
+              "boundaryArgumentsNs": 5250,
+              "vmSetupNs": 26250,
+              "pureExecutionNs": 17330625,
+              "boundaryResultNs": 250,
+              "calxOneShotNs": 17376375,
+              "hotExecutionTotalNs": 1745819458,
+              "hotExecutionPerCallNs": 17458194
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 4808250,
-              "fixtureInstallNs": 13917,
-              "calcitFrontendNs": 20166,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 2209,
-              "planningNs": 1001,
-              "programConstructionNs": 2375,
-              "validationLoweringNs": 709,
-              "calxCompileTotalNs": 5541,
-              "nativeCallNs": 148459,
-              "boundaryArgumentsNs": 1417,
-              "vmSetupNs": 1458,
-              "pureExecutionNs": 30750,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 30708,
-              "hotExecutionPerCallNs": 32725
+              "processWallNs": 98250500,
+              "fixtureInstallNs": 7125,
+              "calcitFrontendNs": 12250,
+              "snapshotCloneNs": 84,
+              "eligibilityNs": 3250,
+              "planningNs": 2667,
+              "programConstructionNs": 3250,
+              "validationLoweringNs": 1749,
+              "calxCompileTotalNs": 5666,
+              "nativeCallNs": 367625,
+              "cachedNativeResolutionNs": 667,
+              "cachedNativeExecutionTotalNs": 101794583,
+              "cachedNativeExecutionPerCallNs": 1017945,
+              "boundaryArgumentsNs": 416,
+              "vmSetupNs": 5125,
+              "pureExecutionNs": 40917,
+              "boundaryResultNs": 209,
+              "calxOneShotNs": 57333,
+              "hotExecutionTotalNs": 9861958,
+              "hotExecutionPerCallNs": 98619
             },
             "derived": {
-              "nativeEndToEndNs": 88668958,
-              "calxEndToEndNs": 18055040,
-              "hotVsNativeRatio": 0.1916796622022806,
-              "oneShotEndToEndRatio": 0.20362300862946872
+              "lookupNativeEndToEndNs": 92816125,
+              "calxEndToEndNs": 18681500,
+              "calxHotVsLookupNativeRatio": 0.1903113314018841,
+              "calxHotVsCachedNativeRatio": 0.18669617498564905,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.20127429366395116
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 2132627333,
+              "processWallNs": 13559309792,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -2120,265 +2281,28 @@
                 "size": 20,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 392708,
-                "calcitFrontendNs": 668542,
-                "snapshotCloneNs": 2333,
-                "compile": {
-                  "eligibilityNs": 65250,
-                  "planningNs": 39584,
-                  "programConstructionNs": 69667,
-                  "validationLoweringNs": 21500,
-                  "totalNs": 202667
-                },
-                "runtime": {
-                  "nativeCallNs": 87727708,
-                  "boundaryArgumentsNs": 8416,
-                  "vmSetupNs": 13125,
-                  "pureExecutionNs": 16919792,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 16942500,
-                  "hotExecutionTotalNs": 1685768917,
-                  "hotExecutionPerCallNs": 16857689
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2117179542,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 394166,
-                "calcitFrontendNs": 618583,
-                "snapshotCloneNs": 2208,
-                "compile": {
-                  "eligibilityNs": 61708,
-                  "planningNs": 43125,
-                  "programConstructionNs": 66667,
-                  "validationLoweringNs": 20625,
-                  "totalNs": 198833
-                },
-                "runtime": {
-                  "nativeCallNs": 89216542,
-                  "boundaryArgumentsNs": 7917,
-                  "vmSetupNs": 14958,
-                  "pureExecutionNs": 16663542,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 16687416,
-                  "hotExecutionTotalNs": 1671208250,
-                  "hotExecutionPerCallNs": 16712082
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2144791250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 405959,
-                "calcitFrontendNs": 672833,
-                "snapshotCloneNs": 2333,
-                "compile": {
-                  "eligibilityNs": 57625,
-                  "planningNs": 39500,
-                  "programConstructionNs": 67292,
-                  "validationLoweringNs": 20042,
-                  "totalNs": 190667
-                },
-                "runtime": {
-                  "nativeCallNs": 87602083,
-                  "boundaryArgumentsNs": 3250,
-                  "vmSetupNs": 8084,
-                  "pureExecutionNs": 16833209,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 16845208,
-                  "hotExecutionTotalNs": 1691941667,
-                  "hotExecutionPerCallNs": 16919416
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2127819083,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 406625,
-                "calcitFrontendNs": 620166,
-                "snapshotCloneNs": 2041,
-                "compile": {
-                  "eligibilityNs": 60750,
-                  "planningNs": 45291,
-                  "programConstructionNs": 62125,
-                  "validationLoweringNs": 20250,
-                  "totalNs": 194958
-                },
-                "runtime": {
-                  "nativeCallNs": 87509208,
-                  "boundaryArgumentsNs": 3250,
-                  "vmSetupNs": 7500,
-                  "pureExecutionNs": 16802459,
-                  "boundaryResultNs": 667,
-                  "calxOneShotNs": 16814500,
-                  "hotExecutionTotalNs": 1680219208,
-                  "hotExecutionPerCallNs": 16802192
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2143428500,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 373459,
-                "calcitFrontendNs": 598708,
-                "snapshotCloneNs": 2375,
-                "compile": {
-                  "eligibilityNs": 60916,
-                  "planningNs": 39625,
-                  "programConstructionNs": 67292,
-                  "validationLoweringNs": 22209,
-                  "totalNs": 196208
-                },
-                "runtime": {
-                  "nativeCallNs": 88233041,
-                  "boundaryArgumentsNs": 4667,
-                  "vmSetupNs": 6292,
-                  "pureExecutionNs": 17325084,
-                  "boundaryResultNs": 542,
-                  "calxOneShotNs": 17337334,
-                  "hotExecutionTotalNs": 1683491709,
-                  "hotExecutionPerCallNs": 16834917
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2126132791,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 365208,
-                "calcitFrontendNs": 585916,
+                "fixtureInstallNs": 427542,
+                "calcitFrontendNs": 680250,
                 "snapshotCloneNs": 2250,
                 "compile": {
-                  "eligibilityNs": 58541,
-                  "planningNs": 38458,
-                  "programConstructionNs": 63583,
-                  "validationLoweringNs": 22125,
-                  "totalNs": 188917
+                  "eligibilityNs": 63542,
+                  "planningNs": 41875,
+                  "programConstructionNs": 74000,
+                  "validationLoweringNs": 19750,
+                  "totalNs": 205500
                 },
                 "runtime": {
-                  "nativeCallNs": 87657667,
-                  "boundaryArgumentsNs": 3667,
-                  "vmSetupNs": 7750,
-                  "pureExecutionNs": 16853333,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 16865500,
-                  "hotExecutionTotalNs": 1677595292,
-                  "hotExecutionPerCallNs": 16775952
+                  "nativeCallNs": 91161833,
+                  "cachedNativeResolutionNs": 6375,
+                  "cachedNativeExecutionTotalNs": 9416090000,
+                  "cachedNativeExecutionPerCallNs": 94160900,
+                  "boundaryArgumentsNs": 5666,
+                  "vmSetupNs": 35625,
+                  "pureExecutionNs": 17541125,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 17583500,
+                  "hotExecutionTotalNs": 1751990750,
+                  "hotExecutionPerCallNs": 17519907
                 },
                 "program": {
                   "functions": 1,
@@ -2393,11 +2317,11 @@
               }
             },
             {
-              "processWallNs": 2124421959,
+              "processWallNs": 13528825125,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -2408,25 +2332,283 @@
                 "size": 20,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 373750,
-                "calcitFrontendNs": 598417,
-                "snapshotCloneNs": 2375,
+                "fixtureInstallNs": 421292,
+                "calcitFrontendNs": 654500,
+                "snapshotCloneNs": 2209,
                 "compile": {
-                  "eligibilityNs": 58250,
-                  "planningNs": 38583,
-                  "programConstructionNs": 89583,
-                  "validationLoweringNs": 21833,
-                  "totalNs": 214583
+                  "eligibilityNs": 72417,
+                  "planningNs": 46416,
+                  "programConstructionNs": 82625,
+                  "validationLoweringNs": 18250,
+                  "totalNs": 225625
                 },
                 "runtime": {
-                  "nativeCallNs": 87361458,
-                  "boundaryArgumentsNs": 5125,
-                  "vmSetupNs": 4875,
-                  "pureExecutionNs": 16804500,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 16815000,
-                  "hotExecutionTotalNs": 1678590833,
-                  "hotExecutionPerCallNs": 16785908
+                  "nativeCallNs": 91696958,
+                  "cachedNativeResolutionNs": 4792,
+                  "cachedNativeExecutionTotalNs": 9351125791,
+                  "cachedNativeExecutionPerCallNs": 93511257,
+                  "boundaryArgumentsNs": 5250,
+                  "vmSetupNs": 21125,
+                  "pureExecutionNs": 17499791,
+                  "boundaryResultNs": 750,
+                  "calxOneShotNs": 17528375,
+                  "hotExecutionTotalNs": 1735957500,
+                  "hotExecutionPerCallNs": 17359575
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 13629562917,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 417792,
+                "calcitFrontendNs": 644042,
+                "snapshotCloneNs": 2000,
+                "compile": {
+                  "eligibilityNs": 67667,
+                  "planningNs": 42500,
+                  "programConstructionNs": 76875,
+                  "validationLoweringNs": 23000,
+                  "totalNs": 216000
+                },
+                "runtime": {
+                  "nativeCallNs": 91734916,
+                  "cachedNativeResolutionNs": 3250,
+                  "cachedNativeExecutionTotalNs": 9507895667,
+                  "cachedNativeExecutionPerCallNs": 95078956,
+                  "boundaryArgumentsNs": 17958,
+                  "vmSetupNs": 26375,
+                  "pureExecutionNs": 17330625,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 17376375,
+                  "hotExecutionTotalNs": 1730505125,
+                  "hotExecutionPerCallNs": 17305051
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 14205113541,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 447667,
+                "calcitFrontendNs": 660708,
+                "snapshotCloneNs": 2458,
+                "compile": {
+                  "eligibilityNs": 74958,
+                  "planningNs": 42875,
+                  "programConstructionNs": 84375,
+                  "validationLoweringNs": 22084,
+                  "totalNs": 230375
+                },
+                "runtime": {
+                  "nativeCallNs": 91670625,
+                  "cachedNativeResolutionNs": 4667,
+                  "cachedNativeExecutionTotalNs": 9954736417,
+                  "cachedNativeExecutionPerCallNs": 99547364,
+                  "boundaryArgumentsNs": 4792,
+                  "vmSetupNs": 31459,
+                  "pureExecutionNs": 17844166,
+                  "boundaryResultNs": 1709,
+                  "calxOneShotNs": 17883583,
+                  "hotExecutionTotalNs": 1745819458,
+                  "hotExecutionPerCallNs": 17458194
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 13400857208,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 435709,
+                "calcitFrontendNs": 669917,
+                "snapshotCloneNs": 2375,
+                "compile": {
+                  "eligibilityNs": 69459,
+                  "planningNs": 50917,
+                  "programConstructionNs": 80125,
+                  "validationLoweringNs": 20208,
+                  "totalNs": 227042
+                },
+                "runtime": {
+                  "nativeCallNs": 92102541,
+                  "cachedNativeResolutionNs": 5792,
+                  "cachedNativeExecutionTotalNs": 9249331208,
+                  "cachedNativeExecutionPerCallNs": 92493312,
+                  "boundaryArgumentsNs": 4791,
+                  "vmSetupNs": 26250,
+                  "pureExecutionNs": 17326125,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 17358250,
+                  "hotExecutionTotalNs": 1742878042,
+                  "hotExecutionPerCallNs": 17428780
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 13430574625,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 424917,
+                "calcitFrontendNs": 656292,
+                "snapshotCloneNs": 2292,
+                "compile": {
+                  "eligibilityNs": 69167,
+                  "planningNs": 46083,
+                  "programConstructionNs": 74541,
+                  "validationLoweringNs": 21542,
+                  "totalNs": 221666
+                },
+                "runtime": {
+                  "nativeCallNs": 93058625,
+                  "cachedNativeResolutionNs": 5542,
+                  "cachedNativeExecutionTotalNs": 9225628542,
+                  "cachedNativeExecutionPerCallNs": 92256285,
+                  "boundaryArgumentsNs": 5583,
+                  "vmSetupNs": 22541,
+                  "pureExecutionNs": 17289708,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 17319042,
+                  "hotExecutionTotalNs": 1769603083,
+                  "hotExecutionPerCallNs": 17696030
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 13476531458,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 396667,
+                "calcitFrontendNs": 602083,
+                "snapshotCloneNs": 2166,
+                "compile": {
+                  "eligibilityNs": 60875,
+                  "planningNs": 40208,
+                  "programConstructionNs": 69333,
+                  "validationLoweringNs": 18459,
+                  "totalNs": 195125
+                },
+                "runtime": {
+                  "nativeCallNs": 92169709,
+                  "cachedNativeResolutionNs": 4875,
+                  "cachedNativeExecutionTotalNs": 9271672375,
+                  "cachedNativeExecutionPerCallNs": 92716723,
+                  "boundaryArgumentsNs": 5083,
+                  "vmSetupNs": 16542,
+                  "pureExecutionNs": 17329208,
+                  "boundaryResultNs": 541,
+                  "calxOneShotNs": 17352875,
+                  "hotExecutionTotalNs": 1776148500,
+                  "hotExecutionPerCallNs": 17761485
                 },
                 "program": {
                   "functions": 1,
@@ -2456,1276 +2638,103 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 3923417,
-              "fixtureInstallNs": 333125,
-              "calcitFrontendNs": 566875,
-              "snapshotCloneNs": 1292,
-              "eligibilityNs": 46750,
-              "planningNs": 32625,
-              "programConstructionNs": 56042,
-              "validationLoweringNs": 11959,
-              "calxCompileTotalNs": 151958,
-              "nativeCallNs": 28208,
-              "boundaryArgumentsNs": 2375,
-              "vmSetupNs": 3084,
-              "pureExecutionNs": 5625,
+              "processWallNs": 5489916,
+              "fixtureInstallNs": 349291,
+              "calcitFrontendNs": 611625,
+              "snapshotCloneNs": 1417,
+              "eligibilityNs": 48083,
+              "planningNs": 33792,
+              "programConstructionNs": 61000,
+              "validationLoweringNs": 10291,
+              "calxCompileTotalNs": 156708,
+              "nativeCallNs": 28917,
+              "cachedNativeResolutionNs": 1125,
+              "cachedNativeExecutionTotalNs": 514708,
+              "cachedNativeExecutionPerCallNs": 5147,
+              "boundaryArgumentsNs": 4917,
+              "vmSetupNs": 3333,
+              "pureExecutionNs": 6750,
               "boundaryResultNs": 125,
-              "calxOneShotNs": 11666,
-              "hotExecutionPerCallNs": 928
+              "calxOneShotNs": 16458,
+              "hotExecutionTotalNs": 93625,
+              "hotExecutionPerCallNs": 936
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 17833,
-              "fixtureInstallNs": 1292,
-              "calcitFrontendNs": 4709,
+              "processWallNs": 63666,
+              "fixtureInstallNs": 2750,
+              "calcitFrontendNs": 5459,
               "snapshotCloneNs": 41,
-              "eligibilityNs": 1000,
-              "planningNs": 42,
-              "programConstructionNs": 292,
-              "validationLoweringNs": 167,
-              "calxCompileTotalNs": 1541,
-              "nativeCallNs": 833,
-              "boundaryArgumentsNs": 42,
-              "vmSetupNs": 125,
-              "pureExecutionNs": 167,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 167,
-              "hotExecutionPerCallNs": 9
-            },
-            "derived": {
-              "nativeEndToEndNs": 928208,
-              "calxEndToEndNs": 1064916,
-              "hotVsNativeRatio": 0.032898468519568916,
-              "oneShotEndToEndRatio": 1.1472816437695
-            }
-          },
-          "rawSamples": [
-            {
-              "processWallNs": 3976708,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 337708,
-                "calcitFrontendNs": 571584,
-                "snapshotCloneNs": 1292,
-                "compile": {
-                  "eligibilityNs": 47750,
-                  "planningNs": 32625,
-                  "programConstructionNs": 55750,
-                  "validationLoweringNs": 11792,
-                  "totalNs": 152833
-                },
-                "runtime": {
-                  "nativeCallNs": 28208,
-                  "boundaryArgumentsNs": 2459,
-                  "vmSetupNs": 2959,
-                  "pureExecutionNs": 5792,
-                  "boundaryResultNs": 208,
-                  "calxOneShotNs": 11833,
-                  "hotExecutionTotalNs": 91958,
-                  "hotExecutionPerCallNs": 919
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3920792,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 337250,
-                "calcitFrontendNs": 566875,
-                "snapshotCloneNs": 1209,
-                "compile": {
-                  "eligibilityNs": 46292,
-                  "planningNs": 32666,
-                  "programConstructionNs": 56292,
-                  "validationLoweringNs": 11959,
-                  "totalNs": 151958
-                },
-                "runtime": {
-                  "nativeCallNs": 28084,
-                  "boundaryArgumentsNs": 2333,
-                  "vmSetupNs": 2917,
-                  "pureExecutionNs": 6083,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 11875,
-                  "hotExecutionTotalNs": 93041,
-                  "hotExecutionPerCallNs": 930
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3904792,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 334417,
-                "calcitFrontendNs": 561875,
-                "snapshotCloneNs": 1291,
-                "compile": {
-                  "eligibilityNs": 46417,
-                  "planningNs": 31875,
-                  "programConstructionNs": 55375,
-                  "validationLoweringNs": 11875,
-                  "totalNs": 150083
-                },
-                "runtime": {
-                  "nativeCallNs": 27375,
-                  "boundaryArgumentsNs": 2417,
-                  "vmSetupNs": 2959,
-                  "pureExecutionNs": 5334,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 11208,
-                  "hotExecutionTotalNs": 93375,
-                  "hotExecutionPerCallNs": 933
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3879083,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 330959,
-                "calcitFrontendNs": 566541,
-                "snapshotCloneNs": 1333,
-                "compile": {
-                  "eligibilityNs": 45459,
-                  "planningNs": 32625,
-                  "programConstructionNs": 56042,
-                  "validationLoweringNs": 11875,
-                  "totalNs": 150417
-                },
-                "runtime": {
-                  "nativeCallNs": 30041,
-                  "boundaryArgumentsNs": 2334,
-                  "vmSetupNs": 3125,
-                  "pureExecutionNs": 5625,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 11666,
-                  "hotExecutionTotalNs": 92875,
-                  "hotExecutionPerCallNs": 928
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3941250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 333125,
-                "calcitFrontendNs": 577916,
-                "snapshotCloneNs": 1375,
-                "compile": {
-                  "eligibilityNs": 48750,
-                  "planningNs": 33792,
-                  "programConstructionNs": 58791,
-                  "validationLoweringNs": 12375,
-                  "totalNs": 158709
-                },
-                "runtime": {
-                  "nativeCallNs": 30375,
-                  "boundaryArgumentsNs": 2625,
-                  "vmSetupNs": 3375,
-                  "pureExecutionNs": 6125,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 12709,
-                  "hotExecutionTotalNs": 96500,
-                  "hotExecutionPerCallNs": 965
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3940917,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 332000,
-                "calcitFrontendNs": 573792,
-                "snapshotCloneNs": 1334,
-                "compile": {
-                  "eligibilityNs": 47833,
-                  "planningNs": 32916,
-                  "programConstructionNs": 56292,
-                  "validationLoweringNs": 12500,
-                  "totalNs": 153917
-                },
-                "runtime": {
-                  "nativeCallNs": 27916,
-                  "boundaryArgumentsNs": 2375,
-                  "vmSetupNs": 3084,
-                  "pureExecutionNs": 5542,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 11583,
-                  "hotExecutionTotalNs": 91250,
-                  "hotExecutionPerCallNs": 912
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3923417,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 332709,
-                "calcitFrontendNs": 566667,
-                "snapshotCloneNs": 1291,
-                "compile": {
-                  "eligibilityNs": 46750,
-                  "planningNs": 32583,
-                  "programConstructionNs": 55292,
-                  "validationLoweringNs": 12209,
-                  "totalNs": 151334
-                },
-                "runtime": {
-                  "nativeCallNs": 29875,
-                  "boundaryArgumentsNs": 2208,
-                  "vmSetupNs": 3250,
-                  "pureExecutionNs": 5500,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 11500,
-                  "hotExecutionTotalNs": 91041,
-                  "hotExecutionPerCallNs": 910
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            }
-          ]
-        },
-        {
-          "kernel": "affine",
-          "size": 1000,
-          "program": {
-            "functions": 2,
-            "imports": 0,
-            "syntaxNodes": 11,
-            "instructions": 11,
-            "diagnosticBytes": 868,
-            "hostBoundaryCallsPerExecution": 0,
-            "reusesVmFramesAndStack": true
-          },
-          "aggregate": {
-            "medians": {
-              "processWallNs": 3995959,
-              "fixtureInstallNs": 335084,
-              "calcitFrontendNs": 576417,
-              "snapshotCloneNs": 1375,
-              "eligibilityNs": 46833,
-              "planningNs": 32542,
-              "programConstructionNs": 55875,
-              "validationLoweringNs": 12250,
-              "calxCompileTotalNs": 151833,
-              "nativeCallNs": 29833,
-              "boundaryArgumentsNs": 2375,
-              "vmSetupNs": 3000,
-              "pureExecutionNs": 5833,
-              "boundaryResultNs": 125,
-              "calxOneShotNs": 11666,
-              "hotExecutionPerCallNs": 915
-            },
-            "medianAbsoluteDeviations": {
-              "processWallNs": 48042,
-              "fixtureInstallNs": 1416,
-              "calcitFrontendNs": 3084,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 208,
-              "planningNs": 250,
-              "programConstructionNs": 542,
-              "validationLoweringNs": 167,
-              "calxCompileTotalNs": 417,
-              "nativeCallNs": 292,
-              "boundaryArgumentsNs": 42,
-              "vmSetupNs": 42,
-              "pureExecutionNs": 124,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 166,
-              "hotExecutionPerCallNs": 4
-            },
-            "derived": {
-              "nativeEndToEndNs": 941334,
-              "calxEndToEndNs": 1076375,
-              "hotVsNativeRatio": 0.030670733751215096,
-              "oneShotEndToEndRatio": 1.143457051376026
-            }
-          },
-          "rawSamples": [
-            {
-              "processWallNs": 3963917,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 334334,
-                "calcitFrontendNs": 570750,
-                "snapshotCloneNs": 1209,
-                "compile": {
-                  "eligibilityNs": 46833,
-                  "planningNs": 32583,
-                  "programConstructionNs": 55333,
-                  "validationLoweringNs": 12250,
-                  "totalNs": 151583
-                },
-                "runtime": {
-                  "nativeCallNs": 30042,
-                  "boundaryArgumentsNs": 2375,
-                  "vmSetupNs": 3083,
-                  "pureExecutionNs": 5583,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 11500,
-                  "hotExecutionTotalNs": 93375,
-                  "hotExecutionPerCallNs": 933
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3947917,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 335250,
-                "calcitFrontendNs": 577667,
-                "snapshotCloneNs": 1375,
-                "compile": {
-                  "eligibilityNs": 47375,
-                  "planningNs": 32292,
-                  "programConstructionNs": 55875,
-                  "validationLoweringNs": 11792,
-                  "totalNs": 151833
-                },
-                "runtime": {
-                  "nativeCallNs": 29833,
-                  "boundaryArgumentsNs": 2084,
-                  "vmSetupNs": 2917,
-                  "pureExecutionNs": 6042,
-                  "boundaryResultNs": 166,
-                  "calxOneShotNs": 11666,
-                  "hotExecutionTotalNs": 91958,
-                  "hotExecutionPerCallNs": 919
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4117334,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 336500,
-                "calcitFrontendNs": 573333,
-                "snapshotCloneNs": 1208,
-                "compile": {
-                  "eligibilityNs": 46750,
-                  "planningNs": 32916,
-                  "programConstructionNs": 58667,
-                  "validationLoweringNs": 12375,
-                  "totalNs": 155125
-                },
-                "runtime": {
-                  "nativeCallNs": 30125,
-                  "boundaryArgumentsNs": 2083,
-                  "vmSetupNs": 3042,
-                  "pureExecutionNs": 5709,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 11375,
-                  "hotExecutionTotalNs": 91375,
-                  "hotExecutionPerCallNs": 913
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3960666,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 329000,
-                "calcitFrontendNs": 571334,
-                "snapshotCloneNs": 1334,
-                "compile": {
-                  "eligibilityNs": 46958,
-                  "planningNs": 32208,
-                  "programConstructionNs": 55750,
-                  "validationLoweringNs": 12083,
-                  "totalNs": 151500
-                },
-                "runtime": {
-                  "nativeCallNs": 30833,
-                  "boundaryArgumentsNs": 2333,
-                  "vmSetupNs": 2958,
-                  "pureExecutionNs": 5750,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 11542,
-                  "hotExecutionTotalNs": 91291,
-                  "hotExecutionPerCallNs": 912
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3995959,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 332584,
-                "calcitFrontendNs": 576417,
-                "snapshotCloneNs": 1417,
-                "compile": {
-                  "eligibilityNs": 46625,
-                  "planningNs": 32542,
-                  "programConstructionNs": 56125,
-                  "validationLoweringNs": 12334,
-                  "totalNs": 152250
-                },
-                "runtime": {
-                  "nativeCallNs": 28209,
-                  "boundaryArgumentsNs": 2375,
-                  "vmSetupNs": 3000,
-                  "pureExecutionNs": 5875,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 11750,
-                  "hotExecutionTotalNs": 90625,
-                  "hotExecutionPerCallNs": 906
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4250334,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 356167,
-                "calcitFrontendNs": 623125,
-                "snapshotCloneNs": 1583,
-                "compile": {
-                  "eligibilityNs": 49708,
-                  "planningNs": 38958,
-                  "programConstructionNs": 65291,
-                  "validationLoweringNs": 14083,
-                  "totalNs": 173000
-                },
-                "runtime": {
-                  "nativeCallNs": 29042,
-                  "boundaryArgumentsNs": 2500,
-                  "vmSetupNs": 3542,
-                  "pureExecutionNs": 6583,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 13250,
-                  "hotExecutionTotalNs": 92416,
-                  "hotExecutionPerCallNs": 924
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4146250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 335084,
-                "calcitFrontendNs": 577625,
-                "snapshotCloneNs": 1375,
-                "compile": {
-                  "eligibilityNs": 45750,
-                  "planningNs": 32500,
-                  "programConstructionNs": 55250,
-                  "validationLoweringNs": 12000,
-                  "totalNs": 150000
-                },
-                "runtime": {
-                  "nativeCallNs": 29542,
-                  "boundaryArgumentsNs": 2417,
-                  "vmSetupNs": 3000,
-                  "pureExecutionNs": 5833,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 11834,
-                  "hotExecutionTotalNs": 91583,
-                  "hotExecutionPerCallNs": 915
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            }
-          ]
-        },
-        {
-          "kernel": "polynomial",
-          "size": 10,
-          "program": {
-            "functions": 1,
-            "imports": 0,
-            "syntaxNodes": 11,
-            "instructions": 11,
-            "diagnosticBytes": 743,
-            "hostBoundaryCallsPerExecution": 0,
-            "reusesVmFramesAndStack": true
-          },
-          "aggregate": {
-            "medians": {
-              "processWallNs": 3754250,
-              "fixtureInstallNs": 335375,
-              "calcitFrontendNs": 464958,
-              "snapshotCloneNs": 1209,
-              "eligibilityNs": 33292,
-              "planningNs": 25000,
-              "programConstructionNs": 33375,
-              "validationLoweringNs": 8416,
-              "calxCompileTotalNs": 102958,
-              "nativeCallNs": 26208,
-              "boundaryArgumentsNs": 1958,
-              "vmSetupNs": 2875,
-              "pureExecutionNs": 4667,
-              "boundaryResultNs": 125,
-              "calxOneShotNs": 9917,
-              "hotExecutionPerCallNs": 927
-            },
-            "medianAbsoluteDeviations": {
-              "processWallNs": 9500,
-              "fixtureInstallNs": 3667,
-              "calcitFrontendNs": 708,
-              "snapshotCloneNs": 41,
-              "eligibilityNs": 874,
-              "planningNs": 875,
-              "programConstructionNs": 208,
-              "validationLoweringNs": 124,
-              "calxCompileTotalNs": 792,
-              "nativeCallNs": 208,
-              "boundaryArgumentsNs": 1,
-              "vmSetupNs": 83,
-              "pureExecutionNs": 84,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 42,
-              "hotExecutionPerCallNs": 4
-            },
-            "derived": {
-              "nativeEndToEndNs": 826541,
-              "calxEndToEndNs": 914417,
-              "hotVsNativeRatio": 0.03537087912087912,
-              "oneShotEndToEndRatio": 1.1063177749198165
-            }
-          },
-          "rawSamples": [
-            {
-              "processWallNs": 3754250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 332334,
-                "calcitFrontendNs": 459916,
-                "snapshotCloneNs": 1166,
-                "compile": {
-                  "eligibilityNs": 33125,
-                  "planningNs": 25167,
-                  "programConstructionNs": 32542,
-                  "validationLoweringNs": 8166,
-                  "totalNs": 102166
-                },
-                "runtime": {
-                  "nativeCallNs": 26167,
-                  "boundaryArgumentsNs": 1959,
-                  "vmSetupNs": 2958,
-                  "pureExecutionNs": 4584,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 9917,
-                  "hotExecutionTotalNs": 92667,
-                  "hotExecutionPerCallNs": 926
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3744750,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 337542,
-                "calcitFrontendNs": 464334,
-                "snapshotCloneNs": 1209,
-                "compile": {
-                  "eligibilityNs": 32958,
-                  "planningNs": 23292,
-                  "programConstructionNs": 33167,
-                  "validationLoweringNs": 8375,
-                  "totalNs": 101333
-                },
-                "runtime": {
-                  "nativeCallNs": 26000,
-                  "boundaryArgumentsNs": 1875,
-                  "vmSetupNs": 2875,
-                  "pureExecutionNs": 4625,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 9917,
-                  "hotExecutionTotalNs": 93167,
-                  "hotExecutionPerCallNs": 931
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3761292,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 331042,
-                "calcitFrontendNs": 464250,
-                "snapshotCloneNs": 1250,
-                "compile": {
-                  "eligibilityNs": 34167,
-                  "planningNs": 25875,
-                  "programConstructionNs": 34667,
-                  "validationLoweringNs": 8917,
-                  "totalNs": 107000
-                },
-                "runtime": {
-                  "nativeCallNs": 26750,
-                  "boundaryArgumentsNs": 1958,
-                  "vmSetupNs": 2833,
-                  "pureExecutionNs": 4667,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 9875,
-                  "hotExecutionTotalNs": 93083,
-                  "hotExecutionPerCallNs": 930
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3714125,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 331458,
-                "calcitFrontendNs": 470375,
-                "snapshotCloneNs": 1125,
-                "compile": {
-                  "eligibilityNs": 33292,
-                  "planningNs": 25000,
-                  "programConstructionNs": 33375,
-                  "validationLoweringNs": 8292,
-                  "totalNs": 103583
-                },
-                "runtime": {
-                  "nativeCallNs": 25666,
-                  "boundaryArgumentsNs": 1834,
-                  "vmSetupNs": 2709,
-                  "pureExecutionNs": 4791,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 9791,
-                  "hotExecutionTotalNs": 95500,
-                  "hotExecutionPerCallNs": 955
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3665375,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 339042,
-                "calcitFrontendNs": 464958,
-                "snapshotCloneNs": 1250,
-                "compile": {
-                  "eligibilityNs": 32208,
-                  "planningNs": 25042,
-                  "programConstructionNs": 32667,
-                  "validationLoweringNs": 8416,
-                  "totalNs": 101708
-                },
-                "runtime": {
-                  "nativeCallNs": 26208,
-                  "boundaryArgumentsNs": 1916,
-                  "vmSetupNs": 2958,
-                  "pureExecutionNs": 4583,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 9875,
-                  "hotExecutionTotalNs": 92708,
-                  "hotExecutionPerCallNs": 927
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3900542,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 341500,
-                "calcitFrontendNs": 465084,
-                "snapshotCloneNs": 1375,
-                "compile": {
-                  "eligibilityNs": 34333,
-                  "planningNs": 23667,
-                  "programConstructionNs": 33541,
-                  "validationLoweringNs": 8542,
-                  "totalNs": 103334
-                },
-                "runtime": {
-                  "nativeCallNs": 26333,
-                  "boundaryArgumentsNs": 1958,
-                  "vmSetupNs": 3041,
-                  "pureExecutionNs": 4792,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 10250,
-                  "hotExecutionTotalNs": 91791,
-                  "hotExecutionPerCallNs": 917
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3758084,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 335375,
-                "calcitFrontendNs": 468625,
-                "snapshotCloneNs": 1209,
-                "compile": {
-                  "eligibilityNs": 34166,
-                  "planningNs": 23667,
-                  "programConstructionNs": 33417,
-                  "validationLoweringNs": 8416,
-                  "totalNs": 102958
-                },
-                "runtime": {
-                  "nativeCallNs": 26792,
-                  "boundaryArgumentsNs": 1959,
-                  "vmSetupNs": 2792,
-                  "pureExecutionNs": 4959,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 10125,
-                  "hotExecutionTotalNs": 92375,
-                  "hotExecutionPerCallNs": 923
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            }
-          ]
-        },
-        {
-          "kernel": "polynomial",
-          "size": 1000,
-          "program": {
-            "functions": 1,
-            "imports": 0,
-            "syntaxNodes": 11,
-            "instructions": 11,
-            "diagnosticBytes": 743,
-            "hostBoundaryCallsPerExecution": 0,
-            "reusesVmFramesAndStack": true
-          },
-          "aggregate": {
-            "medians": {
-              "processWallNs": 3728250,
-              "fixtureInstallNs": 338875,
-              "calcitFrontendNs": 468917,
-              "snapshotCloneNs": 1167,
-              "eligibilityNs": 34250,
-              "planningNs": 24084,
-              "programConstructionNs": 33458,
-              "validationLoweringNs": 8333,
-              "calxCompileTotalNs": 102708,
-              "nativeCallNs": 26125,
-              "boundaryArgumentsNs": 1958,
-              "vmSetupNs": 2833,
-              "pureExecutionNs": 4625,
-              "boundaryResultNs": 84,
-              "calxOneShotNs": 9750,
-              "hotExecutionPerCallNs": 924
-            },
-            "medianAbsoluteDeviations": {
-              "processWallNs": 26292,
-              "fixtureInstallNs": 7875,
-              "calcitFrontendNs": 5750,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 375,
-              "planningNs": 959,
-              "programConstructionNs": 250,
+              "eligibilityNs": 2874,
+              "planningNs": 1209,
+              "programConstructionNs": 1417,
               "validationLoweringNs": 208,
-              "calxCompileTotalNs": 1042,
-              "nativeCallNs": 209,
-              "boundaryArgumentsNs": 41,
-              "vmSetupNs": 83,
-              "pureExecutionNs": 125,
-              "boundaryResultNs": 1,
-              "calxOneShotNs": 83,
+              "calxCompileTotalNs": 9208,
+              "nativeCallNs": 667,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 1208,
+              "cachedNativeExecutionPerCallNs": 12,
+              "boundaryArgumentsNs": 833,
+              "vmSetupNs": 209,
+              "pureExecutionNs": 83,
+              "boundaryResultNs": 41,
+              "calxOneShotNs": 84,
+              "hotExecutionTotalNs": 625,
               "hotExecutionPerCallNs": 6
             },
             "derived": {
-              "nativeEndToEndNs": 833917,
-              "calxEndToEndNs": 921417,
-              "hotVsNativeRatio": 0.03536842105263158,
-              "oneShotEndToEndRatio": 1.1049265094727654
+              "lookupNativeEndToEndNs": 989833,
+              "calxEndToEndNs": 1135499,
+              "calxHotVsLookupNativeRatio": 0.03236850295673825,
+              "calxHotVsCachedNativeRatio": 0.18185350689722168,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1471621980677549
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 3672792,
+              "processWallNs": 5585000,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
                   "architecture": "aarch64"
                 },
-                "kernel": "polynomial",
+                "kernel": "affine",
                 "workload": "scalar-only",
-                "size": 1000,
+                "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 330709,
-                "calcitFrontendNs": 472750,
-                "snapshotCloneNs": 1125,
+                "fixtureInstallNs": 346541,
+                "calcitFrontendNs": 628875,
+                "snapshotCloneNs": 1292,
                 "compile": {
-                  "eligibilityNs": 34292,
-                  "planningNs": 25250,
-                  "programConstructionNs": 33708,
-                  "validationLoweringNs": 8125,
-                  "totalNs": 104750
+                  "eligibilityNs": 44750,
+                  "planningNs": 32417,
+                  "programConstructionNs": 57625,
+                  "validationLoweringNs": 10167,
+                  "totalNs": 148625
                 },
                 "runtime": {
-                  "nativeCallNs": 26334,
-                  "boundaryArgumentsNs": 1916,
-                  "vmSetupNs": 2792,
-                  "pureExecutionNs": 4625,
+                  "nativeCallNs": 27834,
+                  "cachedNativeResolutionNs": 1084,
+                  "cachedNativeExecutionTotalNs": 513500,
+                  "cachedNativeExecutionPerCallNs": 5135,
+                  "boundaryArgumentsNs": 2333,
+                  "vmSetupNs": 3000,
+                  "pureExecutionNs": 6125,
                   "boundaryResultNs": 83,
-                  "calxOneShotNs": 9750,
-                  "hotExecutionTotalNs": 91834,
-                  "hotExecutionPerCallNs": 918
+                  "calxOneShotNs": 11958,
+                  "hotExecutionTotalNs": 93625,
+                  "hotExecutionPerCallNs": 936
                 },
                 "program": {
-                  "functions": 1,
+                  "functions": 2,
                   "imports": 0,
                   "syntaxNodes": 11,
                   "instructions": 11,
-                  "diagnosticBytes": 743,
+                  "diagnosticBytes": 868,
                   "hostBoundaryCallsPerExecution": 0,
                   "reusesVmFramesAndStack": true
                 },
@@ -3733,47 +2742,50 @@
               }
             },
             {
-              "processWallNs": 3681791,
+              "processWallNs": 5765708,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
                   "architecture": "aarch64"
                 },
-                "kernel": "polynomial",
+                "kernel": "affine",
                 "workload": "scalar-only",
-                "size": 1000,
+                "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 331000,
-                "calcitFrontendNs": 462458,
-                "snapshotCloneNs": 1125,
+                "fixtureInstallNs": 375791,
+                "calcitFrontendNs": 650916,
+                "snapshotCloneNs": 1458,
                 "compile": {
-                  "eligibilityNs": 34208,
-                  "planningNs": 23333,
-                  "programConstructionNs": 33041,
-                  "validationLoweringNs": 8125,
-                  "totalNs": 101833
+                  "eligibilityNs": 50834,
+                  "planningNs": 34542,
+                  "programConstructionNs": 84458,
+                  "validationLoweringNs": 11042,
+                  "totalNs": 184833
                 },
                 "runtime": {
-                  "nativeCallNs": 25833,
-                  "boundaryArgumentsNs": 1958,
-                  "vmSetupNs": 2750,
-                  "pureExecutionNs": 4459,
-                  "boundaryResultNs": 208,
-                  "calxOneShotNs": 9667,
-                  "hotExecutionTotalNs": 92041,
-                  "hotExecutionPerCallNs": 920
+                  "nativeCallNs": 30875,
+                  "cachedNativeResolutionNs": 1167,
+                  "cachedNativeExecutionTotalNs": 537291,
+                  "cachedNativeExecutionPerCallNs": 5372,
+                  "boundaryArgumentsNs": 5416,
+                  "vmSetupNs": 3709,
+                  "pureExecutionNs": 6875,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 16500,
+                  "hotExecutionTotalNs": 93833,
+                  "hotExecutionPerCallNs": 938
                 },
                 "program": {
-                  "functions": 1,
+                  "functions": 2,
                   "imports": 0,
                   "syntaxNodes": 11,
                   "instructions": 11,
-                  "diagnosticBytes": 743,
+                  "diagnosticBytes": 868,
                   "hostBoundaryCallsPerExecution": 0,
                   "reusesVmFramesAndStack": true
                 },
@@ -3781,47 +2793,50 @@
               }
             },
             {
-              "processWallNs": 3728250,
+              "processWallNs": 5465833,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
                   "architecture": "aarch64"
                 },
-                "kernel": "polynomial",
+                "kernel": "affine",
                 "workload": "scalar-only",
-                "size": 1000,
+                "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 353125,
-                "calcitFrontendNs": 463167,
-                "snapshotCloneNs": 1209,
+                "fixtureInstallNs": 361209,
+                "calcitFrontendNs": 611042,
+                "snapshotCloneNs": 1417,
                 "compile": {
-                  "eligibilityNs": 32458,
-                  "planningNs": 25125,
-                  "programConstructionNs": 33458,
-                  "validationLoweringNs": 8250,
-                  "totalNs": 102708
+                  "eligibilityNs": 51834,
+                  "planningNs": 37875,
+                  "programConstructionNs": 60750,
+                  "validationLoweringNs": 11334,
+                  "totalNs": 166583
                 },
                 "runtime": {
-                  "nativeCallNs": 26125,
-                  "boundaryArgumentsNs": 1959,
-                  "vmSetupNs": 2792,
-                  "pureExecutionNs": 4625,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 9833,
-                  "hotExecutionTotalNs": 91833,
-                  "hotExecutionPerCallNs": 918
+                  "nativeCallNs": 28917,
+                  "cachedNativeResolutionNs": 1125,
+                  "cachedNativeExecutionTotalNs": 516917,
+                  "cachedNativeExecutionPerCallNs": 5169,
+                  "boundaryArgumentsNs": 2417,
+                  "vmSetupNs": 3542,
+                  "pureExecutionNs": 6750,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 13250,
+                  "hotExecutionTotalNs": 92166,
+                  "hotExecutionPerCallNs": 921
                 },
                 "program": {
-                  "functions": 1,
+                  "functions": 2,
                   "imports": 0,
                   "syntaxNodes": 11,
                   "instructions": 11,
-                  "diagnosticBytes": 743,
+                  "diagnosticBytes": 868,
                   "hostBoundaryCallsPerExecution": 0,
                   "reusesVmFramesAndStack": true
                 },
@@ -3829,47 +2844,373 @@
               }
             },
             {
-              "processWallNs": 3731542,
+              "processWallNs": 5389625,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
                   "architecture": "aarch64"
                 },
-                "kernel": "polynomial",
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 350125,
+                "calcitFrontendNs": 607875,
+                "snapshotCloneNs": 1417,
+                "compile": {
+                  "eligibilityNs": 43708,
+                  "planningNs": 32583,
+                  "programConstructionNs": 57416,
+                  "validationLoweringNs": 10083,
+                  "totalNs": 147500
+                },
+                "runtime": {
+                  "nativeCallNs": 29042,
+                  "cachedNativeResolutionNs": 1167,
+                  "cachedNativeExecutionTotalNs": 511458,
+                  "cachedNativeExecutionPerCallNs": 5114,
+                  "boundaryArgumentsNs": 5250,
+                  "vmSetupNs": 3209,
+                  "pureExecutionNs": 6667,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 16458,
+                  "hotExecutionTotalNs": 94917,
+                  "hotExecutionPerCallNs": 949
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5517792,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 349291,
+                "calcitFrontendNs": 617084,
+                "snapshotCloneNs": 1417,
+                "compile": {
+                  "eligibilityNs": 48333,
+                  "planningNs": 44500,
+                  "programConstructionNs": 62417,
+                  "validationLoweringNs": 10291,
+                  "totalNs": 169833
+                },
+                "runtime": {
+                  "nativeCallNs": 28834,
+                  "cachedNativeResolutionNs": 1125,
+                  "cachedNativeExecutionTotalNs": 514708,
+                  "cachedNativeExecutionPerCallNs": 5147,
+                  "boundaryArgumentsNs": 5750,
+                  "vmSetupNs": 3292,
+                  "pureExecutionNs": 6875,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 16459,
+                  "hotExecutionTotalNs": 93000,
+                  "hotExecutionPerCallNs": 930
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5489916,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 343625,
+                "calcitFrontendNs": 605750,
+                "snapshotCloneNs": 1459,
+                "compile": {
+                  "eligibilityNs": 45209,
+                  "planningNs": 33792,
+                  "programConstructionNs": 61000,
+                  "validationLoweringNs": 10917,
+                  "totalNs": 155084
+                },
+                "runtime": {
+                  "nativeCallNs": 30667,
+                  "cachedNativeResolutionNs": 1334,
+                  "cachedNativeExecutionTotalNs": 515500,
+                  "cachedNativeExecutionPerCallNs": 5155,
+                  "boundaryArgumentsNs": 4917,
+                  "vmSetupNs": 3667,
+                  "pureExecutionNs": 6667,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 16542,
+                  "hotExecutionTotalNs": 92917,
+                  "hotExecutionPerCallNs": 929
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5426250,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 347500,
+                "calcitFrontendNs": 611625,
+                "snapshotCloneNs": 1458,
+                "compile": {
+                  "eligibilityNs": 48083,
+                  "planningNs": 32667,
+                  "programConstructionNs": 61959,
+                  "validationLoweringNs": 10125,
+                  "totalNs": 156708
+                },
+                "runtime": {
+                  "nativeCallNs": 28250,
+                  "cachedNativeResolutionNs": 1083,
+                  "cachedNativeExecutionTotalNs": 514250,
+                  "cachedNativeExecutionPerCallNs": 5142,
+                  "boundaryArgumentsNs": 2333,
+                  "vmSetupNs": 3333,
+                  "pureExecutionNs": 6792,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 13833,
+                  "hotExecutionTotalNs": 93792,
+                  "hotExecutionPerCallNs": 937
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            }
+          ]
+        },
+        {
+          "kernel": "affine",
+          "size": 1000,
+          "program": {
+            "functions": 2,
+            "imports": 0,
+            "syntaxNodes": 11,
+            "instructions": 11,
+            "diagnosticBytes": 868,
+            "hostBoundaryCallsPerExecution": 0,
+            "reusesVmFramesAndStack": true
+          },
+          "aggregate": {
+            "medians": {
+              "processWallNs": 6108458,
+              "fixtureInstallNs": 411000,
+              "calcitFrontendNs": 758250,
+              "snapshotCloneNs": 2083,
+              "eligibilityNs": 64959,
+              "planningNs": 47584,
+              "programConstructionNs": 90375,
+              "validationLoweringNs": 19542,
+              "calxCompileTotalNs": 234875,
+              "nativeCallNs": 33667,
+              "cachedNativeResolutionNs": 1250,
+              "cachedNativeExecutionTotalNs": 517959,
+              "cachedNativeExecutionPerCallNs": 5179,
+              "boundaryArgumentsNs": 3333,
+              "vmSetupNs": 5916,
+              "pureExecutionNs": 11708,
+              "boundaryResultNs": 167,
+              "calxOneShotNs": 23209,
+              "hotExecutionTotalNs": 97500,
+              "hotExecutionPerCallNs": 975
+            },
+            "medianAbsoluteDeviations": {
+              "processWallNs": 434249,
+              "fixtureInstallNs": 8041,
+              "calcitFrontendNs": 34417,
+              "snapshotCloneNs": 83,
+              "eligibilityNs": 3833,
+              "planningNs": 1625,
+              "programConstructionNs": 13125,
+              "validationLoweringNs": 3000,
+              "calxCompileTotalNs": 20291,
+              "nativeCallNs": 4209,
+              "cachedNativeResolutionNs": 84,
+              "cachedNativeExecutionTotalNs": 4250,
+              "cachedNativeExecutionPerCallNs": 42,
+              "boundaryArgumentsNs": 1000,
+              "vmSetupNs": 1416,
+              "pureExecutionNs": 1959,
+              "boundaryResultNs": 42,
+              "calxOneShotNs": 6167,
+              "hotExecutionTotalNs": 1583,
+              "hotExecutionPerCallNs": 15
+            },
+            "derived": {
+              "lookupNativeEndToEndNs": 1202917,
+              "calxEndToEndNs": 1429417,
+              "calxHotVsLookupNativeRatio": 0.028960109305848455,
+              "calxHotVsCachedNativeRatio": 0.1882602819077042,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1882922928182078
+            }
+          },
+          "rawSamples": [
+            {
+              "processWallNs": 6108458,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
                 "workload": "scalar-only",
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 327917,
-                "calcitFrontendNs": 468917,
-                "snapshotCloneNs": 1208,
+                "fixtureInstallNs": 408250,
+                "calcitFrontendNs": 727458,
+                "snapshotCloneNs": 2000,
                 "compile": {
-                  "eligibilityNs": 34625,
-                  "planningNs": 24084,
-                  "programConstructionNs": 33584,
-                  "validationLoweringNs": 8625,
-                  "totalNs": 104459
+                  "eligibilityNs": 59250,
+                  "planningNs": 58584,
+                  "programConstructionNs": 109125,
+                  "validationLoweringNs": 22542,
+                  "totalNs": 255166
                 },
                 "runtime": {
-                  "nativeCallNs": 26250,
-                  "boundaryArgumentsNs": 1958,
-                  "vmSetupNs": 2958,
-                  "pureExecutionNs": 5333,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 10667,
+                  "nativeCallNs": 49167,
+                  "cachedNativeResolutionNs": 1083,
+                  "cachedNativeExecutionTotalNs": 529708,
+                  "cachedNativeExecutionPerCallNs": 5297,
+                  "boundaryArgumentsNs": 3333,
+                  "vmSetupNs": 5458,
+                  "pureExecutionNs": 13667,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 23209,
+                  "hotExecutionTotalNs": 99083,
+                  "hotExecutionPerCallNs": 990
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5445875,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 364333,
+                "calcitFrontendNs": 595209,
+                "snapshotCloneNs": 1333,
+                "compile": {
+                  "eligibilityNs": 54917,
+                  "planningNs": 33041,
+                  "programConstructionNs": 65291,
+                  "validationLoweringNs": 10958,
+                  "totalNs": 168042
+                },
+                "runtime": {
+                  "nativeCallNs": 29125,
+                  "cachedNativeResolutionNs": 1125,
+                  "cachedNativeExecutionTotalNs": 513709,
+                  "cachedNativeExecutionPerCallNs": 5137,
+                  "boundaryArgumentsNs": 2500,
+                  "vmSetupNs": 3208,
+                  "pureExecutionNs": 7084,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 14209,
                   "hotExecutionTotalNs": 92459,
                   "hotExecutionPerCallNs": 924
                 },
                 "program": {
-                  "functions": 1,
+                  "functions": 2,
                   "imports": 0,
                   "syntaxNodes": 11,
                   "instructions": 11,
-                  "diagnosticBytes": 743,
+                  "diagnosticBytes": 868,
                   "hostBoundaryCallsPerExecution": 0,
                   "reusesVmFramesAndStack": true
                 },
@@ -3877,11 +3218,334 @@
               }
             },
             {
-              "processWallNs": 3889708,
+              "processWallNs": 14292917,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 411000,
+                "calcitFrontendNs": 833458,
+                "snapshotCloneNs": 2083,
+                "compile": {
+                  "eligibilityNs": 68792,
+                  "planningNs": 48917,
+                  "programConstructionNs": 401250,
+                  "validationLoweringNs": 120459,
+                  "totalNs": 658500
+                },
+                "runtime": {
+                  "nativeCallNs": 149625,
+                  "cachedNativeResolutionNs": 3917,
+                  "cachedNativeExecutionTotalNs": 4701000,
+                  "cachedNativeExecutionPerCallNs": 47010,
+                  "boundaryArgumentsNs": 19958,
+                  "vmSetupNs": 16750,
+                  "pureExecutionNs": 16542,
+                  "boundaryResultNs": 333,
+                  "calxOneShotNs": 59334,
+                  "hotExecutionTotalNs": 97625,
+                  "hotExecutionPerCallNs": 976
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 8306833,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 444875,
+                "calcitFrontendNs": 758250,
+                "snapshotCloneNs": 2166,
+                "compile": {
+                  "eligibilityNs": 67875,
+                  "planningNs": 49209,
+                  "programConstructionNs": 90375,
+                  "validationLoweringNs": 19875,
+                  "totalNs": 234875
+                },
+                "runtime": {
+                  "nativeCallNs": 34458,
+                  "cachedNativeResolutionNs": 1333,
+                  "cachedNativeExecutionTotalNs": 534959,
+                  "cachedNativeExecutionPerCallNs": 5349,
+                  "boundaryArgumentsNs": 5666,
+                  "vmSetupNs": 10042,
+                  "pureExecutionNs": 13250,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 29958,
+                  "hotExecutionTotalNs": 99334,
+                  "hotExecutionPerCallNs": 993
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 6022000,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 409375,
+                "calcitFrontendNs": 791375,
+                "snapshotCloneNs": 2208,
+                "compile": {
+                  "eligibilityNs": 64959,
+                  "planningNs": 46834,
+                  "programConstructionNs": 95959,
+                  "validationLoweringNs": 18833,
+                  "totalNs": 234125
+                },
+                "runtime": {
+                  "nativeCallNs": 33667,
+                  "cachedNativeResolutionNs": 1292,
+                  "cachedNativeExecutionTotalNs": 517959,
+                  "cachedNativeExecutionPerCallNs": 5179,
+                  "boundaryArgumentsNs": 3208,
+                  "vmSetupNs": 6375,
+                  "pureExecutionNs": 10750,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 21042,
+                  "hotExecutionTotalNs": 96709,
+                  "hotExecutionPerCallNs": 967
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 6381875,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 480792,
+                "calcitFrontendNs": 792667,
+                "snapshotCloneNs": 2166,
+                "compile": {
+                  "eligibilityNs": 77375,
+                  "planningNs": 47584,
+                  "programConstructionNs": 88917,
+                  "validationLoweringNs": 19542,
+                  "totalNs": 240708
+                },
+                "runtime": {
+                  "nativeCallNs": 30833,
+                  "cachedNativeResolutionNs": 1250,
+                  "cachedNativeExecutionTotalNs": 516833,
+                  "cachedNativeExecutionPerCallNs": 5168,
+                  "boundaryArgumentsNs": 5667,
+                  "vmSetupNs": 5916,
+                  "pureExecutionNs": 11708,
+                  "boundaryResultNs": 375,
+                  "calxOneShotNs": 25084,
+                  "hotExecutionTotalNs": 97500,
+                  "hotExecutionPerCallNs": 975
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5674209,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 419041,
+                "calcitFrontendNs": 692875,
+                "snapshotCloneNs": 1709,
+                "compile": {
+                  "eligibilityNs": 61375,
+                  "planningNs": 43125,
+                  "programConstructionNs": 77250,
+                  "validationLoweringNs": 13291,
+                  "totalNs": 200041
+                },
+                "runtime": {
+                  "nativeCallNs": 29458,
+                  "cachedNativeResolutionNs": 1166,
+                  "cachedNativeExecutionTotalNs": 514334,
+                  "cachedNativeExecutionPerCallNs": 5143,
+                  "boundaryArgumentsNs": 2333,
+                  "vmSetupNs": 4500,
+                  "pureExecutionNs": 9375,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 17042,
+                  "hotExecutionTotalNs": 93042,
+                  "hotExecutionPerCallNs": 930
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            }
+          ]
+        },
+        {
+          "kernel": "polynomial",
+          "size": 10,
+          "program": {
+            "functions": 1,
+            "imports": 0,
+            "syntaxNodes": 11,
+            "instructions": 11,
+            "diagnosticBytes": 743,
+            "hostBoundaryCallsPerExecution": 0,
+            "reusesVmFramesAndStack": true
+          },
+          "aggregate": {
+            "medians": {
+              "processWallNs": 5036625,
+              "fixtureInstallNs": 382125,
+              "calcitFrontendNs": 515000,
+              "snapshotCloneNs": 1791,
+              "eligibilityNs": 38166,
+              "planningNs": 33167,
+              "programConstructionNs": 44875,
+              "validationLoweringNs": 9333,
+              "calxCompileTotalNs": 126125,
+              "nativeCallNs": 33625,
+              "cachedNativeResolutionNs": 1750,
+              "cachedNativeExecutionTotalNs": 124417,
+              "cachedNativeExecutionPerCallNs": 1244,
+              "boundaryArgumentsNs": 1042,
+              "vmSetupNs": 6292,
+              "pureExecutionNs": 6333,
+              "boundaryResultNs": 167,
+              "calxOneShotNs": 14916,
+              "hotExecutionTotalNs": 93625,
+              "hotExecutionPerCallNs": 936
+            },
+            "medianAbsoluteDeviations": {
+              "processWallNs": 210208,
+              "fixtureInstallNs": 20792,
+              "calcitFrontendNs": 45416,
+              "snapshotCloneNs": 458,
+              "eligibilityNs": 2916,
+              "planningNs": 3709,
+              "programConstructionNs": 3583,
+              "validationLoweringNs": 1626,
+              "calxCompileTotalNs": 10667,
+              "nativeCallNs": 2083,
+              "cachedNativeResolutionNs": 125,
+              "cachedNativeExecutionTotalNs": 4375,
+              "cachedNativeExecutionPerCallNs": 44,
+              "boundaryArgumentsNs": 208,
+              "vmSetupNs": 2584,
+              "pureExecutionNs": 1083,
+              "boundaryResultNs": 41,
+              "calxOneShotNs": 4334,
+              "hotExecutionTotalNs": 1667,
+              "hotExecutionPerCallNs": 17
+            },
+            "derived": {
+              "lookupNativeEndToEndNs": 930750,
+              "calxEndToEndNs": 1039957,
+              "calxHotVsLookupNativeRatio": 0.0278364312267658,
+              "calxHotVsCachedNativeRatio": 0.752411575562701,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1173322589309695
+            }
+          },
+          "rawSamples": [
+            {
+              "processWallNs": 5075209,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -3889,28 +3553,31 @@
                 },
                 "kernel": "polynomial",
                 "workload": "scalar-only",
-                "size": 1000,
+                "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 341667,
-                "calcitFrontendNs": 474125,
-                "snapshotCloneNs": 1166,
+                "fixtureInstallNs": 382125,
+                "calcitFrontendNs": 482458,
+                "snapshotCloneNs": 1458,
                 "compile": {
-                  "eligibilityNs": 35166,
-                  "planningNs": 26458,
-                  "programConstructionNs": 34042,
-                  "validationLoweringNs": 8959,
-                  "totalNs": 108125
+                  "eligibilityNs": 36417,
+                  "planningNs": 30916,
+                  "programConstructionNs": 44875,
+                  "validationLoweringNs": 8167,
+                  "totalNs": 124000
                 },
                 "runtime": {
-                  "nativeCallNs": 27458,
-                  "boundaryArgumentsNs": 2000,
-                  "vmSetupNs": 3083,
-                  "pureExecutionNs": 4917,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 10500,
-                  "hotExecutionTotalNs": 95667,
-                  "hotExecutionPerCallNs": 956
+                  "nativeCallNs": 33250,
+                  "cachedNativeResolutionNs": 1750,
+                  "cachedNativeExecutionTotalNs": 119666,
+                  "cachedNativeExecutionPerCallNs": 1196,
+                  "boundaryArgumentsNs": 1250,
+                  "vmSetupNs": 3708,
+                  "pureExecutionNs": 6167,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 11541,
+                  "hotExecutionTotalNs": 91958,
+                  "hotExecutionPerCallNs": 919
                 },
                 "program": {
                   "functions": 1,
@@ -3925,11 +3592,385 @@
               }
             },
             {
-              "processWallNs": 3754542,
+              "processWallNs": 5036625,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 411416,
+                "calcitFrontendNs": 574125,
+                "snapshotCloneNs": 1791,
+                "compile": {
+                  "eligibilityNs": 46958,
+                  "planningNs": 40750,
+                  "programConstructionNs": 72375,
+                  "validationLoweringNs": 10959,
+                  "totalNs": 175500
+                },
+                "runtime": {
+                  "nativeCallNs": 35208,
+                  "cachedNativeResolutionNs": 1625,
+                  "cachedNativeExecutionTotalNs": 128750,
+                  "cachedNativeExecutionPerCallNs": 1287,
+                  "boundaryArgumentsNs": 1500,
+                  "vmSetupNs": 6333,
+                  "pureExecutionNs": 7833,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 16292,
+                  "hotExecutionTotalNs": 95416,
+                  "hotExecutionPerCallNs": 954
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4733458,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 367542,
+                "calcitFrontendNs": 515000,
+                "snapshotCloneNs": 5167,
+                "compile": {
+                  "eligibilityNs": 38166,
+                  "planningNs": 32625,
+                  "programConstructionNs": 41792,
+                  "validationLoweringNs": 8459,
+                  "totalNs": 125250
+                },
+                "runtime": {
+                  "nativeCallNs": 31542,
+                  "cachedNativeResolutionNs": 1917,
+                  "cachedNativeExecutionTotalNs": 124417,
+                  "cachedNativeExecutionPerCallNs": 1244,
+                  "boundaryArgumentsNs": 875,
+                  "vmSetupNs": 7125,
+                  "pureExecutionNs": 6333,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 14916,
+                  "hotExecutionTotalNs": 103209,
+                  "hotExecutionPerCallNs": 1032
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5246833,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 370167,
+                "calcitFrontendNs": 513666,
+                "snapshotCloneNs": 1333,
+                "compile": {
+                  "eligibilityNs": 35833,
+                  "planningNs": 33167,
+                  "programConstructionNs": 44292,
+                  "validationLoweringNs": 9333,
+                  "totalNs": 126125
+                },
+                "runtime": {
+                  "nativeCallNs": 33625,
+                  "cachedNativeResolutionNs": 1583,
+                  "cachedNativeExecutionTotalNs": 120042,
+                  "cachedNativeExecutionPerCallNs": 1200,
+                  "boundaryArgumentsNs": 1042,
+                  "vmSetupNs": 3166,
+                  "pureExecutionNs": 5250,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 9959,
+                  "hotExecutionTotalNs": 93625,
+                  "hotExecutionPerCallNs": 936
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4980834,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 402917,
+                "calcitFrontendNs": 621333,
+                "snapshotCloneNs": 1792,
+                "compile": {
+                  "eligibilityNs": 45833,
+                  "planningNs": 47250,
+                  "programConstructionNs": 59458,
+                  "validationLoweringNs": 17708,
+                  "totalNs": 175750
+                },
+                "runtime": {
+                  "nativeCallNs": 41167,
+                  "cachedNativeResolutionNs": 1750,
+                  "cachedNativeExecutionTotalNs": 121250,
+                  "cachedNativeExecutionPerCallNs": 1212,
+                  "boundaryArgumentsNs": 2750,
+                  "vmSetupNs": 6292,
+                  "pureExecutionNs": 9666,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 19250,
+                  "hotExecutionTotalNs": 97042,
+                  "hotExecutionPerCallNs": 970
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4512459,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 352333,
+                "calcitFrontendNs": 469584,
+                "snapshotCloneNs": 1125,
+                "compile": {
+                  "eligibilityNs": 35250,
+                  "planningNs": 29458,
+                  "programConstructionNs": 41292,
+                  "validationLoweringNs": 6542,
+                  "totalNs": 115458
+                },
+                "runtime": {
+                  "nativeCallNs": 30625,
+                  "cachedNativeResolutionNs": 1334,
+                  "cachedNativeExecutionTotalNs": 143417,
+                  "cachedNativeExecutionPerCallNs": 1434,
+                  "boundaryArgumentsNs": 792,
+                  "vmSetupNs": 3208,
+                  "pureExecutionNs": 5375,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 9792,
+                  "hotExecutionTotalNs": 92292,
+                  "hotExecutionPerCallNs": 922
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5578333,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 431500,
+                "calcitFrontendNs": 656416,
+                "snapshotCloneNs": 3500,
+                "compile": {
+                  "eligibilityNs": 62791,
+                  "planningNs": 64042,
+                  "programConstructionNs": 69125,
+                  "validationLoweringNs": 16000,
+                  "totalNs": 219583
+                },
+                "runtime": {
+                  "nativeCallNs": 83125,
+                  "cachedNativeResolutionNs": 1833,
+                  "cachedNativeExecutionTotalNs": 137583,
+                  "cachedNativeExecutionPerCallNs": 1375,
+                  "boundaryArgumentsNs": 1000,
+                  "vmSetupNs": 9250,
+                  "pureExecutionNs": 13125,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 24042,
+                  "hotExecutionTotalNs": 93000,
+                  "hotExecutionPerCallNs": 930
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            }
+          ]
+        },
+        {
+          "kernel": "polynomial",
+          "size": 1000,
+          "program": {
+            "functions": 1,
+            "imports": 0,
+            "syntaxNodes": 11,
+            "instructions": 11,
+            "diagnosticBytes": 743,
+            "hostBoundaryCallsPerExecution": 0,
+            "reusesVmFramesAndStack": true
+          },
+          "aggregate": {
+            "medians": {
+              "processWallNs": 4945959,
+              "fixtureInstallNs": 412459,
+              "calcitFrontendNs": 540166,
+              "snapshotCloneNs": 1583,
+              "eligibilityNs": 37417,
+              "planningNs": 33375,
+              "programConstructionNs": 42041,
+              "validationLoweringNs": 8250,
+              "calxCompileTotalNs": 123250,
+              "nativeCallNs": 30709,
+              "cachedNativeResolutionNs": 1459,
+              "cachedNativeExecutionTotalNs": 121375,
+              "cachedNativeExecutionPerCallNs": 1213,
+              "boundaryArgumentsNs": 1000,
+              "vmSetupNs": 3583,
+              "pureExecutionNs": 5667,
+              "boundaryResultNs": 166,
+              "calxOneShotNs": 10458,
+              "hotExecutionTotalNs": 93875,
+              "hotExecutionPerCallNs": 938
+            },
+            "medianAbsoluteDeviations": {
+              "processWallNs": 392500,
+              "fixtureInstallNs": 53376,
+              "calcitFrontendNs": 67792,
+              "snapshotCloneNs": 291,
+              "eligibilityNs": 4001,
+              "planningNs": 5583,
+              "programConstructionNs": 6125,
+              "validationLoweringNs": 1209,
+              "calxCompileTotalNs": 18667,
+              "nativeCallNs": 2959,
+              "cachedNativeResolutionNs": 124,
+              "cachedNativeExecutionTotalNs": 792,
+              "cachedNativeExecutionPerCallNs": 8,
+              "boundaryArgumentsNs": 250,
+              "vmSetupNs": 375,
+              "pureExecutionNs": 501,
+              "boundaryResultNs": 83,
+              "calxOneShotNs": 750,
+              "hotExecutionTotalNs": 666,
+              "hotExecutionPerCallNs": 6
+            },
+            "derived": {
+              "lookupNativeEndToEndNs": 983334,
+              "calxEndToEndNs": 1087916,
+              "calxHotVsLookupNativeRatio": 0.030544791429222704,
+              "calxHotVsCachedNativeRatio": 0.7732893652102226,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1063545041664378
+            }
+          },
+          "rawSamples": [
+            {
+              "processWallNs": 5647125,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -3940,25 +3981,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 339625,
-                "calcitFrontendNs": 474875,
+                "fixtureInstallNs": 415833,
+                "calcitFrontendNs": 607958,
                 "snapshotCloneNs": 1167,
                 "compile": {
-                  "eligibilityNs": 33583,
-                  "planningNs": 23125,
-                  "programConstructionNs": 33292,
-                  "validationLoweringNs": 8333,
-                  "totalNs": 101666
+                  "eligibilityNs": 35792,
+                  "planningNs": 33375,
+                  "programConstructionNs": 37250,
+                  "validationLoweringNs": 7041,
+                  "totalNs": 116000
                 },
                 "runtime": {
-                  "nativeCallNs": 26042,
-                  "boundaryArgumentsNs": 1875,
-                  "vmSetupNs": 2917,
-                  "pureExecutionNs": 4500,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 9750,
-                  "hotExecutionTotalNs": 94250,
-                  "hotExecutionPerCallNs": 942
+                  "nativeCallNs": 29459,
+                  "cachedNativeResolutionNs": 1459,
+                  "cachedNativeExecutionTotalNs": 121375,
+                  "cachedNativeExecutionPerCallNs": 1213,
+                  "boundaryArgumentsNs": 708,
+                  "vmSetupNs": 3583,
+                  "pureExecutionNs": 5541,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 10292,
+                  "hotExecutionTotalNs": 161041,
+                  "hotExecutionPerCallNs": 1610
                 },
                 "program": {
                   "functions": 1,
@@ -3973,11 +4017,11 @@
               }
             },
             {
-              "processWallNs": 3718459,
+              "processWallNs": 4928917,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -3988,25 +4032,283 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 338875,
-                "calcitFrontendNs": 462167,
-                "snapshotCloneNs": 1292,
+                "fixtureInstallNs": 412459,
+                "calcitFrontendNs": 540166,
+                "snapshotCloneNs": 1708,
                 "compile": {
-                  "eligibilityNs": 34250,
-                  "planningNs": 23708,
-                  "programConstructionNs": 32583,
-                  "validationLoweringNs": 8333,
-                  "totalNs": 102125
+                  "eligibilityNs": 41209,
+                  "planningNs": 47000,
+                  "programConstructionNs": 54125,
+                  "validationLoweringNs": 11292,
+                  "totalNs": 158209
                 },
                 "runtime": {
-                  "nativeCallNs": 25667,
-                  "boundaryArgumentsNs": 1917,
-                  "vmSetupNs": 2833,
-                  "pureExecutionNs": 4584,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 9750,
-                  "hotExecutionTotalNs": 92750,
-                  "hotExecutionPerCallNs": 927
+                  "nativeCallNs": 43208,
+                  "cachedNativeResolutionNs": 1791,
+                  "cachedNativeExecutionTotalNs": 122291,
+                  "cachedNativeExecutionPerCallNs": 1222,
+                  "boundaryArgumentsNs": 3958,
+                  "vmSetupNs": 6000,
+                  "pureExecutionNs": 6958,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 17458,
+                  "hotExecutionTotalNs": 92417,
+                  "hotExecutionPerCallNs": 924
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4624833,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 359083,
+                "calcitFrontendNs": 490375,
+                "snapshotCloneNs": 1292,
+                "compile": {
+                  "eligibilityNs": 31083,
+                  "planningNs": 27792,
+                  "programConstructionNs": 35916,
+                  "validationLoweringNs": 7042,
+                  "totalNs": 104583
+                },
+                "runtime": {
+                  "nativeCallNs": 27750,
+                  "cachedNativeResolutionNs": 1417,
+                  "cachedNativeExecutionTotalNs": 121167,
+                  "cachedNativeExecutionPerCallNs": 1211,
+                  "boundaryArgumentsNs": 833,
+                  "vmSetupNs": 3208,
+                  "pureExecutionNs": 5667,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 10166,
+                  "hotExecutionTotalNs": 93875,
+                  "hotExecutionPerCallNs": 938
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5495208,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 471375,
+                "calcitFrontendNs": 655250,
+                "snapshotCloneNs": 4167,
+                "compile": {
+                  "eligibilityNs": 57542,
+                  "planningNs": 45625,
+                  "programConstructionNs": 75083,
+                  "validationLoweringNs": 31958,
+                  "totalNs": 214292
+                },
+                "runtime": {
+                  "nativeCallNs": 46209,
+                  "cachedNativeResolutionNs": 1333,
+                  "cachedNativeExecutionTotalNs": 121833,
+                  "cachedNativeExecutionPerCallNs": 1218,
+                  "boundaryArgumentsNs": 750,
+                  "vmSetupNs": 3375,
+                  "pureExecutionNs": 5166,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 9708,
+                  "hotExecutionTotalNs": 94000,
+                  "hotExecutionPerCallNs": 940
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5481541,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 440667,
+                "calcitFrontendNs": 613125,
+                "snapshotCloneNs": 2125,
+                "compile": {
+                  "eligibilityNs": 48834,
+                  "planningNs": 42042,
+                  "programConstructionNs": 68292,
+                  "validationLoweringNs": 16667,
+                  "totalNs": 181125
+                },
+                "runtime": {
+                  "nativeCallNs": 44875,
+                  "cachedNativeResolutionNs": 1709,
+                  "cachedNativeExecutionTotalNs": 122375,
+                  "cachedNativeExecutionPerCallNs": 1223,
+                  "boundaryArgumentsNs": 1250,
+                  "vmSetupNs": 6333,
+                  "pureExecutionNs": 9834,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 18042,
+                  "hotExecutionTotalNs": 94834,
+                  "hotExecutionPerCallNs": 948
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4945959,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 359000,
+                "calcitFrontendNs": 494417,
+                "snapshotCloneNs": 1583,
+                "compile": {
+                  "eligibilityNs": 37417,
+                  "planningNs": 32208,
+                  "programConstructionNs": 42041,
+                  "validationLoweringNs": 8250,
+                  "totalNs": 123250
+                },
+                "runtime": {
+                  "nativeCallNs": 30709,
+                  "cachedNativeResolutionNs": 1417,
+                  "cachedNativeExecutionTotalNs": 120292,
+                  "cachedNativeExecutionPerCallNs": 1202,
+                  "boundaryArgumentsNs": 1000,
+                  "vmSetupNs": 3958,
+                  "pureExecutionNs": 6208,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 11709,
+                  "hotExecutionTotalNs": 93875,
+                  "hotExecutionPerCallNs": 938
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4553459,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 342208,
+                "calcitFrontendNs": 472250,
+                "snapshotCloneNs": 1417,
+                "compile": {
+                  "eligibilityNs": 33416,
+                  "planningNs": 30333,
+                  "programConstructionNs": 37958,
+                  "validationLoweringNs": 7917,
+                  "totalNs": 112667
+                },
+                "runtime": {
+                  "nativeCallNs": 29667,
+                  "cachedNativeResolutionNs": 1583,
+                  "cachedNativeExecutionTotalNs": 120583,
+                  "cachedNativeExecutionPerCallNs": 1205,
+                  "boundaryArgumentsNs": 1041,
+                  "vmSetupNs": 3417,
+                  "pureExecutionNs": 5458,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 10458,
+                  "hotExecutionTotalNs": 93209,
+                  "hotExecutionPerCallNs": 932
                 },
                 "program": {
                   "functions": 1,
@@ -4036,55 +4338,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 5235791,
-              "fixtureInstallNs": 346542,
-              "calcitFrontendNs": 517292,
-              "snapshotCloneNs": 1250,
-              "eligibilityNs": 44250,
-              "planningNs": 30833,
-              "programConstructionNs": 56041,
-              "validationLoweringNs": 15459,
-              "calxCompileTotalNs": 152666,
-              "nativeCallNs": 68458,
-              "boundaryArgumentsNs": 2375,
-              "vmSetupNs": 3000,
-              "pureExecutionNs": 16291,
+              "processWallNs": 10875083,
+              "fixtureInstallNs": 434958,
+              "calcitFrontendNs": 632250,
+              "snapshotCloneNs": 2000,
+              "eligibilityNs": 53166,
+              "planningNs": 49125,
+              "programConstructionNs": 89209,
+              "validationLoweringNs": 18250,
+              "calxCompileTotalNs": 218459,
+              "nativeCallNs": 83875,
+              "cachedNativeResolutionNs": 1917,
+              "cachedNativeExecutionTotalNs": 3518000,
+              "cachedNativeExecutionPerCallNs": 35180,
+              "boundaryArgumentsNs": 1250,
+              "vmSetupNs": 5209,
+              "pureExecutionNs": 16167,
               "boundaryResultNs": 125,
-              "calxOneShotNs": 24000,
-              "hotExecutionPerCallNs": 10330
+              "calxOneShotNs": 25500,
+              "hotExecutionTotalNs": 1052250,
+              "hotExecutionPerCallNs": 10522
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 250374,
-              "fixtureInstallNs": 12667,
-              "calcitFrontendNs": 29667,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 5125,
-              "planningNs": 416,
-              "programConstructionNs": 3208,
-              "validationLoweringNs": 1999,
-              "calxCompileTotalNs": 13125,
-              "nativeCallNs": 2500,
-              "boundaryArgumentsNs": 375,
-              "vmSetupNs": 83,
-              "pureExecutionNs": 501,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 750,
-              "hotExecutionPerCallNs": 15
+              "processWallNs": 188334,
+              "fixtureInstallNs": 16249,
+              "calcitFrontendNs": 26458,
+              "snapshotCloneNs": 83,
+              "eligibilityNs": 4959,
+              "planningNs": 1500,
+              "programConstructionNs": 4001,
+              "validationLoweringNs": 2417,
+              "calxCompileTotalNs": 18334,
+              "nativeCallNs": 1667,
+              "cachedNativeResolutionNs": 83,
+              "cachedNativeExecutionTotalNs": 27292,
+              "cachedNativeExecutionPerCallNs": 273,
+              "boundaryArgumentsNs": 250,
+              "vmSetupNs": 1250,
+              "pureExecutionNs": 126,
+              "boundaryResultNs": 0,
+              "calxOneShotNs": 2000,
+              "hotExecutionTotalNs": 2708,
+              "hotExecutionPerCallNs": 27
             },
             "derived": {
-              "nativeEndToEndNs": 932292,
-              "calxEndToEndNs": 1041750,
-              "hotVsNativeRatio": 0.1508954395395717,
-              "oneShotEndToEndRatio": 1.1174074217090784
+              "lookupNativeEndToEndNs": 1151083,
+              "calxEndToEndNs": 1313167,
+              "calxHotVsLookupNativeRatio": 0.12544858420268257,
+              "calxHotVsCachedNativeRatio": 0.2990903922683343,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1408100024064294
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 4985417,
+              "processWallNs": 10875083,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4095,25 +4406,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 333875,
-                "calcitFrontendNs": 484000,
-                "snapshotCloneNs": 1375,
+                "fixtureInstallNs": 418709,
+                "calcitFrontendNs": 632250,
+                "snapshotCloneNs": 1875,
                 "compile": {
-                  "eligibilityNs": 38709,
-                  "planningNs": 30417,
-                  "programConstructionNs": 56041,
-                  "validationLoweringNs": 12667,
-                  "totalNs": 141583
+                  "eligibilityNs": 49250,
+                  "planningNs": 50042,
+                  "programConstructionNs": 90375,
+                  "validationLoweringNs": 18500,
+                  "totalNs": 218459
                 },
                 "runtime": {
-                  "nativeCallNs": 66584,
-                  "boundaryArgumentsNs": 6416,
-                  "vmSetupNs": 3000,
-                  "pureExecutionNs": 15834,
+                  "nativeCallNs": 83834,
+                  "cachedNativeResolutionNs": 2167,
+                  "cachedNativeExecutionTotalNs": 3546917,
+                  "cachedNativeExecutionPerCallNs": 35469,
+                  "boundaryArgumentsNs": 1125,
+                  "vmSetupNs": 4917,
+                  "pureExecutionNs": 16041,
                   "boundaryResultNs": 125,
-                  "calxOneShotNs": 25750,
-                  "hotExecutionTotalNs": 1029875,
-                  "hotExecutionPerCallNs": 10298
+                  "calxOneShotNs": 22625,
+                  "hotExecutionTotalNs": 1067541,
+                  "hotExecutionPerCallNs": 10675
                 },
                 "program": {
                   "functions": 1,
@@ -4128,11 +4442,11 @@
               }
             },
             {
-              "processWallNs": 4963167,
+              "processWallNs": 10715042,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4143,73 +4457,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 340417,
-                "calcitFrontendNs": 487625,
-                "snapshotCloneNs": 1208,
+                "fixtureInstallNs": 453042,
+                "calcitFrontendNs": 645291,
+                "snapshotCloneNs": 2208,
                 "compile": {
-                  "eligibilityNs": 39125,
-                  "planningNs": 30666,
-                  "programConstructionNs": 52833,
-                  "validationLoweringNs": 12583,
-                  "totalNs": 139000
+                  "eligibilityNs": 53166,
+                  "planningNs": 50333,
+                  "programConstructionNs": 112042,
+                  "validationLoweringNs": 22833,
+                  "totalNs": 245458
                 },
                 "runtime": {
-                  "nativeCallNs": 66833,
-                  "boundaryArgumentsNs": 2209,
-                  "vmSetupNs": 2917,
-                  "pureExecutionNs": 16792,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 22375,
-                  "hotExecutionTotalNs": 1033250,
-                  "hotExecutionPerCallNs": 10332
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 5004125,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 332125,
-                "calcitFrontendNs": 491750,
-                "snapshotCloneNs": 1250,
-                "compile": {
-                  "eligibilityNs": 37875,
-                  "planningNs": 30833,
-                  "programConstructionNs": 51583,
-                  "validationLoweringNs": 12625,
-                  "totalNs": 136584
-                },
-                "runtime": {
-                  "nativeCallNs": 65500,
-                  "boundaryArgumentsNs": 2000,
-                  "vmSetupNs": 2917,
-                  "pureExecutionNs": 16083,
+                  "nativeCallNs": 119667,
+                  "cachedNativeResolutionNs": 2458,
+                  "cachedNativeExecutionTotalNs": 3438042,
+                  "cachedNativeExecutionPerCallNs": 34380,
+                  "boundaryArgumentsNs": 1250,
+                  "vmSetupNs": 3875,
+                  "pureExecutionNs": 18417,
                   "boundaryResultNs": 125,
-                  "calxOneShotNs": 21583,
-                  "hotExecutionTotalNs": 1030084,
-                  "hotExecutionPerCallNs": 10300
+                  "calxOneShotNs": 24000,
+                  "hotExecutionTotalNs": 1056000,
+                  "hotExecutionPerCallNs": 10560
                 },
                 "program": {
                   "functions": 1,
@@ -4224,11 +4493,11 @@
               }
             },
             {
-              "processWallNs": 5970041,
+              "processWallNs": 10182250,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4239,121 +4508,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 388541,
-                "calcitFrontendNs": 590125,
-                "snapshotCloneNs": 1792,
+                "fixtureInstallNs": 356000,
+                "calcitFrontendNs": 520875,
+                "snapshotCloneNs": 1500,
                 "compile": {
-                  "eligibilityNs": 55666,
-                  "planningNs": 38042,
-                  "programConstructionNs": 75375,
-                  "validationLoweringNs": 17458,
-                  "totalNs": 191250
-                },
-                "runtime": {
-                  "nativeCallNs": 81792,
-                  "boundaryArgumentsNs": 2250,
-                  "vmSetupNs": 3916,
-                  "pureExecutionNs": 17750,
-                  "boundaryResultNs": 333,
-                  "calxOneShotNs": 24750,
-                  "hotExecutionTotalNs": 1031500,
-                  "hotExecutionPerCallNs": 10315
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 5537167,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 371542,
-                "calcitFrontendNs": 571333,
-                "snapshotCloneNs": 1250,
-                "compile": {
-                  "eligibilityNs": 44458,
-                  "planningNs": 41500,
-                  "programConstructionNs": 59500,
-                  "validationLoweringNs": 15459,
-                  "totalNs": 165791
-                },
-                "runtime": {
-                  "nativeCallNs": 68458,
-                  "boundaryArgumentsNs": 2375,
-                  "vmSetupNs": 3292,
-                  "pureExecutionNs": 17083,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 23250,
-                  "hotExecutionTotalNs": 1041375,
-                  "hotExecutionPerCallNs": 10413
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 5244250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 346542,
-                "calcitFrontendNs": 537583,
-                "snapshotCloneNs": 1208,
-                "compile": {
-                  "eligibilityNs": 44250,
-                  "planningNs": 32000,
-                  "programConstructionNs": 55583,
-                  "validationLoweringNs": 17125,
-                  "totalNs": 152666
+                  "eligibilityNs": 41916,
+                  "planningNs": 36583,
+                  "programConstructionNs": 62125,
+                  "validationLoweringNs": 12708,
+                  "totalNs": 157833
                 },
                 "runtime": {
                   "nativeCallNs": 70958,
-                  "boundaryArgumentsNs": 5208,
-                  "vmSetupNs": 2750,
-                  "pureExecutionNs": 15542,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 24000,
-                  "hotExecutionTotalNs": 1033042,
-                  "hotExecutionPerCallNs": 10330
+                  "cachedNativeResolutionNs": 1917,
+                  "cachedNativeExecutionTotalNs": 3490708,
+                  "cachedNativeExecutionPerCallNs": 34907,
+                  "boundaryArgumentsNs": 875,
+                  "vmSetupNs": 6792,
+                  "pureExecutionNs": 17208,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 25500,
+                  "hotExecutionTotalNs": 1051500,
+                  "hotExecutionPerCallNs": 10515
                 },
                 "program": {
                   "functions": 1,
@@ -4368,11 +4544,11 @@
               }
             },
             {
-              "processWallNs": 5235791,
+              "processWallNs": 11085041,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4383,25 +4559,181 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 354709,
-                "calcitFrontendNs": 517292,
-                "snapshotCloneNs": 1209,
+                "fixtureInstallNs": 434958,
+                "calcitFrontendNs": 658708,
+                "snapshotCloneNs": 2000,
                 "compile": {
-                  "eligibilityNs": 48125,
-                  "planningNs": 30458,
-                  "programConstructionNs": 59041,
-                  "validationLoweringNs": 16083,
-                  "totalNs": 161584
+                  "eligibilityNs": 58125,
+                  "planningNs": 49125,
+                  "programConstructionNs": 89209,
+                  "validationLoweringNs": 18250,
+                  "totalNs": 224084
                 },
                 "runtime": {
-                  "nativeCallNs": 71042,
-                  "boundaryArgumentsNs": 4792,
-                  "vmSetupNs": 3000,
-                  "pureExecutionNs": 16291,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 24542,
-                  "hotExecutionTotalNs": 1033500,
-                  "hotExecutionPerCallNs": 10335
+                  "nativeCallNs": 85542,
+                  "cachedNativeResolutionNs": 1916,
+                  "cachedNativeExecutionTotalNs": 3518000,
+                  "cachedNativeExecutionPerCallNs": 35180,
+                  "boundaryArgumentsNs": 1584,
+                  "vmSetupNs": 6500,
+                  "pureExecutionNs": 21875,
+                  "boundaryResultNs": 292,
+                  "calxOneShotNs": 30709,
+                  "hotExecutionTotalNs": 1178875,
+                  "hotExecutionPerCallNs": 11788
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 11013167,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 449417,
+                "calcitFrontendNs": 666833,
+                "snapshotCloneNs": 2042,
+                "compile": {
+                  "eligibilityNs": 60292,
+                  "planningNs": 67458,
+                  "programConstructionNs": 91833,
+                  "validationLoweringNs": 18917,
+                  "totalNs": 256834
+                },
+                "runtime": {
+                  "nativeCallNs": 93833,
+                  "cachedNativeResolutionNs": 2000,
+                  "cachedNativeExecutionTotalNs": 3534417,
+                  "cachedNativeExecutionPerCallNs": 35344,
+                  "boundaryArgumentsNs": 1500,
+                  "vmSetupNs": 6459,
+                  "pureExecutionNs": 16125,
+                  "boundaryResultNs": 3000,
+                  "calxOneShotNs": 27500,
+                  "hotExecutionTotalNs": 1052250,
+                  "hotExecutionPerCallNs": 10522
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 10450125,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 400541,
+                "calcitFrontendNs": 602333,
+                "snapshotCloneNs": 2042,
+                "compile": {
+                  "eligibilityNs": 52292,
+                  "planningNs": 47625,
+                  "programConstructionNs": 85208,
+                  "validationLoweringNs": 15833,
+                  "totalNs": 206166
+                },
+                "runtime": {
+                  "nativeCallNs": 83875,
+                  "cachedNativeResolutionNs": 1750,
+                  "cachedNativeExecutionTotalNs": 3472000,
+                  "cachedNativeExecutionPerCallNs": 34720,
+                  "boundaryArgumentsNs": 4000,
+                  "vmSetupNs": 5166,
+                  "pureExecutionNs": 16125,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 25833,
+                  "hotExecutionTotalNs": 1049542,
+                  "hotExecutionPerCallNs": 10495
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 11063417,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 435750,
+                "calcitFrontendNs": 606792,
+                "snapshotCloneNs": 1917,
+                "compile": {
+                  "eligibilityNs": 59333,
+                  "planningNs": 39666,
+                  "programConstructionNs": 80583,
+                  "validationLoweringNs": 15458,
+                  "totalNs": 200125
+                },
+                "runtime": {
+                  "nativeCallNs": 83208,
+                  "cachedNativeResolutionNs": 1875,
+                  "cachedNativeExecutionTotalNs": 3520541,
+                  "cachedNativeExecutionPerCallNs": 35205,
+                  "boundaryArgumentsNs": 1250,
+                  "vmSetupNs": 5209,
+                  "pureExecutionNs": 16167,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 23042,
+                  "hotExecutionTotalNs": 1050708,
+                  "hotExecutionPerCallNs": 10507
                 },
                 "program": {
                   "functions": 1,
@@ -4431,55 +4763,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 15864500,
-              "fixtureInstallNs": 343084,
-              "calcitFrontendNs": 503833,
-              "snapshotCloneNs": 1083,
-              "eligibilityNs": 40167,
-              "planningNs": 33250,
-              "programConstructionNs": 56750,
-              "validationLoweringNs": 14000,
-              "calxCompileTotalNs": 148042,
-              "nativeCallNs": 357291,
-              "boundaryArgumentsNs": 2084,
-              "vmSetupNs": 3292,
-              "pureExecutionNs": 102875,
-              "boundaryResultNs": 167,
-              "calxOneShotNs": 110959,
-              "hotExecutionPerCallNs": 96338
+              "processWallNs": 58112667,
+              "fixtureInstallNs": 427917,
+              "calcitFrontendNs": 608666,
+              "snapshotCloneNs": 2000,
+              "eligibilityNs": 57125,
+              "planningNs": 46708,
+              "programConstructionNs": 81792,
+              "validationLoweringNs": 18416,
+              "calxCompileTotalNs": 208125,
+              "nativeCallNs": 379750,
+              "cachedNativeResolutionNs": 2125,
+              "cachedNativeExecutionTotalNs": 33011167,
+              "cachedNativeExecutionPerCallNs": 330111,
+              "boundaryArgumentsNs": 2292,
+              "vmSetupNs": 12583,
+              "pureExecutionNs": 113708,
+              "boundaryResultNs": 208,
+              "calxOneShotNs": 127459,
+              "hotExecutionTotalNs": 10037541,
+              "hotExecutionPerCallNs": 100375
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 46000,
-              "fixtureInstallNs": 4208,
-              "calcitFrontendNs": 8334,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 1709,
-              "planningNs": 1375,
-              "programConstructionNs": 2250,
-              "validationLoweringNs": 1459,
-              "calxCompileTotalNs": 5875,
-              "nativeCallNs": 2125,
-              "boundaryArgumentsNs": 84,
-              "vmSetupNs": 584,
-              "pureExecutionNs": 667,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 832,
-              "hotExecutionPerCallNs": 105
+              "processWallNs": 357459,
+              "fixtureInstallNs": 10874,
+              "calcitFrontendNs": 17416,
+              "snapshotCloneNs": 333,
+              "eligibilityNs": 2916,
+              "planningNs": 3374,
+              "programConstructionNs": 4251,
+              "validationLoweringNs": 1583,
+              "calxCompileTotalNs": 10375,
+              "nativeCallNs": 3292,
+              "cachedNativeResolutionNs": 83,
+              "cachedNativeExecutionTotalNs": 61792,
+              "cachedNativeExecutionPerCallNs": 618,
+              "boundaryArgumentsNs": 542,
+              "vmSetupNs": 4500,
+              "pureExecutionNs": 3584,
+              "boundaryResultNs": 125,
+              "calxOneShotNs": 9751,
+              "hotExecutionTotalNs": 60292,
+              "hotExecutionPerCallNs": 603
             },
             "derived": {
-              "nativeEndToEndNs": 1204208,
-              "calxEndToEndNs": 1107001,
-              "hotVsNativeRatio": 0.2696345555863428,
-              "oneShotEndToEndRatio": 0.9192772344976947
+              "lookupNativeEndToEndNs": 1416333,
+              "calxEndToEndNs": 1374167,
+              "calxHotVsLookupNativeRatio": 0.2643186306780777,
+              "calxHotVsCachedNativeRatio": 0.304064390462602,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.9702287527015186
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 15991209,
+              "processWallNs": 58517667,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4490,25 +4831,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 334083,
-                "calcitFrontendNs": 512167,
-                "snapshotCloneNs": 1167,
+                "fixtureInstallNs": 490625,
+                "calcitFrontendNs": 593667,
+                "snapshotCloneNs": 2750,
                 "compile": {
-                  "eligibilityNs": 40167,
-                  "planningNs": 33541,
-                  "programConstructionNs": 57167,
-                  "validationLoweringNs": 14000,
-                  "totalNs": 148750
+                  "eligibilityNs": 60209,
+                  "planningNs": 53625,
+                  "programConstructionNs": 76750,
+                  "validationLoweringNs": 18500,
+                  "totalNs": 215916
                 },
                 "runtime": {
-                  "nativeCallNs": 354667,
-                  "boundaryArgumentsNs": 2084,
-                  "vmSetupNs": 4292,
-                  "pureExecutionNs": 104750,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 111791,
-                  "hotExecutionTotalNs": 9664125,
-                  "hotExecutionPerCallNs": 96641
+                  "nativeCallNs": 383042,
+                  "cachedNativeResolutionNs": 2125,
+                  "cachedNativeExecutionTotalNs": 33504792,
+                  "cachedNativeExecutionPerCallNs": 335047,
+                  "boundaryArgumentsNs": 2833,
+                  "vmSetupNs": 12583,
+                  "pureExecutionNs": 113708,
+                  "boundaryResultNs": 333,
+                  "calxOneShotNs": 130500,
+                  "hotExecutionTotalNs": 10097833,
+                  "hotExecutionPerCallNs": 100978
                 },
                 "program": {
                   "functions": 1,
@@ -4523,11 +4867,11 @@
               }
             },
             {
-              "processWallNs": 16227625,
+              "processWallNs": 57755208,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4538,25 +4882,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 353458,
-                "calcitFrontendNs": 532709,
-                "snapshotCloneNs": 1209,
+                "fixtureInstallNs": 396125,
+                "calcitFrontendNs": 591250,
+                "snapshotCloneNs": 1667,
                 "compile": {
-                  "eligibilityNs": 41625,
-                  "planningNs": 34625,
-                  "programConstructionNs": 60834,
-                  "validationLoweringNs": 14542,
-                  "totalNs": 155917
+                  "eligibilityNs": 57583,
+                  "planningNs": 39833,
+                  "programConstructionNs": 77541,
+                  "validationLoweringNs": 16833,
+                  "totalNs": 197666
                 },
                 "runtime": {
-                  "nativeCallNs": 359416,
-                  "boundaryArgumentsNs": 2250,
-                  "vmSetupNs": 3250,
-                  "pureExecutionNs": 102125,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 108125,
-                  "hotExecutionTotalNs": 9627792,
-                  "hotExecutionPerCallNs": 96277
+                  "nativeCallNs": 374750,
+                  "cachedNativeResolutionNs": 5916,
+                  "cachedNativeExecutionTotalNs": 32987125,
+                  "cachedNativeExecutionPerCallNs": 329871,
+                  "boundaryArgumentsNs": 1875,
+                  "vmSetupNs": 14334,
+                  "pureExecutionNs": 110583,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 127459,
+                  "hotExecutionTotalNs": 9955875,
+                  "hotExecutionPerCallNs": 99558
                 },
                 "program": {
                   "functions": 1,
@@ -4571,11 +4918,11 @@
               }
             },
             {
-              "processWallNs": 15864500,
+              "processWallNs": 58254166,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4586,25 +4933,79 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 339417,
-                "calcitFrontendNs": 495041,
-                "snapshotCloneNs": 1041,
+                "fixtureInstallNs": 431834,
+                "calcitFrontendNs": 681250,
+                "snapshotCloneNs": 1291,
                 "compile": {
-                  "eligibilityNs": 37875,
-                  "planningNs": 30833,
-                  "programConstructionNs": 54500,
-                  "validationLoweringNs": 12458,
-                  "totalNs": 142167
+                  "eligibilityNs": 45375,
+                  "planningNs": 38958,
+                  "programConstructionNs": 57500,
+                  "validationLoweringNs": 11458,
+                  "totalNs": 157208
                 },
                 "runtime": {
-                  "nativeCallNs": 353500,
-                  "boundaryArgumentsNs": 2042,
-                  "vmSetupNs": 2791,
-                  "pureExecutionNs": 104125,
+                  "nativeCallNs": 378958,
+                  "cachedNativeResolutionNs": 1584,
+                  "cachedNativeExecutionTotalNs": 33293875,
+                  "cachedNativeExecutionPerCallNs": 332938,
+                  "boundaryArgumentsNs": 5666,
+                  "vmSetupNs": 18083,
+                  "pureExecutionNs": 123291,
+                  "boundaryResultNs": 292,
+                  "calxOneShotNs": 148250,
+                  "hotExecutionTotalNs": 10222041,
+                  "hotExecutionPerCallNs": 102220
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 58112667,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 421292,
+                "calcitFrontendNs": 668875,
+                "snapshotCloneNs": 1916,
+                "compile": {
+                  "eligibilityNs": 53709,
+                  "planningNs": 47125,
+                  "programConstructionNs": 81792,
+                  "validationLoweringNs": 17167,
+                  "totalNs": 204833
+                },
+                "runtime": {
+                  "nativeCallNs": 379042,
+                  "cachedNativeResolutionNs": 2125,
+                  "cachedNativeExecutionTotalNs": 33011167,
+                  "cachedNativeExecutionPerCallNs": 330111,
+                  "boundaryArgumentsNs": 2292,
+                  "vmSetupNs": 7208,
+                  "pureExecutionNs": 117292,
                   "boundaryResultNs": 83,
-                  "calxOneShotNs": 110959,
-                  "hotExecutionTotalNs": 9618334,
-                  "hotExecutionPerCallNs": 96183
+                  "calxOneShotNs": 127417,
+                  "hotExecutionTotalNs": 9994458,
+                  "hotExecutionPerCallNs": 99944
                 },
                 "program": {
                   "functions": 1,
@@ -4619,11 +5020,11 @@
               }
             },
             {
-              "processWallNs": 15924958,
+              "processWallNs": 57878250,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4634,25 +5035,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 343084,
-                "calcitFrontendNs": 521458,
-                "snapshotCloneNs": 1250,
+                "fixtureInstallNs": 427917,
+                "calcitFrontendNs": 591792,
+                "snapshotCloneNs": 2000,
                 "compile": {
-                  "eligibilityNs": 43875,
-                  "planningNs": 31417,
-                  "programConstructionNs": 61916,
-                  "validationLoweringNs": 15917,
-                  "totalNs": 157042
+                  "eligibilityNs": 54209,
+                  "planningNs": 43334,
+                  "programConstructionNs": 81792,
+                  "validationLoweringNs": 22708,
+                  "totalNs": 208125
                 },
                 "runtime": {
-                  "nativeCallNs": 357291,
-                  "boundaryArgumentsNs": 4750,
-                  "vmSetupNs": 3292,
-                  "pureExecutionNs": 102208,
-                  "boundaryResultNs": 2666,
-                  "calxOneShotNs": 113291,
-                  "hotExecutionTotalNs": 9623375,
-                  "hotExecutionPerCallNs": 96233
+                  "nativeCallNs": 383708,
+                  "cachedNativeResolutionNs": 2042,
+                  "cachedNativeExecutionTotalNs": 33150250,
+                  "cachedNativeExecutionPerCallNs": 331502,
+                  "boundaryArgumentsNs": 1750,
+                  "vmSetupNs": 7792,
+                  "pureExecutionNs": 105084,
+                  "boundaryResultNs": 84,
+                  "calxOneShotNs": 115167,
+                  "hotExecutionTotalNs": 10037541,
+                  "hotExecutionPerCallNs": 100375
                 },
                 "program": {
                   "functions": 1,
@@ -4667,11 +5071,11 @@
               }
             },
             {
-              "processWallNs": 15818500,
+              "processWallNs": 58865875,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4682,25 +5086,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 347292,
-                "calcitFrontendNs": 503833,
-                "snapshotCloneNs": 1041,
+                "fixtureInstallNs": 438791,
+                "calcitFrontendNs": 633291,
+                "snapshotCloneNs": 6417,
                 "compile": {
-                  "eligibilityNs": 37917,
-                  "planningNs": 33250,
-                  "programConstructionNs": 52291,
-                  "validationLoweringNs": 12666,
-                  "totalNs": 140083
+                  "eligibilityNs": 58958,
+                  "planningNs": 46708,
+                  "programConstructionNs": 85500,
+                  "validationLoweringNs": 18416,
+                  "totalNs": 218500
                 },
                 "runtime": {
-                  "nativeCallNs": 351917,
-                  "boundaryArgumentsNs": 2000,
-                  "vmSetupNs": 5208,
-                  "pureExecutionNs": 103166,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 110959,
-                  "hotExecutionTotalNs": 9633833,
-                  "hotExecutionPerCallNs": 96338
+                  "nativeCallNs": 386334,
+                  "cachedNativeResolutionNs": 2208,
+                  "cachedNativeExecutionTotalNs": 32949375,
+                  "cachedNativeExecutionPerCallNs": 329493,
+                  "boundaryArgumentsNs": 1333,
+                  "vmSetupNs": 9291,
+                  "pureExecutionNs": 106625,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 117708,
+                  "hotExecutionTotalNs": 9937709,
+                  "hotExecutionPerCallNs": 99377
                 },
                 "program": {
                   "functions": 1,
@@ -4715,11 +5122,11 @@
               }
             },
             {
-              "processWallNs": 15857875,
+              "processWallNs": 57730333,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4730,73 +5137,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 335750,
-                "calcitFrontendNs": 502417,
-                "snapshotCloneNs": 1083,
+                "fixtureInstallNs": 415166,
+                "calcitFrontendNs": 608666,
+                "snapshotCloneNs": 2166,
                 "compile": {
-                  "eligibilityNs": 41250,
-                  "planningNs": 33584,
-                  "programConstructionNs": 56750,
-                  "validationLoweringNs": 12541,
-                  "totalNs": 148042
+                  "eligibilityNs": 57125,
+                  "planningNs": 49542,
+                  "programConstructionNs": 86250,
+                  "validationLoweringNs": 23167,
+                  "totalNs": 222666
                 },
                 "runtime": {
-                  "nativeCallNs": 357458,
-                  "boundaryArgumentsNs": 2583,
-                  "vmSetupNs": 2708,
-                  "pureExecutionNs": 102875,
-                  "boundaryResultNs": 167,
-                  "calxOneShotNs": 108709,
-                  "hotExecutionTotalNs": 9666041,
-                  "hotExecutionPerCallNs": 96660
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 15829709,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 344542,
-                "calcitFrontendNs": 501833,
-                "snapshotCloneNs": 1083,
-                "compile": {
-                  "eligibilityNs": 38458,
-                  "planningNs": 30709,
-                  "programConstructionNs": 55375,
-                  "validationLoweringNs": 15542,
-                  "totalNs": 144166
-                },
-                "runtime": {
-                  "nativeCallNs": 357375,
-                  "boundaryArgumentsNs": 2084,
-                  "vmSetupNs": 5459,
-                  "pureExecutionNs": 102375,
-                  "boundaryResultNs": 125,
-                  "calxOneShotNs": 110500,
-                  "hotExecutionTotalNs": 9635500,
-                  "hotExecutionPerCallNs": 96355
+                  "nativeCallNs": 379750,
+                  "cachedNativeResolutionNs": 2125,
+                  "cachedNativeExecutionTotalNs": 32962250,
+                  "cachedNativeExecutionPerCallNs": 329622,
+                  "boundaryArgumentsNs": 4708,
+                  "vmSetupNs": 17083,
+                  "pureExecutionNs": 115625,
+                  "boundaryResultNs": 2916,
+                  "calxOneShotNs": 141375,
+                  "hotExecutionTotalNs": 10073833,
+                  "hotExecutionPerCallNs": 100738
                 },
                 "program": {
                   "functions": 1,
@@ -4826,55 +5188,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 123480417,
-              "fixtureInstallNs": 350375,
-              "calcitFrontendNs": 524750,
-              "snapshotCloneNs": 1500,
-              "eligibilityNs": 43167,
-              "planningNs": 35209,
-              "programConstructionNs": 59792,
-              "validationLoweringNs": 14750,
-              "calxCompileTotalNs": 154875,
-              "nativeCallNs": 3197625,
-              "boundaryArgumentsNs": 2583,
-              "vmSetupNs": 3250,
-              "pureExecutionNs": 968417,
-              "boundaryResultNs": 83,
-              "calxOneShotNs": 975333,
-              "hotExecutionPerCallNs": 957446
+              "processWallNs": 531902833,
+              "fixtureInstallNs": 433750,
+              "calcitFrontendNs": 644959,
+              "snapshotCloneNs": 2167,
+              "eligibilityNs": 61375,
+              "planningNs": 47625,
+              "programConstructionNs": 83041,
+              "validationLoweringNs": 19833,
+              "calxCompileTotalNs": 222708,
+              "nativeCallNs": 3425083,
+              "cachedNativeResolutionNs": 2208,
+              "cachedNativeExecutionTotalNs": 330544125,
+              "cachedNativeExecutionPerCallNs": 3305441,
+              "boundaryArgumentsNs": 5416,
+              "vmSetupNs": 20125,
+              "pureExecutionNs": 1001083,
+              "boundaryResultNs": 334,
+              "calxOneShotNs": 1030750,
+              "hotExecutionTotalNs": 99299833,
+              "hotExecutionPerCallNs": 992998
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 276958,
-              "fixtureInstallNs": 6500,
-              "calcitFrontendNs": 12625,
-              "snapshotCloneNs": 292,
-              "eligibilityNs": 1249,
-              "planningNs": 1834,
-              "programConstructionNs": 1500,
-              "validationLoweringNs": 709,
-              "calxCompileTotalNs": 3333,
-              "nativeCallNs": 8709,
+              "processWallNs": 3976959,
+              "fixtureInstallNs": 25000,
+              "calcitFrontendNs": 34168,
+              "snapshotCloneNs": 84,
+              "eligibilityNs": 4541,
+              "planningNs": 1334,
+              "programConstructionNs": 2416,
+              "validationLoweringNs": 1000,
+              "calxCompileTotalNs": 7750,
+              "nativeCallNs": 82875,
+              "cachedNativeResolutionNs": 292,
+              "cachedNativeExecutionTotalNs": 654000,
+              "cachedNativeExecutionPerCallNs": 6540,
               "boundaryArgumentsNs": 251,
-              "vmSetupNs": 167,
-              "pureExecutionNs": 2958,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 3583,
-              "hotExecutionPerCallNs": 1128
+              "vmSetupNs": 2584,
+              "pureExecutionNs": 6209,
+              "boundaryResultNs": 84,
+              "calxOneShotNs": 3167,
+              "hotExecutionTotalNs": 79249,
+              "hotExecutionPerCallNs": 793
             },
             "derived": {
-              "nativeEndToEndNs": 4072750,
-              "calxEndToEndNs": 2006833,
-              "hotVsNativeRatio": 0.29942410382705914,
-              "oneShotEndToEndRatio": 0.4927464244061138
+              "lookupNativeEndToEndNs": 4503792,
+              "calxEndToEndNs": 2334334,
+              "calxHotVsLookupNativeRatio": 0.28991939757372304,
+              "calxHotVsCachedNativeRatio": 0.3004131672596788,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.5183041312742684
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 123378291,
+              "processWallNs": 526028209,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4885,73 +5256,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 361541,
-                "calcitFrontendNs": 525666,
-                "snapshotCloneNs": 1167,
+                "fixtureInstallNs": 417167,
+                "calcitFrontendNs": 619208,
+                "snapshotCloneNs": 2083,
                 "compile": {
-                  "eligibilityNs": 43167,
-                  "planningNs": 34833,
-                  "programConstructionNs": 58292,
-                  "validationLoweringNs": 14125,
-                  "totalNs": 154875
+                  "eligibilityNs": 54291,
+                  "planningNs": 47625,
+                  "programConstructionNs": 82333,
+                  "validationLoweringNs": 19833,
+                  "totalNs": 210208
                 },
                 "runtime": {
-                  "nativeCallNs": 3188916,
-                  "boundaryArgumentsNs": 2834,
-                  "vmSetupNs": 3083,
-                  "pureExecutionNs": 967583,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 973958,
-                  "hotExecutionTotalNs": 95721459,
-                  "hotExecutionPerCallNs": 957214
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 124401958,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "debug",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 345459,
-                "calcitFrontendNs": 524750,
-                "snapshotCloneNs": 1750,
-                "compile": {
-                  "eligibilityNs": 42292,
-                  "planningNs": 33375,
-                  "programConstructionNs": 57959,
-                  "validationLoweringNs": 15459,
-                  "totalNs": 153459
-                },
-                "runtime": {
-                  "nativeCallNs": 3220541,
-                  "boundaryArgumentsNs": 2416,
-                  "vmSetupNs": 3833,
-                  "pureExecutionNs": 995542,
+                  "nativeCallNs": 3425083,
+                  "cachedNativeResolutionNs": 2084,
+                  "cachedNativeExecutionTotalNs": 328081875,
+                  "cachedNativeExecutionPerCallNs": 3280818,
+                  "boundaryArgumentsNs": 4708,
+                  "vmSetupNs": 17541,
+                  "pureExecutionNs": 1007292,
                   "boundaryResultNs": 83,
-                  "calxOneShotNs": 1002208,
-                  "hotExecutionTotalNs": 96383917,
-                  "hotExecutionPerCallNs": 963839
+                  "calxOneShotNs": 1030750,
+                  "hotExecutionTotalNs": 99299833,
+                  "hotExecutionPerCallNs": 992998
                 },
                 "program": {
                   "functions": 1,
@@ -4966,11 +5292,11 @@
               }
             },
             {
-              "processWallNs": 123757375,
+              "processWallNs": 531902833,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -4981,25 +5307,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 380167,
-                "calcitFrontendNs": 579667,
-                "snapshotCloneNs": 1792,
+                "fixtureInstallNs": 415750,
+                "calcitFrontendNs": 663583,
+                "snapshotCloneNs": 1875,
                 "compile": {
-                  "eligibilityNs": 51833,
-                  "planningNs": 40667,
-                  "programConstructionNs": 66792,
-                  "validationLoweringNs": 19041,
-                  "totalNs": 183334
+                  "eligibilityNs": 61375,
+                  "planningNs": 48959,
+                  "programConstructionNs": 89042,
+                  "validationLoweringNs": 18208,
+                  "totalNs": 223500
                 },
                 "runtime": {
-                  "nativeCallNs": 3197625,
-                  "boundaryArgumentsNs": 4667,
-                  "vmSetupNs": 3750,
-                  "pureExecutionNs": 968417,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 977375,
-                  "hotExecutionTotalNs": 95787500,
-                  "hotExecutionPerCallNs": 957875
+                  "nativeCallNs": 3440125,
+                  "cachedNativeResolutionNs": 6750,
+                  "cachedNativeExecutionTotalNs": 330544125,
+                  "cachedNativeExecutionPerCallNs": 3305441,
+                  "boundaryArgumentsNs": 5667,
+                  "vmSetupNs": 18625,
+                  "pureExecutionNs": 994916,
+                  "boundaryResultNs": 292,
+                  "calxOneShotNs": 1020834,
+                  "hotExecutionTotalNs": 99452125,
+                  "hotExecutionPerCallNs": 994521
                 },
                 "program": {
                   "functions": 1,
@@ -5014,11 +5343,11 @@
               }
             },
             {
-              "processWallNs": 123029083,
+              "processWallNs": 530754667,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -5029,25 +5358,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 340125,
-                "calcitFrontendNs": 512125,
-                "snapshotCloneNs": 3875,
+                "fixtureInstallNs": 467583,
+                "calcitFrontendNs": 610791,
+                "snapshotCloneNs": 1875,
                 "compile": {
-                  "eligibilityNs": 40791,
-                  "planningNs": 35209,
-                  "programConstructionNs": 58667,
-                  "validationLoweringNs": 13958,
-                  "totalNs": 152875
+                  "eligibilityNs": 62166,
+                  "planningNs": 45042,
+                  "programConstructionNs": 80792,
+                  "validationLoweringNs": 20625,
+                  "totalNs": 215000
                 },
                 "runtime": {
-                  "nativeCallNs": 3198041,
-                  "boundaryArgumentsNs": 2583,
-                  "vmSetupNs": 3000,
-                  "pureExecutionNs": 962500,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 968458,
-                  "hotExecutionTotalNs": 95620500,
-                  "hotExecutionPerCallNs": 956205
+                  "nativeCallNs": 3339041,
+                  "cachedNativeResolutionNs": 2208,
+                  "cachedNativeExecutionTotalNs": 330272250,
+                  "cachedNativeExecutionPerCallNs": 3302722,
+                  "boundaryArgumentsNs": 5333,
+                  "vmSetupNs": 18541,
+                  "pureExecutionNs": 1007416,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 1033000,
+                  "hotExecutionTotalNs": 99274542,
+                  "hotExecutionPerCallNs": 992745
                 },
                 "program": {
                   "functions": 1,
@@ -5062,11 +5394,11 @@
               }
             },
             {
-              "processWallNs": 123818000,
+              "processWallNs": 535958042,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -5077,25 +5409,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 350375,
-                "calcitFrontendNs": 523334,
-                "snapshotCloneNs": 1375,
+                "fixtureInstallNs": 622167,
+                "calcitFrontendNs": 785875,
+                "snapshotCloneNs": 2167,
                 "compile": {
-                  "eligibilityNs": 43667,
-                  "planningNs": 43250,
-                  "programConstructionNs": 59792,
-                  "validationLoweringNs": 14791,
-                  "totalNs": 166125
+                  "eligibilityNs": 66708,
+                  "planningNs": 45416,
+                  "programConstructionNs": 83041,
+                  "validationLoweringNs": 21417,
+                  "totalNs": 222708
                 },
                 "runtime": {
-                  "nativeCallNs": 3209625,
-                  "boundaryArgumentsNs": 5500,
-                  "vmSetupNs": 3333,
-                  "pureExecutionNs": 981667,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 992084,
-                  "hotExecutionTotalNs": 95974875,
-                  "hotExecutionPerCallNs": 959748
+                  "nativeCallNs": 3349625,
+                  "cachedNativeResolutionNs": 2042,
+                  "cachedNativeExecutionTotalNs": 336327125,
+                  "cachedNativeExecutionPerCallNs": 3363271,
+                  "boundaryArgumentsNs": 6084,
+                  "vmSetupNs": 20125,
+                  "pureExecutionNs": 996750,
+                  "boundaryResultNs": 334,
+                  "calxOneShotNs": 1024666,
+                  "hotExecutionTotalNs": 99287708,
+                  "hotExecutionPerCallNs": 992877
                 },
                 "program": {
                   "functions": 1,
@@ -5110,11 +5445,11 @@
               }
             },
             {
-              "processWallNs": 123480417,
+              "processWallNs": 535879792,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -5125,25 +5460,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 356875,
-                "calcitFrontendNs": 552792,
-                "snapshotCloneNs": 1500,
+                "fixtureInstallNs": 433750,
+                "calcitFrontendNs": 644959,
+                "snapshotCloneNs": 2167,
                 "compile": {
-                  "eligibilityNs": 44416,
-                  "planningNs": 35958,
-                  "programConstructionNs": 69083,
-                  "validationLoweringNs": 14750,
-                  "totalNs": 168333
+                  "eligibilityNs": 56834,
+                  "planningNs": 48542,
+                  "programConstructionNs": 95250,
+                  "validationLoweringNs": 19333,
+                  "totalNs": 230458
                 },
                 "runtime": {
-                  "nativeCallNs": 3195125,
-                  "boundaryArgumentsNs": 2500,
-                  "vmSetupNs": 3250,
-                  "pureExecutionNs": 965459,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 971750,
-                  "hotExecutionTotalNs": 95631875,
-                  "hotExecutionPerCallNs": 956318
+                  "nativeCallNs": 3565250,
+                  "cachedNativeResolutionNs": 6625,
+                  "cachedNativeExecutionTotalNs": 331847375,
+                  "cachedNativeExecutionPerCallNs": 3318473,
+                  "boundaryArgumentsNs": 5459,
+                  "vmSetupNs": 22792,
+                  "pureExecutionNs": 1001083,
+                  "boundaryResultNs": 458,
+                  "calxOneShotNs": 1030958,
+                  "hotExecutionTotalNs": 102981542,
+                  "hotExecutionPerCallNs": 1029815
                 },
                 "program": {
                   "functions": 1,
@@ -5158,11 +5496,11 @@
               }
             },
             {
-              "processWallNs": 123226417,
+              "processWallNs": 544896292,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "debug",
                   "os": "macos",
@@ -5173,25 +5511,79 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 344666,
-                "calcitFrontendNs": 506208,
-                "snapshotCloneNs": 1125,
+                "fixtureInstallNs": 566500,
+                "calcitFrontendNs": 1482875,
+                "snapshotCloneNs": 2833,
                 "compile": {
-                  "eligibilityNs": 40916,
-                  "planningNs": 32708,
-                  "programConstructionNs": 59833,
-                  "validationLoweringNs": 13958,
-                  "totalNs": 151542
+                  "eligibilityNs": 65458,
+                  "planningNs": 49750,
+                  "programConstructionNs": 88042,
+                  "validationLoweringNs": 20833,
+                  "totalNs": 230625
                 },
                 "runtime": {
-                  "nativeCallNs": 3179083,
-                  "boundaryArgumentsNs": 2250,
-                  "vmSetupNs": 3250,
-                  "pureExecutionNs": 968500,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 975333,
-                  "hotExecutionTotalNs": 95744667,
-                  "hotExecutionPerCallNs": 957446
+                  "nativeCallNs": 3558458,
+                  "cachedNativeResolutionNs": 2875,
+                  "cachedNativeExecutionTotalNs": 329890125,
+                  "cachedNativeExecutionPerCallNs": 3298901,
+                  "boundaryArgumentsNs": 5416,
+                  "vmSetupNs": 27542,
+                  "pureExecutionNs": 1011292,
+                  "boundaryResultNs": 458,
+                  "calxOneShotNs": 1045708,
+                  "hotExecutionTotalNs": 104879917,
+                  "hotExecutionPerCallNs": 1048799
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 529168416,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "debug",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 408750,
+                "calcitFrontendNs": 600542,
+                "snapshotCloneNs": 2167,
+                "compile": {
+                  "eligibilityNs": 53750,
+                  "planningNs": 46458,
+                  "programConstructionNs": 80625,
+                  "validationLoweringNs": 18416,
+                  "totalNs": 205375
+                },
+                "runtime": {
+                  "nativeCallNs": 3342208,
+                  "cachedNativeResolutionNs": 1916,
+                  "cachedNativeExecutionTotalNs": 330810917,
+                  "cachedNativeExecutionPerCallNs": 3308109,
+                  "boundaryArgumentsNs": 5042,
+                  "vmSetupNs": 26750,
+                  "pureExecutionNs": 994292,
+                  "boundaryResultNs": 375,
+                  "calxOneShotNs": 1027583,
+                  "hotExecutionTotalNs": 99220584,
+                  "hotExecutionPerCallNs": 992205
                 },
                 "program": {
                   "functions": 1,
@@ -5211,28 +5603,33 @@
       "crossovers": [
         {
           "kernel": "range-sum",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": 100
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": 100
         },
         {
           "kernel": "fibonacci",
-          "hotExecutionSize": 5,
-          "oneShotEndToEndSize": 10
+          "calxHotVsLookupNativeSize": 5,
+          "calxHotVsCachedNativeSize": 5,
+          "calxOneShotEndToEndVsLookupNativeSize": 10
         },
         {
           "kernel": "affine",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": null
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": null
         },
         {
           "kernel": "polynomial",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": null
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": null
         },
         {
           "kernel": "bounded-simulation",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": 100
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": 100
         }
       ]
     },
@@ -5253,55 +5650,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 3829500,
-              "fixtureInstallNs": 180583,
-              "calcitFrontendNs": 153083,
-              "snapshotCloneNs": 375,
-              "eligibilityNs": 20916,
-              "planningNs": 11459,
-              "programConstructionNs": 32000,
-              "validationLoweringNs": 4875,
-              "calxCompileTotalNs": 72000,
-              "nativeCallNs": 27083,
-              "boundaryArgumentsNs": 208,
-              "vmSetupNs": 416,
-              "pureExecutionNs": 2959,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 4000,
-              "hotExecutionPerCallNs": 1587
+              "processWallNs": 4077750,
+              "fixtureInstallNs": 141500,
+              "calcitFrontendNs": 124417,
+              "snapshotCloneNs": 250,
+              "eligibilityNs": 19333,
+              "planningNs": 7333,
+              "programConstructionNs": 25875,
+              "validationLoweringNs": 4333,
+              "calxCompileTotalNs": 59625,
+              "nativeCallNs": 20333,
+              "cachedNativeResolutionNs": 250,
+              "cachedNativeExecutionTotalNs": 673417,
+              "cachedNativeExecutionPerCallNs": 6734,
+              "boundaryArgumentsNs": 209,
+              "vmSetupNs": 750,
+              "pureExecutionNs": 3541,
+              "boundaryResultNs": 84,
+              "calxOneShotNs": 4791,
+              "hotExecutionTotalNs": 107375,
+              "hotExecutionPerCallNs": 1073
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 207250,
-              "fixtureInstallNs": 11167,
-              "calcitFrontendNs": 17417,
+              "processWallNs": 215166,
+              "fixtureInstallNs": 11875,
+              "calcitFrontendNs": 16041,
               "snapshotCloneNs": 41,
-              "eligibilityNs": 1666,
-              "planningNs": 1041,
-              "programConstructionNs": 4375,
-              "validationLoweringNs": 375,
-              "calxCompileTotalNs": 9333,
-              "nativeCallNs": 2417,
-              "boundaryArgumentsNs": 0,
-              "vmSetupNs": 83,
-              "pureExecutionNs": 167,
-              "boundaryResultNs": 1,
-              "calxOneShotNs": 375,
-              "hotExecutionPerCallNs": 156
+              "eligibilityNs": 1167,
+              "planningNs": 250,
+              "programConstructionNs": 1833,
+              "validationLoweringNs": 666,
+              "calxCompileTotalNs": 3375,
+              "nativeCallNs": 791,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 28917,
+              "cachedNativeExecutionPerCallNs": 289,
+              "boundaryArgumentsNs": 1,
+              "vmSetupNs": 208,
+              "pureExecutionNs": 376,
+              "boundaryResultNs": 42,
+              "calxOneShotNs": 874,
+              "hotExecutionTotalNs": 8541,
+              "hotExecutionPerCallNs": 85
             },
             "derived": {
-              "nativeEndToEndNs": 360749,
-              "calxEndToEndNs": 410041,
-              "hotVsNativeRatio": 0.05859764427869881,
-              "oneShotEndToEndRatio": 1.1366379393983075
+              "lookupNativeEndToEndNs": 286250,
+              "calxEndToEndNs": 330583,
+              "calxHotVsLookupNativeRatio": 0.05277135690749029,
+              "calxHotVsCachedNativeRatio": 0.15934065934065933,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1548751091703058
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 3381583,
+              "processWallNs": 4933542,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -5312,169 +5718,130 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 118333,
-                "calcitFrontendNs": 99417,
-                "snapshotCloneNs": 334,
+                "fixtureInstallNs": 145917,
+                "calcitFrontendNs": 124791,
+                "snapshotCloneNs": 208,
                 "compile": {
-                  "eligibilityNs": 14750,
-                  "planningNs": 6833,
-                  "programConstructionNs": 21083,
-                  "validationLoweringNs": 3375,
-                  "totalNs": 47666
+                  "eligibilityNs": 20500,
+                  "planningNs": 7375,
+                  "programConstructionNs": 26208,
+                  "validationLoweringNs": 4417,
+                  "totalNs": 59875
+                },
+                "runtime": {
+                  "nativeCallNs": 20042,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 736333,
+                  "cachedNativeExecutionPerCallNs": 7363,
+                  "boundaryArgumentsNs": 542,
+                  "vmSetupNs": 792,
+                  "pureExecutionNs": 3791,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 5833,
+                  "hotExecutionTotalNs": 205167,
+                  "hotExecutionPerCallNs": 2051
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4077750,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 134208,
+                "calcitFrontendNs": 124417,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 19333,
+                  "planningNs": 7250,
+                  "programConstructionNs": 27708,
+                  "validationLoweringNs": 3792,
+                  "totalNs": 59625
                 },
                 "runtime": {
                   "nativeCallNs": 19542,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 375,
-                  "pureExecutionNs": 2083,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 2875,
-                  "hotExecutionTotalNs": 103750,
-                  "hotExecutionPerCallNs": 1037
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4009083,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 232958,
-                "calcitFrontendNs": 192583,
-                "snapshotCloneNs": 625,
-                "compile": {
-                  "eligibilityNs": 27208,
-                  "planningNs": 13125,
-                  "programConstructionNs": 41375,
-                  "validationLoweringNs": 5458,
-                  "totalNs": 89750
-                },
-                "runtime": {
-                  "nativeCallNs": 32500,
-                  "boundaryArgumentsNs": 250,
-                  "vmSetupNs": 541,
-                  "pureExecutionNs": 3666,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 4875,
-                  "hotExecutionTotalNs": 179917,
-                  "hotExecutionPerCallNs": 1799
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4148250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 203667,
-                "calcitFrontendNs": 170500,
-                "snapshotCloneNs": 416,
-                "compile": {
-                  "eligibilityNs": 24459,
-                  "planningNs": 11459,
-                  "programConstructionNs": 37167,
-                  "validationLoweringNs": 5541,
-                  "totalNs": 81333
-                },
-                "runtime": {
-                  "nativeCallNs": 32458,
-                  "boundaryArgumentsNs": 250,
-                  "vmSetupNs": 500,
-                  "pureExecutionNs": 3625,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 4709,
-                  "hotExecutionTotalNs": 181250,
-                  "hotExecutionPerCallNs": 1812
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4036750,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 180583,
-                "calcitFrontendNs": 150250,
-                "snapshotCloneNs": 417,
-                "compile": {
-                  "eligibilityNs": 21125,
-                  "planningNs": 11417,
-                  "programConstructionNs": 32000,
-                  "validationLoweringNs": 5000,
-                  "totalNs": 72000
-                },
-                "runtime": {
-                  "nativeCallNs": 28917,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 644500,
+                  "cachedNativeExecutionPerCallNs": 6445,
                   "boundaryArgumentsNs": 208,
-                  "vmSetupNs": 416,
-                  "pureExecutionNs": 2959,
+                  "vmSetupNs": 917,
+                  "pureExecutionNs": 3917,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 5541,
+                  "hotExecutionTotalNs": 98959,
+                  "hotExecutionPerCallNs": 989
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3862584,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 129625,
+                "calcitFrontendNs": 102334,
+                "snapshotCloneNs": 209,
+                "compile": {
+                  "eligibilityNs": 14834,
+                  "planningNs": 6834,
+                  "programConstructionNs": 22250,
+                  "validationLoweringNs": 3667,
+                  "totalNs": 49125
+                },
+                "runtime": {
+                  "nativeCallNs": 20583,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 673417,
+                  "cachedNativeExecutionPerCallNs": 6734,
+                  "boundaryArgumentsNs": 209,
+                  "vmSetupNs": 750,
+                  "pureExecutionNs": 3541,
                   "boundaryResultNs": 84,
-                  "calxOneShotNs": 4000,
-                  "hotExecutionTotalNs": 159083,
-                  "hotExecutionPerCallNs": 1590
+                  "calxOneShotNs": 4791,
+                  "hotExecutionTotalNs": 107375,
+                  "hotExecutionPerCallNs": 1073
                 },
                 "program": {
                   "functions": 1,
@@ -5489,11 +5856,11 @@
               }
             },
             {
-              "processWallNs": 3829500,
+              "processWallNs": 5057042,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -5504,73 +5871,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 185875,
-                "calcitFrontendNs": 153083,
-                "snapshotCloneNs": 375,
+                "fixtureInstallNs": 141500,
+                "calcitFrontendNs": 120250,
+                "snapshotCloneNs": 208,
                 "compile": {
-                  "eligibilityNs": 20916,
-                  "planningNs": 12333,
-                  "programConstructionNs": 33709,
-                  "validationLoweringNs": 4875,
-                  "totalNs": 74208
+                  "eligibilityNs": 15500,
+                  "planningNs": 7333,
+                  "programConstructionNs": 22084,
+                  "validationLoweringNs": 2959,
+                  "totalNs": 49375
                 },
                 "runtime": {
-                  "nativeCallNs": 27083,
-                  "boundaryArgumentsNs": 208,
-                  "vmSetupNs": 500,
-                  "pureExecutionNs": 3083,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 4041,
-                  "hotExecutionTotalNs": 158792,
-                  "hotExecutionPerCallNs": 1587
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3692375,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 178209,
-                "calcitFrontendNs": 153750,
-                "snapshotCloneNs": 375,
-                "compile": {
-                  "eligibilityNs": 19250,
-                  "planningNs": 8916,
-                  "programConstructionNs": 27708,
-                  "validationLoweringNs": 4500,
-                  "totalNs": 62667
-                },
-                "runtime": {
-                  "nativeCallNs": 26250,
-                  "boundaryArgumentsNs": 208,
-                  "vmSetupNs": 333,
-                  "pureExecutionNs": 2792,
+                  "nativeCallNs": 19250,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 971750,
+                  "cachedNativeExecutionPerCallNs": 9717,
+                  "boundaryArgumentsNs": 209,
+                  "vmSetupNs": 417,
+                  "pureExecutionNs": 3334,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 3625,
-                  "hotExecutionTotalNs": 143125,
-                  "hotExecutionPerCallNs": 1431
+                  "calxOneShotNs": 4250,
+                  "hotExecutionTotalNs": 157750,
+                  "hotExecutionPerCallNs": 1577
                 },
                 "program": {
                   "functions": 1,
@@ -5585,11 +5907,11 @@
               }
             },
             {
-              "processWallNs": 3493709,
+              "processWallNs": 4970917,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -5600,25 +5922,130 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 169416,
-                "calcitFrontendNs": 132875,
+                "fixtureInstallNs": 175125,
+                "calcitFrontendNs": 142083,
                 "snapshotCloneNs": 334,
                 "compile": {
                   "eligibilityNs": 19500,
-                  "planningNs": 12500,
-                  "programConstructionNs": 27625,
-                  "validationLoweringNs": 4500,
-                  "totalNs": 66292
+                  "planningNs": 9125,
+                  "programConstructionNs": 25875,
+                  "validationLoweringNs": 5125,
+                  "totalNs": 61500
                 },
                 "runtime": {
-                  "nativeCallNs": 24666,
-                  "boundaryArgumentsNs": 208,
+                  "nativeCallNs": 27416,
+                  "cachedNativeResolutionNs": 292,
+                  "cachedNativeExecutionTotalNs": 952875,
+                  "cachedNativeExecutionPerCallNs": 9528,
+                  "boundaryArgumentsNs": 167,
                   "vmSetupNs": 375,
-                  "pureExecutionNs": 2792,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 3625,
-                  "hotExecutionTotalNs": 145250,
-                  "hotExecutionPerCallNs": 1452
+                  "pureExecutionNs": 2791,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 3666,
+                  "hotExecutionTotalNs": 141084,
+                  "hotExecutionPerCallNs": 1410
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4037500,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 154208,
+                "calcitFrontendNs": 140458,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 19833,
+                  "planningNs": 8458,
+                  "programConstructionNs": 27167,
+                  "validationLoweringNs": 5709,
+                  "totalNs": 63000
+                },
+                "runtime": {
+                  "nativeCallNs": 29125,
+                  "cachedNativeResolutionNs": 459,
+                  "cachedNativeExecutionTotalNs": 644833,
+                  "cachedNativeExecutionPerCallNs": 6448,
+                  "boundaryArgumentsNs": 500,
+                  "vmSetupNs": 1584,
+                  "pureExecutionNs": 5083,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 7500,
+                  "hotExecutionTotalNs": 98834,
+                  "hotExecutionPerCallNs": 988
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3872417,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 125041,
+                "calcitFrontendNs": 108042,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 15500,
+                  "planningNs": 7083,
+                  "programConstructionNs": 20917,
+                  "validationLoweringNs": 4333,
+                  "totalNs": 49209
+                },
+                "runtime": {
+                  "nativeCallNs": 20333,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 654417,
+                  "cachedNativeExecutionPerCallNs": 6544,
+                  "boundaryArgumentsNs": 209,
+                  "vmSetupNs": 542,
+                  "pureExecutionNs": 2833,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 3917,
+                  "hotExecutionTotalNs": 99708,
+                  "hotExecutionPerCallNs": 997
                 },
                 "program": {
                   "functions": 1,
@@ -5648,55 +6075,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 4153250,
-              "fixtureInstallNs": 132583,
-              "calcitFrontendNs": 117666,
-              "snapshotCloneNs": 292,
-              "eligibilityNs": 17375,
-              "planningNs": 9417,
-              "programConstructionNs": 23667,
-              "validationLoweringNs": 3750,
-              "calxCompileTotalNs": 54167,
-              "nativeCallNs": 82667,
-              "boundaryArgumentsNs": 167,
-              "vmSetupNs": 292,
-              "pureExecutionNs": 12208,
+              "processWallNs": 12551667,
+              "fixtureInstallNs": 140750,
+              "calcitFrontendNs": 133542,
+              "snapshotCloneNs": 250,
+              "eligibilityNs": 18208,
+              "planningNs": 7875,
+              "programConstructionNs": 25000,
+              "validationLoweringNs": 4833,
+              "calxCompileTotalNs": 56708,
+              "nativeCallNs": 79833,
+              "cachedNativeResolutionNs": 333,
+              "cachedNativeExecutionTotalNs": 6076041,
+              "cachedNativeExecutionPerCallNs": 60760,
+              "boundaryArgumentsNs": 250,
+              "vmSetupNs": 875,
+              "pureExecutionNs": 11542,
               "boundaryResultNs": 42,
-              "calxOneShotNs": 13041,
-              "hotExecutionPerCallNs": 10117
+              "calxOneShotNs": 14000,
+              "hotExecutionTotalNs": 956709,
+              "hotExecutionPerCallNs": 9567
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 308875,
-              "fixtureInstallNs": 8709,
-              "calcitFrontendNs": 10666,
-              "snapshotCloneNs": 83,
-              "eligibilityNs": 2500,
-              "planningNs": 1667,
-              "programConstructionNs": 2292,
-              "validationLoweringNs": 250,
-              "calxCompileTotalNs": 3584,
-              "nativeCallNs": 5626,
-              "boundaryArgumentsNs": 41,
-              "vmSetupNs": 42,
-              "pureExecutionNs": 1042,
+              "processWallNs": 72208,
+              "fixtureInstallNs": 4708,
+              "calcitFrontendNs": 17083,
+              "snapshotCloneNs": 41,
+              "eligibilityNs": 1708,
+              "planningNs": 250,
+              "programConstructionNs": 3709,
+              "validationLoweringNs": 251,
+              "calxCompileTotalNs": 5416,
+              "nativeCallNs": 2125,
+              "cachedNativeResolutionNs": 125,
+              "cachedNativeExecutionTotalNs": 56958,
+              "cachedNativeExecutionPerCallNs": 570,
+              "boundaryArgumentsNs": 83,
+              "vmSetupNs": 83,
+              "pureExecutionNs": 833,
               "boundaryResultNs": 42,
-              "calxOneShotNs": 1501,
-              "hotExecutionPerCallNs": 445
+              "calxOneShotNs": 1959,
+              "hotExecutionTotalNs": 9957,
+              "hotExecutionPerCallNs": 99
             },
             "derived": {
-              "nativeEndToEndNs": 332916,
-              "calxEndToEndNs": 317749,
-              "hotVsNativeRatio": 0.12238257103802001,
-              "oneShotEndToEndRatio": 0.9544419613355921
+              "lookupNativeEndToEndNs": 354125,
+              "calxEndToEndNs": 345250,
+              "calxHotVsLookupNativeRatio": 0.11983766111758296,
+              "calxHotVsCachedNativeRatio": 0.1574555628703094,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.9749382280268267
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 5084083,
+              "processWallNs": 12229250,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -5707,25 +6143,283 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 155250,
-                "calcitFrontendNs": 156666,
-                "snapshotCloneNs": 375,
+                "fixtureInstallNs": 127584,
+                "calcitFrontendNs": 114625,
+                "snapshotCloneNs": 291,
+                "compile": {
+                  "eligibilityNs": 16500,
+                  "planningNs": 7625,
+                  "programConstructionNs": 20667,
+                  "validationLoweringNs": 4834,
+                  "totalNs": 51292
+                },
+                "runtime": {
+                  "nativeCallNs": 77750,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 6277375,
+                  "cachedNativeExecutionPerCallNs": 62773,
+                  "boundaryArgumentsNs": 250,
+                  "vmSetupNs": 875,
+                  "pureExecutionNs": 11542,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 20166,
+                  "hotExecutionTotalNs": 956458,
+                  "hotExecutionPerCallNs": 9564
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 11856750,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 129375,
+                "calcitFrontendNs": 113042,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 18208,
+                  "planningNs": 6625,
+                  "programConstructionNs": 25000,
+                  "validationLoweringNs": 3333,
+                  "totalNs": 54542
+                },
+                "runtime": {
+                  "nativeCallNs": 77333,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 6045083,
+                  "cachedNativeExecutionPerCallNs": 60450,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 292,
+                  "pureExecutionNs": 10334,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 11000,
+                  "hotExecutionTotalNs": 977250,
+                  "hotExecutionPerCallNs": 9772
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 12332125,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 145458,
+                "calcitFrontendNs": 150625,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 25333,
+                  "planningNs": 8250,
+                  "programConstructionNs": 32208,
+                  "validationLoweringNs": 9833,
+                  "totalNs": 77875
+                },
+                "runtime": {
+                  "nativeCallNs": 81958,
+                  "cachedNativeResolutionNs": 2917,
+                  "cachedNativeExecutionTotalNs": 6076041,
+                  "cachedNativeExecutionPerCallNs": 60760,
+                  "boundaryArgumentsNs": 541,
+                  "vmSetupNs": 875,
+                  "pureExecutionNs": 12167,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 14125,
+                  "hotExecutionTotalNs": 920584,
+                  "hotExecutionPerCallNs": 9205
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 12595292,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 140750,
+                "calcitFrontendNs": 114000,
+                "snapshotCloneNs": 334,
+                "compile": {
+                  "eligibilityNs": 17459,
+                  "planningNs": 7875,
+                  "programConstructionNs": 22500,
+                  "validationLoweringNs": 4833,
+                  "totalNs": 54291
+                },
+                "runtime": {
+                  "nativeCallNs": 73291,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 6179333,
+                  "cachedNativeExecutionPerCallNs": 61793,
+                  "boundaryArgumentsNs": 167,
+                  "vmSetupNs": 958,
+                  "pureExecutionNs": 12375,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 14000,
+                  "hotExecutionTotalNs": 985125,
+                  "hotExecutionPerCallNs": 9851
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 12551667,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 139292,
+                "calcitFrontendNs": 137500,
+                "snapshotCloneNs": 208,
+                "compile": {
+                  "eligibilityNs": 17833,
+                  "planningNs": 7959,
+                  "programConstructionNs": 24458,
+                  "validationLoweringNs": 4416,
+                  "totalNs": 56708
+                },
+                "runtime": {
+                  "nativeCallNs": 79833,
+                  "cachedNativeResolutionNs": 2917,
+                  "cachedNativeExecutionTotalNs": 6250167,
+                  "cachedNativeExecutionPerCallNs": 62501,
+                  "boundaryArgumentsNs": 500,
+                  "vmSetupNs": 583,
+                  "pureExecutionNs": 10208,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 12041,
+                  "hotExecutionTotalNs": 966666,
+                  "hotExecutionPerCallNs": 9666
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 12623875,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 152375,
+                "calcitFrontendNs": 133542,
+                "snapshotCloneNs": 333,
                 "compile": {
                   "eligibilityNs": 24792,
-                  "planningNs": 10416,
-                  "programConstructionNs": 26750,
-                  "validationLoweringNs": 5166,
-                  "totalNs": 69625
+                  "planningNs": 11209,
+                  "programConstructionNs": 28709,
+                  "validationLoweringNs": 5084,
+                  "totalNs": 71583
                 },
                 "runtime": {
-                  "nativeCallNs": 100250,
-                  "boundaryArgumentsNs": 2750,
+                  "nativeCallNs": 80333,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 6019083,
+                  "cachedNativeExecutionPerCallNs": 60190,
+                  "boundaryArgumentsNs": 250,
                   "vmSetupNs": 958,
-                  "pureExecutionNs": 14542,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 18458,
-                  "hotExecutionTotalNs": 1096416,
-                  "hotExecutionPerCallNs": 10964
+                  "pureExecutionNs": 12209,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 13666,
+                  "hotExecutionTotalNs": 956709,
+                  "hotExecutionPerCallNs": 9567
                 },
                 "program": {
                   "functions": 1,
@@ -5740,11 +6434,11 @@
               }
             },
             {
-              "processWallNs": 4694125,
+              "processWallNs": 12617292,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -5755,265 +6449,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 138250,
-                "calcitFrontendNs": 117875,
-                "snapshotCloneNs": 291,
-                "compile": {
-                  "eligibilityNs": 17375,
-                  "planningNs": 6416,
-                  "programConstructionNs": 24750,
-                  "validationLoweringNs": 3708,
-                  "totalNs": 54167
-                },
-                "runtime": {
-                  "nativeCallNs": 91167,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 12292,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 13041,
-                  "hotExecutionTotalNs": 1104458,
-                  "hotExecutionPerCallNs": 11044
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4496583,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 141292,
-                "calcitFrontendNs": 117666,
-                "snapshotCloneNs": 375,
-                "compile": {
-                  "eligibilityNs": 18166,
-                  "planningNs": 11084,
-                  "programConstructionNs": 27584,
-                  "validationLoweringNs": 4000,
-                  "totalNs": 62792
-                },
-                "runtime": {
-                  "nativeCallNs": 92459,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 2875,
-                  "pureExecutionNs": 12208,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 15500,
-                  "hotExecutionTotalNs": 1099500,
-                  "hotExecutionPerCallNs": 10995
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4153250,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 132583,
-                "calcitFrontendNs": 129917,
+                "fixtureInstallNs": 145041,
+                "calcitFrontendNs": 136917,
                 "snapshotCloneNs": 209,
                 "compile": {
-                  "eligibilityNs": 17542,
-                  "planningNs": 8291,
-                  "programConstructionNs": 21375,
-                  "validationLoweringNs": 3750,
-                  "totalNs": 52666
+                  "eligibilityNs": 25209,
+                  "planningNs": 7792,
+                  "programConstructionNs": 33125,
+                  "validationLoweringNs": 4750,
+                  "totalNs": 72875
                 },
                 "runtime": {
-                  "nativeCallNs": 82667,
-                  "boundaryArgumentsNs": 208,
-                  "vmSetupNs": 375,
-                  "pureExecutionNs": 11250,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 12041,
-                  "hotExecutionTotalNs": 1011792,
-                  "hotExecutionPerCallNs": 10117
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4030875,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 118458,
-                "calcitFrontendNs": 107000,
-                "snapshotCloneNs": 2791,
-                "compile": {
-                  "eligibilityNs": 14750,
-                  "planningNs": 12208,
-                  "programConstructionNs": 21792,
-                  "validationLoweringNs": 3792,
-                  "totalNs": 54167
-                },
-                "runtime": {
-                  "nativeCallNs": 81083,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 13834,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 14542,
-                  "hotExecutionTotalNs": 1010417,
-                  "hotExecutionPerCallNs": 10104
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3953709,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 131708,
-                "calcitFrontendNs": 107208,
-                "snapshotCloneNs": 291,
-                "compile": {
-                  "eligibilityNs": 14875,
-                  "planningNs": 7042,
-                  "programConstructionNs": 23667,
-                  "validationLoweringNs": 3333,
-                  "totalNs": 50583
-                },
-                "runtime": {
-                  "nativeCallNs": 79209,
-                  "boundaryArgumentsNs": 209,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 11166,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 11834,
-                  "hotExecutionTotalNs": 967292,
-                  "hotExecutionPerCallNs": 9672
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3844375,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 120125,
-                "calcitFrontendNs": 99208,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 14250,
-                  "planningNs": 9417,
-                  "programConstructionNs": 20375,
-                  "validationLoweringNs": 3292,
-                  "totalNs": 48834
-                },
-                "runtime": {
-                  "nativeCallNs": 77041,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 10625,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 11292,
-                  "hotExecutionTotalNs": 967208,
-                  "hotExecutionPerCallNs": 9672
+                  "nativeCallNs": 83583,
+                  "cachedNativeResolutionNs": 3000,
+                  "cachedNativeExecutionTotalNs": 6043959,
+                  "cachedNativeExecutionPerCallNs": 60439,
+                  "boundaryArgumentsNs": 292,
+                  "vmSetupNs": 583,
+                  "pureExecutionNs": 10334,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 21167,
+                  "hotExecutionTotalNs": 953458,
+                  "hotExecutionPerCallNs": 9534
                 },
                 "program": {
                   "functions": 1,
@@ -6043,55 +6500,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 14239708,
-              "fixtureInstallNs": 117875,
-              "calcitFrontendNs": 93375,
-              "snapshotCloneNs": 250,
-              "eligibilityNs": 13667,
-              "planningNs": 7416,
-              "programConstructionNs": 19792,
-              "validationLoweringNs": 3375,
-              "calxCompileTotalNs": 46625,
-              "nativeCallNs": 609375,
-              "boundaryArgumentsNs": 167,
-              "vmSetupNs": 292,
-              "pureExecutionNs": 90750,
+              "processWallNs": 89913458,
+              "fixtureInstallNs": 138583,
+              "calcitFrontendNs": 135333,
+              "snapshotCloneNs": 291,
+              "eligibilityNs": 20292,
+              "planningNs": 7875,
+              "programConstructionNs": 26250,
+              "validationLoweringNs": 5500,
+              "calxCompileTotalNs": 62792,
+              "nativeCallNs": 627500,
+              "cachedNativeResolutionNs": 375,
+              "cachedNativeExecutionTotalNs": 61173000,
+              "cachedNativeExecutionPerCallNs": 611730,
+              "boundaryArgumentsNs": 791,
+              "vmSetupNs": 1375,
+              "pureExecutionNs": 94792,
               "boundaryResultNs": 42,
-              "calxOneShotNs": 91459,
-              "hotExecutionPerCallNs": 90242
+              "calxOneShotNs": 97458,
+              "hotExecutionTotalNs": 9236083,
+              "hotExecutionPerCallNs": 92360
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 27375,
-              "fixtureInstallNs": 3500,
-              "calcitFrontendNs": 1875,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 458,
-              "planningNs": 1001,
-              "programConstructionNs": 374,
-              "validationLoweringNs": 125,
-              "calxCompileTotalNs": 1208,
-              "nativeCallNs": 3834,
-              "boundaryArgumentsNs": 1,
-              "vmSetupNs": 42,
-              "pureExecutionNs": 334,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 459,
-              "hotExecutionPerCallNs": 127
+              "processWallNs": 814125,
+              "fixtureInstallNs": 8792,
+              "calcitFrontendNs": 10250,
+              "snapshotCloneNs": 41,
+              "eligibilityNs": 1666,
+              "planningNs": 250,
+              "programConstructionNs": 3208,
+              "validationLoweringNs": 375,
+              "calxCompileTotalNs": 7458,
+              "nativeCallNs": 10792,
+              "cachedNativeResolutionNs": 208,
+              "cachedNativeExecutionTotalNs": 491333,
+              "cachedNativeExecutionPerCallNs": 4914,
+              "boundaryArgumentsNs": 208,
+              "vmSetupNs": 416,
+              "pureExecutionNs": 1125,
+              "boundaryResultNs": 1,
+              "calxOneShotNs": 875,
+              "hotExecutionTotalNs": 99542,
+              "hotExecutionPerCallNs": 995
             },
             "derived": {
-              "nativeEndToEndNs": 820625,
-              "calxEndToEndNs": 349584,
-              "hotVsNativeRatio": 0.1480894358974359,
-              "oneShotEndToEndRatio": 0.4259972581873572
+              "lookupNativeEndToEndNs": 901416,
+              "calxEndToEndNs": 434457,
+              "calxHotVsLookupNativeRatio": 0.14718725099601593,
+              "calxHotVsCachedNativeRatio": 0.15098164222778024,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.4819716978620304
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 14457917,
+              "processWallNs": 89344208,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6102,25 +6568,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 133625,
-                "calcitFrontendNs": 110166,
-                "snapshotCloneNs": 292,
+                "fixtureInstallNs": 148625,
+                "calcitFrontendNs": 131208,
+                "snapshotCloneNs": 459,
                 "compile": {
-                  "eligibilityNs": 18708,
-                  "planningNs": 5542,
-                  "programConstructionNs": 19792,
-                  "validationLoweringNs": 3500,
-                  "totalNs": 49042
+                  "eligibilityNs": 20667,
+                  "planningNs": 7708,
+                  "programConstructionNs": 33917,
+                  "validationLoweringNs": 6250,
+                  "totalNs": 70250
                 },
                 "runtime": {
-                  "nativeCallNs": 627042,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 92292,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 93000,
-                  "hotExecutionTotalNs": 9024208,
-                  "hotExecutionPerCallNs": 90242
+                  "nativeCallNs": 623167,
+                  "cachedNativeResolutionNs": 3083,
+                  "cachedNativeExecutionTotalNs": 60720875,
+                  "cachedNativeExecutionPerCallNs": 607208,
+                  "boundaryArgumentsNs": 583,
+                  "vmSetupNs": 834,
+                  "pureExecutionNs": 115458,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 117250,
+                  "hotExecutionTotalNs": 9236083,
+                  "hotExecutionPerCallNs": 92360
                 },
                 "program": {
                   "functions": 1,
@@ -6135,11 +6604,11 @@
               }
             },
             {
-              "processWallNs": 14261750,
+              "processWallNs": 89550583,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6150,25 +6619,181 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 118333,
-                "calcitFrontendNs": 101209,
+                "fixtureInstallNs": 124500,
+                "calcitFrontendNs": 113041,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 17625,
+                  "planningNs": 7833,
+                  "programConstructionNs": 23042,
+                  "validationLoweringNs": 4250,
+                  "totalNs": 54334
+                },
+                "runtime": {
+                  "nativeCallNs": 616708,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 61173000,
+                  "cachedNativeExecutionPerCallNs": 611730,
+                  "boundaryArgumentsNs": 791,
+                  "vmSetupNs": 1375,
+                  "pureExecutionNs": 94541,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 97083,
+                  "hotExecutionTotalNs": 9129333,
+                  "hotExecutionPerCallNs": 91293
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 88974125,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 136583,
+                "calcitFrontendNs": 124916,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 17666,
+                  "planningNs": 7625,
+                  "programConstructionNs": 22291,
+                  "validationLoweringNs": 5417,
+                  "totalNs": 54250
+                },
+                "runtime": {
+                  "nativeCallNs": 611375,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 60681667,
+                  "cachedNativeExecutionPerCallNs": 606816,
+                  "boundaryArgumentsNs": 1000,
+                  "vmSetupNs": 1750,
+                  "pureExecutionNs": 93500,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 96583,
+                  "hotExecutionTotalNs": 9131166,
+                  "hotExecutionPerCallNs": 91311
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 90727583,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 138583,
+                "calcitFrontendNs": 145583,
+                "snapshotCloneNs": 166,
+                "compile": {
+                  "eligibilityNs": 21958,
+                  "planningNs": 8375,
+                  "programConstructionNs": 27167,
+                  "validationLoweringNs": 5875,
+                  "totalNs": 65292
+                },
+                "runtime": {
+                  "nativeCallNs": 642375,
+                  "cachedNativeResolutionNs": 3042,
+                  "cachedNativeExecutionTotalNs": 62063583,
+                  "cachedNativeExecutionPerCallNs": 620635,
+                  "boundaryArgumentsNs": 291,
+                  "vmSetupNs": 542,
+                  "pureExecutionNs": 95167,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 102041,
+                  "hotExecutionTotalNs": 9266250,
+                  "hotExecutionPerCallNs": 92662
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 15,
+                  "instructions": 15,
+                  "diagnosticBytes": 1005,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 89913458,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "range-sum",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 157292,
+                "calcitFrontendNs": 153208,
                 "snapshotCloneNs": 291,
                 "compile": {
-                  "eligibilityNs": 14125,
-                  "planningNs": 5541,
-                  "programConstructionNs": 18292,
-                  "validationLoweringNs": 3416,
-                  "totalNs": 42875
+                  "eligibilityNs": 25417,
+                  "planningNs": 8834,
+                  "programConstructionNs": 37041,
+                  "validationLoweringNs": 5458,
+                  "totalNs": 78833
                 },
                 "runtime": {
-                  "nativeCallNs": 611000,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 90750,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 91416,
-                  "hotExecutionTotalNs": 9051459,
-                  "hotExecutionPerCallNs": 90514
+                  "nativeCallNs": 664167,
+                  "cachedNativeResolutionNs": 375,
+                  "cachedNativeExecutionTotalNs": 61077334,
+                  "cachedNativeExecutionPerCallNs": 610773,
+                  "boundaryArgumentsNs": 1000,
+                  "vmSetupNs": 959,
+                  "pureExecutionNs": 94792,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 97458,
+                  "hotExecutionTotalNs": 9243042,
+                  "hotExecutionPerCallNs": 92430
                 },
                 "program": {
                   "functions": 1,
@@ -6183,11 +6808,11 @@
               }
             },
             {
-              "processWallNs": 14123417,
+              "processWallNs": 91901584,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6198,25 +6823,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 122250,
-                "calcitFrontendNs": 105208,
+                "fixtureInstallNs": 147375,
+                "calcitFrontendNs": 137750,
                 "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 13334,
+                  "eligibilityNs": 20292,
                   "planningNs": 8333,
-                  "programConstructionNs": 20166,
-                  "validationLoweringNs": 3208,
-                  "totalNs": 46625
+                  "programConstructionNs": 26250,
+                  "validationLoweringNs": 6042,
+                  "totalNs": 62792
                 },
                 "runtime": {
-                  "nativeCallNs": 605541,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 333,
-                  "pureExecutionNs": 90709,
+                  "nativeCallNs": 638250,
+                  "cachedNativeResolutionNs": 2916,
+                  "cachedNativeExecutionTotalNs": 63086041,
+                  "cachedNativeExecutionPerCallNs": 630860,
+                  "boundaryArgumentsNs": 750,
+                  "vmSetupNs": 1792,
+                  "pureExecutionNs": 96791,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 91459,
-                  "hotExecutionTotalNs": 9022375,
-                  "hotExecutionPerCallNs": 90223
+                  "calxOneShotNs": 109833,
+                  "hotExecutionTotalNs": 9136541,
+                  "hotExecutionPerCallNs": 91365
                 },
                 "program": {
                   "functions": 1,
@@ -6231,11 +6859,11 @@
               }
             },
             {
-              "processWallNs": 14092459,
+              "processWallNs": 94647500,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6246,169 +6874,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 114917,
-                "calcitFrontendNs": 93000,
-                "snapshotCloneNs": 208,
+                "fixtureInstallNs": 130250,
+                "calcitFrontendNs": 135333,
+                "snapshotCloneNs": 167,
                 "compile": {
-                  "eligibilityNs": 13667,
-                  "planningNs": 8417,
-                  "programConstructionNs": 19833,
-                  "validationLoweringNs": 3208,
-                  "totalNs": 46667
+                  "eligibilityNs": 19375,
+                  "planningNs": 7875,
+                  "programConstructionNs": 24791,
+                  "validationLoweringNs": 5500,
+                  "totalNs": 59542
                 },
                 "runtime": {
-                  "nativeCallNs": 606083,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 90417,
+                  "nativeCallNs": 627500,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 63134959,
+                  "cachedNativeExecutionPerCallNs": 631349,
+                  "boundaryArgumentsNs": 959,
+                  "vmSetupNs": 1667,
+                  "pureExecutionNs": 93667,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 91000,
-                  "hotExecutionTotalNs": 9011542,
-                  "hotExecutionPerCallNs": 90115
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 14267083,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 108333,
-                "calcitFrontendNs": 93375,
-                "snapshotCloneNs": 209,
-                "compile": {
-                  "eligibilityNs": 12917,
-                  "planningNs": 7416,
-                  "programConstructionNs": 19083,
-                  "validationLoweringNs": 3375,
-                  "totalNs": 44459
-                },
-                "runtime": {
-                  "nativeCallNs": 596667,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 92334,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 92958,
-                  "hotExecutionTotalNs": 9047917,
-                  "hotExecutionPerCallNs": 90479
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 14238958,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 114375,
-                "calcitFrontendNs": 91500,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 14708,
-                  "planningNs": 7208,
-                  "programConstructionNs": 18625,
-                  "validationLoweringNs": 3375,
-                  "totalNs": 45417
-                },
-                "runtime": {
-                  "nativeCallNs": 627125,
-                  "boundaryArgumentsNs": 209,
-                  "vmSetupNs": 458,
-                  "pureExecutionNs": 91917,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 92750,
-                  "hotExecutionTotalNs": 9022000,
-                  "hotExecutionPerCallNs": 90220
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 15,
-                  "instructions": 15,
-                  "diagnosticBytes": 1005,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 14239708,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "range-sum",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 117875,
-                "calcitFrontendNs": 91625,
-                "snapshotCloneNs": 208,
-                "compile": {
-                  "eligibilityNs": 13459,
-                  "planningNs": 8833,
-                  "programConstructionNs": 20125,
-                  "validationLoweringNs": 3125,
-                  "totalNs": 47000
-                },
-                "runtime": {
-                  "nativeCallNs": 609375,
-                  "boundaryArgumentsNs": 250,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 90416,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 91125,
-                  "hotExecutionTotalNs": 9048875,
-                  "hotExecutionPerCallNs": 90488
+                  "calxOneShotNs": 96834,
+                  "hotExecutionTotalNs": 12321375,
+                  "hotExecutionPerCallNs": 123213
                 },
                 "program": {
                   "functions": 1,
@@ -6438,55 +6925,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 2827334,
-              "fixtureInstallNs": 114084,
-              "calcitFrontendNs": 99834,
-              "snapshotCloneNs": 333,
-              "eligibilityNs": 14375,
-              "planningNs": 7417,
-              "programConstructionNs": 21291,
-              "validationLoweringNs": 4042,
-              "calxCompileTotalNs": 49292,
-              "nativeCallNs": 25667,
+              "processWallNs": 5255292,
+              "fixtureInstallNs": 143375,
+              "calcitFrontendNs": 118292,
+              "snapshotCloneNs": 250,
+              "eligibilityNs": 16000,
+              "planningNs": 7542,
+              "programConstructionNs": 22375,
+              "validationLoweringNs": 3666,
+              "calxCompileTotalNs": 49917,
+              "nativeCallNs": 36500,
+              "cachedNativeResolutionNs": 209,
+              "cachedNativeExecutionTotalNs": 1230917,
+              "cachedNativeExecutionPerCallNs": 12309,
               "boundaryArgumentsNs": 125,
-              "vmSetupNs": 291,
-              "pureExecutionNs": 2708,
+              "vmSetupNs": 416,
+              "pureExecutionNs": 2667,
               "boundaryResultNs": 41,
-              "calxOneShotNs": 3333,
-              "hotExecutionPerCallNs": 1409
+              "calxOneShotNs": 3583,
+              "hotExecutionTotalNs": 146000,
+              "hotExecutionPerCallNs": 1460
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 32376,
-              "fixtureInstallNs": 1375,
-              "calcitFrontendNs": 1416,
-              "snapshotCloneNs": 1,
-              "eligibilityNs": 625,
-              "planningNs": 583,
-              "programConstructionNs": 624,
-              "validationLoweringNs": 667,
-              "calxCompileTotalNs": 792,
-              "nativeCallNs": 250,
+              "processWallNs": 140666,
+              "fixtureInstallNs": 4000,
+              "calcitFrontendNs": 7792,
+              "snapshotCloneNs": 0,
+              "eligibilityNs": 1292,
+              "planningNs": 1000,
+              "programConstructionNs": 1666,
+              "validationLoweringNs": 874,
+              "calxCompileTotalNs": 3083,
+              "nativeCallNs": 4000,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 22501,
+              "cachedNativeExecutionPerCallNs": 225,
               "boundaryArgumentsNs": 0,
-              "vmSetupNs": 41,
-              "pureExecutionNs": 125,
-              "boundaryResultNs": 1,
-              "calxOneShotNs": 208,
-              "hotExecutionPerCallNs": 2
+              "vmSetupNs": 125,
+              "pureExecutionNs": 250,
+              "boundaryResultNs": 41,
+              "calxOneShotNs": 583,
+              "hotExecutionTotalNs": 625,
+              "hotExecutionPerCallNs": 7
             },
             "derived": {
-              "nativeEndToEndNs": 239585,
-              "calxEndToEndNs": 266876,
-              "hotVsNativeRatio": 0.05489539096894846,
-              "oneShotEndToEndRatio": 1.1139094684558717
+              "lookupNativeEndToEndNs": 298167,
+              "calxEndToEndNs": 315417,
+              "calxHotVsLookupNativeRatio": 0.04,
+              "calxHotVsCachedNativeRatio": 0.11861239743277277,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.0578534847920795
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 2827334,
+              "processWallNs": 4963458,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6497,121 +6993,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 112709,
-                "calcitFrontendNs": 100625,
-                "snapshotCloneNs": 334,
+                "fixtureInstallNs": 133208,
+                "calcitFrontendNs": 111042,
+                "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 14375,
-                  "planningNs": 9000,
-                  "programConstructionNs": 21417,
-                  "validationLoweringNs": 4625,
-                  "totalNs": 50959
+                  "eligibilityNs": 15250,
+                  "planningNs": 7542,
+                  "programConstructionNs": 22375,
+                  "validationLoweringNs": 3333,
+                  "totalNs": 49917
                 },
                 "runtime": {
-                  "nativeCallNs": 25292,
+                  "nativeCallNs": 27208,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 1147500,
+                  "cachedNativeExecutionPerCallNs": 11475,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 333,
-                  "pureExecutionNs": 2583,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 3208,
-                  "hotExecutionTotalNs": 142291,
-                  "hotExecutionPerCallNs": 1422
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2794958,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 5,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 114084,
-                "calcitFrontendNs": 98583,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 14209,
-                  "planningNs": 8459,
-                  "programConstructionNs": 20667,
-                  "validationLoweringNs": 4083,
-                  "totalNs": 49083
-                },
-                "runtime": {
-                  "nativeCallNs": 25667,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 2708,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 3333,
-                  "hotExecutionTotalNs": 140834,
-                  "hotExecutionPerCallNs": 1408
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2903541,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 5,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 115375,
-                "calcitFrontendNs": 96667,
-                "snapshotCloneNs": 333,
-                "compile": {
-                  "eligibilityNs": 18250,
-                  "planningNs": 6834,
-                  "programConstructionNs": 21291,
-                  "validationLoweringNs": 3292,
-                  "totalNs": 51166
-                },
-                "runtime": {
-                  "nativeCallNs": 25917,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 2625,
+                  "vmSetupNs": 208,
+                  "pureExecutionNs": 3709,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 3125,
-                  "hotExecutionTotalNs": 143583,
-                  "hotExecutionPerCallNs": 1435
+                  "calxOneShotNs": 4250,
+                  "hotExecutionTotalNs": 152167,
+                  "hotExecutionPerCallNs": 1521
                 },
                 "program": {
                   "functions": 1,
@@ -6626,11 +7029,11 @@
               }
             },
             {
-              "processWallNs": 3002916,
+              "processWallNs": 5413208,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6641,25 +7044,130 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 113500,
-                "calcitFrontendNs": 101250,
-                "snapshotCloneNs": 333,
+                "fixtureInstallNs": 147375,
+                "calcitFrontendNs": 144166,
+                "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 14042,
-                  "planningNs": 7959,
-                  "programConstructionNs": 21917,
-                  "validationLoweringNs": 4042,
-                  "totalNs": 49458
+                  "eligibilityNs": 23084,
+                  "planningNs": 12458,
+                  "programConstructionNs": 28792,
+                  "validationLoweringNs": 4208,
+                  "totalNs": 74541
                 },
                 "runtime": {
-                  "nativeCallNs": 25541,
+                  "nativeCallNs": 43750,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 1250541,
+                  "cachedNativeExecutionPerCallNs": 12505,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 416,
+                  "pureExecutionNs": 2750,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 3583,
+                  "hotExecutionTotalNs": 146000,
+                  "hotExecutionPerCallNs": 1460
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5255292,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 5,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 143375,
+                "calcitFrontendNs": 113792,
+                "snapshotCloneNs": 209,
+                "compile": {
+                  "eligibilityNs": 15042,
+                  "planningNs": 6000,
+                  "programConstructionNs": 21542,
+                  "validationLoweringNs": 2792,
+                  "totalNs": 46834
+                },
+                "runtime": {
+                  "nativeCallNs": 36500,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 1208416,
+                  "cachedNativeExecutionPerCallNs": 12084,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 3042,
+                  "pureExecutionNs": 2417,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 5792,
+                  "hotExecutionTotalNs": 145375,
+                  "hotExecutionPerCallNs": 1453
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5378417,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 5,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 129834,
+                "calcitFrontendNs": 110500,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 16000,
+                  "planningNs": 7084,
+                  "programConstructionNs": 20709,
+                  "validationLoweringNs": 3666,
+                  "totalNs": 49041
+                },
+                "runtime": {
+                  "nativeCallNs": 35084,
+                  "cachedNativeResolutionNs": 209,
+                  "cachedNativeExecutionTotalNs": 1230917,
+                  "cachedNativeExecutionPerCallNs": 12309,
                   "boundaryArgumentsNs": 125,
                   "vmSetupNs": 292,
-                  "pureExecutionNs": 5084,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 5625,
-                  "hotExecutionTotalNs": 140708,
-                  "hotExecutionPerCallNs": 1407
+                  "pureExecutionNs": 2417,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 3000,
+                  "hotExecutionTotalNs": 145583,
+                  "hotExecutionPerCallNs": 1455
                 },
                 "program": {
                   "functions": 1,
@@ -6674,11 +7182,11 @@
               }
             },
             {
-              "processWallNs": 2771334,
+              "processWallNs": 5193208,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6689,25 +7197,79 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 124250,
-                "calcitFrontendNs": 99834,
-                "snapshotCloneNs": 334,
+                "fixtureInstallNs": 144208,
+                "calcitFrontendNs": 152166,
+                "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 13292,
-                  "planningNs": 6333,
-                  "programConstructionNs": 20417,
-                  "validationLoweringNs": 3333,
-                  "totalNs": 44958
+                  "eligibilityNs": 20791,
+                  "planningNs": 8542,
+                  "programConstructionNs": 25541,
+                  "validationLoweringNs": 6333,
+                  "totalNs": 63375
                 },
                 "runtime": {
-                  "nativeCallNs": 30750,
+                  "nativeCallNs": 38792,
+                  "cachedNativeResolutionNs": 292,
+                  "cachedNativeExecutionTotalNs": 1231416,
+                  "cachedNativeExecutionPerCallNs": 12314,
+                  "boundaryArgumentsNs": 3000,
+                  "vmSetupNs": 1291,
+                  "pureExecutionNs": 5333,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 9958,
+                  "hotExecutionTotalNs": 185333,
+                  "hotExecutionPerCallNs": 1853
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4934500,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 5,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 143208,
+                "calcitFrontendNs": 118292,
+                "snapshotCloneNs": 167,
+                "compile": {
+                  "eligibilityNs": 14708,
+                  "planningNs": 6625,
+                  "programConstructionNs": 22333,
+                  "validationLoweringNs": 2708,
+                  "totalNs": 47750
+                },
+                "runtime": {
+                  "nativeCallNs": 32500,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 1206500,
+                  "cachedNativeExecutionPerCallNs": 12065,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 209,
-                  "pureExecutionNs": 2542,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 3083,
-                  "hotExecutionTotalNs": 140958,
-                  "hotExecutionPerCallNs": 1409
+                  "vmSetupNs": 292,
+                  "pureExecutionNs": 2417,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 3000,
+                  "hotExecutionTotalNs": 145750,
+                  "hotExecutionPerCallNs": 1457
                 },
                 "program": {
                   "functions": 1,
@@ -6722,11 +7284,11 @@
               }
             },
             {
-              "processWallNs": 2837250,
+              "processWallNs": 5395958,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6737,73 +7299,28 @@
                 "size": 5,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 119750,
-                "calcitFrontendNs": 97042,
-                "snapshotCloneNs": 291,
+                "fixtureInstallNs": 157208,
+                "calcitFrontendNs": 150333,
+                "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 15167,
-                  "planningNs": 7417,
-                  "programConstructionNs": 19542,
-                  "validationLoweringNs": 5500,
-                  "totalNs": 49292
+                  "eligibilityNs": 29791,
+                  "planningNs": 9042,
+                  "programConstructionNs": 29041,
+                  "validationLoweringNs": 6375,
+                  "totalNs": 76125
                 },
                 "runtime": {
-                  "nativeCallNs": 25916,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 291,
-                  "pureExecutionNs": 2750,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 3375,
-                  "hotExecutionTotalNs": 140792,
-                  "hotExecutionPerCallNs": 1407
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2815625,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 5,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 110333,
-                "calcitFrontendNs": 101791,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 15000,
-                  "planningNs": 7125,
-                  "programConstructionNs": 21375,
-                  "validationLoweringNs": 3375,
-                  "totalNs": 48500
-                },
-                "runtime": {
-                  "nativeCallNs": 25000,
-                  "boundaryArgumentsNs": 84,
-                  "vmSetupNs": 375,
-                  "pureExecutionNs": 5375,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 6083,
-                  "hotExecutionTotalNs": 143083,
-                  "hotExecutionPerCallNs": 1430
+                  "nativeCallNs": 42041,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 1306875,
+                  "cachedNativeExecutionPerCallNs": 13068,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 541,
+                  "pureExecutionNs": 2667,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 3542,
+                  "hotExecutionTotalNs": 148583,
+                  "hotExecutionPerCallNs": 1485
                 },
                 "program": {
                   "functions": 1,
@@ -6833,55 +7350,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 4933333,
-              "fixtureInstallNs": 117542,
-              "calcitFrontendNs": 99625,
+              "processWallNs": 24417917,
+              "fixtureInstallNs": 139833,
+              "calcitFrontendNs": 130125,
               "snapshotCloneNs": 292,
-              "eligibilityNs": 15291,
-              "planningNs": 7666,
-              "programConstructionNs": 21083,
-              "validationLoweringNs": 3417,
-              "calxCompileTotalNs": 49166,
-              "nativeCallNs": 162875,
-              "boundaryArgumentsNs": 125,
-              "vmSetupNs": 250,
-              "pureExecutionNs": 19792,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 20375,
-              "hotExecutionPerCallNs": 17522
+              "eligibilityNs": 21875,
+              "planningNs": 8792,
+              "programConstructionNs": 25625,
+              "validationLoweringNs": 5083,
+              "calxCompileTotalNs": 62958,
+              "nativeCallNs": 177583,
+              "cachedNativeResolutionNs": 250,
+              "cachedNativeExecutionTotalNs": 14813250,
+              "cachedNativeExecutionPerCallNs": 148132,
+              "boundaryArgumentsNs": 708,
+              "vmSetupNs": 1584,
+              "pureExecutionNs": 23791,
+              "boundaryResultNs": 125,
+              "calxOneShotNs": 26375,
+              "hotExecutionTotalNs": 1790292,
+              "hotExecutionPerCallNs": 17902
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 26749,
-              "fixtureInstallNs": 3834,
-              "calcitFrontendNs": 1291,
-              "snapshotCloneNs": 1,
-              "eligibilityNs": 376,
-              "planningNs": 376,
-              "programConstructionNs": 500,
-              "validationLoweringNs": 125,
-              "calxCompileTotalNs": 874,
-              "nativeCallNs": 2416,
-              "boundaryArgumentsNs": 0,
-              "vmSetupNs": 0,
-              "pureExecutionNs": 792,
+              "processWallNs": 96626,
+              "fixtureInstallNs": 5625,
+              "calcitFrontendNs": 5417,
+              "snapshotCloneNs": 0,
+              "eligibilityNs": 1917,
+              "planningNs": 417,
+              "programConstructionNs": 1125,
+              "validationLoweringNs": 291,
+              "calxCompileTotalNs": 2875,
+              "nativeCallNs": 3624,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 153083,
+              "cachedNativeExecutionPerCallNs": 1531,
+              "boundaryArgumentsNs": 126,
+              "vmSetupNs": 166,
+              "pureExecutionNs": 1749,
               "boundaryResultNs": 0,
-              "calxOneShotNs": 792,
-              "hotExecutionPerCallNs": 37
+              "calxOneShotNs": 333,
+              "hotExecutionTotalNs": 18875,
+              "hotExecutionPerCallNs": 188
             },
             "derived": {
-              "nativeEndToEndNs": 380042,
-              "calxEndToEndNs": 287000,
-              "hotVsNativeRatio": 0.10757943207981581,
-              "oneShotEndToEndRatio": 0.7551796906657685
+              "lookupNativeEndToEndNs": 447541,
+              "calxEndToEndNs": 359583,
+              "calxHotVsLookupNativeRatio": 0.10080919907874064,
+              "calxHotVsCachedNativeRatio": 0.12085167283233872,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.8034638167229371
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 4921333,
+              "processWallNs": 24437459,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6892,25 +7418,181 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 108500,
-                "calcitFrontendNs": 99458,
-                "snapshotCloneNs": 333,
+                "fixtureInstallNs": 145458,
+                "calcitFrontendNs": 125333,
+                "snapshotCloneNs": 416,
                 "compile": {
-                  "eligibilityNs": 14208,
+                  "eligibilityNs": 19958,
+                  "planningNs": 8792,
+                  "programConstructionNs": 25250,
+                  "validationLoweringNs": 5083,
+                  "totalNs": 61375
+                },
+                "runtime": {
+                  "nativeCallNs": 175416,
+                  "cachedNativeResolutionNs": 292,
+                  "cachedNativeExecutionTotalNs": 14988125,
+                  "cachedNativeExecutionPerCallNs": 149881,
+                  "boundaryArgumentsNs": 708,
+                  "vmSetupNs": 1542,
+                  "pureExecutionNs": 23542,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 26375,
+                  "hotExecutionTotalNs": 1790292,
+                  "hotExecutionPerCallNs": 17902
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 24321291,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 142458,
+                "calcitFrontendNs": 145125,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 22084,
+                  "planningNs": 9500,
+                  "programConstructionNs": 63042,
+                  "validationLoweringNs": 6166,
+                  "totalNs": 103667
+                },
+                "runtime": {
+                  "nativeCallNs": 189458,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 14660167,
+                  "cachedNativeExecutionPerCallNs": 146601,
+                  "boundaryArgumentsNs": 750,
+                  "vmSetupNs": 1875,
+                  "pureExecutionNs": 32083,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 35333,
+                  "hotExecutionTotalNs": 1807625,
+                  "hotExecutionPerCallNs": 18076
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 24454334,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 134208,
+                "calcitFrontendNs": 130125,
+                "snapshotCloneNs": 459,
+                "compile": {
+                  "eligibilityNs": 21875,
+                  "planningNs": 7417,
+                  "programConstructionNs": 26750,
+                  "validationLoweringNs": 4958,
+                  "totalNs": 62958
+                },
+                "runtime": {
+                  "nativeCallNs": 178375,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 14813250,
+                  "cachedNativeExecutionPerCallNs": 148132,
+                  "boundaryArgumentsNs": 2250,
+                  "vmSetupNs": 1417,
+                  "pureExecutionNs": 22042,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 26208,
+                  "hotExecutionTotalNs": 1759667,
+                  "hotExecutionPerCallNs": 17596
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 24417917,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 128375,
+                "calcitFrontendNs": 124250,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 17709,
                   "planningNs": 7958,
-                  "programConstructionNs": 21125,
-                  "validationLoweringNs": 4375,
-                  "totalNs": 49166
+                  "programConstructionNs": 21292,
+                  "validationLoweringNs": 4959,
+                  "totalNs": 53500
                 },
                 "runtime": {
-                  "nativeCallNs": 159792,
-                  "boundaryArgumentsNs": 83,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 22125,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 22667,
-                  "hotExecutionTotalNs": 1752292,
-                  "hotExecutionPerCallNs": 17522
+                  "nativeCallNs": 173959,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 14864542,
+                  "cachedNativeExecutionPerCallNs": 148645,
+                  "boundaryArgumentsNs": 500,
+                  "vmSetupNs": 1750,
+                  "pureExecutionNs": 23209,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 26125,
+                  "hotExecutionTotalNs": 1795834,
+                  "hotExecutionPerCallNs": 17958
                 },
                 "program": {
                   "functions": 1,
@@ -6925,11 +7607,11 @@
               }
             },
             {
-              "processWallNs": 4933333,
+              "processWallNs": 23897958,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -6940,169 +7622,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 111750,
-                "calcitFrontendNs": 99625,
-                "snapshotCloneNs": 250,
-                "compile": {
-                  "eligibilityNs": 15291,
-                  "planningNs": 6625,
-                  "programConstructionNs": 21083,
-                  "validationLoweringNs": 3417,
-                  "totalNs": 48041
-                },
-                "runtime": {
-                  "nativeCallNs": 162458,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 22208,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 22875,
-                  "hotExecutionTotalNs": 1761083,
-                  "hotExecutionPerCallNs": 17610
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4877625,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 119500,
-                "calcitFrontendNs": 94625,
-                "snapshotCloneNs": 291,
-                "compile": {
-                  "eligibilityNs": 15542,
-                  "planningNs": 8042,
-                  "programConstructionNs": 20583,
-                  "validationLoweringNs": 3292,
-                  "totalNs": 49042
-                },
-                "runtime": {
-                  "nativeCallNs": 160459,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 22167,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 22875,
-                  "hotExecutionTotalNs": 1760250,
-                  "hotExecutionPerCallNs": 17602
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4953417,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 132209,
-                "calcitFrontendNs": 104667,
-                "snapshotCloneNs": 333,
-                "compile": {
-                  "eligibilityNs": 14250,
-                  "planningNs": 12125,
-                  "programConstructionNs": 21583,
-                  "validationLoweringNs": 3375,
-                  "totalNs": 52916
-                },
-                "runtime": {
-                  "nativeCallNs": 162875,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 19375,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 20000,
-                  "hotExecutionTotalNs": 1749791,
-                  "hotExecutionPerCallNs": 17497
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 5019458,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 121334,
-                "calcitFrontendNs": 97084,
+                "fixtureInstallNs": 139833,
+                "calcitFrontendNs": 128666,
                 "snapshotCloneNs": 292,
                 "compile": {
-                  "eligibilityNs": 19459,
-                  "planningNs": 7666,
-                  "programConstructionNs": 19917,
-                  "validationLoweringNs": 3792,
-                  "totalNs": 52416
+                  "eligibilityNs": 19917,
+                  "planningNs": 8833,
+                  "programConstructionNs": 24500,
+                  "validationLoweringNs": 4792,
+                  "totalNs": 60083
                 },
                 "runtime": {
-                  "nativeCallNs": 163208,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 19792,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 20375,
-                  "hotExecutionTotalNs": 1806334,
-                  "hotExecutionPerCallNs": 18063
+                  "nativeCallNs": 172750,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 14582625,
+                  "cachedNativeExecutionPerCallNs": 145826,
+                  "boundaryArgumentsNs": 708,
+                  "vmSetupNs": 2750,
+                  "pureExecutionNs": 32125,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 36000,
+                  "hotExecutionTotalNs": 1771417,
+                  "hotExecutionPerCallNs": 17714
                 },
                 "program": {
                   "functions": 1,
@@ -7117,11 +7658,11 @@
               }
             },
             {
-              "processWallNs": 4906584,
+              "processWallNs": 24056000,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7132,25 +7673,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 117542,
-                "calcitFrontendNs": 99875,
+                "fixtureInstallNs": 127667,
+                "calcitFrontendNs": 135542,
                 "snapshotCloneNs": 291,
                 "compile": {
-                  "eligibilityNs": 14958,
-                  "planningNs": 6459,
-                  "programConstructionNs": 23459,
-                  "validationLoweringNs": 3584,
-                  "totalNs": 50000
+                  "eligibilityNs": 22833,
+                  "planningNs": 9209,
+                  "programConstructionNs": 25625,
+                  "validationLoweringNs": 5583,
+                  "totalNs": 64875
                 },
                 "runtime": {
-                  "nativeCallNs": 168125,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 417,
-                  "pureExecutionNs": 19042,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 19750,
-                  "hotExecutionTotalNs": 1748583,
-                  "hotExecutionPerCallNs": 17485
+                  "nativeCallNs": 177583,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 14624584,
+                  "cachedNativeExecutionPerCallNs": 146245,
+                  "boundaryArgumentsNs": 834,
+                  "vmSetupNs": 1584,
+                  "pureExecutionNs": 29250,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 32500,
+                  "hotExecutionTotalNs": 1877375,
+                  "hotExecutionPerCallNs": 18773
                 },
                 "program": {
                   "functions": 1,
@@ -7165,11 +7709,11 @@
               }
             },
             {
-              "processWallNs": 5064500,
+              "processWallNs": 24674708,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7180,25 +7724,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 113708,
-                "calcitFrontendNs": 100916,
+                "fixtureInstallNs": 151292,
+                "calcitFrontendNs": 163041,
                 "snapshotCloneNs": 292,
                 "compile": {
-                  "eligibilityNs": 15667,
-                  "planningNs": 7542,
-                  "programConstructionNs": 20083,
-                  "validationLoweringNs": 3375,
-                  "totalNs": 48292
+                  "eligibilityNs": 24459,
+                  "planningNs": 8375,
+                  "programConstructionNs": 29750,
+                  "validationLoweringNs": 5458,
+                  "totalNs": 70084
                 },
                 "runtime": {
-                  "nativeCallNs": 170958,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 19000,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 19583,
-                  "hotExecutionTotalNs": 1750209,
-                  "hotExecutionPerCallNs": 17502
+                  "nativeCallNs": 184416,
+                  "cachedNativeResolutionNs": 292,
+                  "cachedNativeExecutionTotalNs": 14953583,
+                  "cachedNativeExecutionPerCallNs": 149535,
+                  "boundaryArgumentsNs": 417,
+                  "vmSetupNs": 1584,
+                  "pureExecutionNs": 23791,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 26042,
+                  "hotExecutionTotalNs": 1765042,
+                  "hotExecutionPerCallNs": 17650
                 },
                 "program": {
                   "functions": 1,
@@ -7228,55 +7775,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 284511125,
-              "fixtureInstallNs": 125916,
-              "calcitFrontendNs": 127958,
-              "snapshotCloneNs": 375,
-              "eligibilityNs": 18917,
-              "planningNs": 9750,
-              "programConstructionNs": 25292,
+              "processWallNs": 2533781666,
+              "fixtureInstallNs": 143959,
+              "calcitFrontendNs": 145000,
+              "snapshotCloneNs": 333,
+              "eligibilityNs": 24417,
+              "planningNs": 8250,
+              "programConstructionNs": 28500,
               "validationLoweringNs": 5625,
-              "calxCompileTotalNs": 63458,
-              "nativeCallNs": 17919250,
-              "boundaryArgumentsNs": 166,
-              "vmSetupNs": 1084,
-              "pureExecutionNs": 2158583,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 2161083,
-              "hotExecutionPerCallNs": 2165527
+              "calxCompileTotalNs": 69917,
+              "nativeCallNs": 18316250,
+              "cachedNativeResolutionNs": 833,
+              "cachedNativeExecutionTotalNs": 1845976083,
+              "cachedNativeExecutionPerCallNs": 18459760,
+              "boundaryArgumentsNs": 667,
+              "vmSetupNs": 2666,
+              "pureExecutionNs": 2230166,
+              "boundaryResultNs": 166,
+              "calxOneShotNs": 2233209,
+              "hotExecutionTotalNs": 224425875,
+              "hotExecutionPerCallNs": 2244258
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 999292,
-              "fixtureInstallNs": 5166,
-              "calcitFrontendNs": 7874,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 1917,
-              "planningNs": 1500,
-              "programConstructionNs": 2791,
-              "validationLoweringNs": 708,
-              "calxCompileTotalNs": 3083,
-              "nativeCallNs": 122958,
-              "boundaryArgumentsNs": 83,
-              "vmSetupNs": 667,
-              "pureExecutionNs": 1917,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 3792,
-              "hotExecutionPerCallNs": 3913
+              "processWallNs": 16572376,
+              "fixtureInstallNs": 1000,
+              "calcitFrontendNs": 5875,
+              "snapshotCloneNs": 41,
+              "eligibilityNs": 1875,
+              "planningNs": 417,
+              "programConstructionNs": 2250,
+              "validationLoweringNs": 250,
+              "calxCompileTotalNs": 2375,
+              "nativeCallNs": 185583,
+              "cachedNativeResolutionNs": 84,
+              "cachedNativeExecutionTotalNs": 23668084,
+              "cachedNativeExecutionPerCallNs": 236681,
+              "boundaryArgumentsNs": 250,
+              "vmSetupNs": 1000,
+              "pureExecutionNs": 14999,
+              "boundaryResultNs": 42,
+              "calxOneShotNs": 9459,
+              "hotExecutionTotalNs": 1968292,
+              "hotExecutionPerCallNs": 19683
             },
             "derived": {
-              "nativeEndToEndNs": 18173124,
-              "calxEndToEndNs": 2478790,
-              "hotVsNativeRatio": 0.12084919848765992,
-              "oneShotEndToEndRatio": 0.13639867311751133
+              "lookupNativeEndToEndNs": 18605209,
+              "calxEndToEndNs": 2592418,
+              "calxHotVsLookupNativeRatio": 0.12252824677540436,
+              "calxHotVsCachedNativeRatio": 0.12157568679116088,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.13933828961555875
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 284511125,
+              "processWallNs": 2571129291,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7287,25 +7843,28 @@
                 "size": 20,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 125916,
-                "calcitFrontendNs": 110709,
+                "fixtureInstallNs": 140500,
+                "calcitFrontendNs": 150875,
                 "snapshotCloneNs": 333,
                 "compile": {
-                  "eligibilityNs": 17000,
-                  "planningNs": 12208,
-                  "programConstructionNs": 23958,
-                  "validationLoweringNs": 5500,
-                  "totalNs": 60375
+                  "eligibilityNs": 26750,
+                  "planningNs": 7292,
+                  "programConstructionNs": 28500,
+                  "validationLoweringNs": 5541,
+                  "totalNs": 69917
                 },
                 "runtime": {
-                  "nativeCallNs": 18538833,
-                  "boundaryArgumentsNs": 291,
-                  "vmSetupNs": 1667,
-                  "pureExecutionNs": 2167459,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 2169625,
-                  "hotExecutionTotalNs": 216228042,
-                  "hotExecutionPerCallNs": 2162280
+                  "nativeCallNs": 18588625,
+                  "cachedNativeResolutionNs": 833,
+                  "cachedNativeExecutionTotalNs": 1882882708,
+                  "cachedNativeExecutionPerCallNs": 18828827,
+                  "boundaryArgumentsNs": 458,
+                  "vmSetupNs": 8583,
+                  "pureExecutionNs": 2212333,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 2223750,
+                  "hotExecutionTotalNs": 226092917,
+                  "hotExecutionPerCallNs": 2260929
                 },
                 "program": {
                   "functions": 1,
@@ -7320,11 +7879,11 @@
               }
             },
             {
-              "processWallNs": 285510417,
+              "processWallNs": 2524532125,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7335,169 +7894,28 @@
                 "size": 20,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 171875,
-                "calcitFrontendNs": 221958,
-                "snapshotCloneNs": 1500,
+                "fixtureInstallNs": 143959,
+                "calcitFrontendNs": 132000,
+                "snapshotCloneNs": 333,
                 "compile": {
-                  "eligibilityNs": 37000,
-                  "planningNs": 16459,
-                  "programConstructionNs": 41083,
-                  "validationLoweringNs": 12417,
-                  "totalNs": 110041
+                  "eligibilityNs": 29791,
+                  "planningNs": 8667,
+                  "programConstructionNs": 32750,
+                  "validationLoweringNs": 5708,
+                  "totalNs": 78791
                 },
                 "runtime": {
-                  "nativeCallNs": 17866042,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 417,
-                  "pureExecutionNs": 2157250,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 2158000,
-                  "hotExecutionTotalNs": 216161417,
-                  "hotExecutionPerCallNs": 2161614
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 285527292,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 120750,
-                "calcitFrontendNs": 125542,
-                "snapshotCloneNs": 291,
-                "compile": {
-                  "eligibilityNs": 15625,
-                  "planningNs": 8250,
-                  "programConstructionNs": 21666,
-                  "validationLoweringNs": 4833,
-                  "totalNs": 51917
-                },
-                "runtime": {
-                  "nativeCallNs": 18042208,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 2625,
-                  "pureExecutionNs": 2155000,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 2158000,
-                  "hotExecutionTotalNs": 218146208,
-                  "hotExecutionPerCallNs": 2181462
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 283960458,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 124916,
-                "calcitFrontendNs": 127958,
-                "snapshotCloneNs": 208,
-                "compile": {
-                  "eligibilityNs": 18917,
-                  "planningNs": 9750,
-                  "programConstructionNs": 25167,
-                  "validationLoweringNs": 7500,
-                  "totalNs": 63292
-                },
-                "runtime": {
-                  "nativeCallNs": 17919250,
-                  "boundaryArgumentsNs": 83,
-                  "vmSetupNs": 375,
-                  "pureExecutionNs": 2156708,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 2157291,
-                  "hotExecutionTotalNs": 216552791,
-                  "hotExecutionPerCallNs": 2165527
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1144,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 286072083,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "fibonacci",
-                "workload": "scalar-only",
-                "size": 20,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 116958,
-                "calcitFrontendNs": 149750,
-                "snapshotCloneNs": 375,
-                "compile": {
-                  "eligibilityNs": 20708,
-                  "planningNs": 9375,
-                  "programConstructionNs": 28958,
-                  "validationLoweringNs": 5125,
-                  "totalNs": 66250
-                },
-                "runtime": {
-                  "nativeCallNs": 18008542,
-                  "boundaryArgumentsNs": 375,
-                  "vmSetupNs": 1084,
-                  "pureExecutionNs": 2256625,
+                  "nativeCallNs": 18894167,
+                  "cachedNativeResolutionNs": 958,
+                  "cachedNativeExecutionTotalNs": 1837038959,
+                  "cachedNativeExecutionPerCallNs": 18370389,
+                  "boundaryArgumentsNs": 4500,
+                  "vmSetupNs": 4000,
+                  "pureExecutionNs": 2215167,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 2258209,
-                  "hotExecutionTotalNs": 217513583,
-                  "hotExecutionPerCallNs": 2175135
+                  "calxOneShotNs": 2224958,
+                  "hotExecutionTotalNs": 224425875,
+                  "hotExecutionPerCallNs": 2244258
                 },
                 "program": {
                   "functions": 1,
@@ -7512,11 +7930,11 @@
               }
             },
             {
-              "processWallNs": 284133292,
+              "processWallNs": 2524953167,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7527,25 +7945,79 @@
                 "size": 20,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 131708,
-                "calcitFrontendNs": 130875,
+                "fixtureInstallNs": 144417,
+                "calcitFrontendNs": 149250,
+                "snapshotCloneNs": 333,
+                "compile": {
+                  "eligibilityNs": 23500,
+                  "planningNs": 8625,
+                  "programConstructionNs": 28417,
+                  "validationLoweringNs": 5167,
+                  "totalNs": 67708
+                },
+                "runtime": {
+                  "nativeCallNs": 18204041,
+                  "cachedNativeResolutionNs": 833,
+                  "cachedNativeExecutionTotalNs": 1845976083,
+                  "cachedNativeExecutionPerCallNs": 18459760,
+                  "boundaryArgumentsNs": 667,
+                  "vmSetupNs": 5583,
+                  "pureExecutionNs": 2230500,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 2238125,
+                  "hotExecutionTotalNs": 222457583,
+                  "hotExecutionPerCallNs": 2224575
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 2584081291,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 137917,
+                "calcitFrontendNs": 145000,
                 "snapshotCloneNs": 375,
                 "compile": {
-                  "eligibilityNs": 24708,
-                  "planningNs": 9250,
-                  "programConstructionNs": 28083,
-                  "validationLoweringNs": 6333,
-                  "totalNs": 70208
+                  "eligibilityNs": 24417,
+                  "planningNs": 7791,
+                  "programConstructionNs": 30750,
+                  "validationLoweringNs": 5625,
+                  "totalNs": 70375
                 },
                 "runtime": {
-                  "nativeCallNs": 17651042,
-                  "boundaryArgumentsNs": 83,
-                  "vmSetupNs": 791,
-                  "pureExecutionNs": 2160500,
-                  "boundaryResultNs": 2416,
-                  "calxOneShotNs": 2166250,
-                  "hotExecutionTotalNs": 216581584,
-                  "hotExecutionPerCallNs": 2165815
+                  "nativeCallNs": 18316250,
+                  "cachedNativeResolutionNs": 750,
+                  "cachedNativeExecutionTotalNs": 1892948916,
+                  "cachedNativeExecutionPerCallNs": 18929489,
+                  "boundaryArgumentsNs": 417,
+                  "vmSetupNs": 2666,
+                  "pureExecutionNs": 2271083,
+                  "boundaryResultNs": 166,
+                  "calxOneShotNs": 2276500,
+                  "hotExecutionTotalNs": 231356458,
+                  "hotExecutionPerCallNs": 2313564
                 },
                 "program": {
                   "functions": 1,
@@ -7560,11 +8032,11 @@
               }
             },
             {
-              "processWallNs": 282754542,
+              "processWallNs": 2533781666,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7575,25 +8047,130 @@
                 "size": 20,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 130542,
-                "calcitFrontendNs": 120084,
-                "snapshotCloneNs": 417,
+                "fixtureInstallNs": 155083,
+                "calcitFrontendNs": 225750,
+                "snapshotCloneNs": 375,
                 "compile": {
-                  "eligibilityNs": 18708,
-                  "planningNs": 11625,
-                  "programConstructionNs": 25292,
-                  "validationLoweringNs": 5625,
-                  "totalNs": 63458
+                  "eligibilityNs": 25375,
+                  "planningNs": 8250,
+                  "programConstructionNs": 30458,
+                  "validationLoweringNs": 5959,
+                  "totalNs": 72292
                 },
                 "runtime": {
-                  "nativeCallNs": 17714250,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 2250,
-                  "pureExecutionNs": 2158583,
+                  "nativeCallNs": 19773084,
+                  "cachedNativeResolutionNs": 1000,
+                  "cachedNativeExecutionTotalNs": 1838441709,
+                  "cachedNativeExecutionPerCallNs": 18384417,
+                  "boundaryArgumentsNs": 2125,
+                  "vmSetupNs": 2416,
+                  "pureExecutionNs": 4343792,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 4349125,
+                  "hotExecutionTotalNs": 227528208,
+                  "hotExecutionPerCallNs": 2275282
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 2493725875,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 142959,
+                "calcitFrontendNs": 136084,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 22542,
+                  "planningNs": 7833,
+                  "programConstructionNs": 25875,
+                  "validationLoweringNs": 5333,
+                  "totalNs": 63583
+                },
+                "runtime": {
+                  "nativeCallNs": 18130667,
+                  "cachedNativeResolutionNs": 917,
+                  "cachedNativeExecutionTotalNs": 1817653542,
+                  "cachedNativeExecutionPerCallNs": 18176535,
+                  "boundaryArgumentsNs": 417,
+                  "vmSetupNs": 1666,
+                  "pureExecutionNs": 2219833,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 2222709,
+                  "hotExecutionTotalNs": 221994667,
+                  "hotExecutionPerCallNs": 2219946
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1144,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 2550354042,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "fibonacci",
+                "workload": "scalar-only",
+                "size": 20,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 144834,
+                "calcitFrontendNs": 142708,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 20375,
+                  "planningNs": 8583,
+                  "programConstructionNs": 23792,
+                  "validationLoweringNs": 5875,
+                  "totalNs": 60542
+                },
+                "runtime": {
+                  "nativeCallNs": 18278750,
+                  "cachedNativeResolutionNs": 667,
+                  "cachedNativeExecutionTotalNs": 1869644167,
+                  "cachedNativeExecutionPerCallNs": 18696441,
+                  "boundaryArgumentsNs": 917,
+                  "vmSetupNs": 1792,
+                  "pureExecutionNs": 2230166,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 2161083,
-                  "hotExecutionTotalNs": 215729000,
-                  "hotExecutionPerCallNs": 2157290
+                  "calxOneShotNs": 2233209,
+                  "hotExecutionTotalNs": 222597541,
+                  "hotExecutionPerCallNs": 2225975
                 },
                 "program": {
                   "functions": 1,
@@ -7623,55 +8200,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 2642167,
-              "fixtureInstallNs": 116875,
-              "calcitFrontendNs": 113583,
-              "snapshotCloneNs": 334,
-              "eligibilityNs": 15375,
-              "planningNs": 8792,
-              "programConstructionNs": 19417,
-              "validationLoweringNs": 2750,
-              "calxCompileTotalNs": 48292,
-              "nativeCallNs": 6833,
-              "boundaryArgumentsNs": 125,
-              "vmSetupNs": 292,
-              "pureExecutionNs": 1042,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 1666,
-              "hotExecutionPerCallNs": 113
+              "processWallNs": 3434667,
+              "fixtureInstallNs": 130875,
+              "calcitFrontendNs": 129125,
+              "snapshotCloneNs": 333,
+              "eligibilityNs": 17166,
+              "planningNs": 9000,
+              "programConstructionNs": 22167,
+              "validationLoweringNs": 3417,
+              "calxCompileTotalNs": 52916,
+              "nativeCallNs": 8792,
+              "cachedNativeResolutionNs": 209,
+              "cachedNativeExecutionTotalNs": 113167,
+              "cachedNativeExecutionPerCallNs": 1131,
+              "boundaryArgumentsNs": 208,
+              "vmSetupNs": 541,
+              "pureExecutionNs": 1542,
+              "boundaryResultNs": 83,
+              "calxOneShotNs": 2583,
+              "hotExecutionTotalNs": 12083,
+              "hotExecutionPerCallNs": 120
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 5208,
-              "fixtureInstallNs": 2084,
-              "calcitFrontendNs": 3667,
-              "snapshotCloneNs": 41,
-              "eligibilityNs": 166,
-              "planningNs": 624,
-              "programConstructionNs": 417,
-              "validationLoweringNs": 125,
-              "calxCompileTotalNs": 1417,
-              "nativeCallNs": 291,
-              "boundaryArgumentsNs": 0,
-              "vmSetupNs": 42,
+              "processWallNs": 69500,
+              "fixtureInstallNs": 5375,
+              "calcitFrontendNs": 5208,
+              "snapshotCloneNs": 0,
+              "eligibilityNs": 959,
+              "planningNs": 500,
+              "programConstructionNs": 1083,
+              "validationLoweringNs": 625,
+              "calxCompileTotalNs": 1874,
+              "nativeCallNs": 958,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 2416,
+              "cachedNativeExecutionPerCallNs": 24,
+              "boundaryArgumentsNs": 41,
+              "vmSetupNs": 84,
               "pureExecutionNs": 42,
-              "boundaryResultNs": 1,
-              "calxOneShotNs": 41,
-              "hotExecutionPerCallNs": 1
+              "boundaryResultNs": 42,
+              "calxOneShotNs": 291,
+              "hotExecutionTotalNs": 208,
+              "hotExecutionPerCallNs": 2
             },
             "derived": {
-              "nativeEndToEndNs": 237291,
-              "calxEndToEndNs": 280750,
-              "hotVsNativeRatio": 0.016537392067905752,
-              "oneShotEndToEndRatio": 1.1831464320180707
+              "lookupNativeEndToEndNs": 268792,
+              "calxEndToEndNs": 315832,
+              "calxHotVsLookupNativeRatio": 0.01364877161055505,
+              "calxHotVsCachedNativeRatio": 0.10610079575596817,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1750052084883478
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 2749625,
+              "processWallNs": 3434667,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7682,25 +8268,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 111792,
-                "calcitFrontendNs": 117250,
-                "snapshotCloneNs": 292,
+                "fixtureInstallNs": 128583,
+                "calcitFrontendNs": 133125,
+                "snapshotCloneNs": 333,
                 "compile": {
-                  "eligibilityNs": 15209,
-                  "planningNs": 8792,
-                  "programConstructionNs": 20750,
-                  "validationLoweringNs": 3000,
-                  "totalNs": 49542
+                  "eligibilityNs": 17166,
+                  "planningNs": 8542,
+                  "programConstructionNs": 22000,
+                  "validationLoweringNs": 3417,
+                  "totalNs": 52916
                 },
                 "runtime": {
-                  "nativeCallNs": 6875,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 1084,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 1750,
-                  "hotExecutionTotalNs": 11541,
-                  "hotExecutionPerCallNs": 115
+                  "nativeCallNs": 7458,
+                  "cachedNativeResolutionNs": 166,
+                  "cachedNativeExecutionTotalNs": 111833,
+                  "cachedNativeExecutionPerCallNs": 1118,
+                  "boundaryArgumentsNs": 208,
+                  "vmSetupNs": 500,
+                  "pureExecutionNs": 1542,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 2500,
+                  "hotExecutionTotalNs": 11875,
+                  "hotExecutionPerCallNs": 118
                 },
                 "program": {
                   "functions": 2,
@@ -7715,11 +8304,11 @@
               }
             },
             {
-              "processWallNs": 2637875,
+              "processWallNs": 3696333,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7730,25 +8319,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 116875,
-                "calcitFrontendNs": 109458,
-                "snapshotCloneNs": 334,
+                "fixtureInstallNs": 136250,
+                "calcitFrontendNs": 145917,
+                "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 15625,
-                  "planningNs": 7917,
-                  "programConstructionNs": 19417,
-                  "validationLoweringNs": 2750,
-                  "totalNs": 47459
+                  "eligibilityNs": 19834,
+                  "planningNs": 9541,
+                  "programConstructionNs": 24625,
+                  "validationLoweringNs": 4167,
+                  "totalNs": 60084
                 },
                 "runtime": {
-                  "nativeCallNs": 6458,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 208,
-                  "pureExecutionNs": 1000,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 1625,
-                  "hotExecutionTotalNs": 11417,
-                  "hotExecutionPerCallNs": 114
+                  "nativeCallNs": 10083,
+                  "cachedNativeResolutionNs": 292,
+                  "cachedNativeExecutionTotalNs": 115583,
+                  "cachedNativeExecutionPerCallNs": 1155,
+                  "boundaryArgumentsNs": 292,
+                  "vmSetupNs": 917,
+                  "pureExecutionNs": 2333,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 3875,
+                  "hotExecutionTotalNs": 11875,
+                  "hotExecutionPerCallNs": 118
                 },
                 "program": {
                   "functions": 2,
@@ -7763,11 +8355,11 @@
               }
             },
             {
-              "processWallNs": 2642167,
+              "processWallNs": 3351416,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7778,25 +8370,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 114958,
-                "calcitFrontendNs": 117292,
-                "snapshotCloneNs": 334,
+                "fixtureInstallNs": 115916,
+                "calcitFrontendNs": 123917,
+                "snapshotCloneNs": 333,
                 "compile": {
-                  "eligibilityNs": 15458,
-                  "planningNs": 7625,
-                  "programConstructionNs": 19166,
-                  "validationLoweringNs": 2917,
-                  "totalNs": 46875
+                  "eligibilityNs": 16958,
+                  "planningNs": 8375,
+                  "programConstructionNs": 21166,
+                  "validationLoweringNs": 2792,
+                  "totalNs": 51125
                 },
                 "runtime": {
-                  "nativeCallNs": 6417,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 1041,
+                  "nativeCallNs": 8083,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 137708,
+                  "cachedNativeExecutionPerCallNs": 1377,
+                  "boundaryArgumentsNs": 208,
+                  "vmSetupNs": 541,
+                  "pureExecutionNs": 1542,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 1625,
-                  "hotExecutionTotalNs": 11417,
-                  "hotExecutionPerCallNs": 114
+                  "calxOneShotNs": 2583,
+                  "hotExecutionTotalNs": 12292,
+                  "hotExecutionPerCallNs": 122
                 },
                 "program": {
                   "functions": 2,
@@ -7811,11 +8406,11 @@
               }
             },
             {
-              "processWallNs": 2644458,
+              "processWallNs": 3455041,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7826,25 +8421,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 119125,
-                "calcitFrontendNs": 112958,
-                "snapshotCloneNs": 375,
+                "fixtureInstallNs": 131000,
+                "calcitFrontendNs": 128750,
+                "snapshotCloneNs": 333,
                 "compile": {
-                  "eligibilityNs": 15375,
-                  "planningNs": 9208,
-                  "programConstructionNs": 22750,
-                  "validationLoweringNs": 2625,
-                  "totalNs": 51750
+                  "eligibilityNs": 18875,
+                  "planningNs": 8500,
+                  "programConstructionNs": 20500,
+                  "validationLoweringNs": 3042,
+                  "totalNs": 52750
                 },
                 "runtime": {
-                  "nativeCallNs": 6875,
+                  "nativeCallNs": 8792,
+                  "cachedNativeResolutionNs": 209,
+                  "cachedNativeExecutionTotalNs": 121833,
+                  "cachedNativeExecutionPerCallNs": 1218,
                   "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 1208,
+                  "vmSetupNs": 417,
+                  "pureExecutionNs": 1500,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 1792,
-                  "hotExecutionTotalNs": 11375,
-                  "hotExecutionPerCallNs": 113
+                  "calxOneShotNs": 2292,
+                  "hotExecutionTotalNs": 11792,
+                  "hotExecutionPerCallNs": 117
                 },
                 "program": {
                   "functions": 2,
@@ -7859,11 +8457,11 @@
               }
             },
             {
-              "processWallNs": 2624709,
+              "processWallNs": 2946666,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7874,73 +8472,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 118959,
-                "calcitFrontendNs": 118333,
-                "snapshotCloneNs": 375,
+                "fixtureInstallNs": 120666,
+                "calcitFrontendNs": 116083,
+                "snapshotCloneNs": 333,
                 "compile": {
-                  "eligibilityNs": 14708,
-                  "planningNs": 7625,
-                  "programConstructionNs": 19250,
-                  "validationLoweringNs": 2709,
-                  "totalNs": 46042
+                  "eligibilityNs": 15292,
+                  "planningNs": 9000,
+                  "programConstructionNs": 22167,
+                  "validationLoweringNs": 2791,
+                  "totalNs": 51042
                 },
                 "runtime": {
-                  "nativeCallNs": 8250,
+                  "nativeCallNs": 9125,
+                  "cachedNativeResolutionNs": 125,
+                  "cachedNativeExecutionTotalNs": 112375,
+                  "cachedNativeExecutionPerCallNs": 1123,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 1042,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 1666,
-                  "hotExecutionTotalNs": 11375,
-                  "hotExecutionPerCallNs": 113
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2647375,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 111667,
-                "calcitFrontendNs": 112167,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 17583,
-                  "planningNs": 9041,
-                  "programConstructionNs": 22333,
-                  "validationLoweringNs": 2917,
-                  "totalNs": 53750
-                },
-                "runtime": {
-                  "nativeCallNs": 6542,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 334,
-                  "pureExecutionNs": 958,
+                  "vmSetupNs": 375,
+                  "pureExecutionNs": 1209,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 1666,
-                  "hotExecutionTotalNs": 11250,
-                  "hotExecutionPerCallNs": 112
+                  "calxOneShotNs": 1917,
+                  "hotExecutionTotalNs": 12083,
+                  "hotExecutionPerCallNs": 120
                 },
                 "program": {
                   "functions": 2,
@@ -7955,11 +8508,11 @@
               }
             },
             {
-              "processWallNs": 2586458,
+              "processWallNs": 3365167,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -7970,25 +8523,198 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 117250,
-                "calcitFrontendNs": 113583,
+                "fixtureInstallNs": 130875,
+                "calcitFrontendNs": 129125,
+                "snapshotCloneNs": 333,
+                "compile": {
+                  "eligibilityNs": 16541,
+                  "planningNs": 10083,
+                  "programConstructionNs": 23250,
+                  "validationLoweringNs": 3583,
+                  "totalNs": 55333
+                },
+                "runtime": {
+                  "nativeCallNs": 9750,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 113167,
+                  "cachedNativeExecutionPerCallNs": 1131,
+                  "boundaryArgumentsNs": 167,
+                  "vmSetupNs": 583,
+                  "pureExecutionNs": 1542,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 2625,
+                  "hotExecutionTotalNs": 12167,
+                  "hotExecutionPerCallNs": 121
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3455167,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 146333,
+                "calcitFrontendNs": 149667,
+                "snapshotCloneNs": 458,
+                "compile": {
+                  "eligibilityNs": 18125,
+                  "planningNs": 9292,
+                  "programConstructionNs": 23875,
+                  "validationLoweringNs": 4292,
+                  "totalNs": 57458
+                },
+                "runtime": {
+                  "nativeCallNs": 7291,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 110041,
+                  "cachedNativeExecutionPerCallNs": 1100,
+                  "boundaryArgumentsNs": 292,
+                  "vmSetupNs": 625,
+                  "pureExecutionNs": 2166,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 3417,
+                  "hotExecutionTotalNs": 12083,
+                  "hotExecutionPerCallNs": 120
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            }
+          ]
+        },
+        {
+          "kernel": "affine",
+          "size": 1000,
+          "program": {
+            "functions": 2,
+            "imports": 0,
+            "syntaxNodes": 11,
+            "instructions": 11,
+            "diagnosticBytes": 868,
+            "hostBoundaryCallsPerExecution": 0,
+            "reusesVmFramesAndStack": true
+          },
+          "aggregate": {
+            "medians": {
+              "processWallNs": 3481750,
+              "fixtureInstallNs": 126500,
+              "calcitFrontendNs": 125166,
+              "snapshotCloneNs": 292,
+              "eligibilityNs": 15459,
+              "planningNs": 8166,
+              "programConstructionNs": 21041,
+              "validationLoweringNs": 2750,
+              "calxCompileTotalNs": 49042,
+              "nativeCallNs": 7833,
+              "cachedNativeResolutionNs": 167,
+              "cachedNativeExecutionTotalNs": 110875,
+              "cachedNativeExecutionPerCallNs": 1108,
+              "boundaryArgumentsNs": 166,
+              "vmSetupNs": 375,
+              "pureExecutionNs": 1541,
+              "boundaryResultNs": 0,
+              "calxOneShotNs": 2167,
+              "hotExecutionTotalNs": 11708,
+              "hotExecutionPerCallNs": 117
+            },
+            "medianAbsoluteDeviations": {
+              "processWallNs": 75792,
+              "fixtureInstallNs": 3334,
+              "calcitFrontendNs": 4999,
+              "snapshotCloneNs": 41,
+              "eligibilityNs": 249,
+              "planningNs": 417,
+              "programConstructionNs": 1291,
+              "validationLoweringNs": 250,
+              "calxCompileTotalNs": 1083,
+              "nativeCallNs": 1041,
+              "cachedNativeResolutionNs": 0,
+              "cachedNativeExecutionTotalNs": 1375,
+              "cachedNativeExecutionPerCallNs": 13,
+              "boundaryArgumentsNs": 41,
+              "vmSetupNs": 125,
+              "pureExecutionNs": 374,
+              "boundaryResultNs": 0,
+              "calxOneShotNs": 374,
+              "hotExecutionTotalNs": 83,
+              "hotExecutionPerCallNs": 1
+            },
+            "derived": {
+              "lookupNativeEndToEndNs": 259499,
+              "calxEndToEndNs": 303167,
+              "calxHotVsLookupNativeRatio": 0.01493680582152432,
+              "calxHotVsCachedNativeRatio": 0.1055956678700361,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1682781051179387
+            }
+          },
+          "rawSamples": [
+            {
+              "processWallNs": 2917208,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 126500,
+                "calcitFrontendNs": 120167,
                 "snapshotCloneNs": 333,
                 "compile": {
                   "eligibilityNs": 15250,
-                  "planningNs": 9416,
-                  "programConstructionNs": 19000,
+                  "planningNs": 7709,
+                  "programConstructionNs": 22208,
                   "validationLoweringNs": 2750,
-                  "totalNs": 48292
+                  "totalNs": 49708
                 },
                 "runtime": {
-                  "nativeCallNs": 6833,
+                  "nativeCallNs": 6792,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 110750,
+                  "cachedNativeExecutionPerCallNs": 1107,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 333,
-                  "pureExecutionNs": 1083,
+                  "vmSetupNs": 375,
+                  "pureExecutionNs": 1167,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 1750,
-                  "hotExecutionTotalNs": 11375,
-                  "hotExecutionPerCallNs": 113
+                  "calxOneShotNs": 1917,
+                  "hotExecutionTotalNs": 11667,
+                  "hotExecutionPerCallNs": 116
                 },
                 "program": {
                   "functions": 2,
@@ -8001,72 +8727,13 @@
                 },
                 "correctness": true
               }
-            }
-          ]
-        },
-        {
-          "kernel": "affine",
-          "size": 1000,
-          "program": {
-            "functions": 2,
-            "imports": 0,
-            "syntaxNodes": 11,
-            "instructions": 11,
-            "diagnosticBytes": 868,
-            "hostBoundaryCallsPerExecution": 0,
-            "reusesVmFramesAndStack": true
-          },
-          "aggregate": {
-            "medians": {
-              "processWallNs": 2601917,
-              "fixtureInstallNs": 112500,
-              "calcitFrontendNs": 116834,
-              "snapshotCloneNs": 333,
-              "eligibilityNs": 14917,
-              "planningNs": 8458,
-              "programConstructionNs": 20042,
-              "validationLoweringNs": 2666,
-              "calxCompileTotalNs": 47875,
-              "nativeCallNs": 6584,
-              "boundaryArgumentsNs": 125,
-              "vmSetupNs": 250,
-              "pureExecutionNs": 1042,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 1666,
-              "hotExecutionPerCallNs": 113
             },
-            "medianAbsoluteDeviations": {
-              "processWallNs": 19584,
-              "fixtureInstallNs": 416,
-              "calcitFrontendNs": 1793,
-              "snapshotCloneNs": 1,
-              "eligibilityNs": 83,
-              "planningNs": 250,
-              "programConstructionNs": 249,
-              "validationLoweringNs": 41,
-              "calxCompileTotalNs": 375,
-              "nativeCallNs": 42,
-              "boundaryArgumentsNs": 0,
-              "vmSetupNs": 0,
-              "pureExecutionNs": 42,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 43,
-              "hotExecutionPerCallNs": 1
-            },
-            "derived": {
-              "nativeEndToEndNs": 235918,
-              "calxEndToEndNs": 279208,
-              "hotVsNativeRatio": 0.017162818955042528,
-              "oneShotEndToEndRatio": 1.1834959604608382
-            }
-          },
-          "rawSamples": [
             {
-              "processWallNs": 2619209,
+              "processWallNs": 3532708,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8077,25 +8744,181 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 112500,
-                "calcitFrontendNs": 116834,
+                "fixtureInstallNs": 123500,
+                "calcitFrontendNs": 125166,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 15459,
+                  "planningNs": 8083,
+                  "programConstructionNs": 20208,
+                  "validationLoweringNs": 2500,
+                  "totalNs": 47959
+                },
+                "runtime": {
+                  "nativeCallNs": 6458,
+                  "cachedNativeResolutionNs": 125,
+                  "cachedNativeExecutionTotalNs": 110875,
+                  "cachedNativeExecutionPerCallNs": 1108,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 250,
+                  "pureExecutionNs": 1292,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 1917,
+                  "hotExecutionTotalNs": 11625,
+                  "hotExecutionPerCallNs": 116
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3418458,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 123166,
+                "calcitFrontendNs": 120167,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 15708,
+                  "planningNs": 8166,
+                  "programConstructionNs": 19750,
+                  "validationLoweringNs": 2583,
+                  "totalNs": 48042
+                },
+                "runtime": {
+                  "nativeCallNs": 6250,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 113792,
+                  "cachedNativeExecutionPerCallNs": 1137,
+                  "boundaryArgumentsNs": 167,
+                  "vmSetupNs": 625,
+                  "pureExecutionNs": 1542,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 2541,
+                  "hotExecutionTotalNs": 12542,
+                  "hotExecutionPerCallNs": 125
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3481750,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 135125,
+                "calcitFrontendNs": 146958,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 20584,
+                  "planningNs": 9208,
+                  "programConstructionNs": 23333,
+                  "validationLoweringNs": 3500,
+                  "totalNs": 58750
+                },
+                "runtime": {
+                  "nativeCallNs": 9416,
+                  "cachedNativeResolutionNs": 125,
+                  "cachedNativeExecutionTotalNs": 120333,
+                  "cachedNativeExecutionPerCallNs": 1203,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 834,
+                  "pureExecutionNs": 1958,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 4375,
+                  "hotExecutionTotalNs": 11625,
+                  "hotExecutionPerCallNs": 116
+                },
+                "program": {
+                  "functions": 2,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 868,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3743209,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "affine",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 145250,
+                "calcitFrontendNs": 158083,
                 "snapshotCloneNs": 375,
                 "compile": {
-                  "eligibilityNs": 15000,
-                  "planningNs": 8458,
-                  "programConstructionNs": 20291,
-                  "validationLoweringNs": 2750,
-                  "totalNs": 48250
+                  "eligibilityNs": 23541,
+                  "planningNs": 13834,
+                  "programConstructionNs": 23541,
+                  "validationLoweringNs": 3709,
+                  "totalNs": 70791
                 },
                 "runtime": {
-                  "nativeCallNs": 6584,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 1042,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 1666,
-                  "hotExecutionTotalNs": 11584,
-                  "hotExecutionPerCallNs": 115
+                  "nativeCallNs": 8459,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 109500,
+                  "cachedNativeExecutionPerCallNs": 1095,
+                  "boundaryArgumentsNs": 2959,
+                  "vmSetupNs": 1042,
+                  "pureExecutionNs": 2542,
+                  "boundaryResultNs": 209,
+                  "calxOneShotNs": 7166,
+                  "hotExecutionTotalNs": 12041,
+                  "hotExecutionPerCallNs": 120
                 },
                 "program": {
                   "functions": 2,
@@ -8110,11 +8933,11 @@
               }
             },
             {
-              "processWallNs": 2563042,
+              "processWallNs": 3370916,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8125,169 +8948,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 115708,
-                "calcitFrontendNs": 115041,
+                "fixtureInstallNs": 152667,
+                "calcitFrontendNs": 125375,
                 "snapshotCloneNs": 292,
                 "compile": {
-                  "eligibilityNs": 14959,
-                  "planningNs": 8458,
-                  "programConstructionNs": 19625,
-                  "validationLoweringNs": 2666,
-                  "totalNs": 47292
+                  "eligibilityNs": 15042,
+                  "planningNs": 8583,
+                  "programConstructionNs": 21041,
+                  "validationLoweringNs": 2833,
+                  "totalNs": 49042
                 },
                 "runtime": {
-                  "nativeCallNs": 6625,
+                  "nativeCallNs": 8792,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 110625,
+                  "cachedNativeExecutionPerCallNs": 1106,
                   "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 1084,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 1708,
-                  "hotExecutionTotalNs": 11250,
-                  "hotExecutionPerCallNs": 112
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2723500,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 112166,
-                "calcitFrontendNs": 121792,
-                "snapshotCloneNs": 334,
-                "compile": {
-                  "eligibilityNs": 15875,
-                  "planningNs": 7584,
-                  "programConstructionNs": 19834,
-                  "validationLoweringNs": 2625,
-                  "totalNs": 47666
-                },
-                "runtime": {
-                  "nativeCallNs": 6584,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 1000,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 1584,
-                  "hotExecutionTotalNs": 11375,
-                  "hotExecutionPerCallNs": 113
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2601917,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 112584,
-                "calcitFrontendNs": 116625,
-                "snapshotCloneNs": 333,
-                "compile": {
-                  "eligibilityNs": 14833,
-                  "planningNs": 7584,
-                  "programConstructionNs": 19209,
-                  "validationLoweringNs": 2625,
-                  "totalNs": 46042
-                },
-                "runtime": {
-                  "nativeCallNs": 8958,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 1000,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 1542,
-                  "hotExecutionTotalNs": 11334,
-                  "hotExecutionPerCallNs": 113
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2582333,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 108250,
-                "calcitFrontendNs": 116541,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 14875,
-                  "planningNs": 8542,
-                  "programConstructionNs": 20042,
-                  "validationLoweringNs": 2709,
-                  "totalNs": 47875
-                },
-                "runtime": {
-                  "nativeCallNs": 6750,
-                  "boundaryArgumentsNs": 125,
                   "vmSetupNs": 334,
-                  "pureExecutionNs": 1000,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 1666,
-                  "hotExecutionTotalNs": 11417,
-                  "hotExecutionPerCallNs": 114
+                  "pureExecutionNs": 917,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 1625,
+                  "hotExecutionTotalNs": 11875,
+                  "hotExecutionPerCallNs": 118
                 },
                 "program": {
                   "functions": 2,
@@ -8302,11 +8984,11 @@
               }
             },
             {
-              "processWallNs": 2574250,
+              "processWallNs": 3557542,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8317,73 +8999,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 111542,
-                "calcitFrontendNs": 120417,
-                "snapshotCloneNs": 333,
+                "fixtureInstallNs": 123625,
+                "calcitFrontendNs": 122833,
+                "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 14500,
-                  "planningNs": 8792,
-                  "programConstructionNs": 21333,
-                  "validationLoweringNs": 2750,
-                  "totalNs": 49125
+                  "eligibilityNs": 15417,
+                  "planningNs": 8125,
+                  "programConstructionNs": 19375,
+                  "validationLoweringNs": 2417,
+                  "totalNs": 46959
                 },
                 "runtime": {
-                  "nativeCallNs": 6542,
-                  "boundaryArgumentsNs": 125,
+                  "nativeCallNs": 7833,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 116625,
+                  "cachedNativeExecutionPerCallNs": 1166,
+                  "boundaryArgumentsNs": 167,
                   "vmSetupNs": 250,
-                  "pureExecutionNs": 1125,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 1709,
-                  "hotExecutionTotalNs": 11333,
-                  "hotExecutionPerCallNs": 113
-                },
-                "program": {
-                  "functions": 2,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 868,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2604542,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "affine",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 112916,
-                "calcitFrontendNs": 123167,
-                "snapshotCloneNs": 334,
-                "compile": {
-                  "eligibilityNs": 14917,
-                  "planningNs": 8708,
-                  "programConstructionNs": 20125,
-                  "validationLoweringNs": 2625,
-                  "totalNs": 48000
-                },
-                "runtime": {
-                  "nativeCallNs": 6416,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 1083,
+                  "pureExecutionNs": 1541,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 1709,
-                  "hotExecutionTotalNs": 11542,
-                  "hotExecutionPerCallNs": 115
+                  "calxOneShotNs": 2167,
+                  "hotExecutionTotalNs": 11708,
+                  "hotExecutionPerCallNs": 117
                 },
                 "program": {
                   "functions": 2,
@@ -8413,55 +9050,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 2555709,
-              "fixtureInstallNs": 113750,
-              "calcitFrontendNs": 92750,
+              "processWallNs": 3232625,
+              "fixtureInstallNs": 124750,
+              "calcitFrontendNs": 109666,
               "snapshotCloneNs": 250,
-              "eligibilityNs": 12375,
-              "planningNs": 7125,
-              "programConstructionNs": 14750,
-              "validationLoweringNs": 1750,
-              "calxCompileTotalNs": 38000,
-              "nativeCallNs": 6834,
+              "eligibilityNs": 15916,
+              "planningNs": 5917,
+              "programConstructionNs": 16792,
+              "validationLoweringNs": 2375,
+              "calxCompileTotalNs": 41000,
+              "nativeCallNs": 7541,
+              "cachedNativeResolutionNs": 250,
+              "cachedNativeExecutionTotalNs": 21875,
+              "cachedNativeExecutionPerCallNs": 218,
               "boundaryArgumentsNs": 125,
-              "vmSetupNs": 250,
-              "pureExecutionNs": 750,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 1458,
-              "hotExecutionPerCallNs": 82
+              "vmSetupNs": 459,
+              "pureExecutionNs": 1209,
+              "boundaryResultNs": 83,
+              "calxOneShotNs": 2000,
+              "hotExecutionTotalNs": 8583,
+              "hotExecutionPerCallNs": 85
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 17209,
-              "fixtureInstallNs": 3208,
-              "calcitFrontendNs": 1333,
-              "snapshotCloneNs": 41,
-              "eligibilityNs": 167,
-              "planningNs": 334,
-              "programConstructionNs": 541,
-              "validationLoweringNs": 41,
-              "calxCompileTotalNs": 333,
-              "nativeCallNs": 84,
+              "processWallNs": 177334,
+              "fixtureInstallNs": 2000,
+              "calcitFrontendNs": 7749,
+              "snapshotCloneNs": 42,
+              "eligibilityNs": 1416,
+              "planningNs": 917,
+              "programConstructionNs": 917,
+              "validationLoweringNs": 291,
+              "calxCompileTotalNs": 2875,
+              "nativeCallNs": 957,
+              "cachedNativeResolutionNs": 41,
+              "cachedNativeExecutionTotalNs": 125,
+              "cachedNativeExecutionPerCallNs": 2,
               "boundaryArgumentsNs": 0,
-              "vmSetupNs": 0,
-              "pureExecutionNs": 42,
+              "vmSetupNs": 209,
+              "pureExecutionNs": 457,
               "boundaryResultNs": 41,
-              "calxOneShotNs": 125,
+              "calxOneShotNs": 667,
+              "hotExecutionTotalNs": 41,
               "hotExecutionPerCallNs": 0
             },
             "derived": {
-              "nativeEndToEndNs": 213334,
-              "calxEndToEndNs": 246208,
-              "hotVsNativeRatio": 0.01199882938249927,
-              "oneShotEndToEndRatio": 1.1540963934487705
+              "lookupNativeEndToEndNs": 241957,
+              "calxEndToEndNs": 277666,
+              "calxHotVsLookupNativeRatio": 0.011271714626707334,
+              "calxHotVsCachedNativeRatio": 0.38990825688073394,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1475840748562762
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 2559334,
+              "processWallNs": 3649542,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8472,25 +9118,79 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 116958,
-                "calcitFrontendNs": 91417,
+                "fixtureInstallNs": 149666,
+                "calcitFrontendNs": 136750,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 21750,
+                  "planningNs": 9083,
+                  "programConstructionNs": 20000,
+                  "validationLoweringNs": 3125,
+                  "totalNs": 55666
+                },
+                "runtime": {
+                  "nativeCallNs": 11750,
+                  "cachedNativeResolutionNs": 291,
+                  "cachedNativeExecutionTotalNs": 22000,
+                  "cachedNativeExecutionPerCallNs": 220,
+                  "boundaryArgumentsNs": 208,
+                  "vmSetupNs": 3459,
+                  "pureExecutionNs": 2209,
+                  "boundaryResultNs": 84,
+                  "calxOneShotNs": 6333,
+                  "hotExecutionTotalNs": 8583,
+                  "hotExecutionPerCallNs": 85
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3055291,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 137375,
+                "calcitFrontendNs": 111666,
                 "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 12375,
-                  "planningNs": 8084,
-                  "programConstructionNs": 14750,
-                  "validationLoweringNs": 1709,
-                  "totalNs": 38333
+                  "eligibilityNs": 15916,
+                  "planningNs": 5000,
+                  "programConstructionNs": 16334,
+                  "validationLoweringNs": 2417,
+                  "totalNs": 40917
                 },
                 "runtime": {
-                  "nativeCallNs": 6833,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 917,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 1500,
-                  "hotExecutionTotalNs": 8291,
-                  "hotExecutionPerCallNs": 82
+                  "nativeCallNs": 7541,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 22166,
+                  "cachedNativeExecutionPerCallNs": 221,
+                  "boundaryArgumentsNs": 83,
+                  "vmSetupNs": 459,
+                  "pureExecutionNs": 1209,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 2000,
+                  "hotExecutionTotalNs": 8708,
+                  "hotExecutionPerCallNs": 87
                 },
                 "program": {
                   "functions": 1,
@@ -8505,11 +9205,11 @@
               }
             },
             {
-              "processWallNs": 2555709,
+              "processWallNs": 3232625,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8520,121 +9220,181 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 110083,
-                "calcitFrontendNs": 95583,
-                "snapshotCloneNs": 291,
-                "compile": {
-                  "eligibilityNs": 12167,
-                  "planningNs": 6792,
-                  "programConstructionNs": 18917,
-                  "validationLoweringNs": 1750,
-                  "totalNs": 40875
-                },
-                "runtime": {
-                  "nativeCallNs": 6791,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 208,
-                  "pureExecutionNs": 959,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 1500,
-                  "hotExecutionTotalNs": 8292,
-                  "hotExecutionPerCallNs": 82
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2602042,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 109708,
-                "calcitFrontendNs": 92417,
-                "snapshotCloneNs": 250,
-                "compile": {
-                  "eligibilityNs": 12333,
-                  "planningNs": 7125,
-                  "programConstructionNs": 15416,
-                  "validationLoweringNs": 1833,
-                  "totalNs": 38042
-                },
-                "runtime": {
-                  "nativeCallNs": 6834,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 208,
-                  "pureExecutionNs": 916,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 1458,
-                  "hotExecutionTotalNs": 8167,
-                  "hotExecutionPerCallNs": 81
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2549875,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 112750,
-                "calcitFrontendNs": 91250,
+                "fixtureInstallNs": 120875,
+                "calcitFrontendNs": 103500,
                 "snapshotCloneNs": 208,
                 "compile": {
-                  "eligibilityNs": 12542,
-                  "planningNs": 7459,
-                  "programConstructionNs": 14625,
-                  "validationLoweringNs": 1791,
-                  "totalNs": 37667
+                  "eligibilityNs": 14250,
+                  "planningNs": 5917,
+                  "programConstructionNs": 17916,
+                  "validationLoweringNs": 1542,
+                  "totalNs": 41000
+                },
+                "runtime": {
+                  "nativeCallNs": 6625,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 21875,
+                  "cachedNativeExecutionPerCallNs": 218,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 250,
+                  "pureExecutionNs": 958,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 1542,
+                  "hotExecutionTotalNs": 8625,
+                  "hotExecutionPerCallNs": 86
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3726708,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 122750,
+                "calcitFrontendNs": 109666,
+                "snapshotCloneNs": 209,
+                "compile": {
+                  "eligibilityNs": 16334,
+                  "planningNs": 6750,
+                  "programConstructionNs": 16792,
+                  "validationLoweringNs": 2375,
+                  "totalNs": 43875
+                },
+                "runtime": {
+                  "nativeCallNs": 9041,
+                  "cachedNativeResolutionNs": 375,
+                  "cachedNativeExecutionTotalNs": 21917,
+                  "cachedNativeExecutionPerCallNs": 219,
+                  "boundaryArgumentsNs": 167,
+                  "vmSetupNs": 541,
+                  "pureExecutionNs": 1666,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 2750,
+                  "hotExecutionTotalNs": 8542,
+                  "hotExecutionPerCallNs": 85
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3162083,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 125791,
+                "calcitFrontendNs": 122000,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 17292,
+                  "planningNs": 7542,
+                  "programConstructionNs": 17250,
+                  "validationLoweringNs": 2583,
+                  "totalNs": 46042
+                },
+                "runtime": {
+                  "nativeCallNs": 9417,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 21792,
+                  "cachedNativeExecutionPerCallNs": 217,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 708,
+                  "pureExecutionNs": 1959,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 3167,
+                  "hotExecutionTotalNs": 9250,
+                  "hotExecutionPerCallNs": 92
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3175750,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 124750,
+                "calcitFrontendNs": 101083,
+                "snapshotCloneNs": 208,
+                "compile": {
+                  "eligibilityNs": 14500,
+                  "planningNs": 5292,
+                  "programConstructionNs": 15875,
+                  "validationLoweringNs": 2084,
+                  "totalNs": 39000
                 },
                 "runtime": {
                   "nativeCallNs": 7083,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 21500,
+                  "cachedNativeExecutionPerCallNs": 215,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 708,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 1292,
-                  "hotExecutionTotalNs": 8166,
-                  "hotExecutionPerCallNs": 81
+                  "vmSetupNs": 292,
+                  "pureExecutionNs": 1209,
+                  "boundaryResultNs": 84,
+                  "calxOneShotNs": 1875,
+                  "hotExecutionTotalNs": 8542,
+                  "hotExecutionPerCallNs": 85
                 },
                 "program": {
                   "functions": 1,
@@ -8649,11 +9409,11 @@
               }
             },
             {
-              "processWallNs": 2527166,
+              "processWallNs": 3454625,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8664,121 +9424,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 121042,
-                "calcitFrontendNs": 93167,
+                "fixtureInstallNs": 123000,
+                "calcitFrontendNs": 101917,
                 "snapshotCloneNs": 291,
                 "compile": {
-                  "eligibilityNs": 13708,
-                  "planningNs": 4458,
-                  "programConstructionNs": 14209,
-                  "validationLoweringNs": 1584,
-                  "totalNs": 35375
+                  "eligibilityNs": 14333,
+                  "planningNs": 4709,
+                  "programConstructionNs": 14834,
+                  "validationLoweringNs": 1750,
+                  "totalNs": 36792
                 },
                 "runtime": {
-                  "nativeCallNs": 6750,
-                  "boundaryArgumentsNs": 84,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 708,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 1250,
-                  "hotExecutionTotalNs": 8250,
-                  "hotExecutionPerCallNs": 82
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2675459,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 114167,
-                "calcitFrontendNs": 92750,
-                "snapshotCloneNs": 250,
-                "compile": {
-                  "eligibilityNs": 12333,
-                  "planningNs": 7292,
-                  "programConstructionNs": 15417,
-                  "validationLoweringNs": 1709,
-                  "totalNs": 38000
-                },
-                "runtime": {
-                  "nativeCallNs": 7125,
+                  "nativeCallNs": 6584,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 21542,
+                  "cachedNativeExecutionPerCallNs": 215,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 500,
-                  "pureExecutionNs": 750,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 1583,
-                  "hotExecutionTotalNs": 8208,
-                  "hotExecutionPerCallNs": 82
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2538500,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 113750,
-                "calcitFrontendNs": 100209,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 13250,
-                  "planningNs": 4500,
-                  "programConstructionNs": 14333,
-                  "validationLoweringNs": 1834,
-                  "totalNs": 35167
-                },
-                "runtime": {
-                  "nativeCallNs": 6958,
-                  "boundaryArgumentsNs": 83,
                   "vmSetupNs": 250,
                   "pureExecutionNs": 750,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 1250,
-                  "hotExecutionTotalNs": 8292,
-                  "hotExecutionPerCallNs": 82
+                  "calxOneShotNs": 1333,
+                  "hotExecutionTotalNs": 8542,
+                  "hotExecutionPerCallNs": 85
                 },
                 "program": {
                   "functions": 1,
@@ -8808,55 +9475,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 2552042,
-              "fixtureInstallNs": 112417,
-              "calcitFrontendNs": 91334,
+              "processWallNs": 3450541,
+              "fixtureInstallNs": 130083,
+              "calcitFrontendNs": 103541,
               "snapshotCloneNs": 250,
-              "eligibilityNs": 13042,
-              "planningNs": 6584,
-              "programConstructionNs": 15042,
-              "validationLoweringNs": 1958,
-              "calxCompileTotalNs": 38625,
-              "nativeCallNs": 7083,
+              "eligibilityNs": 16417,
+              "planningNs": 6458,
+              "programConstructionNs": 16791,
+              "validationLoweringNs": 2083,
+              "calxCompileTotalNs": 43209,
+              "nativeCallNs": 9333,
+              "cachedNativeResolutionNs": 250,
+              "cachedNativeExecutionTotalNs": 21709,
+              "cachedNativeExecutionPerCallNs": 217,
               "boundaryArgumentsNs": 125,
-              "vmSetupNs": 250,
-              "pureExecutionNs": 750,
-              "boundaryResultNs": 41,
-              "calxOneShotNs": 1333,
-              "hotExecutionPerCallNs": 82
+              "vmSetupNs": 458,
+              "pureExecutionNs": 1167,
+              "boundaryResultNs": 42,
+              "calxOneShotNs": 2083,
+              "hotExecutionTotalNs": 8542,
+              "hotExecutionPerCallNs": 85
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 5292,
-              "fixtureInstallNs": 1417,
-              "calcitFrontendNs": 918,
+              "processWallNs": 424999,
+              "fixtureInstallNs": 8708,
+              "calcitFrontendNs": 6166,
               "snapshotCloneNs": 0,
-              "eligibilityNs": 792,
-              "planningNs": 958,
-              "programConstructionNs": 291,
-              "validationLoweringNs": 84,
-              "calxCompileTotalNs": 167,
-              "nativeCallNs": 166,
-              "boundaryArgumentsNs": 0,
-              "vmSetupNs": 0,
-              "pureExecutionNs": 42,
-              "boundaryResultNs": 1,
-              "calxOneShotNs": 42,
+              "eligibilityNs": 2458,
+              "planningNs": 708,
+              "programConstructionNs": 1250,
+              "validationLoweringNs": 374,
+              "calxCompileTotalNs": 4751,
+              "nativeCallNs": 1708,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 84,
+              "cachedNativeExecutionPerCallNs": 1,
+              "boundaryArgumentsNs": 83,
+              "vmSetupNs": 167,
+              "pureExecutionNs": 417,
+              "boundaryResultNs": 41,
+              "calxOneShotNs": 791,
+              "hotExecutionTotalNs": 41,
               "hotExecutionPerCallNs": 0
             },
             "derived": {
-              "nativeEndToEndNs": 210834,
-              "calxEndToEndNs": 243959,
-              "hotVsNativeRatio": 0.01157701538895948,
-              "oneShotEndToEndRatio": 1.157114127702363
+              "lookupNativeEndToEndNs": 242957,
+              "calxEndToEndNs": 279166,
+              "calxHotVsLookupNativeRatio": 0.009107468123861567,
+              "calxHotVsCachedNativeRatio": 0.391705069124424,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.1490346028309537
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 2526875,
+              "processWallNs": 3450541,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8867,25 +9543,79 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 112292,
-                "calcitFrontendNs": 90416,
+                "fixtureInstallNs": 152583,
+                "calcitFrontendNs": 138500,
+                "snapshotCloneNs": 208,
+                "compile": {
+                  "eligibilityNs": 19291,
+                  "planningNs": 6417,
+                  "programConstructionNs": 20459,
+                  "validationLoweringNs": 2250,
+                  "totalNs": 49833
+                },
+                "runtime": {
+                  "nativeCallNs": 9333,
+                  "cachedNativeResolutionNs": 250,
+                  "cachedNativeExecutionTotalNs": 21792,
+                  "cachedNativeExecutionPerCallNs": 217,
+                  "boundaryArgumentsNs": 208,
+                  "vmSetupNs": 458,
+                  "pureExecutionNs": 1167,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 2083,
+                  "hotExecutionTotalNs": 8500,
+                  "hotExecutionPerCallNs": 85
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 2964708,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 122500,
+                "calcitFrontendNs": 97375,
                 "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 12166,
-                  "planningNs": 8084,
-                  "programConstructionNs": 15042,
-                  "validationLoweringNs": 1791,
+                  "eligibilityNs": 13375,
+                  "planningNs": 6458,
+                  "programConstructionNs": 15584,
+                  "validationLoweringNs": 1792,
                   "totalNs": 38458
                 },
                 "runtime": {
-                  "nativeCallNs": 6917,
+                  "nativeCallNs": 8625,
+                  "cachedNativeResolutionNs": 209,
+                  "cachedNativeExecutionTotalNs": 22708,
+                  "cachedNativeExecutionPerCallNs": 227,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 667,
+                  "vmSetupNs": 333,
+                  "pureExecutionNs": 916,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 1208,
-                  "hotExecutionTotalNs": 8250,
-                  "hotExecutionPerCallNs": 82
+                  "calxOneShotNs": 1584,
+                  "hotExecutionTotalNs": 8583,
+                  "hotExecutionPerCallNs": 85
                 },
                 "program": {
                   "functions": 1,
@@ -8900,11 +9630,11 @@
               }
             },
             {
-              "processWallNs": 2546750,
+              "processWallNs": 3025542,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -8915,217 +9645,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 113834,
-                "calcitFrontendNs": 89417,
-                "snapshotCloneNs": 250,
-                "compile": {
-                  "eligibilityNs": 13834,
-                  "planningNs": 5584,
-                  "programConstructionNs": 14959,
-                  "validationLoweringNs": 1791,
-                  "totalNs": 37334
-                },
-                "runtime": {
-                  "nativeCallNs": 7708,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 792,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 1375,
-                  "hotExecutionTotalNs": 8375,
-                  "hotExecutionPerCallNs": 83
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2586291,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 113917,
-                "calcitFrontendNs": 91709,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 12083,
-                  "planningNs": 7958,
-                  "programConstructionNs": 15333,
-                  "validationLoweringNs": 1958,
-                  "totalNs": 38625
-                },
-                "runtime": {
-                  "nativeCallNs": 6958,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 667,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 1250,
-                  "hotExecutionTotalNs": 8250,
-                  "hotExecutionPerCallNs": 82
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2552625,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 110750,
-                "calcitFrontendNs": 91625,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 12250,
-                  "planningNs": 7542,
-                  "programConstructionNs": 15709,
-                  "validationLoweringNs": 1958,
-                  "totalNs": 38791
-                },
-                "runtime": {
-                  "nativeCallNs": 7083,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 334,
-                  "pureExecutionNs": 750,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 1375,
-                  "hotExecutionTotalNs": 8291,
-                  "hotExecutionPerCallNs": 82
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2540209,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 116708,
-                "calcitFrontendNs": 93000,
-                "snapshotCloneNs": 250,
-                "compile": {
-                  "eligibilityNs": 13459,
-                  "planningNs": 5834,
-                  "programConstructionNs": 16875,
-                  "validationLoweringNs": 2042,
-                  "totalNs": 39458
-                },
-                "runtime": {
-                  "nativeCallNs": 7959,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 791,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 1334,
-                  "hotExecutionTotalNs": 8167,
-                  "hotExecutionPerCallNs": 81
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 11,
-                  "instructions": 11,
-                  "diagnosticBytes": 743,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2554875,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "polynomial",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 112417,
-                "calcitFrontendNs": 91334,
+                "fixtureInstallNs": 122500,
+                "calcitFrontendNs": 102417,
                 "snapshotCloneNs": 291,
                 "compile": {
-                  "eligibilityNs": 13042,
-                  "planningNs": 6584,
-                  "programConstructionNs": 14500,
-                  "validationLoweringNs": 1875,
-                  "totalNs": 37292
+                  "eligibilityNs": 15375,
+                  "planningNs": 5750,
+                  "programConstructionNs": 15541,
+                  "validationLoweringNs": 1542,
+                  "totalNs": 39625
                 },
                 "runtime": {
-                  "nativeCallNs": 7000,
+                  "nativeCallNs": 7625,
+                  "cachedNativeResolutionNs": 291,
+                  "cachedNativeExecutionTotalNs": 21625,
+                  "cachedNativeExecutionPerCallNs": 216,
                   "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 792,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 1333,
-                  "hotExecutionTotalNs": 8250,
-                  "hotExecutionPerCallNs": 82
+                  "vmSetupNs": 291,
+                  "pureExecutionNs": 750,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 1291,
+                  "hotExecutionTotalNs": 8542,
+                  "hotExecutionPerCallNs": 85
                 },
                 "program": {
                   "functions": 1,
@@ -9140,11 +9681,11 @@
               }
             },
             {
-              "processWallNs": 2552042,
+              "processWallNs": 3160542,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9155,25 +9696,181 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 111417,
-                "calcitFrontendNs": 90209,
-                "snapshotCloneNs": 250,
+                "fixtureInstallNs": 121375,
+                "calcitFrontendNs": 100667,
+                "snapshotCloneNs": 209,
                 "compile": {
-                  "eligibilityNs": 14292,
-                  "planningNs": 6250,
-                  "programConstructionNs": 15042,
-                  "validationLoweringNs": 2042,
-                  "totalNs": 38792
+                  "eligibilityNs": 15209,
+                  "planningNs": 4792,
+                  "programConstructionNs": 16791,
+                  "validationLoweringNs": 1709,
+                  "totalNs": 39834
                 },
                 "runtime": {
-                  "nativeCallNs": 7583,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 750,
+                  "nativeCallNs": 6666,
+                  "cachedNativeResolutionNs": 167,
+                  "cachedNativeExecutionTotalNs": 21709,
+                  "cachedNativeExecutionPerCallNs": 217,
+                  "boundaryArgumentsNs": 42,
+                  "vmSetupNs": 333,
+                  "pureExecutionNs": 625,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 1292,
+                  "hotExecutionTotalNs": 8542,
+                  "hotExecutionPerCallNs": 85
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 3848250,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 142209,
+                "calcitFrontendNs": 135958,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 18875,
+                  "planningNs": 8333,
+                  "programConstructionNs": 20375,
+                  "validationLoweringNs": 3250,
+                  "totalNs": 52792
+                },
+                "runtime": {
+                  "nativeCallNs": 12291,
+                  "cachedNativeResolutionNs": 292,
+                  "cachedNativeExecutionTotalNs": 21541,
+                  "cachedNativeExecutionPerCallNs": 215,
+                  "boundaryArgumentsNs": 208,
+                  "vmSetupNs": 959,
+                  "pureExecutionNs": 2084,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 3667,
+                  "hotExecutionTotalNs": 8917,
+                  "hotExecutionPerCallNs": 89
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4450417,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 150125,
+                "calcitFrontendNs": 133666,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 19833,
+                  "planningNs": 7625,
+                  "programConstructionNs": 19833,
+                  "validationLoweringNs": 3292,
+                  "totalNs": 52208
+                },
+                "runtime": {
+                  "nativeCallNs": 11542,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 21625,
+                  "cachedNativeExecutionPerCallNs": 216,
+                  "boundaryArgumentsNs": 417,
+                  "vmSetupNs": 958,
+                  "pureExecutionNs": 2000,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 3625,
+                  "hotExecutionTotalNs": 8541,
+                  "hotExecutionPerCallNs": 85
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 11,
+                  "instructions": 11,
+                  "diagnosticBytes": 743,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4294042,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "polynomial",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 130083,
+                "calcitFrontendNs": 103541,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 16417,
+                  "planningNs": 6792,
+                  "programConstructionNs": 16375,
+                  "validationLoweringNs": 2083,
+                  "totalNs": 43209
+                },
+                "runtime": {
+                  "nativeCallNs": 10250,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 22875,
+                  "cachedNativeExecutionPerCallNs": 228,
+                  "boundaryArgumentsNs": 125,
+                  "vmSetupNs": 792,
+                  "pureExecutionNs": 1167,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 1333,
-                  "hotExecutionTotalNs": 8208,
-                  "hotExecutionPerCallNs": 82
+                  "calxOneShotNs": 2291,
+                  "hotExecutionTotalNs": 8875,
+                  "hotExecutionPerCallNs": 88
                 },
                 "program": {
                   "functions": 1,
@@ -9203,55 +9900,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 2737416,
-              "fixtureInstallNs": 113959,
-              "calcitFrontendNs": 96250,
-              "snapshotCloneNs": 292,
-              "eligibilityNs": 14375,
-              "planningNs": 9750,
-              "programConstructionNs": 25833,
-              "validationLoweringNs": 3750,
-              "calxCompileTotalNs": 55500,
-              "nativeCallNs": 18583,
-              "boundaryArgumentsNs": 167,
-              "vmSetupNs": 250,
-              "pureExecutionNs": 2583,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 3167,
-              "hotExecutionPerCallNs": 1114
+              "processWallNs": 5456958,
+              "fixtureInstallNs": 143250,
+              "calcitFrontendNs": 154833,
+              "snapshotCloneNs": 334,
+              "eligibilityNs": 22417,
+              "planningNs": 11041,
+              "programConstructionNs": 32667,
+              "validationLoweringNs": 5667,
+              "calxCompileTotalNs": 75125,
+              "nativeCallNs": 27834,
+              "cachedNativeResolutionNs": 375,
+              "cachedNativeExecutionTotalNs": 771917,
+              "cachedNativeExecutionPerCallNs": 7719,
+              "boundaryArgumentsNs": 583,
+              "vmSetupNs": 1458,
+              "pureExecutionNs": 4958,
+              "boundaryResultNs": 125,
+              "calxOneShotNs": 7667,
+              "hotExecutionTotalNs": 132125,
+              "hotExecutionPerCallNs": 1321
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 38501,
-              "fixtureInstallNs": 2709,
-              "calcitFrontendNs": 2292,
-              "snapshotCloneNs": 41,
-              "eligibilityNs": 459,
-              "planningNs": 792,
-              "programConstructionNs": 1666,
-              "validationLoweringNs": 166,
-              "calxCompileTotalNs": 1958,
-              "nativeCallNs": 499,
-              "boundaryArgumentsNs": 0,
-              "vmSetupNs": 0,
-              "pureExecutionNs": 84,
+              "processWallNs": 859500,
+              "fixtureInstallNs": 13417,
+              "calcitFrontendNs": 23917,
+              "snapshotCloneNs": 83,
+              "eligibilityNs": 1000,
+              "planningNs": 1499,
+              "programConstructionNs": 708,
+              "validationLoweringNs": 541,
+              "calxCompileTotalNs": 3958,
+              "nativeCallNs": 2042,
+              "cachedNativeResolutionNs": 42,
+              "cachedNativeExecutionTotalNs": 33125,
+              "cachedNativeExecutionPerCallNs": 332,
+              "boundaryArgumentsNs": 208,
+              "vmSetupNs": 208,
+              "pureExecutionNs": 333,
               "boundaryResultNs": 42,
-              "calxOneShotNs": 83,
-              "hotExecutionPerCallNs": 2
+              "calxOneShotNs": 875,
+              "hotExecutionTotalNs": 16500,
+              "hotExecutionPerCallNs": 165
             },
             "derived": {
-              "nativeEndToEndNs": 228792,
-              "calxEndToEndNs": 269168,
-              "hotVsNativeRatio": 0.05994726362804714,
-              "oneShotEndToEndRatio": 1.1764747019126542
+              "lookupNativeEndToEndNs": 325917,
+              "calxEndToEndNs": 381209,
+              "calxHotVsLookupNativeRatio": 0.04745994107925559,
+              "calxHotVsCachedNativeRatio": 0.17113615753335926,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.169650555202705
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 2775917,
+              "processWallNs": 7756042,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9262,25 +9968,283 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 114667,
-                "calcitFrontendNs": 96250,
+                "fixtureInstallNs": 497542,
+                "calcitFrontendNs": 215750,
+                "snapshotCloneNs": 334,
+                "compile": {
+                  "eligibilityNs": 22917,
+                  "planningNs": 11041,
+                  "programConstructionNs": 32667,
+                  "validationLoweringNs": 6291,
+                  "totalNs": 75125
+                },
+                "runtime": {
+                  "nativeCallNs": 27834,
+                  "cachedNativeResolutionNs": 417,
+                  "cachedNativeExecutionTotalNs": 1210041,
+                  "cachedNativeExecutionPerCallNs": 12100,
+                  "boundaryArgumentsNs": 583,
+                  "vmSetupNs": 1833,
+                  "pureExecutionNs": 5625,
+                  "boundaryResultNs": 83,
+                  "calxOneShotNs": 8417,
+                  "hotExecutionTotalNs": 205916,
+                  "hotExecutionPerCallNs": 2059
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 6764625,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 300166,
+                "calcitFrontendNs": 178750,
+                "snapshotCloneNs": 334,
+                "compile": {
+                  "eligibilityNs": 23375,
+                  "planningNs": 18000,
+                  "programConstructionNs": 49250,
+                  "validationLoweringNs": 6208,
+                  "totalNs": 99083
+                },
+                "runtime": {
+                  "nativeCallNs": 33875,
+                  "cachedNativeResolutionNs": 416,
+                  "cachedNativeExecutionTotalNs": 845291,
+                  "cachedNativeExecutionPerCallNs": 8452,
+                  "boundaryArgumentsNs": 2625,
+                  "vmSetupNs": 1334,
+                  "pureExecutionNs": 4958,
+                  "boundaryResultNs": 208,
+                  "calxOneShotNs": 9458,
+                  "hotExecutionTotalNs": 152333,
+                  "hotExecutionPerCallNs": 1523
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5704625,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 141333,
+                "calcitFrontendNs": 154833,
+                "snapshotCloneNs": 417,
+                "compile": {
+                  "eligibilityNs": 22417,
+                  "planningNs": 11708,
+                  "programConstructionNs": 33000,
+                  "validationLoweringNs": 5875,
+                  "totalNs": 75125
+                },
+                "runtime": {
+                  "nativeCallNs": 27084,
+                  "cachedNativeResolutionNs": 459,
+                  "cachedNativeExecutionTotalNs": 940417,
+                  "cachedNativeExecutionPerCallNs": 9404,
+                  "boundaryArgumentsNs": 583,
+                  "vmSetupNs": 1500,
+                  "pureExecutionNs": 5042,
+                  "boundaryResultNs": 250,
+                  "calxOneShotNs": 7667,
+                  "hotExecutionTotalNs": 206792,
+                  "hotExecutionPerCallNs": 2067
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5119125,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 143250,
+                "calcitFrontendNs": 140250,
+                "snapshotCloneNs": 292,
+                "compile": {
+                  "eligibilityNs": 24167,
+                  "planningNs": 12709,
+                  "programConstructionNs": 32375,
+                  "validationLoweringNs": 5667,
+                  "totalNs": 77333
+                },
+                "runtime": {
+                  "nativeCallNs": 26333,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 771917,
+                  "cachedNativeExecutionPerCallNs": 7719,
+                  "boundaryArgumentsNs": 375,
+                  "vmSetupNs": 1250,
+                  "pureExecutionNs": 4625,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 6584,
+                  "hotExecutionTotalNs": 123917,
+                  "hotExecutionPerCallNs": 1239
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 5456958,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 144708,
+                "calcitFrontendNs": 133250,
                 "snapshotCloneNs": 208,
                 "compile": {
+                  "eligibilityNs": 21417,
+                  "planningNs": 10416,
+                  "programConstructionNs": 31417,
+                  "validationLoweringNs": 5625,
+                  "totalNs": 71167
+                },
+                "runtime": {
+                  "nativeCallNs": 25792,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 753000,
+                  "cachedNativeExecutionPerCallNs": 7530,
+                  "boundaryArgumentsNs": 833,
+                  "vmSetupNs": 1750,
+                  "pureExecutionNs": 5167,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 8250,
+                  "hotExecutionTotalNs": 132125,
+                  "hotExecutionPerCallNs": 1321
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 4596833,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 10,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 129833,
+                "calcitFrontendNs": 122750,
+                "snapshotCloneNs": 250,
+                "compile": {
                   "eligibilityNs": 18583,
-                  "planningNs": 6083,
-                  "programConstructionNs": 27083,
-                  "validationLoweringNs": 3917,
-                  "totalNs": 57208
+                  "planningNs": 8708,
+                  "programConstructionNs": 26542,
+                  "validationLoweringNs": 4375,
+                  "totalNs": 60125
                 },
                 "runtime": {
-                  "nativeCallNs": 21083,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 291,
-                  "pureExecutionNs": 2583,
+                  "nativeCallNs": 30291,
+                  "cachedNativeResolutionNs": 208,
+                  "cachedNativeExecutionTotalNs": 738792,
+                  "cachedNativeExecutionPerCallNs": 7387,
+                  "boundaryArgumentsNs": 208,
+                  "vmSetupNs": 708,
+                  "pureExecutionNs": 3375,
                   "boundaryResultNs": 0,
-                  "calxOneShotNs": 3208,
-                  "hotExecutionTotalNs": 111584,
-                  "hotExecutionPerCallNs": 1115
+                  "calxOneShotNs": 4542,
+                  "hotExecutionTotalNs": 115625,
+                  "hotExecutionPerCallNs": 1156
                 },
                 "program": {
                   "functions": 1,
@@ -9295,11 +10259,11 @@
               }
             },
             {
-              "processWallNs": 2713417,
+              "processWallNs": 4597458,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9310,265 +10274,28 @@
                 "size": 10,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 117625,
-                "calcitFrontendNs": 92833,
-                "snapshotCloneNs": 250,
+                "fixtureInstallNs": 125833,
+                "calcitFrontendNs": 205958,
+                "snapshotCloneNs": 417,
                 "compile": {
-                  "eligibilityNs": 15625,
-                  "planningNs": 8083,
-                  "programConstructionNs": 24041,
-                  "validationLoweringNs": 3792,
-                  "totalNs": 53083
+                  "eligibilityNs": 20583,
+                  "planningNs": 9542,
+                  "programConstructionNs": 33375,
+                  "validationLoweringNs": 4625,
+                  "totalNs": 70084
                 },
                 "runtime": {
-                  "nativeCallNs": 18583,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 2416,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 3042,
-                  "hotExecutionTotalNs": 111334,
-                  "hotExecutionPerCallNs": 1113
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2842375,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 110208,
-                "calcitFrontendNs": 99958,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 14375,
-                  "planningNs": 9417,
-                  "programConstructionNs": 24167,
-                  "validationLoweringNs": 3916,
-                  "totalNs": 53542
-                },
-                "runtime": {
-                  "nativeCallNs": 18250,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 2667,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 3334,
-                  "hotExecutionTotalNs": 111875,
-                  "hotExecutionPerCallNs": 1118
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2757917,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 111250,
-                "calcitFrontendNs": 93958,
-                "snapshotCloneNs": 333,
-                "compile": {
-                  "eligibilityNs": 14375,
-                  "planningNs": 10583,
-                  "programConstructionNs": 25833,
-                  "validationLoweringNs": 3458,
-                  "totalNs": 55833
-                },
-                "runtime": {
-                  "nativeCallNs": 19292,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 2667,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 3250,
-                  "hotExecutionTotalNs": 114375,
-                  "hotExecutionPerCallNs": 1143
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2737416,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 119959,
-                "calcitFrontendNs": 97209,
-                "snapshotCloneNs": 333,
-                "compile": {
-                  "eligibilityNs": 13916,
-                  "planningNs": 10542,
-                  "programConstructionNs": 29875,
-                  "validationLoweringNs": 3667,
-                  "totalNs": 59667
-                },
-                "runtime": {
-                  "nativeCallNs": 18666,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 2583,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 3167,
-                  "hotExecutionTotalNs": 111208,
-                  "hotExecutionPerCallNs": 1112
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2697167,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 113959,
-                "calcitFrontendNs": 96542,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 14042,
-                  "planningNs": 10208,
-                  "programConstructionNs": 26000,
-                  "validationLoweringNs": 3750,
-                  "totalNs": 55500
-                },
-                "runtime": {
-                  "nativeCallNs": 17833,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 2500,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 3083,
-                  "hotExecutionTotalNs": 111459,
-                  "hotExecutionPerCallNs": 1114
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 2663958,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 10,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 111500,
-                "calcitFrontendNs": 93417,
-                "snapshotCloneNs": 250,
-                "compile": {
-                  "eligibilityNs": 15208,
-                  "planningNs": 9750,
-                  "programConstructionNs": 23125,
-                  "validationLoweringNs": 3416,
-                  "totalNs": 53125
-                },
-                "runtime": {
-                  "nativeCallNs": 18084,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 2458,
-                  "boundaryResultNs": 84,
-                  "calxOneShotNs": 3125,
-                  "hotExecutionTotalNs": 111292,
-                  "hotExecutionPerCallNs": 1112
+                  "nativeCallNs": 31000,
+                  "cachedNativeResolutionNs": 375,
+                  "cachedNativeExecutionTotalNs": 766916,
+                  "cachedNativeExecutionPerCallNs": 7669,
+                  "boundaryArgumentsNs": 583,
+                  "vmSetupNs": 1458,
+                  "pureExecutionNs": 4166,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 6792,
+                  "hotExecutionTotalNs": 119500,
+                  "hotExecutionPerCallNs": 1195
                 },
                 "program": {
                   "functions": 1,
@@ -9598,55 +10325,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 3999167,
-              "fixtureInstallNs": 115625,
-              "calcitFrontendNs": 96166,
-              "snapshotCloneNs": 250,
-              "eligibilityNs": 15333,
-              "planningNs": 11125,
-              "programConstructionNs": 25375,
-              "validationLoweringNs": 3750,
-              "calxCompileTotalNs": 55500,
-              "nativeCallNs": 79458,
-              "boundaryArgumentsNs": 167,
-              "vmSetupNs": 292,
-              "pureExecutionNs": 13625,
-              "boundaryResultNs": 42,
-              "calxOneShotNs": 14250,
-              "hotExecutionPerCallNs": 10562
+              "processWallNs": 15206792,
+              "fixtureInstallNs": 142916,
+              "calcitFrontendNs": 139958,
+              "snapshotCloneNs": 375,
+              "eligibilityNs": 22375,
+              "planningNs": 11084,
+              "programConstructionNs": 34250,
+              "validationLoweringNs": 6333,
+              "calxCompileTotalNs": 78458,
+              "nativeCallNs": 96208,
+              "cachedNativeResolutionNs": 417,
+              "cachedNativeExecutionTotalNs": 7164750,
+              "cachedNativeExecutionPerCallNs": 71647,
+              "boundaryArgumentsNs": 791,
+              "vmSetupNs": 1792,
+              "pureExecutionNs": 26125,
+              "boundaryResultNs": 125,
+              "calxOneShotNs": 29583,
+              "hotExecutionTotalNs": 1098375,
+              "hotExecutionPerCallNs": 10983
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 50708,
-              "fixtureInstallNs": 2000,
-              "calcitFrontendNs": 1708,
+              "processWallNs": 930667,
+              "fixtureInstallNs": 3958,
+              "calcitFrontendNs": 2750,
               "snapshotCloneNs": 42,
-              "eligibilityNs": 1083,
-              "planningNs": 3500,
-              "programConstructionNs": 1792,
-              "validationLoweringNs": 42,
-              "calxCompileTotalNs": 3541,
-              "nativeCallNs": 3251,
-              "boundaryArgumentsNs": 41,
-              "vmSetupNs": 42,
-              "pureExecutionNs": 375,
-              "boundaryResultNs": 0,
-              "calxOneShotNs": 291,
-              "hotExecutionPerCallNs": 95
+              "eligibilityNs": 1459,
+              "planningNs": 1082,
+              "programConstructionNs": 1125,
+              "validationLoweringNs": 541,
+              "calxCompileTotalNs": 4125,
+              "nativeCallNs": 1667,
+              "cachedNativeResolutionNs": 83,
+              "cachedNativeExecutionTotalNs": 207958,
+              "cachedNativeExecutionPerCallNs": 2080,
+              "boundaryArgumentsNs": 125,
+              "vmSetupNs": 458,
+              "pureExecutionNs": 4250,
+              "boundaryResultNs": 42,
+              "calxOneShotNs": 3417,
+              "hotExecutionTotalNs": 27750,
+              "hotExecutionPerCallNs": 277
             },
             "derived": {
-              "nativeEndToEndNs": 291249,
-              "calxEndToEndNs": 281791,
-              "hotVsNativeRatio": 0.13292557074177552,
-              "oneShotEndToEndRatio": 0.9675260687590344
+              "lookupNativeEndToEndNs": 379082,
+              "calxEndToEndNs": 391290,
+              "calxHotVsLookupNativeRatio": 0.11415890570430734,
+              "calxHotVsCachedNativeRatio": 0.15329322930478598,
+              "calxOneShotEndToEndVsLookupNativeRatio": 1.0322041141494451
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 3989792,
+              "processWallNs": 18005291,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9657,121 +10393,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 117875,
-                "calcitFrontendNs": 94708,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 14125,
-                  "planningNs": 16125,
-                  "programConstructionNs": 31666,
-                  "validationLoweringNs": 3750,
-                  "totalNs": 67375
-                },
-                "runtime": {
-                  "nativeCallNs": 79084,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 14333,
-                  "boundaryResultNs": 41,
-                  "calxOneShotNs": 15083,
-                  "hotExecutionTotalNs": 1133667,
-                  "hotExecutionPerCallNs": 11336
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 4153375,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 112166,
-                "calcitFrontendNs": 100625,
-                "snapshotCloneNs": 208,
-                "compile": {
-                  "eligibilityNs": 15334,
-                  "planningNs": 11709,
-                  "programConstructionNs": 26042,
-                  "validationLoweringNs": 3792,
-                  "totalNs": 58625
-                },
-                "runtime": {
-                  "nativeCallNs": 76625,
-                  "boundaryArgumentsNs": 208,
-                  "vmSetupNs": 417,
-                  "pureExecutionNs": 13250,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 14041,
-                  "hotExecutionTotalNs": 1046875,
-                  "hotExecutionPerCallNs": 10468
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 3999167,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 100,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 116417,
-                "calcitFrontendNs": 96166,
+                "fixtureInstallNs": 142916,
+                "calcitFrontendNs": 142708,
                 "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 15041,
-                  "planningNs": 6792,
-                  "programConstructionNs": 23583,
-                  "validationLoweringNs": 3541,
-                  "totalNs": 50708
+                  "eligibilityNs": 21833,
+                  "planningNs": 10375,
+                  "programConstructionNs": 34916,
+                  "validationLoweringNs": 6625,
+                  "totalNs": 76000
                 },
                 "runtime": {
-                  "nativeCallNs": 84042,
-                  "boundaryArgumentsNs": 125,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 13250,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 13959,
-                  "hotExecutionTotalNs": 1049292,
-                  "hotExecutionPerCallNs": 10492
+                  "nativeCallNs": 180625,
+                  "cachedNativeResolutionNs": 708,
+                  "cachedNativeExecutionTotalNs": 9915916,
+                  "cachedNativeExecutionPerCallNs": 99159,
+                  "boundaryArgumentsNs": 791,
+                  "vmSetupNs": 1792,
+                  "pureExecutionNs": 21542,
+                  "boundaryResultNs": 167,
+                  "calxOneShotNs": 24583,
+                  "hotExecutionTotalNs": 1272375,
+                  "hotExecutionPerCallNs": 12723
                 },
                 "program": {
                   "functions": 1,
@@ -9786,11 +10429,11 @@
               }
             },
             {
-              "processWallNs": 3953583,
+              "processWallNs": 17369500,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9801,25 +10444,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 117250,
-                "calcitFrontendNs": 94208,
+                "fixtureInstallNs": 138958,
+                "calcitFrontendNs": 139958,
                 "snapshotCloneNs": 208,
                 "compile": {
-                  "eligibilityNs": 14042,
-                  "planningNs": 11125,
-                  "programConstructionNs": 24917,
-                  "validationLoweringNs": 3708,
-                  "totalNs": 55500
+                  "eligibilityNs": 25917,
+                  "planningNs": 12166,
+                  "programConstructionNs": 33125,
+                  "validationLoweringNs": 8250,
+                  "totalNs": 82583
                 },
                 "runtime": {
-                  "nativeCallNs": 74334,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 14125,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 14750,
-                  "hotExecutionTotalNs": 1068708,
-                  "hotExecutionPerCallNs": 10687
+                  "nativeCallNs": 95208,
+                  "cachedNativeResolutionNs": 500,
+                  "cachedNativeExecutionTotalNs": 9024541,
+                  "cachedNativeExecutionPerCallNs": 90245,
+                  "boundaryArgumentsNs": 791,
+                  "vmSetupNs": 2041,
+                  "pureExecutionNs": 26125,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 29583,
+                  "hotExecutionTotalNs": 1312333,
+                  "hotExecutionPerCallNs": 13123
                 },
                 "program": {
                   "functions": 1,
@@ -9834,11 +10480,11 @@
               }
             },
             {
-              "processWallNs": 4049875,
+              "processWallNs": 15269667,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9849,25 +10495,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 115625,
-                "calcitFrontendNs": 94458,
-                "snapshotCloneNs": 291,
+                "fixtureInstallNs": 143500,
+                "calcitFrontendNs": 145125,
+                "snapshotCloneNs": 375,
                 "compile": {
-                  "eligibilityNs": 16792,
-                  "planningNs": 30750,
-                  "programConstructionNs": 28667,
-                  "validationLoweringNs": 3958,
-                  "totalNs": 81917
+                  "eligibilityNs": 24375,
+                  "planningNs": 11500,
+                  "programConstructionNs": 33916,
+                  "validationLoweringNs": 6334,
+                  "totalNs": 78458
                 },
                 "runtime": {
-                  "nativeCallNs": 79458,
-                  "boundaryArgumentsNs": 208,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 13250,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 13958,
-                  "hotExecutionTotalNs": 1124042,
-                  "hotExecutionPerCallNs": 11240
+                  "nativeCallNs": 97875,
+                  "cachedNativeResolutionNs": 416,
+                  "cachedNativeExecutionTotalNs": 7164750,
+                  "cachedNativeExecutionPerCallNs": 71647,
+                  "boundaryArgumentsNs": 1917,
+                  "vmSetupNs": 3708,
+                  "pureExecutionNs": 43917,
+                  "boundaryResultNs": 375,
+                  "calxOneShotNs": 50375,
+                  "hotExecutionTotalNs": 1084875,
+                  "hotExecutionPerCallNs": 10848
                 },
                 "program": {
                   "functions": 1,
@@ -9882,11 +10531,11 @@
               }
             },
             {
-              "processWallNs": 4106208,
+              "processWallNs": 14823250,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9897,25 +10546,28 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 112125,
-                "calcitFrontendNs": 100500,
+                "fixtureInstallNs": 140916,
+                "calcitFrontendNs": 137750,
                 "snapshotCloneNs": 208,
                 "compile": {
-                  "eligibilityNs": 16416,
-                  "planningNs": 7625,
-                  "programConstructionNs": 25375,
-                  "validationLoweringNs": 3750,
-                  "totalNs": 54833
+                  "eligibilityNs": 22125,
+                  "planningNs": 11084,
+                  "programConstructionNs": 78125,
+                  "validationLoweringNs": 5792,
+                  "totalNs": 120042
                 },
                 "runtime": {
-                  "nativeCallNs": 90833,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 334,
-                  "pureExecutionNs": 13625,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 14250,
-                  "hotExecutionTotalNs": 1046792,
-                  "hotExecutionPerCallNs": 10467
+                  "nativeCallNs": 103250,
+                  "cachedNativeResolutionNs": 417,
+                  "cachedNativeExecutionTotalNs": 7325583,
+                  "cachedNativeExecutionPerCallNs": 73255,
+                  "boundaryArgumentsNs": 4416,
+                  "vmSetupNs": 2584,
+                  "pureExecutionNs": 22084,
+                  "boundaryResultNs": 41,
+                  "calxOneShotNs": 29458,
+                  "hotExecutionTotalNs": 1063833,
+                  "hotExecutionPerCallNs": 10638
                 },
                 "program": {
                   "functions": 1,
@@ -9930,11 +10582,11 @@
               }
             },
             {
-              "processWallNs": 3933791,
+              "processWallNs": 14276125,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -9945,25 +10597,130 @@
                 "size": 100,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 113625,
-                "calcitFrontendNs": 97042,
-                "snapshotCloneNs": 291,
+                "fixtureInstallNs": 150250,
+                "calcitFrontendNs": 143583,
+                "snapshotCloneNs": 417,
                 "compile": {
-                  "eligibilityNs": 15333,
-                  "planningNs": 7833,
-                  "programConstructionNs": 23542,
-                  "validationLoweringNs": 3584,
-                  "totalNs": 51959
+                  "eligibilityNs": 25291,
+                  "planningNs": 9917,
+                  "programConstructionNs": 34250,
+                  "validationLoweringNs": 5459,
+                  "totalNs": 76958
                 },
                 "runtime": {
-                  "nativeCallNs": 82709,
-                  "boundaryArgumentsNs": 209,
-                  "vmSetupNs": 291,
-                  "pureExecutionNs": 13625,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 14292,
-                  "hotExecutionTotalNs": 1056292,
-                  "hotExecutionPerCallNs": 10562
+                  "nativeCallNs": 84291,
+                  "cachedNativeResolutionNs": 2458,
+                  "cachedNativeExecutionTotalNs": 6956792,
+                  "cachedNativeExecutionPerCallNs": 69567,
+                  "boundaryArgumentsNs": 666,
+                  "vmSetupNs": 1625,
+                  "pureExecutionNs": 30375,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 33000,
+                  "hotExecutionTotalNs": 1098375,
+                  "hotExecutionPerCallNs": 10983
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 15206792,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 137250,
+                "calcitFrontendNs": 138708,
+                "snapshotCloneNs": 417,
+                "compile": {
+                  "eligibilityNs": 22375,
+                  "planningNs": 12875,
+                  "programConstructionNs": 50792,
+                  "validationLoweringNs": 6333,
+                  "totalNs": 94708
+                },
+                "runtime": {
+                  "nativeCallNs": 96208,
+                  "cachedNativeResolutionNs": 334,
+                  "cachedNativeExecutionTotalNs": 6986166,
+                  "cachedNativeExecutionPerCallNs": 69861,
+                  "boundaryArgumentsNs": 458,
+                  "vmSetupNs": 1334,
+                  "pureExecutionNs": 19875,
+                  "boundaryResultNs": 84,
+                  "calxOneShotNs": 25750,
+                  "hotExecutionTotalNs": 1109875,
+                  "hotExecutionPerCallNs": 11098
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 14251000,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 100,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 165459,
+                "calcitFrontendNs": 136375,
+                "snapshotCloneNs": 375,
+                "compile": {
+                  "eligibilityNs": 20916,
+                  "planningNs": 9792,
+                  "programConstructionNs": 28375,
+                  "validationLoweringNs": 5333,
+                  "totalNs": 66208
+                },
+                "runtime": {
+                  "nativeCallNs": 95583,
+                  "cachedNativeResolutionNs": 375,
+                  "cachedNativeExecutionTotalNs": 6816458,
+                  "cachedNativeExecutionPerCallNs": 68164,
+                  "boundaryArgumentsNs": 833,
+                  "vmSetupNs": 1334,
+                  "pureExecutionNs": 27459,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 30125,
+                  "hotExecutionTotalNs": 1070625,
+                  "hotExecutionPerCallNs": 10706
                 },
                 "program": {
                   "functions": 1,
@@ -9993,55 +10750,64 @@
           },
           "aggregate": {
             "medians": {
-              "processWallNs": 15936667,
-              "fixtureInstallNs": 112292,
-              "calcitFrontendNs": 97417,
-              "snapshotCloneNs": 292,
-              "eligibilityNs": 15625,
-              "planningNs": 8417,
-              "programConstructionNs": 24750,
-              "validationLoweringNs": 3750,
-              "calxCompileTotalNs": 56584,
-              "nativeCallNs": 654958,
-              "boundaryArgumentsNs": 167,
-              "vmSetupNs": 250,
-              "pureExecutionNs": 107125,
+              "processWallNs": 99692833,
+              "fixtureInstallNs": 139041,
+              "calcitFrontendNs": 138625,
+              "snapshotCloneNs": 250,
+              "eligibilityNs": 23583,
+              "planningNs": 10500,
+              "programConstructionNs": 33917,
+              "validationLoweringNs": 5625,
+              "calxCompileTotalNs": 73375,
+              "nativeCallNs": 712625,
+              "cachedNativeResolutionNs": 542,
+              "cachedNativeExecutionTotalNs": 67748625,
+              "cachedNativeExecutionPerCallNs": 677486,
+              "boundaryArgumentsNs": 916,
+              "vmSetupNs": 1666,
+              "pureExecutionNs": 117000,
               "boundaryResultNs": 42,
-              "calxOneShotNs": 107833,
-              "hotExecutionPerCallNs": 104078
+              "calxOneShotNs": 120709,
+              "hotExecutionTotalNs": 10711083,
+              "hotExecutionPerCallNs": 107110
             },
             "medianAbsoluteDeviations": {
-              "processWallNs": 68083,
-              "fixtureInstallNs": 1667,
-              "calcitFrontendNs": 1667,
-              "snapshotCloneNs": 42,
-              "eligibilityNs": 1167,
-              "planningNs": 1292,
-              "programConstructionNs": 375,
-              "validationLoweringNs": 42,
-              "calxCompileTotalNs": 2208,
-              "nativeCallNs": 14083,
-              "boundaryArgumentsNs": 1,
-              "vmSetupNs": 0,
-              "pureExecutionNs": 292,
+              "processWallNs": 1990542,
+              "fixtureInstallNs": 2501,
+              "calcitFrontendNs": 5708,
+              "snapshotCloneNs": 0,
+              "eligibilityNs": 1792,
+              "planningNs": 292,
+              "programConstructionNs": 2501,
+              "validationLoweringNs": 334,
+              "calxCompileTotalNs": 2750,
+              "nativeCallNs": 7125,
+              "cachedNativeResolutionNs": 209,
+              "cachedNativeExecutionTotalNs": 1089916,
+              "cachedNativeExecutionPerCallNs": 10899,
+              "boundaryArgumentsNs": 624,
+              "vmSetupNs": 709,
+              "pureExecutionNs": 875,
               "boundaryResultNs": 1,
-              "calxOneShotNs": 416,
-              "hotExecutionPerCallNs": 229
+              "calxOneShotNs": 1750,
+              "hotExecutionTotalNs": 101417,
+              "hotExecutionPerCallNs": 1015
             },
             "derived": {
-              "nativeEndToEndNs": 864667,
-              "calxEndToEndNs": 374418,
-              "hotVsNativeRatio": 0.15890789943782654,
-              "oneShotEndToEndRatio": 0.4330198793292678
+              "lookupNativeEndToEndNs": 990291,
+              "calxEndToEndNs": 472000,
+              "calxHotVsLookupNativeRatio": 0.1503034555341168,
+              "calxHotVsCachedNativeRatio": 0.1580992079541127,
+              "calxOneShotEndToEndVsLookupNativeRatio": 0.47662757714651555
             }
           },
           "rawSamples": [
             {
-              "processWallNs": 16021958,
+              "processWallNs": 101683375,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -10052,25 +10818,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 110625,
-                "calcitFrontendNs": 95750,
-                "snapshotCloneNs": 334,
+                "fixtureInstallNs": 139041,
+                "calcitFrontendNs": 154667,
+                "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 18959,
-                  "planningNs": 7209,
-                  "programConstructionNs": 25125,
-                  "validationLoweringNs": 3750,
-                  "totalNs": 56584
+                  "eligibilityNs": 25375,
+                  "planningNs": 10625,
+                  "programConstructionNs": 33917,
+                  "validationLoweringNs": 5166,
+                  "totalNs": 80417
                 },
                 "runtime": {
-                  "nativeCallNs": 640875,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 292,
-                  "pureExecutionNs": 106667,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 107417,
-                  "hotExecutionTotalNs": 10503709,
-                  "hotExecutionPerCallNs": 105037
+                  "nativeCallNs": 717917,
+                  "cachedNativeResolutionNs": 2750,
+                  "cachedNativeExecutionTotalNs": 68838541,
+                  "cachedNativeExecutionPerCallNs": 688385,
+                  "boundaryArgumentsNs": 750,
+                  "vmSetupNs": 1500,
+                  "pureExecutionNs": 119541,
+                  "boundaryResultNs": 125,
+                  "calxOneShotNs": 122250,
+                  "hotExecutionTotalNs": 10582459,
+                  "hotExecutionPerCallNs": 105824
                 },
                 "program": {
                   "functions": 1,
@@ -10085,11 +10854,11 @@
               }
             },
             {
-              "processWallNs": 15936667,
+              "processWallNs": 99766083,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -10100,25 +10869,181 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 112292,
-                "calcitFrontendNs": 98083,
+                "fixtureInstallNs": 141542,
+                "calcitFrontendNs": 138625,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 24500,
+                  "planningNs": 10167,
+                  "programConstructionNs": 29375,
+                  "validationLoweringNs": 5625,
+                  "totalNs": 71750
+                },
+                "runtime": {
+                  "nativeCallNs": 723250,
+                  "cachedNativeResolutionNs": 541,
+                  "cachedNativeExecutionTotalNs": 67882708,
+                  "cachedNativeExecutionPerCallNs": 678827,
+                  "boundaryArgumentsNs": 3792,
+                  "vmSetupNs": 3000,
+                  "pureExecutionNs": 117000,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 124125,
+                  "hotExecutionTotalNs": 10939042,
+                  "hotExecutionPerCallNs": 109390
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 96044625,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 137709,
+                "calcitFrontendNs": 132917,
+                "snapshotCloneNs": 459,
+                "compile": {
+                  "eligibilityNs": 20625,
+                  "planningNs": 10917,
+                  "programConstructionNs": 34375,
+                  "validationLoweringNs": 6208,
+                  "totalNs": 74209
+                },
+                "runtime": {
+                  "nativeCallNs": 712625,
+                  "cachedNativeResolutionNs": 917,
+                  "cachedNativeExecutionTotalNs": 64580875,
+                  "cachedNativeExecutionPerCallNs": 645808,
+                  "boundaryArgumentsNs": 8917,
+                  "vmSetupNs": 1666,
+                  "pureExecutionNs": 109834,
+                  "boundaryResultNs": 84,
+                  "calxOneShotNs": 120709,
+                  "hotExecutionTotalNs": 10556000,
+                  "hotExecutionPerCallNs": 105560
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 95747625,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 138625,
+                "calcitFrontendNs": 135167,
+                "snapshotCloneNs": 250,
+                "compile": {
+                  "eligibilityNs": 23583,
+                  "planningNs": 8083,
+                  "programConstructionNs": 34042,
+                  "validationLoweringNs": 5500,
+                  "totalNs": 73375
+                },
+                "runtime": {
+                  "nativeCallNs": 686542,
+                  "cachedNativeResolutionNs": 333,
+                  "cachedNativeExecutionTotalNs": 64354084,
+                  "cachedNativeExecutionPerCallNs": 643540,
+                  "boundaryArgumentsNs": 292,
+                  "vmSetupNs": 750,
+                  "pureExecutionNs": 110875,
+                  "boundaryResultNs": 42,
+                  "calxOneShotNs": 112209,
+                  "hotExecutionTotalNs": 10682041,
+                  "hotExecutionPerCallNs": 106820
+                },
+                "program": {
+                  "functions": 1,
+                  "imports": 0,
+                  "syntaxNodes": 18,
+                  "instructions": 18,
+                  "diagnosticBytes": 1360,
+                  "hostBoundaryCallsPerExecution": 0,
+                  "reusesVmFramesAndStack": true
+                },
+                "correctness": true
+              }
+            },
+            {
+              "processWallNs": 101706166,
+              "report": {
+                "schema": "calcit-calx-benchmark/2",
+                "environment": {
+                  "packageVersion": "0.13.72",
+                  "calxVmVersion": "0.3.0",
+                  "profile": "release",
+                  "os": "macos",
+                  "architecture": "aarch64"
+                },
+                "kernel": "bounded-simulation",
+                "workload": "scalar-only",
+                "size": 1000,
+                "vmWarmup": 20,
+                "hotIterations": 100,
+                "fixtureInstallNs": 158708,
+                "calcitFrontendNs": 143792,
                 "snapshotCloneNs": 333,
                 "compile": {
-                  "eligibilityNs": 14458,
-                  "planningNs": 9958,
-                  "programConstructionNs": 28917,
-                  "validationLoweringNs": 5042,
-                  "totalNs": 60000
+                  "eligibilityNs": 19750,
+                  "planningNs": 10500,
+                  "programConstructionNs": 29125,
+                  "validationLoweringNs": 5125,
+                  "totalNs": 70458
                 },
                 "runtime": {
-                  "nativeCallNs": 632292,
-                  "boundaryArgumentsNs": 209,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 106917,
+                  "nativeCallNs": 705500,
+                  "cachedNativeResolutionNs": 500,
+                  "cachedNativeExecutionTotalNs": 69265458,
+                  "cachedNativeExecutionPerCallNs": 692654,
+                  "boundaryArgumentsNs": 3583,
+                  "vmSetupNs": 2375,
+                  "pureExecutionNs": 117666,
                   "boundaryResultNs": 42,
-                  "calxOneShotNs": 107584,
-                  "hotExecutionTotalNs": 10384958,
-                  "hotExecutionPerCallNs": 103849
+                  "calxOneShotNs": 123958,
+                  "hotExecutionTotalNs": 10812500,
+                  "hotExecutionPerCallNs": 108125
                 },
                 "program": {
                   "functions": 1,
@@ -10133,11 +11058,11 @@
               }
             },
             {
-              "processWallNs": 15960625,
+              "processWallNs": 99072875,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -10148,121 +11073,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 112709,
-                "calcitFrontendNs": 103125,
+                "fixtureInstallNs": 135375,
+                "calcitFrontendNs": 128666,
                 "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 16167,
-                  "planningNs": 8333,
-                  "programConstructionNs": 24750,
-                  "validationLoweringNs": 3708,
-                  "totalNs": 54625
+                  "eligibilityNs": 20750,
+                  "planningNs": 10500,
+                  "programConstructionNs": 31416,
+                  "validationLoweringNs": 5959,
+                  "totalNs": 70625
                 },
                 "runtime": {
-                  "nativeCallNs": 675875,
-                  "boundaryArgumentsNs": 209,
-                  "vmSetupNs": 458,
-                  "pureExecutionNs": 107125,
-                  "boundaryResultNs": 0,
-                  "calxOneShotNs": 108000,
-                  "hotExecutionTotalNs": 10431458,
-                  "hotExecutionPerCallNs": 104314
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 15867750,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 109417,
-                "calcitFrontendNs": 96334,
-                "snapshotCloneNs": 334,
-                "compile": {
-                  "eligibilityNs": 14000,
-                  "planningNs": 14583,
-                  "programConstructionNs": 31542,
-                  "validationLoweringNs": 3791,
-                  "totalNs": 65500
-                },
-                "runtime": {
-                  "nativeCallNs": 662292,
-                  "boundaryArgumentsNs": 208,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 107208,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 107833,
-                  "hotExecutionTotalNs": 10409083,
-                  "hotExecutionPerCallNs": 104090
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 15888125,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 111584,
-                "calcitFrontendNs": 94667,
-                "snapshotCloneNs": 292,
-                "compile": {
-                  "eligibilityNs": 15625,
-                  "planningNs": 7125,
-                  "programConstructionNs": 23875,
-                  "validationLoweringNs": 3667,
-                  "totalNs": 51959
-                },
-                "runtime": {
-                  "nativeCallNs": 683125,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 208,
-                  "pureExecutionNs": 106833,
+                  "nativeCallNs": 755833,
+                  "cachedNativeResolutionNs": 542,
+                  "cachedNativeExecutionTotalNs": 67263417,
+                  "cachedNativeExecutionPerCallNs": 672634,
+                  "boundaryArgumentsNs": 916,
+                  "vmSetupNs": 3167,
+                  "pureExecutionNs": 116125,
                   "boundaryResultNs": 41,
-                  "calxOneShotNs": 107416,
-                  "hotExecutionTotalNs": 10407875,
-                  "hotExecutionPerCallNs": 104078
+                  "calxOneShotNs": 120583,
+                  "hotExecutionTotalNs": 10796959,
+                  "hotExecutionPerCallNs": 107969
                 },
                 "program": {
                   "functions": 1,
@@ -10277,11 +11109,11 @@
               }
             },
             {
-              "processWallNs": 16004750,
+              "processWallNs": 99692833,
               "report": {
-                "schema": "calcit-calx-benchmark/1",
+                "schema": "calcit-calx-benchmark/2",
                 "environment": {
-                  "packageVersion": "0.13.67",
+                  "packageVersion": "0.13.72",
                   "calxVmVersion": "0.3.0",
                   "profile": "release",
                   "os": "macos",
@@ -10292,73 +11124,28 @@
                 "size": 1000,
                 "vmWarmup": 20,
                 "hotIterations": 100,
-                "fixtureInstallNs": 116916,
-                "calcitFrontendNs": 100000,
-                "snapshotCloneNs": 291,
-                "compile": {
-                  "eligibilityNs": 14458,
-                  "planningNs": 14083,
-                  "programConstructionNs": 24667,
-                  "validationLoweringNs": 4000,
-                  "totalNs": 58792
-                },
-                "runtime": {
-                  "nativeCallNs": 654958,
-                  "boundaryArgumentsNs": 167,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 109416,
-                  "boundaryResultNs": 42,
-                  "calxOneShotNs": 110042,
-                  "hotExecutionTotalNs": 10388584,
-                  "hotExecutionPerCallNs": 103885
-                },
-                "program": {
-                  "functions": 1,
-                  "imports": 0,
-                  "syntaxNodes": 18,
-                  "instructions": 18,
-                  "diagnosticBytes": 1360,
-                  "hostBoundaryCallsPerExecution": 0,
-                  "reusesVmFramesAndStack": true
-                },
-                "correctness": true
-              }
-            },
-            {
-              "processWallNs": 15858084,
-              "report": {
-                "schema": "calcit-calx-benchmark/1",
-                "environment": {
-                  "packageVersion": "0.13.67",
-                  "calxVmVersion": "0.3.0",
-                  "profile": "release",
-                  "os": "macos",
-                  "architecture": "aarch64"
-                },
-                "kernel": "bounded-simulation",
-                "workload": "scalar-only",
-                "size": 1000,
-                "vmWarmup": 20,
-                "hotIterations": 100,
-                "fixtureInstallNs": 114917,
-                "calcitFrontendNs": 97417,
+                "fixtureInstallNs": 157708,
+                "calcitFrontendNs": 153792,
                 "snapshotCloneNs": 250,
                 "compile": {
-                  "eligibilityNs": 18292,
-                  "planningNs": 8417,
-                  "programConstructionNs": 24458,
-                  "validationLoweringNs": 3750,
-                  "totalNs": 56500
+                  "eligibilityNs": 25250,
+                  "planningNs": 10208,
+                  "programConstructionNs": 45750,
+                  "validationLoweringNs": 5750,
+                  "totalNs": 88875
                 },
                 "runtime": {
-                  "nativeCallNs": 654042,
-                  "boundaryArgumentsNs": 166,
-                  "vmSetupNs": 250,
-                  "pureExecutionNs": 109542,
-                  "boundaryResultNs": 83,
-                  "calxOneShotNs": 110208,
-                  "hotExecutionTotalNs": 10373417,
-                  "hotExecutionPerCallNs": 103734
+                  "nativeCallNs": 708458,
+                  "cachedNativeResolutionNs": 3000,
+                  "cachedNativeExecutionTotalNs": 67748625,
+                  "cachedNativeExecutionPerCallNs": 677486,
+                  "boundaryArgumentsNs": 542,
+                  "vmSetupNs": 1250,
+                  "pureExecutionNs": 117000,
+                  "boundaryResultNs": 0,
+                  "calxOneShotNs": 118959,
+                  "hotExecutionTotalNs": 10711083,
+                  "hotExecutionPerCallNs": 107110
                 },
                 "program": {
                   "functions": 1,
@@ -10378,28 +11165,33 @@
       "crossovers": [
         {
           "kernel": "range-sum",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": 100
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": 100
         },
         {
           "kernel": "fibonacci",
-          "hotExecutionSize": 5,
-          "oneShotEndToEndSize": 10
+          "calxHotVsLookupNativeSize": 5,
+          "calxHotVsCachedNativeSize": 5,
+          "calxOneShotEndToEndVsLookupNativeSize": 10
         },
         {
           "kernel": "affine",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": null
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": null
         },
         {
           "kernel": "polynomial",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": null
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": null
         },
         {
           "kernel": "bounded-simulation",
-          "hotExecutionSize": 10,
-          "oneShotEndToEndSize": 100
+          "calxHotVsLookupNativeSize": 10,
+          "calxHotVsCachedNativeSize": 10,
+          "calxOneShotEndToEndVsLookupNativeSize": 1000
         }
       ]
     }

--- a/benchmarks/calx/README.md
+++ b/benchmarks/calx/README.md
@@ -2,30 +2,32 @@
 
 ## 中文
 
-首份完整 baseline 是 [`20260831-macos-arm64.json`](./20260831-macos-arm64.json)。采集环境为 Apple M1 Pro
+当前完整 schema v2 baseline 是 [`20260831-macos-arm64.json`](./20260831-macos-arm64.json)。采集环境为 Apple M1 Pro
 8 logical CPUs、macOS arm64、Rust 1.97.1，代码 commit 为
-`a1708055af6a0ab6ba04cda8cada3bc3d4720dae`，采集开始时 `gitDirty=false`。每个 case 丢弃 2 个 fresh-process
-预热样本，保留 7 个原始样本；hot call 使用 20 次 VM 预热和 100 次测量。报告同时保存 debug/release，
-使用 median 与 median absolute deviation。
+`88bb5a2250ba65b0e35c4d1809e6d49a14c61623`，采集开始时 `gitDirty=false`。每个 case 丢弃 2 个
+fresh-process 预热样本，保留 7 个原始样本；cached Calcit callable 与 reused Calx VM 都使用 20 次预热和
+100 次测量。报告同时保存 debug/release，使用 median 与 median absolute deviation，共保留 182 个原始样本。
 
 release 采样点的有限结果：
 
-| Kernel | 采样规模 | 首个 hot ≤ native | 首个 one-shot end-to-end ≤ native |
-| --- | --- | --- | --- |
-| range-sum | 10, 100, 1000 | 10 | 100 |
-| fibonacci | 5, 10, 20 | 5 | 10 |
-| affine | 10, 1000 | 10 | 未出现 |
-| polynomial | 10, 1000 | 10 | 未出现 |
-| bounded-simulation | 10, 100, 1000 | 10 | 100 |
+| Kernel | 采样规模 | 首个 Calx hot ≤ lookup native | 首个 Calx hot ≤ cached native | 首个 one-shot end-to-end ≤ lookup native |
+| --- | --- | --- | --- | --- |
+| range-sum | 10, 100, 1000 | 10 | 10 | 100 |
+| fibonacci | 5, 10, 20 | 5 | 5 | 10 |
+| affine | 10, 1000 | 10 | 10 | 未出现 |
+| polynomial | 10, 1000 | 10 | 10 | 未出现 |
+| bounded-simulation | 10, 100, 1000 | 10 | 10 | 1000 |
 
-在 release 样本中，Calx compile total 的中位数约为 38–72 μs。规模增长的 range-sum、Fibonacci 和
+在 release 样本中，Calx compile total 的中位数约为 41–78 μs。规模增长的 range-sum、Fibonacci 和
 bounded-simulation 能摊薄 frontend/compile/setup 成本；固定深度 affine/polynomial 在所测输入点没有
-one-shot crossover。这支持下一步研究 compile cache 与 VM reuse，但不证明所有 Calcit 代码适合 Calx。
+one-shot crossover。bounded-simulation 的采样 one-shot crossover 从旧基线的 100 移到 1000，说明阈值只能
+解释为当前样本点，不能固定写进选择策略。
 
-hot 对比尤其需要谨慎：Calx 侧复用已经实例化的 VM，而当前 Calcit baseline 每次通过
-`run_program_with_docs` 完成入口查找与调用。它衡量的是 embedding 可见的重复调用路径，不是纯粹的 VM opcode
-dispatch 对 runner opcode dispatch。后续选择策略若依赖该数据，必须先增加等价的 cached Calcit callable
-baseline。
+公平的 cached-callable 对比消除了 Calcit 每次 entry lookup 的不对称，但仍保留函数 scope、参数绑定和真实
+runner execution。release 下 Calx hot / cached Calcit ratio 为 0.106–0.392，即在这些 scalar kernels 和
+输入点上约快 2.6–9.5 倍。旧的 lookup-native ratio 为 0.009–0.150，确实夸大了微型 kernel 的差距；不过
+cached 对比没有消除 Calx 的有限收益。证据支持下一步先用 profile 建立 compile/program cache issue；当前
+compile 成本远大于 VM setup，尚不足以优先实现 VM pooling，也不证明任意 Calcit 代码适合 Calx。
 
 本报告仍缺少 typed-buffer workload、平台 profiler 的 peak RSS/allocation hotspot、WASM 同 kernel 参照，
 以及跨机器重复采样。因此 calx-vm #39 保持打开；不能根据这一个环境承诺固定倍数或自动 offload 阈值。
@@ -34,31 +36,35 @@ baseline。
 
 ## English
 
-The first complete baseline is [`20260831-macos-arm64.json`](./20260831-macos-arm64.json). It was collected on an
+The current complete schema-v2 baseline is [`20260831-macos-arm64.json`](./20260831-macos-arm64.json). It was collected on an
 Apple M1 Pro with 8 logical CPUs, macOS arm64, and Rust 1.97.1, at commit
-`a1708055af6a0ab6ba04cda8cada3bc3d4720dae` with `gitDirty=false`. Each case discards two fresh-process warm-up
-samples and preserves seven raw samples. Hot calls use 20 VM warm-ups and 100 measured calls. The report contains
-both debug and release profiles and uses the median plus median absolute deviation.
+`88bb5a2250ba65b0e35c4d1809e6d49a14c61623` with `gitDirty=false`. Each case discards two fresh-process warm-up
+samples and preserves seven raw samples. Both the cached Calcit callable and reused Calx VM use 20 warm-ups and
+100 measured calls. The report contains debug and release profiles, uses the median plus median absolute deviation,
+and preserves 182 raw samples.
 
 Bounded results at the sampled release points:
 
-| Kernel | Sampled sizes | First hot ≤ native | First one-shot end-to-end ≤ native |
-| --- | --- | --- | --- |
-| range-sum | 10, 100, 1000 | 10 | 100 |
-| fibonacci | 5, 10, 20 | 5 | 10 |
-| affine | 10, 1000 | 10 | none |
-| polynomial | 10, 1000 | 10 | none |
-| bounded-simulation | 10, 100, 1000 | 10 | 100 |
+| Kernel | Sampled sizes | First Calx hot ≤ lookup native | First Calx hot ≤ cached native | First one-shot end-to-end ≤ lookup native |
+| --- | --- | --- | --- | --- |
+| range-sum | 10, 100, 1000 | 10 | 10 | 100 |
+| fibonacci | 5, 10, 20 | 5 | 5 | 10 |
+| affine | 10, 1000 | 10 | 10 | none |
+| polynomial | 10, 1000 | 10 | 10 | none |
+| bounded-simulation | 10, 100, 1000 | 10 | 10 | 1000 |
 
-Median Calx compile total is approximately 38–72 μs in the release samples. The input-scaled range-sum,
+Median Calx compile total is approximately 41–78 μs in the release samples. The input-scaled range-sum,
 Fibonacci, and bounded-simulation cases amortize frontend, compile, and setup costs; fixed-depth affine and
-polynomial do not reach a one-shot crossover at their sampled points. This supports investigating compile caching
-and VM reuse next, but it does not show that arbitrary Calcit code belongs on Calx.
+polynomial do not reach a one-shot crossover at their sampled points. The sampled bounded-simulation one-shot
+crossover moves from 100 in the old baseline to 1000, demonstrating that a sampled threshold must not be frozen
+into a selection policy.
 
-The hot comparison needs particular care. Calx reuses an instantiated VM, while the current Calcit baseline calls
-through `run_program_with_docs`, including entry lookup, every time. This measures embedding-visible repeated-call
-paths, not an isolated comparison of VM opcode dispatch with runner opcode dispatch. Any selection policy based on
-this evidence first needs an equivalent baseline that uses a cached Calcit callable.
+The fair cached-callable comparison removes repeated Calcit entry lookup while retaining function-scope setup,
+argument binding, and real runner execution. The release Calx-hot/cached-Calcit ratio is 0.106–0.392, or about
+2.6–9.5 times faster for these scalar kernels and sampled inputs. The old lookup-native ratio of 0.009–0.150 did
+overstate the tiny-kernel gap, but the cached comparison does not eliminate the bounded Calx gain. This evidence
+supports filing a profile-backed compile/program-cache issue next. Compilation remains much larger than VM setup,
+so it does not yet justify prioritizing VM pooling or claiming that arbitrary Calcit code belongs on Calx.
 
 The report still lacks a typed-buffer workload, platform-profiler peak RSS/allocation hotspots, a same-kernel WASM
 reference, and cross-machine repetition. calx-vm #39 therefore remains open; this one environment cannot justify a

--- a/docs/run/calx-benchmark.md
+++ b/docs/run/calx-benchmark.md
@@ -43,7 +43,7 @@ CALX_BENCH_QUICK=1 CALX_BENCH_SAMPLES=1 yarn bench-calx-e2e
 
 - `CALX_BENCH_SAMPLES`：保留的 fresh-process 样本数；
 - `CALX_BENCH_PROCESS_WARMUP`：每个 case 丢弃的 fresh-process 样本数；
-- `CALX_BENCH_VM_WARMUP`：hot call 前复用同一 VM 的预热次数；
+- `CALX_BENCH_VM_WARMUP`：cached Calcit callable 与复用的 Calx VM 在 hot call 前各自的预热次数；
 - `CALX_BENCH_HOT_ITERATIONS`：每个进程内的 hot call 测量次数；
 - `CALX_BENCH_OUTPUT`：相对仓库根目录或绝对 JSON 输出路径。
 
@@ -126,7 +126,8 @@ The first complete clean-worktree baseline and its bounded conclusions are recor
 [`benchmarks/calx/README.md`](../../benchmarks/calx/README.md).
 
 The experiment can be pinned with `CALX_BENCH_SAMPLES`, `CALX_BENCH_PROCESS_WARMUP`,
-`CALX_BENCH_VM_WARMUP`, `CALX_BENCH_HOT_ITERATIONS`, and `CALX_BENCH_OUTPUT`.
+`CALX_BENCH_VM_WARMUP` (applied separately to the cached Calcit callable and reused Calx VM),
+`CALX_BENCH_HOT_ITERATIONS`, and `CALX_BENCH_OUTPUT`.
 
 On success, the single-case runner emits exactly one `calcit-calx-benchmark/2` JSON value on stdout. Failures are
 reported on stderr with a nonzero exit status:

--- a/docs/run/calx-benchmark.md
+++ b/docs/run/calx-benchmark.md
@@ -23,8 +23,8 @@ buffer 前，typed-buffer 结果保持 `not-measured-no-typed-buffer-abi`。WASM
 
 ### 复现命令
 
-完整矩阵同时构建 debug/release runner，默认每个 case 丢弃 2 个进程样本、保留 7 个样本，在复用 VM
-中预热 20 次并测量 100 次：
+完整矩阵同时构建 debug/release runner，默认每个 case 丢弃 2 个进程样本、保留 7 个样本，并分别对缓存的
+Calcit callable 与复用的 Calx VM 预热 20 次、测量 100 次：
 
 ```bash
 yarn bench-calx-e2e
@@ -47,7 +47,7 @@ CALX_BENCH_QUICK=1 CALX_BENCH_SAMPLES=1 yarn bench-calx-e2e
 - `CALX_BENCH_HOT_ITERATIONS`：每个进程内的 hot call 测量次数；
 - `CALX_BENCH_OUTPUT`：相对仓库根目录或绝对 JSON 输出路径。
 
-单 case runner 成功时，stdout 恰好输出一个 `calcit-calx-benchmark/1` JSON；失败写入 stderr 并以非零状态退出：
+单 case runner 成功时，stdout 恰好输出一个 `calcit-calx-benchmark/2` JSON；失败写入 stderr 并以非零状态退出：
 
 ```bash
 cargo run --release --bin calcit-calx-bench -- \
@@ -67,13 +67,15 @@ cargo run --release --bin calcit-calx-bench -- \
 - `runtime.vmSetupNs`：从 immutable validated program 建立 VM；
 - `runtime.pureExecutionNs`：一次 `run_typed`，包含 strict runtime argument validation；
 - `runtime.hotExecutionPerCallNs`：预先准备参数并复用 VM frames/stack 后的平均调用耗时；
-- `runtime.nativeCallNs`：同一已 preprocess Calcit definition 的 native runner 调用；
+- `runtime.nativeCallNs`：经 `run_program_with_docs` 完成 guard、entry lookup 与执行的一次 embedding-visible 调用；
+- `runtime.cachedNativeResolutionNs`：从已 preprocess program 解析并缓存 Calcit callable 的一次性成本；
+- `runtime.cachedNativeExecutionPerCallNs`：预先准备参数并复用 callable 后的平均调用耗时，仍包含函数 scope、参数绑定与 runner execution；
 - `processWallNs`：Node 从 spawn 到进程退出的总墙钟时间，包含 OS process startup 与所有阶段。
 
 suite 报告保留每个原始样本，并为每个字段给出 median 与 median absolute deviation。crossover 只表示
-采样输入点中首次出现 ratio ≤ 1 的位置，不做曲线外推。`oneShotEndToEndRatio` 包含 frontend、snapshot、
-compile、boundary、VM setup 和执行；`hotVsNativeRatio` 比较复用 VM 的 Calx 调用与已 preprocess 的 Calcit
-调用。两者回答不同部署场景，不能互相替代。
+采样输入点中首次出现 ratio ≤ 1 的位置，不做曲线外推。`calxOneShotEndToEndVsLookupNativeRatio` 包含
+frontend、snapshot、compile、boundary、VM setup 和执行；`calxHotVsLookupNativeRatio` 保留 embedding-visible
+对比；`calxHotVsCachedNativeRatio` 才比较已经解析的两条重复执行路径。三个指标回答不同部署场景，不能互相替代。
 
 `program` 同时记录 function/import/syntax/instruction 数、diagnostic report 字节数、host-boundary 次数和
 VM reuse 状态。峰值内存与 allocation hotspot 需要平台 profiler；不能从墙钟时间猜测，采集时应把
@@ -107,7 +109,8 @@ comparison number.
 ### Reproduction
 
 The full matrix builds both debug and release runners. By default it discards two fresh-process samples, retains
-seven, warms a reused VM for 20 calls, and measures 100 hot calls per process:
+seven, then warms both a cached Calcit callable and a reused Calx VM for 20 calls and measures 100 hot calls per
+process:
 
 ```bash
 yarn bench-calx-e2e
@@ -125,7 +128,7 @@ The first complete clean-worktree baseline and its bounded conclusions are recor
 The experiment can be pinned with `CALX_BENCH_SAMPLES`, `CALX_BENCH_PROCESS_WARMUP`,
 `CALX_BENCH_VM_WARMUP`, `CALX_BENCH_HOT_ITERATIONS`, and `CALX_BENCH_OUTPUT`.
 
-On success, the single-case runner emits exactly one `calcit-calx-benchmark/1` JSON value on stdout. Failures are
+On success, the single-case runner emits exactly one `calcit-calx-benchmark/2` JSON value on stdout. Failures are
 reported on stderr with a nonzero exit status:
 
 ```bash
@@ -146,14 +149,17 @@ cargo run --release --bin calcit-calx-bench -- \
 - `runtime.vmSetupNs`: instantiate a VM from the immutable validated program;
 - `runtime.pureExecutionNs`: one `run_typed`, including strict runtime argument validation;
 - `runtime.hotExecutionPerCallNs`: average call time with prebuilt arguments and reused VM frames/stack;
-- `runtime.nativeCallNs`: invoke the same already-preprocessed definition in the native Calcit runner;
+- `runtime.nativeCallNs`: one embedding-visible call through `run_program_with_docs`, including its guard, entry lookup, and execution;
+- `runtime.cachedNativeResolutionNs`: one-time resolution of the cached Calcit callable from the already-preprocessed program;
+- `runtime.cachedNativeExecutionPerCallNs`: average call time with prebuilt arguments and a reused callable, while still timing function scope setup, argument binding, and runner execution;
 - `processWallNs`: Node wall time from spawn through process exit, including OS startup and every measured phase.
 
 The suite preserves every raw sample and reports the median plus median absolute deviation for every field. A
-crossover is only the first sampled input whose ratio is at most one; it is not an extrapolation. The
-`oneShotEndToEndRatio` includes frontend, snapshot, compilation, boundaries, VM setup, and execution, while
-`hotVsNativeRatio` compares a reused Calx VM call with an already-preprocessed Calcit call. They model different
-deployment scenarios and are not interchangeable.
+crossover is only the first sampled input whose ratio is at most one; it is not an extrapolation.
+`calxOneShotEndToEndVsLookupNativeRatio` includes frontend, snapshot, compilation, boundaries, VM setup, and
+execution. `calxHotVsLookupNativeRatio` preserves the embedding-visible comparison, while
+`calxHotVsCachedNativeRatio` compares the two already-resolved repeated-execution paths. The three metrics model
+different deployment scenarios and are not interchangeable.
 
 The `program` section records function/import/syntax/instruction counts, diagnostic-report bytes, host-boundary
 calls, and VM reuse. Peak memory and allocation hotspots require a platform profiler; they must not be inferred

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -133,5 +133,8 @@ generated-program golden 固定 import declaration、guest syntax 与 Calcit tre
 cache、profiling/selection policy，也还没有基于 benchmark 的自动 offload。correctness corpus 已覆盖 scalar
 kernel、zero/single-result typed imports、generated program、trap 与 fallback。分阶段 benchmark matrix、
 采样 crossover point 和首份 scalar baseline 已建立；[calx-vm #39](https://github.com/calcit-lang/calx-vm/issues/39)
-后续仍需用公平的 cached Calcit 调用基线与 profile 证据决定 compile cache、VM reuse 与 selection policy。
+现已补充公平的 cached Calcit callable 基线：有限 scalar 样本仍显示 Calx hot 收益，但 lookup-call 对比确实
+夸大了微型 kernel 差距。后续先用 profile 证据决定 compile/program cache，VM pooling 不在缺少独立证据时
+提前实现；实用 bulk workload 由 [calx-vm #50](https://github.com/calcit-lang/calx-vm/issues/50) 以严格、
+non-nil、zero-Dynamic typed buffer 单独推进，再决定 selection policy。
 基准命令、阶段定义和原始 JSON 格式见[《Calcit→Calx benchmark methodology》](./calx-benchmark.md)。

--- a/editing-history/202608311323-calx-cached-callable-baseline.md
+++ b/editing-history/202608311323-calx-cached-callable-baseline.md
@@ -1,0 +1,31 @@
+# Calx cached callable 公平基线
+
+## 中文
+
+为 calcit#548 与 calx-vm#39 增加公平的 Calcit→Calx repeated-call 计量边界：
+
+- 保留 `run_program_with_docs` 的 embedding-visible lookup-call 指标；
+- 从已经 preprocess 的 program 解析并缓存同一个 `CalcitFn`，直接通过 `runner::run_fn` 建立 cached-native baseline；
+- cached Calcit 与 reused Calx VM 使用相同 warm-up/iteration 数，并在计时前准备每次调用的输入；
+- Calcit cached 路径仍计入函数 scope 建立、参数绑定与 runner execution，不把它缩减成空 dispatch；
+- 单 case 与 suite schema 升级到 edition 2，分别报告 lookup-native、cached-native 与 Calx hot ratio/crossover；
+- correctness gate 同时验证 lookup Calcit、cached Calcit 与 Calx 结果，缺失 callable 明确失败；
+- 这一步只修正 benchmark 证据，不引入 production cache、VM pool、自动 offload，也不改变 Nil/Dynamic strict boundary。
+
+快速 debug/release matrix 已验证 schema、correctness 与三类 crossover 输出。完整 clean-worktree baseline 在首个实现提交后重新采集。
+
+---
+
+## English
+
+Add a fair repeated-call boundary for calcit#548 and calx-vm#39:
+
+- Preserve the embedding-visible lookup-call metric through `run_program_with_docs`.
+- Resolve and cache the same `CalcitFn` from the already-preprocessed program, then call it directly through `runner::run_fn` for the cached-native baseline.
+- Use equal warm-up and iteration counts for cached Calcit and a reused Calx VM, with per-call inputs prepared before timing.
+- Keep function-scope setup, argument binding, and runner execution inside the cached Calcit timing boundary instead of reducing it to an empty dispatch.
+- Bump the single-case and suite schemas to edition 2 and report lookup-native, cached-native, and Calx hot ratios/crossovers separately.
+- Gate correctness across lookup Calcit, cached Calcit, and Calx, with an explicit failure for missing cached callables.
+- This slice corrects benchmark evidence only. It does not add a production cache, VM pool, automatic offload, or any relaxation of the strict Nil/Dynamic boundary.
+
+The quick debug/release matrix verifies the schema, correctness gate, and three crossover views. The complete clean-worktree baseline is recollected after the first implementation commit.

--- a/editing-history/202608311330-calx-cached-baseline-results.md
+++ b/editing-history/202608311330-calx-cached-baseline-results.md
@@ -1,0 +1,36 @@
+# Calx cached baseline 结果
+
+## 中文
+
+从 clean commit `88bb5a2250ba65b0e35c4d1809e6d49a14c61623` 重新采集完整 schema v2 baseline：
+
+- Apple M1 Pro、macOS arm64、Rust 1.97.1，`gitDirty=false`；
+- debug/release 共 26 个 case，每个 case 保留 7 个 fresh-process 样本，共 182 个原始样本；
+- cached Calcit callable 与 reused Calx VM 都预热 20 次并测量 100 次；
+- release Calx compile total 中位数约 41–78 μs；
+- release Calx hot / cached Calcit ratio 为 0.106–0.392，即有限样本约 2.6–9.5 倍；
+- lookup-native ratio 为 0.009–0.150，确认旧比较夸大了微型 kernel 差距，但公平 cached 对比下 scalar 收益仍存在；
+- range-sum、Fibonacci 的 one-shot crossover 仍分别为 100、10；bounded-simulation 在本次样本移到 1000；affine、polynomial 未出现；
+- 大型 JSON 继续由 `.gitattributes` 标记为 `-diff linguist-generated`。
+
+这些证据支持下一步先建立 profile-backed compile/program cache issue。VM setup 明显小于 compile，但仍需独立
+profile 才能决定 VM pooling。typed buffer、peak RSS/allocation、WASM 参照与跨机器重复仍由 calx-vm #39/#50 追踪。
+
+---
+
+## English
+
+Recollect the complete schema-v2 baseline from clean commit `88bb5a2250ba65b0e35c4d1809e6d49a14c61623`:
+
+- Apple M1 Pro, macOS arm64, Rust 1.97.1, with `gitDirty=false`;
+- 26 debug/release cases with seven retained fresh-process samples each, for 182 raw samples;
+- 20 warm-ups and 100 measured calls for both the cached Calcit callable and reused Calx VM;
+- median release Calx compile total of approximately 41–78 μs;
+- a release Calx-hot/cached-Calcit ratio of 0.106–0.392, or about 2.6–9.5 times faster in the bounded sample;
+- a lookup-native ratio of 0.009–0.150, confirming that the old comparison overstated tiny-kernel gaps while the fair cached comparison still retains a scalar gain;
+- one-shot crossovers of 100 for range-sum and 10 for Fibonacci; bounded-simulation moves to 1000 in this sample, while affine and polynomial have none;
+- the large JSON remains marked `-diff linguist-generated` through `.gitattributes`.
+
+The evidence supports filing a profile-backed compile/program-cache issue next. VM setup is much smaller than
+compilation, but VM pooling still requires separate profile evidence. Typed buffers, peak RSS/allocation, the Wasm
+reference, and cross-machine repetition remain tracked by calx-vm #39/#50.

--- a/editing-history/202608311341-calx-benchmark-warmup-review.md
+++ b/editing-history/202608311341-calx-benchmark-warmup-review.md
@@ -1,0 +1,14 @@
+# Calx benchmark warm-up review
+
+## 中文
+
+处理 calcit#551 的文档 review：`CALX_BENCH_VM_WARMUP` 实际分别作用于 cached Calcit callable 与 reused
+Calx VM，环境变量说明现在与 runner 和 methodology 一致，不再把它描述成只预热 VM。
+
+---
+
+## English
+
+Address the documentation review on calcit#551. `CALX_BENCH_VM_WARMUP` is applied separately to the cached Calcit
+callable and reused Calx VM, so the environment-variable description now matches the runner and methodology instead
+of describing a VM-only warm-up.

--- a/scripts/bench-calx-e2e.mjs
+++ b/scripts/bench-calx-e2e.mjs
@@ -98,8 +98,16 @@ function runCase(binary, kernel, size) {
     throw new Error(`benchmark failed for ${kernel}/${size}\n${result.stdout}\n${result.stderr}`);
   }
   const report = JSON.parse(result.stdout);
-  if (report.schema !== "calcit-calx-benchmark/1" || report.correctness !== true) {
+  if (report.schema !== "calcit-calx-benchmark/2" || report.correctness !== true) {
     throw new Error(`invalid or unverified benchmark report for ${kernel}/${size}`);
+  }
+  const cachedNativeMetrics = [
+    report.runtime?.cachedNativeResolutionNs,
+    report.runtime?.cachedNativeExecutionTotalNs,
+    report.runtime?.cachedNativeExecutionPerCallNs,
+  ];
+  if (!cachedNativeMetrics.every((value) => Number.isFinite(value) && value >= 0)) {
+    throw new Error(`benchmark report lacks valid cached-native metrics for ${kernel}/${size}`);
   }
   return { processWallNs, report };
 }
@@ -133,11 +141,15 @@ function selectMetrics(sample) {
     validationLoweringNs: report.compile.validationLoweringNs,
     calxCompileTotalNs: report.compile.totalNs,
     nativeCallNs: report.runtime.nativeCallNs,
+    cachedNativeResolutionNs: report.runtime.cachedNativeResolutionNs,
+    cachedNativeExecutionTotalNs: report.runtime.cachedNativeExecutionTotalNs,
+    cachedNativeExecutionPerCallNs: report.runtime.cachedNativeExecutionPerCallNs,
     boundaryArgumentsNs: report.runtime.boundaryArgumentsNs,
     vmSetupNs: report.runtime.vmSetupNs,
     pureExecutionNs: report.runtime.pureExecutionNs,
     boundaryResultNs: report.runtime.boundaryResultNs,
     calxOneShotNs: report.runtime.calxOneShotNs,
+    hotExecutionTotalNs: report.runtime.hotExecutionTotalNs,
     hotExecutionPerCallNs: report.runtime.hotExecutionPerCallNs,
   };
 }
@@ -150,7 +162,7 @@ function aggregate(rawSamples) {
   const medianAbsoluteDeviations = Object.fromEntries(
     names.map((name) => [name, medianAbsoluteDeviation(rows.map((row) => row[name]))]),
   );
-  const nativeEndToEndNs = medians.fixtureInstallNs + medians.calcitFrontendNs + medians.nativeCallNs;
+  const lookupNativeEndToEndNs = medians.fixtureInstallNs + medians.calcitFrontendNs + medians.nativeCallNs;
   const calxEndToEndNs =
     medians.fixtureInstallNs +
     medians.calcitFrontendNs +
@@ -161,10 +173,11 @@ function aggregate(rawSamples) {
     medians,
     medianAbsoluteDeviations,
     derived: {
-      nativeEndToEndNs,
+      lookupNativeEndToEndNs,
       calxEndToEndNs,
-      hotVsNativeRatio: medians.hotExecutionPerCallNs / medians.nativeCallNs,
-      oneShotEndToEndRatio: calxEndToEndNs / nativeEndToEndNs,
+      calxHotVsLookupNativeRatio: medians.hotExecutionPerCallNs / medians.nativeCallNs,
+      calxHotVsCachedNativeRatio: medians.hotExecutionPerCallNs / medians.cachedNativeExecutionPerCallNs,
+      calxOneShotEndToEndVsLookupNativeRatio: calxEndToEndNs / lookupNativeEndToEndNs,
     },
   };
 }
@@ -201,8 +214,12 @@ for (const profile of ["debug", "release"]) {
     const kernelCases = cases.filter((item) => item.kernel === kernel).sort((a, b) => a.size - b.size);
     return {
       kernel,
-      hotExecutionSize: crossover(kernelCases, "hotVsNativeRatio"),
-      oneShotEndToEndSize: crossover(kernelCases, "oneShotEndToEndRatio"),
+      calxHotVsLookupNativeSize: crossover(kernelCases, "calxHotVsLookupNativeRatio"),
+      calxHotVsCachedNativeSize: crossover(kernelCases, "calxHotVsCachedNativeRatio"),
+      calxOneShotEndToEndVsLookupNativeSize: crossover(
+        kernelCases,
+        "calxOneShotEndToEndVsLookupNativeRatio",
+      ),
     };
   });
   profiles.push({ profile, cases, crossovers });
@@ -210,7 +227,7 @@ for (const profile of ["debug", "release"]) {
 
 const cpu = os.cpus()[0];
 const report = {
-  schema: "calcit-calx-benchmark-suite/1",
+  schema: "calcit-calx-benchmark-suite/2",
   generatedAt: new Date().toISOString(),
   scope: {
     workload: "scalar-only",
@@ -235,6 +252,8 @@ const report = {
     samples,
     vmWarmup,
     hotIterations,
+    hotWarmupMeaning: "applied equally to the cached Calcit callable and reused Calx VM",
+    cachedNativeMeaning: "resolved callable reused; scope setup, argument binding, and runner execution remain timed",
     noiseStatistic: "median-and-median-absolute-deviation",
     processWallMeaning: "Node spawn wall time including process startup and all measured phases",
     regressionPolicy: "informational-no-absolute-ci-threshold",
@@ -250,7 +269,9 @@ for (const { profile, crossovers } of profiles) {
   console.log(`${profile} sampled crossover points:`);
   for (const item of crossovers) {
     console.log(
-      `  ${item.kernel}: hot=${item.hotExecutionSize ?? "none"}, one-shot=${item.oneShotEndToEndSize ?? "none"}`,
+      `  ${item.kernel}: hot-vs-lookup=${item.calxHotVsLookupNativeSize ?? "none"}, ` +
+        `hot-vs-cached=${item.calxHotVsCachedNativeSize ?? "none"}, ` +
+        `one-shot-vs-lookup=${item.calxOneShotEndToEndVsLookupNativeSize ?? "none"}`,
     );
   }
 }

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use argh::FromArgs;
-use calcit::calcit::{CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind};
+use calcit::calcit::{CalcitFn, CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind};
 use calcit::call_stack::CallStackList;
 use calcit::codegen::calx::{CalxCompiledKernel, CalxScalarType, CalxValue, compile_calx_kernel_measured};
 use calcit::data::cirru::code_to_calcit;
@@ -67,6 +67,9 @@ struct CompileReport {
 #[serde(rename_all = "camelCase")]
 struct RuntimeReport {
   native_call_ns: u64,
+  cached_native_resolution_ns: u64,
+  cached_native_execution_total_ns: u64,
+  cached_native_execution_per_call_ns: u64,
   boundary_arguments_ns: u64,
   vm_setup_ns: u64,
   pure_execution_ns: u64,
@@ -230,6 +233,14 @@ fn convert_result(kernel: &CalxCompiledKernel, result: CalxRunResult) -> Result<
   }
 }
 
+/// Resolve the already-preprocessed Calcit entry once for a fair repeated-call baseline.
+fn resolve_cached_calcit_callable(kernel: &str, call_stack: &CallStackList) -> Result<Arc<CalcitFn>, String> {
+  match calcit::runner::evaluate_symbol_from_program(kernel, FIXTURE_NAMESPACE, None, call_stack).map_err(|error| error.to_string())? {
+    Calcit::Fn { info, .. } => Ok(info),
+    value => Err(format!("expected cached benchmark callable, found {value}")),
+  }
+}
+
 /// Run correctness first, then collect one process-local staged measurement.
 fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   if args.hot_iterations == 0 {
@@ -261,6 +272,30 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   let native_result = run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from(args.kernel.as_str()), &calcit_args)
     .map_err(|error| error.to_string())?;
   let native_call_ns = nanos(native_started.elapsed());
+
+  let native_call_stack = CallStackList::default();
+  let cached_native_resolution_started = Instant::now();
+  let cached_native_callable = resolve_cached_calcit_callable(&args.kernel, &native_call_stack)?;
+  let cached_native_resolution_ns = nanos(cached_native_resolution_started.elapsed());
+  let cached_native_result =
+    calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?;
+  if cached_native_result != native_result {
+    return Err(format!(
+      "correctness mismatch for {}/{}: Calcit lookup={native_result}, Calcit cached={cached_native_result}",
+      FIXTURE_NAMESPACE, args.kernel
+    ));
+  }
+
+  for _ in 0..args.vm_warmup {
+    black_box(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+  }
+  let cached_native_inputs = (0..args.hot_iterations).map(|_| calcit_args.clone()).collect::<Vec<_>>();
+  let cached_native_started = Instant::now();
+  for input in cached_native_inputs {
+    black_box(calcit::runner::run_fn(&input, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+  }
+  let cached_native_execution_total_ns = nanos(cached_native_started.elapsed());
+  let cached_native_execution_per_call_ns = cached_native_execution_total_ns / u64::from(args.hot_iterations);
 
   let calx_one_shot_started = Instant::now();
   let boundary_arguments_started = Instant::now();
@@ -307,7 +342,7 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   let diagnostic_bytes = kernel.stable_program_summary().len();
 
   Ok(BenchmarkReport {
-    schema: "calcit-calx-benchmark/1",
+    schema: "calcit-calx-benchmark/2",
     environment: EnvironmentReport {
       package_version: env!("CARGO_PKG_VERSION"),
       calx_vm_version: resolved_dependency_version(CARGO_LOCK, "calx_vm")?.to_owned(),
@@ -332,6 +367,9 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
     },
     runtime: RuntimeReport {
       native_call_ns,
+      cached_native_resolution_ns,
+      cached_native_execution_total_ns,
+      cached_native_execution_per_call_ns,
       boundary_arguments_ns,
       vm_setup_ns,
       pure_execution_ns,
@@ -381,5 +419,20 @@ mod tests {
     let duplicate = "[[package]]\nname = \"demo\"\nversion = \"1.0.0\"\n[[package]]\nname = \"demo\"\nversion = \"2.0.0\"\n";
     assert!(resolved_dependency_version(duplicate, "demo").is_err());
     assert!(resolved_dependency_version(duplicate, "missing").is_err());
+  }
+
+  #[test]
+  fn cached_callable_matches_lookup_execution_and_rejects_missing_entries() {
+    install_fixture().expect("install benchmark fixture");
+    let args = kernel_arguments("range-sum", 10).expect("range-sum arguments");
+    let lookup_result =
+      run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from("range-sum"), &args).expect("run lookup baseline");
+    let call_stack = CallStackList::default();
+    let callable = resolve_cached_calcit_callable("range-sum", &call_stack).expect("resolve cached callable");
+    let cached_result = calcit::runner::run_fn(&args, &callable, &call_stack).expect("run cached callable");
+    assert_eq!(cached_result, lookup_result);
+
+    let error = resolve_cached_calcit_callable("missing-kernel", &call_stack).expect_err("missing entries must fail");
+    assert!(error.contains("missing-kernel"));
   }
 }


### PR DESCRIPTION
## 中文

### 背景

#535 建立的首份 Calcit→Calx baseline 中，Calx hot 路径复用已实例化 VM，而 Calcit 每次通过 `run_program_with_docs` 重新执行 guard、entry lookup 与 callable resolution。这个不对称会放大微型 kernel 的 hot ratio，阻塞 calx-vm#39 后续的 cache/selection 决策。

### 改动

- 保留 embedding-visible 的 native lookup-call 指标；
- 从已 preprocess program 一次解析并缓存同一个 `CalcitFn`；
- 直接通过 `runner::run_fn` 建立 cached-native repeated-call baseline；
- cached Calcit 与 reused Calx VM 使用相同的 20 次 warm-up、100 次测量，并在计时前准备输入；
- cached-native 计时仍包含函数 scope、参数绑定与真实 runner execution；
- correctness gate 同时比较 lookup Calcit、cached Calcit 与 Calx；
- 单 case 与 suite JSON 升级为 edition 2；
- suite 新增 lookup-native、cached-native 与 Calx hot 的明确 ratio/crossover；
- 更新 benchmark methodology、Calx target 文档和 clean-worktree 原始 baseline；
- 原始 JSON 继续由 `.gitattributes` 标记为 `-diff linguist-generated`。

本 PR 不增加 production compile cache、VM pool、自动 offload，也不放宽 Calx 对 Nil、Dynamic、Optional/JsNullish 的严格拒绝。

### 数据

完整 baseline 来自 clean commit `88bb5a2250ba65b0e35c4d1809e6d49a14c61623`：

- Apple M1 Pro、macOS arm64、Rust 1.97.1；
- `gitDirty=false`；
- debug/release 共 26 个 case；
- 182 个保留 raw samples；
- release Calx compile total 中位数约 41–78 μs；
- release Calx hot / cached Calcit ratio 为 0.106–0.392，即有限样本约 2.6–9.5 倍；
- lookup-native ratio 为 0.009–0.150，确认旧比较夸大了微型 kernel 差距，但公平 cached 对比下 scalar 收益仍存在；
- range-sum、Fibonacci 的 one-shot crossover 分别为 100、10；
- bounded-simulation 本次为 1000；
- affine、polynomial 未出现 one-shot crossover。

这支持下一步先用 profile 建立 revision-safe compile/program cache issue。VM pooling 继续等待独立证据；typed-buffer 工作由 calcit-lang/calx-vm#50 严格推进。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`（18/18）
- `yarn check-all`
- `CALX_BENCH_QUICK=1 CALX_BENCH_SAMPLES=1 yarn bench-calx-e2e`
- 完整 debug/release benchmark matrix
- JSON schema/commit/`gitDirty`/182 samples/correctness 查询
- `.gitattributes` diff 与 `linguist-generated` 属性检查

---

## English

### Context

The first Calcit-to-Calx baseline from #535 reused an instantiated VM for the Calx hot path, while every Calcit call went through `run_program_with_docs`, including its guard, entry lookup, and callable resolution. That asymmetry inflated tiny-kernel hot ratios and blocked evidence-based cache and selection decisions in calx-vm#39.

### Changes

- Preserve the embedding-visible native lookup-call metric.
- Resolve and cache the same `CalcitFn` once from the already-preprocessed program.
- Call `runner::run_fn` directly for a cached-native repeated-call baseline.
- Give cached Calcit and the reused Calx VM the same 20 warm-ups and 100 measured calls, with inputs prepared before timing.
- Keep function-scope setup, argument binding, and real runner execution inside the cached-native timing boundary.
- Gate correctness across lookup Calcit, cached Calcit, and Calx.
- Upgrade the single-case and suite JSON documents to edition 2.
- Add explicit lookup-native, cached-native, and Calx-hot ratios and crossovers.
- Update the benchmark methodology, Calx target documentation, and clean-worktree raw baseline.
- Keep the raw JSON marked `-diff linguist-generated` through `.gitattributes`.

This PR does not add a production compile cache, VM pool, or automatic offload policy, and it does not relax strict Calx rejection of Nil, Dynamic, Optional, or JsNullish boundaries.

### Evidence

The complete baseline was collected from clean commit `88bb5a2250ba65b0e35c4d1809e6d49a14c61623`:

- Apple M1 Pro, macOS arm64, Rust 1.97.1;
- `gitDirty=false`;
- 26 debug/release cases;
- 182 retained raw samples;
- median release Calx compile total of approximately 41–78 μs;
- a release Calx-hot/cached-Calcit ratio of 0.106–0.392, or approximately 2.6–9.5 times faster in this bounded sample;
- a lookup-native ratio of 0.009–0.150, confirming that the old comparison overstated tiny-kernel gaps while the fair cached comparison still retains scalar gains;
- one-shot crossovers of 100 for range-sum and 10 for Fibonacci;
- a bounded-simulation crossover of 1000 in this collection;
- no one-shot crossover for affine or polynomial.

This supports profiling and then filing a revision-safe compile/program-cache issue next. VM pooling continues to wait for separate evidence, while strict typed-buffer work is tracked by calcit-lang/calx-vm#50.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (18/18)
- `yarn check-all`
- `CALX_BENCH_QUICK=1 CALX_BENCH_SAMPLES=1 yarn bench-calx-e2e`
- complete debug/release benchmark matrix
- JSON schema, commit, `gitDirty`, 182-sample, and correctness queries
- `.gitattributes` diff and `linguist-generated` attribute checks

Closes calcit-lang/calcit#548  
Refs calcit-lang/calx-vm#39  
Refs calcit-lang/calx-vm#50
