### PR TITLE
perf: 增加 revision-safe Calx artifact cache / add a revision-safe Calx artifact cache

### DIFF
--- a/docs/run/calx-benchmark.md
+++ b/docs/run/calx-benchmark.md
@@ -89,6 +89,26 @@ release profile 默认移除 debug info；上面的临时 Cargo override 只为 
 迭代数、阶段摘要和可复查的 top stacks。profile mode 仍然执行完整 compile pipeline，因此它用于定位
 cache candidate，不代表 cache-hit 成本。
 
+### Cache profile 模式
+
+显式传入 `--cache-profile-iterations` 会先产生一次完整 cache miss，再对同一 snapshot/entry 重复执行
+revision validation、fresh host-binding attachment、fresh VM setup 与执行。它另外测量 reused Calx VM 和
+cached Calcit callable，避免把 cache-hit prepare 与纯执行混成一个数字：
+
+```bash
+cargo run --release --bin calcit-calx-bench -- \
+  --kernel affine --size 1000 \
+  --cache-profile-warmup 100 \
+  --cache-profile-iterations 10000
+```
+
+成功 stdout 只有一个 `calcit-calx-cache-profile/1` JSON。报告包含 initial miss 的完整 compile stages、
+hit prepare/revision validation/binding attachment、fresh VM setup/execution、reused VM execution、cached
+native execution，以及 cache hit/miss/entry/instruction/estimated-byte gauges。每条路径都执行同一输入并与
+Calcit 结果核对后才输出 `correctness: true`。compile-profile 与 cache-profile 参数互斥，失败不输出 partial
+JSON。该新 schema 不修改冻结的 `calcit-calx-benchmark/2` 历史报告；迁移到独立 harness 后由新仓库负责
+跨机器样本、median/MAD 与 crossover 汇总。
+
 ### 阶段定义
 
 - `fixtureInstallNs`：解析并安装固定 source fixture；
@@ -210,6 +230,27 @@ size, while the replaced block is not counted again as an explicit deallocation.
 Raw Samply/Instruments artifacts stay under `target/`; the repository records tool versions, commit, hardware,
 commands, iteration counts, stage summaries, and reviewable top stacks. Profile mode still executes the complete
 compile pipeline, so it locates cache candidates but does not model cache-hit cost.
+
+### Cache profile mode
+
+Passing `--cache-profile-iterations` first records one complete cache miss, then repeatedly measures revision
+validation, fresh host-binding attachment, fresh VM setup, and execution for the same snapshot and entry. It also
+measures a reused Calx VM and a cached Calcit callable so cache-hit preparation is not conflated with pure execution:
+
+```bash
+cargo run --release --bin calcit-calx-bench -- \
+  --kernel affine --size 1000 \
+  --cache-profile-warmup 100 \
+  --cache-profile-iterations 10000
+```
+
+Successful stdout contains exactly one `calcit-calx-cache-profile/1` JSON value. The report includes complete
+initial-miss compilation stages; hit preparation, revision validation, and binding attachment; fresh VM setup and
+execution; reused-VM and cached-native execution; and cache hit/miss/entry/instruction/estimated-byte gauges. Every
+path executes the same input and is compared with the Calcit result before `correctness: true` is emitted. Compile
+and cache profile modes are mutually exclusive, and failures emit no partial JSON. This new schema does not rewrite
+the frozen `calcit-calx-benchmark/2` archive. After extraction, the standalone harness owns cross-machine sampling,
+median/MAD aggregation, and crossover reports.
 
 ### Phase definitions
 

