### PR TITLE
feat: 固定 Calx benchmark session adapter / add revision-pinned Calx benchmark session adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cadence are maintained separately or tracked for extraction:
 | [`calcit-bindgen`](https://github.com/calcit-lang/calcit-bindgen) | Independent repository; production generator parity and removal of the core preview are tracked in [#544](https://github.com/calcit-lang/calcit/issues/544). |
 | [`calcit-native-ffi`](https://github.com/calcit-lang/calcit-native-ffi) | Independent production shared ABI/helper crate for native modules; canonical ABI ownership is tracked in [calcit-native-ffi#7](https://github.com/calcit-lang/calcit-native-ffi/issues/7). |
 | `caps` | Still shipped from this repository while independent package-manager extraction is tracked in [#546](https://github.com/calcit-lang/calcit/issues/546). |
-| `calcit-calx-bench` | Experimental harness still in this repository; extraction of benchmark policy and reports is tracked in [#547](https://github.com/calcit-lang/calcit/issues/547), while Calx backend semantics remain in core. |
+| `calcit-calx-bench` | The standalone experimental harness exists at [`calcit-lang/calcit-calx-bench`](https://github.com/calcit-lang/calcit-calx-bench). The transitional runner remains here until the revision-pinned adapter reproduction and [#559](https://github.com/calcit-lang/calcit/issues/559) cutover; Calx backend semantics remain in core. |
 
 See [#549](https://github.com/calcit-lang/calcit/issues/549) for the bilingual repository-boundary roadmap.
 Calcit has no near-term LSP plan, so analysis and Agent CLI capabilities remain in this repository and release

--- a/docs/run/calx-harness-bootstrap.json
+++ b/docs/run/calx-harness-bootstrap.json
@@ -9,7 +9,7 @@
   },
   "targetRepository": {
     "suggested": "calcit-lang/calcit-calx-bench",
-    "confirmed": false,
+    "confirmed": true,
     "existingCalcitCalxRole": "native-ffi-demo-do-not-absorb-harness"
   },
   "sourcesOfTruth": {
@@ -36,6 +36,7 @@
   ],
   "stayInCore": [
     "src/codegen/calx.rs",
+    "src/codegen/calx/benchmark.rs",
     "src/codegen/calx/lowering.rs",
     "src/program/tests.rs",
     "tests/fixtures/calx/scalar-kernels.cirru",
@@ -56,6 +57,8 @@
     "absoluteCiThresholds": false
   },
   "adapter": {
+    "implementation": "src/codegen/calx/benchmark.rs",
+    "transitionalConsumer": "src/bin/calx_bench.rs",
     "requiredOperations": [
       "install-explicit-source-corpus",
       "preprocess-to-immutable-program-handle",

--- a/docs/run/calx-harness-extraction.md
+++ b/docs/run/calx-harness-extraction.md
@@ -2,17 +2,17 @@
 
 ## Status / 状态
 
-This document freezes the phase-one boundary tracked by
+This document freezes the extraction boundary tracked by
 [calcit#557](https://github.com/calcit-lang/calcit/issues/557). The harness is
 an **experimental benchmark/research product**, not a Calcit runtime feature,
-language correctness gate, or production dependency. This phase documents the
-contract and bootstrap inventory; it does not create a repository or remove
-assets from Calcit core.
+language correctness gate, or production dependency. The standalone repository
+now exists; core removal remains a later cutover after the pinned adapter and
+reproduction evidence are complete.
 
 本文冻结 [calcit#557](https://github.com/calcit-lang/calcit/issues/557)
-追踪的第一阶段边界。该 harness 是**实验性 benchmark/research 产品**，不是 Calcit
-runtime 功能、语言正确性 gate 或生产依赖。本阶段只记录契约和 bootstrap inventory，
-不创建仓库，也不从 Calcit core 删除资产。
+追踪的拆分边界。该 harness 是**实验性 benchmark/research 产品**，不是 Calcit runtime
+功能、语言正确性 gate 或生产依赖。独立仓库已经建立；只有 pinned adapter 与复现实证完成后，
+后续 cutover 才会从 Calcit core 删除产品资产。
 
 The machine-readable bootstrap manifest is
 [`calx-harness-bootstrap.json`](./calx-harness-bootstrap.json). Issue
@@ -23,13 +23,15 @@ owns the later core cutover.
 
 ## Product and repository boundary / 产品与仓库边界
 
-The proposed standalone repository name is `calcit-lang/calcit-calx-bench`,
-pending maintainer confirmation in #558. The existing
+The confirmed standalone repository is
+[`calcit-lang/calcit-calx-bench`](https://github.com/calcit-lang/calcit-calx-bench).
+The existing
 [`calcit-lang/calcit-calx`](https://github.com/calcit-lang/calcit-calx) remains
 a native FFI demo and must not silently absorb benchmark orchestration,
 historical reports, or release policy.
 
-建议的独立仓库名为 `calcit-lang/calcit-calx-bench`，等待维护者在 #558 确认。已有
+已确认并建立的独立仓库为
+[`calcit-lang/calcit-calx-bench`](https://github.com/calcit-lang/calcit-calx-bench)。已有
 [`calcit-lang/calcit-calx`](https://github.com/calcit-lang/calcit-calx)
 继续保持 native FFI demo 定位，不静默承接 benchmark orchestration、历史报告或发布策略。
 
@@ -128,9 +130,24 @@ quick-smoke matrix before changing the pin. Mutable-global access, implicit
 source installation, automatic fallback after effects, and benchmark policy
 inside core are forbidden.
 
+The implementation lives in the doc-hidden
+`codegen::calx::benchmark` module. `CalxBenchmarkSession` serializes explicit
+corpus installation, preprocesses every declared function exactly once, owns
+an immutable `CompiledProgram` snapshot, and validates both Calcit and Calx
+calls against concrete scalar signatures. Unit is explicit; Nil, Dynamic, and
+persistent collection coercion are absent from the adapter contract. The
+transitional core runner consumes only this session API, and a source-level
+contract regression prevents it from reaching compiler registries again.
+
 该 adapter 是 **internal benchmark API**，不承诺 semver 兼容，也不能意外扩张成通用
 embedding API。harness 固定 Calcit commit/tag，升级 pin 前运行 compile 与 quick-smoke matrix。
 禁止暴露可变全局、隐式安装源码、effect 后自动 fallback，以及把 benchmark policy 放回 core。
+
+实现位于 doc-hidden 的 `codegen::calx::benchmark` 模块。`CalxBenchmarkSession`
+串行封装显式 corpus 安装，一次预处理所有声明函数，持有 immutable `CompiledProgram` snapshot，
+并用 concrete scalar schema 校验 Calcit 与 Calx 两条调用路径。Unit 为显式返回类型；adapter
+契约不包含 Nil、Dynamic 或 persistent collection coercion。过渡期 core runner 只消费该
+session API，source-level contract regression 阻止它重新访问 compiler registry。
 
 ## Test and smoke migration matrix / 测试与 smoke 迁移矩阵
 

--- a/editing-history/202608311859-calx-benchmark-session-adapter.md
+++ b/editing-history/202608311859-calx-benchmark-session-adapter.md
@@ -1,0 +1,63 @@
+# Calx benchmark session adapter
+
+## 中文
+
+### 背景
+
+独立 `calcit-calx-bench` 已建立，但过渡 runner 仍直接访问
+`PROGRAM_CODE_DATA`、`ProgramFileData`、`ensure_def_id`、`run_fn` 等进程级内部实现。
+这会把 benchmark 产品绑定到 mutable compiler registry，也无法形成 #557 约定的
+revision-pinned session boundary。
+
+### 本次改动
+
+- 增加 doc-hidden 的 `codegen::calx::benchmark` 内部模块；
+- 通过显式命名 corpus 和完整 concrete scalar schema 建立单活动 session；
+- session 一次完成 source install、preprocess 和 immutable `CompiledProgram` snapshot；
+- 封装 cached Calcit callable、measured Calx compile、revision-safe cache prepare、strict
+  argument/result conversion 和稳定 program counts；
+- 使用显式 `Unit` / scalar return contract，不允许 Nil、Dynamic 或 persistent collection
+  coercion；
+- 过渡 runner 改为只消费 session adapter，并增加 source-level forbidden-symbol regression；
+- 更新 extraction manifest，记录独立仓库已确认和 adapter implementation path。
+
+### 约束与经验
+
+现有 Calcit preprocess/runtime 仍使用进程级 registry，cached callable 的同命名空间调用也可能
+读取 runtime cell。因此 adapter 串行持有 session guard，并在 session 生命周期内保留已安装
+namespace；它是固定 revision 的 benchmark API，不是并发 embedding API，也不承诺 semver。
+benchmark 采样、迭代次数、统计和 fallback policy 继续留在独立 harness。
+
+## English
+
+### Context
+
+The standalone `calcit-calx-bench` repository existed, but the transitional
+runner still reached process-level compiler internals directly. That coupled
+the product to mutable registries and did not satisfy the revision-pinned
+session boundary frozen by #557.
+
+### Changes
+
+- Add the doc-hidden `codegen::calx::benchmark` internal module.
+- Build one serialized session from an explicitly named corpus and a complete
+  concrete scalar schema table.
+- Perform source installation, preprocessing, and immutable snapshot creation
+  once per session.
+- Encapsulate cached Calcit calls, measured Calx compilation, revision-safe
+  cache preparation, strict value conversion, and stable program counts.
+- Model Unit explicitly and admit no Nil, Dynamic, or persistent-collection
+  coercion.
+- Refactor the transitional runner to consume only the adapter and guard that
+  boundary with a forbidden-symbol contract regression.
+- Update the extraction manifest with the confirmed repository and adapter
+  implementation path.
+
+### Constraint
+
+Calcit preprocessing and runtime resolution remain process-global today, and
+same-namespace calls from cached functions may consult runtime cells. The
+adapter therefore serializes active sessions and retains the installed
+namespace for the session lifetime. It is a revision-pinned benchmark API, not
+a concurrent embedding API or a semver-stable surface. Sampling, statistics,
+and fallback policy stay in the standalone harness.

--- a/editing-history/202608311913-bind-calx-benchmark-callable-to-session.md
+++ b/editing-history/202608311913-bind-calx-benchmark-callable-to-session.md
@@ -1,0 +1,13 @@
+# 将 Calx benchmark callable 绑定到 session
+
+## 中文
+
+- `CalxBenchmarkCalcitCallable` 现在携带创建它的 `CalxBenchmarkSession` 借用，Rust 生命周期会阻止 callable 脱离 session 存活。
+- cached callable 每次执行都通过原 session 读取固定 definition contract；session guard 在 callable 存活期间保持当前 corpus 的进程级 runtime ownership。
+- 这避免后续 benchmark session 替换 namespace 后，旧 callable 继续对新的 runtime cells 执行。
+
+## English
+
+- `CalxBenchmarkCalcitCallable` now borrows the `CalxBenchmarkSession` that resolved it, so Rust lifetimes prevent the callable from outliving or detaching from that session.
+- Every cached invocation reads its fixed definition contract through the originating session; the session guard retains process-level runtime ownership for the corpus while the callable is alive.
+- This prevents an old callable from executing against replacement runtime cells after a later benchmark session installs another namespace corpus.

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -4,24 +4,17 @@
 //! process-level cold cost without mixing benchmark policy into the compiler.
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
 use std::hint::black_box;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use argh::FromArgs;
-use calcit::calcit::{CalcitFn, CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind};
-use calcit::call_stack::CallStackList;
-use calcit::codegen::calx::{
-  CalxCompileCache, CalxCompiledKernel, CalxHostImports, CalxScalarType, CalxValue, compile_calx_kernel, compile_calx_kernel_measured,
+use calcit::Calcit;
+use calcit::codegen::calx::benchmark::{
+  CalxBenchmarkCorpus, CalxBenchmarkDefinition, CalxBenchmarkReturn, CalxBenchmarkSession, CalxBenchmarkSessionPreparation,
 };
-use calcit::data::cirru::code_to_calcit;
-use calcit::program::{PROGRAM_CODE_DATA, ProgramDefEntry, ProgramFileData, clone_existing_compiled_program, ensure_def_id};
-use calcit::{Calcit, run_program_with_docs};
-use calx_vm::CalxRunResult;
-use cirru_parser::Cirru;
+use calcit::codegen::calx::{CalxCompileCache, CalxHostImports, CalxScalarType};
 use serde::Serialize;
 
 const FIXTURE_NAMESPACE: &str = "bench.calx-kernels";
@@ -369,61 +362,37 @@ fn resolved_dependency_version<'a>(lockfile: &'a str, package_name: &str) -> Res
   }
 }
 
-/// Build the fixed Number-only function schema for one benchmark definition.
-fn number_fn_schema(arity: usize) -> Arc<CalcitTypeAnnotation> {
-  Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
-    generics: Arc::new(vec![]),
-    where_bounds: Arc::new(vec![]),
-    arg_types: (0..arity).map(|_| Arc::new(CalcitTypeAnnotation::Number)).collect(),
-    return_type: Arc::new(CalcitTypeAnnotation::Number),
-    fn_kind: SchemaKind::Fn,
-    rest_type: None,
-    features: Arc::new(HashSet::new()),
-  })))
-}
-
-/// Parse and install the source-backed scalar corpus in a fresh benchmark process.
-fn install_fixture() -> Result<(), String> {
-  let arities = HashMap::from([
+/// Declare the fixed source corpus and every concrete scalar function schema.
+fn benchmark_corpus() -> Result<CalxBenchmarkCorpus, String> {
+  let definitions = [
     ("range-sum", 2),
     ("fibonacci", 1),
     ("affine-helper", 3),
     ("affine", 3),
     ("polynomial", 1),
     ("bounded-simulation", 3),
-  ]);
-  let mut definitions = HashMap::new();
-  for node in cirru_parser::parse(include_str!("../../tests/fixtures/calx/scalar-kernels.cirru"))? {
-    let Cirru::List(items) = &node else {
-      return Err(format!("Calx benchmark fixture definition must be a list: {node}"));
-    };
-    let Some(Cirru::Leaf(definition)) = items.get(1) else {
-      return Err(format!("Calx benchmark fixture definition must have a name: {node}"));
-    };
-    let Some(arity) = arities.get(definition.as_ref()) else {
-      return Err(format!("Calx benchmark fixture `{definition}` has no declared signature"));
-    };
-    let code = code_to_calcit(&node, FIXTURE_NAMESPACE, definition, vec![])?;
-    let _ = ensure_def_id(FIXTURE_NAMESPACE, definition);
-    definitions.insert(
-      Arc::from(definition.as_ref()),
-      ProgramDefEntry {
-        code,
-        schema: number_fn_schema(*arity),
-        doc: Arc::from(""),
-        examples: vec![],
-        ffi: None,
-      },
-    );
-  }
-  PROGRAM_CODE_DATA.write().map_err(|error| error.to_string())?.insert(
-    Arc::from(FIXTURE_NAMESPACE),
-    ProgramFileData {
-      import_map: HashMap::new(),
-      defs: definitions,
-    },
-  );
-  Ok(())
+  ]
+  .into_iter()
+  .map(|(name, arity)| {
+    CalxBenchmarkDefinition::new(
+      name,
+      vec![CalxScalarType::F64; arity],
+      CalxBenchmarkReturn::Scalar(CalxScalarType::F64),
+    )
+  })
+  .collect::<Result<Vec<_>, _>>()
+  .map_err(|error| error.to_string())?;
+  CalxBenchmarkCorpus::new(
+    FIXTURE_NAMESPACE,
+    include_str!("../../tests/fixtures/calx/scalar-kernels.cirru"),
+    definitions,
+  )
+  .map_err(|error| error.to_string())
+}
+
+/// Install and preprocess the explicit corpus through the internal adapter.
+fn prepare_benchmark_session() -> Result<CalxBenchmarkSessionPreparation, String> {
+  CalxBenchmarkSession::prepare(benchmark_corpus()?).map_err(|error| error.to_string())
 }
 
 /// Map a named corpus case and its input size to concrete Calcit arguments.
@@ -436,41 +405,6 @@ fn kernel_arguments(kernel: &str, size: u32) -> Result<Vec<Calcit>, String> {
     "polynomial" => Ok(vec![Calcit::Number(n)]),
     "bounded-simulation" => Ok(vec![Calcit::Number(n), Calcit::Number(0.5), Calcit::Number(0.999)]),
     _ => Err(format!("unknown Calx benchmark kernel `{kernel}`")),
-  }
-}
-
-/// Convert proven scalar arguments without admitting Nil or Dynamic values.
-fn convert_arguments(kernel: &CalxCompiledKernel, args: &[Calcit]) -> Result<Vec<CalxValue>, String> {
-  if kernel.params().len() != args.len() {
-    return Err(format!("expected {} arguments, found {}", kernel.params().len(), args.len()));
-  }
-  args
-    .iter()
-    .zip(kernel.params())
-    .enumerate()
-    .map(|(index, (value, expected))| match (value, expected) {
-      (Calcit::Number(value), CalxScalarType::F64) => Ok(CalxValue::F64(*value)),
-      (Calcit::Bool(value), CalxScalarType::Bool) => Ok(CalxValue::Bool(*value)),
-      _ => Err(format!("argument {index} does not match the proven Calx scalar type")),
-    })
-    .collect()
-}
-
-/// Convert one strict Calx result back through the proven scalar boundary.
-fn convert_result(kernel: &CalxCompiledKernel, result: CalxRunResult) -> Result<Calcit, String> {
-  match (kernel.result(), result) {
-    (None, CalxRunResult::Void) => Ok(Calcit::Unit),
-    (Some(CalxScalarType::F64), CalxRunResult::Value(CalxValue::F64(value))) => Ok(Calcit::Number(value)),
-    (Some(CalxScalarType::Bool), CalxRunResult::Value(CalxValue::Bool(value))) => Ok(Calcit::Bool(value)),
-    (expected, actual) => Err(format!("validated result contract {expected:?} produced {actual:?}")),
-  }
-}
-
-/// Resolve the already-preprocessed Calcit entry once for a fair repeated-call baseline.
-fn resolve_cached_calcit_callable(kernel: &str, call_stack: &CallStackList) -> Result<Arc<CalcitFn>, String> {
-  match calcit::runner::evaluate_symbol_from_program(kernel, FIXTURE_NAMESPACE, None, call_stack).map_err(|error| error.to_string())? {
-    Calcit::Fn { info, .. } => Ok(info),
-    value => Err(format!("expected cached benchmark callable, found {value}")),
   }
 }
 
@@ -526,31 +460,25 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
     return Err("--compile-profile-allocation-iterations must be greater than zero in compile profile mode".to_owned());
   }
 
-  let fixture_started = Instant::now();
-  install_fixture()?;
-  let fixture_install_ns = nanos(fixture_started.elapsed());
-
-  let frontend_started = Instant::now();
-  let warnings = RefCell::new(vec![]);
-  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
-    .map_err(|error| error.to_string())?;
-  if !warnings.borrow().is_empty() {
-    return Err(format!("Calx compile profile frontend produced warnings: {:#?}", warnings.borrow()));
-  }
-  let calcit_frontend_ns = nanos(frontend_started.elapsed());
-
-  let snapshot_started = Instant::now();
-  let snapshot = clone_existing_compiled_program();
-  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
+  let (session, session_timings) = prepare_benchmark_session()?.into_parts();
+  let fixture_install_ns = nanos(session_timings.source_install);
+  let calcit_frontend_ns = nanos(session_timings.preprocess);
+  let snapshot_clone_ns = nanos(session_timings.snapshot_clone);
+  let imports = CalxHostImports::new();
 
   for _ in 0..args.compile_profile_warmup {
-    black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+    black_box(
+      session
+        .compile_calx(args.kernel.as_str(), &imports)
+        .map_err(|error| error.to_string())?,
+    );
   }
 
   let mut stage_timing_total = CompileReport::default();
   for _ in 0..args.compile_profile_stage_iterations {
-    let (kernel, timings) =
-      compile_calx_kernel_measured(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?;
+    let (kernel, timings) = session
+      .compile_calx_measured(args.kernel.as_str(), &imports)
+      .map_err(|error| error.to_string())?;
     add_compile_timings(&mut stage_timing_total, timings);
     black_box(kernel);
   }
@@ -559,7 +487,11 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
   let allocation_window = ProfileAllocationWindow::begin()?;
   let allocation_result = (|| {
     for _ in 0..args.compile_profile_allocation_iterations {
-      black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+      black_box(
+        session
+          .compile_calx(args.kernel.as_str(), &imports)
+          .map_err(|error| error.to_string())?,
+      );
     }
     Ok::<(), String>(())
   })();
@@ -569,7 +501,11 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
 
   let compile_started = Instant::now();
   for _ in 0..args.compile_profile_iterations {
-    black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+    black_box(
+      session
+        .compile_calx(args.kernel.as_str(), &imports)
+        .map_err(|error| error.to_string())?,
+    );
   }
   let compile_total_ns = nanos(compile_started.elapsed());
 
@@ -601,27 +537,15 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
     return Err("--cache-profile-iterations must be greater than zero in cache profile mode".to_owned());
   }
 
-  let fixture_started = Instant::now();
-  install_fixture()?;
-  let fixture_install_ns = nanos(fixture_started.elapsed());
-
-  let frontend_started = Instant::now();
-  let warnings = RefCell::new(vec![]);
-  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
-    .map_err(|error| error.to_string())?;
-  if !warnings.borrow().is_empty() {
-    return Err(format!("Calx cache profile frontend produced warnings: {:#?}", warnings.borrow()));
-  }
-  let calcit_frontend_ns = nanos(frontend_started.elapsed());
-
-  let snapshot_started = Instant::now();
-  let snapshot = clone_existing_compiled_program();
-  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
+  let (session, session_timings) = prepare_benchmark_session()?.into_parts();
+  let fixture_install_ns = nanos(session_timings.source_install);
+  let calcit_frontend_ns = nanos(session_timings.preprocess);
+  let snapshot_clone_ns = nanos(session_timings.snapshot_clone);
   let imports = CalxHostImports::new();
   let mut cache = CalxCompileCache::new(1);
   let initial_started = Instant::now();
-  let initial = cache
-    .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+  let initial = session
+    .prepare_calx_cache(&mut cache, args.kernel.as_str(), &imports)
     .map_err(|error| error.to_string())?;
   let initial_miss_prepare_ns = nanos(initial_started.elapsed());
   let initial_miss_reason = initial
@@ -636,23 +560,27 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
   );
   let initial_kernel = initial.into_kernel();
   let calcit_args = kernel_arguments(&args.kernel, args.size)?;
-  let vm_args = convert_arguments(&initial_kernel, &calcit_args)?;
-
-  let native_result = run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from(args.kernel.as_str()), &calcit_args)
+  let vm_args = session
+    .prepare_calx_arguments(args.kernel.as_str(), &initial_kernel, &calcit_args)
     .map_err(|error| error.to_string())?;
-  let native_call_stack = CallStackList::default();
-  let cached_native_callable = resolve_cached_calcit_callable(&args.kernel, &native_call_stack)?;
+
+  let native_result = session
+    .run_calcit_lookup(args.kernel.as_str(), &calcit_args)
+    .map_err(|error| error.to_string())?;
+  let cached_native_callable = session
+    .resolve_calcit_callable(args.kernel.as_str())
+    .map_err(|error| error.to_string())?;
 
   for _ in 0..args.cache_profile_warmup {
-    let preparation = cache
-      .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+    let preparation = session
+      .prepare_calx_cache(&mut cache, args.kernel.as_str(), &imports)
       .map_err(|error| error.to_string())?;
     if !preparation.report().cache_hit {
       return Err("cache profile warmup unexpectedly missed".to_owned());
     }
     let mut vm = preparation.kernel().instantiate().map_err(|error| error.to_string())?;
     black_box(vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?);
-    black_box(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    black_box(cached_native_callable.run(&calcit_args).map_err(|error| error.to_string())?);
   }
 
   let mut hit_prepare_total_ns = 0u64;
@@ -663,8 +591,8 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
   let mut last_fresh_result = None;
   for _ in 0..args.cache_profile_iterations {
     let prepare_started = Instant::now();
-    let preparation = cache
-      .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+    let preparation = session
+      .prepare_calx_cache(&mut cache, args.kernel.as_str(), &imports)
       .map_err(|error| error.to_string())?;
     hit_prepare_total_ns = hit_prepare_total_ns.saturating_add(nanos(prepare_started.elapsed()));
     if !preparation.report().cache_hit {
@@ -679,7 +607,11 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
     let execution_started = Instant::now();
     let result = vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?;
     fresh_vm_execution_total_ns = fresh_vm_execution_total_ns.saturating_add(nanos(execution_started.elapsed()));
-    last_fresh_result = Some(convert_result(preparation.kernel(), result)?);
+    last_fresh_result = Some(
+      session
+        .finish_calx_result(args.kernel.as_str(), preparation.kernel(), result)
+        .map_err(|error| error.to_string())?,
+    );
   }
 
   let mut reused_vm = initial_kernel.instantiate().map_err(|error| error.to_string())?;
@@ -689,18 +621,19 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
   let reused_started = Instant::now();
   let mut last_reused_result = None;
   for _ in 0..args.cache_profile_iterations {
-    last_reused_result = Some(convert_result(
-      &initial_kernel,
-      reused_vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?,
-    )?);
+    let result = reused_vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?;
+    last_reused_result = Some(
+      session
+        .finish_calx_result(args.kernel.as_str(), &initial_kernel, result)
+        .map_err(|error| error.to_string())?,
+    );
   }
   let reused_vm_execution_total_ns = nanos(reused_started.elapsed());
 
   let cached_native_started = Instant::now();
   let mut last_cached_native_result = None;
   for _ in 0..args.cache_profile_iterations {
-    last_cached_native_result =
-      Some(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    last_cached_native_result = Some(cached_native_callable.run(&calcit_args).map_err(|error| error.to_string())?);
   }
   let cached_native_execution_total_ns = nanos(cached_native_started.elapsed());
 
@@ -766,38 +699,28 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
     return Err("--hot-iterations must be greater than zero".to_owned());
   }
 
-  let fixture_started = Instant::now();
-  install_fixture()?;
-  let fixture_install_ns = nanos(fixture_started.elapsed());
-
-  let frontend_started = Instant::now();
-  let warnings = RefCell::new(vec![]);
-  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
+  let (session, session_timings) = prepare_benchmark_session()?.into_parts();
+  let fixture_install_ns = nanos(session_timings.source_install);
+  let calcit_frontend_ns = nanos(session_timings.preprocess);
+  let snapshot_clone_ns = nanos(session_timings.snapshot_clone);
+  let imports = CalxHostImports::new();
+  let (kernel, compile_timings) = session
+    .compile_calx_measured(args.kernel.as_str(), &imports)
     .map_err(|error| error.to_string())?;
-  if !warnings.borrow().is_empty() {
-    return Err(format!("Calx benchmark frontend produced warnings: {:#?}", warnings.borrow()));
-  }
-  let calcit_frontend_ns = nanos(frontend_started.elapsed());
-
-  let snapshot_started = Instant::now();
-  let snapshot = clone_existing_compiled_program();
-  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
-
-  let (kernel, compile_timings) =
-    compile_calx_kernel_measured(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?;
   let calcit_args = kernel_arguments(&args.kernel, args.size)?;
 
   let native_started = Instant::now();
-  let native_result = run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from(args.kernel.as_str()), &calcit_args)
+  let native_result = session
+    .run_calcit_lookup(args.kernel.as_str(), &calcit_args)
     .map_err(|error| error.to_string())?;
   let native_call_ns = nanos(native_started.elapsed());
 
-  let native_call_stack = CallStackList::default();
   let cached_native_resolution_started = Instant::now();
-  let cached_native_callable = resolve_cached_calcit_callable(&args.kernel, &native_call_stack)?;
+  let cached_native_callable = session
+    .resolve_calcit_callable(args.kernel.as_str())
+    .map_err(|error| error.to_string())?;
   let cached_native_resolution_ns = nanos(cached_native_resolution_started.elapsed());
-  let cached_native_result =
-    calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?;
+  let cached_native_result = cached_native_callable.run(&calcit_args).map_err(|error| error.to_string())?;
   if cached_native_result != native_result {
     return Err(format!(
       "correctness mismatch for {}/{}: Calcit lookup={native_result}, Calcit cached={cached_native_result}",
@@ -806,19 +729,21 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   }
 
   for _ in 0..args.vm_warmup {
-    black_box(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    black_box(cached_native_callable.run(&calcit_args).map_err(|error| error.to_string())?);
   }
   let cached_native_inputs = (0..args.hot_iterations).map(|_| calcit_args.clone()).collect::<Vec<_>>();
   let cached_native_started = Instant::now();
   for input in cached_native_inputs {
-    black_box(calcit::runner::run_fn(&input, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    black_box(cached_native_callable.run(&input).map_err(|error| error.to_string())?);
   }
   let cached_native_execution_total_ns = nanos(cached_native_started.elapsed());
   let cached_native_execution_per_call_ns = cached_native_execution_total_ns / u64::from(args.hot_iterations);
 
   let calx_one_shot_started = Instant::now();
   let boundary_arguments_started = Instant::now();
-  let vm_args = convert_arguments(&kernel, &calcit_args)?;
+  let vm_args = session
+    .prepare_calx_arguments(args.kernel.as_str(), &kernel, &calcit_args)
+    .map_err(|error| error.to_string())?;
   let boundary_arguments_ns = nanos(boundary_arguments_started.elapsed());
 
   let setup_started = Instant::now();
@@ -831,7 +756,9 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   let pure_execution_ns = nanos(execution_started.elapsed());
 
   let result_boundary_started = Instant::now();
-  let calx_result = convert_result(&kernel, vm_result)?;
+  let calx_result = session
+    .finish_calx_result(args.kernel.as_str(), &kernel, vm_result)
+    .map_err(|error| error.to_string())?;
   let boundary_result_ns = nanos(result_boundary_started.elapsed());
   let calx_one_shot_ns = nanos(calx_one_shot_started.elapsed());
   if calx_result != native_result {
@@ -853,12 +780,9 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   let hot_execution_total_ns = nanos(hot_started.elapsed());
   let hot_execution_per_call_ns = hot_execution_total_ns / u64::from(args.hot_iterations);
 
-  let validated = kernel.validated_program();
-  let functions = validated.functions().len();
-  let imports = validated.imports().len();
-  let syntax_nodes = validated.functions().iter().map(|function| function.syntax.len()).sum();
-  let instructions = validated.functions().iter().map(|function| function.instrs.len()).sum();
-  let diagnostic_bytes = kernel.stable_program_summary().len();
+  let program_counts = session
+    .program_counts(args.kernel.as_str(), &kernel)
+    .map_err(|error| error.to_string())?;
 
   Ok(BenchmarkReport {
     schema: "calcit-calx-benchmark/2",
@@ -892,11 +816,11 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
       hot_execution_per_call_ns,
     },
     program: ProgramReport {
-      functions,
-      imports,
-      syntax_nodes,
-      instructions,
-      diagnostic_bytes,
+      functions: program_counts.functions,
+      imports: program_counts.imports,
+      syntax_nodes: program_counts.syntax_nodes,
+      instructions: program_counts.instructions,
+      diagnostic_bytes: program_counts.diagnostic_bytes,
       host_boundary_calls_per_execution: 0,
       reuses_vm_frames_and_stack: true,
     },
@@ -945,17 +869,18 @@ mod tests {
 
   #[test]
   fn cached_callable_matches_lookup_execution_and_rejects_missing_entries() {
-    install_fixture().expect("install benchmark fixture");
+    let session = prepare_benchmark_session().expect("prepare benchmark session").into_session();
     let args = kernel_arguments("range-sum", 10).expect("range-sum arguments");
-    let lookup_result =
-      run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from("range-sum"), &args).expect("run lookup baseline");
-    let call_stack = CallStackList::default();
-    let callable = resolve_cached_calcit_callable("range-sum", &call_stack).expect("resolve cached callable");
-    let cached_result = calcit::runner::run_fn(&args, &callable, &call_stack).expect("run cached callable");
+    let lookup_result = session.run_calcit_lookup("range-sum", &args).expect("run lookup baseline");
+    let callable = session.resolve_calcit_callable("range-sum").expect("resolve cached callable");
+    let cached_result = callable.run(&args).expect("run cached callable");
     assert_eq!(cached_result, lookup_result);
 
-    let error = resolve_cached_calcit_callable("missing-kernel", &call_stack).expect_err("missing entries must fail");
-    assert!(error.contains("missing-kernel"));
+    let error = session
+      .resolve_calcit_callable("missing-kernel")
+      .err()
+      .expect("missing entries must fail");
+    assert!(error.to_string().contains("missing-kernel"));
   }
 
   #[test]

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -8,6 +8,9 @@
 mod cache;
 mod lowering;
 
+#[doc(hidden)]
+pub mod benchmark;
+
 pub use cache::{CalxCacheMissReason, CalxCachePreparation, CalxCachePrepareReport, CalxCompileCache, CalxCompileCacheStats};
 pub use calx_vm::{Calx as CalxValue, CalxBuildError, CalxError, CalxProgramError};
 pub use lowering::{

--- a/src/codegen/calx/benchmark.rs
+++ b/src/codegen/calx/benchmark.rs
@@ -235,20 +235,22 @@ pub struct CalxBenchmarkProgramCounts {
   pub diagnostic_bytes: usize,
 }
 
-/// Cached Calcit function plus the concrete schema used at every invocation.
-pub struct CalxBenchmarkCalcitCallable {
-  qualified_name: Arc<str>,
-  params: Vec<CalxScalarType>,
-  result: CalxBenchmarkReturn,
+/// Cached Calcit function bound to the session that resolved it.
+pub struct CalxBenchmarkCalcitCallable<'session> {
+  session: &'session CalxBenchmarkSession,
+  definition: Arc<str>,
   callable: Arc<CalcitFn>,
 }
 
-impl CalxBenchmarkCalcitCallable {
+impl CalxBenchmarkCalcitCallable<'_> {
+  /// Run the cached function while its source session still owns the runtime corpus.
   pub fn run(&self, args: &[Calcit]) -> Result<Calcit, CalxBenchmarkAdapterError> {
-    validate_calcit_arguments(&self.qualified_name, &self.params, args)?;
+    let contract = self.session.definition(&self.definition)?;
+    let qualified_name = format!("{}/{}", self.session.namespace, self.definition);
+    validate_calcit_arguments(&qualified_name, &contract.params, args)?;
     let result = runner::run_fn(args, &self.callable, &CallStackList::default())
       .map_err(|error| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::NativeRun, error.to_string()))?;
-    validate_calcit_result(&self.qualified_name, self.result, &result)?;
+    validate_calcit_result(&qualified_name, contract.result, &result)?;
     Ok(result)
   }
 }
@@ -328,8 +330,9 @@ impl CalxBenchmarkSession {
     })
   }
 
-  pub fn resolve_calcit_callable(&self, definition: &str) -> Result<CalxBenchmarkCalcitCallable, CalxBenchmarkAdapterError> {
-    let contract = self.definition(definition)?;
+  /// Resolve a cached callable whose lifetime cannot outlive this session.
+  pub fn resolve_calcit_callable(&self, definition: &str) -> Result<CalxBenchmarkCalcitCallable<'_>, CalxBenchmarkAdapterError> {
+    self.definition(definition)?;
     let value = runner::evaluate_symbol_from_program(definition, &self.namespace, None, &CallStackList::default())
       .map_err(|error| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::Resolve, error.to_string()))?;
     let Calcit::Fn { info, .. } = value else {
@@ -339,9 +342,8 @@ impl CalxBenchmarkSession {
       ));
     };
     Ok(CalxBenchmarkCalcitCallable {
-      qualified_name: Arc::from(format!("{}/{definition}", self.namespace)),
-      params: contract.params.clone(),
-      result: contract.result,
+      session: self,
+      definition: Arc::from(definition),
       callable: info,
     })
   }

--- a/src/codegen/calx/benchmark.rs
+++ b/src/codegen/calx/benchmark.rs
@@ -1,0 +1,605 @@
+//! Revision-pinned internal adapter for the standalone Calx benchmark harness.
+//!
+//! This API deliberately has no semver compatibility promise. It encapsulates
+//! Calcit's process-level preprocessing registries behind one serialized
+//! session, then exposes only an immutable compiled-program snapshot, cached
+//! callable handles, strict scalar conversion, Calx compilation, and stable
+//! report inputs. Benchmark iteration and statistics policy stay outside core.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::error::Error;
+use std::fmt;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+use calx_vm::CalxRunResult;
+use cirru_parser::Cirru;
+
+use crate::calcit::{Calcit, CalcitFn, CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind, brief_type_of_value};
+use crate::call_stack::CallStackList;
+use crate::data::cirru::code_to_calcit;
+use crate::program::{CompiledProgram, ProgramDefEntry, ProgramFileData, clone_existing_compiled_program, replace_benchmark_namespace};
+use crate::run_program_with_docs;
+use crate::runner;
+use crate::runner::preprocess::ensure_ns_def_compiled;
+
+use super::{
+  CalxCachePreparation, CalxCompileCache, CalxHostImports, CalxKernelCompileError, CalxKernelCompileTimings, CalxPreparedKernel,
+  CalxScalarType, CalxValue, compile_calx_kernel_with_imports, compile_calx_kernel_with_imports_measured,
+};
+
+static BENCHMARK_SESSION_LOCK: Mutex<()> = Mutex::new(());
+
+/// Stage assigned to one adapter failure without leaking registry details.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalxBenchmarkAdapterStage {
+  Corpus,
+  Install,
+  Preprocess,
+  Snapshot,
+  Resolve,
+  Compile,
+  NativeRun,
+  Boundary,
+}
+
+impl CalxBenchmarkAdapterStage {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::Corpus => "corpus",
+      Self::Install => "install",
+      Self::Preprocess => "preprocess",
+      Self::Snapshot => "snapshot",
+      Self::Resolve => "resolve",
+      Self::Compile => "compile",
+      Self::NativeRun => "native-run",
+      Self::Boundary => "boundary",
+    }
+  }
+}
+
+/// Structured adapter failure suitable for a benchmark process diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxBenchmarkAdapterError {
+  stage: CalxBenchmarkAdapterStage,
+  message: String,
+}
+
+impl CalxBenchmarkAdapterError {
+  fn new(stage: CalxBenchmarkAdapterStage, message: impl Into<String>) -> Self {
+    Self {
+      stage,
+      message: message.into(),
+    }
+  }
+
+  pub const fn stage(&self) -> CalxBenchmarkAdapterStage {
+    self.stage
+  }
+
+  pub fn message(&self) -> &str {
+    &self.message
+  }
+}
+
+impl fmt::Display for CalxBenchmarkAdapterError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "Calx benchmark adapter {} failed: {}", self.stage.as_str(), self.message)
+  }
+}
+
+impl Error for CalxBenchmarkAdapterError {}
+
+/// Explicit benchmark return contract; unit is never encoded as Nil.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalxBenchmarkReturn {
+  Unit,
+  Scalar(CalxScalarType),
+}
+
+impl CalxBenchmarkReturn {
+  const fn scalar(self) -> Option<CalxScalarType> {
+    match self {
+      Self::Unit => None,
+      Self::Scalar(value) => Some(value),
+    }
+  }
+}
+
+/// One declared function in an explicit benchmark source corpus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxBenchmarkDefinition {
+  name: Arc<str>,
+  params: Vec<CalxScalarType>,
+  result: CalxBenchmarkReturn,
+}
+
+impl CalxBenchmarkDefinition {
+  pub fn new(
+    name: impl Into<Arc<str>>,
+    params: Vec<CalxScalarType>,
+    result: CalxBenchmarkReturn,
+  ) -> Result<Self, CalxBenchmarkAdapterError> {
+    let name = name.into();
+    if name.is_empty() {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        "definition name must not be empty",
+      ));
+    }
+    Ok(Self { name, params, result })
+  }
+
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn params(&self) -> &[CalxScalarType] {
+    &self.params
+  }
+
+  pub const fn result(&self) -> CalxBenchmarkReturn {
+    self.result
+  }
+}
+
+/// Named source corpus with a complete, fixed scalar schema table.
+#[derive(Debug, Clone)]
+pub struct CalxBenchmarkCorpus {
+  namespace: Arc<str>,
+  source: Arc<str>,
+  definitions: BTreeMap<Arc<str>, CalxBenchmarkDefinition>,
+}
+
+impl CalxBenchmarkCorpus {
+  pub fn new(
+    namespace: impl Into<Arc<str>>,
+    source: impl Into<Arc<str>>,
+    definitions: Vec<CalxBenchmarkDefinition>,
+  ) -> Result<Self, CalxBenchmarkAdapterError> {
+    let namespace = namespace.into();
+    if namespace.is_empty() {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        "namespace must not be empty",
+      ));
+    }
+    let source = source.into();
+    if source.trim().is_empty() {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        "source corpus must not be empty",
+      ));
+    }
+    if definitions.is_empty() {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        "at least one explicit function schema is required",
+      ));
+    }
+
+    let mut by_name = BTreeMap::new();
+    for definition in definitions {
+      let name = definition.name.clone();
+      if by_name.insert(name.clone(), definition).is_some() {
+        return Err(CalxBenchmarkAdapterError::new(
+          CalxBenchmarkAdapterStage::Corpus,
+          format!("duplicate schema declaration for `{name}`"),
+        ));
+      }
+    }
+    Ok(Self {
+      namespace,
+      source,
+      definitions: by_name,
+    })
+  }
+}
+
+/// One-time source installation, preprocessing, and snapshot timings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalxBenchmarkSessionTimings {
+  pub source_install: Duration,
+  pub preprocess: Duration,
+  pub snapshot_clone: Duration,
+}
+
+/// Prepared session plus its one-time stage timings.
+pub struct CalxBenchmarkSessionPreparation {
+  session: CalxBenchmarkSession,
+  timings: CalxBenchmarkSessionTimings,
+}
+
+impl CalxBenchmarkSessionPreparation {
+  pub const fn timings(&self) -> CalxBenchmarkSessionTimings {
+    self.timings
+  }
+
+  pub fn into_session(self) -> CalxBenchmarkSession {
+    self.session
+  }
+
+  pub fn into_parts(self) -> (CalxBenchmarkSession, CalxBenchmarkSessionTimings) {
+    (self.session, self.timings)
+  }
+}
+
+/// Stable program metrics consumed by the external report schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalxBenchmarkProgramCounts {
+  pub functions: usize,
+  pub imports: usize,
+  pub syntax_nodes: usize,
+  pub instructions: usize,
+  pub diagnostic_bytes: usize,
+}
+
+/// Cached Calcit function plus the concrete schema used at every invocation.
+pub struct CalxBenchmarkCalcitCallable {
+  qualified_name: Arc<str>,
+  params: Vec<CalxScalarType>,
+  result: CalxBenchmarkReturn,
+  callable: Arc<CalcitFn>,
+}
+
+impl CalxBenchmarkCalcitCallable {
+  pub fn run(&self, args: &[Calcit]) -> Result<Calcit, CalxBenchmarkAdapterError> {
+    validate_calcit_arguments(&self.qualified_name, &self.params, args)?;
+    let result = runner::run_fn(args, &self.callable, &CallStackList::default())
+      .map_err(|error| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::NativeRun, error.to_string()))?;
+    validate_calcit_result(&self.qualified_name, self.result, &result)?;
+    Ok(result)
+  }
+}
+
+/// Serialized benchmark session backed by one immutable compiled snapshot.
+///
+/// The guard intentionally prevents multiple active adapters in one process.
+/// A harness uses fresh processes for samples, so concurrent or nested corpus
+/// installation would be an API misuse rather than a supported workload.
+pub struct CalxBenchmarkSession {
+  namespace: Arc<str>,
+  definitions: BTreeMap<Arc<str>, CalxBenchmarkDefinition>,
+  program: Arc<CompiledProgram>,
+  _session_guard: MutexGuard<'static, ()>,
+}
+
+impl CalxBenchmarkSession {
+  pub fn prepare(corpus: CalxBenchmarkCorpus) -> Result<CalxBenchmarkSessionPreparation, CalxBenchmarkAdapterError> {
+    let session_guard = BENCHMARK_SESSION_LOCK
+      .lock()
+      .map_err(|_| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::Install, "benchmark session lock is poisoned"))?;
+
+    let install_started = Instant::now();
+    let file = parse_explicit_corpus(&corpus)?;
+    replace_benchmark_namespace(corpus.namespace.clone(), file);
+    let source_install = install_started.elapsed();
+
+    let preprocess_started = Instant::now();
+    let warnings = RefCell::new(vec![]);
+    let call_stack = CallStackList::default();
+    for definition in corpus.definitions.keys() {
+      ensure_ns_def_compiled(&corpus.namespace, definition, &warnings, &call_stack).map_err(|error| {
+        CalxBenchmarkAdapterError::new(
+          CalxBenchmarkAdapterStage::Preprocess,
+          format!("failed to preprocess `{}/{definition}`: {error}", corpus.namespace),
+        )
+      })?;
+    }
+    if !warnings.borrow().is_empty() {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Preprocess,
+        format!("source corpus produced warnings: {:#?}", warnings.borrow()),
+      ));
+    }
+    let preprocess = preprocess_started.elapsed();
+
+    let snapshot_started = Instant::now();
+    let program = Arc::new(clone_existing_compiled_program());
+    let snapshot_clone = snapshot_started.elapsed();
+    let Some(file) = program.get(&corpus.namespace) else {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Snapshot,
+        format!("compiled snapshot is missing namespace `{}`", corpus.namespace),
+      ));
+    };
+    for definition in corpus.definitions.keys() {
+      if file.get(definition).is_none() {
+        return Err(CalxBenchmarkAdapterError::new(
+          CalxBenchmarkAdapterStage::Snapshot,
+          format!("compiled snapshot is missing `{}/{definition}`", corpus.namespace),
+        ));
+      }
+    }
+
+    Ok(CalxBenchmarkSessionPreparation {
+      session: Self {
+        namespace: corpus.namespace,
+        definitions: corpus.definitions,
+        program,
+        _session_guard: session_guard,
+      },
+      timings: CalxBenchmarkSessionTimings {
+        source_install,
+        preprocess,
+        snapshot_clone,
+      },
+    })
+  }
+
+  pub fn resolve_calcit_callable(&self, definition: &str) -> Result<CalxBenchmarkCalcitCallable, CalxBenchmarkAdapterError> {
+    let contract = self.definition(definition)?;
+    let value = runner::evaluate_symbol_from_program(definition, &self.namespace, None, &CallStackList::default())
+      .map_err(|error| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::Resolve, error.to_string()))?;
+    let Calcit::Fn { info, .. } = value else {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Resolve,
+        format!("expected `{}/{definition}` to resolve to a function, found {value}", self.namespace),
+      ));
+    };
+    Ok(CalxBenchmarkCalcitCallable {
+      qualified_name: Arc::from(format!("{}/{definition}", self.namespace)),
+      params: contract.params.clone(),
+      result: contract.result,
+      callable: info,
+    })
+  }
+
+  pub fn run_calcit_lookup(&self, definition: &str, args: &[Calcit]) -> Result<Calcit, CalxBenchmarkAdapterError> {
+    let contract = self.definition(definition)?;
+    let qualified = format!("{}/{definition}", self.namespace);
+    validate_calcit_arguments(&qualified, &contract.params, args)?;
+    let result = run_program_with_docs(self.namespace.clone(), Arc::from(definition), args)
+      .map_err(|error| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::NativeRun, error.to_string()))?;
+    validate_calcit_result(&qualified, contract.result, &result)?;
+    Ok(result)
+  }
+
+  pub fn compile_calx(&self, definition: &str, imports: &CalxHostImports) -> Result<CalxPreparedKernel, CalxBenchmarkAdapterError> {
+    self.definition(definition)?;
+    let kernel =
+      compile_calx_kernel_with_imports(&self.program, self.namespace.clone(), Arc::from(definition), imports).map_err(compile_error)?;
+    self.verify_kernel_contract(definition, &kernel)?;
+    Ok(kernel)
+  }
+
+  pub fn compile_calx_measured(
+    &self,
+    definition: &str,
+    imports: &CalxHostImports,
+  ) -> Result<(CalxPreparedKernel, CalxKernelCompileTimings), CalxBenchmarkAdapterError> {
+    self.definition(definition)?;
+    let (kernel, timings) =
+      compile_calx_kernel_with_imports_measured(&self.program, self.namespace.clone(), Arc::from(definition), imports)
+        .map_err(compile_error)?;
+    self.verify_kernel_contract(definition, &kernel)?;
+    Ok((kernel, timings))
+  }
+
+  pub fn prepare_calx_cache(
+    &self,
+    cache: &mut CalxCompileCache,
+    definition: &str,
+    imports: &CalxHostImports,
+  ) -> Result<CalxCachePreparation, CalxBenchmarkAdapterError> {
+    self.definition(definition)?;
+    let preparation = cache
+      .prepare(&self.program, self.namespace.clone(), Arc::from(definition), imports)
+      .map_err(compile_error)?;
+    self.verify_kernel_contract(definition, preparation.kernel())?;
+    Ok(preparation)
+  }
+
+  pub fn prepare_calx_arguments(
+    &self,
+    definition: &str,
+    kernel: &CalxPreparedKernel,
+    args: &[Calcit],
+  ) -> Result<Vec<CalxValue>, CalxBenchmarkAdapterError> {
+    let contract = self.definition(definition)?;
+    self.verify_kernel_contract(definition, kernel)?;
+    let qualified = format!("{}/{definition}", self.namespace);
+    validate_calcit_arguments(&qualified, &contract.params, args)?;
+    Ok(
+      args
+        .iter()
+        .zip(&contract.params)
+        .map(|(value, expected)| match (value, expected) {
+          (Calcit::Number(value), CalxScalarType::F64) => CalxValue::F64(*value),
+          (Calcit::Bool(value), CalxScalarType::Bool) => CalxValue::Bool(*value),
+          _ => unreachable!("arguments were validated against the same scalar contract"),
+        })
+        .collect(),
+    )
+  }
+
+  pub fn finish_calx_result(
+    &self,
+    definition: &str,
+    kernel: &CalxPreparedKernel,
+    result: CalxRunResult,
+  ) -> Result<Calcit, CalxBenchmarkAdapterError> {
+    let contract = self.definition(definition)?;
+    self.verify_kernel_contract(definition, kernel)?;
+    let value = match (contract.result, result) {
+      (CalxBenchmarkReturn::Unit, CalxRunResult::Void) => Calcit::Unit,
+      (CalxBenchmarkReturn::Scalar(CalxScalarType::F64), CalxRunResult::Value(CalxValue::F64(value))) => Calcit::Number(value),
+      (CalxBenchmarkReturn::Scalar(CalxScalarType::Bool), CalxRunResult::Value(CalxValue::Bool(value))) => Calcit::Bool(value),
+      (expected, actual) => {
+        return Err(CalxBenchmarkAdapterError::new(
+          CalxBenchmarkAdapterStage::Boundary,
+          format!("validated result contract {expected:?} produced {actual:?}"),
+        ));
+      }
+    };
+    Ok(value)
+  }
+
+  pub fn program_counts(
+    &self,
+    definition: &str,
+    kernel: &CalxPreparedKernel,
+  ) -> Result<CalxBenchmarkProgramCounts, CalxBenchmarkAdapterError> {
+    self.verify_kernel_contract(definition, kernel)?;
+    let validated = kernel.validated_program();
+    Ok(CalxBenchmarkProgramCounts {
+      functions: validated.functions().len(),
+      imports: validated.imports().len(),
+      syntax_nodes: validated.functions().iter().map(|function| function.syntax.len()).sum(),
+      instructions: validated.functions().iter().map(|function| function.instrs.len()).sum(),
+      diagnostic_bytes: kernel.stable_program_summary().len(),
+    })
+  }
+
+  fn definition(&self, definition: &str) -> Result<&CalxBenchmarkDefinition, CalxBenchmarkAdapterError> {
+    self.definitions.get(definition).ok_or_else(|| {
+      CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Resolve,
+        format!("benchmark corpus `{}` does not declare `{definition}`", self.namespace),
+      )
+    })
+  }
+
+  fn verify_kernel_contract(&self, definition: &str, kernel: &CalxPreparedKernel) -> Result<(), CalxBenchmarkAdapterError> {
+    let contract = self.definition(definition)?;
+    if kernel.params() != contract.params || kernel.result() != contract.result.scalar() {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Boundary,
+        format!(
+          "compiled kernel `{}/{definition}` has {:?}->{:?}, expected {:?}->{:?}",
+          self.namespace,
+          kernel.params(),
+          kernel.result(),
+          contract.params,
+          contract.result
+        ),
+      ));
+    }
+    Ok(())
+  }
+}
+
+fn compile_error(error: CalxKernelCompileError) -> CalxBenchmarkAdapterError {
+  CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::Compile, error.to_string())
+}
+
+fn parse_explicit_corpus(corpus: &CalxBenchmarkCorpus) -> Result<ProgramFileData, CalxBenchmarkAdapterError> {
+  let nodes =
+    cirru_parser::parse(&corpus.source).map_err(|error| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::Corpus, error))?;
+  let mut definitions = HashMap::new();
+  for node in nodes {
+    let Cirru::List(items) = &node else {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        format!("definition must be a list: {node}"),
+      ));
+    };
+    let Some(Cirru::Leaf(name)) = items.get(1) else {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        format!("definition must have a name: {node}"),
+      ));
+    };
+    let Some(contract) = corpus.definitions.get(name.as_ref()) else {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        format!("source definition `{name}` has no explicit schema"),
+      ));
+    };
+    let code = code_to_calcit(&node, &corpus.namespace, name, vec![])
+      .map_err(|error| CalxBenchmarkAdapterError::new(CalxBenchmarkAdapterStage::Corpus, error.to_string()))?;
+    let entry = ProgramDefEntry {
+      code,
+      schema: function_schema(contract),
+      doc: Arc::from(""),
+      examples: vec![],
+      ffi: None,
+    };
+    if definitions.insert(Arc::from(name.as_ref()), entry).is_some() {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        format!("source corpus defines `{name}` more than once"),
+      ));
+    }
+  }
+  for name in corpus.definitions.keys() {
+    if !definitions.contains_key(name) {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Corpus,
+        format!("schema declaration `{name}` has no source definition"),
+      ));
+    }
+  }
+  Ok(ProgramFileData {
+    import_map: HashMap::new(),
+    defs: definitions,
+  })
+}
+
+fn function_schema(definition: &CalxBenchmarkDefinition) -> Arc<CalcitTypeAnnotation> {
+  let arg_types = definition.params.iter().copied().map(scalar_annotation).collect();
+  let return_type = match definition.result {
+    CalxBenchmarkReturn::Unit => Arc::new(CalcitTypeAnnotation::Unit),
+    CalxBenchmarkReturn::Scalar(value) => scalar_annotation(value),
+  };
+  Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+    generics: Arc::new(vec![]),
+    where_bounds: Arc::new(vec![]),
+    arg_types,
+    return_type,
+    fn_kind: SchemaKind::Fn,
+    rest_type: None,
+    features: Arc::new(HashSet::new()),
+  })))
+}
+
+fn scalar_annotation(value: CalxScalarType) -> Arc<CalcitTypeAnnotation> {
+  match value {
+    CalxScalarType::F64 => Arc::new(CalcitTypeAnnotation::Number),
+    CalxScalarType::Bool => Arc::new(CalcitTypeAnnotation::Bool),
+  }
+}
+
+fn validate_calcit_arguments(qualified: &str, expected: &[CalxScalarType], args: &[Calcit]) -> Result<(), CalxBenchmarkAdapterError> {
+  if args.len() != expected.len() {
+    return Err(CalxBenchmarkAdapterError::new(
+      CalxBenchmarkAdapterStage::Boundary,
+      format!("`{qualified}` expected {} arguments, found {}", expected.len(), args.len()),
+    ));
+  }
+  for (index, (value, scalar)) in args.iter().zip(expected).enumerate() {
+    let matches = matches!(
+      (value, scalar),
+      (Calcit::Number(_), CalxScalarType::F64) | (Calcit::Bool(_), CalxScalarType::Bool)
+    );
+    if !matches {
+      return Err(CalxBenchmarkAdapterError::new(
+        CalxBenchmarkAdapterStage::Boundary,
+        format!(
+          "`{qualified}` argument {index} expected {}, found {}",
+          scalar.as_str(),
+          brief_type_of_value(value)
+        ),
+      ));
+    }
+  }
+  Ok(())
+}
+
+fn validate_calcit_result(qualified: &str, expected: CalxBenchmarkReturn, value: &Calcit) -> Result<(), CalxBenchmarkAdapterError> {
+  let matches = matches!(
+    (expected, value),
+    (CalxBenchmarkReturn::Unit, Calcit::Unit)
+      | (CalxBenchmarkReturn::Scalar(CalxScalarType::F64), Calcit::Number(_))
+      | (CalxBenchmarkReturn::Scalar(CalxScalarType::Bool), Calcit::Bool(_))
+  );
+  if matches {
+    Ok(())
+  } else {
+    Err(CalxBenchmarkAdapterError::new(
+      CalxBenchmarkAdapterStage::Boundary,
+      format!("`{qualified}` expected result {expected:?}, found {}", brief_type_of_value(value)),
+    ))
+  }
+}

