### PR TITLE
feat: add typed filter-map-kv decisions / 新增强类型 filter-map-kv 决策

### DIFF
--- a/calcit/test-map.cirru
+++ b/calcit/test-map.cirru
@@ -1,20 +1,38 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |test-map) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |test-map)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'test-map.main/main!) (:mode :native) (:reload-fn 'test-map.main/reload!)
+      :feature-policy $ {}
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-map.main $ %{} 'FileEntry
+    'test-map.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} 'CodeEntry (:doc |)
+        'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn main! () (log-title "|Testing maps") (test-maps) (log-title "|Testing map syntax") (test-native-map-syntax) (test-map-comma) (test-get) (test-shorthand) (do true)
+            defn main! () (log-title "|Testing maps") (test-maps) (log-title "|Testing map syntax") (test-native-map-syntax) (test-map-comma) (test-get) (test-shorthand) (test-filter-map-kv) (do true)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-get $ %{} 'CodeEntry (:doc |)
+        'test-filter-map-kv $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-filter-map-kv ()
+              assert=
+                {} (:b 20) (:c 30)
+                filter-map-kv
+                  {} (:a 1) (:b 2) (:c 3)
+                  fn (k v)
+                    if (> v 1)
+                      %:: MapEntryDecision :keep k $ * v 10
+                      %:: MapEntryDecision :drop
+              assert= ({})
+                .filter-map-kv
+                  {} $ :a 1
+                  fn (k v) (%:: MapEntryDecision :drop)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        'test-get $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing get")
               assert= (%none)
@@ -38,7 +56,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-map-comma $ %{} 'CodeEntry (:doc |)
+        'test-map-comma $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing {,}")
               inside-eval: $ assert=
@@ -51,7 +69,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-maps $ %{} 'CodeEntry (:doc |)
+        'test-maps $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-maps ()
               assert= 2 $ count
@@ -124,7 +142,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-native-map-syntax $ %{} 'CodeEntry (:doc |)
+        'test-native-map-syntax $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-native-map-syntax () $ inside-eval:
               assert=
@@ -135,7 +153,7 @@
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |test-shorthand $ %{} 'CodeEntry (:doc |)
+        'test-shorthand $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing shorthand")
               let

--- a/calcit/test-types-inference.cirru
+++ b/calcit/test-types-inference.cirru
@@ -1,56 +1,57 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |test-types-inference) (:version |0.0.0)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |test-types-inference)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'test-types-inference.main/main!) (:mode :native) (:reload-fn 'test-types-inference.main/reload!)
+      :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |test-types-inference.main $ %{} 'FileEntry
+    'test-types-inference.main $ %{} 'FileEntry
       :defs $ {}
-        |Address $ %{} 'CodeEntry (:doc |)
+        'Address $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Address $ :city 'String
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Job $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'Job $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Job (:title 'String) (:status Status)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Outcome $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'Outcome $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Outcome (:status Status) (:none)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Person $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'EnumDef
+        'Person $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstruct Person (:name 'String) (:age 'Number)
               :address $ :: Address
           :examples $ []
-          :schema $ :: 'Dynamic
-        |PersonWrap $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'StructDef
+        'PersonWrap $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum PersonWrap
               :person $ :: Person
               :none
           :examples $ []
-          :schema $ :: 'Dynamic
-        |Status $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'EnumDef
+        'Status $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Status (:ok 'Number) (:err 'String)
           :examples $ []
-          :schema $ :: 'Dynamic
-        |main! $ %{} 'CodeEntry (:doc |)
+          :schema $ :: 'EnumDef
+        'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn main! () (println "|Testing type inference...") (test-list-inference) (test-optional-inference) (test-count-inference) (test-fn-inference) (test-map-inference) (test-set-inference) (test-ref-inference) (test-struct-inference) (test-type-ref-combos) (test-generics-identity)
+            defn main! () (println "|Testing type inference...") (test-list-inference) (test-optional-inference) (test-count-inference) (test-fn-inference) (test-map-inference) (test-filter-map-kv-inference) (test-set-inference) (test-ref-inference) (test-struct-inference) (test-type-ref-combos) (test-generics-identity)
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} 'CodeEntry (:doc |)
+        'reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ :: 'Unit
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-count-inference $ %{} 'CodeEntry (:doc |)
+        'test-count-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-count-inference ()
               assert-type
