### PR TITLE
加强 Calx harness 契约回归 / Strengthen Calx harness contract regression

### DIFF
--- a/editing-history/202608311634-strengthen-calx-harness-contract-regression.md
+++ b/editing-history/202608311634-strengthen-calx-harness-contract-regression.md
@@ -1,0 +1,15 @@
+# 2026-08-31 16:34 — strengthen Calx harness contract regression
+
+## 中文
+
+- 根据 PR #560 review，把 bootstrap tracking 从宽松的字符串形状检查收紧为 #547/#557/#558/#559 精确映射。
+- 对 `move` 与 `stayInCore` 资产集合做完整相等检查，防止静默遗漏或额外迁移 core correctness 资产。
+- 固定归档报告的 debug/release profile、13 case × 7 samples × 2 profiles，以及 182 个 raw samples 总数。
+- 验证归档主机身份、精确 Calcit commit/package version、resolved `calx-vm` version 和每个 sample 的 profile/OS/architecture。
+
+## English
+
+- Replace loose bootstrap tracking checks with exact #547/#557/#558/#559 mappings after the PR #560 review.
+- Assert complete equality for the `move` and `stayInCore` asset sets so omissions or accidental correctness-asset migration cannot pass silently.
+- Freeze the archived debug/release profiles, 13 cases × 7 samples × 2 profiles, and all 182 retained raw samples.
+- Verify archived host identity, the exact Calcit commit/package version, the resolved `calx-vm` version, and each sample profile/OS/architecture.

--- a/tests/calx_harness_contract.rs
+++ b/tests/calx_harness_contract.rs
@@ -6,6 +6,9 @@ use serde_json::Value;
 
 const BOOTSTRAP: &str = "docs/run/calx-harness-bootstrap.json";
 const ARCHIVED_REPORT: &str = "benchmarks/calx/20260831-macos-arm64.json";
+const EXPECTED_CALCIT_COMMIT: &str = "88bb5a2250ba65b0e35c4d1809e6d49a14c61623";
+const EXPECTED_CALCIT_VERSION: &str = "0.13.72";
+const EXPECTED_CALX_VM_VERSION: &str = "0.3.0";
 
 #[test]
 fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
@@ -17,9 +20,10 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
     manifest["targetRepository"]["existingCalcitCalxRole"],
     "native-ffi-demo-do-not-absorb-harness"
   );
-  for key in ["parent", "contract", "bootstrap", "cutover"] {
-    assert!(manifest["tracking"][key].as_str().is_some_and(|value| value.contains('#')));
-  }
+  assert_eq!(manifest["tracking"]["parent"], "calcit-lang/calcit#547");
+  assert_eq!(manifest["tracking"]["contract"], "calcit-lang/calcit#557");
+  assert_eq!(manifest["tracking"]["bootstrap"], "calcit-lang/calcit#558");
+  assert_eq!(manifest["tracking"]["cutover"], "calcit-lang/calcit#559");
 
   let moved = asset_paths(&manifest["move"]);
   let copied = asset_paths(&manifest["copyWithProvenance"]);
@@ -29,6 +33,33 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
     .iter()
     .map(|value| value.as_str().expect("stay path").to_owned())
     .collect::<BTreeSet<_>>();
+  assert_eq!(
+    moved,
+    string_set(&[
+      "src/bin/calx_bench.rs",
+      "scripts/bench-calx-e2e.mjs",
+      "scripts/bench-calx-settings.mjs",
+      "scripts/bench-calx-settings.test.mjs",
+      "docs/run/calx-benchmark.md",
+      "benchmarks/calx/README.md",
+      "benchmarks/calx/20260831-macos-arm64.json",
+    ])
+  );
+  assert_eq!(
+    stayed,
+    string_set(&[
+      "src/codegen/calx.rs",
+      "src/codegen/calx/lowering.rs",
+      "src/program/tests.rs",
+      "tests/fixtures/calx/scalar-kernels.cirru",
+      "tests/fixtures/calx/scalar-kernels.golden.txt",
+      "tests/fixtures/calx/generated-program.golden.txt",
+      "tests/fixtures/calx/fallback.cirru",
+      "tests/fixtures/calx/fallback.golden.txt",
+      "tests/fixtures/calx/typed-imports.cirru",
+      "tests/fixtures/calx/trap.golden.txt",
+    ])
+  );
   for path in moved.iter().chain(copied.iter()).chain(stayed.iter()) {
     assert!(Path::new(path).exists(), "contract asset does not exist: {path}");
   }
