### PR TITLE
冻结 Calx harness 拆分契约 / freeze Calx harness extraction contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 - **状态必须可发现**：每个拆出或供多个仓库复用的模块，都必须在自己的 README 或 AGENTS.md 说明状态（production / experimental / template / internal）、职责与非职责、上游/下游契约和 source of truth、兼容矩阵、版本与发布策略、迁移/验证命令以及关联 umbrella/child Issues。
 - **模板不冒充产品**：workflow/template 仓库必须明确标记用途及“不随业务功能迭代版本”；实验性 benchmark 也必须明确结果可比性和非生产定位。
 - **迁移完成才删除**：只有目标仓库具备文档、Actions、发布或实验运行入口、兼容验证与跨仓库 smoke 后，才能从主仓库删除原实现；迁移期 README 必须同时说明当前入口与目标状态。
+- **Calx harness 契约**：实验性 benchmark 拆分以 `docs/run/calx-harness-extraction.md` 和 machine-readable bootstrap manifest 为准；lowering/correctness 留在 core，外部 harness 必须 pin Calcit revision，不能依赖可变全局或把机器阈值写成 correctness gate。
 
 直接使用命令修改 calcit 程序时不需要调用 cargo, 直接按照文档给出的命令行示例执行即可。
 

--- a/docs/run/calx-harness-bootstrap.json
+++ b/docs/run/calx-harness-bootstrap.json
@@ -1,0 +1,81 @@
+{
+  "schema": "calcit-calx-harness-bootstrap/1",
+  "status": "experimental-benchmark",
+  "tracking": {
+    "parent": "calcit-lang/calcit#547",
+    "contract": "calcit-lang/calcit#557",
+    "bootstrap": "calcit-lang/calcit#558",
+    "cutover": "calcit-lang/calcit#559"
+  },
+  "targetRepository": {
+    "suggested": "calcit-lang/calcit-calx-bench",
+    "confirmed": false,
+    "existingCalcitCalxRole": "native-ffi-demo-do-not-absorb-harness"
+  },
+  "sourcesOfTruth": {
+    "loweringAndCorrectness": "calcit-lang/calcit",
+    "vmSemantics": "calcit-lang/calx-vm",
+    "measurementPolicy": "standalone-harness-after-bootstrap"
+  },
+  "revisionPolicy": {
+    "calcit": "exact-commit-or-tag-required",
+    "calxVm": "resolved-version-and-source-required",
+    "adapterStability": "internal-revision-pinned-no-semver-promise"
+  },
+  "move": [
+    { "path": "src/bin/calx_bench.rs", "role": "single-case-runner" },
+    { "path": "scripts/bench-calx-e2e.mjs", "role": "suite-orchestration" },
+    { "path": "scripts/bench-calx-settings.mjs", "role": "settings-policy" },
+    { "path": "scripts/bench-calx-settings.test.mjs", "role": "settings-tests" },
+    { "path": "docs/run/calx-benchmark.md", "role": "methodology" },
+    { "path": "benchmarks/calx/README.md", "role": "archive-index" },
+    { "path": "benchmarks/calx/20260831-macos-arm64.json", "role": "immutable-raw-report" }
+  ],
+  "copyWithProvenance": [
+    { "path": "tests/fixtures/calx/scalar-kernels.cirru", "coreRemainsAuthoritative": true }
+  ],
+  "stayInCore": [
+    "src/codegen/calx.rs",
+    "src/codegen/calx/lowering.rs",
+    "src/program/tests.rs",
+    "tests/fixtures/calx/scalar-kernels.cirru",
+    "tests/fixtures/calx/scalar-kernels.golden.txt",
+    "tests/fixtures/calx/generated-program.golden.txt",
+    "tests/fixtures/calx/fallback.cirru",
+    "tests/fixtures/calx/fallback.golden.txt",
+    "tests/fixtures/calx/typed-imports.cirru",
+    "tests/fixtures/calx/trap.golden.txt"
+  ],
+  "reportContract": {
+    "caseSchema": "calcit-calx-benchmark/2",
+    "suiteSchema": "calcit-calx-benchmark-suite/2",
+    "successStdout": "exactly-one-json-value",
+    "failure": "stderr-and-nonzero-exit",
+    "preserveRawSamples": true,
+    "statistics": ["median", "median-absolute-deviation"],
+    "absoluteCiThresholds": false
+  },
+  "adapter": {
+    "requiredOperations": [
+      "install-explicit-source-corpus",
+      "preprocess-to-immutable-program-handle",
+      "resolve-cached-calcit-callable",
+      "compile-measured-calx-kernel",
+      "run-prepared-calcit-callable",
+      "run-strict-calx-kernel",
+      "read-stage-timings-and-program-counts"
+    ],
+    "forbidden": [
+      "mutable-global-access",
+      "implicit-source-installation",
+      "automatic-effectful-fallback",
+      "benchmark-policy-inside-core"
+    ]
+  },
+  "migrationTests": {
+    "rust": 3,
+    "node": 4,
+    "quickSmoke": "CALX_BENCH_QUICK=1 CALX_BENCH_SAMPLES=1 yarn bench-calx-e2e",
+    "fullMatrix": "yarn bench-calx-e2e"
+  }
+}