--- a/docs/run/calx-compile-cache.md
+++ b/docs/run/calx-compile-cache.md
@@ -2,6 +2,13 @@
 
 Tracking: [calcit#552](https://github.com/calcit-lang/calcit/issues/552) and [calx-vm#39](https://github.com/calcit-lang/calx-vm/issues/39)
 
+Implementation status: the embedding-owned in-memory artifact cache described
+here is implemented in Calcit core. Standalone benchmark ownership and the
+cross-machine cache-hit evidence archive remain tracked separately by calcit#558/#559.
+
+实现状态：本文定义的 embedding-owned 内存 artifact cache 已在 Calcit core 实现；独立 benchmark
+归属与跨机器 cache-hit 证据归档仍由 calcit#558/#559 分开追踪。
+
 ## 中文
 
 ### Profile 结论
@@ -29,7 +36,10 @@ Samply 的 20,987 个 CPU samples 将主要 inclusive 路径定位到 `emit_expr
   `CalxHostBindings`；运行或建立 fresh VM 只通过这一层。
 
 callback、capability state、buffer input、VM instance、stack/frame 和 runtime trap 都不进入 artifact。
-缓存命中也必须重新校验 typed import declarations，并从本次 `CalxHostImports` 重新附着 callbacks。
+缓存命中也必须重新校验 typed import declarations 与实际使用的 Calcit import definition schema，并从本次
+`CalxHostImports` 重新附着 callbacks。
+当前 Calx `ValidatedProgram` 含单线程 `Rc` 值，因此 artifact 也以 `Rc` 在一个 embedding thread 内共享，
+不承诺 `Send`/`Sync`；跨线程宿主应各自持有 cache，不能用 `Arc` 伪装线程安全。
 
 ### Revision key 与命中算法
 
@@ -64,13 +74,15 @@ lookup 顺序：
 
 ### API、容量与观测
 
-公共能力优先以对象方法提供。建议的实验接口为：
+公共能力优先以对象方法提供。当前实验接口为：
 
-```text
-CalxCompileCache::new(capacity)
-cache.prepare(program, namespace, definition, imports)
-cache.stats()
-cache.clear()
+```rust
+let mut cache = CalxCompileCache::new(8);
+let preparation = cache.prepare(program, namespace, definition, imports)?;
+let value = preparation.kernel().run(args)?;
+let report = preparation.report();
+let stats = cache.stats();
+cache.clear();
 ```
 
 `capacity` 首版按 artifact 个数设置硬上限，使用确定性的 LRU eviction；不得无界增长。stats 至少包含 hit、
@@ -78,6 +90,9 @@ miss、miss reason、eviction、clear、entry count、reachable function count�
 miss reason 固定区分 `empty`、`entry-changed`、`callee-changed`、`schema-changed`、`abi-changed`、
 `import-contract-changed`、`dependency-missing` 和 `evicted`。命中报告明确标记跳过 eligibility、planning、
 program construction、validation/lowering，但仍记录 revision validation 与 binding attachment 成本。
+`capacity == 0` 是受支持的 always-miss 模式：仍完整编译并重新附着 bindings，但不保存 artifact 或
+tombstone。`clear()` 清空 artifact 与 ledger、递增 clear counter，并保留其余历史 counters 供 embedding
+观察；current-entry、instruction 与 estimated-byte gauges 则立即归零。
 
 为了让 `evicted` 可判定，cache 维护独立的 recently-evicted slot-key ledger。ledger 保存完整 slot key，容量不超过
 artifact capacity，并按确定性的 LRU 顺序裁剪；它不是 artifact，也不保存 program、callback 或 definition stamp。
@@ -132,7 +147,10 @@ The first implementation splits the current `CalxCompiledKernel` into two layers
 
 Callbacks, capability state, buffer inputs, VM instances, stack/frame state, and runtime traps never enter the
 artifact. A cache hit must revalidate typed import declarations and attach callbacks again from the current
-`CalxHostImports` value.
+`CalxHostImports` value. It also rechecks the schema of every Calcit definition actually used as a host import. The
+current Calx `ValidatedProgram` contains single-threaded `Rc` values, so an artifact is
+also shared with `Rc` inside one embedding thread and makes no `Send`/`Sync` promise. Cross-thread hosts own separate
+caches rather than using `Arc` to imply thread safety that the VM does not provide.
 
 ### Revision key and hit algorithm
 
@@ -170,13 +188,15 @@ invalidating every Calx artifact for an unrelated definition update.
 
 ### API, capacity, and observability
 
-Public capability should be method-oriented. The proposed experimental surface is:
+Public capability is method-oriented. The current experimental surface is:
 
-```text
-CalxCompileCache::new(capacity)
-cache.prepare(program, namespace, definition, imports)
-cache.stats()
-cache.clear()
+```rust
+let mut cache = CalxCompileCache::new(8);
+let preparation = cache.prepare(program, namespace, definition, imports)?;
+let value = preparation.kernel().run(args)?;
+let report = preparation.report();
+let stats = cache.stats();
+cache.clear();
 ```
 
 The first `capacity` is a hard artifact-count limit with deterministic LRU eviction; growth is never unbounded.
@@ -185,6 +205,10 @@ syntax/instruction count, and estimated bytes. Stable miss reasons distinguish `
 `callee-changed`, `schema-changed`, `abi-changed`, `import-contract-changed`, `dependency-missing`, and `evicted`.
 A hit reports that eligibility, planning, program construction, and validation/lowering were skipped while still
 recording revision-validation and binding-attachment cost.
+Capacity zero is a supported always-miss mode: compilation and fresh binding attachment still occur, but no artifact
+or tombstone is retained. `clear()` removes artifacts and the ledger and increments the clear counter while retaining
+historical hit/miss/eviction counters; current entry, instruction, and estimated-byte gauges immediately return to
+zero.
 
 To make `evicted` observable, the cache keeps a separate recently-evicted slot-key ledger. It stores complete slot
 keys, is bounded to at most the artifact capacity, and is trimmed in deterministic LRU order. It is not an artifact

--- a/docs/run/calx-harness-extraction.md
+++ b/docs/run/calx-harness-extraction.md
@@ -74,6 +74,10 @@ scalar source fixture 是唯一明确允许 copy-with-provenance 的共享资产
   schema `calcit-calx-benchmark/2`; progress and diagnostics never share stdout.
 - A successful suite writes schema `calcit-calx-benchmark-suite/2` and preserves
   every `rawSamples` entry in addition to median and median absolute deviation.
+- The core transition adds opt-in `calcit-calx-compile-profile/1` and
+  `calcit-calx-cache-profile/1` single-case evidence. Both schemas and their
+  commands migrate with the runner; they do not extend the archived suite-v2
+  objects in place.
 - Parse, build, correctness, schema, and runtime failures go to stderr and exit
   nonzero. Partial JSON is never reported as success.
 - Reports retain debug/release profile, OS/architecture/CPU/memory, complete
@@ -87,6 +91,8 @@ scalar source fixture 是唯一明确允许 copy-with-provenance 的共享资产
 - 单 case 成功时 stdout 只写一个 `calcit-calx-benchmark/2` JSON；进度和诊断不混入 stdout。
 - suite 成功时写 `calcit-calx-benchmark-suite/2`，在 median 与 MAD 之外保留全部
   `rawSamples`。
+- core 迁移期新增 opt-in 的 `calcit-calx-compile-profile/1` 与
+  `calcit-calx-cache-profile/1` 单 case 证据；schema 与命令随 runner 一起迁移，不原地扩展历史 suite-v2。
 - parse/build/correctness/schema/runtime 失败写 stderr 并非零退出，不把 partial JSON 当成功结果。
 - 报告保留 profile、主机/工具链、精确 Calcit commit 与 dirty 状态、resolved `calx-vm`
   版本、workload/matrix/settings、预热政策和未覆盖范围。

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -32,6 +32,28 @@ let kernel = compile_calx_kernel(&snapshot, "app.kernel", "range-sum")?;
 let value = kernel.run(&[Calcit::Number(10.0), Calcit::Number(0.0)])?;
 ```
 
+需要跨重复请求复用完整 validated artifact 时，由 embedding 显式持有有界 cache；cache 不进入全局状态：
+
+```rust
+use calcit::codegen::calx::{CalxCompileCache, CalxHostImports};
+
+let mut cache = CalxCompileCache::new(8);
+let imports = CalxHostImports::new();
+let preparation = cache.prepare(&snapshot, "app.kernel", "range-sum", &imports)?;
+assert!(!preparation.report().cache_hit);
+
+let hit = cache.prepare(&snapshot, "app.kernel", "range-sum", &imports)?;
+assert!(hit.report().cache_hit);
+let value = hit.kernel().run(&[Calcit::Number(10.0), Calcit::Number(0.0)])?;
+```
+
+cache 保存的 `CalxCompiledArtifact` 只有 eligible graph、strict boundary、`ValidatedProgram`、reachable
+definition structural stamps、used-import schema stamps、ABI 与 callback-free import contract。`CalxPreparedKernel` 每次由当前
+`CalxHostImports` 新建，host callback、capability state、VM、buffer input 与 runtime state 都不会进入
+artifact。命中逐项核对旧 reachable set；entry/direct/transitive/schema 变化会 miss，无关 definition
+变化保持 hit。API、LRU、eviction ledger、miss reason 与统计契约见
+[revision-safe cache 文档](./calx-compile-cache.md)。
+
 需要宿主能力时，embedding 必须显式构造 `CalxHostImports`，以 Calcit definition 为 capability key，
 再调用 `analyze_calx_eligibility_with_imports` / `compile_calx_kernel_with_imports`。普通未知调用不会自动
 变成 import，allowlist 中的 declaration 也必须与 typed snapshot 的 fixed-arity Number/Bool/Unit
@@ -130,7 +152,9 @@ generated-program golden 固定 import declaration、guest syntax 与 Calcit tre
 ## 尚未实现
 
 当前 API 仍是 Rust embedding，不是 `calcit` CLI 的正式 backend。首批没有 collection/nominal value、closure、
-cache、profiling/selection policy，也还没有基于 benchmark 的自动 offload。correctness corpus 已覆盖 scalar
+持久化 cache、VM pool 或 selection policy，也还没有基于 benchmark 的自动 offload。embedding-owned、
+容量有界、revision-safe 的 validated-artifact cache 已实现，但 cache-hit 性能报告仍等待独立 harness。
+correctness corpus 已覆盖 scalar
 kernel、zero/single-result typed imports、generated program、trap 与 fallback。分阶段 benchmark matrix、
 采样 crossover point 和首份 scalar baseline 已建立；[calx-vm #39](https://github.com/calcit-lang/calx-vm/issues/39)
 现已补充公平的 cached Calcit callable 基线：有限 scalar 样本仍显示 Calx hot 收益，但 lookup-call 对比确实

--- a/editing-history/202608311817-calx-artifact-cache.md
+++ b/editing-history/202608311817-calx-artifact-cache.md
@@ -1,0 +1,19 @@
+# Calx revision-safe artifact cache / Calx revision-safe artifact 缓存
+
+## 中文
+
+- 将原先同时持有 validated program 与 host callbacks 的 kernel 拆成 immutable `CalxCompiledArtifact` 与每次请求重新构造的 `CalxPreparedKernel`。
+- 新增 embedding-owned、容量有界、确定性 LRU 的 `CalxCompileCache`；缓存只保存 source-derived artifact，不保存 callback、capability state、VM、输入或 runtime state。
+- cache hit 逐项核对 reachable definition 的结构化 code/schema，并额外核对实际使用的 Calcit host-import definition schema；同 contract 的 callback 热替换继续命中，但静态签名变化必须 miss。
+- miss reason、eviction ledger、clear、capacity-zero、stale callback、entry/callee/schema/unrelated change 与 negative eligibility 均有回归覆盖。
+- 增加迁移期 `calcit-calx-cache-profile/1` 单 JSON runner contract，分开报告 revision validation、binding attachment、fresh VM、reused VM、cached Calcit 与估算 cache bytes；该 runner/schema 后续随独立 harness 迁移。
+- strict Calx boundary 继续只接受 concrete Number/Bool/Unit；本次没有增加 Nil、Dynamic、List coercion、VM pool 或自动 offload。
+
+## English
+
+- Split the former kernel, which combined a validated program with host callbacks, into an immutable `CalxCompiledArtifact` and a freshly attached `CalxPreparedKernel` per request.
+- Added an embedding-owned, capacity-bounded, deterministic-LRU `CalxCompileCache`. Cached artifacts contain no callbacks, capability state, VM instances, inputs, or runtime state.
+- Cache hits validate structural code/schema for every reachable definition and also recheck the schema of each Calcit definition actually used as a host import. A callback replacement with the same contract remains a hit, while a static-signature change must miss.
+- Regression coverage includes miss reasons, the eviction ledger, clear, zero capacity, stale callbacks, entry/callee/schema/unrelated changes, and uncached negative eligibility.
+- Added the transitional single-JSON `calcit-calx-cache-profile/1` runner contract, separating revision validation, binding attachment, fresh VM, reused VM, cached Calcit, and estimated cache bytes. This runner and schema migrate with the standalone harness.
+- The strict Calx boundary remains limited to concrete Number/Bool/Unit values. This change adds no Nil, Dynamic, List coercion, VM pool, or automatic offload.

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -14,7 +14,9 @@ use std::time::{Duration, Instant};
 use argh::FromArgs;
 use calcit::calcit::{CalcitFn, CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind};
 use calcit::call_stack::CallStackList;
-use calcit::codegen::calx::{CalxCompiledKernel, CalxScalarType, CalxValue, compile_calx_kernel, compile_calx_kernel_measured};
+use calcit::codegen::calx::{
+  CalxCompileCache, CalxCompiledKernel, CalxHostImports, CalxScalarType, CalxValue, compile_calx_kernel, compile_calx_kernel_measured,
+};
 use calcit::data::cirru::code_to_calcit;
 use calcit::program::{PROGRAM_CODE_DATA, ProgramDefEntry, ProgramFileData, clone_existing_compiled_program, ensure_def_id};
 use calcit::{Calcit, run_program_with_docs};
@@ -142,6 +144,14 @@ struct Args {
   /// compilations used for allocation counters in profile mode
   #[argh(option, default = "10000")]
   compile_profile_allocation_iterations: u32,
+
+  /// cache hits measured with fresh binding attachment and VM setup; zero disables cache profile mode
+  #[argh(option, default = "0")]
+  cache_profile_iterations: u32,
+
+  /// cache-hit preparations discarded before cache profile measurement
+  #[argh(option, default = "100")]
+  cache_profile_warmup: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -232,6 +242,59 @@ struct CompileProfileReport {
   allocations: AllocationReport,
   allocations_per_iteration: AllocationReport,
   compilation_succeeded: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheProfileRuntimeReport {
+  initial_miss_prepare_ns: u64,
+  hit_prepare_total_ns: u64,
+  hit_prepare_per_iteration_ns: u64,
+  revision_validation_total_ns: u64,
+  revision_validation_per_iteration_ns: u64,
+  binding_attachment_total_ns: u64,
+  binding_attachment_per_iteration_ns: u64,
+  fresh_vm_setup_total_ns: u64,
+  fresh_vm_setup_per_iteration_ns: u64,
+  fresh_vm_execution_total_ns: u64,
+  fresh_vm_execution_per_iteration_ns: u64,
+  reused_vm_execution_total_ns: u64,
+  reused_vm_execution_per_iteration_ns: u64,
+  cached_native_execution_total_ns: u64,
+  cached_native_execution_per_iteration_ns: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheProfileStateReport {
+  capacity: usize,
+  hits: u64,
+  misses: u64,
+  initial_miss_reason: &'static str,
+  evictions: u64,
+  entries: usize,
+  reachable_functions: usize,
+  syntax_instructions: usize,
+  lowered_instructions: usize,
+  estimated_bytes: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CacheProfileReport {
+  schema: &'static str,
+  environment: EnvironmentReport,
+  kernel: String,
+  workload: &'static str,
+  warmup_iterations: u32,
+  measured_iterations: u32,
+  fixture_install_ns: u64,
+  calcit_frontend_ns: u64,
+  snapshot_clone_ns: u64,
+  initial_compile: CompileReport,
+  runtime: CacheProfileRuntimeReport,
+  cache: CacheProfileStateReport,
+  correctness: bool,
 }
 
 #[derive(Debug, Default, Serialize)]
@@ -440,6 +503,16 @@ fn add_compile_timings(report: &mut CompileReport, timings: calcit::codegen::cal
   report.total_ns = report.total_ns.saturating_add(nanos(timings.total));
 }
 
+fn compile_report(timings: calcit::codegen::calx::CalxKernelCompileTimings) -> CompileReport {
+  CompileReport {
+    eligibility_ns: nanos(timings.eligibility),
+    planning_ns: nanos(timings.planning),
+    program_construction_ns: nanos(timings.program_construction),
+    validation_lowering_ns: nanos(timings.validation_lowering),
+    total_ns: nanos(timings.total),
+  }
+}
+
 /// Amplify the complete compile pipeline so sampling and allocation profilers
 /// can distinguish its stages from process/frontend setup.
 fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> {
@@ -519,6 +592,171 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
     allocations,
     allocations_per_iteration,
     compilation_succeeded: true,
+  })
+}
+
+/// Measure cache-hit preparation separately from fresh-VM and reused-VM work.
+fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
+  if args.cache_profile_iterations == 0 {
+    return Err("--cache-profile-iterations must be greater than zero in cache profile mode".to_owned());
+  }
+
+  let fixture_started = Instant::now();
+  install_fixture()?;
+  let fixture_install_ns = nanos(fixture_started.elapsed());
+
+  let frontend_started = Instant::now();
+  let warnings = RefCell::new(vec![]);
+  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
+    .map_err(|error| error.to_string())?;
+  if !warnings.borrow().is_empty() {
+    return Err(format!("Calx cache profile frontend produced warnings: {:#?}", warnings.borrow()));
+  }
+  let calcit_frontend_ns = nanos(frontend_started.elapsed());
+
+  let snapshot_started = Instant::now();
+  let snapshot = clone_existing_compiled_program();
+  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
+  let imports = CalxHostImports::new();
+  let mut cache = CalxCompileCache::new(1);
+  let initial_started = Instant::now();
+  let initial = cache
+    .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+    .map_err(|error| error.to_string())?;
+  let initial_miss_prepare_ns = nanos(initial_started.elapsed());
+  let initial_miss_reason = initial
+    .report()
+    .miss_reason
+    .ok_or_else(|| "initial cache preparation unexpectedly hit".to_owned())?;
+  let initial_compile = compile_report(
+    initial
+      .report()
+      .compilation
+      .ok_or_else(|| "initial cache miss did not report compilation stages".to_owned())?,
+  );
+  let initial_kernel = initial.into_kernel();
+  let calcit_args = kernel_arguments(&args.kernel, args.size)?;
+  let vm_args = convert_arguments(&initial_kernel, &calcit_args)?;
+
+  let native_result = run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from(args.kernel.as_str()), &calcit_args)
+    .map_err(|error| error.to_string())?;
+  let native_call_stack = CallStackList::default();
+  let cached_native_callable = resolve_cached_calcit_callable(&args.kernel, &native_call_stack)?;
+
+  for _ in 0..args.cache_profile_warmup {
+    let preparation = cache
+      .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+      .map_err(|error| error.to_string())?;
+    if !preparation.report().cache_hit {
+      return Err("cache profile warmup unexpectedly missed".to_owned());
+    }
+    let mut vm = preparation.kernel().instantiate().map_err(|error| error.to_string())?;
+    black_box(vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?);
+    black_box(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+  }
+
+  let mut hit_prepare_total_ns = 0u64;
+  let mut revision_validation_total_ns = 0u64;
+  let mut binding_attachment_total_ns = 0u64;
+  let mut fresh_vm_setup_total_ns = 0u64;
+  let mut fresh_vm_execution_total_ns = 0u64;
+  let mut last_fresh_result = None;
+  for _ in 0..args.cache_profile_iterations {
+    let prepare_started = Instant::now();
+    let preparation = cache
+      .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+      .map_err(|error| error.to_string())?;
+    hit_prepare_total_ns = hit_prepare_total_ns.saturating_add(nanos(prepare_started.elapsed()));
+    if !preparation.report().cache_hit {
+      return Err("cache profile measured preparation unexpectedly missed".to_owned());
+    }
+    revision_validation_total_ns = revision_validation_total_ns.saturating_add(nanos(preparation.report().revision_validation));
+    binding_attachment_total_ns = binding_attachment_total_ns.saturating_add(nanos(preparation.report().binding_attachment));
+
+    let setup_started = Instant::now();
+    let mut vm = preparation.kernel().instantiate().map_err(|error| error.to_string())?;
+    fresh_vm_setup_total_ns = fresh_vm_setup_total_ns.saturating_add(nanos(setup_started.elapsed()));
+    let execution_started = Instant::now();
+    let result = vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?;
+    fresh_vm_execution_total_ns = fresh_vm_execution_total_ns.saturating_add(nanos(execution_started.elapsed()));
+    last_fresh_result = Some(convert_result(preparation.kernel(), result)?);
+  }
+
+  let mut reused_vm = initial_kernel.instantiate().map_err(|error| error.to_string())?;
+  for _ in 0..args.cache_profile_warmup {
+    black_box(reused_vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?);
+  }
+  let reused_started = Instant::now();
+  let mut last_reused_result = None;
+  for _ in 0..args.cache_profile_iterations {
+    last_reused_result = Some(convert_result(
+      &initial_kernel,
+      reused_vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?,
+    )?);
+  }
+  let reused_vm_execution_total_ns = nanos(reused_started.elapsed());
+
+  let cached_native_started = Instant::now();
+  let mut last_cached_native_result = None;
+  for _ in 0..args.cache_profile_iterations {
+    last_cached_native_result =
+      Some(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+  }
+  let cached_native_execution_total_ns = nanos(cached_native_started.elapsed());
+
+  if last_fresh_result.as_ref() != Some(&native_result)
+    || last_reused_result.as_ref() != Some(&native_result)
+    || last_cached_native_result.as_ref() != Some(&native_result)
+  {
+    return Err(format!(
+      "cache profile correctness mismatch for {}/{}",
+      FIXTURE_NAMESPACE, args.kernel
+    ));
+  }
+
+  let divisor = u64::from(args.cache_profile_iterations);
+  let stats = cache.stats();
+  Ok(CacheProfileReport {
+    schema: "calcit-calx-cache-profile/1",
+    environment: environment_report()?,
+    kernel: args.kernel.clone(),
+    workload: "revision-validated-cache-hit-plus-fresh-vm",
+    warmup_iterations: args.cache_profile_warmup,
+    measured_iterations: args.cache_profile_iterations,
+    fixture_install_ns,
+    calcit_frontend_ns,
+    snapshot_clone_ns,
+    initial_compile,
+    runtime: CacheProfileRuntimeReport {
+      initial_miss_prepare_ns,
+      hit_prepare_total_ns,
+      hit_prepare_per_iteration_ns: hit_prepare_total_ns / divisor,
+      revision_validation_total_ns,
+      revision_validation_per_iteration_ns: revision_validation_total_ns / divisor,
+      binding_attachment_total_ns,
+      binding_attachment_per_iteration_ns: binding_attachment_total_ns / divisor,
+      fresh_vm_setup_total_ns,
+      fresh_vm_setup_per_iteration_ns: fresh_vm_setup_total_ns / divisor,
+      fresh_vm_execution_total_ns,
+      fresh_vm_execution_per_iteration_ns: fresh_vm_execution_total_ns / divisor,
+      reused_vm_execution_total_ns,
+      reused_vm_execution_per_iteration_ns: reused_vm_execution_total_ns / divisor,
+      cached_native_execution_total_ns,
+      cached_native_execution_per_iteration_ns: cached_native_execution_total_ns / divisor,
+    },
+    cache: CacheProfileStateReport {
+      capacity: cache.capacity(),
+      hits: stats.hits,
+      misses: stats.misses,
+      initial_miss_reason: initial_miss_reason.as_str(),
+      evictions: stats.evictions,
+      entries: stats.entry_count,
+      reachable_functions: stats.reachable_function_count,
+      syntax_instructions: stats.syntax_instruction_count,
+      lowered_instructions: stats.lowered_instruction_count,
+      estimated_bytes: stats.estimated_bytes,
+    },
+    correctness: true,
   })
 }
 
@@ -669,10 +907,14 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
 /// Emit exactly one JSON report on success and keep failures on stderr.
 fn main() {
   let args: Args = argh::from_env();
-  let report = if args.compile_profile_iterations == 0 {
-    measure(&args).and_then(|report| serde_json::to_string(&report).map_err(|error| error.to_string()))
-  } else {
+  let report = if args.compile_profile_iterations > 0 && args.cache_profile_iterations > 0 {
+    Err("compile profile mode and cache profile mode are mutually exclusive".to_owned())
+  } else if args.compile_profile_iterations > 0 {
     measure_compile_profile(&args).and_then(|report| serde_json::to_string(&report).map_err(|error| error.to_string()))
+  } else if args.cache_profile_iterations > 0 {
+    measure_cache_profile(&args).and_then(|report| serde_json::to_string(&report).map_err(|error| error.to_string()))
+  } else {
+    measure(&args).and_then(|report| serde_json::to_string(&report).map_err(|error| error.to_string()))
   };
   match report {
     Ok(json) => println!("{json}"),
@@ -727,6 +969,8 @@ mod tests {
       compile_profile_warmup: 1,
       compile_profile_stage_iterations: 2,
       compile_profile_allocation_iterations: 2,
+      cache_profile_iterations: 0,
+      cache_profile_warmup: 0,
     })
     .expect("measure repeated complete compilation");
 
@@ -748,5 +992,39 @@ mod tests {
     let serialized = serde_json::to_value(&report).expect("serialize compile profile report");
     assert_eq!(serialized["compilationSucceeded"], true);
     assert!(serialized.get("correctness").is_none());
+  }
+
+  #[test]
+  fn cache_profile_separates_hit_validation_binding_and_fresh_vm_costs() {
+    let report = measure_cache_profile(&Args {
+      kernel: "affine".to_owned(),
+      size: 10,
+      vm_warmup: 0,
+      hot_iterations: 1,
+      compile_profile_iterations: 0,
+      compile_profile_warmup: 0,
+      compile_profile_stage_iterations: 1,
+      compile_profile_allocation_iterations: 1,
+      cache_profile_iterations: 2,
+      cache_profile_warmup: 1,
+    })
+    .expect("measure revision-safe cache hits");
+
+    assert_eq!(report.schema, "calcit-calx-cache-profile/1");
+    assert_eq!(report.workload, "revision-validated-cache-hit-plus-fresh-vm");
+    assert_eq!(report.cache.capacity, 1);
+    assert_eq!(report.cache.misses, 1);
+    assert_eq!(report.cache.initial_miss_reason, "empty");
+    assert_eq!(report.cache.evictions, 0);
+    assert_eq!(report.cache.entries, 1);
+    assert_eq!(report.cache.hits, 3);
+    assert!(report.cache.estimated_bytes > 0);
+    assert!(report.initial_compile.total_ns > 0);
+    assert!(report.runtime.hit_prepare_total_ns > 0);
+    assert!(report.runtime.fresh_vm_setup_total_ns > 0);
+    assert!(report.runtime.fresh_vm_execution_total_ns > 0);
+    assert!(report.runtime.reused_vm_execution_total_ns > 0);
+    assert!(report.runtime.cached_native_execution_total_ns > 0);
+    assert!(report.correctness);
   }
 }

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -5,13 +5,15 @@
 //! call graph, or one stable fallback report. Eligible graphs can then be lowered through
 //! `calx_vm::ProgramBuilder` and strict validation without admitting Nil or Dynamic values.
 
+mod cache;
 mod lowering;
 
+pub use cache::{CalxCacheMissReason, CalxCachePreparation, CalxCachePrepareReport, CalxCompileCache, CalxCompileCacheStats};
 pub use calx_vm::{Calx as CalxValue, CalxBuildError, CalxError, CalxProgramError};
 pub use lowering::{
-  CalxCompiledKernel, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelCompileTimings,
-  CalxKernelRunError, CalxLoweringError, compile_calx_kernel, compile_calx_kernel_measured, compile_calx_kernel_with_imports,
-  compile_calx_kernel_with_imports_measured,
+  CalxCompiledArtifact, CalxCompiledKernel, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind, CalxKernelCompileError,
+  CalxKernelCompileTimings, CalxKernelRunError, CalxLoweringError, CalxPreparedKernel, compile_calx_kernel,
+  compile_calx_kernel_measured, compile_calx_kernel_with_imports, compile_calx_kernel_with_imports_measured,
 };
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -79,6 +81,15 @@ pub struct CalxHostImport {
   binding: CalxHostBinding,
 }
 
+/// Callback-free typed declaration used in revision-safe Calx artifact keys.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CalxImportContract {
+  pub definition: CalxDefinitionRef,
+  pub export_name: Arc<str>,
+  pub params: Vec<CalxScalarType>,
+  pub result: Option<CalxScalarType>,
+}
+
 impl CalxHostImport {
   /// Declares a zero-result import backed by `Result<(), CalxError>`.
   pub fn void(
@@ -130,13 +141,29 @@ impl CalxHostImport {
     self.result
   }
 
-  fn binding(&self) -> &CalxHostBinding {
+  fn contract(&self, definition: CalxDefinitionRef) -> CalxImportContract {
+    CalxImportContract {
+      definition,
+      export_name: self.name.clone(),
+      params: self.params.clone(),
+      result: self.result,
+    }
+  }
+
+  pub(super) fn binding(&self) -> &CalxHostBinding {
     &self.binding
   }
 }
 
 /// Explicit Calcit-definition to Calx-host-capability mapping.
 pub type CalxHostImports = BTreeMap<CalxDefinitionRef, CalxHostImport>;
+
+fn import_contract(imports: &CalxHostImports) -> Vec<CalxImportContract> {
+  imports
+    .iter()
+    .map(|(definition, import)| import.contract(definition.clone()))
+    .collect()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CalxFallbackCode {

--- a/src/codegen/calx/cache.rs
+++ b/src/codegen/calx/cache.rs
@@ -1,0 +1,431 @@
+//! Embedding-owned, revision-safe cache for immutable Calx artifacts.
+
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::program::CompiledProgram;
+
+use super::lowering::{
+  CalxCompiledArtifact, CalxKernelCompileError, CalxKernelCompileTimings, CalxPreparedKernel,
+  compile_calx_artifact_with_imports_measured, prepare_calx_artifact,
+};
+use super::{CALX_KERNEL_ABI_EDITION, CalxDefinitionRef, CalxHostImports, CalxImportContract, import_contract, lookup_compiled_def};
+
+/// Stable reason assigned to one source-derived cache miss.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalxCacheMissReason {
+  Empty,
+  EntryChanged,
+  CalleeChanged,
+  SchemaChanged,
+  AbiChanged,
+  ImportContractChanged,
+  DependencyMissing,
+  Evicted,
+}
+
+impl CalxCacheMissReason {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::Empty => "empty",
+      Self::EntryChanged => "entry-changed",
+      Self::CalleeChanged => "callee-changed",
+      Self::SchemaChanged => "schema-changed",
+      Self::AbiChanged => "abi-changed",
+      Self::ImportContractChanged => "import-contract-changed",
+      Self::DependencyMissing => "dependency-missing",
+      Self::Evicted => "evicted",
+    }
+  }
+}
+
+/// Aggregate counters and current bounded-cache gauges.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CalxCompileCacheStats {
+  pub hits: u64,
+  pub misses: u64,
+  pub misses_by_reason: BTreeMap<CalxCacheMissReason, u64>,
+  pub evictions: u64,
+  pub clears: u64,
+  pub entry_count: usize,
+  pub recently_evicted_count: usize,
+  pub reachable_function_count: usize,
+  pub syntax_instruction_count: usize,
+  pub lowered_instruction_count: usize,
+  pub estimated_bytes: usize,
+}
+
+impl CalxCompileCacheStats {
+  pub fn miss_count(&self, reason: CalxCacheMissReason) -> u64 {
+    self.misses_by_reason.get(&reason).copied().unwrap_or(0)
+  }
+}
+
+/// Per-request evidence showing which stages were skipped or executed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxCachePrepareReport {
+  pub cache_hit: bool,
+  pub miss_reason: Option<CalxCacheMissReason>,
+  pub skipped_eligibility: bool,
+  pub skipped_planning: bool,
+  pub skipped_program_construction: bool,
+  pub skipped_validation_lowering: bool,
+  pub revision_validation: Duration,
+  pub binding_attachment: Duration,
+  pub compilation: Option<CalxKernelCompileTimings>,
+}
+
+/// A freshly prepared kernel and the cache decision that produced it.
+#[derive(Debug)]
+pub struct CalxCachePreparation {
+  kernel: CalxPreparedKernel,
+  report: CalxCachePrepareReport,
+}
+
+impl CalxCachePreparation {
+  pub fn kernel(&self) -> &CalxPreparedKernel {
+    &self.kernel
+  }
+
+  pub fn report(&self) -> &CalxCachePrepareReport {
+    &self.report
+  }
+
+  pub fn into_kernel(self) -> CalxPreparedKernel {
+    self.kernel
+  }
+
+  pub fn into_parts(self) -> (CalxPreparedKernel, CalxCachePrepareReport) {
+    (self.kernel, self.report)
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CalxCacheSlotKey {
+  entry: CalxDefinitionRef,
+  abi_edition: Arc<str>,
+  imports: Vec<CalxImportContract>,
+}
+
+impl CalxCacheSlotKey {
+  fn current(entry: CalxDefinitionRef, imports: &CalxHostImports) -> Self {
+    Self {
+      entry,
+      abi_edition: Arc::from(CALX_KERNEL_ABI_EDITION),
+      imports: import_contract(imports),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+struct CalxCacheEntry {
+  artifact: Rc<CalxCompiledArtifact>,
+  last_used: u64,
+}
+
+#[derive(Debug, Default)]
+struct CalxCacheCounters {
+  hits: u64,
+  misses: u64,
+  misses_by_reason: BTreeMap<CalxCacheMissReason, u64>,
+  evictions: u64,
+  clears: u64,
+}
+
+/// Explicit, capacity-bounded LRU cache owned by one embedding.
+///
+/// The cache stores only immutable source-derived artifacts. Host bindings are
+/// checked and reattached on every prepare, including cache hits.
+#[derive(Debug)]
+pub struct CalxCompileCache {
+  capacity: usize,
+  clock: u64,
+  entries: BTreeMap<CalxCacheSlotKey, CalxCacheEntry>,
+  recently_evicted: BTreeMap<CalxCacheSlotKey, u64>,
+  counters: CalxCacheCounters,
+}
+
+impl CalxCompileCache {
+  /// Create a bounded cache. Capacity zero is a supported always-miss mode.
+  pub fn new(capacity: usize) -> Self {
+    Self {
+      capacity,
+      clock: 0,
+      entries: BTreeMap::new(),
+      recently_evicted: BTreeMap::new(),
+      counters: CalxCacheCounters::default(),
+    }
+  }
+
+  pub fn capacity(&self) -> usize {
+    self.capacity
+  }
+
+  /// Validate dependencies, compile on miss, and attach this request's hosts.
+  pub fn prepare(
+    &mut self,
+    program: &CompiledProgram,
+    namespace: impl Into<Arc<str>>,
+    definition: impl Into<Arc<str>>,
+    imports: &CalxHostImports,
+  ) -> Result<CalxCachePreparation, CalxKernelCompileError> {
+    let entry = CalxDefinitionRef::new(namespace, definition);
+    let key = CalxCacheSlotKey::current(entry, imports);
+    let revision_started = Instant::now();
+    let candidate = self.entries.get(&key).map(|entry| entry.artifact.clone());
+    let miss_reason = match candidate.as_ref() {
+      Some(artifact) => validate_reachable_stamps(program, artifact),
+      None => Some(self.classify_absent_slot(&key)),
+    };
+    let revision_validation = revision_started.elapsed();
+
+    if let (Some(artifact), None) = (candidate, miss_reason) {
+      let binding_started = Instant::now();
+      let kernel = prepare_calx_artifact(artifact, imports)?;
+      let binding_attachment = binding_started.elapsed();
+      let tick = self.next_tick();
+      if let Some(entry) = self.entries.get_mut(&key) {
+        entry.last_used = tick;
+      }
+      self.counters.hits += 1;
+      return Ok(CalxCachePreparation {
+        kernel,
+        report: CalxCachePrepareReport {
+          cache_hit: true,
+          miss_reason: None,
+          skipped_eligibility: true,
+          skipped_planning: true,
+          skipped_program_construction: true,
+          skipped_validation_lowering: true,
+          revision_validation,
+          binding_attachment,
+          compilation: None,
+        },
+      });
+    }
+
+    let reason = miss_reason.unwrap_or(CalxCacheMissReason::Empty);
+    self.record_miss(reason);
+    let (artifact, compilation) =
+      compile_calx_artifact_with_imports_measured(program, key.entry.namespace.clone(), key.entry.definition.clone(), imports)?;
+    let binding_started = Instant::now();
+    let kernel = prepare_calx_artifact(artifact.clone(), imports)?;
+    let binding_attachment = binding_started.elapsed();
+    self.insert(key, artifact);
+    Ok(CalxCachePreparation {
+      kernel,
+      report: CalxCachePrepareReport {
+        cache_hit: false,
+        miss_reason: Some(reason),
+        skipped_eligibility: false,
+        skipped_planning: false,
+        skipped_program_construction: false,
+        skipped_validation_lowering: false,
+        revision_validation,
+        binding_attachment,
+        compilation: Some(compilation),
+      },
+    })
+  }
+
+  /// Remove artifacts and eviction provenance while retaining counters.
+  pub fn clear(&mut self) {
+    self.entries.clear();
+    self.recently_evicted.clear();
+    self.counters.clears += 1;
+  }
+
+  pub fn stats(&self) -> CalxCompileCacheStats {
+    let mut stats = CalxCompileCacheStats {
+      hits: self.counters.hits,
+      misses: self.counters.misses,
+      misses_by_reason: self.counters.misses_by_reason.clone(),
+      evictions: self.counters.evictions,
+      clears: self.counters.clears,
+      entry_count: self.entries.len(),
+      recently_evicted_count: self.recently_evicted.len(),
+      ..CalxCompileCacheStats::default()
+    };
+    for entry in self.entries.values() {
+      stats.reachable_function_count += entry.artifact.reachable_definition_count();
+      stats.syntax_instruction_count += entry.artifact.syntax_instruction_count();
+      stats.lowered_instruction_count += entry.artifact.lowered_instruction_count();
+      stats.estimated_bytes += entry.artifact.estimated_bytes();
+    }
+    stats
+  }
+
+  fn classify_absent_slot(&self, key: &CalxCacheSlotKey) -> CalxCacheMissReason {
+    if self.recently_evicted.contains_key(key) {
+      return CalxCacheMissReason::Evicted;
+    }
+    for active in self.entries.keys().filter(|active| active.entry == key.entry) {
+      if active.abi_edition != key.abi_edition {
+        return CalxCacheMissReason::AbiChanged;
+      }
+      if active.imports != key.imports {
+        return CalxCacheMissReason::ImportContractChanged;
+      }
+    }
+    CalxCacheMissReason::Empty
+  }
+
+  fn record_miss(&mut self, reason: CalxCacheMissReason) {
+    self.counters.misses += 1;
+    *self.counters.misses_by_reason.entry(reason).or_insert(0) += 1;
+  }
+
+  fn insert(&mut self, key: CalxCacheSlotKey, artifact: Rc<CalxCompiledArtifact>) {
+    self.recently_evicted.remove(&key);
+    if self.capacity == 0 {
+      return;
+    }
+    if !self.entries.contains_key(&key)
+      && self.entries.len() >= self.capacity
+      && let Some(evicted) = least_recent_key(&self.entries)
+    {
+      self.entries.remove(&evicted);
+      self.counters.evictions += 1;
+      self.record_evicted(evicted);
+    }
+    let tick = self.next_tick();
+    self.entries.insert(key, CalxCacheEntry { artifact, last_used: tick });
+  }
+
+  fn record_evicted(&mut self, key: CalxCacheSlotKey) {
+    if self.capacity == 0 {
+      return;
+    }
+    let tick = self.next_tick();
+    self.recently_evicted.insert(key, tick);
+    while self.recently_evicted.len() > self.capacity {
+      let Some(oldest) = least_recent_tombstone(&self.recently_evicted) else {
+        break;
+      };
+      self.recently_evicted.remove(&oldest);
+    }
+  }
+
+  fn next_tick(&mut self) -> u64 {
+    self.clock = self.clock.wrapping_add(1);
+    self.clock
+  }
+}
+
+fn validate_reachable_stamps(program: &CompiledProgram, artifact: &CalxCompiledArtifact) -> Option<CalxCacheMissReason> {
+  for stamp in &artifact.reachable_stamps {
+    let Some(current) = lookup_compiled_def(program, &stamp.definition) else {
+      return Some(CalxCacheMissReason::DependencyMissing);
+    };
+    if current.schema != stamp.schema {
+      return Some(CalxCacheMissReason::SchemaChanged);
+    }
+    if current.def_id != stamp.def_id || current.preprocessed_code != stamp.preprocessed_code {
+      return Some(if stamp.definition == artifact.graph().entry {
+        CalxCacheMissReason::EntryChanged
+      } else {
+        CalxCacheMissReason::CalleeChanged
+      });
+    }
+  }
+  for stamp in &artifact.import_schema_stamps {
+    let Some(current) = lookup_compiled_def(program, &stamp.definition) else {
+      return Some(CalxCacheMissReason::DependencyMissing);
+    };
+    if current.schema != stamp.schema {
+      return Some(CalxCacheMissReason::SchemaChanged);
+    }
+  }
+  None
+}
+
+fn least_recent_key(entries: &BTreeMap<CalxCacheSlotKey, CalxCacheEntry>) -> Option<CalxCacheSlotKey> {
+  entries
+    .iter()
+    .min_by(|(left_key, left), (right_key, right)| left.last_used.cmp(&right.last_used).then_with(|| left_key.cmp(right_key)))
+    .map(|(key, _)| key.clone())
+}
+
+fn least_recent_tombstone(entries: &BTreeMap<CalxCacheSlotKey, u64>) -> Option<CalxCacheSlotKey> {
+  entries
+    .iter()
+    .min_by(|(left_key, left), (right_key, right)| left.cmp(right).then_with(|| left_key.cmp(right_key)))
+    .map(|(key, _)| key.clone())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn absent_slot_classification_distinguishes_abi_and_import_contract() {
+    let entry = CalxDefinitionRef::new("app.kernel", "main");
+    let current = CalxCacheSlotKey {
+      entry: entry.clone(),
+      abi_edition: Arc::from("calcit-calx-kernel/2"),
+      imports: vec![],
+    };
+    let mut cache = CalxCompileCache::new(2);
+    let old_abi = CalxCacheSlotKey {
+      entry: entry.clone(),
+      abi_edition: Arc::from("calcit-calx-kernel/1"),
+      imports: vec![],
+    };
+    cache.entries.insert(
+      old_abi,
+      CalxCacheEntry {
+        artifact: test_artifact(),
+        last_used: 1,
+      },
+    );
+    assert_eq!(cache.classify_absent_slot(&current), CalxCacheMissReason::AbiChanged);
+
+    cache.entries.clear();
+    let different_import = CalxCacheSlotKey {
+      entry,
+      abi_edition: Arc::from("calcit-calx-kernel/2"),
+      imports: vec![CalxImportContract {
+        definition: CalxDefinitionRef::new("app.host", "read"),
+        export_name: Arc::from("host.read"),
+        params: vec![],
+        result: None,
+      }],
+    };
+    cache.entries.insert(
+      different_import,
+      CalxCacheEntry {
+        artifact: test_artifact(),
+        last_used: 2,
+      },
+    );
+    assert_eq!(cache.classify_absent_slot(&current), CalxCacheMissReason::ImportContractChanged);
+  }
+
+  fn test_artifact() -> Rc<CalxCompiledArtifact> {
+    use calx_vm::{CalxFunc, CalxProgram, CalxSyntax, CalxType, ValidatedProgram};
+
+    let function = CalxFunc::new(
+      "main",
+      vec![],
+      vec![CalxType::F64],
+      vec![CalxSyntax::Const(super::super::CalxValue::F64(0.0))],
+    );
+    let program = CalxProgram::try_new(vec![function], vec![], vec![]).expect("test program");
+    let program = ValidatedProgram::try_from_program(program).expect("validated test program");
+    Rc::new(CalxCompiledArtifact {
+      graph: super::super::CalxEligibleCallGraph {
+        abi_edition: Arc::from(CALX_KERNEL_ABI_EDITION),
+        entry: CalxDefinitionRef::new("app.kernel", "main"),
+        functions: vec![],
+      },
+      params: vec![],
+      result: Some(super::super::CalxScalarType::F64),
+      program,
+      reachable_stamps: vec![],
+      import_schema_stamps: vec![],
+      import_contract: vec![],
+    })
+  }
+}

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -12,12 +13,12 @@ use calx_vm::{
   CalxVM, FunctionBuilder, ImportId, LocalId, ProgramBuilder, SourceSpan, ValidatedProgram,
 };
 
-use crate::calcit::{Calcit, CalcitFnArgs, CalcitLocal, CalcitProc, CalcitSyntax, brief_type_of_value};
-use crate::program::CompiledProgram;
+use crate::calcit::{Calcit, CalcitFnArgs, CalcitLocal, CalcitProc, CalcitSyntax, CalcitTypeAnnotation, brief_type_of_value};
+use crate::program::{CompiledProgram, DefId};
 
 use super::{
-  CalxDefinitionRef, CalxEligibleCallGraph, CalxFallbackReport, CalxHostImports, CalxScalarType, analyze_calx_eligibility_with_imports,
-  extract_fn_parts, lookup_compiled_def, source_path,
+  CalxDefinitionRef, CalxEligibleCallGraph, CalxFallbackReport, CalxHostImports, CalxImportContract, CalxScalarType,
+  analyze_calx_eligibility_with_imports, extract_fn_parts, import_contract, lookup_compiled_def, source_path,
 };
 
 /// A mismatch discovered while converting a graph that already passed the
@@ -90,7 +91,7 @@ pub struct CalxKernelCompileTimings {
 }
 
 #[derive(Debug, Default)]
-struct CalxKernelCompileStageTimings {
+pub(super) struct CalxKernelCompileStageTimings {
   eligibility: Duration,
   planning: Duration,
   program_construction: Duration,
@@ -167,17 +168,36 @@ impl Error for CalxKernelRunError {
   }
 }
 
-/// An immutable strict Calx program plus its proven Calcit kernel boundary.
-#[derive(Debug, Clone)]
-pub struct CalxCompiledKernel {
-  graph: CalxEligibleCallGraph,
-  params: Vec<CalxScalarType>,
-  result: Option<CalxScalarType>,
-  program: ValidatedProgram,
-  host_bindings: CalxHostBindings,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CalxDefinitionStamp {
+  pub definition: CalxDefinitionRef,
+  pub def_id: DefId,
+  pub preprocessed_code: Calcit,
+  pub schema: Arc<CalcitTypeAnnotation>,
 }
 
-impl CalxCompiledKernel {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CalxImportSchemaStamp {
+  pub definition: CalxDefinitionRef,
+  pub schema: Arc<CalcitTypeAnnotation>,
+}
+
+/// Immutable source-derived output of eligibility, lowering, and validation.
+///
+/// Host callbacks, VM instances, runtime values, and capability state are
+/// deliberately absent so this value can be shared by a revision-safe cache.
+#[derive(Debug, Clone)]
+pub struct CalxCompiledArtifact {
+  pub(super) graph: CalxEligibleCallGraph,
+  pub(super) params: Vec<CalxScalarType>,
+  pub(super) result: Option<CalxScalarType>,
+  pub(super) program: ValidatedProgram,
+  pub(super) reachable_stamps: Vec<CalxDefinitionStamp>,
+  pub(super) import_schema_stamps: Vec<CalxImportSchemaStamp>,
+  pub(super) import_contract: Vec<CalxImportContract>,
+}
+
+impl CalxCompiledArtifact {
   pub fn graph(&self) -> &CalxEligibleCallGraph {
     &self.graph
   }
@@ -192,6 +212,52 @@ impl CalxCompiledKernel {
 
   pub fn validated_program(&self) -> &ValidatedProgram {
     &self.program
+  }
+
+  pub fn import_contract(&self) -> &[CalxImportContract] {
+    &self.import_contract
+  }
+
+  pub fn reachable_definition_count(&self) -> usize {
+    self.reachable_stamps.len()
+  }
+
+  pub fn syntax_instruction_count(&self) -> usize {
+    self.program.functions().iter().map(|function| function.syntax.len()).sum()
+  }
+
+  pub fn lowered_instruction_count(&self) -> usize {
+    self.program.functions().iter().map(|function| function.instrs.len()).sum()
+  }
+
+  /// Deterministic shallow estimate used for bounded-cache observability.
+  ///
+  /// Shared persistent Calcit storage is intentionally not walked recursively;
+  /// the estimate counts owned vectors, declarations, instructions, and names.
+  pub fn estimated_bytes(&self) -> usize {
+    let mut bytes = std::mem::size_of::<Self>();
+    bytes += self.params.len() * std::mem::size_of::<CalxScalarType>();
+    bytes += self.reachable_stamps.len() * std::mem::size_of::<CalxDefinitionStamp>();
+    bytes += self.import_schema_stamps.len() * std::mem::size_of::<CalxImportSchemaStamp>();
+    bytes += self.import_contract.len() * std::mem::size_of::<CalxImportContract>();
+    for stamp in &self.reachable_stamps {
+      bytes += stamp.definition.namespace.len() + stamp.definition.definition.len();
+      bytes += std::mem::size_of_val(&stamp.preprocessed_code) + std::mem::size_of_val(stamp.schema.as_ref());
+    }
+    for stamp in &self.import_schema_stamps {
+      bytes += stamp.definition.namespace.len() + stamp.definition.definition.len();
+      bytes += std::mem::size_of_val(stamp.schema.as_ref());
+    }
+    for contract in &self.import_contract {
+      bytes += contract.definition.namespace.len() + contract.definition.definition.len() + contract.export_name.len();
+      bytes += contract.params.len() * std::mem::size_of::<CalxScalarType>();
+    }
+    for function in self.program.functions() {
+      bytes += function.name.len();
+      bytes += std::mem::size_of_val(function.syntax.as_slice());
+      bytes += std::mem::size_of_val(function.instrs.as_slice());
+    }
+    bytes
   }
 
   /// Deterministic generated-program report for repository golden fixtures.
@@ -230,20 +296,58 @@ impl CalxCompiledKernel {
     }
     output
   }
+}
+
+/// Per-request executable kernel with freshly attached host capabilities.
+#[derive(Debug, Clone)]
+pub struct CalxPreparedKernel {
+  artifact: Rc<CalxCompiledArtifact>,
+  host_bindings: CalxHostBindings,
+}
+
+/// Compatibility name for the pre-cache API.
+pub type CalxCompiledKernel = CalxPreparedKernel;
+
+impl CalxPreparedKernel {
+  pub fn artifact(&self) -> &Rc<CalxCompiledArtifact> {
+    &self.artifact
+  }
+
+  pub fn graph(&self) -> &CalxEligibleCallGraph {
+    self.artifact.graph()
+  }
+
+  pub fn params(&self) -> &[CalxScalarType] {
+    self.artifact.params()
+  }
+
+  pub fn result(&self) -> Option<CalxScalarType> {
+    self.artifact.result()
+  }
+
+  pub fn validated_program(&self) -> &ValidatedProgram {
+    self.artifact.validated_program()
+  }
+
+  /// Deterministic generated-program report for repository golden fixtures.
+  /// This is diagnostic text, not a serialized Calx program ABI.
+  pub fn stable_program_summary(&self) -> String {
+    self.artifact.stable_program_summary()
+  }
 
   pub fn instantiate(&self) -> Result<CalxVM, CalxKernelRunError> {
-    CalxVM::from_validated_program(self.program.clone(), self.host_bindings.clone()).map_err(CalxKernelRunError::Instantiate)
+    CalxVM::from_validated_program(self.artifact.program.clone(), self.host_bindings.clone()).map_err(CalxKernelRunError::Instantiate)
   }
 
   pub fn run(&self, args: &[Calcit]) -> Result<Calcit, CalxKernelRunError> {
-    if args.len() != self.params.len() {
+    if args.len() != self.artifact.params.len() {
       return Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
         kind: CalxKernelBoundaryErrorKind::Arity,
-        message: format!("expected {} arguments, found {}", self.params.len(), args.len()),
+        message: format!("expected {} arguments, found {}", self.artifact.params.len(), args.len()),
       }));
     }
     let mut vm_args = Vec::with_capacity(args.len());
-    for (index, (value, expected)) in args.iter().zip(&self.params).enumerate() {
+    for (index, (value, expected)) in args.iter().zip(&self.artifact.params).enumerate() {
       let converted = match (expected, value) {
         (CalxScalarType::F64, Calcit::Number(value)) => VmValue::F64(*value),
         (CalxScalarType::Bool, Calcit::Bool(value)) => VmValue::Bool(*value),
@@ -263,7 +367,7 @@ impl CalxCompiledKernel {
 
     let mut vm = self.instantiate()?;
     let output = vm.run_typed(vm_args).map_err(CalxKernelRunError::Runtime)?;
-    match (self.result, output) {
+    match (self.artifact.result, output) {
       (None, CalxRunResult::Void) => Ok(Calcit::Unit),
       (Some(CalxScalarType::F64), CalxRunResult::Value(VmValue::F64(value))) => Ok(Calcit::Number(value)),
       (Some(CalxScalarType::Bool), CalxRunResult::Value(VmValue::Bool(value))) => Ok(Calcit::Bool(value)),
@@ -285,7 +389,7 @@ pub fn compile_calx_kernel(
   namespace: impl Into<Arc<str>>,
   definition: impl Into<Arc<str>>,
 ) -> Result<CalxCompiledKernel, CalxKernelCompileError> {
-  compile_calx_kernel_with_imports_inner(program, namespace, definition, &CalxHostImports::new(), None)
+  compile_calx_kernel_with_imports(program, namespace, definition, &CalxHostImports::new())
 }
 
 /// Compile a closed scalar kernel and report each compilation-stage duration.
@@ -304,7 +408,8 @@ pub fn compile_calx_kernel_with_imports(
   definition: impl Into<Arc<str>>,
   imports: &CalxHostImports,
 ) -> Result<CalxCompiledKernel, CalxKernelCompileError> {
-  compile_calx_kernel_with_imports_inner(program, namespace, definition, imports, None)
+  let artifact = compile_calx_artifact_with_imports_inner(program, namespace.into(), definition.into(), imports, None)?;
+  prepare_calx_artifact(artifact, imports)
 }
 
 /// Compile with explicit typed imports and report each compilation-stage duration.
@@ -315,10 +420,23 @@ pub fn compile_calx_kernel_with_imports_measured(
   imports: &CalxHostImports,
 ) -> Result<(CalxCompiledKernel, CalxKernelCompileTimings), CalxKernelCompileError> {
   let total_started = Instant::now();
+  let (artifact, mut timings) = compile_calx_artifact_with_imports_measured(program, namespace.into(), definition.into(), imports)?;
+  let kernel = prepare_calx_artifact(artifact, imports)?;
+  timings.total = total_started.elapsed();
+  Ok((kernel, timings))
+}
+
+pub(super) fn compile_calx_artifact_with_imports_measured(
+  program: &CompiledProgram,
+  namespace: Arc<str>,
+  definition: Arc<str>,
+  imports: &CalxHostImports,
+) -> Result<(Rc<CalxCompiledArtifact>, CalxKernelCompileTimings), CalxKernelCompileError> {
+  let total_started = Instant::now();
   let mut stage_timings = CalxKernelCompileStageTimings::default();
-  let kernel = compile_calx_kernel_with_imports_inner(program, namespace, definition, imports, Some(&mut stage_timings))?;
+  let artifact = compile_calx_artifact_with_imports_inner(program, namespace, definition, imports, Some(&mut stage_timings))?;
   Ok((
-    kernel,
+    artifact,
     CalxKernelCompileTimings {
       eligibility: stage_timings.eligibility,
       planning: stage_timings.planning,
@@ -329,13 +447,13 @@ pub fn compile_calx_kernel_with_imports_measured(
   ))
 }
 
-fn compile_calx_kernel_with_imports_inner(
+pub(super) fn compile_calx_artifact_with_imports_inner(
   program: &CompiledProgram,
-  namespace: impl Into<Arc<str>>,
-  definition: impl Into<Arc<str>>,
+  namespace: Arc<str>,
+  definition: Arc<str>,
   imports: &CalxHostImports,
   mut stage_timings: Option<&mut CalxKernelCompileStageTimings>,
-) -> Result<CalxCompiledKernel, CalxKernelCompileError> {
+) -> Result<Rc<CalxCompiledArtifact>, CalxKernelCompileError> {
   let eligibility_started = stage_timings.as_ref().map(|_| Instant::now());
   let graph =
     analyze_calx_eligibility_with_imports(program, namespace, definition, imports).map_err(CalxKernelCompileError::Eligibility)?;
@@ -385,11 +503,10 @@ fn compile_calx_kernel_with_imports_inner(
     .flat_map(|function| function.host_imports.iter().cloned())
     .collect::<BTreeSet<_>>();
   let mut import_ids = BTreeMap::new();
-  let mut host_bindings = CalxHostBindings::new();
-  for target in used_imports {
-    let import = imports.get(&target).ok_or_else(|| {
+  for target in &used_imports {
+    let import = imports.get(target).ok_or_else(|| {
       CalxKernelCompileError::Lowering(lower_error(
-        &target,
+        target,
         None,
         "eligible host import has no compile-time capability binding",
       ))
@@ -398,30 +515,95 @@ fn compile_calx_kernel_with_imports_inner(
       import.name(),
       import.params().iter().copied().map(CalxScalarType::vm_type).collect(),
       import.result().map(CalxScalarType::vm_type),
-      Some(SourceSpan::synthetic(source_origin(&target, None))),
+      Some(SourceSpan::synthetic(source_origin(target, None))),
     )?;
-    import_ids.insert(target, id);
-    host_bindings.insert(import.name().into(), import.binding().clone());
+    import_ids.insert(target.clone(), id);
   }
   for plan in &plans {
     builder.function(emit_function(plan, &import_ids)?)?;
   }
-  let program = builder.build()?;
+  let built_program = builder.build()?;
   if let (Some(timings), Some(started)) = (stage_timings.as_deref_mut(), construction_started) {
     timings.program_construction = started.elapsed();
   }
   let validation_started = stage_timings.as_ref().map(|_| Instant::now());
-  let program = ValidatedProgram::try_from_program(program)?;
+  let validated_program = ValidatedProgram::try_from_program(built_program)?;
   if let (Some(timings), Some(started)) = (stage_timings, validation_started) {
     timings.validation_lowering = started.elapsed();
   }
-  Ok(CalxCompiledKernel {
+  let reachable_stamps = graph
+    .functions
+    .iter()
+    .map(|function| {
+      let compiled = lookup_compiled_def(program, &function.definition).ok_or_else(|| {
+        CalxKernelCompileError::Lowering(lower_error(
+          &function.definition,
+          None,
+          "eligible definition disappeared before artifact stamping",
+        ))
+      })?;
+      Ok(CalxDefinitionStamp {
+        definition: function.definition.clone(),
+        def_id: compiled.def_id,
+        preprocessed_code: compiled.preprocessed_code.clone(),
+        schema: compiled.schema.clone(),
+      })
+    })
+    .collect::<Result<Vec<_>, CalxKernelCompileError>>()?;
+  let import_schema_stamps = used_imports
+    .iter()
+    .map(|definition| {
+      let compiled = lookup_compiled_def(program, definition).ok_or_else(|| {
+        CalxKernelCompileError::Lowering(lower_error(
+          definition,
+          None,
+          "eligible host import disappeared before artifact stamping",
+        ))
+      })?;
+      Ok(CalxImportSchemaStamp {
+        definition: definition.clone(),
+        schema: compiled.schema.clone(),
+      })
+    })
+    .collect::<Result<Vec<_>, CalxKernelCompileError>>()?;
+  Ok(Rc::new(CalxCompiledArtifact {
     graph,
     params,
     result,
-    program,
-    host_bindings,
-  })
+    program: validated_program,
+    reachable_stamps,
+    import_schema_stamps,
+    import_contract: import_contract(imports),
+  }))
+}
+
+pub(super) fn prepare_calx_artifact(
+  artifact: Rc<CalxCompiledArtifact>,
+  imports: &CalxHostImports,
+) -> Result<CalxPreparedKernel, CalxKernelCompileError> {
+  let actual_contract = import_contract(imports);
+  if actual_contract != artifact.import_contract {
+    return Err(CalxKernelCompileError::Lowering(lower_error(
+      &artifact.graph.entry,
+      None,
+      "typed host import declarations changed while attaching a compiled artifact",
+    )));
+  }
+
+  let used_imports = artifact
+    .graph
+    .functions
+    .iter()
+    .flat_map(|function| function.host_imports.iter())
+    .collect::<BTreeSet<_>>();
+  let mut host_bindings = CalxHostBindings::new();
+  for target in used_imports {
+    let import = imports.get(target).ok_or_else(|| {
+      CalxKernelCompileError::Lowering(lower_error(target, None, "compiled host import has no current capability binding"))
+    })?;
+    host_bindings.insert(import.name().into(), import.binding().clone());
+  }
+  Ok(CalxPreparedKernel { artifact, host_bindings })
 }
 
 fn function_names(graph: &CalxEligibleCallGraph) -> BTreeMap<CalxDefinitionRef, String> {

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -3,9 +3,9 @@ use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
 use crate::calcit::{CalcitFnTypeAnnotation, CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo, SchemaKind};
 use crate::call_stack::CallStackList;
 use crate::codegen::calx::{
-  CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport, CalxHostImports, CalxKernelBoundaryErrorKind, CalxKernelCompileError,
-  CalxKernelRunError, CalxScalarType, CalxValue, analyze_calx_eligibility, analyze_calx_eligibility_with_imports, compile_calx_kernel,
-  compile_calx_kernel_measured, compile_calx_kernel_with_imports,
+  CalxCacheMissReason, CalxCompileCache, CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport, CalxHostImports,
+  CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError, CalxScalarType, CalxValue, analyze_calx_eligibility,
+  analyze_calx_eligibility_with_imports, compile_calx_kernel, compile_calx_kernel_measured, compile_calx_kernel_with_imports,
 };
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
@@ -460,6 +460,13 @@ fn calx_test_scale(args: &[CalxValue]) -> Result<CalxValue, CalxError> {
   Ok(CalxValue::F64(value * 2.0))
 }
 
+fn calx_test_scale_three(args: &[CalxValue]) -> Result<CalxValue, CalxError> {
+  let [CalxValue::F64(value)] = args else {
+    return Err(CalxError::new_raw("fixture scale expected one F64".to_owned()));
+  };
+  Ok(CalxValue::F64(value * 3.0))
+}
+
 fn calx_test_observe(args: &[CalxValue]) -> Result<(), CalxError> {
   let [CalxValue::F64(_)] = args else {
     return Err(CalxError::new_raw("fixture observe expected one F64".to_owned()));
@@ -473,11 +480,18 @@ fn calx_test_trap(_args: &[CalxValue]) -> Result<CalxValue, CalxError> {
 }
 
 fn calx_test_host_imports(namespace: &str) -> CalxHostImports {
+  calx_test_host_imports_with_scale(namespace, "fixture.scale", calx_test_scale)
+}
+
+fn calx_test_host_imports_with_scale(
+  namespace: &str,
+  export_name: &str,
+  callback: fn(&[CalxValue]) -> Result<CalxValue, CalxError>,
+) -> CalxHostImports {
   let mut imports = CalxHostImports::new();
   imports.insert(
     CalxDefinitionRef::new(namespace, "host-scale"),
-    CalxHostImport::value("fixture.scale", vec![CalxScalarType::F64], CalxScalarType::F64, calx_test_scale)
-      .expect("valid value host import"),
+    CalxHostImport::value(export_name, vec![CalxScalarType::F64], CalxScalarType::F64, callback).expect("valid value host import"),
   );
   imports.insert(
     CalxDefinitionRef::new(namespace, "host-observe"),
@@ -489,6 +503,235 @@ fn calx_test_host_imports(namespace: &str) -> CalxHostImports {
       .expect("valid trapping host import"),
   );
   imports
+}
+
+#[test]
+fn calx_compile_cache_hits_reuse_artifacts_but_reattach_current_callbacks() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-cache-imports";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed import cache fixture");
+  let imports_a = calx_test_host_imports_with_scale(namespace, "fixture.scale", calx_test_scale);
+  let imports_b = calx_test_host_imports_with_scale(namespace, "fixture.scale", calx_test_scale_three);
+  let mut cache = CalxCompileCache::new(2);
+
+  let first = cache
+    .prepare(&snapshot, namespace, "imported-pipeline", &imports_a)
+    .expect("compile initial cached artifact");
+  assert_eq!(first.report().miss_reason, Some(CalxCacheMissReason::Empty));
+  assert!(!first.report().cache_hit);
+  assert_eq!(
+    first.kernel().run(&[Calcit::Number(3.0)]).expect("run callback A"),
+    Calcit::Number(7.0)
+  );
+  let first_artifact = first.kernel().artifact().clone();
+
+  let second = cache
+    .prepare(&snapshot, namespace, "imported-pipeline", &imports_b)
+    .expect("hit artifact with callback B");
+  assert!(second.report().cache_hit);
+  assert!(second.report().miss_reason.is_none());
+  assert!(second.report().skipped_eligibility);
+  assert!(second.report().skipped_planning);
+  assert!(second.report().skipped_program_construction);
+  assert!(second.report().skipped_validation_lowering);
+  assert!(std::rc::Rc::ptr_eq(&first_artifact, second.kernel().artifact()));
+  assert_eq!(
+    second.kernel().run(&[Calcit::Number(3.0)]).expect("run callback B"),
+    Calcit::Number(10.0),
+    "cache hit must use the current callback rather than stale capability state"
+  );
+
+  let mut host_schema_changed = snapshot.clone();
+  host_schema_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("host-scale")
+    .expect("host import definition")
+    .schema = calx_test_fn_schema(vec![CalcitTypeAnnotation::Bool], CalcitTypeAnnotation::Number);
+  assert!(matches!(
+    cache.prepare(&host_schema_changed, namespace, "imported-pipeline", &imports_b),
+    Err(CalxKernelCompileError::Eligibility(_))
+  ));
+
+  let changed_contract = calx_test_host_imports_with_scale(namespace, "fixture.scale.v2", calx_test_scale_three);
+  let third = cache
+    .prepare(&snapshot, namespace, "imported-pipeline", &changed_contract)
+    .expect("changed import declaration recompiles");
+  assert_eq!(third.report().miss_reason, Some(CalxCacheMissReason::ImportContractChanged));
+  assert!(!std::rc::Rc::ptr_eq(&first_artifact, third.kernel().artifact()));
+
+  let stats = cache.stats();
+  assert_eq!(stats.hits, 1);
+  assert_eq!(stats.misses, 3);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::Empty), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::SchemaChanged), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::ImportContractChanged), 1);
+  assert_eq!(stats.entry_count, 2);
+  assert!(stats.reachable_function_count >= 2);
+  assert!(stats.syntax_instruction_count > 0);
+  assert!(stats.lowered_instruction_count > 0);
+  assert!(stats.estimated_bytes > 0);
+}
+
+#[test]
+fn calx_compile_cache_validates_reachable_revisions_without_global_invalidation() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-cache-revisions";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone revision cache fixture");
+  let imports = CalxHostImports::new();
+  let mut cache = CalxCompileCache::new(2);
+
+  let initial = cache.prepare(&snapshot, namespace, "affine", &imports).expect("cache affine");
+  assert_eq!(initial.report().miss_reason, Some(CalxCacheMissReason::Empty));
+  let initial_artifact = initial.kernel().artifact().clone();
+
+  let mut unrelated = snapshot.clone();
+  unrelated
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("polynomial")
+    .expect("unrelated definition")
+    .def_id
+    .0 += 10_000;
+  let unrelated_hit = cache
+    .prepare(&unrelated, namespace, "affine", &imports)
+    .expect("unrelated change must preserve hit");
+  assert!(unrelated_hit.report().cache_hit);
+  assert!(std::rc::Rc::ptr_eq(&initial_artifact, unrelated_hit.kernel().artifact()));
+
+  let mut entry_changed = unrelated.clone();
+  entry_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("affine")
+    .expect("entry definition")
+    .def_id
+    .0 += 20_000;
+  let entry_miss = cache
+    .prepare(&entry_changed, namespace, "affine", &imports)
+    .expect("entry replacement recompiles");
+  assert_eq!(entry_miss.report().miss_reason, Some(CalxCacheMissReason::EntryChanged));
+
+  let mut callee_changed = entry_changed.clone();
+  callee_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("affine-helper")
+    .expect("callee definition")
+    .def_id
+    .0 += 30_000;
+  let callee_miss = cache
+    .prepare(&callee_changed, namespace, "affine", &imports)
+    .expect("callee replacement recompiles");
+  assert_eq!(callee_miss.report().miss_reason, Some(CalxCacheMissReason::CalleeChanged));
+
+  let mut schema_changed = callee_changed.clone();
+  schema_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("affine-helper")
+    .expect("callee definition")
+    .schema = DYNAMIC_TYPE.clone();
+  assert!(matches!(
+    cache.prepare(&schema_changed, namespace, "affine", &imports),
+    Err(CalxKernelCompileError::Eligibility(_))
+  ));
+
+  let mut dependency_missing = callee_changed;
+  dependency_missing
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .remove("affine-helper");
+  assert!(matches!(
+    cache.prepare(&dependency_missing, namespace, "affine", &imports),
+    Err(CalxKernelCompileError::Eligibility(_))
+  ));
+
+  let stats = cache.stats();
+  assert_eq!(stats.hits, 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::EntryChanged), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::CalleeChanged), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::SchemaChanged), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::DependencyMissing), 1);
+  assert_eq!(stats.entry_count, 1, "failed recompilation must not cache a partial artifact");
+}
+
+#[test]
+fn calx_compile_cache_bounds_lru_and_eviction_provenance() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-cache-lru";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone LRU cache fixture");
+  let imports = CalxHostImports::new();
+  let mut cache = CalxCompileCache::new(1);
+
+  cache.prepare(&snapshot, namespace, "range-sum", &imports).expect("insert A");
+  cache
+    .prepare(&snapshot, namespace, "fibonacci", &imports)
+    .expect("insert B and evict A");
+  assert_eq!(cache.stats().entry_count, 1);
+  assert_eq!(cache.stats().recently_evicted_count, 1);
+  assert_eq!(cache.stats().evictions, 1);
+
+  cache
+    .prepare(&snapshot, namespace, "polynomial", &imports)
+    .expect("insert C and overflow ledger");
+  let forgotten = cache
+    .prepare(&snapshot, namespace, "range-sum", &imports)
+    .expect("oldest tombstone must become empty");
+  assert_eq!(forgotten.report().miss_reason, Some(CalxCacheMissReason::Empty));
+
+  let evicted = cache
+    .prepare(&snapshot, namespace, "polynomial", &imports)
+    .expect("most recent tombstone must remain observable");
+  assert_eq!(evicted.report().miss_reason, Some(CalxCacheMissReason::Evicted));
+  assert_eq!(cache.stats().entry_count, 1);
+  assert!(cache.stats().evictions >= 4);
+  assert_eq!(cache.stats().miss_count(CalxCacheMissReason::Evicted), 1);
+
+  cache.clear();
+  let after_clear = cache
+    .prepare(&snapshot, namespace, "range-sum", &imports)
+    .expect("clear removes artifacts and tombstones");
+  assert_eq!(after_clear.report().miss_reason, Some(CalxCacheMissReason::Empty));
+  assert_eq!(cache.stats().clears, 1);
+
+  let mut disabled = CalxCompileCache::new(0);
+  for _ in 0..2 {
+    let preparation = disabled
+      .prepare(&snapshot, namespace, "range-sum", &imports)
+      .expect("zero-capacity cache compiles without storing");
+    assert_eq!(preparation.report().miss_reason, Some(CalxCacheMissReason::Empty));
+  }
+  assert_eq!(disabled.stats().entry_count, 0);
+  assert_eq!(disabled.stats().misses, 2);
+
+  let mut lru = CalxCompileCache::new(2);
+  lru.prepare(&snapshot, namespace, "range-sum", &imports).expect("insert LRU A");
+  lru.prepare(&snapshot, namespace, "fibonacci", &imports).expect("insert LRU B");
+  assert!(
+    lru
+      .prepare(&snapshot, namespace, "range-sum", &imports)
+      .expect("touch LRU A")
+      .report()
+      .cache_hit
+  );
+  lru.prepare(&snapshot, namespace, "polynomial", &imports).expect("insert LRU C");
+  let evicted_b = lru
+    .prepare(&snapshot, namespace, "fibonacci", &imports)
+    .expect("least recently used B was evicted");
+  assert_eq!(evicted_b.report().miss_reason, Some(CalxCacheMissReason::Evicted));
 }
 
 #[test]
@@ -619,6 +862,18 @@ fn calx_eligibility_falls_back_for_the_whole_reachable_closure() {
     compile_calx_kernel(&snapshot, namespace, "entry"),
     Err(CalxKernelCompileError::Eligibility(_))
   ));
+
+  let mut cache = CalxCompileCache::new(2);
+  for _ in 0..2 {
+    assert!(matches!(
+      cache.prepare(&snapshot, namespace, "entry", &CalxHostImports::new()),
+      Err(CalxKernelCompileError::Eligibility(_))
+    ));
+  }
+  let stats = cache.stats();
+  assert_eq!(stats.entry_count, 0, "negative eligibility results must never be cached");
+  assert_eq!(stats.misses, 2);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::Empty), 2);
 }
 
 fn compiled_def_for_test(def_id: DefId, deps: Vec<DefId>) -> CompiledDef {

--- a/tests/calx_cache_profile_contract.rs
+++ b/tests/calx_cache_profile_contract.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+
+use serde_json::Value;
+
+fn run(args: &[&str]) -> std::process::Output {
+  Command::new(env!("CARGO_BIN_EXE_calcit-calx-bench"))
+    .args(args)
+    .output()
+    .expect("cache profile runner must start")
+}
+
+#[test]
+fn cache_profile_stdout_is_one_versioned_correctness_checked_json_value() {
+  let output = run(&[
+    "--kernel",
+    "affine",
+    "--size",
+    "10",
+    "--cache-profile-warmup",
+    "1",
+    "--cache-profile-iterations",
+    "2",
+  ]);
+  assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+  let stdout = String::from_utf8(output.stdout).expect("cache profile stdout must be UTF-8");
+  let report: Value = serde_json::from_str(stdout.trim()).expect("stdout must contain exactly one JSON value");
+
+  assert_eq!(report["schema"], "calcit-calx-cache-profile/1");
+  assert_eq!(report["workload"], "revision-validated-cache-hit-plus-fresh-vm");
+  assert_eq!(report["correctness"], true);
+  assert_eq!(report["cache"]["misses"], 1);
+  assert_eq!(report["cache"]["initialMissReason"], "empty");
+  assert_eq!(report["cache"]["entries"], 1);
+  assert!(report["cache"]["hits"].as_u64().is_some_and(|value| value >= 3));
+  assert!(report["cache"]["estimatedBytes"].as_u64().is_some_and(|value| value > 0));
+  assert!(report["runtime"]["hitPreparePerIterationNs"].as_u64().is_some());
+  assert!(report["runtime"]["revisionValidationPerIterationNs"].as_u64().is_some());
+  assert!(report["runtime"]["bindingAttachmentPerIterationNs"].as_u64().is_some());
+  assert!(report["runtime"]["freshVmSetupPerIterationNs"].as_u64().is_some());
+  assert!(report["runtime"]["freshVmExecutionPerIterationNs"].as_u64().is_some());
+  assert!(report["runtime"]["reusedVmExecutionPerIterationNs"].as_u64().is_some());
+  assert!(report["runtime"]["cachedNativeExecutionPerIterationNs"].as_u64().is_some());
+}
+
+#[test]
+fn compile_and_cache_profile_modes_are_mutually_exclusive() {
+  let output = run(&["--compile-profile-iterations", "1", "--cache-profile-iterations", "1"]);
+  assert!(!output.status.success());
+  assert!(output.stdout.is_empty(), "failure must not emit partial JSON");
+  assert!(
+    String::from_utf8_lossy(&output.stderr).contains("mutually exclusive"),
+    "{}",
+    String::from_utf8_lossy(&output.stderr)
+  );
+}


### PR DESCRIPTION
## 中文

### 结果

- 将 Calx kernel 拆成 callback-free、source-derived 的 `CalxCompiledArtifact` 与每次请求重新附着 capability 的 `CalxPreparedKernel`。
- 新增 embedding-owned、容量有界、确定性 LRU 的 `CalxCompileCache`，支持稳定 miss reason、eviction ledger、clear、capacity-zero 与内存/程序规模观测。
- cache hit 跳过 eligibility、planning、program construction、validation/lowering，同时逐项验证 reachable definition 的结构化 code/schema 和实际使用的 host-import definition schema。
- host callback 不进入 artifact；相同 typed contract 下替换 callback 会复用 artifact 并执行新 callback，静态 import signature 变化则 miss 并重新走 eligibility。
- 增加 `calcit-calx-cache-profile/1` 单 JSON contract，分开报告 revision validation、binding attachment、fresh VM、reused VM、cached Calcit 与估算 cache bytes。

### 语义与仓库边界

- strict Calx boundary 继续只接受 concrete Number/Bool/Unit；没有增加 Nil、Dynamic、persistent List coercion、VM pool 或自动 offload。
- negative eligibility 不缓存，失败编译不会留下 partial artifact。
- cache 为 embedding 显式持有的单线程对象；底层 `ValidatedProgram` 使用 `Rc`，因此不伪装为 `Send`/`Sync`。
- cache-profile runner/schema 是拆仓迁移期 contract，后续随独立 `calcit-calx-bench` harness 迁移；跨机器报告与采样政策不固化进 core。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`：除两个读取本机全局 docs 软链的环境测试外，其余 Rust suite 全部通过；软链指向旧 checkout，其中 caps 文档仍是已由 #563 修复的旧 category。仓库内对应 frontmatter 回归通过。
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`：18/18
- release cache-profile smoke：`affine`、100 warmup、1000 measured，`correctness: true`，1100 hits / 1 empty miss / 0 evictions；hit prepare 365 ns/次，revision validation 123 ns/次，binding attachment 34 ns/次。该单机 smoke 只验证 runner contract，不作为跨机器性能结论。

Closes #552

---

## English

### Outcome

- Split a Calx kernel into a callback-free, source-derived `CalxCompiledArtifact` and a `CalxPreparedKernel` that attaches current capabilities for every request.
- Add an embedding-owned, capacity-bounded, deterministic-LRU `CalxCompileCache` with stable miss reasons, an eviction ledger, clear and zero-capacity behavior, and memory/program-size gauges.
- A cache hit skips eligibility, planning, program construction, and validation/lowering while validating structural code/schema for every reachable definition and the schema of every Calcit definition actually used as a host import.
- Host callbacks never enter artifacts. Replacing a callback under the same typed contract reuses the artifact and executes the new callback; changing a static import signature misses and reruns eligibility.
- Add the single-JSON `calcit-calx-cache-profile/1` contract, separating revision validation, binding attachment, fresh VM, reused VM, cached Calcit, and estimated cache bytes.

### Semantics and repository boundary

- The strict Calx boundary remains limited to concrete Number/Bool/Unit values. This change adds no Nil, Dynamic, persistent-List coercion, VM pool, or automatic offload.
- Negative eligibility is not cached, and failed compilation leaves no partial artifact.
- The embedding explicitly owns this single-threaded cache. The underlying `ValidatedProgram` uses `Rc`, so the API does not pretend to be `Send` or `Sync`.
- The cache-profile runner and schema are transitional extraction contracts and migrate with the standalone `calcit-calx-bench` harness. Cross-machine reporting and sampling policy do not become core responsibilities.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`: every Rust suite passes except two environment tests that read the machine-global docs symlink. That symlink targets an older checkout whose caps category is the stale value already fixed by #563; the repository-local frontmatter regression passes.
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`: 18/18
- Release cache-profile smoke: `affine`, 100 warmup and 1000 measured iterations, `correctness: true`, 1100 hits / 1 empty miss / 0 evictions; 365 ns hit preparation, 123 ns revision validation, and 34 ns binding attachment per iteration. This local smoke validates the runner contract and is not a cross-machine performance claim.

Closes #552
