### PR TITLE
修复 caps 文档分类 / fix the caps documentation category

### DIFF
--- a/docs/run/caps-extraction-contract.md
+++ b/docs/run/caps-extraction-contract.md
@@ -3,7 +3,7 @@ title: "Caps extraction contract"
 summary: "Compatibility, version, storage, command, dependency, and regression boundaries for extracting caps from Calcit core"
 scope: "tool"
 kind: "maintainer-guide"
-category: "packages"
+category: "run"
 aliases:
   - "caps repository extraction"
   - "caps compatibility contract"

--- a/editing-history/202608311721-fix-caps-doc-category.md
+++ b/editing-history/202608311721-fix-caps-doc-category.md
@@ -1,0 +1,15 @@
+# 2026-08-31 17:21 Fix caps documentation category
+
+## 中文
+
+- 将 `caps-extraction-contract.md` 的 frontmatter category 从未注册的 `packages` 改为已注册的 `run`，使
+  `calcit docs list/read/search` 可以加载完整 guidebook。
+- 增加直接读取仓库文档并调用 frontmatter validator 的回归测试，防止 extraction contract 再次绕过
+  docs category 契约。
+
+## English
+
+- Changed the `caps-extraction-contract.md` frontmatter category from unregistered `packages` to registered `run`,
+  allowing `calcit docs list/read/search` to load the complete guidebook.
+- Added a regression that reads the repository document and validates its frontmatter so the extraction contract
+  cannot drift outside the docs category contract again.

--- a/src/bin/cli_handlers/docs_tests.rs
+++ b/src/bin/cli_handlers/docs_tests.rs
@@ -398,6 +398,17 @@ fn repository_query_doc_frontmatter_keeps_search_metadata_separate() {
 }
 
 #[test]
+fn repository_caps_extraction_contract_uses_registered_frontmatter() {
+  let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/run/caps-extraction-contract.md");
+  let content = fs::read_to_string(path).expect("caps extraction contract should be readable");
+  let (frontmatter, _) = parse_doc_frontmatter(&content);
+
+  assert_eq!(frontmatter.category.as_deref(), Some("run"));
+  validate_doc_frontmatter("docs/run/caps-extraction-contract.md", &frontmatter)
+    .expect("caps extraction contract should remain loadable by calcit docs");
+}
+
+#[test]
 fn collect_search_results_uses_alias_matches_without_body_hits() {
   let docs = vec![GuideDoc {
     filename: "edit-tree.md".to_string(),


### PR DESCRIPTION
## 中文

### 问题

已合并的 caps extraction contract 使用了未注册的 frontmatter category `packages`。当
`~/.config/calcit/docs` 指向该仓库时，`calcit docs list/read/search` 会在加载 guidebook 时直接失败。

### 修改

- 将 `docs/run/caps-extraction-contract.md` 的 category 改为已注册的 `run`；
- 增加读取真实仓库文档并调用 frontmatter validator 的回归测试；
- 记录编辑历史。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- 新增 docs contract test
- Rust suite：613 lib、271 CLI（本地跳过仍读取原 checkout 全局 docs 链接的环境测试）、其余 bins/integration/doc tests 全部通过
- `yarn check-all`

关联 #546、#554。

---

## English

### Problem

The merged caps extraction contract used the unregistered frontmatter category `packages`. When
`~/.config/calcit/docs` points at this repository, `calcit docs list/read/search` fails while loading the guidebook.

### Changes

- change `docs/run/caps-extraction-contract.md` to the registered `run` category;
- add a regression that reads the real repository document and invokes the frontmatter validator;
- record the editing history.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- new docs contract test
- Rust suite: 613 library tests, 271 CLI tests (locally skipping the environment test that still reads the global docs link to the original checkout), and all remaining bin/integration/doc tests
- `yarn check-all`

Related to #546 and #554.
