### PR TITLE
feat: require homogeneous public equality / 收紧公共相等性类型

### DIFF
--- a/calcit/test-js.cirru
+++ b/calcit/test-js.cirru
@@ -6,19 +6,19 @@
       :modules $ [] |./util.cirru
       :type-slots $ {}
   :files $ {}
-    |test-js.main $ %{} 'FileEntry
+    'test-js.main $ %{} 'FileEntry
       :defs $ {}
-        |load-data-code $ %{} 'CodeEntry (:doc |)
+        'load-data-code $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro load-data-code (s)
-              &data-to-code $ parse-cirru-edn
-                unsafe-coerce s 'String
+              &data-to-code $ parse-cirru-edn (unsafe-coerce s 'String)
           :examples $ []
           :schema $ :: 'Macro
-            {} (:required $ [] (:: 'Expr 'String))
+            {}
               :capabilities $ #{}
               :expansion $ :: 'Expr 'Dynamic
-        |main! $ %{} 'CodeEntry (:doc |)
+              :required $ [] (:: 'Expr 'String)
+        'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (log-title "|Testing js") (test-js) (test-let-example) (test-collection) (test-async) (test-async-in-data) (test-data-gen) (test-regexp) (test-property) (test-tag-keys)
               when (> 1 2)
@@ -40,7 +40,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-async $ %{} 'CodeEntry (:doc |)
+        'test-async $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () $ let
                 f1 $ fn ()
@@ -63,7 +63,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-async-in-data $ %{} 'CodeEntry (:doc "|async fn inside data. if wrong, it will be a syntax error from await outside async")
+        'test-async-in-data $ %{} 'CodeEntry (:doc "|async fn inside data. if wrong, it will be a syntax error from await outside async")
           :code $ quote
             fn () $ let
                 timeout $ fn (ms)
@@ -83,7 +83,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-case-async $ %{} 'CodeEntry (:doc "|case async")
+        'test-case-async $ %{} 'CodeEntry (:doc "|case async")
           :code $ quote
             fn ()
               hint-fn $ {} (:async true)
@@ -106,7 +106,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-collection $ %{} 'CodeEntry (:doc |)
+        'test-collection $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing quick collection syntax")
               &let
@@ -145,7 +145,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-data-gen $ %{} 'CodeEntry (:doc |)
+        'test-data-gen $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing code gen from Cirru Edn")
               assert=
@@ -153,7 +153,7 @@
                 load-data-code "|:: :code $ quote $ + 1 2"
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-for-await $ %{} 'CodeEntry (:doc "|for await")
+        'test-for-await $ %{} 'CodeEntry (:doc "|for await")
           :code $ quote
             fn ()
               hint-fn $ {} (:async true)
@@ -170,13 +170,13 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-js $ %{} 'CodeEntry (:doc |)
+        'test-js $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn ()
               js/console.log $ js/Math.pow 4 4
               js/console.log $ * (unsafe-coerce js/Math.PI Number) 2
               when
-                = |number $ js/typeof 1
+                = |number $ assert-type (js/typeof 1) (quote String)
                 js/console.log "|is a Number"
               .!log (unsafe-coerce js/console JsObject) |demo
               js/console.log "|Dates in difference syntax" $ .!now (unsafe-coerce js/Date JsObject)
@@ -235,7 +235,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-let-example $ %{} 'CodeEntry (:doc |)
+        'test-let-example $ %{} 'CodeEntry (:doc |)
           :code $ quote
             fn () (log-title "|Testing code emitting of using let")
               let
@@ -256,7 +256,7 @@
                 assert= b -1
           :examples $ []
           :schema $ :: 'Dynamic
-        |test-property $ %{} 'CodeEntry (:doc "|try property ops")
+        'test-property $ %{} 'CodeEntry (:doc "|try property ops")
           :code $ quote
             fn () $ let
                 a $ js-object
@@ -269,7 +269,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-regexp $ %{} 'CodeEntry (:doc "|try raw code and regexp")
+        'test-regexp $ %{} 'CodeEntry (:doc "|try raw code and regexp")
           :code $ quote
             fn () $ let
                 pattern $ &raw-code |/^\d+$/
@@ -283,7 +283,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-return-raw-code $ %{} 'CodeEntry (:doc "|return with &raw-code")
+        'test-return-raw-code $ %{} 'CodeEntry (:doc "|return with &raw-code")
           :code $ quote
             fn () $ let
                 a $ js-array 1 2
@@ -296,7 +296,7 @@
             {} (:return 'Dynamic)
               :args $ []
               :features $ #{} :js-ffi
-        |test-tag-keys $ %{} 'CodeEntry (:doc "|tag keys for js")
+        'test-tag-keys $ %{} 'CodeEntry (:doc "|tag keys for js")
           :code $ quote
             fn ()
               assert= |a_b $ turn-string :a_b

--- a/calcit/test-struct.cirru
+++ b/calcit/test-struct.cirru
@@ -338,7 +338,7 @@
                 assert-detect identity $ = p1 p1
                 assert-detect identity $ = p1 p2
                 assert-detect not $ = p1 p3
-                assert-detect not $ = p1 c1
+                assert-detect not $ &= p1 c1
                 assert=
                   %{} Person (:age 23) (:name |Ye) (:position :mainland)
                   merge p1 $ {} (:age 23) (:name |Ye)

--- a/config/calcit-core-quality.cirru
+++ b/config/calcit-core-quality.cirru
@@ -540,15 +540,6 @@
       :typeNotFull 1
       :unresolved 0
       :unsafeCoerce 0
-    |calcit.core//= $ {} (:codeDynamic 0)
-      :codeNil 0
-      :declaredOptional 0
-      :deprecatedCalls 0
-      :schemaDynamic 2
-      :typeNone 0
-      :typeNotFull 1
-      :unresolved 2
-      :unsafeCoerce 0
     |calcit.core/: $ {} (:codeDynamic 0)
       :codeNil 0
       :declaredOptional 0
@@ -566,15 +557,6 @@
       :typeNone 0
       :typeNotFull 0
       :unresolved 1
-      :unsafeCoerce 0
-    |calcit.core/= $ {} (:codeDynamic 0)
-      :codeNil 0
-      :declaredOptional 0
-      :deprecatedCalls 0
-      :schemaDynamic 2
-      :typeNone 0
-      :typeNotFull 1
-      :unresolved 2
       :unsafeCoerce 0
     |calcit.core/? $ {} (:codeDynamic 0)
       :codeNil 0
@@ -1160,15 +1142,6 @@
       :typeNone 0
       :typeNotFull 1
       :unresolved 1
-      :unsafeCoerce 0
-    |calcit.core/not= $ {} (:codeDynamic 0)
-      :codeNil 0
-      :declaredOptional 0
-      :deprecatedCalls 0
-      :schemaDynamic 2
-      :typeNone 0
-      :typeNotFull 1
-      :unresolved 2
       :unsafeCoerce 0
     |calcit.core/nth $ {} (:codeDynamic 0)
       :codeNil 0
@@ -1858,10 +1831,10 @@
     :codeNil 0
     :declaredOptional 0
     :deprecatedCalls 0
-    :schemaDynamic 297
+    :schemaDynamic 291
     :typeNone 47
-    :typeNotFull 144
-    :unresolved 203
+    :typeNotFull 141
+    :unresolved 197
     :unsafeCoerce 0
   :scope $ {} (:includeDependencies false)
     :namespace nil

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -569,6 +569,23 @@ calcit calcit.cirru analyze quality --baseline config/calcit-quality.cirru
 不同分类间迁移时，应在 PR 中解释并显式更新 baseline，而不是让一个总数相互抵消。baseline 归零后
 保留 `analyze quality`，以阻止后续重新引入。
 
+#### 公共 equality 改为同类型契约
+
+公共 `=`、`not=` 和 `/=` 只接受同一静态类型的操作数：`=` 的第一个参数和所有 rest 参数共享类型变量
+`T`，另外两个函数的左右参数也共享 `T`。底层运行时仍能比较不同类别的值，但应用代码不能再依赖这种
+隐式跨类型行为；它通常来自未收窄的 FFI 值、把类型谓词写成 equality，或遗漏了 nominal enum 的
+pattern match。
+
+升级后出现 `W_FN_ARG_TYPE_MISMATCH` 时，根据值的来源选择明确迁移：
+
+- 两边本应是同一种数据：先 parse/normalize，再比较；
+- 一边来自 Dynamic 或 FFI：在 adapter 中使用 typed FFI、validator 或 `assert-type` 收窄；
+- 只是判断类别：使用 `string?`、`number?`、`tag?` 等类型谓词；
+- 比较 Option/Result 或其他 nominal enum：先使用对应 predicate/method 或 pattern match，再比较 payload。
+
+不要把业务调用改成底层 `&=` 来绕过检查。`&=` 和 `&compare` 保留跨类型运行时语义，只供经过审计的
+core/runtime 边界使用，后续会作为独立的 internal runtime-polymorphic contract 继续跟踪。
+
 ### 3.7 format 的边界
 
 `calcit edit format` 负责可解析性、canonical serialization 和已知旧结构迁移；它不是完整的语义 linter。告警写到 stderr 且不会阻止格式化。CI 需要在 format 后检查 `git diff`，并单独读取 `check-types` / `weak-types --format json` 来执行项目自己的质量阈值。

--- a/editing-history/202609021018-public-equality-contracts.md
+++ b/editing-history/202609021018-public-equality-contracts.md
@@ -1,0 +1,31 @@
+# Public equality contracts / 公共相等性同类型契约
+
+## Summary / 概要
+
+- Changed public `=`, `not=`, and `/=` schemas from `Dynamic` operands to a shared generic `T`, including variadic rest arguments for `=`.
+- Added definition-attached tests, examples, upgrade guidance, and a focused negative test for mixed-type diagnostics.
+- Added equality-specific migration guidance to `W_FN_ARG_TYPE_MISMATCH` without changing the raw runtime primitives `&=` and `&compare`.
+- Kept `assert=` as an intentional open macro boundary. Its generated runtime assertion explicitly coerces captured expressions locally before calling raw `&=`, so assertions can still inspect arbitrary runtime values without weakening public equality.
+- Migrated the nominal cross-type struct test to explicit raw equality and narrowed the JavaScript `typeof` result to `String` at the FFI boundary with `assert-type`.
+
+## Quality movement / 质量变化
+
+- `schemaDynamic`: 297 -> 291
+- `unresolved`: 203 -> 197
+- `typeNotFull`: 144 -> 141
+- `codeDynamic`, `codeNil`, `declaredOptional`, `unsafeCoerce`: remain 0
+
+## Ecosystem regression / 生态回归
+
+- Respo check-only reaches one expected migration point in `respo.css/detect-nodejs?`: a raw JS value must be narrowed before comparing it with `|node`.
+- Recollect analysis is currently blocked earlier by its installed Respo dependency's pre-existing legacy Dynamic macro schema; this change did not introduce that blocker.
+
+## Validation / 验证
+
+- `cargo fmt -- --check`
+- `cargo clippy -- -D warnings`
+- `cargo test`
+- `yarn compile`
+- `yarn check-agent-interface` (18/18)
+- `yarn check-all`
+- Calcit core unit tests (233/233), equality examples, upgrade markdown examples, quality baseline, native/JS/WASM integration checks

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -192,6 +192,44 @@ fn type_fail_call_arg_fixture_reports_warning_code() {
 }
 
 #[test]
+fn mixed_public_equality_reports_guided_type_mismatches() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries("do\n  = 1 |one\n  = 1 1 |one\n  not= 1 |one\n  /= 1 |one");
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("mixed public equality should preprocess with migration warnings, not hard errors");
+
+    let warnings = warnings.borrow();
+    let equality_warnings = warnings
+      .iter()
+      .filter(|warning| {
+        warning.code() == Some("W_FN_ARG_TYPE_MISMATCH")
+          && ["calcit.core/=`", "calcit.core/not=`", "calcit.core//=`"]
+            .iter()
+            .any(|operation| warning.message().contains(operation))
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(
+      equality_warnings.len(),
+      4,
+      "expected fixed and variadic equality warnings: {warnings:?}"
+    );
+    assert!(
+      equality_warnings.iter().all(|warning| {
+        warning
+          .message()
+          .contains("public equality now requires operands of one static type")
+          && warning.message().contains("narrow Dynamic/FFI values")
+          && warning.message().contains("type predicate")
+          && warning.message().contains("pattern-match nominal values")
+      }),
+      "every equality mismatch should carry migration guidance: {equality_warnings:?}"
+    );
+  });
+}
+
+#[test]
 fn option_migration_source_calls_fail_during_preprocessing() {
   run_with_large_stack(|| {
     let entries = load_snippet_entries(

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2671,13 +2671,23 @@
                   assert= 15 $ / 360 2 3 4
                   assert= 0.5 $ / 2
               :tags $ #{} :core :unit
-        '/= $ %{} 'CodeEntry (:doc "|not equal")
+        '/= $ %{} 'CodeEntry (:doc "|Alias of not= for two values of the same static type. Mixed-type callers must normalize values or narrow them before comparing.")
           :code $ quote
             defn /= (a b) (not= a b)
           :examples $ []
+            quote $ assert= true (/= 1 2)
+            quote $ assert= false (/= :same :same)
           :schema $ :: 'Fn
             {} (:return 'Bool)
-              :args $ [] 'Dynamic 'Dynamic
+              :args $ [] 'T 'T
+              :generics $ [] 'T
+          :tests $ []
+            %{} 'TestEntry (:name |homogeneous-inequality-alias)
+              :code $ quote
+                do
+                  assert= true $ /= 1 2
+                  assert= false $ /= :same :same
+              :tags $ #{} :core :unit
         ': $ %{} 'CodeEntry (:doc "|Macro sugar for anonymous enums. Expands to `::` and normalizes the variant tag with `turn-tag`.")
           :code $ quote
             defmacro : (tag & args)
@@ -2745,7 +2755,7 @@
           :schema $ :: 'Fn
             {} (:rest 'Number) (:return 'Bool)
               :args $ [] 'Number
-        '= $ %{} 'CodeEntry (:doc "|Equality predicate for one or more values\nReturns true only when every provided argument is equal, short-circuiting on the first mismatch.")
+        '= $ %{} 'CodeEntry (:doc "|Equality predicate for one or more values of the same static type. Returns true only when every argument is equal, short-circuiting on the first mismatch. Mixed-type callers must normalize values, use a type predicate for category checks, or pattern-match nominal values before comparing.")
           :code $ quote
             defn = (x & ys)
               if
@@ -2758,8 +2768,17 @@
             quote $ assert= true
               = ([] 1 2) ([] 1 2)
           :schema $ :: 'Fn
-            {} (:rest 'Dynamic) (:return 'Bool)
-              :args $ [] 'Dynamic
+            {} (:rest 'T) (:return 'Bool)
+              :args $ [] 'T
+              :generics $ [] 'T
+          :tests $ []
+            %{} 'TestEntry (:name |homogeneous-variadic-equality)
+              :code $ quote
+                do
+                  assert= true $ = 3 3 3
+                  assert= true $ = ([] 1 2) ([] 1 2)
+                  assert= true $ = (%some 1) (%some 1)
+              :tags $ #{} :core :unit
         '> $ %{} 'CodeEntry (:doc "|Greater-than comparison for one or more numbers\nReturns true only when the value strictly decreases across every argument.")
           :code $ quote
             defn > (x & ys)
@@ -3320,7 +3339,8 @@
                   vb $ gensym |vb
                   quasiquote $ &let (~va ~a)
                     &let (~vb ~b)
-                      if (not= ~va ~vb)
+                      if
+                        not $ &= (unsafe-coerce ~va 'Dynamic) (unsafe-coerce ~vb 'Dynamic)
                         &let () (eprintln) (eprintln "|Left: " ~va)
                           eprintln "|      " $ format-to-lisp (quote ~a)
                           eprintln |Right: ~vb
@@ -6613,7 +6633,7 @@
               :args $ [] 'T
               :generics $ [] 'T
           :tags $ #{} :builtin :internal
-        'not= $ %{} 'CodeEntry (:doc "|Returns true when its two arguments are not identical according to `=`.")
+        'not= $ %{} 'CodeEntry (:doc "|Returns true when two values of the same static type are not equal. Mixed-type callers must normalize values or narrow them before comparing.")
           :code $ quote
             defn not= (x y)
               not $ &= x y
@@ -6623,7 +6643,15 @@
             quote $ assert= true (not= |a |b)
           :schema $ :: 'Fn
             {} (:return 'Bool)
-              :args $ [] 'Dynamic 'Dynamic
+              :args $ [] 'T 'T
+              :generics $ [] 'T
+          :tests $ []
+            %{} 'TestEntry (:name |homogeneous-inequality)
+              :code $ quote
+                do
+                  assert= true $ not= |a |b
+                  assert= false $ not= :same :same
+              :tags $ #{} :core :unit
         'noted $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro noted (_doc v) v

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -524,6 +524,7 @@ pub(crate) fn check_user_fn_arg_types(
 
   let fn_def_ns = fn_info.def_ns.clone();
   let fn_name = fn_info.name.clone();
+  let equality_migration = fn_def_ns.as_ref() == crate::calcit::CORE_NS && matches!(fn_name.as_ref(), "=" | "not=" | "/=");
   let def_name = call_info.def_name.to_owned();
   let file_ns_owned = call_info.file_ns.to_owned();
   let ctx = CheckContext {
@@ -538,8 +539,13 @@ pub(crate) fn check_user_fn_arg_types(
     check_warnings,
   };
   check_arg_types_loop(ctx, |arg_idx, expected_str, actual_str, expr_str| {
+    let migration = if equality_migration {
+      "\n  Migration: public equality now requires operands of one static type. Normalize both values, narrow Dynamic/FFI values with a typed adapter, validator, or assert-type, use a type predicate for category checks, or pattern-match nominal values before comparing."
+    } else {
+      ""
+    };
     format!(
-      "[Warn] Function `{fn_def_ns}/{fn_name}` arg {arg_idx} expects type `{expected_str}`, but got `{actual_str}` in call at {file_ns_owned}/{def_name}\n  Expression: `{expr_str}`"
+      "[Warn] Function `{fn_def_ns}/{fn_name}` arg {arg_idx} expects type `{expected_str}`, but got `{actual_str}` in call at {file_ns_owned}/{def_name}\n  Expression: `{expr_str}`{migration}"
     )
   });
 }


### PR DESCRIPTION
## Summary / 概要

- Require one shared static type `T` across public `=`, `not=`, and `/=` operands, including variadic arguments to `=`.
- Add focused success and failure coverage plus actionable `W_FN_ARG_TYPE_MISMATCH` migration guidance.
- Keep raw `&=` / `&compare` runtime-polymorphic and keep `assert=` as an intentional open assertion boundary.
- Migrate core cross-type/FFI tests explicitly, including narrowing JavaScript `typeof` to `String` before public equality.
- Update the Cirru EDN quality baseline: `schemaDynamic` 297 -> 291, `unresolved` 203 -> 197, `typeNotFull` 144 -> 141.

## Breaking-change guidance / Breaking change 迁移

Mixed-type public equality now reports a guided type warning. Callers should normalize values, validate/narrow Dynamic or FFI values, use type predicates for category checks, or pattern-match nominal values before comparing. Application code should not switch to raw `&=` merely to silence the checker.

## Ecosystem regression / 生态回归

- Respo exposes one expected migration point in `respo.css/detect-nodejs?`, where a raw JS value must be narrowed before comparing it with `|node`.
- Recollect is currently blocked earlier by its installed Respo module's pre-existing legacy Dynamic macro schema; that blocker is unrelated to this PR.

## Validation / 验证

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (18/18)
- `yarn check-all`
- core definition tests 233/233; equality examples and upgrade markdown checks pass

Continues #579 and the roadmap in #577.

---

- 公共 `=` / `not=` / `/=` 改为共享同一静态类型 `T`，`=` 的可变参数也同样受约束。
- 增加成功/失败测试与可操作的迁移诊断；底层 `&=` / `&compare` 仍保留运行时多态语义。
- 引导调用方在 Dynamic/FFI 边界先验证或收窄，类别判断使用 predicate，nominal 数据使用 pattern match。
- 质量基线从 `297/203/144` 降为 `291/197/141`（schemaDynamic/unresolved/typeNotFull），完整本地验证通过。
