### PR TITLE
feat: reject map-kv nil sentinels in strict mode

### DIFF
--- a/docs/features/hashmap.md
+++ b/docs/features/hashmap.md
@@ -125,7 +125,10 @@ let
 Legacy native and JavaScript execution accepts `nil` or an enum value as a
 drop sentinel, but new code must not rely on that behavior. It cannot describe
 the callback result precisely and historically was not consistent across
-backends. Use `filter-map-kv` when entries may be omitted.
+backends. Use `filter-map-kv` when entries may be omitted. In `--strict-types`,
+an inline callback with a structurally visible nil return path is rejected with
+`E_NIL_CALLBACK_SENTINEL`; a nil nested inside the returned pair remains valid
+map data.
 
 ### `filter-map-kv` — typed transform and filter
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -147,6 +147,10 @@ implicitly:
   distinct `Nil` value. Replace returned `nil` / `;nil` with `&unit`, or end the
   body with an effect that already returns Unit. Intermediate nil expressions
   are not classified as the function return.
+- `E_NIL_CALLBACK_SENTINEL`: an inline `map-kv` callback has a structurally
+  visible return path that uses `nil` to drop an entry. Use `filter-map-kv` and
+  return `MapEntryDecision :keep key value` or `MapEntryDecision :drop` on every
+  path. A nil nested inside the returned pair remains map data.
 
 These compatibility paths remain available outside `--strict-types` during
 ecosystem migration. Partial Struct construction is not auto-fixed because the

--- a/docs/run/strict-nil-migration.md
+++ b/docs/run/strict-nil-migration.md
@@ -12,6 +12,7 @@ keeps the legacy runtime behavior during migration.
 | `E_LEGACY_OPTIONAL_PARAM` | `defn f (required ? optional) ...` or the equivalent `fn` form | Remove `?`, declare trailing parameters as `Option<T>`, and rely on trailing omission to insert `%none`; use `%some value` / `%none` at explicit call sites. |
 | `E_PARTIAL_STRUCT_NIL_FILL` | `%{}? Struct ...` and `&%{}? Struct ...` | Use `%{}` with every field present. Change genuinely absent fields to `Option<T>` and provide `%none`. Do not infer business defaults automatically. |
 | `E_NIL_FOR_UNIT` | A function declared to return `Unit` whose returned expression has static type `Nil`, including legacy `;nil` | Return `&unit`, or end the body with an effect that already returns `Unit`. Intermediate nil values are not treated as the function return. |
+| `E_NIL_CALLBACK_SENTINEL` | An inline `map-kv` callback has a return path that uses `nil` to drop an entry, including an `if` without an else branch | Use `filter-map-kv`; return `MapEntryDecision :keep key value` or `MapEntryDecision :drop` on every path. A `nil` nested inside the returned key/value pair remains ordinary data and is not rejected. |
 
 The runtime `nil` value, Cirru EDN nil, and explicit untyped/FFI boundaries are
 not removed. The strict errors only close constructs that silently manufacture
@@ -19,6 +20,15 @@ nil inside typed code.
 
 运行时 `nil`、Cirru EDN nil 以及明确的 untyped/FFI 边界不会删除；上述错误只阻断
 typed code 中静默制造 nil 的语法。
+
+`E_NIL_CALLBACK_SENTINEL` is intentionally conservative. It checks only
+structurally visible return paths of inline `fn` / `defn` callbacks. It does not
+guess through named callbacks or reject `[] key nil`, where nil is the mapped
+value rather than a drop sentinel.
+
+`E_NIL_CALLBACK_SENTINEL` 采用保守检查：只分析内联 `fn` / `defn` 回调中结构上
+可见的返回路径，不猜测具名回调；`[] key nil` 中的 nil 是映射后的值，不是丢弃
+sentinel，因此不会被拒绝。
 
 ## Initial executable census / 首轮可执行调用点盘点
 