@@ -59,7 +60,20 @@
               assert-type (count |abc) 'Number
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-fn-inference $ %{} 'CodeEntry (:doc |)
+        'test-filter-map-kv-inference $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn test-filter-map-kv-inference () $ let
+                output $ filter-map-kv
+                  {} (|a 1) (|b 2) (|c 3)
+                  fn (k v)
+                    if (> v 1)
+                      %:: MapEntryDecision :keep (str k |!) (* v 10)
+                      %:: MapEntryDecision :drop
+              assert-type output $ :: 'Map 'String 'Number
+              &inspect-type output
+          :examples $ []
+          :schema $ :: 'Dynamic
+        'test-fn-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-fn-inference () $ let
                 f $ fn (x) (+ x 1)
@@ -70,7 +84,7 @@
               &inspect-type f
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-generics-identity $ %{} 'CodeEntry (:doc |)
+        'test-generics-identity $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-generics-identity () $ let
                 n $ identity 42
@@ -81,7 +95,7 @@
               &inspect-type s
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-list-inference $ %{} 'CodeEntry (:doc |)
+        'test-list-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-list-inference () $ let
                 nested $ [] ([] 1 2) ([] 3)
@@ -102,7 +116,7 @@
                 &inspect-type rest-xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-map-inference $ %{} 'CodeEntry (:doc |)
+        'test-map-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-map-inference () $ let
                 m $ {}
@@ -120,7 +134,7 @@
                 &inspect-type m5
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-optional-inference $ %{} 'CodeEntry (:doc |)
+        'test-optional-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-optional-inference ()
               let
@@ -277,7 +291,7 @@
                 &inspect-type nil-nested
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-ref-inference $ %{} 'CodeEntry (:doc |)
+        'test-ref-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-ref-inference () $ let
                 r $ atom 1
@@ -289,7 +303,7 @@
                 &inspect-type x
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-set-inference $ %{} 'CodeEntry (:doc |)
+        'test-set-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-set-inference () $ let
                 s $ #{}
@@ -300,7 +314,7 @@
                 &inspect-type xs
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-struct-inference $ %{} 'CodeEntry (:doc |)
+        'test-struct-inference $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-struct-inference () $ let
                 addr $ %{} Address (:city |sh)
@@ -320,7 +334,7 @@
                 &inspect-type city-v
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-type-ref-combos $ %{} 'CodeEntry (:doc |)
+        'test-type-ref-combos $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-type-ref-combos () $ let
                 addr $ %{} Address (:city |sh)

--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -266,6 +266,17 @@
               &+ (&enum:nth t 1) (&enum:nth t 2)
           :examples $ []
           :schema $ :: 'Dynamic
+        'test-filter-map-kv $ %{} 'CodeEntry (:doc "|Typed filter-map-kv keeps two transformed entries and drops one.")
+          :code $ quote
+            defn test-filter-map-kv () $ let
+                output $ filter-map-kv (&{} :a 1 :b 2 :c 3)
+                  fn (k v)
+                    if (&> v 1)
+                      %:: MapEntryDecision :keep k $ &* v 10
+                      %:: MapEntryDecision :drop
+              &+ (&map:count output) (&map:get output :c)
+          :examples $ []
+          :schema $ :: 'Dynamic
         'test-find-found $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-find-found () $ option:unwrap-or

--- a/docs/features/hashmap.md
+++ b/docs/features/hashmap.md
@@ -21,7 +21,7 @@ All map operations return new maps — the original is never mutated.
 - **Create**: `{} (:a 1) (:b 2)`
 - **Access**: `get m :a`, `contains? m :a`
 - **Modify**: `assoc m :c 3`, `dissoc m :a`, `update m :a inc`
