### PR TITLE
feat: 增加固定 revision 的 Calx benchmark session adapter / add revision-pinned adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - **Calx profile 证据**：Calx 性能与 cache 决策以 `docs/run/calx-benchmark.md`、`docs/run/calx-compile-cache.md` 和 `benchmarks/calx/*.json` 为 source of truth；原始 profiler 文件留在 `target/`，提交的摘要必须记录干净 commit、环境、命令、迭代数、原始文件哈希与 inclusive-stack 限制。
 - **迁移完成才删除**：只有目标仓库具备文档、Actions、发布或实验运行入口、兼容验证与跨仓库 smoke 后，才能从主仓库删除原实现；迁移期 README 必须同时说明当前入口与目标状态。
 - **Calx harness 契约**：实验性 benchmark 拆分以 `docs/run/calx-harness-extraction.md` 和 machine-readable bootstrap manifest 为准；lowering/correctness 留在 core，外部 harness 必须 pin Calcit revision，不能依赖可变全局或把机器阈值写成 correctness gate。
+- **Calx session adapter**：外部 harness 只能经 `calcit::codegen::calx::benchmark_session` 使用固定 revision 的内部接口，并记录 `CALX_BENCHMARK_SESSION_EDITION`；不得重新引入 `PROGRAM_CODE_DATA`、`ProgramFileData`、`ensure_def_id`、`run_fn` 或其他 mutable-global 访问。
 
 直接使用命令修改 calcit 程序时不需要调用 cargo, 直接按照文档给出的命令行示例执行即可。
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cadence are maintained separately or tracked for extraction:
 | [`calcit-bindgen`](https://github.com/calcit-lang/calcit-bindgen) | Independent repository; production generator parity and removal of the core preview are tracked in [#544](https://github.com/calcit-lang/calcit/issues/544). |
 | [`calcit-native-ffi`](https://github.com/calcit-lang/calcit-native-ffi) | Independent production shared ABI/helper crate for native modules; canonical ABI ownership is tracked in [calcit-native-ffi#7](https://github.com/calcit-lang/calcit-native-ffi/issues/7). |
 | `caps` | Still shipped from this repository while independent package-manager extraction is tracked in [#546](https://github.com/calcit-lang/calcit/issues/546). |
-| `calcit-calx-bench` | Experimental harness still in this repository; extraction of benchmark policy and reports is tracked in [#547](https://github.com/calcit-lang/calcit/issues/547), while Calx backend semantics remain in core. |
+| [`calcit-calx-bench`](https://github.com/calcit-lang/calcit-calx-bench) | Independent experimental harness is bootstrapped; the revision-pinned session-adapter migration and removal of duplicate core benchmark assets are tracked in [#558](https://github.com/calcit-lang/calcit/issues/558) and [#559](https://github.com/calcit-lang/calcit/issues/559), while Calx backend semantics remain in core. |
 
 See [#549](https://github.com/calcit-lang/calcit/issues/549) for the bilingual repository-boundary roadmap.
 Calcit has no near-term LSP plan, so analysis and Agent CLI capabilities remain in this repository and release

--- a/docs/run/calx-harness-bootstrap.json
+++ b/docs/run/calx-harness-bootstrap.json
@@ -8,8 +8,8 @@
     "cutover": "calcit-lang/calcit#559"
   },
   "targetRepository": {
-    "suggested": "calcit-lang/calcit-calx-bench",
-    "confirmed": false,
+    "name": "calcit-lang/calcit-calx-bench",
+    "confirmed": true,
     "existingCalcitCalxRole": "native-ffi-demo-do-not-absorb-harness"
   },
   "sourcesOfTruth": {
@@ -36,6 +36,7 @@
   ],
   "stayInCore": [
     "src/codegen/calx.rs",
+    "src/codegen/calx/benchmark_session.rs",
     "src/codegen/calx/lowering.rs",
     "src/program/tests.rs",
     "tests/fixtures/calx/scalar-kernels.cirru",
@@ -56,6 +57,9 @@
     "absoluteCiThresholds": false
   },
   "adapter": {
+    "module": "calcit::codegen::calx::benchmark_session",
+    "edition": "calcit-calx-benchmark-session/1",
+    "coreTransitionalRunnerUsesAdapter": true,
     "requiredOperations": [
       "install-explicit-source-corpus",
       "preprocess-to-immutable-program-handle",

--- a/docs/run/calx-harness-extraction.md
+++ b/docs/run/calx-harness-extraction.md
@@ -2,17 +2,19 @@
 
 ## Status / 状态
 
-This document freezes the phase-one boundary tracked by
+This document freezes the boundary tracked by
 [calcit#557](https://github.com/calcit-lang/calcit/issues/557). The harness is
 an **experimental benchmark/research product**, not a Calcit runtime feature,
-language correctness gate, or production dependency. This phase documents the
-contract and bootstrap inventory; it does not create a repository or remove
-assets from Calcit core.
+language correctness gate, or production dependency. The standalone repository
+is now bootstrapped. The current transition adds the revision-pinned adapter and
+routes the temporary core runner through it; duplicate core assets remain until
+the standalone quick matrix passes on the adapter revision.
 
 本文冻结 [calcit#557](https://github.com/calcit-lang/calcit/issues/557)
-追踪的第一阶段边界。该 harness 是**实验性 benchmark/research 产品**，不是 Calcit
-runtime 功能、语言正确性 gate 或生产依赖。本阶段只记录契约和 bootstrap inventory，
-不创建仓库，也不从 Calcit core 删除资产。
+追踪的拆分边界。该 harness 是**实验性 benchmark/research 产品**，不是 Calcit runtime
+功能、语言正确性 gate 或生产依赖。独立仓库已经 bootstrap；当前过渡阶段增加固定 revision
+的 adapter，并让 core 中的临时 runner 先通过它运行。只有独立仓库基于该 revision
+通过 quick matrix 后，才删除 core 中的重复资产。
 
 The machine-readable bootstrap manifest is
 [`calx-harness-bootstrap.json`](./calx-harness-bootstrap.json). Issue
@@ -23,13 +25,15 @@ owns the later core cutover.
 
 ## Product and repository boundary / 产品与仓库边界
 
-The proposed standalone repository name is `calcit-lang/calcit-calx-bench`,
-pending maintainer confirmation in #558. The existing
+The standalone repository is
+[`calcit-lang/calcit-calx-bench`](https://github.com/calcit-lang/calcit-calx-bench).
+The existing
 [`calcit-lang/calcit-calx`](https://github.com/calcit-lang/calcit-calx) remains
 a native FFI demo and must not silently absorb benchmark orchestration,
 historical reports, or release policy.
 
-建议的独立仓库名为 `calcit-lang/calcit-calx-bench`，等待维护者在 #558 确认。已有
+独立仓库为
+[`calcit-lang/calcit-calx-bench`](https://github.com/calcit-lang/calcit-calx-bench)。已有
 [`calcit-lang/calcit-calx`](https://github.com/calcit-lang/calcit-calx)
 继续保持 native FFI demo 定位，不静默承接 benchmark orchestration、历史报告或发布策略。
 
@@ -49,7 +53,7 @@ harness/schema 变化，每次测量必须固定精确的 Calcit 与 `calx-vm` r
 
 | Asset | Phase-two action | Long-term owner | Reason |
 | --- | --- | --- | --- |
-| `src/bin/calx_bench.rs` | migrate, then replace with the narrow adapter consumer | standalone harness | single-case runner and measurement phases |
+| `src/bin/calx_bench.rs` | now consumes only the narrow adapter; migrate and then remove | standalone harness | single-case runner and measurement phases |
 | `scripts/bench-calx-e2e.mjs` | migrate | standalone harness | process/profile/sample orchestration and aggregation |
 | `scripts/bench-calx-settings.mjs` and test | migrate | standalone harness | experiment-setting policy |
 | `docs/run/calx-benchmark.md` | migrate methodology; leave a short core link | standalone harness | measurement and comparison policy |
@@ -131,6 +135,24 @@ inside core are forbidden.
 该 adapter 是 **internal benchmark API**，不承诺 semver 兼容，也不能意外扩张成通用
 embedding API。harness 固定 Calcit commit/tag，升级 pin 前运行 compile 与 quick-smoke matrix。
 禁止暴露可变全局、隐式安装源码、effect 后自动 fallback，以及把 benchmark policy 放回 core。
+
+The adapter lives at `calcit::codegen::calx::benchmark_session` and identifies
+its contract with `CALX_BENCHMARK_SESSION_EDITION`. `CalxBenchmarkCorpus`
+requires a complete name-to-schema declaration before source installation;
+`CalxBenchmarkSession` then owns the process-local setup lock, immutable
+preprocessed program snapshot, and cached callable. Its methods expose measured
+compile/cache preparation, lookup/cached Calcit execution, strict Calx argument
+encoding, VM execution/result decoding, timings, and stable program counts. The
+temporary core runner consumes this same surface so migration cannot depend on
+additional private hooks.
+
+adapter 位于 `calcit::codegen::calx::benchmark_session`，通过
+`CALX_BENCHMARK_SESSION_EDITION` 标识契约。`CalxBenchmarkCorpus` 在安装源码前要求
+完整的 definition-name 到 schema 声明；`CalxBenchmarkSession` 随后持有进程内 setup
+锁、不可变的 preprocess program snapshot 和 cached callable。它的方法只暴露 measured
+compile/cache preparation、Calcit lookup/cached 执行、严格 Calx 参数编码、VM 执行/结果解码、
+timing 与稳定 program counts。core 中的临时 runner 也只消费这组接口，确保迁移时不能依赖
+额外 private hook。
 
 ## Test and smoke migration matrix / 测试与 smoke 迁移矩阵
 

--- a/editing-history/202608311914-calx-benchmark-session-adapter.md
+++ b/editing-history/202608311914-calx-benchmark-session-adapter.md
@@ -1,7 +1,7 @@
 # Calx benchmark session adapter
 
 - Added the revision-pinned `calcit::codegen::calx::benchmark_session` boundary for the standalone benchmark harness.
-- Require an explicit complete source/schema corpus, serialize isolated setup, reject namespace replacement, preprocess once, and keep the immutable program snapshot plus cached Calcit callable private.
+- Require an explicit complete source/schema corpus, reject non-function schemas and non-`defn` source before installation, serialize isolated setup, reject namespace replacement, preprocess once, and keep the immutable program snapshot plus cached Calcit callable private.
 - Expose only measured Calx compilation/cache preparation, prepared Calcit and strict Calx execution, boundary conversion, stage timings, and stable program counts.
 - Migrated the transitional in-core runner away from `PROGRAM_CODE_DATA`, `ProgramFileData`, `ensure_def_id`, `run_fn`, raw `CalxVM`, and other private setup hooks.
 - Added adapter lifecycle, complete-schema, Calcit/Calx differential, and artifact-cache tests; preserved all three existing benchmark report schemas in release-mode smoke runs.

--- a/editing-history/202608311914-calx-benchmark-session-adapter.md
+++ b/editing-history/202608311914-calx-benchmark-session-adapter.md
@@ -1,0 +1,8 @@
+# Calx benchmark session adapter
+
+- Added the revision-pinned `calcit::codegen::calx::benchmark_session` boundary for the standalone benchmark harness.
+- Require an explicit complete source/schema corpus, serialize isolated setup, reject namespace replacement, preprocess once, and keep the immutable program snapshot plus cached Calcit callable private.
+- Expose only measured Calx compilation/cache preparation, prepared Calcit and strict Calx execution, boundary conversion, stage timings, and stable program counts.
+- Migrated the transitional in-core runner away from `PROGRAM_CODE_DATA`, `ProgramFileData`, `ensure_def_id`, `run_fn`, raw `CalxVM`, and other private setup hooks.
+- Added adapter lifecycle, complete-schema, Calcit/Calx differential, and artifact-cache tests; preserved all three existing benchmark report schemas in release-mode smoke runs.
+- Updated the bilingual extraction contract, repository boundary, AGENTS guidance, and machine-readable bootstrap state for the confirmed standalone repository.

--- a/editing-history/202608311942-reused-vm-timing-review.md
+++ b/editing-history/202608311942-reused-vm-timing-review.md
@@ -1,0 +1,5 @@
+# Reused VM timing review
+
+- Verified the review finding against the cache-profile measurement path.
+- Kept only `run_values` calls inside the reused-VM execution timer.
+- Moved Calx result decoding after the timer so fresh, reused, and ordinary hot execution measurements use the same boundary.

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -332,7 +332,7 @@ fn nanos(duration: Duration) -> u64 {
 
 fn environment_report() -> Result<EnvironmentReport, String> {
   Ok(EnvironmentReport {
-    package_version: env!("CARGO_PKG_VERSION"),
+    package_version: calcit::cli_args::CALCIT_VERSION,
     calx_vm_version: resolved_dependency_version(CARGO_LOCK, "calx_vm")?.to_owned(),
     profile: if cfg!(debug_assertions) { "debug" } else { "release" },
     os: std::env::consts::OS,

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -4,24 +4,17 @@
 //! process-level cold cost without mixing benchmark policy into the compiler.
 
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::hint::black_box;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use argh::FromArgs;
-use calcit::calcit::{CalcitFn, CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind};
-use calcit::call_stack::CallStackList;
-use calcit::codegen::calx::{
-  CalxCompileCache, CalxCompiledKernel, CalxHostImports, CalxScalarType, CalxValue, compile_calx_kernel, compile_calx_kernel_measured,
-};
-use calcit::data::cirru::code_to_calcit;
-use calcit::program::{PROGRAM_CODE_DATA, ProgramDefEntry, ProgramFileData, clone_existing_compiled_program, ensure_def_id};
-use calcit::{Calcit, run_program_with_docs};
-use calx_vm::CalxRunResult;
-use cirru_parser::Cirru;
+use calcit::Calcit;
+use calcit::calcit::{CalcitFnTypeAnnotation, CalcitTypeAnnotation, SchemaKind};
+use calcit::codegen::calx::benchmark_session::{CalxBenchmarkCorpus, CalxBenchmarkDefinition, CalxBenchmarkSession};
+use calcit::codegen::calx::{CalxCompileCache, CalxHostImports};
 use serde::Serialize;
 
 const FIXTURE_NAMESPACE: &str = "bench.calx-kernels";
@@ -382,48 +375,28 @@ fn number_fn_schema(arity: usize) -> Arc<CalcitTypeAnnotation> {
   })))
 }
 
-/// Parse and install the source-backed scalar corpus in a fresh benchmark process.
-fn install_fixture() -> Result<(), String> {
-  let arities = HashMap::from([
+/// Declare the complete source-backed scalar corpus and fixed schemas.
+fn benchmark_corpus() -> Result<CalxBenchmarkCorpus, String> {
+  let definitions = [
     ("range-sum", 2),
     ("fibonacci", 1),
     ("affine-helper", 3),
     ("affine", 3),
     ("polynomial", 1),
     ("bounded-simulation", 3),
-  ]);
-  let mut definitions = HashMap::new();
-  for node in cirru_parser::parse(include_str!("../../tests/fixtures/calx/scalar-kernels.cirru"))? {
-    let Cirru::List(items) = &node else {
-      return Err(format!("Calx benchmark fixture definition must be a list: {node}"));
-    };
-    let Some(Cirru::Leaf(definition)) = items.get(1) else {
-      return Err(format!("Calx benchmark fixture definition must have a name: {node}"));
-    };
-    let Some(arity) = arities.get(definition.as_ref()) else {
-      return Err(format!("Calx benchmark fixture `{definition}` has no declared signature"));
-    };
-    let code = code_to_calcit(&node, FIXTURE_NAMESPACE, definition, vec![])?;
-    let _ = ensure_def_id(FIXTURE_NAMESPACE, definition);
-    definitions.insert(
-      Arc::from(definition.as_ref()),
-      ProgramDefEntry {
-        code,
-        schema: number_fn_schema(*arity),
-        doc: Arc::from(""),
-        examples: vec![],
-        ffi: None,
-      },
-    );
-  }
-  PROGRAM_CODE_DATA.write().map_err(|error| error.to_string())?.insert(
-    Arc::from(FIXTURE_NAMESPACE),
-    ProgramFileData {
-      import_map: HashMap::new(),
-      defs: definitions,
-    },
-  );
-  Ok(())
+  ]
+  .into_iter()
+  .map(|(name, arity)| CalxBenchmarkDefinition::new(name, number_fn_schema(arity)));
+  CalxBenchmarkCorpus::new(
+    FIXTURE_NAMESPACE,
+    include_str!("../../tests/fixtures/calx/scalar-kernels.cirru"),
+    definitions,
+  )
+}
+
+/// Create the only mutable setup phase, then retain the immutable pinned session.
+fn prepare_session(kernel: &str) -> Result<CalxBenchmarkSession, String> {
+  CalxBenchmarkSession::prepare(&benchmark_corpus()?, kernel)
 }
 
 /// Map a named corpus case and its input size to concrete Calcit arguments.
@@ -436,41 +409,6 @@ fn kernel_arguments(kernel: &str, size: u32) -> Result<Vec<Calcit>, String> {
     "polynomial" => Ok(vec![Calcit::Number(n)]),
     "bounded-simulation" => Ok(vec![Calcit::Number(n), Calcit::Number(0.5), Calcit::Number(0.999)]),
     _ => Err(format!("unknown Calx benchmark kernel `{kernel}`")),
-  }
-}
-
-/// Convert proven scalar arguments without admitting Nil or Dynamic values.
-fn convert_arguments(kernel: &CalxCompiledKernel, args: &[Calcit]) -> Result<Vec<CalxValue>, String> {
-  if kernel.params().len() != args.len() {
-    return Err(format!("expected {} arguments, found {}", kernel.params().len(), args.len()));
-  }
-  args
-    .iter()
-    .zip(kernel.params())
-    .enumerate()
-    .map(|(index, (value, expected))| match (value, expected) {
-      (Calcit::Number(value), CalxScalarType::F64) => Ok(CalxValue::F64(*value)),
-      (Calcit::Bool(value), CalxScalarType::Bool) => Ok(CalxValue::Bool(*value)),
-      _ => Err(format!("argument {index} does not match the proven Calx scalar type")),
-    })
-    .collect()
-}
-
-/// Convert one strict Calx result back through the proven scalar boundary.
-fn convert_result(kernel: &CalxCompiledKernel, result: CalxRunResult) -> Result<Calcit, String> {
-  match (kernel.result(), result) {
-    (None, CalxRunResult::Void) => Ok(Calcit::Unit),
-    (Some(CalxScalarType::F64), CalxRunResult::Value(CalxValue::F64(value))) => Ok(Calcit::Number(value)),
-    (Some(CalxScalarType::Bool), CalxRunResult::Value(CalxValue::Bool(value))) => Ok(Calcit::Bool(value)),
-    (expected, actual) => Err(format!("validated result contract {expected:?} produced {actual:?}")),
-  }
-}
-
-/// Resolve the already-preprocessed Calcit entry once for a fair repeated-call baseline.
-fn resolve_cached_calcit_callable(kernel: &str, call_stack: &CallStackList) -> Result<Arc<CalcitFn>, String> {
-  match calcit::runner::evaluate_symbol_from_program(kernel, FIXTURE_NAMESPACE, None, call_stack).map_err(|error| error.to_string())? {
-    Calcit::Fn { info, .. } => Ok(info),
-    value => Err(format!("expected cached benchmark callable, found {value}")),
   }
 }
 
@@ -526,31 +464,20 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
     return Err("--compile-profile-allocation-iterations must be greater than zero in compile profile mode".to_owned());
   }
 
-  let fixture_started = Instant::now();
-  install_fixture()?;
-  let fixture_install_ns = nanos(fixture_started.elapsed());
-
-  let frontend_started = Instant::now();
-  let warnings = RefCell::new(vec![]);
-  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
-    .map_err(|error| error.to_string())?;
-  if !warnings.borrow().is_empty() {
-    return Err(format!("Calx compile profile frontend produced warnings: {:#?}", warnings.borrow()));
-  }
-  let calcit_frontend_ns = nanos(frontend_started.elapsed());
-
-  let snapshot_started = Instant::now();
-  let snapshot = clone_existing_compiled_program();
-  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
+  let session = prepare_session(&args.kernel)?;
+  let session_timings = session.timings();
+  let fixture_install_ns = nanos(session_timings.source_install);
+  let calcit_frontend_ns = nanos(session_timings.frontend);
+  let snapshot_clone_ns = nanos(session_timings.program_snapshot);
+  let imports = CalxHostImports::new();
 
   for _ in 0..args.compile_profile_warmup {
-    black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+    black_box(session.compile_calx(&imports).map_err(|error| error.to_string())?);
   }
 
   let mut stage_timing_total = CompileReport::default();
   for _ in 0..args.compile_profile_stage_iterations {
-    let (kernel, timings) =
-      compile_calx_kernel_measured(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?;
+    let (kernel, timings) = session.compile_calx_measured(&imports).map_err(|error| error.to_string())?;
     add_compile_timings(&mut stage_timing_total, timings);
     black_box(kernel);
   }
@@ -559,7 +486,7 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
   let allocation_window = ProfileAllocationWindow::begin()?;
   let allocation_result = (|| {
     for _ in 0..args.compile_profile_allocation_iterations {
-      black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+      black_box(session.compile_calx(&imports).map_err(|error| error.to_string())?);
     }
     Ok::<(), String>(())
   })();
@@ -569,7 +496,7 @@ fn measure_compile_profile(args: &Args) -> Result<CompileProfileReport, String> 
 
   let compile_started = Instant::now();
   for _ in 0..args.compile_profile_iterations {
-    black_box(compile_calx_kernel(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?);
+    black_box(session.compile_calx(&imports).map_err(|error| error.to_string())?);
   }
   let compile_total_ns = nanos(compile_started.elapsed());
 
@@ -601,27 +528,16 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
     return Err("--cache-profile-iterations must be greater than zero in cache profile mode".to_owned());
   }
 
-  let fixture_started = Instant::now();
-  install_fixture()?;
-  let fixture_install_ns = nanos(fixture_started.elapsed());
-
-  let frontend_started = Instant::now();
-  let warnings = RefCell::new(vec![]);
-  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
-    .map_err(|error| error.to_string())?;
-  if !warnings.borrow().is_empty() {
-    return Err(format!("Calx cache profile frontend produced warnings: {:#?}", warnings.borrow()));
-  }
-  let calcit_frontend_ns = nanos(frontend_started.elapsed());
-
-  let snapshot_started = Instant::now();
-  let snapshot = clone_existing_compiled_program();
-  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
+  let session = prepare_session(&args.kernel)?;
+  let session_timings = session.timings();
+  let fixture_install_ns = nanos(session_timings.source_install);
+  let calcit_frontend_ns = nanos(session_timings.frontend);
+  let snapshot_clone_ns = nanos(session_timings.program_snapshot);
   let imports = CalxHostImports::new();
   let mut cache = CalxCompileCache::new(1);
   let initial_started = Instant::now();
-  let initial = cache
-    .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+  let initial = session
+    .prepare_cached_calx(&mut cache, &imports)
     .map_err(|error| error.to_string())?;
   let initial_miss_prepare_ns = nanos(initial_started.elapsed());
   let initial_miss_reason = initial
@@ -636,23 +552,20 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
   );
   let initial_kernel = initial.into_kernel();
   let calcit_args = kernel_arguments(&args.kernel, args.size)?;
-  let vm_args = convert_arguments(&initial_kernel, &calcit_args)?;
+  let vm_args = CalxBenchmarkSession::encode_calx_arguments(&initial_kernel, &calcit_args)?;
 
-  let native_result = run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from(args.kernel.as_str()), &calcit_args)
-    .map_err(|error| error.to_string())?;
-  let native_call_stack = CallStackList::default();
-  let cached_native_callable = resolve_cached_calcit_callable(&args.kernel, &native_call_stack)?;
+  let native_result = session.run_calcit_lookup(&calcit_args)?;
 
   for _ in 0..args.cache_profile_warmup {
-    let preparation = cache
-      .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+    let preparation = session
+      .prepare_cached_calx(&mut cache, &imports)
       .map_err(|error| error.to_string())?;
     if !preparation.report().cache_hit {
       return Err("cache profile warmup unexpectedly missed".to_owned());
     }
-    let mut vm = preparation.kernel().instantiate().map_err(|error| error.to_string())?;
-    black_box(vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?);
-    black_box(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    let mut vm = CalxBenchmarkSession::instantiate_calx(preparation.kernel()).map_err(|error| error.to_string())?;
+    black_box(vm.run_values(vm_args.clone())?);
+    black_box(session.run_calcit_cached(&calcit_args)?);
   }
 
   let mut hit_prepare_total_ns = 0u64;
@@ -663,8 +576,8 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
   let mut last_fresh_result = None;
   for _ in 0..args.cache_profile_iterations {
     let prepare_started = Instant::now();
-    let preparation = cache
-      .prepare(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str(), &imports)
+    let preparation = session
+      .prepare_cached_calx(&mut cache, &imports)
       .map_err(|error| error.to_string())?;
     hit_prepare_total_ns = hit_prepare_total_ns.saturating_add(nanos(prepare_started.elapsed()));
     if !preparation.report().cache_hit {
@@ -674,24 +587,24 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
     binding_attachment_total_ns = binding_attachment_total_ns.saturating_add(nanos(preparation.report().binding_attachment));
 
     let setup_started = Instant::now();
-    let mut vm = preparation.kernel().instantiate().map_err(|error| error.to_string())?;
+    let mut vm = CalxBenchmarkSession::instantiate_calx(preparation.kernel()).map_err(|error| error.to_string())?;
     fresh_vm_setup_total_ns = fresh_vm_setup_total_ns.saturating_add(nanos(setup_started.elapsed()));
     let execution_started = Instant::now();
-    let result = vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?;
+    let result = vm.run_values(vm_args.clone())?;
     fresh_vm_execution_total_ns = fresh_vm_execution_total_ns.saturating_add(nanos(execution_started.elapsed()));
-    last_fresh_result = Some(convert_result(preparation.kernel(), result)?);
+    last_fresh_result = Some(CalxBenchmarkSession::decode_calx_result(preparation.kernel(), result)?);
   }
 
-  let mut reused_vm = initial_kernel.instantiate().map_err(|error| error.to_string())?;
+  let mut reused_vm = CalxBenchmarkSession::instantiate_calx(&initial_kernel).map_err(|error| error.to_string())?;
   for _ in 0..args.cache_profile_warmup {
-    black_box(reused_vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?);
+    black_box(reused_vm.run_values(vm_args.clone())?);
   }
   let reused_started = Instant::now();
   let mut last_reused_result = None;
   for _ in 0..args.cache_profile_iterations {
-    last_reused_result = Some(convert_result(
+    last_reused_result = Some(CalxBenchmarkSession::decode_calx_result(
       &initial_kernel,
-      reused_vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?,
+      reused_vm.run_values(vm_args.clone())?,
     )?);
   }
   let reused_vm_execution_total_ns = nanos(reused_started.elapsed());
@@ -699,8 +612,7 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
   let cached_native_started = Instant::now();
   let mut last_cached_native_result = None;
   for _ in 0..args.cache_profile_iterations {
-    last_cached_native_result =
-      Some(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    last_cached_native_result = Some(session.run_calcit_cached(&calcit_args)?);
   }
   let cached_native_execution_total_ns = nanos(cached_native_started.elapsed());
 
@@ -766,38 +678,23 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
     return Err("--hot-iterations must be greater than zero".to_owned());
   }
 
-  let fixture_started = Instant::now();
-  install_fixture()?;
-  let fixture_install_ns = nanos(fixture_started.elapsed());
+  let session = prepare_session(&args.kernel)?;
+  let session_timings = session.timings();
+  let fixture_install_ns = nanos(session_timings.source_install);
+  let calcit_frontend_ns = nanos(session_timings.frontend);
+  let snapshot_clone_ns = nanos(session_timings.program_snapshot);
 
-  let frontend_started = Instant::now();
-  let warnings = RefCell::new(vec![]);
-  calcit::runner::preprocess::ensure_ns_def_compiled(FIXTURE_NAMESPACE, &args.kernel, &warnings, &CallStackList::default())
+  let (kernel, compile_timings) = session
+    .compile_calx_measured(&CalxHostImports::new())
     .map_err(|error| error.to_string())?;
-  if !warnings.borrow().is_empty() {
-    return Err(format!("Calx benchmark frontend produced warnings: {:#?}", warnings.borrow()));
-  }
-  let calcit_frontend_ns = nanos(frontend_started.elapsed());
-
-  let snapshot_started = Instant::now();
-  let snapshot = clone_existing_compiled_program();
-  let snapshot_clone_ns = nanos(snapshot_started.elapsed());
-
-  let (kernel, compile_timings) =
-    compile_calx_kernel_measured(&snapshot, FIXTURE_NAMESPACE, args.kernel.as_str()).map_err(|error| error.to_string())?;
   let calcit_args = kernel_arguments(&args.kernel, args.size)?;
 
   let native_started = Instant::now();
-  let native_result = run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from(args.kernel.as_str()), &calcit_args)
-    .map_err(|error| error.to_string())?;
+  let native_result = session.run_calcit_lookup(&calcit_args)?;
   let native_call_ns = nanos(native_started.elapsed());
 
-  let native_call_stack = CallStackList::default();
-  let cached_native_resolution_started = Instant::now();
-  let cached_native_callable = resolve_cached_calcit_callable(&args.kernel, &native_call_stack)?;
-  let cached_native_resolution_ns = nanos(cached_native_resolution_started.elapsed());
-  let cached_native_result =
-    calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?;
+  let cached_native_resolution_ns = nanos(session_timings.cached_calcit_resolution);
+  let cached_native_result = session.run_calcit_cached(&calcit_args)?;
   if cached_native_result != native_result {
     return Err(format!(
       "correctness mismatch for {}/{}: Calcit lookup={native_result}, Calcit cached={cached_native_result}",
@@ -806,32 +703,32 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
   }
 
   for _ in 0..args.vm_warmup {
-    black_box(calcit::runner::run_fn(&calcit_args, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    black_box(session.run_calcit_cached(&calcit_args)?);
   }
   let cached_native_inputs = (0..args.hot_iterations).map(|_| calcit_args.clone()).collect::<Vec<_>>();
   let cached_native_started = Instant::now();
   for input in cached_native_inputs {
-    black_box(calcit::runner::run_fn(&input, &cached_native_callable, &native_call_stack).map_err(|error| error.to_string())?);
+    black_box(session.run_calcit_cached(&input)?);
   }
   let cached_native_execution_total_ns = nanos(cached_native_started.elapsed());
   let cached_native_execution_per_call_ns = cached_native_execution_total_ns / u64::from(args.hot_iterations);
 
   let calx_one_shot_started = Instant::now();
   let boundary_arguments_started = Instant::now();
-  let vm_args = convert_arguments(&kernel, &calcit_args)?;
+  let vm_args = CalxBenchmarkSession::encode_calx_arguments(&kernel, &calcit_args)?;
   let boundary_arguments_ns = nanos(boundary_arguments_started.elapsed());
 
   let setup_started = Instant::now();
-  let mut vm = kernel.instantiate().map_err(|error| error.to_string())?;
+  let mut vm = CalxBenchmarkSession::instantiate_calx(&kernel).map_err(|error| error.to_string())?;
   let vm_setup_ns = nanos(setup_started.elapsed());
 
   let one_shot_input = vm_args.clone();
   let execution_started = Instant::now();
-  let vm_result = vm.run_typed(one_shot_input).map_err(|error| error.to_string())?;
+  let vm_result = vm.run_values(one_shot_input)?;
   let pure_execution_ns = nanos(execution_started.elapsed());
 
   let result_boundary_started = Instant::now();
-  let calx_result = convert_result(&kernel, vm_result)?;
+  let calx_result = CalxBenchmarkSession::decode_calx_result(&kernel, vm_result)?;
   let boundary_result_ns = nanos(result_boundary_started.elapsed());
   let calx_one_shot_ns = nanos(calx_one_shot_started.elapsed());
   if calx_result != native_result {
@@ -841,24 +738,19 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
     ));
   }
 
-  let mut hot_vm = kernel.instantiate().map_err(|error| error.to_string())?;
+  let mut hot_vm = CalxBenchmarkSession::instantiate_calx(&kernel).map_err(|error| error.to_string())?;
   for _ in 0..args.vm_warmup {
-    black_box(hot_vm.run_typed(vm_args.clone()).map_err(|error| error.to_string())?);
+    black_box(hot_vm.run_values(vm_args.clone())?);
   }
   let hot_inputs = (0..args.hot_iterations).map(|_| vm_args.clone()).collect::<Vec<_>>();
   let hot_started = Instant::now();
   for input in hot_inputs {
-    black_box(hot_vm.run_typed(input).map_err(|error| error.to_string())?);
+    black_box(hot_vm.run_values(input)?);
   }
   let hot_execution_total_ns = nanos(hot_started.elapsed());
   let hot_execution_per_call_ns = hot_execution_total_ns / u64::from(args.hot_iterations);
 
-  let validated = kernel.validated_program();
-  let functions = validated.functions().len();
-  let imports = validated.imports().len();
-  let syntax_nodes = validated.functions().iter().map(|function| function.syntax.len()).sum();
-  let instructions = validated.functions().iter().map(|function| function.instrs.len()).sum();
-  let diagnostic_bytes = kernel.stable_program_summary().len();
+  let counts = CalxBenchmarkSession::program_counts(&kernel);
 
   Ok(BenchmarkReport {
     schema: "calcit-calx-benchmark/2",
@@ -892,11 +784,11 @@ fn measure(args: &Args) -> Result<BenchmarkReport, String> {
       hot_execution_per_call_ns,
     },
     program: ProgramReport {
-      functions,
-      imports,
-      syntax_nodes,
-      instructions,
-      diagnostic_bytes,
+      functions: counts.functions,
+      imports: counts.imports,
+      syntax_nodes: counts.syntax_nodes,
+      instructions: counts.instructions,
+      diagnostic_bytes: counts.diagnostic_bytes,
       host_boundary_calls_per_execution: 0,
       reuses_vm_frames_and_stack: true,
     },
@@ -945,16 +837,15 @@ mod tests {
 
   #[test]
   fn cached_callable_matches_lookup_execution_and_rejects_missing_entries() {
-    install_fixture().expect("install benchmark fixture");
     let args = kernel_arguments("range-sum", 10).expect("range-sum arguments");
-    let lookup_result =
-      run_program_with_docs(Arc::from(FIXTURE_NAMESPACE), Arc::from("range-sum"), &args).expect("run lookup baseline");
-    let call_stack = CallStackList::default();
-    let callable = resolve_cached_calcit_callable("range-sum", &call_stack).expect("resolve cached callable");
-    let cached_result = calcit::runner::run_fn(&args, &callable, &call_stack).expect("run cached callable");
-    assert_eq!(cached_result, lookup_result);
+    {
+      let session = prepare_session("range-sum").expect("prepare benchmark session");
+      let lookup_result = session.run_calcit_lookup(&args).expect("run lookup baseline");
+      let cached_result = session.run_calcit_cached(&args).expect("run cached callable");
+      assert_eq!(cached_result, lookup_result);
+    }
 
-    let error = resolve_cached_calcit_callable("missing-kernel", &call_stack).expect_err("missing entries must fail");
+    let error = prepare_session("missing-kernel").err().expect("missing entries must fail");
     assert!(error.contains("missing-kernel"));
   }
 

--- a/src/bin/calx_bench.rs
+++ b/src/bin/calx_bench.rs
@@ -600,14 +600,14 @@ fn measure_cache_profile(args: &Args) -> Result<CacheProfileReport, String> {
     black_box(reused_vm.run_values(vm_args.clone())?);
   }
   let reused_started = Instant::now();
-  let mut last_reused_result = None;
+  let mut last_reused_raw_result = None;
   for _ in 0..args.cache_profile_iterations {
-    last_reused_result = Some(CalxBenchmarkSession::decode_calx_result(
-      &initial_kernel,
-      reused_vm.run_values(vm_args.clone())?,
-    )?);
+    last_reused_raw_result = Some(reused_vm.run_values(vm_args.clone())?);
   }
   let reused_vm_execution_total_ns = nanos(reused_started.elapsed());
+  let last_reused_result = last_reused_raw_result
+    .map(|result| CalxBenchmarkSession::decode_calx_result(&initial_kernel, result))
+    .transpose()?;
 
   let cached_native_started = Instant::now();
   let mut last_cached_native_result = None;

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -5,6 +5,7 @@
 //! call graph, or one stable fallback report. Eligible graphs can then be lowered through
 //! `calx_vm::ProgramBuilder` and strict validation without admitting Nil or Dynamic values.
 
+pub mod benchmark_session;
 mod cache;
 mod lowering;
 

--- a/src/codegen/calx/benchmark_session.rs
+++ b/src/codegen/calx/benchmark_session.rs
@@ -77,6 +77,12 @@ impl CalxBenchmarkCorpus {
       if definition.name.is_empty() {
         return Err("Calx benchmark definition name must not be empty".to_owned());
       }
+      if !matches!(definition.schema.as_ref(), CalcitTypeAnnotation::Fn(_)) {
+        return Err(format!(
+          "Calx benchmark definition {}/{} must declare a function schema",
+          namespace, definition.name
+        ));
+      }
       if schemas.insert(definition.name.clone(), definition.schema).is_some() {
         return Err(format!("duplicate Calx benchmark schema for {}/{}", namespace, definition.name));
       }
@@ -104,6 +110,9 @@ impl CalxBenchmarkCorpus {
       let Cirru::List(items) = &node else {
         return Err(format!("Calx benchmark source definition must be a list: {node}"));
       };
+      if !matches!(items.first(), Some(Cirru::Leaf(kind)) if kind.as_ref() == "defn") {
+        return Err(format!("Calx benchmark source only accepts top-level defn forms: {node}"));
+      }
       let Some(Cirru::Leaf(definition)) = items.get(1) else {
         return Err(format!("Calx benchmark source definition must have a name: {node}"));
       };
@@ -467,6 +476,31 @@ mod tests {
         .expect("read source registry")
         .contains_key(corpus.namespace())
     );
+  }
+
+  #[test]
+  fn corpus_rejects_non_function_schemas_and_non_defn_source() {
+    let schema_error = CalxBenchmarkCorpus::new(
+      "test.calx-benchmark-session-schema",
+      "defn value ()\n  , 1",
+      [CalxBenchmarkDefinition::new("value", Arc::new(CalcitTypeAnnotation::Number))],
+    )
+    .expect_err("non-function schema must fail");
+    assert!(schema_error.contains("function schema"));
+
+    let source_result = CalxBenchmarkSession::prepare(
+      &CalxBenchmarkCorpus::new(
+        "test.calx-benchmark-session-source",
+        "def value 1",
+        [CalxBenchmarkDefinition::new("value", number_fn_schema(0))],
+      )
+      .expect("declare invalid source corpus"),
+      "value",
+    );
+    let Err(source_error) = source_result else {
+      panic!("non-defn source must fail");
+    };
+    assert!(source_error.contains("top-level defn"));
   }
 
   #[test]

--- a/src/codegen/calx/benchmark_session.rs
+++ b/src/codegen/calx/benchmark_session.rs
@@ -1,0 +1,491 @@
+//! Revision-pinned internal adapter for the standalone Calx benchmark harness.
+//!
+//! This API intentionally has no SemVer stability promise. A consumer must pin the
+//! exact Calcit revision it compiles and validate its quick benchmark matrix before
+//! advancing that pin. The adapter hides process-wide compiler registries and exposes
+//! only one isolated source/preprocess/compile/run session.
+
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+use calx_vm::{CalxRunResult, CalxVM};
+use cirru_parser::Cirru;
+
+use crate::calcit::{Calcit, CalcitFn, CalcitTypeAnnotation};
+use crate::call_stack::CallStackList;
+use crate::data::cirru::code_to_calcit;
+use crate::program::{self, CompiledProgram, ProgramDefEntry, ProgramFileData};
+use crate::runner;
+
+use super::{
+  CalxCachePreparation, CalxCompileCache, CalxHostImports, CalxKernelCompileError, CalxKernelCompileTimings, CalxKernelRunError,
+  CalxPreparedKernel, CalxScalarType, CalxValue, compile_calx_kernel_with_imports_measured,
+};
+
+/// Contract identifier recorded by revision-pinned harness consumers.
+pub const CALX_BENCHMARK_SESSION_EDITION: &str = "calcit-calx-benchmark-session/1";
+
+static BENCHMARK_SESSION_LOCK: Mutex<()> = Mutex::new(());
+
+/// One explicitly named source definition and its fixed type schema.
+#[derive(Debug, Clone)]
+pub struct CalxBenchmarkDefinition {
+  name: Arc<str>,
+  schema: Arc<CalcitTypeAnnotation>,
+}
+
+impl CalxBenchmarkDefinition {
+  /// Declare one definition that must occur exactly once in the source corpus.
+  pub fn new(name: impl Into<Arc<str>>, schema: Arc<CalcitTypeAnnotation>) -> Self {
+    Self { name: name.into(), schema }
+  }
+
+  /// Declared definition name.
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  /// Fixed schema supplied before preprocessing.
+  pub fn schema(&self) -> &Arc<CalcitTypeAnnotation> {
+    &self.schema
+  }
+}
+
+/// Explicit source corpus accepted by the internal benchmark adapter.
+#[derive(Debug, Clone)]
+pub struct CalxBenchmarkCorpus {
+  namespace: Arc<str>,
+  source: Arc<str>,
+  definitions: BTreeMap<Arc<str>, Arc<CalcitTypeAnnotation>>,
+}
+
+impl CalxBenchmarkCorpus {
+  /// Create a corpus with complete schemas for every top-level source definition.
+  pub fn new(
+    namespace: impl Into<Arc<str>>,
+    source: impl Into<Arc<str>>,
+    definitions: impl IntoIterator<Item = CalxBenchmarkDefinition>,
+  ) -> Result<Self, String> {
+    let namespace = namespace.into();
+    if namespace.is_empty() {
+      return Err("Calx benchmark corpus namespace must not be empty".to_owned());
+    }
+    let mut schemas = BTreeMap::new();
+    for definition in definitions {
+      if definition.name.is_empty() {
+        return Err("Calx benchmark definition name must not be empty".to_owned());
+      }
+      if schemas.insert(definition.name.clone(), definition.schema).is_some() {
+        return Err(format!("duplicate Calx benchmark schema for {}/{}", namespace, definition.name));
+      }
+    }
+    if schemas.is_empty() {
+      return Err("Calx benchmark corpus must declare at least one definition".to_owned());
+    }
+    Ok(Self {
+      namespace,
+      source: source.into(),
+      definitions: schemas,
+    })
+  }
+
+  /// Corpus namespace installed for the lifetime of one session.
+  pub fn namespace(&self) -> &str {
+    &self.namespace
+  }
+
+  fn install(&self) -> Result<(), String> {
+    let mut remaining = self.definitions.clone();
+    let mut source_names: HashSet<Arc<str>> = HashSet::new();
+    let mut definitions = HashMap::new();
+    for node in cirru_parser::parse(&self.source)? {
+      let Cirru::List(items) = &node else {
+        return Err(format!("Calx benchmark source definition must be a list: {node}"));
+      };
+      let Some(Cirru::Leaf(definition)) = items.get(1) else {
+        return Err(format!("Calx benchmark source definition must have a name: {node}"));
+      };
+      if !source_names.insert(Arc::from(definition.as_ref())) {
+        return Err(format!("duplicate Calx benchmark source definition: {definition}"));
+      }
+      let Some(schema) = remaining.remove(definition.as_ref()) else {
+        return Err(format!(
+          "Calx benchmark source {}/{} has no explicit schema",
+          self.namespace, definition
+        ));
+      };
+      let code = code_to_calcit(&node, &self.namespace, definition, vec![])?;
+      definitions.insert(
+        Arc::from(definition.as_ref()),
+        ProgramDefEntry {
+          code,
+          schema,
+          doc: Arc::from(""),
+          examples: vec![],
+          ffi: None,
+        },
+      );
+    }
+    if !remaining.is_empty() {
+      let names = remaining.keys().map(AsRef::as_ref).collect::<Vec<&str>>().join(", ");
+      return Err(format!("Calx benchmark schemas have no matching source definitions: {names}"));
+    }
+    program::install_internal_source_namespace(
+      self.namespace.clone(),
+      ProgramFileData {
+        import_map: HashMap::new(),
+        defs: definitions,
+      },
+    )
+  }
+}
+
+/// Frontend stages measured while creating one immutable program session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalxBenchmarkSessionTimings {
+  /// Parse, schema validation, and explicit source installation.
+  pub source_install: Duration,
+  /// Preprocessing of the selected entry and reachable definitions.
+  pub frontend: Duration,
+  /// Clone of the already-preprocessed immutable program handle.
+  pub program_snapshot: Duration,
+  /// Resolution of the cached Calcit callable stored by the session.
+  pub cached_calcit_resolution: Duration,
+}
+
+/// Stable program-size evidence derived from one compiled Calx kernel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalxBenchmarkProgramCounts {
+  /// Validated Calx function count.
+  pub functions: usize,
+  /// Validated host import count.
+  pub imports: usize,
+  /// Source-level validated syntax instruction count.
+  pub syntax_nodes: usize,
+  /// Lowered Calx instruction count.
+  pub instructions: usize,
+  /// Byte length of the deterministic diagnostic summary.
+  pub diagnostic_bytes: usize,
+}
+
+/// Raw strict result returned before the adapter applies the proven result boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CalxBenchmarkRawResult {
+  /// A function with no result values completed.
+  Void,
+  /// One strict floating-point result.
+  F64(f64),
+  /// One strict boolean result.
+  Bool(bool),
+}
+
+/// Reusable Calx VM owned by a benchmark call path.
+pub struct CalxBenchmarkVm {
+  vm: CalxVM,
+}
+
+impl CalxBenchmarkVm {
+  /// Execute already-validated strict values without rebuilding the VM.
+  pub fn run_values(&mut self, args: Vec<CalxValue>) -> Result<CalxBenchmarkRawResult, String> {
+    match self.vm.run_typed(args).map_err(|error| error.to_string())? {
+      CalxRunResult::Void => Ok(CalxBenchmarkRawResult::Void),
+      CalxRunResult::Value(CalxValue::F64(value)) => Ok(CalxBenchmarkRawResult::F64(value)),
+      CalxRunResult::Value(CalxValue::Bool(value)) => Ok(CalxBenchmarkRawResult::Bool(value)),
+      CalxRunResult::Value(value) => Err(format!("validated scalar kernel produced unsupported VM value: {value:?}")),
+    }
+  }
+}
+
+/// Immutable benchmark program handle plus one cached Calcit callable.
+///
+/// The session owns the process-local adapter lock for its lifetime. Consumers can
+/// compile and execute through methods here but cannot access compiler registries or
+/// the underlying mutable source state.
+pub struct CalxBenchmarkSession {
+  _guard: MutexGuard<'static, ()>,
+  namespace: Arc<str>,
+  definition: Arc<str>,
+  program: CompiledProgram,
+  calcit_callable: Arc<CalcitFn>,
+  timings: CalxBenchmarkSessionTimings,
+}
+
+impl CalxBenchmarkSession {
+  /// Install a corpus, preprocess one entry, and freeze an immutable program handle.
+  pub fn prepare(corpus: &CalxBenchmarkCorpus, definition: impl Into<Arc<str>>) -> Result<Self, String> {
+    let definition = definition.into();
+    if !corpus.definitions.contains_key(&definition) {
+      return Err(format!(
+        "Calx benchmark entry {}/{} has no explicit schema",
+        corpus.namespace, definition
+      ));
+    }
+    let guard = BENCHMARK_SESSION_LOCK
+      .lock()
+      .map_err(|error| format!("Calx benchmark session lock is poisoned: {error}"))?;
+
+    let install_started = Instant::now();
+    corpus.install()?;
+    let source_install = install_started.elapsed();
+    let result = (|| {
+      let frontend_started = Instant::now();
+      let warnings = RefCell::new(vec![]);
+      runner::preprocess::ensure_ns_def_compiled(&corpus.namespace, &definition, &warnings, &CallStackList::default())
+        .map_err(|error| error.to_string())?;
+      if !warnings.borrow().is_empty() {
+        return Err(format!("Calx benchmark frontend produced warnings: {:#?}", warnings.borrow()));
+      }
+      let frontend = frontend_started.elapsed();
+
+      let snapshot_started = Instant::now();
+      let program = program::clone_existing_compiled_program();
+      let program_snapshot = snapshot_started.elapsed();
+
+      let resolution_started = Instant::now();
+      let calcit_callable = match runner::evaluate_symbol_from_program(&definition, &corpus.namespace, None, &CallStackList::default())
+        .map_err(|error| error.to_string())?
+      {
+        Calcit::Fn { info, .. } => info,
+        value => return Err(format!("expected cached benchmark callable, found {value}")),
+      };
+      let cached_calcit_resolution = resolution_started.elapsed();
+
+      Ok((
+        program,
+        calcit_callable,
+        CalxBenchmarkSessionTimings {
+          source_install,
+          frontend,
+          program_snapshot,
+          cached_calcit_resolution,
+        },
+      ))
+    })();
+
+    match result {
+      Ok((program, calcit_callable, timings)) => Ok(Self {
+        _guard: guard,
+        namespace: corpus.namespace.clone(),
+        definition,
+        program,
+        calcit_callable,
+        timings,
+      }),
+      Err(error) => {
+        program::remove_internal_source_namespace(&corpus.namespace);
+        Err(error)
+      }
+    }
+  }
+
+  /// Adapter contract identifier; consumers record this with their pinned revision.
+  pub const fn edition(&self) -> &'static str {
+    CALX_BENCHMARK_SESSION_EDITION
+  }
+
+  /// Prepared entry namespace.
+  pub fn namespace(&self) -> &str {
+    &self.namespace
+  }
+
+  /// Prepared entry definition.
+  pub fn definition(&self) -> &str {
+    &self.definition
+  }
+
+  /// Measured source, frontend, snapshot, and cached-callable stages.
+  pub const fn timings(&self) -> CalxBenchmarkSessionTimings {
+    self.timings
+  }
+
+  /// Execute through normal symbol lookup for one correctness baseline.
+  pub fn run_calcit_lookup(&self, args: &[Calcit]) -> Result<Calcit, String> {
+    crate::run_program_with_docs(self.namespace.clone(), self.definition.clone(), args).map_err(|error| error.to_string())
+  }
+
+  /// Execute the callable resolved once when the session was prepared.
+  pub fn run_calcit_cached(&self, args: &[Calcit]) -> Result<Calcit, String> {
+    runner::run_fn(args, &self.calcit_callable, &CallStackList::default()).map_err(|error| error.to_string())
+  }
+
+  /// Compile one strict Calx kernel and return complete compile-stage timings.
+  pub fn compile_calx_measured(
+    &self,
+    imports: &CalxHostImports,
+  ) -> Result<(CalxPreparedKernel, CalxKernelCompileTimings), CalxKernelCompileError> {
+    compile_calx_kernel_with_imports_measured(&self.program, self.namespace.clone(), self.definition.clone(), imports)
+  }
+
+  /// Compile one strict Calx kernel without retaining measurement stages.
+  pub fn compile_calx(&self, imports: &CalxHostImports) -> Result<CalxPreparedKernel, CalxKernelCompileError> {
+    self.compile_calx_measured(imports).map(|(kernel, _)| kernel)
+  }
+
+  /// Validate or populate an embedding-owned revision-safe artifact cache.
+  pub fn prepare_cached_calx(
+    &self,
+    cache: &mut CalxCompileCache,
+    imports: &CalxHostImports,
+  ) -> Result<CalxCachePreparation, CalxKernelCompileError> {
+    cache.prepare(&self.program, self.namespace.clone(), self.definition.clone(), imports)
+  }
+
+  /// Convert Calcit arguments through one compiled kernel's strict scalar boundary.
+  pub fn encode_calx_arguments(kernel: &CalxPreparedKernel, args: &[Calcit]) -> Result<Vec<CalxValue>, String> {
+    if kernel.params().len() != args.len() {
+      return Err(format!("expected {} arguments, found {}", kernel.params().len(), args.len()));
+    }
+    args
+      .iter()
+      .zip(kernel.params())
+      .enumerate()
+      .map(|(index, (value, expected))| match (value, expected) {
+        (Calcit::Number(value), CalxScalarType::F64) => Ok(CalxValue::F64(*value)),
+        (Calcit::Bool(value), CalxScalarType::Bool) => Ok(CalxValue::Bool(*value)),
+        _ => Err(format!("argument {index} does not match the proven Calx scalar type")),
+      })
+      .collect()
+  }
+
+  /// Create a fresh VM while keeping the underlying Calx program private to the adapter.
+  pub fn instantiate_calx(kernel: &CalxPreparedKernel) -> Result<CalxBenchmarkVm, CalxKernelRunError> {
+    kernel.instantiate().map(|vm| CalxBenchmarkVm { vm })
+  }
+
+  /// Decode a raw VM result through one compiled kernel's proven result boundary.
+  pub fn decode_calx_result(kernel: &CalxPreparedKernel, result: CalxBenchmarkRawResult) -> Result<Calcit, String> {
+    match (kernel.result(), result) {
+      (None, CalxBenchmarkRawResult::Void) => Ok(Calcit::Unit),
+      (Some(CalxScalarType::F64), CalxBenchmarkRawResult::F64(value)) => Ok(Calcit::Number(value)),
+      (Some(CalxScalarType::Bool), CalxBenchmarkRawResult::Bool(value)) => Ok(Calcit::Bool(value)),
+      (expected, actual) => Err(format!("validated result contract {expected:?} produced {actual:?}")),
+    }
+  }
+
+  /// Derive stable size counts without exposing the immutable program handle.
+  pub fn program_counts(kernel: &CalxPreparedKernel) -> CalxBenchmarkProgramCounts {
+    let validated = kernel.validated_program();
+    CalxBenchmarkProgramCounts {
+      functions: validated.functions().len(),
+      imports: validated.imports().len(),
+      syntax_nodes: validated.functions().iter().map(|function| function.syntax.len()).sum(),
+      instructions: validated.functions().iter().map(|function| function.instrs.len()).sum(),
+      diagnostic_bytes: kernel.stable_program_summary().len(),
+    }
+  }
+}
+
+impl Drop for CalxBenchmarkSession {
+  fn drop(&mut self) {
+    program::remove_internal_source_namespace(&self.namespace);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::HashSet;
+
+  use crate::calcit::{CalcitFnTypeAnnotation, SchemaKind};
+
+  use super::*;
+
+  fn number_fn_schema(arity: usize) -> Arc<CalcitTypeAnnotation> {
+    Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: (0..arity).map(|_| Arc::new(CalcitTypeAnnotation::Number)).collect(),
+      return_type: Arc::new(CalcitTypeAnnotation::Number),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })))
+  }
+
+  fn scalar_corpus() -> CalxBenchmarkCorpus {
+    CalxBenchmarkCorpus::new(
+      "test.calx-benchmark-session",
+      "defn add-one (x)\n  &+ x 1",
+      [CalxBenchmarkDefinition::new("add-one", number_fn_schema(1))],
+    )
+    .expect("declare scalar corpus")
+  }
+
+  #[test]
+  fn pinned_session_runs_equivalent_calcit_and_calx_paths() {
+    let session = CalxBenchmarkSession::prepare(&scalar_corpus(), "add-one").expect("prepare benchmark session");
+    assert_eq!(session.edition(), CALX_BENCHMARK_SESSION_EDITION);
+    assert_eq!(session.namespace(), "test.calx-benchmark-session");
+    assert_eq!(session.definition(), "add-one");
+
+    let calcit_args = vec![Calcit::Number(4.0)];
+    let lookup = session.run_calcit_lookup(&calcit_args).expect("run lookup path");
+    let cached = session.run_calcit_cached(&calcit_args).expect("run cached path");
+    assert_eq!(lookup, Calcit::Number(5.0));
+    assert_eq!(cached, lookup);
+
+    let imports = CalxHostImports::new();
+    let (kernel, compile_timings) = session.compile_calx_measured(&imports).expect("compile strict kernel");
+    assert!(compile_timings.total > Duration::ZERO);
+    let calx_args = CalxBenchmarkSession::encode_calx_arguments(&kernel, &calcit_args).expect("encode strict arguments");
+    let mut vm = CalxBenchmarkSession::instantiate_calx(&kernel).expect("create benchmark VM");
+    let raw = vm.run_values(calx_args).expect("execute strict kernel");
+    let calx = CalxBenchmarkSession::decode_calx_result(&kernel, raw).expect("decode strict result");
+    assert_eq!(calx, lookup);
+
+    let counts = CalxBenchmarkSession::program_counts(&kernel);
+    assert_eq!(counts.functions, 1);
+    assert!(counts.syntax_nodes > 0);
+    assert!(counts.instructions > 0);
+
+    let mut cache = CalxCompileCache::new(1);
+    let miss = session.prepare_cached_calx(&mut cache, &imports).expect("populate artifact cache");
+    assert!(!miss.report().cache_hit);
+    let hit = session.prepare_cached_calx(&mut cache, &imports).expect("reuse artifact cache");
+    assert!(hit.report().cache_hit);
+  }
+
+  #[test]
+  fn corpus_rejects_incomplete_schema_sets_without_installing_source() {
+    let corpus = CalxBenchmarkCorpus::new(
+      "test.calx-benchmark-session-invalid",
+      "defn add-one (x)\n  &+ x 1",
+      [
+        CalxBenchmarkDefinition::new("add-one", number_fn_schema(1)),
+        CalxBenchmarkDefinition::new("missing", number_fn_schema(1)),
+      ],
+    )
+    .expect("declare intentionally mismatched corpus");
+    let error = CalxBenchmarkSession::prepare(&corpus, "add-one")
+      .err()
+      .expect("missing source definition must fail");
+    assert!(error.contains("missing"));
+    assert!(
+      !program::PROGRAM_CODE_DATA
+        .read()
+        .expect("read source registry")
+        .contains_key(corpus.namespace())
+    );
+  }
+
+  #[test]
+  fn session_drop_releases_its_source_namespace() {
+    let corpus = scalar_corpus();
+    {
+      let _session = CalxBenchmarkSession::prepare(&corpus, "add-one").expect("prepare benchmark session");
+      assert!(
+        program::PROGRAM_CODE_DATA
+          .read()
+          .expect("read source registry")
+          .contains_key(corpus.namespace())
+      );
+    }
+    assert!(
+      !program::PROGRAM_CODE_DATA
+        .read()
+        .expect("read source registry")
+        .contains_key(corpus.namespace())
+    );
+  }
+}

--- a/src/program.rs
+++ b/src/program.rs
@@ -1116,6 +1116,32 @@ pub fn clone_existing_compiled_program() -> CompiledProgram {
   PROGRAM_COMPILED_DATA_STATE.read().expect("read compiled program data").clone()
 }
 
+/// Install one explicitly named source namespace for an internal isolated session.
+///
+/// This is intentionally crate-private: external adapters must not receive mutable
+/// access to the process-wide source and compiled registries. Existing namespaces
+/// are never overwritten by benchmark setup.
+pub(crate) fn install_internal_source_namespace(ns: Arc<str>, file: ProgramFileData) -> Result<(), String> {
+  let mut source = PROGRAM_CODE_DATA.write().map_err(|error| error.to_string())?;
+  if source.contains_key(&ns) {
+    return Err(format!("internal source namespace already exists: {ns}"));
+  }
+  clear_runtime_ns(&ns);
+  remove_compiled_ns(&ns);
+  for def in file.defs.keys() {
+    let _ = register_program_def_id(&ns, def);
+  }
+  source.insert(ns, file);
+  Ok(())
+}
+
+/// Remove a namespace installed by an internal isolated session.
+pub(crate) fn remove_internal_source_namespace(ns: &str) {
+  clear_runtime_ns(ns);
+  PROGRAM_CODE_DATA.write().expect("write program code").remove(ns);
+  remove_compiled_ns(ns);
+}
+
 pub fn apply_code_changes(changes: &snapshot::ChangesDict) -> Result<(), String> {
   let mut program_code = PROGRAM_CODE_DATA.write().expect("open program code");
   let coord0 = vec![];

--- a/tests/calx_harness_contract.rs
+++ b/tests/calx_harness_contract.rs
@@ -15,7 +15,8 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
   let manifest = read_json(BOOTSTRAP);
   assert_eq!(manifest["schema"], "calcit-calx-harness-bootstrap/1");
   assert_eq!(manifest["status"], "experimental-benchmark");
-  assert_eq!(manifest["targetRepository"]["confirmed"], false);
+  assert_eq!(manifest["targetRepository"]["name"], "calcit-lang/calcit-calx-bench");
+  assert_eq!(manifest["targetRepository"]["confirmed"], true);
   assert_eq!(
     manifest["targetRepository"]["existingCalcitCalxRole"],
     "native-ffi-demo-do-not-absorb-harness"
@@ -49,6 +50,7 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
     stayed,
     string_set(&[
       "src/codegen/calx.rs",
+      "src/codegen/calx/benchmark_session.rs",
       "src/codegen/calx/lowering.rs",
       "src/program/tests.rs",
       "tests/fixtures/calx/scalar-kernels.cirru",
@@ -69,6 +71,9 @@ fn bootstrap_manifest_has_valid_tracking_ownership_and_assets() {
 
   assert_eq!(manifest["migrationTests"]["rust"], 3);
   assert_eq!(manifest["migrationTests"]["node"], 4);
+  assert_eq!(manifest["adapter"]["module"], "calcit::codegen::calx::benchmark_session");
+  assert_eq!(manifest["adapter"]["edition"], "calcit-calx-benchmark-session/1");
+  assert_eq!(manifest["adapter"]["coreTransitionalRunnerUsesAdapter"], true);
   assert_eq!(manifest["reportContract"]["preserveRawSamples"], true);
   assert_eq!(manifest["reportContract"]["absoluteCiThresholds"], false);
 }


### PR DESCRIPTION
## Summary / 概要

- add revision-pinned internal adapter edition `calcit-calx-benchmark-session/1` at `calcit::codegen::calx::benchmark_session`
- require a complete named source/schema corpus, serialize isolated setup, reject namespace replacement, preprocess once, and retain a private immutable program snapshot plus cached Calcit callable
- expose measured Calx compile/cache preparation, Calcit lookup/cached execution, strict Calx boundary conversion, VM execution, timings, and stable program counts without exposing mutable registries
- migrate the temporary in-core benchmark runner away from `PROGRAM_CODE_DATA`, `ProgramFileData`, `ensure_def_id`, `run_fn`, raw `CalxVM`, and other private setup hooks
- update the bilingual extraction contract, confirmed standalone repository state, README/AGENTS ownership notes, and machine-readable contract tests

- 在 `calcit::codegen::calx::benchmark_session` 增加固定 revision 的内部 adapter，契约版本为 `calcit-calx-benchmark-session/1`
- 要求完整的命名源码/schema corpus，串行化隔离 setup，拒绝覆盖已有 namespace，只 preprocess 一次，并私有持有不可变 program snapshot 与 cached Calcit callable
- 只暴露 measured Calx compile/cache preparation、Calcit lookup/cached 执行、严格 Calx 边界转换、VM 执行、timing 与稳定 program counts，不暴露 mutable registry
- 将 core 中的过渡 benchmark runner 从 `PROGRAM_CODE_DATA`、`ProgramFileData`、`ensure_def_id`、`run_fn`、raw `CalxVM` 等 private hook 迁到 adapter
- 同步中英双语拆分契约、已确认的独立仓库状态、README/AGENTS 职责说明和 machine-readable contract tests

## Validation / 验证

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- isolated-HOME `cargo test`: 620 library, 272 CLI, 5 runner, 24 caps, 21 wasm and all integration contract tests passed
- `yarn compile`
- `yarn check-all`: core 225/225, Agent interface 18/18, JS/IR/WASM and performance smoke passed
- release-mode normal/cache/compile-profile runner smoke preserved `calcit-calx-benchmark/2`, `calcit-calx-cache-profile/1`, and `calcit-calx-compile-profile/1`, with correctness true and expected cache miss/hit behavior

## Follow-up / 后续

After this PR is merged, `calcit-lang/calcit-calx-bench` can pin the merge revision, migrate its transitional submodule runner onto this adapter, run the quick matrix, and then unblock core asset removal in #559.

本 PR 合并后，`calcit-lang/calcit-calx-bench` 可以固定该 merge revision，把过渡 submodule runner 迁到此 adapter，运行 quick matrix；通过后再解除 #559 中删除 core 重复资产的阻塞。

Issue #558 remains open until the standalone migration smoke is recorded; this PR satisfies its core-adapter prerequisite. / 本 PR 完成 #558 的 core-adapter 前置条件；只有独立仓库迁移 smoke 留证后才关闭 #558。