--- a/editing-history/202609021157-strict-map-kv-nil-sentinel.md
+++ b/editing-history/202609021157-strict-map-kv-nil-sentinel.md
@@ -1,0 +1,7 @@
+# strict map-kv nil sentinel diagnostic
+
+- Added strict-mode diagnostic `E_NIL_CALLBACK_SENTINEL` for inline `map-kv` callbacks with structurally visible nil return paths.
+- Kept compatibility mode behavior unchanged and preserved nil values nested inside returned key/value pairs.
+- Guided migrations to `filter-map-kv` with explicit `MapEntryDecision :keep/:drop` results.
+- Added focused tests and updated the strict nil, hashmap, and CLI diagnostic documentation.
+- Validated the ecosystem migration in `editor`, plus downstream `gen-code` with the local Respo FFI fix.

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1537,6 +1537,21 @@ fn preprocess_list_call(
       || matches!(&head_form, Calcit::Symbol { sym, .. } if sym.as_ref() == name)
   };
 
+  if strict_types_enabled()
+    && should_emit_project_source_lint(file_ns)
+    && is_constructor_named("map-kv")
+    && let Some(callback) = args.get(1)
+    && inline_callback_has_nil_return_path(callback)
+  {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      "`map-kv` callback uses nil as a legacy drop sentinel; use `filter-map-kv` and return `MapEntryDecision :keep key value` or `MapEntryDecision :drop` on every path",
+      "E_NIL_CALLBACK_SENTINEL",
+      call_stack,
+      call_location,
+    ));
+  }
+
   // `%{} _ (:field value) ...` is the canonical anonymous-struct
   // constructor. Lower it before macro arguments are preprocessed so `_`
   // cannot be mistaken for a normal unresolved symbol.
@@ -2615,6 +2630,56 @@ fn preprocess_list_call(
         ))
       }
     },
+  }
+}
+
+/// Conservatively recognizes only inline callbacks whose return control flow
+/// structurally contains `nil`. A nil nested inside a returned pair is data,
+/// not the legacy `map-kv` drop sentinel, and must remain valid.
+fn inline_callback_has_nil_return_path(callback: &Calcit) -> bool {
+  let Calcit::List(nodes) = callback else {
+    return false;
+  };
+  let body_start = match nodes.first().and_then(source_callable_name) {
+    Some("fn") => 2,
+    Some("defn") => 3,
+    _ => return false,
+  };
+  nodes.len() > body_start && nodes.get(nodes.len() - 1).is_some_and(expression_has_nil_return_path)
+}
+
+fn expression_has_nil_return_path(expr: &Calcit) -> bool {
+  if matches!(expr, Calcit::Nil) {
+    return true;
+  }
+  let Calcit::List(nodes) = expr else {
+    return false;
+  };
+  let Some(head) = nodes.first() else {
+    return false;
+  };
+  match source_callable_name(head) {
+    Some("if") => {
+      // `if` without an else branch manufactures nil when the condition is false.
+      nodes.len() == 3
+        || nodes.get(2).is_some_and(expression_has_nil_return_path)
+        || nodes.get(3).is_some_and(expression_has_nil_return_path)
+    }
+    Some("do" | "let" | "let-sugar" | "&let") => nodes.get(nodes.len() - 1).is_some_and(expression_has_nil_return_path),
+    Some("match") => nodes
+      .iter()
+      .skip(2)
+      .any(|branch| matches!(branch, Calcit::List(pair) if pair.get(1).is_some_and(expression_has_nil_return_path))),
+    _ => false,
+  }
+}
+
+fn source_callable_name(value: &Calcit) -> Option<&str> {
+  match value {
+    Calcit::Symbol { sym, .. } => Some(sym.as_ref()),
+    Calcit::Import(CalcitImport { def, .. }) => Some(def.as_ref()),
+    Calcit::Syntax(name, _) => Some(name.as_ref()),
+    _ => None,
   }
 }
 