@@ -46,27 +77,51 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
 fn archived_suite_is_a_traceable_schema_v2_raw_report() {
   let report = read_json(ARCHIVED_REPORT);
   assert_eq!(report["schema"], "calcit-calx-benchmark-suite/2");
+  assert_eq!(report["environment"]["platform"], "darwin");
+  assert_eq!(report["environment"]["release"], "25.5.0");
+  assert_eq!(report["environment"]["architecture"], "arm64");
+  assert_eq!(report["environment"]["cpuModel"], "Apple M1 Pro");
+  assert_eq!(report["environment"]["logicalCpuCount"], 8);
+  assert_eq!(report["environment"]["totalMemoryBytes"], 17_179_869_184_u64);
   assert_eq!(report["environment"]["gitDirty"], false);
-  assert!(non_empty_string(&report["environment"]["gitCommit"]));
-  assert!(non_empty_string(&report["environment"]["rustc"]));
-  assert!(non_empty_string(&report["environment"]["cargo"]));
-  assert!(non_empty_string(&report["environment"]["node"]));
+  assert_eq!(report["environment"]["gitCommit"], EXPECTED_CALCIT_COMMIT);
+  assert_eq!(
+    report["environment"]["rustc"],
+    "rustc 1.97.1 (8bab26f4f 2026-07-14)\nbinary: rustc\ncommit-hash: 8bab26f4f68e0e26f0bb7960be334d5b520ea452\ncommit-date: 2026-07-14\nhost: aarch64-apple-darwin\nrelease: 1.97.1\nLLVM version: 22.1.6"
+  );
+  assert_eq!(report["environment"]["cargo"], "cargo 1.97.1 (c980f4866 2026-06-30)");
+  assert_eq!(report["environment"]["node"], "v24.4.1");
 
   let profiles = report["profiles"].as_array().expect("profiles array");
   assert_eq!(profiles.len(), 2);
+  assert_eq!(
+    profiles
+      .iter()
+      .map(|profile| profile["profile"].as_str().expect("profile name"))
+      .collect::<BTreeSet<_>>(),
+    BTreeSet::from(["debug", "release"])
+  );
+  let mut raw_sample_count = 0;
   for profile in profiles {
-    assert!(matches!(profile["profile"].as_str(), Some("debug" | "release")));
-    for case in profile["cases"].as_array().expect("case array") {
+    let profile_name = profile["profile"].as_str().expect("profile name");
+    let cases = profile["cases"].as_array().expect("case array");
+    assert_eq!(cases.len(), 13);
+    for case in cases {
       let samples = case["rawSamples"].as_array().expect("rawSamples array");
-      assert!(!samples.is_empty());
+      assert_eq!(samples.len(), 7);
+      raw_sample_count += samples.len();
       for sample in samples {
         assert_eq!(sample["report"]["schema"], "calcit-calx-benchmark/2");
         assert_eq!(sample["report"]["correctness"], true);
-        assert!(non_empty_string(&sample["report"]["environment"]["calxVmVersion"]));
-        assert!(non_empty_string(&sample["report"]["environment"]["packageVersion"]));
+        assert_eq!(sample["report"]["environment"]["packageVersion"], EXPECTED_CALCIT_VERSION);
+        assert_eq!(sample["report"]["environment"]["calxVmVersion"], EXPECTED_CALX_VM_VERSION);
+        assert_eq!(sample["report"]["environment"]["profile"], profile_name);
+        assert_eq!(sample["report"]["environment"]["os"], "macos");
+        assert_eq!(sample["report"]["environment"]["architecture"], "aarch64");
       }
     }
   }
+  assert_eq!(raw_sample_count, 182);
 }
 
 fn read_json(path: &str) -> Value {
@@ -83,6 +138,6 @@ fn asset_paths(value: &Value) -> BTreeSet<String> {
     .collect()
 }
 
-fn non_empty_string(value: &Value) -> bool {
-  value.as_str().is_some_and(|value| !value.is_empty())
+fn string_set(values: &[&str]) -> BTreeSet<String> {
+  values.iter().map(|value| (*value).to_owned()).collect()
 }


### PR DESCRIPTION
## 中文

### 背景

PR #560 在 CodeRabbit 指出的 contract regression review 修复推送前已经合并。本 follow-up 保留原拆分契约不变，只补齐冻结数据的精确回归保护。

### 修改

- 精确断言 #547/#557/#558/#559 tracking 映射；
- 精确断言完整 `move` 与 `stayInCore` 资产集合；
- 固定 debug/release profile、13 cases × 7 samples × 2 profiles 和全部 182 个 raw samples；
- 验证主机身份、完整工具链、精确 Calcit commit/package version、resolved `calx-vm` version，以及每个 sample 的 profile/OS/architecture。

### 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- `cargo test --test calx_harness_contract`

关联：#557、PR #560、原 review thread。

## English

### Context

PR #560 merged before the contract-regression review fix could be pushed. This follow-up keeps the extraction contract unchanged and only adds exact regression protection for the frozen data.

### Changes

- Assert exact #547/#557/#558/#559 tracking mappings.
- Assert the complete `move` and `stayInCore` asset sets.
- Freeze the debug/release profiles, 13 cases × 7 samples × 2 profiles, and all 182 raw samples.
- Verify host identity, complete toolchain identity, the exact Calcit commit/package version, the resolved `calx-vm` version, and every sample profile/OS/architecture.

### Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- `cargo test --test calx_harness_contract`

Related: #557, PR #560, and the original review thread.