--- a/docs/run/calx-harness-extraction.md
+++ b/docs/run/calx-harness-extraction.md
@@ -1,0 +1,151 @@
+# Calx benchmark harness extraction contract / Calx 基准工具拆分契约
+
+## Status / 状态
+
+This document freezes the phase-one boundary tracked by
+[calcit#557](https://github.com/calcit-lang/calcit/issues/557). The harness is
+an **experimental benchmark/research product**, not a Calcit runtime feature,
+language correctness gate, or production dependency. This phase documents the
+contract and bootstrap inventory; it does not create a repository or remove
+assets from Calcit core.
+
+本文冻结 [calcit#557](https://github.com/calcit-lang/calcit/issues/557)
+追踪的第一阶段边界。该 harness 是**实验性 benchmark/research 产品**，不是 Calcit
+runtime 功能、语言正确性 gate 或生产依赖。本阶段只记录契约和 bootstrap inventory，
+不创建仓库，也不从 Calcit core 删除资产。
+
+The machine-readable bootstrap manifest is
+[`calx-harness-bootstrap.json`](./calx-harness-bootstrap.json). Issue
+[calcit#547](https://github.com/calcit-lang/calcit/issues/547) is the product
+tracker; [calcit#558](https://github.com/calcit-lang/calcit/issues/558) owns the
+standalone bootstrap, and [calcit#559](https://github.com/calcit-lang/calcit/issues/559)
+owns the later core cutover.
+
+## Product and repository boundary / 产品与仓库边界
+
+The proposed standalone repository name is `calcit-lang/calcit-calx-bench`,
+pending maintainer confirmation in #558. The existing
+[`calcit-lang/calcit-calx`](https://github.com/calcit-lang/calcit-calx) remains
+a native FFI demo and must not silently absorb benchmark orchestration,
+historical reports, or release policy.
+
+建议的独立仓库名为 `calcit-lang/calcit-calx-bench`，等待维护者在 #558 确认。已有
+[`calcit-lang/calcit-calx`](https://github.com/calcit-lang/calcit-calx)
+继续保持 native FFI demo 定位，不静默承接 benchmark orchestration、历史报告或发布策略。
+
+Calcit core and `calx-vm` remain the source of truth for lowering, eligibility,
+typed boundaries, VM semantics, and differential correctness. The standalone
+harness owns experiment settings, process orchestration, report aggregation,
+raw sample preservation, methodology, and archived measurements. It has no
+business version cadence; releases identify harness/schema changes, while each
+measurement pins exact Calcit and `calx-vm` revisions.
+
+Calcit core 与 `calx-vm` 继续作为 lowering、eligibility、typed boundary、VM
+语义和 differential correctness 的 source of truth。独立 harness 负责实验参数、进程调度、
+报告聚合、原始样本保留、方法文档和历史测量。它不按业务功能迭代版本；release 只标识
+harness/schema 变化，每次测量必须固定精确的 Calcit 与 `calx-vm` revision。
+
+## Asset ownership and migration / 资产归属与迁移
+
+| Asset | Phase-two action | Long-term owner | Reason |
+| --- | --- | --- | --- |
+| `src/bin/calx_bench.rs` | migrate, then replace with the narrow adapter consumer | standalone harness | single-case runner and measurement phases |
+| `scripts/bench-calx-e2e.mjs` | migrate | standalone harness | process/profile/sample orchestration and aggregation |
+| `scripts/bench-calx-settings.mjs` and test | migrate | standalone harness | experiment-setting policy |
+| `docs/run/calx-benchmark.md` | migrate methodology; leave a short core link | standalone harness | measurement and comparison policy |
+| `benchmarks/calx/README.md` and versioned JSON | migrate without rewriting raw data | standalone harness | archive and bounded conclusions |
+| `tests/fixtures/calx/scalar-kernels.cirru` | copy with source revision and keep original | both, core authoritative | benchmark workload also serves differential correctness |
+| `src/codegen/calx.rs`, `src/codegen/calx/lowering.rs` | stay | Calcit core | backend semantics and typed boundary |
+| `src/program/tests.rs` Calx tests | stay | Calcit core | eligibility, golden, trap, fallback, and differential correctness |
+| all `tests/fixtures/calx/*.golden.txt`, `fallback.cirru`, `typed-imports.cirru` | stay | Calcit core | language/backend correctness, not benchmark policy |
+| `Cargo.toml` binary entry and `package.json` benchmark scripts/check | remove only in #559 | Calcit core during migration | cut over only after standalone reproduction succeeds |
+
+The scalar source fixture is deliberately the only shared/copy-with-provenance
+asset. The standalone copy records its originating Calcit commit and must not
+become the correctness source of truth. Golden and fallback fixtures do not
+move.
+
+scalar source fixture 是唯一明确允许 copy-with-provenance 的共享资产。独立仓库副本必须记录
+来源 Calcit commit，不能成为 correctness source of truth；golden 与 fallback fixtures 不迁移。
+
+## Frozen report and process contract / 固化的报告与进程契约
+
+- A successful single-case runner writes exactly one JSON value to stdout with
+  schema `calcit-calx-benchmark/2`; progress and diagnostics never share stdout.
+- A successful suite writes schema `calcit-calx-benchmark-suite/2` and preserves
+  every `rawSamples` entry in addition to median and median absolute deviation.
+- Parse, build, correctness, schema, and runtime failures go to stderr and exit
+  nonzero. Partial JSON is never reported as success.
+- Reports retain debug/release profile, OS/architecture/CPU/memory, complete
+  Rust/Cargo/Node identity, exact Calcit commit plus dirty state, resolved
+  `calx-vm` version, workload/matrix/settings, warm-up policy, and scope gaps.
+- Archived raw reports are immutable. A schema change creates a new schema ID
+  and migration note rather than rewriting old files.
+- Ratios and crossover points are informational. Machine-specific absolute
+  thresholds do not enter ordinary Calcit correctness CI.
+
+- 单 case 成功时 stdout 只写一个 `calcit-calx-benchmark/2` JSON；进度和诊断不混入 stdout。
+- suite 成功时写 `calcit-calx-benchmark-suite/2`，在 median 与 MAD 之外保留全部
+  `rawSamples`。
+- parse/build/correctness/schema/runtime 失败写 stderr 并非零退出，不把 partial JSON 当成功结果。
+- 报告保留 profile、主机/工具链、精确 Calcit commit 与 dirty 状态、resolved `calx-vm`
+  版本、workload/matrix/settings、预热政策和未覆盖范围。
+- 已归档 raw report 不可改写；schema 变化使用新 ID 和 migration note。
+- ratio/crossover 只提供信息，不把机器相关绝对阈值加入普通 correctness CI。
+
+## Revision-pinned internal adapter / 固定 revision 的内部 adapter
+
+The standalone runner must stop reaching `PROGRAM_CODE_DATA`,
+`ProgramFileData`, `ensure_def_id`, `run_fn`, or mutable global registries
+directly. A narrow adapter compiled from the pinned Calcit revision exposes one
+session-oriented path:
+
+1. install a named source corpus with explicit fixed function schemas;
+2. preprocess once and return an immutable benchmark program handle;
+3. resolve one cached Calcit callable from that handle;
+4. compile one measured Calx kernel from the same handle;
+5. execute prepared Calcit arguments and strict Calx values through the two
+   cached call paths;
+6. return stage timings, stable program counts, and correctness values without
+   exposing mutable registries.
+
+独立 runner 不再直接访问 `PROGRAM_CODE_DATA`、`ProgramFileData`、`ensure_def_id`、
+`run_fn` 或可变全局 registry。由固定 Calcit revision 编译的窄 adapter 只暴露 session
+路径：安装带显式 schema 的 source corpus、一次 preprocess 得到 immutable handle、从同一
+handle 解析 cached Calcit callable 和 measured Calx kernel、执行预先准备的两条调用路径，并返回
+阶段 timing、稳定 program counts 和 correctness value。
+
+This adapter is an **internal benchmark API**. It has no semver compatibility
+promise and must not become a general embedding API by accident. The harness
+pins a Calcit commit/tag, upgrades deliberately, and runs its compile and
+quick-smoke matrix before changing the pin. Mutable-global access, implicit
+source installation, automatic fallback after effects, and benchmark policy
+inside core are forbidden.
+
+该 adapter 是 **internal benchmark API**，不承诺 semver 兼容，也不能意外扩张成通用
+embedding API。harness 固定 Calcit commit/tag，升级 pin 前运行 compile 与 quick-smoke matrix。
+禁止暴露可变全局、隐式安装源码、effect 后自动 fallback，以及把 benchmark policy 放回 core。
+
+## Test and smoke migration matrix / 测试与 smoke 迁移矩阵
+
+| Current coverage | Phase-two destination | Core after cutover |
+| --- | --- | --- |
+| Rust: resolved `calx_vm` lockfile identity | standalone runner test | dependency/build correctness remains |
+| Rust: duplicate/missing dependency identity rejection | standalone runner test | not required by language semantics |
+| Rust: cached callable equals lookup execution and missing entry fails | adapter integration test | differential execution remains in `src/program/tests.rs` |
+| Node: absent setting uses fallback | standalone settings test | removed from `check-all` in #559 |
+| Node: complete safe integers accepted | standalone settings test | removed from `check-all` in #559 |
+| Node: partial/fractional/exponential/padded values rejected | standalone settings test | removed from `check-all` in #559 |
+| Node: unsafe/below-minimum values rejected | standalone settings test | removed from `check-all` in #559 |
+| `CALX_BENCH_QUICK=1 CALX_BENCH_SAMPLES=1 yarn bench-calx-e2e` | required PR smoke | core keeps it until standalone passes |
+| full debug/release matrix | manual/versioned evidence workflow | not a correctness gate |
+
+The phase-two bootstrap is accepted only when the standalone harness builds
+against an explicit Calcit revision, passes all seven migrated tests, emits a
+schema-v2 quick report with raw samples, and links its README/AGENTS status and
+boundaries back to #547/#558. Only then may #559 remove the core binary and
+policy checks.
+
+第二阶段只有在独立 harness 固定 Calcit revision、通过迁移的 3 Rust + 4 Node tests、输出保留
+raw samples 的 schema-v2 quick report，并在 README/AGENTS 回链 #547/#558 后才通过验收；之后
+#559 才能删除 core binary 和 policy checks。

--- a/editing-history/202608311510-freeze-calx-harness-extraction.md
+++ b/editing-history/202608311510-freeze-calx-harness-extraction.md
@@ -1,0 +1,17 @@
+# 2026-08-31 15:10 — freeze Calx harness extraction
+
+## 中文
+
+- 明确实验性 Calx benchmark harness 与 Calcit core lowering/correctness 的产品边界。
+- 新增双语 extraction contract，冻结 schema v2、stdout/stderr、provenance、raw samples 和无绝对 CI 阈值的报告政策。
+- 定义 revision-pinned internal adapter 的最小 session 能力，禁止外部 harness 直接访问可变 program globals。
+- 新增 machine-readable bootstrap manifest，逐项标记 move、copy-with-provenance、stay-in-core 和 3 Rust + 4 Node tests/smoke 迁移矩阵。
+- 增加 regression tests，验证 manifest 资产、tracking、所有权无误，并检查归档 suite 的工具链/版本/raw sample 可追溯性。
+
+## English
+
+- Separate the experimental Calx benchmark product from core lowering and correctness ownership.
+- Freeze schema-v2 IO, provenance, raw-sample preservation, and informational-only threshold policy in a bilingual contract.
+- Define a revision-pinned internal session adapter and forbid direct mutable-global access from the standalone harness.
+- Add a machine-readable bootstrap manifest for moved, copied-with-provenance, and core-owned assets plus the 3 Rust + 4 Node test/smoke matrix.
+- Add regression tests for manifest ownership/tracking and archived report provenance/raw samples.

--- a/tests/calx_harness_contract.rs
+++ b/tests/calx_harness_contract.rs
@@ -1,0 +1,88 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+const BOOTSTRAP: &str = "docs/run/calx-harness-bootstrap.json";
+const ARCHIVED_REPORT: &str = "benchmarks/calx/20260831-macos-arm64.json";
+
+#[test]
+fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
+  let manifest = read_json(BOOTSTRAP);
+  assert_eq!(manifest["schema"], "calcit-calx-harness-bootstrap/1");
+  assert_eq!(manifest["status"], "experimental-benchmark");
+  assert_eq!(manifest["targetRepository"]["confirmed"], false);
+  assert_eq!(
+    manifest["targetRepository"]["existingCalcitCalxRole"],
+    "native-ffi-demo-do-not-absorb-harness"
+  );
+  for key in ["parent", "contract", "bootstrap", "cutover"] {
+    assert!(manifest["tracking"][key].as_str().is_some_and(|value| value.contains('#')));
+  }
+
+  let moved = asset_paths(&manifest["move"]);
+  let copied = asset_paths(&manifest["copyWithProvenance"]);
+  let stayed = manifest["stayInCore"]
+    .as_array()
+    .expect("stayInCore array")
+    .iter()
+    .map(|value| value.as_str().expect("stay path").to_owned())
+    .collect::<BTreeSet<_>>();
+  for path in moved.iter().chain(copied.iter()).chain(stayed.iter()) {
+    assert!(Path::new(path).exists(), "contract asset does not exist: {path}");
+  }
+  assert!(moved.is_disjoint(&stayed));
+  assert_eq!(copied, BTreeSet::from(["tests/fixtures/calx/scalar-kernels.cirru".to_owned()]));
+  assert!(stayed.contains("tests/fixtures/calx/scalar-kernels.cirru"));
+
+  assert_eq!(manifest["migrationTests"]["rust"], 3);
+  assert_eq!(manifest["migrationTests"]["node"], 4);
+  assert_eq!(manifest["reportContract"]["preserveRawSamples"], true);
+  assert_eq!(manifest["reportContract"]["absoluteCiThresholds"], false);
+}
+
+#[test]
+fn archived_suite_is_a_traceable_schema_v2_raw_report() {
+  let report = read_json(ARCHIVED_REPORT);
+  assert_eq!(report["schema"], "calcit-calx-benchmark-suite/2");
+  assert_eq!(report["environment"]["gitDirty"], false);
+  assert!(non_empty_string(&report["environment"]["gitCommit"]));
+  assert!(non_empty_string(&report["environment"]["rustc"]));
+  assert!(non_empty_string(&report["environment"]["cargo"]));
+  assert!(non_empty_string(&report["environment"]["node"]));
+
+  let profiles = report["profiles"].as_array().expect("profiles array");
+  assert_eq!(profiles.len(), 2);
+  for profile in profiles {
+    assert!(matches!(profile["profile"].as_str(), Some("debug" | "release")));
+    for case in profile["cases"].as_array().expect("case array") {
+      let samples = case["rawSamples"].as_array().expect("rawSamples array");
+      assert!(!samples.is_empty());
+      for sample in samples {
+        assert_eq!(sample["report"]["schema"], "calcit-calx-benchmark/2");
+        assert_eq!(sample["report"]["correctness"], true);
+        assert!(non_empty_string(&sample["report"]["environment"]["calxVmVersion"]));
+        assert!(non_empty_string(&sample["report"]["environment"]["packageVersion"]));
+      }
+    }
+  }
+}
+
+fn read_json(path: &str) -> Value {
+  serde_json::from_slice(&fs::read(path).unwrap_or_else(|error| panic!("read {path}: {error}")))
+    .unwrap_or_else(|error| panic!("parse {path}: {error}"))
+}
+
+fn asset_paths(value: &Value) -> BTreeSet<String> {
+  value
+    .as_array()
+    .expect("asset array")
+    .iter()
+    .map(|asset| asset["path"].as_str().expect("asset path").to_owned())
+    .collect()
+}
+
+fn non_empty_string(value: &Value) -> bool {
+  value.as_str().is_some_and(|value| !value.is_empty())
+}


### PR DESCRIPTION
## 中文

### 目标

在创建独立 Calx benchmark harness 前冻结产品边界、资产所有权、schema/report contract、revision-pinned adapter 和测试迁移矩阵。

### 改动

- 新增双语 `docs/run/calx-harness-extraction.md`：明确 experimental benchmark 定位、`calcit-calx` 继续作为 FFI demo，以及 core/harness/calx-vm 的 source-of-truth 边界；
- 逐项标记 runner、orchestration、settings、methodology、archive 的迁移方式，以及 lowering、eligibility、golden、fallback、differential correctness 必须留在 core；
- 固化单 case/suite schema v2、stdout 单 JSON、stderr/nonzero failure、完整 host/toolchain/revision identity、raw sample preservation 和 informational-only threshold policy；
- 定义不暴露 `PROGRAM_CODE_DATA` 等可变全局的 revision-pinned internal session adapter；
- 新增 machine-readable `calx-harness-bootstrap/1` manifest，供 #558 bootstrap 使用；
- 新增 2 项 regression tests，校验 tracking/asset ownership，并验证现有 182 raw-sample archive 的 schema、correctness 和 provenance。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`：全量通过（含 613 lib、3 Calx runner、24 caps、21 WASM-bin、2 新 contract tests 等）
- `yarn check-all`：225/225 core、Agent interface 18/18、JS/IR/WASM 与 benchmark checks 全部通过
- `CALX_BENCH_QUICK=1 CALX_BENCH_SAMPLES=1 node scripts/bench-calx-e2e.mjs`：debug/release 五个 kernel 均产生有效 schema-v2 report
- `calcit docs check-md docs/run/calx-harness-extraction.md`

Closes #557. 合并后 #558 可以进入 `status:ready`，但仍需维护者确认建议仓库名 `calcit-lang/calcit-calx-bench`。

## English

### Goal

Freeze the product boundary, asset ownership, schema/report contract, revision-pinned adapter, and test migration matrix before bootstrapping the standalone Calx benchmark harness.

### Changes

- add a bilingual extraction contract covering experimental status, the existing `calcit-calx` FFI-demo role, and core/harness/calx-vm sources of truth;
- classify movable runner/policy/archive assets versus core-owned lowering, eligibility, golden, fallback, and differential-correctness assets;
- freeze schema-v2 IO, provenance, raw-sample preservation, and informational-only threshold policy;
- define a narrow internal session adapter that does not expose mutable program globals;
- add a machine-readable `calcit-calx-harness-bootstrap/1` manifest for #558;
- add regression tests for tracking/ownership and the archived 182-sample report's schema, correctness, and provenance.

### Verification

Formatting, strict clippy, full Rust tests, `yarn check-all`, docs validation, and the debug/release five-kernel quick benchmark smoke all pass.

Closes #557. After merge, #558 can become ready, pending maintainer confirmation of the suggested `calcit-lang/calcit-calx-bench` repository name.