--- a/src/program.rs
+++ b/src/program.rs
@@ -627,6 +627,22 @@ fn remove_compiled_ns(ns: &str) {
   program.remove(ns);
 }
 
+/// Replace one explicitly named benchmark namespace without exposing the
+/// compiler's mutable registries to the benchmark consumer.
+///
+/// The revision-pinned benchmark adapter is the only intended caller. It
+/// serializes session creation, registers stable definition ids, and retains
+/// the installed namespace for the lifetime of the session because cached
+/// Calcit callables may resolve same-namespace callees through runtime cells.
+pub(crate) fn replace_benchmark_namespace(ns: Arc<str>, file: ProgramFileData) {
+  for def in file.defs.keys() {
+    let _ = register_program_def_id(&ns, def);
+  }
+  clear_runtime_ns(&ns);
+  remove_compiled_ns(&ns);
+  PROGRAM_CODE_DATA.write().expect("write benchmark source corpus").insert(ns, file);
+}
+
 fn collect_transitive_dependent_def_ids(compiled: &ProgramCompiledData, seed_ids: &HashSet<DefId>) -> HashSet<DefId> {
   if seed_ids.is_empty() {
     return HashSet::new();

--- a/tests/calx_benchmark_adapter_contract.rs
+++ b/tests/calx_benchmark_adapter_contract.rs
@@ -1,0 +1,103 @@
+use calcit::Calcit;
+use calcit::codegen::calx::benchmark::{
+  CalxBenchmarkAdapterStage, CalxBenchmarkCorpus, CalxBenchmarkDefinition, CalxBenchmarkReturn, CalxBenchmarkSession,
+};
+use calcit::codegen::calx::{CalxHostImports, CalxScalarType};
+
+const SOURCE: &str = r#"defn affine-helper (x scale offset)
+  &+
+    &* x scale
+    , offset
+
+defn affine (x scale offset)
+  affine-helper x scale offset
+"#;
+
+fn scalar_definition(name: &str, arity: usize) -> CalxBenchmarkDefinition {
+  CalxBenchmarkDefinition::new(
+    name,
+    vec![CalxScalarType::F64; arity],
+    CalxBenchmarkReturn::Scalar(CalxScalarType::F64),
+  )
+  .expect("valid scalar definition")
+}
+
+#[test]
+fn revision_pinned_session_encapsulates_source_runtime_and_strict_calx_paths() {
+  let corpus = CalxBenchmarkCorpus::new(
+    "bench.adapter-contract",
+    SOURCE,
+    vec![scalar_definition("affine-helper", 3), scalar_definition("affine", 3)],
+  )
+  .expect("valid explicit corpus");
+  let preparation = CalxBenchmarkSession::prepare(corpus).expect("prepare immutable benchmark session");
+  let timings = preparation.timings();
+  assert!(timings.source_install <= timings.source_install + timings.preprocess + timings.snapshot_clone);
+  let session = preparation.into_session();
+
+  let args = vec![Calcit::Number(4.0), Calcit::Number(1.5), Calcit::Number(2.0)];
+  let lookup = session.run_calcit_lookup("affine", &args).expect("run lookup path");
+  let callable = session.resolve_calcit_callable("affine").expect("resolve cached callable");
+  let cached = callable.run(&args).expect("run cached callable");
+  assert_eq!(cached, lookup);
+
+  let (kernel, compile_timings) = session
+    .compile_calx_measured("affine", &CalxHostImports::new())
+    .expect("compile measured Calx kernel");
+  assert!(compile_timings.total >= compile_timings.eligibility);
+  let vm_args = session
+    .prepare_calx_arguments("affine", &kernel, &args)
+    .expect("prepare strict scalar arguments");
+  let mut vm = kernel.instantiate().expect("instantiate Calx VM");
+  let vm_result = vm.run_typed(vm_args).expect("execute Calx kernel");
+  let calx = session
+    .finish_calx_result("affine", &kernel, vm_result)
+    .expect("finish strict result boundary");
+  assert_eq!(calx, lookup);
+
+  let counts = session.program_counts("affine", &kernel).expect("stable program counts");
+  assert_eq!(counts.functions, 2);
+  assert_eq!(counts.imports, 0);
+  assert!(counts.syntax_nodes > 0);
+  assert!(counts.instructions > 0);
+  assert!(counts.diagnostic_bytes > 0);
+
+  let boundary_error = callable
+    .run(&[Calcit::Nil, Calcit::Number(1.5), Calcit::Number(2.0)])
+    .expect_err("Nil must not cross a strict scalar boundary");
+  assert_eq!(boundary_error.stage(), CalxBenchmarkAdapterStage::Boundary);
+  drop(session);
+
+  let undeclared_source = CalxBenchmarkCorpus::new("bench.adapter-contract-invalid", SOURCE, vec![scalar_definition("affine", 3)])
+    .expect("constructor accepts a schema table before parsing source");
+  let corpus_error = CalxBenchmarkSession::prepare(undeclared_source)
+    .err()
+    .expect("every source definition must have an explicit schema");
+  assert_eq!(corpus_error.stage(), CalxBenchmarkAdapterStage::Corpus);
+
+  let duplicate_error = CalxBenchmarkCorpus::new(
+    "bench.adapter-contract-duplicate",
+    SOURCE,
+    vec![scalar_definition("affine", 3), scalar_definition("affine", 3)],
+  )
+  .expect_err("duplicate schema declarations must fail");
+  assert_eq!(duplicate_error.stage(), CalxBenchmarkAdapterStage::Corpus);
+}
+
+#[test]
+fn benchmark_runner_consumes_only_the_session_adapter() {
+  let runner = include_str!("../src/bin/calx_bench.rs");
+  for forbidden in [
+    "PROGRAM_CODE_DATA",
+    "ProgramFileData",
+    "ensure_def_id",
+    "run_fn",
+    "clone_existing_compiled_program",
+    "run_program_with_docs",
+  ] {
+    assert!(
+      !runner.contains(forbidden),
+      "runner must not reach forbidden core symbol `{forbidden}`"
+    );
+  }
+}

--- a/tests/calx_harness_contract.rs
+++ b/tests/calx_harness_contract.rs
@@ -15,7 +15,7 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
   let manifest = read_json(BOOTSTRAP);
   assert_eq!(manifest["schema"], "calcit-calx-harness-bootstrap/1");
   assert_eq!(manifest["status"], "experimental-benchmark");
-  assert_eq!(manifest["targetRepository"]["confirmed"], false);
+  assert_eq!(manifest["targetRepository"]["confirmed"], true);
   assert_eq!(
     manifest["targetRepository"]["existingCalcitCalxRole"],
     "native-ffi-demo-do-not-absorb-harness"
@@ -49,6 +49,7 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
     stayed,
     string_set(&[
       "src/codegen/calx.rs",
+      "src/codegen/calx/benchmark.rs",
       "src/codegen/calx/lowering.rs",
       "src/program/tests.rs",
       "tests/fixtures/calx/scalar-kernels.cirru",
@@ -69,6 +70,8 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
 
   assert_eq!(manifest["migrationTests"]["rust"], 3);
   assert_eq!(manifest["migrationTests"]["node"], 4);
+  assert_eq!(manifest["adapter"]["implementation"], "src/codegen/calx/benchmark.rs");
+  assert_eq!(manifest["adapter"]["transitionalConsumer"], "src/bin/calx_bench.rs");
   assert_eq!(manifest["reportContract"]["preserveRawSamples"], true);
   assert_eq!(manifest["reportContract"]["absoluteCiThresholds"], false);
 }


### PR DESCRIPTION
## 中文

### 目标

实现 calcit#557 冻结的 revision-pinned internal benchmark adapter，使 Calx benchmark runner 不再直接访问 Calcit 的 mutable compiler/runtime registries，并为独立 `calcit-calx-bench` 的 runner 切换提供固定 revision 调用边界。

### 改动

- 新增 doc-hidden 的 `codegen::calx::benchmark` 内部模块；
- 使用显式 namespace、完整 concrete scalar schema 和单活动 session 安装 source corpus；
- session 一次完成 source install、preprocess 与 immutable `CompiledProgram` snapshot；
- 封装 cached Calcit callable、measured Calx compile、revision-safe cache prepare、strict argument/result conversion 和稳定 program counts；
- 返回契约使用显式 Unit 或 scalar，不允许 Nil、Dynamic、List/Map/Set coercion；
- 过渡期 `calcit-calx-bench` runner 只消费 session adapter，不再引用 `PROGRAM_CODE_DATA`、`ProgramFileData`、`ensure_def_id`、`run_fn`、`clone_existing_compiled_program` 或 `run_program_with_docs`；
- 增加 source-level contract regression、nested callable differential、严格 Nil rejection、corpus declaration validation；
- 更新 extraction manifest：独立仓库已确认，adapter implementation path 已记录。

### 边界

该 API 为 fixed-revision internal benchmark surface，不承诺 semver，也不是通用并发 embedding API。benchmark iteration、统计、process orchestration 和 fallback policy 继续由独立 harness 负责。本 PR 不关闭 #558；合并后仍需在 `calcit-calx-bench` 中更新 Calcit pin 并切换 runner，随后才能解除 #559 与 calx-vm#53。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn compile`
- `yarn check-all`，包含 Agent interface 18/18、Calcit/JS/IR/WASM 与性能回归
- `cargo test -- --skip cli_handlers::docs::tests::collect_docs_for_query_uses_guidebook_without_module --skip cli_handlers::docs::tests::module_docs_do_not_fall_back_to_a_global_modules_directory`
- debug/release `calcit-calx-bench` affine schema-v2 smoke，stdout 均为单个 JSON 且 `correctness: true`

直接执行无 skip 的 `cargo test` 时，仍会复现当前 worktree 环境已有的两项全局 docs 目录测试失败；它们读取 checkout 外的用户级 docs 配置，和本改动无关。其余测试全绿，clean GitHub Actions 将继续验证完整 suite。

关联：#547、#558、#559、calcit-lang/calx-vm#39、calcit-lang/calx-vm#53

## English

### Goal

Implement the revision-pinned internal benchmark adapter frozen by calcit#557. The Calx benchmark runner no longer reaches mutable Calcit compiler/runtime registries directly, and the standalone `calcit-calx-bench` repository gets a fixed-revision boundary for its runner migration.

### Changes

- Add the doc-hidden `codegen::calx::benchmark` internal module.
- Install an explicit source corpus from a named namespace and a complete concrete scalar schema table under one active session.
- Perform source installation, preprocessing, and immutable `CompiledProgram` snapshot creation once per session.
- Encapsulate cached Calcit callables, measured Calx compilation, revision-safe cache preparation, strict argument/result conversion, and stable program counts.
- Model results as explicit Unit or scalar contracts; admit no Nil, Dynamic, or List/Map/Set coercion.
- Refactor the transitional `calcit-calx-bench` runner to consume only the session adapter and stop referencing `PROGRAM_CODE_DATA`, `ProgramFileData`, `ensure_def_id`, `run_fn`, `clone_existing_compiled_program`, or `run_program_with_docs`.
- Add a source-level boundary regression, nested-callable differential coverage, strict Nil rejection, and corpus declaration validation.
- Update the extraction manifest with the confirmed standalone repository and adapter implementation path.

### Boundary

This API is a fixed-revision internal benchmark surface with no semver promise. It is not a general concurrent embedding API. Benchmark iterations, statistics, process orchestration, and fallback policy remain in the standalone harness. This PR does not close #558: after merge, `calcit-calx-bench` must update its Calcit pin and switch its runner before #559 and calx-vm#53 can be unblocked.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn compile`
- `yarn check-all`, including Agent interface 18/18, Calcit/JS/IR/WASM, and performance regressions
- `cargo test -- --skip cli_handlers::docs::tests::collect_docs_for_query_uses_guidebook_without_module --skip cli_handlers::docs::tests::module_docs_do_not_fall_back_to_a_global_modules_directory`
- Debug and release affine schema-v2 runner smokes, each emitting exactly one JSON value with `correctness: true`

An unfiltered local `cargo test` still reproduces the worktree environment's two pre-existing user-level docs-directory failures. They read docs configuration outside this checkout and are unrelated to this change. Every other test passes, and clean GitHub Actions will validate the complete suite.

Related: #547, #558, #559, calcit-lang/calx-vm#39, calcit-lang/calx-vm#53