@@ -8708,6 +8773,59 @@ mod tests {
     assert_eq!(error.code.as_deref(), Some("E_LEGACY_OPTIONAL_PARAM"));
     assert!(error.msg.contains("Option<T>"));
     assert!(error.location.is_some(), "strict diagnostic should retain the definition location");
+  }
+
+  #[test]
+  fn strict_types_rejects_inline_map_kv_nil_sentinel_without_rejecting_nil_pair_values() {
+    let _state = lock_preprocess_test_state();
+    let callback = Cirru::List(vec![
+      Cirru::leaf("fn"),
+      Cirru::List(vec![Cirru::leaf("k"), Cirru::leaf("v")]),
+      Cirru::List(vec![
+        Cirru::leaf("if"),
+        Cirru::List(vec![Cirru::leaf("nil?"), Cirru::leaf("v")]),
+        Cirru::List(vec![Cirru::leaf("[]"), Cirru::leaf("k"), Cirru::leaf("v")]),
+        Cirru::leaf("nil"),
+      ]),
+    ]);
+    let expr = Cirru::List(vec![Cirru::leaf("map-kv"), Cirru::List(vec![Cirru::leaf("{}")]), callback]);
+    let code = code_to_calcit(&expr, "tests.strict-nil", "map-entries", vec![]).expect("parse map-kv callback");
+
+    {
+      let _compat = StrictTypesGuard::new(false);
+      preprocess_test_expr(&code).expect("compatibility mode should preserve the legacy map-kv sentinel");
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    let error = preprocess_test_expr(&code).expect_err("strict mode should reject the nil drop sentinel");
+    assert_eq!(error.code.as_deref(), Some("E_NIL_CALLBACK_SENTINEL"));
+    assert!(error.msg.contains("filter-map-kv"));
+    assert!(error.location.is_some(), "strict diagnostic should retain the map-kv call location");
+
+    let nil_value_callback = Cirru::List(vec![
+      Cirru::leaf("fn"),
+      Cirru::List(vec![Cirru::leaf("k"), Cirru::leaf("v")]),
+      Cirru::List(vec![Cirru::leaf("[]"), Cirru::leaf("k"), Cirru::leaf("nil")]),
+    ]);
+    let nil_value_code =
+      code_to_calcit(&nil_value_callback, "tests.strict-nil", "keep-nil-value", vec![]).expect("parse callback that keeps a nil value");
+    assert!(
+      !inline_callback_has_nil_return_path(&nil_value_code),
+      "nil nested in the returned key/value pair is data, not a drop sentinel"
+    );
+
+    let missing_else_callback = Cirru::List(vec![
+      Cirru::leaf("fn"),
+      Cirru::List(vec![Cirru::leaf("k"), Cirru::leaf("v")]),
+      Cirru::List(vec![
+        Cirru::leaf("if"),
+        Cirru::List(vec![Cirru::leaf("nil?"), Cirru::leaf("v")]),
+        Cirru::List(vec![Cirru::leaf("[]"), Cirru::leaf("k"), Cirru::leaf("v")]),
+      ]),
+    ]);
+    let missing_else_code = code_to_calcit(&missing_else_callback, "tests.strict-nil", "implicit-drop", vec![])
+      .expect("parse callback with an implicit nil branch");
+    assert!(inline_callback_has_nil_return_path(&missing_else_code));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add strict-only `E_NIL_CALLBACK_SENTINEL` for inline `map-kv` callbacks whose return control flow visibly uses `nil` as the legacy drop sentinel
- guide callers to typed `filter-map-kv` / `MapEntryDecision :keep/:drop`
- keep compatibility-mode runtime behavior unchanged and preserve `[key nil]` as valid mapped data
- document the diagnostic and migration boundary

## 中文说明

- 在 `--strict-types` 下检查内联 `map-kv` 回调中结构上可见的 nil 返回路径
- 引导迁移到 `filter-map-kv` 和显式的 `MapEntryDecision :keep/:drop`
- 非严格模式行为不变；返回 pair 中作为数据的 nil 不会被误判
- 检查故意保持保守：暂不跨具名回调做推断

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- focused preprocess test for compatibility mode, strict diagnostic, implicit else-nil, and nested nil data
- `cargo test -- --test-threads=1` (all suites pass)
- `CR_WASM_BIN=./target/debug/cr-wasm yarn check-all`
  - core tests: 233/233
  - agent interface: 18/18
  - JS / IR / WASM checks pass, including `filter-map-kv() = 32`
  - static quality baseline has zero regressions

Parallel `cargo test` currently exposes pre-existing global test-state interference; each affected test and the full single-thread suite pass. Tracked separately in #588.

Ecosystem migration was also exercised in the editor and downstream `gen-code`; companion PRs are Respo/respo.calcit#125 and calcit-lang/gen-code#12.

Refs #578