-- **Transform**: `map-kv m f`, `merge m1 m2`
+- **Transform**: `map-kv m f`, `filter-map-kv m f`, `merge m1 m2`
 - **Keys/Values**: `keys m`, `vals m`, `to-pairs m`
 
 ## Creating Maps
@@ -111,20 +111,42 @@ assoc-in config $ [] :server :port $ 8080
 
 ### `map-kv` — transform entries
 
-Returns a new map. If the callback returns `nil`, the entry is dropped (used as filter):
+Returns a new map. The callback transforms each entry and returns a two-item list
+containing the output key and value:
 
 ```cirru
 let
     m $ {} (:a 1) (:b 2) (:c 13)
     doubled $ map-kv m $ fn (k v) ([] k (* v 2))
-    filtered $ map-kv m $ fn (k v)
-      if (> v 10) nil
-        [] k v
   println doubled
   ; => ({} (:a 2) (:b 4) (:c 26))
+```
+
+Legacy native and JavaScript execution accepts `nil` or an enum value as a
+drop sentinel, but new code must not rely on that behavior. It cannot describe
+the callback result precisely and historically was not consistent across
+backends. Use `filter-map-kv` when entries may be omitted.
+
+### `filter-map-kv` — typed transform and filter
+
+`filter-map-kv` requires the callback to return a
+`MapEntryDecision<OutputKey, OutputValue>`. Return `:keep` with the transformed
+key and value, or `:drop` without a payload:
+
+```cirru
+let
+    m $ {} (:a 1) (:b 2) (:c 13)
+    filtered $ filter-map-kv m $ fn (k v)
+      if (> v 10)
+        %:: MapEntryDecision :drop
+        %:: MapEntryDecision :keep k v
   println filtered
   ; => ({} (:a 1) (:b 2))
 ```
+
+The method form is also available as `.filter-map-kv`. Prefer this API over a
+`nil` callback sentinel so the compiler can relate the callback payload to the
+resulting map's key and value types.
 
 ### `to-pairs` — convert to set of pairs
 

--- a/editing-history/202609020051-filter-map-kv-typed-decision.md
+++ b/editing-history/202609020051-filter-map-kv-typed-decision.md
@@ -1,0 +1,36 @@
+# 2026-09-02 00:51 — typed `filter-map-kv` decision
+
+## Summary
+
+- Added generic nominal enum `MapEntryDecision<K, V>` with `:keep K V` and
+  `:drop` variants.
+- Added `filter-map-kv` and `.filter-map-kv`, with a schema that propagates the
+  callback decision payload types to the output `Map` key/value types.
+- Kept legacy `map-kv` sentinel behavior for compatibility, while documenting
+  it as a migration-only path rather than a supported filtering contract.
+- Added native, JavaScript, static-inference, and WASM coverage.
+
+## Knowledge captured
+
+- Returning `nil` or an arbitrary enum from `map-kv` was implemented by the
+  shared Calcit core runtime path, but the WASM `map-kv` lowering only understood
+  a two-item pair. The old filtering behavior was therefore cross-backend
+  inconsistent.
+- A generic nominal decision enum lets preprocessing infer
+  `MapEntryDecision<R, S>` and consequently `Map<R, S>` without using a
+  heterogeneous pair-list type or a `nil` union.
+- WASM does not automatically lower every higher-order core helper. Public HOFs
+  that accept inline lambdas need explicit import/symbol/function dispatch and a
+  dedicated loop emitter. Named enum values use the memory layout
+  `[payload_count, tag, payload...]`; `filter-map-kv` reads `:keep` payloads at
+  offsets 16 and 24 and leaves the accumulator unchanged for `:drop`.
+- `scripts/test-wasm.sh` prefers an existing release binary. During development,
+  build `cr-wasm` and set `CR_WASM_BIN=./target/debug/cr-wasm` so a regression
+  run exercises the current source rather than a stale release artifact.
+
+## Follow-up
+
+- Migrate known `map-kv` sentinel call sites to `filter-map-kv`.
+- After the replacement API is available in a release, add a stable strict-mode
+  diagnostic for legacy `nil`/anonymous-enum callback sentinels and eventually
+  make `map-kv` transform-only across all backends.

