### PR TITLE
chore: 删除 caps 遗留的 dirs 依赖 / remove unused dirs after caps cutover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,6 @@ dependencies = [
  "cirru_parser",
  "colored",
  "ctrlc",
- "dirs",
  "hex",
  "im_ternary_tree",
  "libloading",
@@ -289,27 +288,6 @@ dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -506,16 +484,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,12 +612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,17 +640,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "redox_users"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror",
-]
 
 [[package]]
 name = "regex"
@@ -950,26 +901,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ serde = { version = "1.0.229", features = ["derive"] }
 cirru_parser = "=0.2.15"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-dirs = "6.0.0"
 notify = "8.0.0"
 notify-debouncer-mini = "0.7.0"
 ureq = "3.3.0"

--- a/editing-history/202609010018-remove-unused-dirs-after-caps.md
+++ b/editing-history/202609010018-remove-unused-dirs-after-caps.md
@@ -1,0 +1,22 @@
+# Remove unused dirs after caps cutover / Caps 切换后删除未使用的 dirs
+
+## 中文
+
+PR #567 删除了 core 内的 caps binary 与源码，但 `dirs = "6.0.0"` 仍留在 Calcit 的
+non-Wasm direct dependencies。全仓搜索确认原唯一调用 `dirs::home_dir()` 已随
+`src/bin/calcit_deps.rs` 删除，当前 `src/` 与 `tests/` 不再消费该 crate。
+
+本次 follow-up 删除 `dirs` direct dependency，并通过 `cargo update --workspace` 清理
+`dirs`、`dirs-sys`、`option-ext`、`redox_users`、`libredox`、`thiserror 2` 与对应 proc macro。
+这不改变 Snapshot/module loading、独立 caps 或 Calx 语义。
+
+## English
+
+PR #567 removed the core caps binary and sources, but `dirs = "6.0.0"` remained in
+Calcit's non-Wasm direct dependencies. A repository-wide search confirms that its sole
+`dirs::home_dir()` call disappeared with `src/bin/calcit_deps.rs`; current `src/` and
+`tests/` no longer consume the crate.
+
+This follow-up removes the direct dependency and lets `cargo update --workspace` prune
+`dirs`, `dirs-sys`, `option-ext`, `redox_users`, `libredox`, `thiserror 2`, and its proc
+macro. Snapshot/module loading, standalone caps, and Calx semantics are unchanged.


### PR DESCRIPTION
## 中文

### 背景

PR #567 已从 Calcit core 删除 `caps` binary、resolver/store 实现与 `fs4`，但 `dirs = "6.0.0"` 仍留在 non-Wasm direct dependencies。全仓搜索确认它的唯一调用 `dirs::home_dir()` 已随 `src/bin/calcit_deps.rs` 删除，当前 `src/` 与 `tests/` 没有消费方。

### 修改

- 删除未使用的 `dirs` direct dependency；
- 更新 workspace lockfile，清理 `dirs`、`dirs-sys`、`option-ext`、`redox_users`、`libredox`、`thiserror 2` 与对应 proc macro；
- 增加时间戳 editing history，记录判断依据和边界。

Cargo.lock package 数从 `149` 降到 `142`，Calcit direct dependencies 从 `30` 降到 `29`。不修改 Snapshot/module loading、standalone caps、Calx backend 或 release targets。

### 验证

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`（621 个 library tests、21 个 cr-wasm tests 全部通过）
- `yarn check-all`（core attached tests 225/225，JS/WASM 全部通过）
- `yarn check-agent-interface`（18/18）
- `git diff --check`

关联：#555、#567。

## English

### Context

PR #567 removed the core `caps` binary, resolver/store implementation, and `fs4`, but left `dirs = "6.0.0"` in the non-Wasm direct dependencies. A repository-wide search confirms that its only `dirs::home_dir()` call disappeared with `src/bin/calcit_deps.rs`; current `src/` and `tests/` have no consumer.

### Changes

- Remove the unused direct `dirs` dependency.
- Update the workspace lockfile and prune `dirs`, `dirs-sys`, `option-ext`, `redox_users`, `libredox`, `thiserror 2`, and its proc macro.
- Add a timestamped editing-history entry documenting the evidence and boundary.

The Cargo.lock package count drops from `149` to `142`, and Calcit direct dependencies drop from `30` to `29`. Snapshot/module loading, standalone caps, the Calx backend, and release targets are unchanged.

### Verification

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test` (all 621 library tests and 21 cr-wasm tests pass)
- `yarn check-all` (225/225 attached core tests; JS and WASM pass)
- `yarn check-agent-interface` (18/18)
- `git diff --check`

Related: #555 and #567.
