### PR TITLE
feat: enforce strict typed boundaries / 强化严格类型边界

### DIFF
--- a/calcit/test-struct.cirru
+++ b/calcit/test-struct.cirru
@@ -1,114 +1,115 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |test-struct) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |test-struct)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'test-struct.main/main!) (:mode :native) (:reload-fn 'test-struct.main/reload!)
+      :feature-policy $ {}
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-struct.main $ %{} 'FileEntry
+    'test-struct.main $ %{} 'FileEntry
       :defs $ {}
-        |A $ %{} 'CodeEntry (:doc |)
+        'A $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct A $ :a 'Dynamic
           :examples $ []
-          :schema $ :: 'Dynamic
-        |A0 $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'A0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct A0 $ :name 'String
           :examples $ []
-          :schema $ :: 'Dynamic
-        |B $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'B $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct B $ :b 'Dynamic
           :examples $ []
-          :schema $ :: 'Dynamic
-        |BirdImpl $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'BirdImpl $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defimpl BirdImpl BirdTrait
               .show $ fn (self)
                 println $ &struct:get self :name
               .rename $ fn (self name) (assoc self :name name)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |BirdShape $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'Impl
+        'BirdShape $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct BirdShape (:show 'Fn) (:rename 'Fn)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |BirdTrait $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'BirdTrait $ %{} 'CodeEntry (:doc |)
           :code $ quote
             deftrait BirdTrait (.show :fn) (.rename :fn)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |C $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'Trait
+        'C $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct C $ :c 'Dynamic
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Cat $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'Cat $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Cat (:name 'String) (:color 'Tag)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |City $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'City $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct City (:name 'String) (:province 'String)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Demo $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'Demo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Demo (:a 'Dynamic) (:b 'Dynamic) (:c 'Dynamic) (:d 'Dynamic)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Lagopus $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'Lagopus $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def Lagopus $ impl-traits Lagopus0 BirdImpl
           :examples $ []
           :schema $ :: 'Dynamic
-        |Lagopus0 $ %{} 'CodeEntry (:doc |)
+        'Lagopus0 $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Lagopus0 $ :name (:: 'Optional 'String)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |MapLiteralStore $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'MapLiteralStore $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct MapLiteralStore $ {} (:text 'String)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'StructDef
           :tests $ []
             %{} 'TestEntry (:name |map-literal-fields)
               :code $ quote
                 let
                     store $ MapLiteralStore :text |ok
                   assert= |ok $ :text store
-        |Person $ %{} 'CodeEntry (:doc |)
+        'Person $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Person
               :name $ :: 'Optional 'String
               :age $ :: 'Optional 'Number
               :position $ :: 'Optional 'Tag
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Point2D $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'Point2D $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Point2D (:x 'Number) (:y 'Number)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |check-point-type $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'check-point-type $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn check-point-type (p) (struct? p)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] 'test-struct.main/Point2D
-        |main! $ %{} 'CodeEntry (:doc |)
+        'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (test-struct) (test-methods) (test-match) (test-polymorphism) (test-edn) (test-struct-with) (test-partial-struct) (test-loose-struct-rewrite) (test-map-to-struct) (test-postfix) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |read-asserted-map-literal-store $ %{} 'CodeEntry (:doc |)
+        'read-asserted-map-literal-store $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn read-asserted-map-literal-store (source)
               let
@@ -121,7 +122,7 @@
             %{} 'TestEntry (:name |assert-type-statement-narrows-struct)
               :code $ quote
                 assert= |ok $ read-asserted-map-literal-store (MapLiteralStore :text |ok)
-        |read-let-asserted-map-literal-store $ %{} 'CodeEntry (:doc |)
+        'read-let-asserted-map-literal-store $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn read-let-asserted-map-literal-store (source)
               let
@@ -133,12 +134,12 @@
             %{} 'TestEntry (:name |assert-type-expression-narrows-struct)
               :code $ quote
                 assert= |ok $ read-let-asserted-map-literal-store (MapLiteralStore :text |ok)
-        |reload! $ %{} 'CodeEntry (:doc |)
+        'reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ println |reloaded
           :examples $ []
           :schema $ :: 'Dynamic
-        |sum-point $ %{} 'CodeEntry (:doc |)
+        'sum-point $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn sum-point (p)
               &+ (:x p) (:y p)
@@ -146,7 +147,7 @@
           :schema $ :: 'Fn
             {} (:return 'Number)
               :args $ [] 'test-struct.main/Point2D
-        |test-edn $ %{} 'CodeEntry (:doc |)
+        'test-edn $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               let
@@ -171,14 +172,14 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-loose-struct-rewrite $ %{} 'CodeEntry (:doc |)
+        'test-loose-struct-rewrite $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing loose-to-struct rewrite")
               assert= 30 $ sum-point (?{} :x 10 :y 20)
               assert= true $ check-point-type (?{} :x 10 :y 20)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-to-struct $ %{} 'CodeEntry (:doc |)
+        'test-map-to-struct $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing map-to-struct rewrite")
               assert= 30 $ sum-point
@@ -187,7 +188,7 @@
                 {} (:x 10) (:y 20)
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-match $ %{} 'CodeEntry (:doc |)
+        'test-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing struct match")
               let
@@ -210,7 +211,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-methods $ %{} 'CodeEntry (:doc |)
+        'test-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing struct methods")
               &let
@@ -235,13 +236,13 @@
                   %{} Cat (:name |kitty) (:color :red)
                 &let
                   persian $ &struct:extend-as kitty :Persian :age 10
-                  assert= 10 $ &struct:nth persian 0
+                  assert= 10 $ &struct:nth persian 0 :age
                   assert= :Persian $ &struct:get-name persian
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-partial-struct $ %{} 'CodeEntry (:doc |)
+        'test-partial-struct $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing partial struct")
               let
@@ -259,7 +260,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-polymorphism $ %{} 'CodeEntry (:doc |)
+        'test-polymorphism $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Test struct polymorphism") (println Lagopus)
               let
@@ -281,7 +282,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-postfix $ %{} 'CodeEntry (:doc "|test postfix syntax")
+        'test-postfix $ %{} 'CodeEntry (:doc "|test postfix syntax")
           :code $ quote
             fn () (log-title "|Testing postfix syntax")
               let
@@ -303,7 +304,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-struct $ %{} 'CodeEntry (:doc |)
+        'test-struct $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing struct")
               let
@@ -356,7 +357,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-struct-with $ %{} 'CodeEntry (:doc "|test struct-with")
+        'test-struct-with $ %{} 'CodeEntry (:doc "|test struct-with")
           :code $ quote
             fn () (log-title "|Testing struct-with")
               let

--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -84,6 +84,12 @@ Its inferred return type is `Result<List<Person>,String>`, not `Result<Dynamic,S
 
 `decode-map-as` is the companion for data that has already crossed a host boundary and is now an evaluated Calcit value, such as a JSON object returned by a JavaScript FFI. It derives the target shape at compile time and returns the declared type, so it is the typed replacement for ad-hoc map readers and runtime schema libraries. Struct targets consume maps, while list, map, enum, ref, and scalar targets are decoded recursively as well.
 
+Decode exactly once, at the boundary. Passing an already nominal Struct to
+`decode-map-as` or `try-decode-map-as` is a compile-time
+`E_DECODE_MAP_AS_ALREADY_STRUCT` error; use that Struct directly. This prevents
+an updater or history loader from accidentally re-decoding typed state and
+failing later with “expected map, got struct”.
+
 It converts a Map to a nominal Struct recursively, rejects unknown keys and missing required fields, and reports the path of a bad nested value. A missing `Option<T>` field becomes `%none`; a present raw `T` becomes `%some T`. Already-wrapped `%some` and `%none` values are also accepted.
 
 ```cirru.no-run

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -115,6 +115,29 @@ Warn when dynamic method dispatch cannot be specialized at preprocess time, and 
 calcit --warn-dyn-method
 ```
 
+### Strict type preflight (`--strict-types`)
+
+Use `--strict-types` for new or fully migrated modules that must carry no local
+type debt:
+
+```bash
+calcit --check-only --strict-types
+calcit --strict-types js
+```
+
+The flag enables the location-aware untyped JS FFI diagnostics from
+`--warn-dyn-method`, then runs the zero-baseline static quality gate before
+execution or code generation. It rejects unresolved or schema `Dynamic`, code
+`nil`, declared legacy optional values, deprecated calls, and explicit
+`unsafe-coerce` boundaries. Deep/open payloads may still use `Dynamic`, but a
+project that intentionally retains such boundaries should document and freeze
+them with `calcit analyze quality --baseline <file>` instead of claiming the
+zero-debt strict policy.
+
+`--strict-types` also rejects hand-written runtime Struct index operations such
+as `&struct:nth` without matching nominal type evidence. Use `(:field value)` with a concrete nominal Struct; generic
+helpers need a typed trait/accessor or a deliberately open Map boundary.
+
 For a focused, machine-readable inventory that excludes unrelated type and FFI warnings, use the dedicated analysis command:
 
 ```bash

--- a/editing-history/20260901-1833-strict-struct-boundaries.md
+++ b/editing-history/20260901-1833-strict-struct-boundaries.md
@@ -1,0 +1,10 @@
+# Strict Struct boundaries / 严格 Struct 边界
+
+- Hand-written `&struct:nth` embeds a field index from one nominal Struct layout. It must remain compiler/runtime IR and must not be used in reusable or generic library code.
+- Persisted indexed IR is accepted only when the receiver's concrete nominal Struct proves that the embedded field index and tag still match. This avoids false positives for ordinary `(:field value)` lowering while catching generic or stale indexed access.
+- Source-level code should use `(:field value)` on a concrete nominal Struct. Generic helpers should expose a typed trait/accessor, or retain a Map boundary when the record shape is intentionally open.
+- The runtime field tag remains useful for detecting stale generated code, but it cannot make a hard-coded index polymorphic.
+- Regression context: a Respo cursor helper embedded `:states` at index `1`; a consumer `Store` placed the field at a different index, so the JS runtime rejected the otherwise matching field name.
+- `--strict-types` combines location-aware untyped JS FFI diagnostics with the zero-baseline quality gate, so new modules cannot silently accumulate Dynamic, nil, legacy Optional, deprecated-call, or unsafe-coerce debt before execution/codegen.
+- Intentionally open deep payloads remain possible through a reviewed `analyze quality --baseline` workflow; they are not mislabeled as zero-debt strict code.
+- `decode-map-as` and `try-decode-map-as` reject an already nominal Struct during preprocessing with `E_DECODE_MAP_AS_ALREADY_STRUCT`, so accidental double decoding cannot survive until a runtime history or updater path.

--- a/editing-history/20260901-1920-review-strict-boundaries.md
+++ b/editing-history/20260901-1920-review-strict-boundaries.md
@@ -1,0 +1,10 @@
+# Strict boundary review follow-up / 严格边界审查跟进
+
+- Strict eval/exec already performs its mandatory preprocessing pass before
+  evaluation. The strict quality gate must reuse that result instead of
+  preprocessing the same entries twice.
+- Raw Struct index diagnostics may receive malformed or legacy IR without a
+  Tag field operand. In that case the remediation must show the generic valid
+  `(:field value)` form, never synthesize `(<unknown field> value)`.
+- These review fixes preserve strict-mode behavior while avoiding duplicated
+  work and keeping diagnostics directly actionable.

--- a/editing-history/20260901-1930-review-strict-fixtures.md
+++ b/editing-history/20260901-1930-review-strict-fixtures.md
@@ -1,0 +1,10 @@
+# Strict fixture review / 严格模式测试夹具审查
+
+- Low-level `&struct:nth` fixture calls should include the expected field Tag,
+  even when the runtime primitive accepts the shorter form.
+- The Tag keeps the runtime stale-layout assertion explicit. This fixture still
+  intentionally exercises the low-level primitive on a runtime-extended Struct,
+  so it has no nominal type evidence and is not a zero-debt strict-mode sample.
+- `W_STRUCT_INDEX_RAW_ACCESS` follows the existing opt-in dynamic/FFI diagnostic
+  switch. Ordinary compiler primitive fixtures keep running unchanged, while
+  `--warn-dyn-method` and `--strict-types` surface the unsafe source boundary.

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -285,7 +285,10 @@ fn run_cli() -> Result<(), String> {
   }
 
   // Query/analyze commands may run preprocessing before the normal program-loading path.
-  runner::preprocess::set_warn_dyn_method(cli_args.warn_dyn_method);
+  // Strict type mode includes every location-aware JS FFI diagnostic. The
+  // ordinary flag remains available for migration audits that are not ready
+  // for the zero-debt Dynamic/nil quality gate yet.
+  runner::preprocess::set_warn_dyn_method(cli_args.warn_dyn_method || cli_args.strict_types);
   runner::preprocess::set_verbose_preprocess(cli_args.verbose);
   let _macro_metrics_report = runner::macro_metrics::ReportOnDrop::new(cli_args.macro_metrics);
   #[cfg(not(target_arch = "wasm32"))]
@@ -520,10 +523,33 @@ fn run_cli() -> Result<(), String> {
     run_check_only(&entries)?;
   }
 
+  let run_strict_type_gate = || {
+    run_quality(
+      &QualityCommand {
+        ns: None,
+        ns_prefix: None,
+        deps: false,
+        baseline: None,
+        write_baseline: None,
+        format: "human".to_owned(),
+      },
+      &snapshot,
+    )
+  };
+
+  // `--strict-types` is a preflight for every execution/codegen mode, not just
+  // another spelling of check-only. Existing projects with reviewed debt keep
+  // using `analyze quality --baseline ...`; strict mode is intentionally the
+  // zero-debt policy for new modules and fully migrated libraries.
+  if cli_args.strict_types && !check_only {
+    run_check_only(&entries)?;
+    run_strict_type_gate()?;
+  }
+
   let use_configured_js_mode = should_emit_js(&cli_args.subcommand, configured_run_mode);
 
   let task = if check_only {
-    run_check_only(&entries)
+    run_check_only(&entries).and_then(|_| if cli_args.strict_types { run_strict_type_gate() } else { Ok(()) })
   } else if let Some(CalcitCommand::Test(test_options)) = &cli_args.subcommand {
     eval_once = true;
     run_tests(test_options, &snapshot, &project_namespaces)

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -542,7 +542,11 @@ fn run_cli() -> Result<(), String> {
   // using `analyze quality --baseline ...`; strict mode is intentionally the
   // zero-debt policy for new modules and fully migrated libraries.
   if cli_args.strict_types && !check_only {
-    run_check_only(&entries)?;
+    // Eval/exec already preprocess above so they can fail before evaluating.
+    // Other run/codegen modes still need the explicit strict preflight here.
+    if !is_eval_mode {
+      run_check_only(&entries)?;
+    }
     run_strict_type_gate()?;
   }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -22,6 +22,9 @@ pub struct ToplevelCalcit {
   /// warn on dynamic method calls that cannot be monomorphized
   #[argh(switch)]
   pub warn_dyn_method: bool,
+  /// enforce a zero-debt Dynamic, nil, unsafe-coerce, and untyped JS FFI gate before running
+  #[argh(switch)]
+  pub strict_types: bool,
   /// print FFI dylib calls and callbacks for debugging native crashes
   #[argh(switch)]
   pub trace_ffi: bool,

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3361,8 +3361,20 @@ fn check_struct_field_access(
   call_stack: &CallStackList,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
+  // `&struct:nth` embeds one concrete Struct layout in source. It is safe only
+  // as compiler-generated IR: a reusable helper may later receive a different
+  // nominal Struct with the same field name at another index. Keep the field
+  // tag as a runtime stale-schema assertion, but reject hand-written indexed
+  // access before it can escape in a published JS module.
+  if let Calcit::Proc(CalcitProc::NativeStructNth) = head {
+    if args.len() >= 2
+      && let (Some(receiver), Some(index)) = (args.first(), args.get(1))
+    {
+      warn_on_raw_struct_index_access(receiver, index, args.get(2), scope_types, file_ns, call_stack, check_warnings);
+    }
+  }
   // Check if this is a call to &struct:get
-  if let Calcit::Proc(CalcitProc::NativeStructGet) = head {
+  else if let Calcit::Proc(CalcitProc::NativeStructGet) = head {
     // &struct:get takes 2 args: (struct_value, field)
     if args.len() >= 2
       && let (Some(struct_arg), Some(field_arg)) = (args.first(), args.get(1))
@@ -3440,6 +3452,66 @@ fn check_struct_field_access(
       check_field_in_struct(struct_arg, &field_tag, scope_types, file_ns, check_warnings);
     }
   }
+}
+
+fn warn_on_raw_struct_index_access(
+  receiver: &Calcit,
+  index: &Calcit,
+  field: Option<&Calcit>,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  call_stack: &CallStackList,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  if !should_emit_project_source_lint(file_ns)
+    || file_ns == calcit::CORE_NS
+    || call_stack
+      .0
+      .iter()
+      .any(|frame| matches!(frame.kind, StackKind::Macro) && frame.def.as_ref() == "defimpl")
+  {
+    return;
+  }
+
+  // Typed `(:field value)` reads are lowered to `&struct:nth` and persisted in
+  // Snapshot IR. Accept that representation when the receiver still proves the
+  // exact nominal layout and the embedded index/tag pair agrees with it. Raw
+  // indexed access is hazardous only when that proof is absent or stale.
+  let matches_known_layout = resolve_type_value(receiver, scope_types)
+    .as_deref()
+    .and_then(CalcitTypeAnnotation::resolve_to_struct)
+    .is_some_and(|struct_def| {
+      let Calcit::Number(raw_index) = index else {
+        return false;
+      };
+      let Some(Calcit::Tag(field_tag)) = field else {
+        return false;
+      };
+      *raw_index >= 0.0
+        && raw_index.fract() == 0.0
+        && struct_def
+          .index_of(field_tag.ref_str())
+          .is_some_and(|field_index| field_index == *raw_index as usize)
+    });
+  if matches_known_layout {
+    return;
+  }
+
+  let field_text = field.map(Calcit::lisp_str).unwrap_or_else(|| "<unknown field>".to_owned());
+  let message = format!(
+    "[Warn] `&struct:nth` for {field_text} at index {} in {file_ns} has no matching concrete nominal Struct layout. A hard-coded index is unsafe in reusable or generic code. Use `({field_text} value)` on a concrete typed Struct so the compiler derives the index; generic helpers must use a typed trait/accessor or keep a Map boundary. `&struct:nth` is valid only as compiler/runtime IR backed by matching type evidence",
+    index.lisp_str()
+  );
+  gen_check_warning_code_at(
+    message,
+    "W_STRUCT_INDEX_RAW_ACCESS",
+    file_ns,
+    field
+      .and_then(Calcit::get_location)
+      .or_else(|| index.get_location())
+      .or_else(|| receiver.get_location()),
+    check_warnings,
+  );
 }
 
 fn warn_on_raw_struct_field_access(
@@ -7040,6 +7112,20 @@ pub fn preprocess_decode_map_as(
     ctx.check_warnings,
     ctx.call_stack,
   )?;
+  if let Some(actual) = resolve_type_value(&value_form, ctx.scope_types)
+    && actual.as_ref().resolve_to_struct().is_some()
+  {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      format!(
+        "{head} expects an undecoded Map/host value, but received the already nominal Struct `{}`. Use the typed Struct directly; decode only at the external data boundary before storing or dispatching it",
+        actual.to_brief_string()
+      ),
+      "E_DECODE_MAP_AS_ALREADY_STRUCT",
+      ctx.call_stack,
+      value_form.get_location(),
+    ));
+  }
   let type_form = args.get(1).expect("validated decode-map-as type");
   let target = CalcitTypeAnnotation::parse_type_annotation_form_with_generics(type_form, &[]);
   let decoder = crate::calcit::data_shape::DataShapeGraph::build_open(target.as_ref(), ctx.file_ns).map_err(|error| {
@@ -9710,6 +9796,115 @@ mod tests {
     assert_eq!(warnings.len(), 1);
     assert_eq!(warnings[0].code(), Some("W_STRUCT_RAW_ACCESS"));
     assert!(warnings[0].message().contains("Use `(:name value)`"));
+  }
+
+  #[test]
+  fn rejects_source_struct_index_access_in_generic_helpers() {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("&struct:nth"),
+      Cirru::leaf("store"),
+      Cirru::leaf("1"),
+      Cirru::leaf(":states"),
+    ]);
+    let code = code_to_calcit(&expr, "tests.struct", "update-states", vec![]).expect("parse raw indexed field access");
+    let scope_defs = HashSet::from([Arc::from("store")]);
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(Arc::from("store"), Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))));
+    let warnings = RefCell::new(vec![]);
+
+    let _resolved = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut scope_types,
+      "tests.struct",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess raw indexed field access");
+
+    let warnings = warnings.borrow();
+    assert!(
+      warnings.iter().any(|warning| warning.code() == Some("W_STRUCT_INDEX_RAW_ACCESS")),
+      "raw source index must not be published from a generic helper: {warnings:?}"
+    );
+    assert!(warnings.iter().any(|warning| warning.message().contains("matching type evidence")));
+  }
+
+  #[test]
+  fn accepts_persisted_struct_index_ir_with_matching_nominal_layout() {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("&struct:nth"),
+      Cirru::leaf("store"),
+      Cirru::leaf("1"),
+      Cirru::leaf(":states"),
+    ]);
+    let code = code_to_calcit(&expr, "tests.struct", "read-states", vec![]).expect("parse indexed field IR");
+    let scope_defs = HashSet::from([Arc::from("store")]);
+    let store_def = Arc::new(CalcitStructDef::from_fields(
+      EdnTag::from("Store"),
+      vec![EdnTag::from("count"), EdnTag::from("states")],
+    ));
+    let mut scope_types = ScopeTypes::new();
+    scope_types.insert(
+      Arc::from("store"),
+      Arc::new(CalcitTypeAnnotation::Struct(store_def, Arc::new(vec![]))),
+    );
+    let warnings = RefCell::new(vec![]);
+
+    let _resolved = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut scope_types,
+      "tests.struct",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("preprocess persisted indexed field IR");
+
+    assert!(
+      warnings
+        .borrow()
+        .iter()
+        .all(|warning| warning.code() != Some("W_STRUCT_INDEX_RAW_ACCESS")),
+      "matching typed Snapshot IR must not be treated as hand-written unsafe access"
+    );
+  }
+
+  #[test]
+  fn rejects_decode_map_as_on_an_already_typed_struct() {
+    let store_def = Arc::new(CalcitStructDef::from_fields(EdnTag::from("Store"), vec![EdnTag::from("states")]));
+    let store = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("store")),
+      sym: Arc::from("store"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.decode"),
+        at_def: Arc::from("updater"),
+      }),
+      location: Some(Arc::from(vec![1, 2, 3])),
+      type_info: Arc::new(CalcitTypeAnnotation::Struct(store_def, Arc::new(vec![]))),
+    });
+    let args = CalcitList::from(&[
+      store,
+      Calcit::Symbol {
+        sym: Arc::from("Dynamic"),
+        info: Arc::new(CalcitSymbolInfo {
+          at_ns: Arc::from("tests.decode"),
+          at_def: Arc::from("updater"),
+        }),
+        location: Some(Arc::from(vec![1, 2, 4])),
+      },
+    ]);
+    let scope_defs = HashSet::from([Arc::from("store")]);
+    let mut scope_types = ScopeTypes::new();
+    let warnings = RefCell::new(vec![]);
+    let stack = CallStackList::default();
+    let mut context = PreprocessContext::new(&scope_defs, &mut scope_types, "tests.decode", &warnings, &stack);
+
+    let error = preprocess_decode_map_as(&CalcitSyntax::DecodeMapAs, calcit::CORE_NS, &args, &mut context)
+      .expect_err("an already decoded Struct must fail before runtime");
+
+    assert_eq!(error.code(), Some("E_DECODE_MAP_AS_ALREADY_STRUCT"));
+    assert!(error.to_string().contains("Use the typed Struct directly"));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3463,7 +3463,8 @@ fn warn_on_raw_struct_index_access(
   call_stack: &CallStackList,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
-  if !should_emit_project_source_lint(file_ns)
+  if !warn_dyn_method_enabled()
+    || !should_emit_project_source_lint(file_ns)
     || file_ns == calcit::CORE_NS
     || call_stack
       .0
@@ -9808,6 +9809,7 @@ mod tests {
 
   #[test]
   fn rejects_source_struct_index_access_in_generic_helpers() {
+    let _guard = WarnDynMethodGuard::new(true);
     let expr = Cirru::List(vec![
       Cirru::leaf("&struct:nth"),
       Cirru::leaf("store"),
@@ -9840,6 +9842,7 @@ mod tests {
 
   #[test]
   fn accepts_persisted_struct_index_ir_with_matching_nominal_layout() {
+    let _guard = WarnDynMethodGuard::new(true);
     let expr = Cirru::List(vec![
       Cirru::leaf("&struct:nth"),
       Cirru::leaf("store"),

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3497,9 +3497,17 @@ fn warn_on_raw_struct_index_access(
     return;
   }
 
-  let field_text = field.map(Calcit::lisp_str).unwrap_or_else(|| "<unknown field>".to_owned());
+  let (field_text, field_access_hint) = match field {
+    Some(Calcit::Tag(field_tag)) => {
+      let field_text = Calcit::Tag(field_tag.to_owned()).lisp_str();
+      let access_hint = format!("({field_text} value)");
+      (field_text, access_hint)
+    }
+    Some(value) => (value.lisp_str(), "(:field value)".to_owned()),
+    None => ("<missing field tag>".to_owned(), "(:field value)".to_owned()),
+  };
   let message = format!(
-    "[Warn] `&struct:nth` for {field_text} at index {} in {file_ns} has no matching concrete nominal Struct layout. A hard-coded index is unsafe in reusable or generic code. Use `({field_text} value)` on a concrete typed Struct so the compiler derives the index; generic helpers must use a typed trait/accessor or keep a Map boundary. `&struct:nth` is valid only as compiler/runtime IR backed by matching type evidence",
+    "[Warn] `&struct:nth` for {field_text} at index {} in {file_ns} has no matching concrete nominal Struct layout. A hard-coded index is unsafe in reusable or generic code. Use `{field_access_hint}` on a concrete typed Struct so the compiler derives the index; generic helpers must use a typed trait/accessor or keep a Map boundary. `&struct:nth` is valid only as compiler/runtime IR backed by matching type evidence",
     index.lisp_str()
   );
   gen_check_warning_code_at(


### PR DESCRIPTION
## English

Closes #575.

This adds a project-level `--strict-types` preflight and moves two recurring runtime failures into preprocessing:

- reject `decode-map-as` / `try-decode-map-as` when the input is already a nominal Struct;
- block raw `&struct:nth` without matching nominal layout evidence while preserving compiler-generated indexed IR whose receiver, field tag, and index agree;
- combine location-aware untyped JS FFI diagnostics with the zero-baseline Dynamic, nil, legacy optional, deprecated-call, and `unsafe-coerce` quality gate.

Deep/open payloads remain supported through an explicitly reviewed `analyze quality --baseline` workflow.

## 中文

关闭 #575。

本 PR 新增项目级 `--strict-types` 预检，并把两类反复出现的运行时错误提前到预处理阶段：

- 当输入已经是 nominal Struct 时，拒绝再次调用 `decode-map-as` / `try-decode-map-as`；
- 阻止缺少 nominal 布局证据的原始 `&struct:nth`，同时保留接收者类型、字段 tag 与索引完全一致的编译器生成 IR；
- 将带位置的非类型化 JS FFI 诊断，与 Dynamic、nil、旧 Optional、deprecated call、`unsafe-coerce` 的零基线门禁组合起来。

深层开放数据仍可通过明确审核的 `analyze quality --baseline` 工作流保留。

## Validation / 验证

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUST_MIN_STACK=67108864 cargo test -- --test-threads=1`
- `yarn check-all`
- Respo and msg-buffer cross-project compile checks / Respo 与 msg-buffer 跨项目编译检查
