### PR TITLE
采集 Calx compile profile 并冻结 cache 边界 / profile Calx compilation and freeze the cache boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 - **拆分总索引**：跨仓库职责和迁移顺序由 [calcit#549](https://github.com/calcit-lang/calcit/issues/549) 追踪；bindgen、caps、Calx benchmark 和 native ABI 的具体任务使用总索引中的 child Issues，避免重复立项。
 - **状态必须可发现**：每个拆出或供多个仓库复用的模块，都必须在自己的 README 或 AGENTS.md 说明状态（production / experimental / template / internal）、职责与非职责、上游/下游契约和 source of truth、兼容矩阵、版本与发布策略、迁移/验证命令以及关联 umbrella/child Issues。
 - **模板不冒充产品**：workflow/template 仓库必须明确标记用途及“不随业务功能迭代版本”；实验性 benchmark 也必须明确结果可比性和非生产定位。
+- **Calx profile 证据**：Calx 性能与 cache 决策以 `docs/run/calx-benchmark.md`、`docs/run/calx-compile-cache.md` 和 `benchmarks/calx/*.json` 为 source of truth；原始 profiler 文件留在 `target/`，提交的摘要必须记录干净 commit、环境、命令、迭代数、原始文件哈希与 inclusive-stack 限制。
 - **迁移完成才删除**：只有目标仓库具备文档、Actions、发布或实验运行入口、兼容验证与跨仓库 smoke 后，才能从主仓库删除原实现；迁移期 README 必须同时说明当前入口与目标状态。
 - **Calx harness 契约**：实验性 benchmark 拆分以 `docs/run/calx-harness-extraction.md` 和 machine-readable bootstrap manifest 为准；lowering/correctness 留在 core，外部 harness 必须 pin Calcit revision，不能依赖可变全局或把机器阈值写成 correctness gate。
 

--- a/benchmarks/calx/20260831-compile-profile-macos-arm64.json
+++ b/benchmarks/calx/20260831-compile-profile-macos-arm64.json
@@ -1,0 +1,163 @@
+{
+  "schema": "calcit-calx-compile-profile-suite/1",
+  "environment": {
+    "gitCommit": "ef04017f0bc60e2d8f6341599f00d426a11ed360",
+    "gitDirty": false,
+    "packageVersion": "0.13.72",
+    "calxVmVersion": "0.3.0",
+    "operatingSystem": "macOS 26.5.2 (25F84)",
+    "architecture": "arm64",
+    "cpu": "Apple M1 Pro",
+    "logicalCpus": 8,
+    "rustc": "1.97.1 (8bab26f4f 2026-07-14)",
+    "samply": "0.13.1"
+  },
+  "build": {
+    "cargoProfile": "release",
+    "repositoryReleaseOptLevel": "s",
+    "repositoryReleaseLto": true,
+    "temporaryStripOverride": "none",
+    "temporaryDebugOverride": "line-tables-only"
+  },
+  "measurement": {
+    "warmupIterations": 1000,
+    "stageTimingIterations": 10000,
+    "allocationIterations": 10000,
+    "uninstrumentedIterationsPerKernel": 100000,
+    "samplyKernel": "bounded-simulation",
+    "samplyUninstrumentedIterations": 1000000,
+    "samplyRateHz": 1000,
+    "samplySamples": 20987,
+    "samplyAllocationStackSamples": 8018
+  },
+  "rawProfile": {
+    "committed": false,
+    "profilePath": "target/calx-bench/compile-profile-ef04017f.json.gz",
+    "profileBytes": 247218,
+    "profileSha256": "f7e076a85ea810f218a971e3bf58d4c5fdf40a897d4a497d22bad2c5acd40399",
+    "symbolsPath": "target/calx-bench/compile-profile-ef04017f.json.syms.json",
+    "symbolsBytes": 63787,
+    "symbolsSha256": "38f61b2da3f242f059494c11cbb0ac4e4eea5f86af0d2c9a6217a71c9dbeb376"
+  },
+  "kernels": [
+    {
+      "kernel": "range-sum",
+      "compilePerIterationNs": 15354,
+      "stageTimingPerIterationNs": {
+        "eligibility": 3013,
+        "planning": 3148,
+        "programConstruction": 8118,
+        "validationLowering": 1093,
+        "total": 15990
+      },
+      "allocationsPerIteration": {
+        "allocationCalls": 301,
+        "reallocationCalls": 59,
+        "deallocationCalls": 301,
+        "requestedBytes": 28339,
+        "explicitlyDeallocatedBytes": 24794
+      }
+    },
+    {
+      "kernel": "fibonacci",
+      "compilePerIterationNs": 17398,
+      "stageTimingPerIterationNs": {
+        "eligibility": 3207,
+        "planning": 3255,
+        "programConstruction": 8642,
+        "validationLowering": 1234,
+        "total": 16941
+      },
+      "allocationsPerIteration": {
+        "allocationCalls": 337,
+        "reallocationCalls": 69,
+        "deallocationCalls": 337,
+        "requestedBytes": 34914,
+        "explicitlyDeallocatedBytes": 29543
+      }
+    },
+    {
+      "kernel": "affine",
+      "compilePerIterationNs": 20859,
+      "stageTimingPerIterationNs": {
+        "eligibility": 4336,
+        "planning": 3985,
+        "programConstruction": 9243,
+        "validationLowering": 987,
+        "total": 19334
+      },
+      "allocationsPerIteration": {
+        "allocationCalls": 392,
+        "reallocationCalls": 57,
+        "deallocationCalls": 392,
+        "requestedBytes": 27275,
+        "explicitlyDeallocatedBytes": 25555
+      }
+    },
+    {
+      "kernel": "polynomial",
+      "compilePerIterationNs": 15252,
+      "stageTimingPerIterationNs": {
+        "eligibility": 2875,
+        "planning": 3028,
+        "programConstruction": 6318,
+        "validationLowering": 628,
+        "total": 13352
+      },
+      "allocationsPerIteration": {
+        "allocationCalls": 222,
+        "reallocationCalls": 52,
+        "deallocationCalls": 222,
+        "requestedBytes": 22561,
+        "explicitlyDeallocatedBytes": 20009
+      }
+    },
+    {
+      "kernel": "bounded-simulation",
+      "compilePerIterationNs": 20011,
+      "stageTimingPerIterationNs": {
+        "eligibility": 4536,
+        "planning": 4484,
+        "programConstruction": 12624,
+        "validationLowering": 1435,
+        "total": 23807
+      },
+      "allocationsPerIteration": {
+        "allocationCalls": 355,
+        "reallocationCalls": 91,
+        "deallocationCalls": 355,
+        "requestedBytes": 37569,
+        "explicitlyDeallocatedBytes": 31393
+      }
+    }
+  ],
+  "selectedInclusiveCpuStacks": [
+    { "symbol": "calcit::codegen::calx::lowering::emit_expression", "samples": 9296, "sampleRatio": 0.4429 },
+    { "symbol": "calcit::codegen::calx::lowering::source_origin", "samples": 7475, "sampleRatio": 0.3562 },
+    { "symbol": "calx_vm::builder::BodyBuilder::if_else_at", "samples": 7221, "sampleRatio": 0.3441 },
+    { "symbol": "calcit::codegen::calx::EligibilityAnalyzer::visit", "samples": 3580, "sampleRatio": 0.1706 },
+    { "symbol": "calcit::codegen::calx::lowering::plan_expression", "samples": 2640, "sampleRatio": 0.1258 },
+    { "symbol": "calx_vm::program::ValidatedProgram::try_from_program", "samples": 1216, "sampleRatio": 0.0579 },
+    { "symbol": "calx_vm::validator::validate_typed_program", "samples": 845, "sampleRatio": 0.0403 },
+    { "symbol": "calx_vm::builder::ProgramBuilder::build", "samples": 278, "sampleRatio": 0.0132 }
+  ],
+  "selectedAllocationStackAncestors": [
+    { "symbol": "calcit::codegen::calx::lowering::emit_expression", "samples": 5006, "allocationSampleRatio": 0.6243 },
+    { "symbol": "calcit::codegen::calx::lowering::source_origin", "samples": 4313, "allocationSampleRatio": 0.5379 },
+    { "symbol": "calx_vm::builder::BodyBuilder::if_else_at", "samples": 3884, "allocationSampleRatio": 0.4844 },
+    { "symbol": "calcit::codegen::calx::EligibilityAnalyzer::visit", "samples": 861, "allocationSampleRatio": 0.1074 },
+    { "symbol": "calcit::codegen::calx::lowering::plan_expression", "samples": 747, "allocationSampleRatio": 0.0932 },
+    { "symbol": "calx_vm::program::ValidatedProgram::try_from_program", "samples": 533, "allocationSampleRatio": 0.0665 },
+    { "symbol": "calx_vm::validator::validate_typed_program", "samples": 304, "allocationSampleRatio": 0.0379 },
+    { "symbol": "calx_vm::builder::ProgramBuilder::build", "samples": 47, "allocationSampleRatio": 0.0059 }
+  ],
+  "interpretation": {
+    "primaryCacheTarget": "the immutable source-derived validated artifact after eligibility and lowering",
+    "primaryMissPathHotspot": "program construction, especially expression emission and source-origin formatting",
+    "stageRatiosAreInclusive": false,
+    "stackRatiosAreInclusiveAndOverlap": true,
+    "requestedBytesArePeakResidentMemory": false,
+    "instrumentsAllocationsAvailable": false,
+    "instrumentsFailure": "macOS authorization service rejected attachment with status -60006"
+  }
+}

--- a/benchmarks/calx/README.md
+++ b/benchmarks/calx/README.md
@@ -32,6 +32,13 @@ compile 成本远大于 VM setup，尚不足以优先实现 VM pooling，也不�
 本报告仍缺少 typed-buffer workload、平台 profiler 的 peak RSS/allocation hotspot、WASM 同 kernel 参照，
 以及跨机器重复采样。因此 calx-vm #39 保持打开；不能根据这一个环境承诺固定倍数或自动 offload 阈值。
 
+编译阶段 profile 见 [`20260831-compile-profile-macos-arm64.json`](./20260831-compile-profile-macos-arm64.json)。
+它从干净提交 `ef04017f0bc60e2d8f6341599f00d426a11ed360` 采集五个 kernel 的分阶段时间与 allocator counters，
+并在 bounded-simulation 上保留 Samply profile 哈希和 top stacks。program construction 占约 47–54%，
+主要 CPU/分配路径为 `emit_expression`、`source_origin` 与 builder emission。这个证据把下一阶段收敛为
+revision-safe validated-artifact cache；详细边界见
+[compile cache design](../../docs/run/calx-compile-cache.md)。
+
 ---
 
 ## English
@@ -69,3 +76,11 @@ so it does not yet justify prioritizing VM pooling or claiming that arbitrary Ca
 The report still lacks a typed-buffer workload, platform-profiler peak RSS/allocation hotspots, a same-kernel WASM
 reference, and cross-machine repetition. calx-vm #39 therefore remains open; this one environment cannot justify a
 fixed multiplier or an automatic offload threshold.
+
+The compile-stage profile is recorded in
+[`20260831-compile-profile-macos-arm64.json`](./20260831-compile-profile-macos-arm64.json). It captures staged timings
+and allocator counters for all five kernels from clean commit `ef04017f0bc60e2d8f6341599f00d426a11ed360`, plus
+the Samply profile hashes and selected stacks for bounded-simulation. Program construction accounts for roughly
+47–54%, with `emit_expression`, `source_origin`, and builder emission dominating CPU and allocation paths. This
+evidence narrows the next slice to a revision-safe validated-artifact cache; see the
+[compile cache design](../../docs/run/calx-compile-cache.md) for the boundary.

--- a/docs/run/calx-benchmark.md
+++ b/docs/run/calx-benchmark.md
@@ -54,6 +54,37 @@ cargo run --release --bin calcit-calx-bench -- \
   --kernel range-sum --size 1000 --vm-warmup 20 --hot-iterations 100
 ```
 
+### Compile profile 模式
+
+CPU/allocation profiler 不能从单次约几十微秒的编译可靠分辨热点。显式传入
+`--compile-profile-iterations` 后，runner 只安装并 preprocess source fixture 一次，再重复完整、未缓存的
+eligibility → planning → program construction → validation/lowering 链。stdout 仍恰好输出一个 JSON，
+schema 为 `calcit-calx-compile-profile/1`；默认 benchmark 模式和 schema 不变。
+
+```bash
+CARGO_PROFILE_RELEASE_STRIP=none \
+  CARGO_PROFILE_RELEASE_DEBUG=line-tables-only \
+  cargo build --release --bin calcit-calx-bench
+
+samply record --save-only --main-thread-only --unstable-presymbolicate \
+  --output target/calx-profile/compile-cpu.json.gz \
+  ./target/release/calcit-calx-bench \
+  --kernel affine \
+  --compile-profile-warmup 1000 \
+  --compile-profile-stage-iterations 10000 \
+  --compile-profile-allocation-iterations 10000 \
+  --compile-profile-iterations 100000
+```
+
+release profile 默认移除 debug info；上面的临时 Cargo override 只为 profiler 保留 line tables，不改变正式发布配置。
+`stageTimingPerIteration` 来自单独的阶段计时窗口，`allocationsPerIteration` 来自只在指定窗口开启的
+单线程 allocator counters。`requestedBytes` 是累计请求量，不是 peak RSS；reallocation 的新大小计入请求量，
+旧 block 不重复计入显式 deallocation。无插桩的 `compilePerIterationNs` 才是外部 CPU profiler 的主负载。
+
+原始 Samply/Instruments artifact 写在 `target/` 而不提交；仓库只保存工具版本、commit、硬件、命令、
+迭代数、阶段摘要和可复查的 top stacks。profile mode 仍然执行完整 compile pipeline，因此它用于定位
+cache candidate，不代表 cache-hit 成本。
+
 ### 阶段定义
 
 - `fixtureInstallNs`：解析并安装固定 source fixture；
@@ -136,6 +167,40 @@ reported on stderr with a nonzero exit status:
 cargo run --release --bin calcit-calx-bench -- \
   --kernel range-sum --size 1000 --vm-warmup 20 --hot-iterations 100
 ```
+
+### Compile profile mode
+
+A CPU or allocation profiler cannot reliably distinguish hotspots from a single compilation lasting only tens of
+microseconds. Passing `--compile-profile-iterations` installs and preprocesses the source fixture once, then repeats
+the complete uncached eligibility → planning → program construction → validation/lowering pipeline. Stdout still
+contains exactly one JSON value, using `calcit-calx-compile-profile/1`; the default benchmark mode and schema are
+unchanged.
+
+```bash
+CARGO_PROFILE_RELEASE_STRIP=none \
+  CARGO_PROFILE_RELEASE_DEBUG=line-tables-only \
+  cargo build --release --bin calcit-calx-bench
+
+samply record --save-only --main-thread-only --unstable-presymbolicate \
+  --output target/calx-profile/compile-cpu.json.gz \
+  ./target/release/calcit-calx-bench \
+  --kernel affine \
+  --compile-profile-warmup 1000 \
+  --compile-profile-stage-iterations 10000 \
+  --compile-profile-allocation-iterations 10000 \
+  --compile-profile-iterations 100000
+```
+
+The release profile strips debug information by default. The temporary Cargo overrides above retain line tables for
+the profiler without changing the shipping configuration. `stageTimingPerIteration` comes from a separate staged
+timing window, while `allocationsPerIteration` comes from single-threaded allocator counters enabled only for the
+requested window. `requestedBytes` is cumulative request volume, not peak RSS. A reallocation adds its new requested
+size, while the replaced block is not counted again as an explicit deallocation. The uninstrumented
+`compilePerIterationNs` remains the workload observed by the external CPU profiler.
+
+Raw Samply/Instruments artifacts stay under `target/`; the repository records tool versions, commit, hardware,
+commands, iteration counts, stage summaries, and reviewable top stacks. Profile mode still executes the complete
+compile pipeline, so it locates cache candidates but does not model cache-hit cost.
 
 ### Phase definitions
 

--- a/docs/run/calx-benchmark.md
+++ b/docs/run/calx-benchmark.md
@@ -61,6 +61,10 @@ CPU/allocation profiler 不能从单次约几十微秒的编译可靠分辨热�
 eligibility → planning → program construction → validation/lowering 链。stdout 仍恰好输出一个 JSON，
 schema 为 `calcit-calx-compile-profile/1`；默认 benchmark 模式和 schema 不变。
 
+profile report 的 `compilationSucceeded` 只表示全部 warmup、stage、allocation 与未插桩编译都成功完成；
+profile mode 不执行 kernel，因此不会输出 `correctness: true`。语义正确性仍由默认 benchmark 与 core
+differential corpus 验证。
+
 ```bash
 CARGO_PROFILE_RELEASE_STRIP=none \
   CARGO_PROFILE_RELEASE_DEBUG=line-tables-only \
@@ -175,6 +179,11 @@ microseconds. Passing `--compile-profile-iterations` installs and preprocesses t
 the complete uncached eligibility → planning → program construction → validation/lowering pipeline. Stdout still
 contains exactly one JSON value, using `calcit-calx-compile-profile/1`; the default benchmark mode and schema are
 unchanged.
+
+The profile report's `compilationSucceeded` field means only that every warmup, staged, allocation, and
+uninstrumented compilation completed successfully. Profile mode does not execute the kernel and therefore does not
+emit `correctness: true`; semantic correctness remains covered by the default benchmark and the core differential
+corpus.
 
 ```bash
 CARGO_PROFILE_RELEASE_STRIP=none \

--- a/docs/run/calx-compile-cache.md
+++ b/docs/run/calx-compile-cache.md
@@ -1,0 +1,191 @@
+# Revision-safe Calx compile cache design / revision-safe Calx 编译缓存设计
+
+Tracking: [calcit#552](https://github.com/calcit-lang/calcit/issues/552) and [calx-vm#39](https://github.com/calcit-lang/calx-vm/issues/39)
+
+## 中文
+
+### Profile 结论
+
+基于干净提交 `ef04017f0bc60e2d8f6341599f00d426a11ed360` 的 release profile 见
+[`20260831-compile-profile-macos-arm64.json`](../../benchmarks/calx/20260831-compile-profile-macos-arm64.json)。
+五个 scalar kernel 的未插桩完整编译约为 15.3–20.9 μs/次；分阶段测量中 program construction 占总时间
+约 47–54%，eligibility 与 planning 各约 17–23%，validation/lowering 约 5–7%。每次编译产生约
+222–392 次 allocation、52–91 次 reallocation 和 22–38 KiB 累计请求。
+
+Samply 的 20,987 个 CPU samples 将主要 inclusive 路径定位到 `emit_expression`（44.3%）、
+`source_origin`（35.6%）和 `BodyBuilder::if_else_at`（34.4%）。8,018 个包含 allocator frame 的 samples 中，
+62.4% 经过 `emit_expression`，53.8% 经过 `source_origin`。inclusive stack 会重叠，不能把百分比相加；但阶段
+计时和调用栈共同说明，首个高价值切片应缓存完整、已经验证的 source-derived artifact，而不是只微调
+`ProgramBuilder::build`，也不是先做 VM pool。`source_origin` 的字符串构造仍值得作为 cache miss 路径的
+后续独立优化。
+
+### 对象边界
+
+首版把当前 `CalxCompiledKernel` 拆成两层：
+
+- `CalxCompiledArtifact`：不可变、可缓存，只持有 eligible graph、entry boundary、`ValidatedProgram`、
+  reachable definition stamps、Calx ABI edition 与 typed import declaration contract；
+- `CalxPreparedKernel`：每次调用产生，持有一个 artifact 引用和本次 embedding 提供的
+  `CalxHostBindings`；运行或建立 fresh VM 只通过这一层。
+
+callback、capability state、buffer input、VM instance、stack/frame 和 runtime trap 都不进入 artifact。
+缓存命中也必须重新校验 typed import declarations，并从本次 `CalxHostImports` 重新附着 callbacks。
+
+### Revision key 与命中算法
+
+缓存由 embedding 显式创建并传入，不使用进程级 singleton。顶层 slot key 包含：
+
+1. fully-qualified entry；
+2. Calx kernel ABI edition；
+3. 排序后的 typed import declaration contract（definition、export name、参数与结果类型），不含 callback identity。
+
+每个 artifact 另外保存排序后的 reachable definition stamps。当前 `CompiledDef::version_id` 尚未提供可用的
+内容 revision（现有路径仍写入 `0`），因此首版不能把它单独当作 correctness key。stamp 必须保存并比较：
+
+- `DefId` 与 fully-qualified definition；
+- `preprocessed_code` 的结构值；
+- `schema` 的结构值。
+
+Calcit 与 type annotation 都已有一致的 `Eq`/`Hash`；hash 只用于加速候选查找，最终命中必须做结构相等
+比较，不能让 hash collision 变成 stale hit。`Calcit` collection clone 复用持久化结构，stamp 不需要复制整份
+source store。以后若 `CompiledDef` 获得“内容未变则稳定、内容或 schema 变化则递增”的真实 revision，才可用
+它替代结构 stamp。
+
+lookup 顺序：
+
+1. 用 slot key 查找 candidate；
+2. 逐个从当前 `CompiledProgram` 读取 candidate 已记录的 reachable definitions，并比较 stamp；
+3. entry 或任意旧 callee 缺失、代码/schema 改变时 miss；entry 改变会触发重新编译并发现新的 call graph；
+4. 未出现在旧 reachable set 的无关 definition 不参与比较，因此保持 hit；
+5. 命中后使用本次 imports 重新建立 bindings，并再次检查声明签名；只有完成 attachment 才返回 prepared kernel。
+
+这是一种 dependency-validation cache，而不是“对整个 Snapshot 求 hash”。它既覆盖 transitive change，也不会让
+无关 definition 的热更新冲掉全部 Calx artifact。
+
+### API、容量与观测
+
+公共能力优先以对象方法提供。建议的实验接口为：
+
+```text
+CalxCompileCache::new(capacity)
+cache.prepare(program, namespace, definition, imports)
+cache.stats()
+cache.clear()
+```
+
+`capacity` 首版按 artifact 个数设置硬上限，使用确定性的 LRU eviction；不得无界增长。stats 至少包含 hit、
+miss、miss reason、eviction、clear、entry count、reachable function count、syntax/instruction count 与估算字节数。
+miss reason 固定区分 `empty`、`entry-changed`、`callee-changed`、`schema-changed`、`abi-changed`、
+`import-contract-changed`、`dependency-missing` 和 `evicted`。命中报告明确标记跳过 eligibility、planning、
+program construction、validation/lowering，但仍记录 revision validation 与 binding attachment 成本。
+
+### 安全与测试门槛
+
+- hot reload 改 entry、direct/transitive callee 或 schema 必须 miss；无关 definition 改动必须 hit；
+- callback A 编译后，以相同声明传 callback B 命中缓存，执行必须只调用 B；
+- import declaration 改动必须 miss，callback identity 改动本身不能污染 source-derived key；
+- capacity、LRU eviction、显式 clear 与 stats 必须可测试；
+- partial lowering、placeholder 和 negative eligibility result 不缓存；
+- eligibility fallback 仍只发生在执行前，runtime trap 后不重跑 Calcit；
+- benchmark 必须同时报告 uncached one-shot、cache hit + fresh VM、cached-native 与 reused-Calx execution，
+  并保留 allocation/estimated-memory 成本。
+
+首版不包含 VM pool、自动 offload、持久化磁盘 cache、persistent collection 或 typed-buffer 扩展。
+
+---
+
+## English
+
+### Profile findings
+
+The release profile from clean commit `ef04017f0bc60e2d8f6341599f00d426a11ed360` is recorded in
+[`20260831-compile-profile-macos-arm64.json`](../../benchmarks/calx/20260831-compile-profile-macos-arm64.json).
+Uninstrumented complete compilation takes approximately 15.3–20.9 μs per scalar kernel. In staged measurements,
+program construction accounts for approximately 47–54% of total time, eligibility and planning each account for
+approximately 17–23%, and validation/lowering accounts for approximately 5–7%. One compilation performs roughly
+222–392 allocations, 52–91 reallocations, and requests a cumulative 22–38 KiB.
+
+Across 20,987 Samply CPU samples, the main inclusive paths are `emit_expression` (44.3%), `source_origin` (35.6%),
+and `BodyBuilder::if_else_at` (34.4%). Of 8,018 samples containing an allocator frame, 62.4% pass through
+`emit_expression` and 53.8% pass through `source_origin`. Inclusive stacks overlap and their percentages must not be
+summed. Together, the stage timings and call stacks show that the first high-value slice is caching the complete
+validated source-derived artifact, not only tuning `ProgramBuilder::build` and not premature VM pooling.
+`source_origin` string construction remains a separate follow-up for cache-miss performance.
+
+### Object boundary
+
+The first implementation splits the current `CalxCompiledKernel` into two layers:
+
+- `CalxCompiledArtifact`: immutable and cacheable; owns the eligible graph, entry boundary, `ValidatedProgram`,
+  reachable-definition stamps, Calx ABI edition, and typed-import declaration contract;
+- `CalxPreparedKernel`: created per request; holds an artifact reference and the `CalxHostBindings` supplied by the
+  current embedding call. Execution and fresh-VM construction are available only through this layer.
+
+Callbacks, capability state, buffer inputs, VM instances, stack/frame state, and runtime traps never enter the
+artifact. A cache hit must revalidate typed import declarations and attach callbacks again from the current
+`CalxHostImports` value.
+
+### Revision key and hit algorithm
+
+The embedding creates and passes the cache explicitly; there is no process singleton. The top-level slot key
+contains:
+
+1. the fully qualified entry;
+2. the Calx kernel ABI edition;
+3. the sorted typed-import declaration contract (definition, export name, parameter types, and result type), excluding callback identity.
+
+Each artifact also stores sorted reachable-definition stamps. `CompiledDef::version_id` is not yet a usable content
+revision because current paths still write `0`, so the first implementation must not use it as the sole correctness
+key. A stamp stores and compares:
+
+- `DefId` and the fully qualified definition;
+- the structural value of `preprocessed_code`;
+- the structural value of `schema`.
+
+Calcit values and type annotations already provide consistent `Eq` and `Hash`. A hash may accelerate candidate
+lookup, but a final structural equality check is required so a collision cannot create a stale hit. Cloning Calcit
+collections shares their persistent structure, so stamps need not duplicate the complete source store. A future
+`CompiledDef` revision may replace structural stamps only after it remains stable for unchanged content and advances
+for every code or schema change.
+
+Lookup proceeds as follows:
+
+1. find a candidate by slot key;
+2. read every previously reachable definition from the current `CompiledProgram` and compare its stamp;
+3. miss when the entry or any old callee is missing or its code/schema changed; an entry change recompiles and discovers the new graph;
+4. ignore definitions outside the old reachable set, preserving a hit for unrelated hot reloads;
+5. on a candidate hit, rebuild bindings from the current imports and check declaration signatures again; return a prepared kernel only after attachment succeeds.
+
+This is a dependency-validation cache, not a hash of the whole Snapshot. It covers transitive changes without
+invalidating every Calx artifact for an unrelated definition update.
+
+### API, capacity, and observability
+
+Public capability should be method-oriented. The proposed experimental surface is:
+
+```text
+CalxCompileCache::new(capacity)
+cache.prepare(program, namespace, definition, imports)
+cache.stats()
+cache.clear()
+```
+
+The first `capacity` is a hard artifact-count limit with deterministic LRU eviction; growth is never unbounded.
+Stats include hits, misses, miss reasons, evictions, clears, entry count, reachable function count,
+syntax/instruction count, and estimated bytes. Stable miss reasons distinguish `empty`, `entry-changed`,
+`callee-changed`, `schema-changed`, `abi-changed`, `import-contract-changed`, `dependency-missing`, and `evicted`.
+A hit reports that eligibility, planning, program construction, and validation/lowering were skipped while still
+recording revision-validation and binding-attachment cost.
+
+### Safety and test gate
+
+- Hot reloads of the entry, a direct/transitive callee, or a schema must miss; an unrelated definition change must hit.
+- After compiling with callback A, a hit with the same declaration and callback B must execute only B.
+- Import declaration changes must miss; callback identity itself must not contaminate the source-derived key.
+- Capacity, deterministic LRU eviction, explicit clear, and stats must be covered.
+- Partial lowering, placeholders, and negative eligibility results are never cached.
+- Eligibility fallback remains compile-time only; a runtime trap never reruns Calcit.
+- Benchmarks compare uncached one-shot, cache hit plus fresh VM, cached-native, and reused-Calx execution while retaining allocation and estimated-memory costs.
+
+The first slice does not include VM pooling, automatic offload, persistent disk caching, persistent collections, or
+typed-buffer extensions.

--- a/docs/run/calx-compile-cache.md
+++ b/docs/run/calx-compile-cache.md
@@ -79,12 +79,21 @@ miss reason 固定区分 `empty`、`entry-changed`、`callee-changed`、`schema-
 `import-contract-changed`、`dependency-missing` 和 `evicted`。命中报告明确标记跳过 eligibility、planning、
 program construction、validation/lowering，但仍记录 revision validation 与 binding attachment 成本。
 
+为了让 `evicted` 可判定，cache 维护独立的 recently-evicted slot-key ledger。ledger 保存完整 slot key，容量不超过
+artifact capacity，并按确定性的 LRU 顺序裁剪；它不是 artifact，也不保存 program、callback 或 definition stamp。
+淘汰 artifact 时插入或刷新其 key；再次插入同 key 时移除 tombstone；`clear()` 同时清空 artifact 与 ledger。
+当 active slots 中没有 key 时，ledger 命中报告 `evicted`，否则报告 `empty`。artifact 淘汰当下只增加
+`evictions`，后续实际 lookup 才增加 `misses.evicted`，避免一次淘汰重复计为 miss。ledger 自身淘汰旧 key 不增加
+artifact eviction 统计，之后该旧 key 按 `empty` 处理。
+
 ### 安全与测试门槛
 
 - hot reload 改 entry、direct/transitive callee 或 schema 必须 miss；无关 definition 改动必须 hit；
 - callback A 编译后，以相同声明传 callback B 命中缓存，执行必须只调用 B；
 - import declaration 改动必须 miss，callback identity 改动本身不能污染 source-derived key；
 - capacity、LRU eviction、显式 clear 与 stats 必须可测试；
+- eviction provenance 必须覆盖 capacity=1 下插入 A、插入 B、查询 A 得到 `evicted`；ledger 溢出后最旧
+  tombstone 查询得到 `empty`；重新插入或 clear 后旧 tombstone 不得继续报告 `evicted`；
 - partial lowering、placeholder 和 negative eligibility result 不缓存；
 - eligibility fallback 仍只发生在执行前，runtime trap 后不重跑 Calcit；
 - benchmark 必须同时报告 uncached one-shot、cache hit + fresh VM、cached-native 与 reused-Calx execution，
@@ -177,12 +186,23 @@ syntax/instruction count, and estimated bytes. Stable miss reasons distinguish `
 A hit reports that eligibility, planning, program construction, and validation/lowering were skipped while still
 recording revision-validation and binding-attachment cost.
 
+To make `evicted` observable, the cache keeps a separate recently-evicted slot-key ledger. It stores complete slot
+keys, is bounded to at most the artifact capacity, and is trimmed in deterministic LRU order. It is not an artifact
+and retains no program, callback, or definition stamp. Evicting an artifact inserts or refreshes its key; reinserting
+that key removes its tombstone; `clear()` clears both artifacts and the ledger. When no active slot matches, a ledger
+hit reports `evicted`, otherwise the miss is `empty`. The eviction itself increments only `evictions`; a later lookup
+increments `misses.evicted`, avoiding double-counting. Removing an old key from the bounded ledger does not count as
+an artifact eviction, and a later lookup of that forgotten key reports `empty`.
+
 ### Safety and test gate
 
 - Hot reloads of the entry, a direct/transitive callee, or a schema must miss; an unrelated definition change must hit.
 - After compiling with callback A, a hit with the same declaration and callback B must execute only B.
 - Import declaration changes must miss; callback identity itself must not contaminate the source-derived key.
 - Capacity, deterministic LRU eviction, explicit clear, and stats must be covered.
+- Eviction-provenance coverage inserts A then B at capacity one and expects an A lookup to report `evicted`; after
+  the ledger overflows its oldest tombstone reports `empty`; reinsertion and clear must not leave a stale `evicted`
+  reason.
 - Partial lowering, placeholders, and negative eligibility results are never cached.
 - Eligibility fallback remains compile-time only; a runtime trap never reruns Calcit.
 - Benchmarks compare uncached one-shot, cache hit plus fresh VM, cached-native, and reused-Calx execution while retaining allocation and estimated-memory costs.

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -134,7 +134,10 @@ cache、profiling/selection policy，也还没有基于 benchmark 的自动 offl
 kernel、zero/single-result typed imports、generated program、trap 与 fallback。分阶段 benchmark matrix、
 采样 crossover point 和首份 scalar baseline 已建立；[calx-vm #39](https://github.com/calcit-lang/calx-vm/issues/39)
 现已补充公平的 cached Calcit callable 基线：有限 scalar 样本仍显示 Calx hot 收益，但 lookup-call 对比确实
-夸大了微型 kernel 差距。后续先用 profile 证据决定 compile/program cache，VM pooling 不在缺少独立证据时
-提前实现；实用 bulk workload 由 [calx-vm #50](https://github.com/calcit-lang/calx-vm/issues/50) 以严格、
+夸大了微型 kernel 差距。[compile profile](../../benchmarks/calx/20260831-compile-profile-macos-arm64.json)
+进一步确认 program construction 及其 expression/source-origin emission 是首要 CPU 与分配目标；
+[revision-safe cache design](./calx-compile-cache.md) 因此选择缓存完整 validated source-derived artifact，并在
+每次命中重新附着 host bindings。VM pooling 不在缺少独立证据时提前实现；实用 bulk workload 由
+[calx-vm #50](https://github.com/calcit-lang/calx-vm/issues/50) 以严格、
 non-nil、zero-Dynamic typed buffer 单独推进，再决定 selection policy。
 基准命令、阶段定义和原始 JSON 格式见[《Calcit→Calx benchmark methodology》](./calx-benchmark.md)。

--- a/editing-history/202608311631-calx-compile-profile-runner.md
+++ b/editing-history/202608311631-calx-compile-profile-runner.md
@@ -1,0 +1,17 @@
+# Calx compile profile runner / Calx 编译 profile runner
+
+## 中文
+
+- 为 `calcit-calx-bench` 增加显式 compile profile 模式，在一次 source fixture 安装和 preprocessing 后重复完整未缓存的 eligibility、planning、program construction 与 validation/lowering 链路。
+- 分离三类测量：无阶段计时插桩的 profiler 负载、聚合的分阶段墙钟时间、仅在指定窗口启用的单线程 allocator 计数。
+- allocator 报告 allocation/reallocation/deallocation 次数、请求字节数与显式释放字节数；它只用于定位分配压力，不把累计请求字节误称为峰值驻留内存。
+- 默认 benchmark 模式与 `calcit-calx-benchmark/2` schema 保持不变；profile 模式使用独立的 `calcit-calx-compile-profile/1` schema，并继续保证 stdout 只有一个 JSON。
+- 增加小规模回归测试，验证完整编译重复执行、stage timing 与 allocation 统计均可用。
+
+## English
+
+- Added an explicit compile-profile mode to `calcit-calx-bench`. It installs and preprocesses the source fixture once, then repeats the complete uncached eligibility, planning, program-construction, and validation/lowering pipeline.
+- Separated three measurements: a profiler workload without per-stage timing instrumentation, aggregate per-stage wall time, and single-threaded allocator counters enabled only for a bounded window.
+- The allocator report records allocation, reallocation, and deallocation calls, requested bytes, and explicitly deallocated bytes. It locates allocation pressure and does not mislabel cumulative requested bytes as peak resident memory.
+- Kept the default benchmark mode and `calcit-calx-benchmark/2` schema unchanged. Profile mode uses the separate `calcit-calx-compile-profile/1` schema and still emits exactly one JSON value on stdout.
+- Added a bounded regression test that exercises complete repeated compilation and verifies stage-timing and allocation evidence.

--- a/editing-history/202608311642-profile-calx-compile-cache-boundary.md
+++ b/editing-history/202608311642-profile-calx-compile-cache-boundary.md
@@ -1,0 +1,21 @@
+# Profile Calx compile cache boundary / 用 profile 固定 Calx 编译缓存边界
+
+## 中文
+
+- 从干净提交 `ef04017f0bc60e2d8f6341599f00d426a11ed360` 采集五个 scalar kernel 的 release 分阶段时间、allocator counters，以及 bounded-simulation 的 1 kHz Samply CPU profile。
+- 保存机器、工具链、命令参数、原始 profile 路径/大小/SHA-256、20,987 个 CPU samples、8,018 个 allocator-stack samples 和可复查的 selected stacks；原始 profiler 文件继续留在 `target/`。
+- 证据显示 program construction 占分阶段总时间约 47–54%，`emit_expression`、`source_origin` 和 builder emission 主导 CPU 与分配路径。
+- 将下一实现边界固定为 embedding-owned、容量有界的 validated-artifact cache；artifact 与每次调用的 host binding attachment 分离，避免 callback/capability state 过期。
+- 设计 dependency-validation key：fully-qualified entry、ABI、typed import declaration contract，以及 reachable definitions 的 `DefId`、结构化 `preprocessed_code` 与 schema；无关 definition 变化不失效，transitive code/schema 变化必须 miss。
+- 明确当前 `CompiledDef::version_id` 仍为 `0`，不能作为 correctness key；hash 只加速候选查找，最终必须结构比较。
+- 增加 profile contract tests，守住干净 commit、五个 kernel、主要 stage、allocator 数据、原始文件哈希与 inclusive-stack 限制。
+
+## English
+
+- Collected release staged timings and allocator counters for all five scalar kernels from clean commit `ef04017f0bc60e2d8f6341599f00d426a11ed360`, plus a 1 kHz Samply CPU profile of bounded-simulation.
+- Recorded the machine, toolchain, command parameters, raw-profile paths/sizes/SHA-256 values, 20,987 CPU samples, 8,018 allocator-stack samples, and reviewable selected stacks. Raw profiler files remain under `target/`.
+- The evidence shows program construction accounting for approximately 47–54% of staged total time, with `emit_expression`, `source_origin`, and builder emission dominating CPU and allocation paths.
+- Froze the next implementation boundary as an embedding-owned, capacity-bounded validated-artifact cache. The artifact is separate from per-call host-binding attachment, preventing stale callbacks or capability state.
+- Designed a dependency-validation key covering the fully qualified entry, ABI, typed-import declaration contract, and each reachable definition's `DefId`, structural `preprocessed_code`, and schema. Unrelated definitions preserve hits; transitive code or schema changes must miss.
+- Documented that `CompiledDef::version_id` is still `0` and cannot be a correctness key. Hashing may accelerate candidate lookup, but final structural equality remains mandatory.
+- Added profile contract tests that preserve the clean commit, five-kernel matrix, dominant stage, allocator evidence, raw-file hashes, and inclusive-stack limitations.

--- a/editing-history/202608311707-address-calx-profile-review.md
+++ b/editing-history/202608311707-address-calx-profile-review.md
@@ -1,0 +1,19 @@
+# 2026-08-31 17:07 Calx compile profile review follow-up
+
+## 中文
+
+- compile profile 不再把“所有编译完成”写成 `correctness: true`，改为语义准确的
+  `compilationSucceeded`；kernel 执行正确性继续由默认 benchmark 与 core differential corpus 负责。
+- allocation window 通过进程内 mutex 串行化，并用 RAII 在错误或 panic unwind 时关闭全局计数开关，避免
+  重叠或异常路径污染后续采样。
+- revision-safe cache 契约增加有界 recently-evicted slot-key ledger，明确 `empty`/`evicted` 判定、
+  reinsertion、clear、统计与测试序列。
+
+## English
+
+- Compile-profile output now reports `compilationSucceeded` instead of claiming unexecuted kernels have
+  `correctness: true`; execution correctness remains owned by the default benchmark and core differential corpus.
+- The allocation window is serialized by a process-local mutex and uses RAII to disable global counting after errors
+  or panic unwinding, preventing overlapping or abandoned measurements from contaminating later samples.
+- The revision-safe cache contract now specifies a bounded recently-evicted slot-key ledger, including
+  `empty`/`evicted` classification, reinsertion, clear, statistics, and required test sequences.

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -3,16 +3,18 @@
 //! The orchestration script runs this binary in fresh processes to measure
 //! process-level cold cost without mixing benchmark policy into the compiler.
 
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::hint::black_box;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use argh::FromArgs;
 use calcit::calcit::{CalcitFn, CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind};
 use calcit::call_stack::CallStackList;
-use calcit::codegen::calx::{CalxCompiledKernel, CalxScalarType, CalxValue, compile_calx_kernel_measured};
+use calcit::codegen::calx::{CalxCompiledKernel, CalxScalarType, CalxValue, compile_calx_kernel, compile_calx_kernel_measured};
 use calcit::data::cirru::code_to_calcit;
 use calcit::program::{PROGRAM_CODE_DATA, ProgramDefEntry, ProgramFileData, clone_existing_compiled_program, ensure_def_id};
 use calcit::{Calcit, run_program_with_docs};
@@ -22,6 +24,60 @@ use serde::Serialize;
 
 const FIXTURE_NAMESPACE: &str = "bench.calx-kernels";
 const CARGO_LOCK: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.lock"));
+
+struct ProfileAllocator;
+
+static COUNT_PROFILE_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static PROFILE_ALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
+static PROFILE_REALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
+static PROFILE_DEALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
+static PROFILE_REQUESTED_BYTES: AtomicU64 = AtomicU64::new(0);
+static PROFILE_DEALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+fn record_profile_allocation(bytes: usize) {
+  if COUNT_PROFILE_ALLOCATIONS.load(Ordering::Relaxed) {
+    PROFILE_ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+    PROFILE_REQUESTED_BYTES.fetch_add(bytes as u64, Ordering::Relaxed);
+  }
+}
+
+unsafe impl GlobalAlloc for ProfileAllocator {
+  unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+    let value = unsafe { System.alloc(layout) };
+    if !value.is_null() {
+      record_profile_allocation(layout.size());
+    }
+    value
+  }
+
+  unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+    let value = unsafe { System.alloc_zeroed(layout) };
+    if !value.is_null() {
+      record_profile_allocation(layout.size());
+    }
+    value
+  }
+
+  unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    if COUNT_PROFILE_ALLOCATIONS.load(Ordering::Relaxed) {
+      PROFILE_DEALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+      PROFILE_DEALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+    }
+    unsafe { System.dealloc(ptr, layout) };
+  }
+
+  unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+    let value = unsafe { System.realloc(ptr, layout, new_size) };
+    if !value.is_null() && COUNT_PROFILE_ALLOCATIONS.load(Ordering::Relaxed) {
+      PROFILE_REALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+      PROFILE_REQUESTED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+    }
+    value
+  }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: ProfileAllocator = ProfileAllocator;
 
 #[derive(Debug, FromArgs)]
 /// measure one source-backed Calcit-to-Calx scalar kernel
@@ -41,6 +97,22 @@ struct Args {
   /// reused-VM calls included in hot measurement
   #[argh(option, default = "100")]
   hot_iterations: u32,
+
+  /// repeat complete Calx compilation for profiler sampling; zero runs the normal benchmark
+  #[argh(option, default = "0")]
+  compile_profile_iterations: u32,
+
+  /// complete Calx compilations discarded before profiler sampling
+  #[argh(option, default = "100")]
+  compile_profile_warmup: u32,
+
+  /// compilations used for aggregate per-stage timings in profile mode
+  #[argh(option, default = "10000")]
+  compile_profile_stage_iterations: u32,
+
+  /// compilations used for allocation counters in profile mode
+  #[argh(option, default = "10000")]
+  compile_profile_allocation_iterations: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -53,7 +125,7 @@ struct EnvironmentReport {
   architecture: &'static str,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CompileReport {
   eligibility_ns: u64,
@@ -110,8 +182,77 @@ struct BenchmarkReport {
   correctness: bool,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CompileProfileReport {
+  schema: &'static str,
+  environment: EnvironmentReport,
+  kernel: String,
+  workload: &'static str,
+  warmup_iterations: u32,
+  measured_iterations: u32,
+  fixture_install_ns: u64,
+  calcit_frontend_ns: u64,
+  snapshot_clone_ns: u64,
+  compile_total_ns: u64,
+  compile_per_iteration_ns: u64,
+  stage_timing_iterations: u32,
+  stage_timing_total: CompileReport,
+  stage_timing_per_iteration: CompileReport,
+  allocation_iterations: u32,
+  allocations: AllocationReport,
+  allocations_per_iteration: AllocationReport,
+  correctness: bool,
+}
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AllocationReport {
+  allocation_calls: u64,
+  reallocation_calls: u64,
+  deallocation_calls: u64,
+  requested_bytes: u64,
+  explicitly_deallocated_bytes: u64,
+}
+
+impl AllocationReport {
+  fn divided_by(&self, iterations: u32) -> Self {
+    let divisor = u64::from(iterations);
+    Self {
+      allocation_calls: self.allocation_calls / divisor,
+      reallocation_calls: self.reallocation_calls / divisor,
+      deallocation_calls: self.deallocation_calls / divisor,
+      requested_bytes: self.requested_bytes / divisor,
+      explicitly_deallocated_bytes: self.explicitly_deallocated_bytes / divisor,
+    }
+  }
+}
+
+impl CompileReport {
+  fn divided_by(&self, iterations: u32) -> Self {
+    let divisor = u64::from(iterations);
+    Self {
+      eligibility_ns: self.eligibility_ns / divisor,
+      planning_ns: self.planning_ns / divisor,
+      program_construction_ns: self.program_construction_ns / divisor,
+      validation_lowering_ns: self.validation_lowering_ns / divisor,
+      total_ns: self.total_ns / divisor,
+    }
+  }
+}
+
 fn nanos(duration: Duration) -> u64 {
   u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+}
+
+fn environment_report() -> Result<EnvironmentReport, String> {
+  Ok(EnvironmentReport {
+    package_version: env!("CARGO_PKG_VERSION"),
+    calx_vm_version: resolved_dependency_version(CARGO_LOCK, "calx_vm")?.to_owned(),
+    profile: if cfg!(debug_assertions) { "debug" } else { "release" },
+    os: std::env::consts::OS,
+    architecture: std::env::consts::ARCH,
+  })
 }
 
 /// Resolve one uniquely-versioned package from the lockfile embedded at build time.
@@ -241,6 +382,116 @@ fn resolve_cached_calcit_callable(kernel: &str, call_stack: &CallStackList) -> R
   }
 }
 
+fn reset_profile_allocations() {
+  PROFILE_ALLOCATION_CALLS.store(0, Ordering::Relaxed);
+  PROFILE_REALLOCATION_CALLS.store(0, Ordering::Relaxed);
+  PROFILE_DEALLOCATION_CALLS.store(0, Ordering::Relaxed);
+  PROFILE_REQUESTED_BYTES.store(0, Ordering::Relaxed);
+  PROFILE_DEALLOCATED_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn read_profile_allocations() -> AllocationReport {
+  AllocationReport {
+    allocation_calls: PROFILE_ALLOCATION_CALLS.load(Ordering::Relaxed),
+    reallocation_calls: PROFILE_REALLOCATION_CALLS.load(Ordering::Relaxed),
+    deallocation_calls: PROFILE_DEALLOCATION_CALLS.load(Ordering::Relaxed),
+    requested_bytes: PROFILE_REQUESTED_BYTES.load(Ordering::Relaxed),
+    explicitly_deallocated_bytes: PROFILE_DEALLOCATED_BYTES.load(Ordering::Relaxed),
+  }
+}
+
+fn add_compile_timings(report: &mut CompileReport, timings: calcit::codegen::calx::CalxKernelCompileTimings) {
+  report.eligibility_ns = report.eligibility_ns.saturating_add(nanos(timings.eligibility));
+  report.planning_ns = report.planning_ns.saturating_add(nanos(timings.planning));
+  report.program_construction_ns = report.program_construction_ns.saturating_add(nanos(timings.program_construction));
+  report.validation_lowering_ns = report.validation_lowering_ns.saturating_add(nanos(timings.validation_lowering));
+  report.total_ns = report.total_ns.saturating_add(nanos(timings.total));
+}
+
+/// Amplify the complete compile pipeline so sampling and allocation profilers
+/// can distinguish its stages from process/frontend setup.
+fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> {
+  if args.compile_profile_iterations == 0 {
+    return Err("--compile-profile-iterations must be greater than zero in compile profile mode".to_owned());
+  }
+  if args.compile_profile_stage_iterations == 0 {
+    return Err("--compile-profile-stage-iterations must be greater than zero in compile profile mode".to_owned());
+  }
+  if args.compile_profile_allocation_iterations == 0 {
+    return Err("--compile-profile-allocation-iterations must be greater than zero in compile profile mode".to_owned());
+  }
+
+  let fixture_started = Instant::now();
+  install_fixture()?;
+  let fixture_install_ns = nanos(fixture_started.elapsed());
+
+  let frontend_started = Instant::now();
+  let warnings = RefCell::new(vec![]);
+  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
+    .map_err(|error| error.to_string())?;
+  if !warnings.borrow().is_empty() {
+    return Err(format!("Calx compile profile frontend produced warnings: {:#?}", warnings.borrow()));
+  }
+  let calcit_frontend_ns = nanos(frontend_started.elapsed());
+
+  let snapshot_started = Instant::now();
+  let snapshot = clone_existing_compiled_program();
+  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
+
+  for _ in 0..args.compile_profile_warmup {
+    black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+  }
+
+  let mut stage_timing_total = CompileReport::default();
+  for _ in 0..args.compile_profile_stage_iterations {
+    let (kernel, timings) =
+      compile_calx_kernel_measured(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?;
+    add_compile_timings(&mut stage_timing_total, timings);
+    black_box(kernel);
+  }
+  let stage_timing_per_iteration = stage_timing_total.divided_by(args.compile_profile_stage_iterations);
+
+  reset_profile_allocations();
+  COUNT_PROFILE_ALLOCATIONS.store(true, Ordering::Relaxed);
+  let allocation_result = (|| {
+    for _ in 0..args.compile_profile_allocation_iterations {
+      black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+    }
+    Ok::<(), String>(())
+  })();
+  COUNT_PROFILE_ALLOCATIONS.store(false, Ordering::Relaxed);
+  allocation_result?;
+  let allocations = read_profile_allocations();
+  let allocations_per_iteration = allocations.divided_by(args.compile_profile_allocation_iterations);
+
+  let compile_started = Instant::now();
+  for _ in 0..args.compile_profile_iterations {
+    black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+  }
+  let compile_total_ns = nanos(compile_started.elapsed());
+
+  Ok(CompileProfileReport {
+    schema: "calcit-calx-compile-profile/1",
+    environment: environment_report()?,
+    kernel: args.kernel.clone(),
+    workload: "complete-uncached-scalar-compilation",
+    warmup_iterations: args.compile_profile_warmup,
+    measured_iterations: args.compile_profile_iterations,
+    fixture_install_ns,
+    calcit_frontend_ns,
+    snapshot_clone_ns,
+    compile_total_ns,
+    compile_per_iteration_ns: compile_total_ns / u64::from(args.compile_profile_iterations),
+    stage_timing_iterations: args.compile_profile_stage_iterations,
+    stage_timing_total,
+    stage_timing_per_iteration,
+    allocation_iterations: args.compile_profile_allocation_iterations,
+    allocations,
+    allocations_per_iteration,
+    correctness: true,
+  })
+}
+
 /// Run correctness first, then collect one process-local staged measurement.
 fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   if args.hot_iterations == 0 {
@@ -343,13 +594,7 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
 
   Ok(BenchmarkReport {
     schema: "calcit-calx-benchmark/2",
-    environment: EnvironmentReport {
-      package_version: env!("CARGO_PKG_VERSION"),
-      calx_vm_version: resolved_dependency_version(CARGO_LOCK, "calx_vm")?.to_owned(),
-      profile: if cfg!(debug_assertions) { "debug" } else { "release" },
-      os: std::env::consts::OS,
-      architecture: std::env::consts::ARCH,
-    },
+    environment: environment_report()?,
     kernel: args.kernel.clone(),
     workload: "scalar-only",
     size: args.size,
@@ -394,7 +639,12 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
 /// Emit exactly one JSON report on success and keep failures on stderr.
 fn main() {
   let args: Args = argh::from_env();
-  match measure(&args).and_then(|report| serde_json::to_string(&report).map_err(|error| error.to_string())) {
+  let report = if args.compile_profile_iterations == 0 {
+    measure(&args).and_then(|report| serde_json::to_string(&report).map_err(|error| error.to_string()))
+  } else {
+    measure_compile_profile(&args).and_then(|report| serde_json::to_string(&report).map_err(|error| error.to_string()))
+  };
+  match report {
     Ok(json) => println!("{json}"),
     Err(error) => {
       eprintln!("calcit-calx-bench: {error}");
@@ -434,5 +684,36 @@ mod tests {
 
     let error = resolve_cached_calcit_callable("missing-kernel", &call_stack).expect_err("missing entries must fail");
     assert!(error.contains("missing-kernel"));
+  }
+
+  #[test]
+  fn compile_profile_mode_repeats_complete_uncached_compilation() {
+    let report = measure_compile_profile(&Args {
+      kernel: "affine".to_owned(),
+      size: 10,
+      vm_warmup: 0,
+      hot_iterations: 1,
+      compile_profile_iterations: 2,
+      compile_profile_warmup: 1,
+      compile_profile_stage_iterations: 2,
+      compile_profile_allocation_iterations: 2,
+    })
+    .expect("measure repeated complete compilation");
+
+    assert_eq!(report.schema, "calcit-calx-compile-profile/1");
+    assert_eq!(report.workload, "complete-uncached-scalar-compilation");
+    assert_eq!(report.warmup_iterations, 1);
+    assert_eq!(report.measured_iterations, 2);
+    assert_eq!(report.stage_timing_iterations, 2);
+    assert_eq!(report.allocation_iterations, 2);
+    assert!(report.compile_total_ns > 0);
+    assert!(report.compile_per_iteration_ns > 0);
+    assert!(report.stage_timing_total.total_ns > 0);
+    assert!(report.stage_timing_per_iteration.total_ns > 0);
+    assert!(report.allocations.allocation_calls > 0);
+    assert!(report.allocations.requested_bytes > 0);
+    assert!(report.allocations_per_iteration.allocation_calls > 0);
+    assert!(report.allocations_per_iteration.requested_bytes > 0);
+    assert!(report.correctness);
   }
 }

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -7,8 +7,8 @@ use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::hint::black_box;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use argh::FromArgs;
@@ -33,6 +33,35 @@ static PROFILE_REALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
 static PROFILE_DEALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
 static PROFILE_REQUESTED_BYTES: AtomicU64 = AtomicU64::new(0);
 static PROFILE_DEALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+static PROFILE_ALLOCATION_WINDOW: Mutex<()> = Mutex::new(());
+
+struct ProfileAllocationWindow {
+  _guard: MutexGuard<'static, ()>,
+}
+
+impl ProfileAllocationWindow {
+  /// Start one exclusive allocation-measurement window and reset its counters.
+  fn begin() -> Result<Self, String> {
+    let guard = PROFILE_ALLOCATION_WINDOW
+      .lock()
+      .map_err(|error| format!("Calx compile profile allocation window is poisoned: {error}"))?;
+    reset_profile_allocations();
+    COUNT_PROFILE_ALLOCATIONS.store(true, Ordering::Relaxed);
+    Ok(Self { _guard: guard })
+  }
+
+  /// Stop counting before exposing the counters to report construction.
+  fn finish(self) -> AllocationReport {
+    COUNT_PROFILE_ALLOCATIONS.store(false, Ordering::Relaxed);
+    read_profile_allocations()
+  }
+}
+
+impl Drop for ProfileAllocationWindow {
+  fn drop(&mut self) {
+    COUNT_PROFILE_ALLOCATIONS.store(false, Ordering::Relaxed);
+  }
+}
 
 fn record_profile_allocation(bytes: usize) {
   if COUNT_PROFILE_ALLOCATIONS.load(Ordering::Relaxed) {
@@ -202,7 +231,7 @@ struct CompileProfileReport {
   allocation_iterations: u32,
   allocations: AllocationReport,
   allocations_per_iteration: AllocationReport,
-  correctness: bool,
+  compilation_succeeded: bool,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -382,6 +411,7 @@ fn resolve_cached_calcit_callable(kernel: &str, call_stack: &CallStackList) -> R
   }
 }
 
+/// Reset counters while holding the exclusive profile allocation window.
 fn reset_profile_allocations() {
   PROFILE_ALLOCATION_CALLS.store(0, Ordering::Relaxed);
   PROFILE_REALLOCATION_CALLS.store(0, Ordering::Relaxed);
@@ -390,6 +420,7 @@ fn reset_profile_allocations() {
   PROFILE_DEALLOCATED_BYTES.store(0, Ordering::Relaxed);
 }
 
+/// Snapshot counters before releasing the exclusive profile allocation window.
 fn read_profile_allocations() -> AllocationReport {
   AllocationReport {
     allocation_calls: PROFILE_ALLOCATION_CALLS.load(Ordering::Relaxed),
@@ -400,6 +431,7 @@ fn read_profile_allocations() -> AllocationReport {
   }
 }
 
+/// Accumulate one measured compilation into an aggregate stage report.
 fn add_compile_timings(report: &mut CompileReport, timings: calcit::codegen::calx::CalxKernelCompileTimings) {
   report.eligibility_ns = report.eligibility_ns.saturating_add(nanos(timings.eligibility));
   report.planning_ns = report.planning_ns.saturating_add(nanos(timings.planning));
@@ -451,17 +483,15 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
   }
   let stage_timing_per_iteration = stage_timing_total.divided_by(args.compile_profile_stage_iterations);
 
-  reset_profile_allocations();
-  COUNT_PROFILE_ALLOCATIONS.store(true, Ordering::Relaxed);
+  let allocation_window = ProfileAllocationWindow::begin()?;
   let allocation_result = (|| {
     for _ in 0..args.compile_profile_allocation_iterations {
       black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
     }
     Ok::<(), String>(())
   })();
-  COUNT_PROFILE_ALLOCATIONS.store(false, Ordering::Relaxed);
   allocation_result?;
-  let allocations = read_profile_allocations();
+  let allocations = allocation_window.finish();
   let allocations_per_iteration = allocations.divided_by(args.compile_profile_allocation_iterations);
 
   let compile_started = Instant::now();
@@ -488,7 +518,7 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
     allocation_iterations: args.compile_profile_allocation_iterations,
     allocations,
     allocations_per_iteration,
-    correctness: true,
+    compilation_succeeded: true,
   })
 }
 
@@ -714,6 +744,9 @@ mod tests {
     assert!(report.allocations.requested_bytes > 0);
     assert!(report.allocations_per_iteration.allocation_calls > 0);
     assert!(report.allocations_per_iteration.requested_bytes > 0);
-    assert!(report.correctness);
+    assert!(report.compilation_succeeded);
+    let serialized = serde_json::to_value(&report).expect("serialize compile profile report");
+    assert_eq!(serialized["compilationSucceeded"], true);
+    assert!(serialized.get("correctness").is_none());
   }
 }

--- a/tests/calx_compile_profile_contract.rs
+++ b/tests/calx_compile_profile_contract.rs
@@ -1,0 +1,49 @@
+use serde_json::Value;
+
+const PROFILE: &str = include_str!("../benchmarks/calx/20260831-compile-profile-macos-arm64.json");
+
+#[test]
+fn compile_profile_preserves_clean_provenance_and_complete_kernel_evidence() {
+  let report: Value = serde_json::from_str(PROFILE).expect("parse Calx compile profile");
+  assert_eq!(report["schema"], "calcit-calx-compile-profile-suite/1");
+  assert_eq!(report["environment"]["gitDirty"], false);
+  assert_eq!(report["environment"]["gitCommit"].as_str().map(str::len), Some(40));
+  assert_eq!(report["kernels"].as_array().map(Vec::len), Some(5));
+  assert!(report["measurement"]["samplySamples"].as_u64().is_some_and(|value| value > 10_000));
+  assert!(
+    report["measurement"]["samplyAllocationStackSamples"]
+      .as_u64()
+      .is_some_and(|value| value > 0)
+  );
+
+  for kernel in report["kernels"].as_array().expect("kernel profile array") {
+    let stages = &kernel["stageTimingPerIterationNs"];
+    let construction = stages["programConstruction"].as_u64().expect("program construction duration");
+    assert!(construction > stages["eligibility"].as_u64().expect("eligibility duration"));
+    assert!(construction > stages["planning"].as_u64().expect("planning duration"));
+    assert!(construction > stages["validationLowering"].as_u64().expect("validation duration"));
+    assert!(
+      kernel["allocationsPerIteration"]["allocationCalls"]
+        .as_u64()
+        .is_some_and(|value| value > 0)
+    );
+    assert!(
+      kernel["allocationsPerIteration"]["requestedBytes"]
+        .as_u64()
+        .is_some_and(|value| value > 0)
+    );
+  }
+}
+
+#[test]
+fn compile_profile_keeps_raw_artifacts_external_but_content_addressed() {
+  let report: Value = serde_json::from_str(PROFILE).expect("parse Calx compile profile");
+  let raw = &report["rawProfile"];
+  assert_eq!(raw["committed"], false);
+  assert!(raw["profilePath"].as_str().is_some_and(|value| value.starts_with("target/")));
+  assert!(raw["symbolsPath"].as_str().is_some_and(|value| value.starts_with("target/")));
+  assert_eq!(raw["profileSha256"].as_str().map(str::len), Some(64));
+  assert_eq!(raw["symbolsSha256"].as_str().map(str::len), Some(64));
+  assert_eq!(report["interpretation"]["stackRatiosAreInclusiveAndOverlap"], true);
+  assert_eq!(report["interpretation"]["requestedBytesArePeakResidentMemory"], false);
+}


### PR DESCRIPTION
## 中文

### 背景

#552 要求先用实际 CPU/allocation profile 确认 Calx compile cache 的目标，再实现 revision-safe cache。现有单次编译只有几十微秒，无法被采样 profiler 稳定分辨；同时当前 `CalxCompiledKernel` 把 immutable validated program 与本次 host bindings 放在同一个对象中，直接缓存会留下 stale callback 风险。

### 改动

- 为 `calcit-calx-bench` 增加独立的 `calcit-calx-compile-profile/1` 模式；
- 在一次 fixture install/preprocess 后重复完整、未缓存的 eligibility、planning、program construction、validation/lowering；
- 分离无插桩 CPU 负载、聚合 stage timing 和有界单线程 allocator counters；
- 保持默认 `calcit-calx-benchmark/2` 模式与 stdout 单 JSON 契约不变；
- 从 clean commit `ef04017f0bc60e2d8f6341599f00d426a11ed360` 采集五个 scalar kernels 与 1 kHz Samply profile；
- 保存原始 profile 的路径、大小、SHA-256、环境、命令参数和 selected inclusive stacks；原始 profiler 文件保留在 `target/`；
- 增加 profile contract tests；
- 冻结 revision-safe cache 设计：embedding-owned、容量有界、dependency validation、immutable artifact 与 per-call host binding attachment 分离；
- 更新 benchmark/Calx target/AGENTS 文档与 editing history。

### 证据与结论

- 未插桩完整编译约 15.3–20.9 μs/次；
- program construction 占分阶段总时间约 47–54%；
- 每次编译约 222–392 次 allocation、52–91 次 reallocation、22–38 KiB 累计请求；
- 20,987 个 CPU samples 中，主要 inclusive 路径为 `emit_expression` 44.3%、`source_origin` 35.6%、`BodyBuilder::if_else_at` 34.4%；
- 8,018 个 allocator-stack samples 中，62.4% 经过 `emit_expression`，53.8% 经过 `source_origin`；inclusive ratios 会重叠，不能相加；
- 下一实现应缓存完整 validated source-derived artifact，并在每次 hit 重新附着/校验 host bindings；不应先做 VM pool。

当前 `CompiledDef::version_id` 仍写入 `0`，因此设计明确禁止把它单独作为 correctness key。首版使用 reachable definitions 的 `DefId`、结构化 `preprocessed_code` 与 schema；hash 只加速候选查找，最终必须结构比较。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn check-all`
- Calcit core 225/225
- Agent interface 18/18
- JS/IR/WASM 与性能 smoke
- 两份 Markdown `docs check-md`
- clean-commit 五 kernel profile matrix
- clean-commit 1 kHz Samply profile 与 SHA-256 复核

本 PR 完成 #552 的 profile 与设计阶段，不关闭 Issue；cache 实现、hot reload/stale callback/eviction tests 和 cache-hit benchmark 留在下一阶段。

---

## English

### Context

#552 requires real CPU and allocation evidence before implementing a revision-safe Calx compile cache. A single compilation lasts only tens of microseconds and cannot be sampled reliably. The current `CalxCompiledKernel` also combines an immutable validated program with the current host bindings, so caching it directly risks retaining stale callbacks.

### Changes

- Add a separate `calcit-calx-compile-profile/1` mode to `calcit-calx-bench`.
- Install and preprocess the fixture once, then repeat the complete uncached eligibility, planning, program-construction, and validation/lowering pipeline.
- Separate an uninstrumented CPU workload, aggregate staged timing, and bounded single-threaded allocator counters.
- Preserve the default `calcit-calx-benchmark/2` mode and single-JSON stdout contract.
- Collect all five scalar kernels and a 1 kHz Samply profile from clean commit `ef04017f0bc60e2d8f6341599f00d426a11ed360`.
- Record raw-profile paths, sizes, SHA-256 values, environment, command settings, and selected inclusive stacks while keeping raw profiler files under `target/`.
- Add profile contract tests.
- Freeze the revision-safe cache design: embedding-owned, capacity-bounded, dependency-validated, with immutable artifacts separated from per-call host-binding attachment.
- Update benchmark, Calx target, AGENTS, and editing-history documentation.

### Evidence and conclusion

- Uninstrumented complete compilation takes approximately 15.3–20.9 μs per call.
- Program construction accounts for approximately 47–54% of staged total time.
- One compilation performs roughly 222–392 allocations, 52–91 reallocations, and requests a cumulative 22–38 KiB.
- Across 20,987 CPU samples, the main inclusive paths are `emit_expression` at 44.3%, `source_origin` at 35.6%, and `BodyBuilder::if_else_at` at 34.4%.
- Of 8,018 allocator-stack samples, 62.4% pass through `emit_expression` and 53.8% pass through `source_origin`. Inclusive ratios overlap and must not be summed.
- The next implementation should cache the complete validated source-derived artifact and reattach/revalidate host bindings on every hit. VM pooling should not come first.

`CompiledDef::version_id` is still written as `0`, so the design explicitly rejects it as the sole correctness key. The first implementation uses each reachable definition's `DefId`, structural `preprocessed_code`, and schema. Hashing may accelerate candidate lookup, but final structural equality remains mandatory.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn check-all`
- Calcit core 225/225
- Agent interface 18/18
- JS/IR/WASM and performance smokes
- `docs check-md` for both Markdown documents
- clean-commit five-kernel profile matrix
- clean-commit 1 kHz Samply profile and SHA-256 verification

This PR completes the profile and design stage of #552 without closing the Issue. Cache implementation, hot-reload/stale-callback/eviction tests, and cache-hit benchmarks remain for the next stage.

Refs #552
Refs calcit-lang/calx-vm#39
