### PR TITLE
feat: reject implicit nil boundaries in strict mode / strict 模式阻断隐式 nil

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -367,7 +367,7 @@ defstruct Profile (:name 'String) (:bio (:: 'Option 'String))
 Profile :name |Ada
 ```
 
-这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数仍用于兼容已有的非类型化 API，其缺省值是 `nil`；修改旧接口时，优先逐步迁移到 `Option`。在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。
+这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数只用于兼容已有的非类型化 API，其缺省值是 `nil`；`--strict-types` 会以 `E_LEGACY_OPTIONAL_PARAM` 拒绝它。`%{}?` 同样会隐式用 `nil` 补 Struct 字段，并在 strict 模式触发 `E_PARTIAL_STRUCT_NIL_FILL`。修改旧接口时迁移到 `Option` 和完整 `%{}` 构造；在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。
 
 Option/Result 的级联优先使用接收者方法，不要在每一层都 `unwrap`：
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -482,6 +482,10 @@ defn factorial (n acc)
 - Macro-generated functions (e.g., from `loop` macro)
 - `calcit.core` namespace functions
 
+This compatibility exception applies to ordinary preprocessing. Under
+`--strict-types`, `?` parameters fail earlier with `E_LEGACY_OPTIONAL_PARAM` and
+must migrate to trailing `Option<T>` parameters.
+
 ## Type Inference
 
 The system infers types from various sources:

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -208,7 +208,8 @@ let
 
 ## Partial Struct Construction
 
-Use `%{}?` to create a partial struct with only some fields set (others default to `nil`):
+Legacy code may use `%{}?` to create a partial struct with only some fields set
+(others default to `nil`):
 
 ```cirru
 let
@@ -219,6 +220,12 @@ let
   println $ :age p1
   ; => nil
 ```
+
+This is a compatibility surface, not a typed construction pattern.
+`--strict-types` rejects it with `E_PARTIAL_STRUCT_NIL_FILL`. Migrate by using
+`%{}` with every field present, or change fields that are genuinely absent to
+`Option<T>` and provide `%none`. There is no automatic rewrite because omitted
+fields may require business defaults rather than absence.
 
 The low-level `&%{}` form accepts fields as flat keyword-value pairs (no type checking):
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -287,7 +287,8 @@ let
 
 - `defstruct` - define a struct type with typed fields
 - `%{}` - create a named struct value, or an anonymous value with `%{} _ ...`
-- `%{}?` - create a partial struct (unset fields default to nil)
+- `%{}?` - legacy partial Struct constructor (unset fields default to nil;
+  rejected by `--strict-types` with `E_PARTIAL_STRUCT_NIL_FILL`)
 - `&%{}` - low-level struct constructor (flat key-value pairs, no type check)
 - `struct-with` - update multiple declared fields
 - `&struct:get` - internal/dynamic-boundary field lookup; normal typed code must use `(:field value)`

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -134,6 +134,21 @@ project that intentionally retains such boundaries should document and freeze
 them with `calcit analyze quality --baseline <file>` instead of claiming the
 zero-debt strict policy.
 
+Strict preprocessing also rejects two constructs that manufacture `nil`
+implicitly:
+
+- `E_LEGACY_OPTIONAL_PARAM`: a `?` parameter would bind an omitted argument to
+  `nil`. Remove the marker, declare trailing parameters as `Option<T>`, and let
+  omission insert `%none` (or pass `%some value` / `%none` explicitly).
+- `E_PARTIAL_STRUCT_NIL_FILL`: `%{}?` / `&%{}?` would fill omitted Struct fields
+  with `nil`. Use `%{}` and provide every field explicitly; an `Option<T>` field
+  receives `%none` rather than `nil`.
+
+Both constructs remain available outside `--strict-types` during ecosystem
+migration. Partial Struct construction is not auto-fixed because the compiler
+cannot infer whether an omitted business field should become `Option<T>`, gain a
+default, or be supplied by the caller.
+
 `--strict-types` also rejects hand-written runtime Struct index operations such
 as `&struct:nth` without matching nominal type evidence. Use `(:field value)` with a concrete nominal Struct; generic
 helpers need a typed trait/accessor or a deliberately open Map boundary.

--- a/docs/run/strict-nil-migration.md
+++ b/docs/run/strict-nil-migration.md
@@ -1,0 +1,56 @@
+# Strict nil migration / strict nil 迁移
+
+`--strict-types` treats implicit absence as a compiler error while ordinary mode
+keeps the legacy runtime behavior during migration.
+
+`--strict-types` 把隐式缺失值视为编译错误；迁移期间，普通模式仍保留旧运行时语义。
+
+## Diagnostics / 诊断
+
+| Code | Rejected form | Migration |
+| --- | --- | --- |
+| `E_LEGACY_OPTIONAL_PARAM` | `defn f (required ? optional) ...` or the equivalent `fn` form | Remove `?`, declare trailing parameters as `Option<T>`, and rely on trailing omission to insert `%none`; use `%some value` / `%none` at explicit call sites. |
+| `E_PARTIAL_STRUCT_NIL_FILL` | `%{}? Struct ...` and `&%{}? Struct ...` | Use `%{}` with every field present. Change genuinely absent fields to `Option<T>` and provide `%none`. Do not infer business defaults automatically. |
+
+The runtime `nil` value, Cirru EDN nil, and explicit untyped/FFI boundaries are
+not removed. The strict errors only close constructs that silently manufacture
+nil inside typed code.
+
+运行时 `nil`、Cirru EDN nil 以及明确的 untyped/FFI 边界不会删除；上述错误只阻断
+typed code 中静默制造 nil 的语法。
+
+## Initial executable census / 首轮可执行调用点盘点
+
+The 2026-09-02 workspace census separated executable source from documentation,
+quoted examples, vendored copies, and obsolete `compact.cirru` snapshots.
+
+- Calcit keeps four executable `%{}?` compatibility tests: one in
+  `calcit/test-edn.cirru` and three in `calcit/test-struct.cirru`. The core macro,
+  its quoted example, and API metadata are definitions/documentation rather than
+  application call sites.
+- Calcit's `fn` placeholder lowering still generates `(? % %2)` when a `%2`
+  placeholder is present. The matching `test-macro.cirru` forms exercise that
+  generated compatibility behavior.
+- Current source snapshots with direct `?` parameters were found in `std`
+  (`nanoid!`, `rand`, `rand-int`), `lilac` (seven optional constructor helpers),
+  `editor` (two callback parameters), and `gen-code` (one callback parameter).
+- `reacher`, `explain-ternary-tree`, `std-old`, and `.compact-inc.cirru` hits are
+  legacy snapshot inputs and must first follow the `calcit.cirru` source-model
+  migration; they are not migration templates for new code.
+- No direct `?` or `%{}?` call was found in the checked Respo or msg-buffer
+  workspaces. Caltrop retains its own legacy macro and four test calls; `apis`
+  contains documentation metadata only.
+
+首轮结果说明真正需要迁移的重点是 `fn` 的 `%2` placeholder lowering、std/lilac 的
+公共可选参数，以及 editor/gen-code 的宿主回调；Calcit 内的 `%{}?` 调用目前都是兼容
+测试，不应误当成推荐写法。
+
+Reproduce the text-level census with:
+
+```bash
+rg -n -F --glob '*.cirru' --glob '!**/.git/**' -- '%{}?' /path/to/calcit-lang
+rg -n -F --glob '*.cirru' --glob '!**/.git/**' -- '(? ' /path/to/calcit-lang
+```
+
+Each hit still needs AST/context review: quoted code and macro definitions are
+not ordinary executable call sites.

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -117,8 +117,9 @@ Profile :name |Ada
 ```
 
 参数必须是 `:field value` 对，必填字段不能省略；末尾声明为 `Option<T>`
-的字段可以省略，Calcit 会补成 `%none`。需要显式控制所有字段或构造部分值时，
-继续使用 `%{} Profile ...` / `%{}? Profile ...`。
+的字段可以省略，Calcit 会补成 `%none`。需要显式控制所有字段时使用
+`%{} Profile ...` 并完整提供字段。`%{}?` 会把遗漏字段补成 `nil`，只作为迁移期
+兼容入口保留，并会被 `--strict-types` 以 `E_PARTIAL_STRUCT_NIL_FILL` 拒绝。
 
 已知 Enum 定义时使用头部调用：
 

--- a/editing-history/202609020024-strict-implicit-nil-boundaries.md
+++ b/editing-history/202609020024-strict-implicit-nil-boundaries.md
@@ -1,0 +1,33 @@
+# Strict implicit nil boundaries / strict 隐式 nil 边界
+
+## Summary / 概要
+
+- Added a dedicated strict-preprocess flag wired from `--strict-types`.
+- Added stable hard diagnostics for legacy `?` parameters
+  (`E_LEGACY_OPTIONAL_PARAM`) and partial Struct constructors
+  (`E_PARTIAL_STRUCT_NIL_FILL`).
+- Kept both legacy behaviors available in ordinary mode so ecosystem migration
+  can proceed incrementally.
+- Preserved user-source locations through `fn` macro expansion by reusing the
+  preferred macro call-site location.
+- Added compatibility/strict branch tests, migration documentation, and a
+  first text-level census of Calcit workspace and ecosystem call sites.
+
+## Design notes / 设计要点
+
+Trailing parameters declared as `Option<T>` already support deterministic
+omission by inserting `%none`; therefore the compiler can give a complete
+migration for `?` without retaining nil binding in strict code. `%{}?` cannot be
+auto-fixed safely because an omitted field may need `%none`, a domain default,
+or a caller-provided value, so the diagnostic only gives explicit alternatives.
+
+尾部 `Option<T>` 参数已经支持缺参自动补 `%none`，因此 strict 模式可以完整替代旧
+`?` 的 nil 注入。Struct 缺失字段的业务语义无法由编译器猜测，所以 `%{}?` 只提供
+定位和迁移建议，不做自动重写。
+
+## Verification / 验证
+
+- Targeted Rust tests cover ordinary compatibility and strict rejection for
+  both constructs.
+- Manual `calcit eval --strict-types` checks cover macro-expanded `fn (? x)` and
+  both `%{}?` / `&%{}?`, including user call-site locations.

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -289,6 +289,7 @@ fn run_cli() -> Result<(), String> {
   // ordinary flag remains available for migration audits that are not ready
   // for the zero-debt Dynamic/nil quality gate yet.
   runner::preprocess::set_warn_dyn_method(cli_args.warn_dyn_method || cli_args.strict_types);
+  runner::preprocess::set_strict_types(cli_args.strict_types);
   runner::preprocess::set_verbose_preprocess(cli_args.verbose);
   let _macro_metrics_report = runner::macro_metrics::ReportOnDrop::new(cli_args.macro_metrics);
   #[cfg(not(target_arch = "wasm32"))]

--- a/src/call_stack.rs
+++ b/src/call_stack.rs
@@ -295,7 +295,7 @@ fn find_location_in_calcit(v: &Calcit) -> Option<NodeLocation> {
   }
 }
 
-fn find_preferred_macro_location(stack: &CallStackList) -> Option<NodeLocation> {
+pub(crate) fn find_preferred_macro_location(stack: &CallStackList) -> Option<NodeLocation> {
   let mut macro_locations: Vec<NodeLocation> = vec![];
   for item in &stack.0 {
     if item.kind != StackKind::Macro {

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     MacroExpansionType, MacroSignature, MacroSyntaxType, NodeLocation, ParamShape, ParamShapeToken, RawCodeType, SchemaKind,
     brief_type_of_value, compare_param_shapes, pop_type_slot_override, push_type_slot_override, register_type_slot,
   },
-  call_stack::{CallStackList, StackKind},
+  call_stack::{CallStackList, StackKind, find_preferred_macro_location},
   codegen, program, runner,
 };
 
@@ -42,6 +42,7 @@ use strum::ParseError;
 pub(crate) type ScopeTypes = HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>;
 
 static WARN_DYN_METHOD: AtomicBool = AtomicBool::new(false);
+static STRICT_TYPES: AtomicBool = AtomicBool::new(false);
 static VERBOSE_PREPROCESS: AtomicBool = AtomicBool::new(false);
 static PROJECT_NAMESPACES: LazyLock<RwLock<HashSet<Arc<str>>>> = LazyLock::new(|| RwLock::new(HashSet::new()));
 
@@ -136,6 +137,18 @@ fn warn_dyn_method_enabled() -> bool {
 
 pub fn is_warn_dyn_method_enabled() -> bool {
   warn_dyn_method_enabled()
+}
+
+pub fn set_strict_types(enabled: bool) {
+  STRICT_TYPES.store(enabled, Ordering::SeqCst);
+}
+
+fn strict_types_enabled() -> bool {
+  STRICT_TYPES.load(Ordering::Relaxed)
+}
+
+pub fn is_strict_types_enabled() -> bool {
+  strict_types_enabled()
 }
 
 pub(crate) fn tag_annotation(name: &str) -> Arc<CalcitTypeAnnotation> {
@@ -1501,6 +1514,19 @@ fn preprocess_list_call(
     def_name: &def_name,
     call_location: call_location.clone(),
   };
+
+  if strict_types_enabled()
+    && should_emit_project_source_lint(file_ns)
+    && (matches!(def_name.as_ref(), "%{}?" | "&%{}?") || matches!(head_form, Calcit::Proc(CalcitProc::NativeStructPartial)))
+  {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      "partial Struct construction implicitly fills omitted fields with nil; use `%{}` and provide every field explicitly, using `%none` for fields declared as Option<T>",
+      "E_PARTIAL_STRUCT_NIL_FILL",
+      call_stack,
+      call_location,
+    ));
+  }
   warn_on_removed_data_api_call(&head_form, call_location.clone(), file_ns, check_warnings);
 
   let has_anonymous_definition_marker = matches!(args.first(), Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "_");
@@ -6408,6 +6434,23 @@ pub fn preprocess_defn(
       let mut param_symbols: Vec<Arc<str>> = vec![];
       let mut has_marked_args = false; // Track if function has & or ? markers
 
+      if strict_types_enabled()
+        && should_emit_project_source_lint(ctx.file_ns)
+        && ys.iter().any(|arg| matches!(arg, Calcit::Syntax(CalcitSyntax::ArgOptional, _)))
+      {
+        return Err(CalcitErr::use_msg_stack_location_with_code(
+          CalcitErrKind::Type,
+          "legacy `?` parameters implicitly bind omitted arguments to nil; remove `?`, declare trailing parameters as Option<T>, and pass `%some value` or `%none` explicitly when omission sugar is not used",
+          "E_LEGACY_OPTIONAL_PARAM",
+          ctx.call_stack,
+          find_preferred_macro_location(ctx.call_stack).or(Some(NodeLocation::new(
+            info.at_ns.to_owned(),
+            info.at_def.to_owned(),
+            location.to_owned().unwrap_or_default(),
+          ))),
+        ));
+      }
+
       xs = xs.push_right(Calcit::Symbol {
         sym: def_name.to_owned(),
         info: Arc::new(CalcitSymbolInfo {
@@ -8539,6 +8582,79 @@ mod tests {
     fn drop(&mut self) {
       set_warn_dyn_method(self.prev);
     }
+  }
+
+  struct StrictTypesGuard {
+    prev: bool,
+  }
+
+  impl StrictTypesGuard {
+    fn new(enabled: bool) -> Self {
+      let prev = strict_types_enabled();
+      set_strict_types(enabled);
+      Self { prev }
+    }
+  }
+
+  impl Drop for StrictTypesGuard {
+    fn drop(&mut self) {
+      set_strict_types(self.prev);
+    }
+  }
+
+  fn legacy_optional_definition() -> Calcit {
+    let expr = Cirru::List(vec![
+      Cirru::leaf("defn"),
+      Cirru::leaf("demo"),
+      Cirru::List(vec![Cirru::leaf("?"), Cirru::leaf("value")]),
+      Cirru::leaf("value"),
+    ]);
+    code_to_calcit(&expr, "tests.strict-nil", "demo", vec![]).expect("parse optional definition")
+  }
+
+  fn preprocess_test_expr(expr: &Calcit) -> Result<Calcit, CalcitErr> {
+    let warnings = RefCell::new(vec![]);
+    preprocess_expr(
+      expr,
+      &HashSet::new(),
+      &mut ScopeTypes::new(),
+      "tests.strict-nil",
+      &warnings,
+      &CallStackList::default(),
+    )
+  }
+
+  #[test]
+  fn strict_types_rejects_legacy_optional_parameters_but_compat_mode_keeps_them() {
+    let _state = lock_preprocess_test_state();
+    let code = legacy_optional_definition();
+
+    {
+      let _strict = StrictTypesGuard::new(false);
+      preprocess_test_expr(&code).expect("compatibility mode should keep legacy optional parameters");
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    let error = preprocess_test_expr(&code).expect_err("strict mode should reject implicit nil parameter binding");
+    assert_eq!(error.code.as_deref(), Some("E_LEGACY_OPTIONAL_PARAM"));
+    assert!(error.msg.contains("Option<T>"));
+    assert!(error.location.is_some(), "strict diagnostic should retain the definition location");
+  }
+
+  #[test]
+  fn strict_types_rejects_partial_struct_nil_fill_but_compat_mode_keeps_it() {
+    let _state = lock_preprocess_test_state();
+    let code = Calcit::from(vec![Calcit::Proc(CalcitProc::NativeStructPartial), Calcit::Nil]);
+
+    {
+      let _strict = StrictTypesGuard::new(false);
+      preprocess_test_expr(&code).expect("compatibility mode should keep partial Struct construction");
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    let error = preprocess_test_expr(&code).expect_err("strict mode should reject omitted Struct fields");
+    assert_eq!(error.code.as_deref(), Some("E_PARTIAL_STRUCT_NIL_FILL"));
+    assert!(error.msg.contains("%none"));
   }
 
   #[test]


### PR DESCRIPTION
Part of #578; tracked by #577.

## 中文

### 内容

- 将 `--strict-types` 状态显式传入 preprocess。
- 在 strict 模式以稳定错误码拒绝旧式 `?` 参数：`E_LEGACY_OPTIONAL_PARAM`。
- 在 strict 模式以稳定错误码拒绝 `%{}?` / `&%{}?` 隐式 nil 补字段：`E_PARTIAL_STRUCT_NIL_FILL`。
- 普通模式继续保留两类兼容语义，方便生态分阶段迁移。
- 宏展开后的 `fn (? x)` 诊断定位回用户调用点。
- 补齐正常/错误分支测试、迁移文档，以及 Calcit workspace 与生态调用点首轮盘点。

### 迁移指导

- `?` 参数改为尾部 `Option<T>`；省略时由现有调用规则自动补 `%none`，显式调用使用 `%some value` / `%none`。
- `%{}?` 改为完整 `%{}`；真正允许缺失的字段改为 `Option<T>` 并显式提供 `%none`。编译器不猜测业务默认值。

### 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`（18/18）
- 对 7 个变更 markdown 逐一执行 `calcit docs check-md`
- 手动验证 `fn (? x)`、`%{}?`、`&%{}?` 的 strict 错误码与用户源码位置

## English

### Changes

- Propagate explicit `--strict-types` state into preprocessing.
- Reject legacy `?` parameters in strict mode with `E_LEGACY_OPTIONAL_PARAM`.
- Reject `%{}?` / `&%{}?` implicit nil field filling in strict mode with `E_PARTIAL_STRUCT_NIL_FILL`.
- Preserve both compatibility behaviors outside strict mode for staged ecosystem migration.
- Recover the user call-site location for macro-expanded `fn (? x)` diagnostics.
- Add compatibility/error branch tests, migration docs, and an initial Calcit workspace/ecosystem census.

### Migration guidance

- Replace `?` parameters with trailing `Option<T>` parameters. Existing call semantics insert `%none` for omitted trailing Option arguments; explicit callers use `%some value` / `%none`.
- Replace `%{}?` with complete `%{}` construction. Model genuinely absent fields as `Option<T>` and provide `%none`. The compiler does not guess domain defaults.

### Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface` (18/18)
- `calcit docs check-md` for all 7 changed Markdown files
- Manual strict checks for `fn (? x)`, `%{}?`, and `&%{}?`, including user-source locations
