### PR TITLE
对齐 native FFI 0.1.3 / align native FFI 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "calcit_native_ffi"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a8cfaff7caed355a63e9df68c57cea5af1d01b1b37734ed812a4a9ed2faeed"
+checksum = "73ebd0fd554c1e6778850f26743d7a06dca3f387e945d03f202abd424c4b1743"
 
 [[package]]
 name = "calx_vm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cirru_edn = "0.8.0"
 cirru_parser = "=0.2.15"
 bisection_key = "0.0.1"
 calx_vm = "0.3.0"
-calcit_native_ffi = { version = "0.1.2", default-features = false }
+calcit_native_ffi = { version = "0.1.3", default-features = false }
 rmp-serde = "1.3.0"
 semver = "1.0.28"
 regex = "1.13.1"

--- a/editing-history/202609010059-align-native-ffi-013.md
+++ b/editing-history/202609010059-align-native-ffi-013.md
@@ -1,0 +1,13 @@
+# 对齐 native FFI 0.1.3 / Align native FFI 0.1.3
+
+## 中文
+
+- 将 Calcit core 的 raw ABI 依赖从 `calcit_native_ffi 0.1.2` 对齐到生态统一使用的 0.1.3。
+- 保持 `default-features = false`，core 仍只消费 constants、symbols、function types 与 C-layout descriptors，不引入 EDN/module adapter 依赖。
+- 该组合已由 calcit-native-ffi#10 的 revision-pinned matrix 验证：core raw ABI 20/20、host async/blocking lifecycle 17/17，并通过 generated、std、wss 与 regex 真实 dylib smoke。
+
+## English
+
+- Align Calcit core's raw-ABI dependency from `calcit_native_ffi 0.1.2` to the ecosystem-wide 0.1.3 release.
+- Retain `default-features = false`; core still consumes only constants, symbols, function types, and C-layout descriptors without pulling EDN/module adapters into the host.
+- The revision-pinned matrix from calcit-native-ffi#10 already validates this combination through 20/20 raw-ABI tests, 17/17 host async/blocking lifecycle tests, and generated, std, WSS, and regex real-dylib smokes.


### PR DESCRIPTION
## 中文

### 变更

- 将 Calcit core 的 `calcit_native_ffi` 从 0.1.2 对齐到生态统一使用的 0.1.3；
- 保持 `default-features = false`，不把 EDN/module adapter 依赖引入 host；
- 更新 Cargo.lock，并记录双语 editing history。

该精确组合已在 calcit-native-ffi#10 的 revision-pinned matrix 中通过 core/caps/bindgen/std/wss/regex 真实验证；本 PR 让生产 lockfile 与该验证组合一致。

### 验证

- `cargo fmt --check`
- strict all-target/all-feature clippy
- `cargo test`：621 library + 272 calcit CLI + 21 cr-wasm
- `yarn compile`
- Agent interface 18/18
- `yarn check-all`：core 225/225、JS/IR/WASM、literal-path 与 typed-method 性能门禁
- calcit-native-ffi#10 cross-consumer matrix：Ubuntu 5m07s，全绿

## English

### Changes

- align Calcit core from `calcit_native_ffi` 0.1.2 to the ecosystem-wide 0.1.3 release;
- retain `default-features = false`, keeping EDN/module adapters out of the host dependency boundary;
- refresh Cargo.lock and add bilingual editing history.

The exact combination already passes the revision-pinned core/caps/bindgen/std/wss/regex matrix from calcit-native-ffi#10. This pull request makes the production lockfile match that validated set.

### Verification

- formatting and strict all-target/all-feature clippy;
- 621 library, 272 calcit CLI, and 21 cr-wasm tests;
- compile and Agent interface 18/18;
- full `yarn check-all`, including core 225/225, JS/IR/WASM, and both performance gates;
- green calcit-native-ffi#10 cross-consumer matrix on Ubuntu (5m07s).