--- a/scripts/test-wasm.mjs
+++ b/scripts/test-wasm.mjs
@@ -440,6 +440,7 @@ check("test-to-pairs()", 4, e["test-to-pairs"]); // list count=2 + first pair co
 // --- Map merge/diff tests ---
 check("test-map-merge()", 3, e["test-map-merge"]); // {a:1, b:3, c:4}
 check("test-map-merge-value()", 99, e["test-map-merge-value"]); // b overridden to 99
+check("test-filter-map-kv()", 32, e["test-filter-map-kv"]); // count=2 plus transformed c=30
 check("test-map-diff-new()", 1, e["test-map-diff-new"]); // {a:1} — entries of a not in b
 check("test-map-diff-keys()", 2, e["test-map-diff-keys"]); // #{a, c} not in b
 check("test-map-common-keys()", 2, e["test-map-common-keys"]); // #{b, c} in both

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -270,27 +270,6 @@
             {} (:return 'Buffer)
               :args $ [] 'Dynamic
           :tags $ #{} :builtin :internal :state
-        '&f64-buffer:len $ %{} 'CodeEntry (:doc "|strict immutable F64Buffer length")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Number)
-              :args $ [] 'F64Buffer
-          :tags $ #{} :builtin :internal
-        '&f64:to-i64-index $ %{} 'CodeEntry (:doc "|checked strict F64Buffer index conversion")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Number)
-              :args $ [] 'Number
-          :tags $ #{} :builtin :internal
-        '&f64-buffer:get $ %{} 'CodeEntry (:doc "|strict immutable F64Buffer checked read")
-          :code $ quote &runtime-implementation
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return 'Number)
-              :args $ [] 'F64Buffer 'Number
-          :tags $ #{} :builtin :internal
         '&call-spread $ %{} 'CodeEntry (:doc "|internal syntax for handling & spreading in function calls\nSyntax: (&call-spread fn args)\nParams: fn (function), args (list with spread)\nReturns: function call result\nHandles argument spreading in function calls")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -415,7 +394,7 @@
           :tags $ #{} :internal
         '&core-map-methods $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def &core-map-methods $ &impl::new :&core-map-methods (:: :add &map:add-entry) (:: :assoc &map:assoc) (:: :common-keys &map:common-keys) (:: :contains? &map:contains?) (:: :count &map:count) (:: :destruct destruct-map) (:: :diff-keys &map:diff-keys) (:: :diff-new &map:diff-new) (:: :diff-triple &map:diff-triple) (:: :dissoc &map:dissoc) (:: :empty &map:empty) (:: :empty? &map:empty?) (:: :filter &map:filter) (:: :filter-kv &map:filter-kv) (:: :get get) (:: :get-in get-in) (:: :includes? &map:includes?) (:: :keys keys) (:: :map &map:map) (:: :map-kv map-kv) (:: :map-list &map:map-list) (:: :mappend merge) (:: :merge merge) (:: :to-list &map:to-list) (:: :to-map identity) (:: :to-pairs to-pairs) (:: :values vals)
+            def &core-map-methods $ &impl::new :&core-map-methods (:: :add &map:add-entry) (:: :assoc &map:assoc) (:: :common-keys &map:common-keys) (:: :contains? &map:contains?) (:: :count &map:count) (:: :destruct destruct-map) (:: :diff-keys &map:diff-keys) (:: :diff-new &map:diff-new) (:: :diff-triple &map:diff-triple) (:: :dissoc &map:dissoc) (:: :empty &map:empty) (:: :empty? &map:empty?) (:: :filter &map:filter) (:: :filter-kv &map:filter-kv) (:: :filter-map-kv filter-map-kv) (:: :get get) (:: :get-in get-in) (:: :includes? &map:includes?) (:: :keys keys) (:: :map &map:map) (:: :map-kv map-kv) (:: :map-list &map:map-list) (:: :mappend merge) (:: :merge merge) (:: :to-list &map:to-list) (:: :to-map identity) (:: :to-pairs to-pairs) (:: :values vals)
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :internal
@@ -639,6 +618,27 @@
           :examples $ []
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal :meta
+        '&f64-buffer:get $ %{} 'CodeEntry (:doc "|strict immutable F64Buffer checked read")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'F64Buffer 'Number
+          :tags $ #{} :builtin :internal
+        '&f64-buffer:len $ %{} 'CodeEntry (:doc "|strict immutable F64Buffer length")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'F64Buffer
+          :tags $ #{} :builtin :internal
+        '&f64:to-i64-index $ %{} 'CodeEntry (:doc "|checked strict F64Buffer index conversion")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'Number
+          :tags $ #{} :builtin :internal
         '&fn:apply $ %{} 'CodeEntry (:doc "|internal helper for fn :apply method entry")
           :code $ quote
             defn &fn:apply (f g)
@@ -2988,6 +2988,14 @@
           :examples $ []
           :schema $ :: 'Enum
           :tags $ #{} :data
+        'MapEntryDecision $ %{} 'CodeEntry (:doc "|Typed decision returned by filter-map-kv: :keep supplies the output key/value and :drop omits the input entry.")
+          :code $ quote
+            def MapEntryDecision $ impl-traits
+              defenum MapEntryDecision ([] 'K 'V) (:keep 'K 'V) (:drop)
+              , internal/&core-debug-impl internal/&core-eq-impl
+          :examples $ []
+          :schema $ :: 'Dynamic
+          :tags $ #{} :data
         'Mappable $ %{} 'CodeEntry (:doc "|Core trait: Mappable")
           :code $ quote
             deftrait Mappable $ .map
@@ -4902,6 +4910,47 @@
                 assert= (#{} 7 9)
                   filter (#{} 1 3 5 7 9)
                     fn (x) (> x 5)
+              :tags $ #{} :core :unit
+        'filter-map-kv $ %{} 'CodeEntry (:doc "|Transforms and filters map entries with a typed MapEntryDecision callback. Return :keep with the output key/value or :drop to omit an entry.")
+          :code $ quote
+            defn filter-map-kv (xs f)
+              foldl xs ({})
+                defn %filter-map-kv (acc pair)
+                  hint-fn $ {}
+                    :args $ [] 'Map 'List
+                    :return 'Map
+                  let
+                      key $ &list:nth pair 0
+                      value $ &list:nth pair 1
+                      decision $ f key value
+                    match decision
+                      (:keep next-key next-value) (&map:assoc acc next-key next-value)
+                      (:drop) (identity acc)
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] (:: 'Map 'K 'V)
+                :: 'Fn $ {}
+                  :args $ [] 'K 'V
+                  :return $ :: 'MapEntryDecision 'R 'S
+              :generics $ [] 'K 'V 'R 'S
+              :return $ :: 'Map 'R 'S
+          :tests $ []
+            %{} 'TestEntry (:name |transforms-and-drops)
+              :code $ quote
+                do
+                  assert=
+                    {} (:b 20) (:c 30)
+                    filter-map-kv
+                      {} (:a 1) (:b 2) (:c 3)
+                      fn (k v)
+                        if (> v 1)
+                          %:: MapEntryDecision :keep k $ * v 10
+                          %:: MapEntryDecision :drop
+                  assert= ({})
+                    .filter-map-kv
+                      {} $ :a 1
+                      fn (k v) (%:: MapEntryDecision :drop)
               :tags $ #{} :core :unit
         'filter-not $ %{} 'CodeEntry (:doc |)
           :code $ quote

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -1233,6 +1233,8 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
           "let" if !args_list.is_empty() => return emit_let_multi(ctx, &args_list),
           // `map-kv xs f` — apply a binary function to each map entry, returning a new map.
           "map-kv" if args_list.len() == 2 => return emit_map_kv(ctx, &args_list),
+          // `filter-map-kv xs f` — consume typed :keep/:drop decisions.
+          "filter-map-kv" if args_list.len() == 2 => return emit_filter_map_kv(ctx, &args_list),
           // `'` — list literal constructor (calcit.core/'), same as ([] a b c).
           "'" => return emit_list_new(ctx, &args_list),
           _ => {}
@@ -1296,6 +1298,8 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
         "reduce" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
         "foldl'" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
         "update" if args_list.len() == 3 => return emit_update(ctx, &args_list),
+        "map-kv" if args_list.len() == 2 => return emit_map_kv(ctx, &args_list),
+        "filter-map-kv" if args_list.len() == 2 => return emit_filter_map_kv(ctx, &args_list),
         _ => {}
       }
       // Check if this symbol refers to an inline lambda captured in this scope.
@@ -1370,6 +1374,8 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
           "reduce" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
           "foldl'" if args_list.len() == 3 => return emit_foldl(ctx, &args_list),
           "update" if args_list.len() == 3 => return emit_update(ctx, &args_list),
+          "map-kv" if args_list.len() == 2 => return emit_map_kv(ctx, &args_list),
+          "filter-map-kv" if args_list.len() == 2 => return emit_filter_map_kv(ctx, &args_list),
           _ => {}
         }
       }

--- a/src/codegen/emit_wasm/hof.rs
+++ b/src/codegen/emit_wasm/hof.rs
@@ -935,16 +935,27 @@ pub(super) fn emit_find_index(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(
 /// `map-kv xs f` — apply binary `f(k, v) → [k', v']` to every entry of a map, returning a new map.
 /// Iterates via `__rt_map_linearize` which returns a flat `[n_pairs, k0, v0, k1, v1, ...]` buffer.
 pub(super) fn emit_map_kv(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
-  expect_arity(2, args, "map-kv")?;
+  emit_map_kv_impl(ctx, args, false)
+}
+
+/// `filter-map-kv xs f` — apply binary `f(k, v) → MapEntryDecision<k', v'>`,
+/// associating `:keep` payloads and omitting `:drop` results.
+pub(super) fn emit_filter_map_kv(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  emit_map_kv_impl(ctx, args, true)
+}
+
+fn emit_map_kv_impl(ctx: &mut WasmGenCtx, args: &[Calcit], uses_decision: bool) -> Result<(), String> {
+  let op_name = if uses_decision { "filter-map-kv" } else { "map-kv" };
+  expect_arity(2, args, op_name)?;
 
   // Resolve binary callee: f(k, v) → [k', v']
   let kind = if let Some((params, body)) = try_extract_inline_lambda(&args[1]) {
     if params.len() < 2 {
-      return Err("map-kv: inline lambda needs at least 2 params".into());
+      return Err(format!("{op_name}: inline lambda needs at least 2 params"));
     }
     FoldlCallKind::Inline(params, body)
   } else {
-    return Err("map-kv: callee must be an inline lambda in WASM".into());
+    return Err(format!("{op_name}: callee must be an inline lambda in WASM"));
   };
 
   // Evaluate map source → i32 ptr
@@ -1039,21 +1050,46 @@ pub(super) fn emit_map_kv(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), S
   ctx.emit(Instruction::I32TruncF64U);
   ctx.emit(Instruction::LocalSet(result_ptr));
 
-  // new_key = result[0] at offset 8, new_val = result[1] at offset 16
-  ctx.emit(Instruction::LocalGet(result_ptr));
-  ctx.emit(Instruction::F64Load(mem_arg_f64(8)));
-  ctx.emit(Instruction::LocalSet(new_key));
-  ctx.emit(Instruction::LocalGet(result_ptr));
-  ctx.emit(Instruction::F64Load(mem_arg_f64(16)));
-  ctx.emit(Instruction::LocalSet(new_val));
-
-  // acc = __rt_map_assoc(acc, new_key, new_val)
   let assoc_idx = *ctx.runtime_fn_index.get("__rt_map_assoc").expect("__rt_map_assoc");
-  ctx.emit(Instruction::LocalGet(acc));
-  ctx.emit(Instruction::LocalGet(new_key));
-  ctx.emit(Instruction::LocalGet(new_val));
-  ctx.emit(Instruction::Call(assoc_idx));
-  ctx.emit(Instruction::LocalSet(acc));
+  if uses_decision {
+    let keep_tag = *ctx.tag_index.get("keep").ok_or("filter-map-kv: :keep tag missing")?;
+
+    // Named enum layout is [payload_count, tag, payload_0, payload_1, ...].
+    // Only :keep carries the replacement key and value; :drop leaves acc intact.
+    ctx.emit(Instruction::LocalGet(result_ptr));
+    ctx.emit(Instruction::F64Load(mem_arg_f64(8)));
+    ctx.emit(f64_const(keep_tag as f64));
+    ctx.emit(Instruction::F64Eq);
+    ctx.begin_block_if();
+
+    ctx.emit(Instruction::LocalGet(result_ptr));
+    ctx.emit(Instruction::F64Load(mem_arg_f64(16)));
+    ctx.emit(Instruction::LocalSet(new_key));
+    ctx.emit(Instruction::LocalGet(result_ptr));
+    ctx.emit(Instruction::F64Load(mem_arg_f64(24)));
+    ctx.emit(Instruction::LocalSet(new_val));
+
+    ctx.emit(Instruction::LocalGet(acc));
+    ctx.emit(Instruction::LocalGet(new_key));
+    ctx.emit(Instruction::LocalGet(new_val));
+    ctx.emit(Instruction::Call(assoc_idx));
+    ctx.emit(Instruction::LocalSet(acc));
+    ctx.emit(Instruction::End);
+  } else {
+    // Pair-list layout is [count, key, value].
+    ctx.emit(Instruction::LocalGet(result_ptr));
+    ctx.emit(Instruction::F64Load(mem_arg_f64(8)));
+    ctx.emit(Instruction::LocalSet(new_key));
+    ctx.emit(Instruction::LocalGet(result_ptr));
+    ctx.emit(Instruction::F64Load(mem_arg_f64(16)));
+    ctx.emit(Instruction::LocalSet(new_val));
+
+    ctx.emit(Instruction::LocalGet(acc));
+    ctx.emit(Instruction::LocalGet(new_key));
+    ctx.emit(Instruction::LocalGet(new_val));
+    ctx.emit(Instruction::Call(assoc_idx));
+    ctx.emit(Instruction::LocalSet(acc));
+  }
 
   ctx.emit(Instruction::LocalGet(i));
   ctx.emit(Instruction::I32Const(1));


### PR DESCRIPTION
## Summary / 概要

- add generic nominal `MapEntryDecision<K, V>` with `:keep K V` and `:drop`
- add `filter-map-kv` and `.filter-map-kv`, propagating callback payload types to `Map<R, S>`
- add dedicated WASM lowering so native, JavaScript, and WASM share the same keep/drop semantics
- document legacy `map-kv` nil/enum sentinels as compatibility-only behavior and provide the migration path

- 新增泛型 nominal enum `MapEntryDecision<K, V>`，包含 `:keep K V` 与 `:drop`
- 新增 `filter-map-kv` 和 `.filter-map-kv`，将回调 payload 类型传播到输出 `Map<R, S>`
- 增加专用 WASM lowering，统一 native、JavaScript 与 WASM 的 keep/drop 语义
- 将旧 `map-kv` 的 nil/enum sentinel 标记为仅兼容行为，并给出迁移入口

## Validation / 验证

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `CR_WASM_BIN=./target/debug/cr-wasm yarn check-all`
- `calcit docs check-md docs/features/hashmap.md --entry calcit/test.cirru` (18/18)
- static inference: `filter-map-kv` result inferred as `Map<String, Number>`
- WASM regression: `test-filter-map-kv() = 32`

## Migration sequencing / 迁移顺序

This PR intentionally lands the typed replacement before enabling a strict diagnostic for legacy callback sentinels. A follow-up can migrate known ecosystem call sites and add the stable strict-mode diagnostic without leaving users no valid filtering API.

本 PR 先落地强类型替代 API，暂不立即开启旧 callback sentinel 的严格诊断。后续可先迁移已知生态调用点，再加入稳定的 strict-mode diagnostic，避免用户在迁移期间没有合法的过滤入口。

Closes part of #578.