### PR TITLE
feat: stable nominal callables and typed literal paths / 稳定 nominal callable 与类型化字面量路径

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -404,7 +404,7 @@ Option 容器；Result 错误类型需要转换时显式使用 `.map-err`。
 
 需要尝试备用来源时使用 `.or-else`；它只在 `none`/`err` 分支调用 fallback。`.unwrap` 只适合已经由 `tag-match`、`.some?` 或明确不变量证明为 `some` 的位置；默认值用 `.unwrap-or`，继续转换用 `.map` / `.and-then`。接收者已静态推断为 `Option`/`Result` 时，避免使用 `option:*` / `result:*` 的函数形式，以便接收者类型和类型流保持可见；未类型化 legacy 数据或 core 边界才保留直接 helper。
 
-`get-in` 返回 `Option<T>`，适合 Map/List/字符串等可能缺失的路径；路径进入 Struct 时应改用类型化的 `(:field value)` 访问，字段需要可缺失时在 Struct 中声明 `Option<T>`。`update-in` 的 updater 接收 `Option<T>`，缺失分支应显式处理，不要无条件 unwrap：
+`get-in` 返回 `Option<T>`，适合开放数据中可能缺失的路径。完整类型的嵌套 Map 配合非空字面量路径时，`get-in`、`assoc-in`、`update-in` 会编译为直接的类型化访问/重建链，并保证接收者、各路径段和 updater 按源码顺序各求值一次。动态路径、动态接收者和混合容器保留为显式兼容边界。路径进入 Struct 时应改用类型化的 `(:field value)` 或 `value.:field` 访问，字段需要可缺失时在 Struct 中声明 `Option<T>`。`update-in` 的 updater 接收 `Option<T>`，缺失分支应显式处理，不要无条件 unwrap：
 
 ```cirru.no-check
 update-in data ([] :profile :visits)

--- a/docs/features/polymorphism.md
+++ b/docs/features/polymorphism.md
@@ -277,7 +277,7 @@ in receiver-first form.
 Core lookup APIs that no longer need to preserve bootstrapping compatibility use nominal results directly:
 
 - `find`, `find-index`, `find-last`, `find-last-index`, `index-of`, and `last-index-of` return `Option`.
-- `get-in` returns `Option<Dynamic>` while preserving a more precise payload type for literal paths when inference can resolve it.
+- `get-in` returns `Option<Dynamic>` while preserving a more precise payload type for literal paths when inference can resolve it. Fully typed Map receivers with non-empty literal paths are lowered, together with `assoc-in` and `update-in`, to direct typed lookup/association chains; dynamic paths and open containers remain an explicit compatibility boundary.
 - List/set `max` and `min` return `Option<Number>` so empty collections are explicit.
 - String `.find-index` and `str-find-index` return `Option<Number>`; the internal `&str:find-index` primitive retains its `-1` ABI sentinel.
 - `get-env` returns `Option<String>`; use `.unwrap-or` for a default.
@@ -285,7 +285,7 @@ Core lookup APIs that no longer need to preserve bootstrapping compatibility use
 - Reflection uses `enum-definition: Enum -> Option<EnumDef>`, `struct-definition: Struct -> Option<StructDef>`, and `impl-origin: Impl -> Option<Trait>`.
 - `destruct-list`, `destruct-map`, `destruct-set`, and `destruct-str` return named `*Destruct` enums, preserving the familiar `:some`/`:none` branches with checked payloads.
 - Public collection methods follow the same contract: Map/Set `.destruct` return their named destruct enums. Struct does not expose `.nth`, because field position is not stable across backends; field-name `get` returns the field's declared type directly.
-- `when-let` consumes `Option<T>` and returns `Option<R>`; `update-in` passes `Option<T>` to its updater so a missing leaf is never represented by nil.
+- `when-let` consumes `Option<T>` and returns `Option<R>`; `update-in` passes `Option<T>` to its updater so a missing leaf is never represented by nil. The typed literal-path lowering evaluates the receiver, every path segment, and the updater exactly once in source order.
 
 When a query immediately ends in a business default, call `.unwrap-or` on its
 Option result. An incompatible fallback is rejected whenever the payload type

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -356,7 +356,11 @@ let
 - `when-let` - run a body for `%some` and return `Option<R>`
 
 Nested updates are nominal as well: `update-in` passes `Option<T>` to its
-updater, and `dissoc-in` treats an empty path as a no-op. Public lookup and
+updater, and `dissoc-in` treats an empty path as a no-op. On a fully typed nested
+Map, non-empty literal paths in `get-in`, `assoc-in`, and `update-in` compile to
+direct typed lookup/association chains with single evaluation of each argument.
+Dynamic paths, open containers, and mixed traversal deliberately keep the
+runtime compatibility API. Public lookup and
 positional APIs (`get`, `get-in`, `first`, `last`, and collection `nth`) return
 `Option<T>`. Accessing a statically known struct field with `(:field value)` or
 receiver-first `value.:field` returns the field's declared type directly and is

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -93,11 +93,13 @@ reason/payload 使用方法级泛型，因此不会为了宿主编码而抹掉�
 `option:let` 的 body 必须继续返回 `Option`。普通组合函数仍以接收者方法
 作为公开形式，`option:*` / `result:*` 直接函数调用主要保留给 core lowering。
 
-## get-in / update-in
+## get-in / assoc-in / update-in
 
-`get-in` 是可能失败的开放数据访问，返回 `Option<T>`。不要用它绕过 Struct 字段检查；Struct 路径应使用 `(:field value)`，字段可缺失就把字段声明为 `Option<T>`。
+`get-in` 是可能失败的开放数据访问，返回 `Option<T>`。当接收者是完整类型的嵌套 Map、路径是非空字面量时，编译器会把 `get-in`、`assoc-in` 和 `update-in` 展开为类型化的直接 `get` / `assoc` 链，不再经过运行时动态路径遍历；调用参数仍按源码顺序各求值一次。`update-in` 的 updater 接收 `Option<T>`，因此缺失叶子不会退回 nil。
 
-`update-in` 的 updater 接收 `Option<T>`。对缺失值给默认值或明确返回 `%none`，不要无条件 unwrap：
+动态接收者、动态路径和混合容器仍是明确的兼容边界，会保留动态路径 API。新代码在数据形状已知时优先使用直接 `.get`、Option 组合和名义字段访问；只有开放数据才使用路径 API。不要用路径函数绕过 Struct 字段检查：Struct 应使用 `(:field value)` 或 `value.:field`，字段可缺失就把字段声明为 `Option<T>`。
+
+对 `update-in` 的缺失值给默认值或明确处理 `%none`，不要无条件 unwrap：
 
 ```cirru.no-check
 update-in data ([] :settings :retries)

--- a/editing-history/202609021604-nominal-callable-symbols-and-typed-paths.md
+++ b/editing-history/202609021604-nominal-callable-symbols-and-typed-paths.md
@@ -1,0 +1,25 @@
+# Stable nominal callables and typed literal-path updates
+
+2026-09-02 16:04 CST
+
+## English
+
+- Promoted capture-free anonymous nominal impl methods to deterministic compiler-owned callables such as `&lagopus0:show`, while preserving lowercase `.show` in application source.
+- Kept captured impl closures on runtime dispatch, converted existing named method functions to direct imports, and added namespace qualification only when cross-namespace nominal names could collide.
+- Recorded the source `defimpl` as a compiled dependency so changing an implementation invalidates its generated callable and direct callers. Source and generated-symbol collisions report stable typed diagnostics instead of silently overwriting definitions.
+- Extended typed literal-path lowering from `get-in` and `assoc-in` to `update-in`. Fully typed nested Maps with non-empty literal paths now use direct Option-aware lookup and reconstruction, with the receiver, path expressions, updater, and replacement each evaluated once in source order.
+- Preserved dynamic paths, Dynamic receivers, mixed containers, and captured closures as explicit compatibility boundaries rather than guessing static semantics.
+- Allowed a named `impl-traits` wrapper type to match the concrete Struct/Enum value it resolves to, so hooks can expose precise nominal plugin return types without losing method lookup identity.
+- Preserved legacy `?` optional-parameter evidence in the cached callable shape and method checker, preventing valid calls such as `.show d!` from being rejected when the final text argument is omitted.
+- Added Rust unit coverage, generated-JS assertions, native runtime checks, documentation, and cross-backend regression coverage.
+
+## 中文
+
+- 将不捕获词法环境的匿名 nominal impl 方法提升为确定的编译器内部 callable，例如 `&lagopus0:show`；应用源码仍然只写小写 `.show`。
+- 捕获闭包继续使用运行时分发；已有命名方法函数改为直接 Import；只有跨命名空间同名 nominal 类型存在冲突风险时，生成 scope 才自动带命名空间。
+- 将来源 `defimpl` 记录为编译依赖，使实现变更能够使生成 callable 和直接调用者失效重编译。与源码定义或其他生成符号冲突时返回稳定的类型错误码，不再静默覆盖。
+- 将类型化字面量路径优化从 `get-in`、`assoc-in` 扩展到 `update-in`。完整类型的嵌套 Map 与非空字面量路径会生成 Option 感知的直接读取和重建链，并保证接收者、路径表达式、updater 与 replacement 按源码顺序各求值一次。
+- 动态路径、Dynamic 接收者、混合容器和捕获闭包继续作为显式兼容边界，不猜测其静态语义。
+- 允许命名的 `impl-traits` 包装类型与其解析得到的具体 Struct/Enum 值匹配，使 hook 可以声明精确的 nominal plugin 返回类型，同时保留方法查找身份。
+- 在缓存的 callable shape 与方法检查器中保留旧式 `?` 可选参数证据，避免 `.show d!` 这类省略末尾文本参数的合法调用被误报。
+- 补充 Rust 单元测试、生成 JS 断言、native 运行验证、文档与跨后端回归门禁。

--- a/editing-history/202609021604-nominal-callable-symbols-and-typed-paths.md
+++ b/editing-history/202609021604-nominal-callable-symbols-and-typed-paths.md
@@ -11,6 +11,7 @@
 - Preserved dynamic paths, Dynamic receivers, mixed containers, and captured closures as explicit compatibility boundaries rather than guessing static semantics.
 - Allowed a named `impl-traits` wrapper type to match the concrete Struct/Enum value it resolves to, so hooks can expose precise nominal plugin return types without losing method lookup identity.
 - Preserved legacy `?` optional-parameter evidence in the cached callable shape and method checker, preventing valid calls such as `.show d!` from being rejected when the final text argument is omitted.
+- Hardened generated-callable invalidation after review: canonical impl tags win over aliases, inline `impl-traits` values depend on their nominal source definition, and synthesis falls back to runtime dispatch when no reliable source owner exists. Reprocessed Dynamic parameters also clear shadowed outer type evidence.
 - Added Rust unit coverage, generated-JS assertions, native runtime checks, documentation, and cross-backend regression coverage.
 
 ## 中文
@@ -22,4 +23,5 @@
 - 动态路径、Dynamic 接收者、混合容器和捕获闭包继续作为显式兼容边界，不猜测其静态语义。
 - 允许命名的 `impl-traits` 包装类型与其解析得到的具体 Struct/Enum 值匹配，使 hook 可以声明精确的 nominal plugin 返回类型，同时保留方法查找身份。
 - 在缓存的 callable shape 与方法检查器中保留旧式 `?` 可选参数证据，避免 `.show d!` 这类省略末尾文本参数的合法调用被误报。
+- 根据 review 加固生成 callable 的失效关系：canonical impl tag 优先于别名，inline `impl-traits` 依赖其 nominal 源定义；找不到可靠源码 owner 时回退到运行时分发。重新处理 Dynamic 参数时也会清除被遮蔽的外层类型证据。
 - 补充 Rust 单元测试、生成 JS 断言、native 运行验证、文档与跨后端回归门禁。

--- a/scripts/check-static-method-lowering.mjs
+++ b/scripts/check-static-method-lowering.mjs
@@ -12,6 +12,23 @@ assert.doesNotMatch(
 const appOutput = readFileSync("js-out/app.main.mjs", "utf8");
 assert.match(appOutput, /\$clt\._\$n_atom_\$o_deref\([^)]*\)/, "typed Ref .deref must lower to &atom:deref");
 
+const structOutput = readFileSync("js-out/test-struct.main.mjs", "utf8");
+assert.match(
+  structOutput,
+  /export function _\$n_lagopus0_\$o_show\(self\)/,
+  "an anonymous nominal impl method must receive a stable &lagopus0:show callable",
+);
+assert.match(
+  structOutput,
+  /_\$n_lagopus0_\$o_rename\(l1t, "LagopusB"\)/,
+  "typed source .rename must call the generated nominal callable directly",
+);
+assert.doesNotMatch(
+  structOutput,
+  /invoke_method\(\s*"show"\s*,\s*l1t\b/,
+  "a statically known nominal .show call must not retain dynamic dispatch",
+);
+
 const coreOutput = readFileSync("js-out/calcit.core.mjs", "utf8");
 assert.match(coreOutput, /ref:\s*_\$n_core_ref_impls/, "generated JS must register the Ref fallback impl table");
 

--- a/src/calcit/fns.rs
+++ b/src/calcit/fns.rs
@@ -185,9 +185,10 @@ impl CalcitFnCallShape {
     let param_len = args.param_len();
     let has_marked_rest =
       matches!(args, CalcitFnArgs::MarkedArgs(labels) if labels.iter().any(|label| matches!(label, CalcitArgLabel::RestMark)));
+    let marked_optionals = args.marked_optional_count();
     Self {
       param_len: u16::try_from(param_len).expect("function parameter count exceeds local index capacity"),
-      trailing_optionals: u16::try_from(trailing_option_arg_count(arg_types, param_len))
+      trailing_optionals: u16::try_from(marked_optionals.max(trailing_option_arg_count(arg_types, param_len)))
         .expect("optional parameter count exceeds local index capacity"),
       has_rest: has_typed_rest || has_marked_rest,
     }
@@ -212,6 +213,25 @@ impl CalcitFnArgs {
     match self {
       CalcitFnArgs::MarkedArgs(xs) => xs.iter().filter(|label| matches!(label, CalcitArgLabel::Idx(_))).count(),
       CalcitFnArgs::Args(xs) => xs.len(),
+    }
+  }
+
+  /// Counts the trailing parameters made optional by a legacy `?` marker.
+  ///
+  /// Keep this evidence available independently from typed `Option` metadata:
+  /// imported and anonymous impl callables may still originate from source that
+  /// uses the marker while their schema remains intentionally broad.
+  pub fn marked_optional_count(&self) -> usize {
+    match self {
+      CalcitFnArgs::MarkedArgs(labels) => {
+        let shape = ParamShape::from_tokens(labels.iter().map(|label| match label {
+          CalcitArgLabel::Idx(_) => ParamShapeToken::Binding,
+          CalcitArgLabel::OptionalMark => ParamShapeToken::OptionalMark,
+          CalcitArgLabel::RestMark => ParamShapeToken::RestMark,
+        }));
+        if shape.errors.is_empty() { shape.optional } else { 0 }
+      }
+      CalcitFnArgs::Args(_) => 0,
     }
   }
 
@@ -348,6 +368,17 @@ mod tests {
 
     let typed = CalcitFnArgs::Args(vec![1]);
     assert!(CalcitFnCallShape::from_parts(&typed, std::slice::from_ref(&*crate::calcit::DYNAMIC_TYPE), true).has_rest());
+
+    let optional = CalcitFnArgs::MarkedArgs(vec![
+      CalcitArgLabel::Idx(1),
+      CalcitArgLabel::Idx(2),
+      CalcitArgLabel::OptionalMark,
+      CalcitArgLabel::Idx(3),
+    ]);
+    let optional_shape = CalcitFnCallShape::from_parts(&optional, &[], false);
+    assert_eq!(optional.marked_optional_count(), 1);
+    assert_eq!(optional_shape.param_len(), 3);
+    assert_eq!(optional_shape.trailing_optionals(), 1);
   }
 
   #[test]
@@ -436,6 +467,10 @@ impl Display for ScopePair {
 pub struct CalcitScope(Vec<ScopePair>);
 
 impl CalcitScope {
+  pub(crate) fn is_empty(&self) -> bool {
+    self.0.is_empty()
+  }
+
   /// Capture the current end of a lexical frame before adding call-local bindings.
   pub(crate) fn frame_checkpoint(&self) -> usize {
     self.0.len()

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -960,6 +960,18 @@ impl CalcitTypeAnnotation {
     left == right || left.rsplit('/').next().is_some_and(|segment| segment == right)
   }
 
+  fn type_ref_resolves_to_struct_name(name: &str, target: &str) -> bool {
+    Self::TypeRef(Arc::from(name), Arc::new(vec![]))
+      .resolve_to_struct()
+      .is_some_and(|resolved| resolved.name.ref_str() == target)
+  }
+
+  fn type_ref_resolves_to_enum_name(name: &str, target: &str) -> bool {
+    Self::TypeRef(Arc::from(name), Arc::new(vec![]))
+      .resolve_to_enum()
+      .is_some_and(|resolved| resolved.name().ref_str() == target)
+  }
+
   fn is_hint_fn_form(list: &CalcitList) -> bool {
     match list.first() {
       Some(Calcit::Syntax(CalcitSyntax::HintFn, _)) => true,
@@ -3034,7 +3046,8 @@ impl CalcitTypeAnnotation {
       (Self::Set(a), Self::Set(b)) => a.matches_with_bindings(b, bindings),
       (Self::Ref(a), Self::Ref(b)) => a.matches_with_bindings(b, bindings),
       (Self::TypeRef(name, args), Self::Struct(base, other_args)) | (Self::Struct(base, other_args), Self::TypeRef(name, args)) => {
-        if !Self::type_ref_name_matches(name, base.name.ref_str()) {
+        if !Self::type_ref_name_matches(name, base.name.ref_str()) && !Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
+        {
           return false;
         }
         match (args.is_empty(), other_args.is_empty()) {
@@ -3051,7 +3064,9 @@ impl CalcitTypeAnnotation {
         }
       }
       (Self::TypeRef(name, args), Self::Enum(base, other_args)) | (Self::Enum(base, other_args), Self::TypeRef(name, args)) => {
-        if !Self::type_ref_name_matches(name, base.name().ref_str()) {
+        if !Self::type_ref_name_matches(name, base.name().ref_str())
+          && !Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
+        {
           return false;
         }
         match (args.is_empty(), other_args.is_empty()) {
@@ -3071,10 +3086,12 @@ impl CalcitTypeAnnotation {
         // Structs are structurally map-like (field name -> value), so procs typed as
         // accepting a generic "map" (e.g. `to-pairs`/`keys`) should also accept structs,
         // in addition to matching the struct's own type name.
-        Self::type_ref_name_matches(name, base.name.ref_str()) || Self::type_ref_name_matches(name, "map")
+        Self::type_ref_name_matches(name, base.name.ref_str())
+          || Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
+          || Self::type_ref_name_matches(name, "map")
       }
       (Self::TypeRef(name, _), Self::EnumValue(base)) | (Self::EnumValue(base), Self::TypeRef(name, _)) => {
-        Self::type_ref_name_matches(name, base.name().ref_str())
+        Self::type_ref_name_matches(name, base.name().ref_str()) || Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
       }
       (Self::Struct(a, a_args), Self::Struct(b, b_args)) => {
         if a.name != b.name {

--- a/src/program.rs
+++ b/src/program.rs
@@ -329,6 +329,37 @@ pub fn lookup_runtime_ready(ns: &str, def: &str) -> Option<Calcit> {
   lookup_def_id(ns, def).and_then(lookup_runtime_ready_by_id)
 }
 
+/// Find the source definition that currently owns an evaluated metadata value.
+///
+/// Static impl-callable synthesis uses this provenance edge so changing a
+/// `defimpl` invalidates both its generated callable and every direct caller.
+pub(crate) fn find_source_def_for_runtime_value(ns: &str, target: &Calcit) -> Option<Arc<str>> {
+  let source_defs = {
+    let source = PROGRAM_CODE_DATA.read().expect("read program code");
+    source.get(ns)?.defs.keys().cloned().collect::<HashSet<_>>()
+  };
+  let candidates = {
+    let index = PROGRAM_DEF_ID_INDEX.read().expect("read program def id index");
+    index
+      .by_ns
+      .get(ns)?
+      .iter()
+      .filter(|(def, _)| source_defs.contains(def.as_ref()))
+      .map(|(def, def_id)| (def.clone(), *def_id))
+      .collect::<Vec<_>>()
+  };
+  let runtime = PROGRAM_RUNTIME_DATA_STATE.read().expect("read runtime data");
+  let mut matches = candidates
+    .into_iter()
+    .filter_map(|(def, def_id)| match runtime.get(def_id.0 as usize) {
+      Some(RuntimeCell::Ready(value)) if value == target => Some(def),
+      _ => None,
+    })
+    .collect::<Vec<_>>();
+  matches.sort();
+  matches.into_iter().next()
+}
+
 pub fn mark_runtime_def_resolving(ns: &str, def: &str) {
   let def_id = ensure_def_id(ns, def);
   write_runtime_cell(def_id, RuntimeCell::Resolving);

--- a/src/program.rs
+++ b/src/program.rs
@@ -329,15 +329,22 @@ pub fn lookup_runtime_ready(ns: &str, def: &str) -> Option<Calcit> {
   lookup_def_id(ns, def).and_then(lookup_runtime_ready_by_id)
 }
 
-/// Find the source definition that currently owns an evaluated metadata value.
+/// Find the source definition that owns a runtime metadata value.
 ///
-/// Static impl-callable synthesis uses this provenance edge so changing a
-/// `defimpl` invalidates both its generated callable and every direct caller.
+/// An impl tag names its canonical `defimpl` owner even while that definition
+/// is not `Ready`. Other metadata values fall back to deterministic equality
+/// over evaluated source-backed definitions.
 pub(crate) fn find_source_def_for_runtime_value(ns: &str, target: &Calcit) -> Option<Arc<str>> {
   let source_defs = {
     let source = PROGRAM_CODE_DATA.read().expect("read program code");
     source.get(ns)?.defs.keys().cloned().collect::<HashSet<_>>()
   };
+  if let Calcit::Impl(impl_value) = target {
+    let tagged_owner: Arc<str> = Arc::from(impl_value.name().ref_str());
+    if source_defs.contains(tagged_owner.as_ref()) {
+      return Some(tagged_owner);
+    }
+  }
   let candidates = {
     let index = PROGRAM_DEF_ID_INDEX.read().expect("read program def id index");
     index

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
-use crate::calcit::{CalcitFnTypeAnnotation, CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo, SchemaKind};
+use crate::calcit::{CalcitFnTypeAnnotation, CalcitImpl, CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo, SchemaKind};
 use crate::call_stack::CallStackList;
 use crate::codegen::calx::{
   CalxCacheMissReason, CalxCompileCache, CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport, CalxHostImports,
@@ -99,6 +99,17 @@ fn runtime_value_provenance_resolves_only_source_backed_definitions() {
     find_source_def_for_runtime_value("tests.runtime-provenance", &target).as_deref(),
     Some("a-owner"),
     "provenance is source-backed and deterministic"
+  );
+  let tagged_impl = Calcit::Impl(CalcitImpl {
+    name: EdnTag::new("z-owner"),
+    origin: None,
+    fields: Arc::new(vec![]),
+    values: Arc::new(vec![]),
+  });
+  assert_eq!(
+    find_source_def_for_runtime_value("tests.runtime-provenance", &tagged_impl).as_deref(),
+    Some("z-owner"),
+    "an impl tag identifies its source owner even before that owner is Ready"
   );
   assert_eq!(find_source_def_for_runtime_value("tests.missing", &target), None);
 }

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -58,6 +58,105 @@ fn strict_edn_decoder_nominals_are_compiled_dependencies() {
 }
 
 #[test]
+fn runtime_value_provenance_resolves_only_source_backed_definitions() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+
+  let target = Calcit::Str(Arc::from("impl-metadata-value"));
+  PROGRAM_CODE_DATA.write().expect("seed source program").insert(
+    Arc::from("tests.runtime-provenance"),
+    ProgramFileData {
+      import_map: HashMap::new(),
+      defs: HashMap::from([
+        (
+          Arc::from("z-owner"),
+          ProgramDefEntry {
+            code: Calcit::Nil,
+            schema: DYNAMIC_TYPE.clone(),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: None,
+          },
+        ),
+        (
+          Arc::from("a-owner"),
+          ProgramDefEntry {
+            code: Calcit::Nil,
+            schema: DYNAMIC_TYPE.clone(),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: None,
+          },
+        ),
+      ]),
+    },
+  );
+  write_runtime_ready("tests.runtime-provenance", "runtime-only", target.clone()).expect("seed runtime-only value");
+  write_runtime_ready("tests.runtime-provenance", "z-owner", target.clone()).expect("seed source-backed value");
+  write_runtime_ready("tests.runtime-provenance", "a-owner", target.clone()).expect("seed second source-backed value");
+
+  assert_eq!(
+    find_source_def_for_runtime_value("tests.runtime-provenance", &target).as_deref(),
+    Some("a-owner"),
+    "provenance is source-backed and deterministic"
+  );
+  assert_eq!(find_source_def_for_runtime_value("tests.missing", &target), None);
+}
+
+#[test]
+fn nominal_impl_wrapper_type_ref_matches_its_concrete_enum_value() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  calcit::register_program_lookups(lookup_runtime_ready, lookup_def_code, lookup_def_schema);
+
+  let wrapper_code = code_to_calcit(
+    &cirru_list(vec![
+      cirru_leaf("def"),
+      cirru_leaf("alert-actions-plugin"),
+      cirru_list(vec![
+        cirru_leaf("impl-traits"),
+        cirru_list(vec![
+          cirru_leaf("defenum"),
+          cirru_leaf("PluginNode"),
+          cirru_list(vec![cirru_leaf(":value"), cirru_leaf("Dynamic")]),
+        ]),
+        cirru_leaf("PluginActions"),
+      ]),
+    ]),
+    "tests.nominal-wrapper",
+    "alert-actions-plugin",
+    vec![],
+  )
+  .expect("build nominal impl wrapper source");
+
+  PROGRAM_CODE_DATA.write().expect("seed nominal wrapper source").insert(
+    Arc::from("tests.nominal-wrapper"),
+    ProgramFileData {
+      import_map: HashMap::new(),
+      defs: HashMap::from([(
+        Arc::from("alert-actions-plugin"),
+        ProgramDefEntry {
+          code: wrapper_code,
+          schema: DYNAMIC_TYPE.clone(),
+          doc: Arc::from(""),
+          examples: vec![],
+          ffi: None,
+        },
+      )]),
+    },
+  );
+
+  let wrapper_ref = CalcitTypeAnnotation::TypeRef(Arc::from("tests.nominal-wrapper/alert-actions-plugin"), Arc::new(vec![]));
+  let concrete = CalcitTypeAnnotation::Enum(
+    Arc::new(wrapper_ref.resolve_to_enum().expect("resolve wrapper to its underlying enum")),
+    Arc::new(vec![]),
+  );
+
+  assert!(wrapper_ref.matches_annotation(&concrete));
+  assert!(concrete.matches_annotation(&wrapper_ref));
+}
+
+#[test]
 fn import_rule_validation_rejects_short_rules_without_panicking() {
   let error =
     validate_import_rules(&[cirru_list(vec![cirru_leaf("audit.invalid")])]).expect_err("short import rule should be rejected");

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1194,6 +1194,28 @@ fn try_expand_typed_literal_path_call(
       let body = generated_lets(path_bindings, body, file_ns);
       Ok(Some(generated_let(base_binding, base.to_owned(), body, file_ns)))
     }
+    "update-in" if args.len() == 3 => {
+      let Some(path) = fully_typed_literal_assoc_path(base_type.as_ref(), path_arg) else {
+        return Ok(None);
+      };
+      let base_binding = generated_path_symbol("typed_path_base", file_ns, call_stack)?;
+      let updater_binding = generated_path_symbol("typed_path_updater", file_ns, call_stack)?;
+      let replacement_binding = generated_path_symbol("typed_path_replacement", file_ns, call_stack)?;
+      let mut path_bindings = Vec::with_capacity(path.len());
+      let mut path_locals = Vec::with_capacity(path.len());
+      for key in path {
+        let binding = generated_path_symbol("typed_path_key", file_ns, call_stack)?;
+        path_locals.push(binding.to_owned());
+        path_bindings.push((binding, key));
+      }
+      let current = generated_get_in_step(base_binding.to_owned(), &path_locals, file_ns, call_stack)?;
+      let replacement = generated_call(vec![updater_binding.to_owned(), current]);
+      let body = generated_assoc_in_step(base_binding.to_owned(), &replacement_binding, &path_locals, file_ns, call_stack)?;
+      let body = generated_let(replacement_binding, replacement, body, file_ns);
+      let body = generated_let(updater_binding, args[2].to_owned(), body, file_ns);
+      let body = generated_lets(path_bindings, body, file_ns);
+      Ok(Some(generated_let(base_binding, base.to_owned(), body, file_ns)))
+    }
     _ => Ok(None),
   }
 }
@@ -1741,7 +1763,7 @@ fn preprocess_list_call(
             // generic prefix-call branch below. Specialize it before returning
             // so typed source such as `m .keys` reaches codegen with the direct
             // `&scope:name` callable as its head instead of `invoke-method`.
-            if let Some(optimized_call) = try_inline_method_call(&typed_method, &processed_args, scope_types, file_ns) {
+            if let Some(optimized_call) = try_inline_method_call(&typed_method, &processed_args, scope_types, file_ns, call_stack)? {
               return Ok(optimized_call);
             }
 
@@ -2032,7 +2054,7 @@ fn preprocess_list_call(
         // Try to specialize polymorphic calls when receiver type is known
         if let Calcit::Import(CalcitImport { ns, def, .. }) = &head_form {
           let current_args = CalcitList::from(ys.drop_left());
-          if matches!(def.as_ref(), "get-in" | "assoc-in")
+          if matches!(def.as_ref(), "get-in" | "assoc-in" | "update-in")
             && let Some(expanded) = try_expand_typed_literal_path_call(&head_form, &current_args, scope_types, file_ns, call_stack)?
           {
             return preprocess_generated_path_expansion(&expanded, scope_defs, scope_types, file_ns, call_stack);
@@ -2591,7 +2613,7 @@ fn preprocess_list_call(
         if !has_spread
           && let Some(call_head @ Calcit::Import(CalcitImport { ns, def, .. })) = ys.first()
           && ns.as_ref() == calcit::CORE_NS
-          && matches!(def.as_ref(), "get-in" | "assoc-in")
+          && matches!(def.as_ref(), "get-in" | "assoc-in" | "update-in")
           && let Some(expanded) = try_expand_typed_literal_path_call(call_head, &processed_args, scope_types, file_ns, call_stack)?
         {
           return preprocess_generated_path_expansion(&expanded, scope_defs, scope_types, file_ns, call_stack);
@@ -2599,7 +2621,7 @@ fn preprocess_list_call(
 
         if !has_spread
           && let Some(call_head) = ys.first()
-          && let Some(optimized_call) = try_inline_method_call(call_head, &processed_args, scope_types, file_ns)
+          && let Some(optimized_call) = try_inline_method_call(call_head, &processed_args, scope_types, file_ns, call_stack)?
         {
           return Ok(optimized_call);
         }
@@ -4050,15 +4072,17 @@ fn check_struct_method_args(
   let actual_with_receiver = actual_count + 1; // Include receiver in count
 
   // Check for variadic args (has RestMark)
-  let has_variadic = match fn_info.args.as_ref() {
-    CalcitFnArgs::MarkedArgs(xs) => xs.iter().any(|label| matches!(label, CalcitArgLabel::RestMark)),
-    CalcitFnArgs::Args(_) => false,
-  };
+  let has_variadic = fn_info.call_shape.has_rest()
+    || matches!(fn_info.args.as_ref(), CalcitFnArgs::MarkedArgs(xs) if xs.iter().any(|label| matches!(label, CalcitArgLabel::RestMark)));
 
   let trailing_options = if has_variadic {
     0
   } else {
-    calcit::trailing_option_arg_count(&fn_info.arg_types, expected_count)
+    fn_info
+      .call_shape
+      .trailing_optionals()
+      .max(fn_info.args.marked_optional_count())
+      .max(calcit::trailing_option_arg_count(&fn_info.arg_types, expected_count))
   };
   let accepts_omission = trailing_options > 0 && (expected_count - trailing_options..=expected_count).contains(&actual_with_receiver);
   if !has_variadic && expected_count != actual_with_receiver && !accepts_omission {
@@ -5043,7 +5067,15 @@ fn try_specialize_polymorphic_call(
   Some(Calcit::from(items))
 }
 
-fn try_inline_method_call(head: &Calcit, args: &CalcitList, scope_types: &ScopeTypes, file_ns: &str) -> Option<Calcit> {
+/// Resolve a typed receiver method to a direct callable when its implementation
+/// can be selected without runtime dispatch.
+fn try_inline_method_call(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Option<Calcit>, CalcitErr> {
   match head {
     Calcit::Method(method_name, calcit::MethodKind::Invoke(type_value)) => {
       let mut resolved_type = type_value.clone();
@@ -5055,36 +5087,276 @@ fn try_inline_method_call(head: &Calcit, args: &CalcitList, scope_types: &ScopeT
         resolved_type = inferred;
       }
       if matches!(resolved_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
-        return None;
+        return Ok(None);
       }
       let type_ref = resolved_type.as_ref();
-      let impl_values = get_impls_from_type(type_ref)?;
-      let (_impl_index, _impl_value, method_entry) = find_method_entry_with_impl(type_ref, &impl_values, method_name.as_ref())?;
+      let Some(impl_values) = get_impls_from_type(type_ref) else {
+        return Ok(None);
+      };
+      let Some((_impl_index, impl_value, method_entry)) = find_method_entry_with_impl(type_ref, &impl_values, method_name.as_ref())
+      else {
+        return Ok(None);
+      };
 
-      if let Some(callable_head) = pick_callable_from_method_entry(method_entry, file_ns) {
-        return Some(build_inlined_call(callable_head, args, scope_types));
+      if let Some(callable_head) =
+        pick_callable_from_method_entry(method_entry, impl_value, type_ref, method_name.as_ref(), file_ns, call_stack)?
+      {
+        return Ok(Some(build_inlined_call(callable_head, args, scope_types)));
       }
 
-      None
+      Ok(None)
     }
-    _ => None,
+    _ => Ok(None),
   }
 }
 
-fn pick_callable_from_method_entry(entry: &Calcit, _file_ns: &str) -> Option<Calcit> {
+/// Convert a selected method entry into a stable direct-call head.
+fn pick_callable_from_method_entry(
+  entry: &Calcit,
+  impl_value: &CalcitImpl,
+  receiver_type: &CalcitTypeAnnotation,
+  method_name: &str,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Option<Calcit>, CalcitErr> {
   match entry {
     // Avoid inlining Fn literals: JS codegen would embed large function bodies and lose closure semantics.
-    Calcit::Import(..) | Calcit::Proc(..) | Calcit::Registered(..) | Calcit::Symbol { .. } => Some(entry.to_owned()),
+    Calcit::Import(..) | Calcit::Proc(..) | Calcit::Registered(..) | Calcit::Symbol { .. } => Ok(Some(entry.to_owned())),
     Calcit::Fn { info, .. }
-      if info
-        .def_ref
-        .as_ref()
-        .is_some_and(|def_ref| !def_ref.is_macro_gen && program::has_def_code(def_ref.def_ns.as_ref(), def_ref.def_name.as_ref())) =>
+      if let Some(def_ref) = info.def_ref.as_ref()
+        && !def_ref.is_macro_gen
+        && (program::has_def_code(def_ref.def_ns.as_ref(), def_ref.def_name.as_ref())
+          || program::lookup_compiled_def(def_ref.def_ns.as_ref(), def_ref.def_name.as_ref()).is_some()) =>
     {
-      Some(entry.to_owned())
+      let import_info = if def_ref.def_ns.as_ref() == calcit::CORE_NS {
+        ImportInfo::Core { at_ns: Arc::from(file_ns) }
+      } else if def_ref.def_ns.as_ref() == file_ns {
+        ImportInfo::SameFile {
+          at_def: def_ref.def_name.clone(),
+        }
+      } else {
+        ImportInfo::NsReferDef {
+          at_ns: Arc::from(file_ns),
+          at_def: def_ref.def_name.clone(),
+        }
+      };
+      Ok(Some(Calcit::Import(CalcitImport {
+        ns: def_ref.def_ns.clone(),
+        def: def_ref.def_name.clone(),
+        info: Arc::new(import_info),
+        def_id: Some(program::ensure_def_id(def_ref.def_ns.as_ref(), def_ref.def_name.as_ref()).0),
+      })))
     }
-    _ => None,
+    Calcit::Fn { info, .. } if info.scope.is_empty() => {
+      synthesize_nominal_impl_callable(info, impl_value, receiver_type, method_name, file_ns, call_stack).map(Some)
+    }
+    // A closure that captures lexical state cannot be promoted to a top-level
+    // callable without changing its semantics. It remains on the explicit
+    // runtime dispatch path until closure conversion is modeled separately.
+    _ => Ok(None),
   }
+}
+
+/// Derive the lowercase internal `&scope:name` scope from a nominal receiver.
+fn nominal_callable_scope_name(receiver_type: &CalcitTypeAnnotation, target_ns: &str) -> Option<String> {
+  let raw_name = match receiver_type {
+    CalcitTypeAnnotation::TypeRef(path, _) => match path.rsplit_once('/') {
+      Some((type_ns, name)) if type_ns != target_ns => format!("{type_ns}/{name}"),
+      Some((_, name)) => name.to_owned(),
+      None => path.to_string(),
+    },
+    CalcitTypeAnnotation::Struct(definition, _) | CalcitTypeAnnotation::StructValue(definition) => definition.name.ref_str().to_owned(),
+    CalcitTypeAnnotation::Enum(definition, _) | CalcitTypeAnnotation::EnumValue(definition) => definition.name().ref_str().to_owned(),
+    CalcitTypeAnnotation::Optional(inner) => return nominal_callable_scope_name(inner.as_ref(), target_ns),
+    _ => return None,
+  };
+
+  let mut normalized = String::with_capacity(raw_name.len());
+  let mut previous_was_lower_or_digit = false;
+  let mut previous_was_separator = false;
+  for ch in raw_name.trim_start_matches(['\'', ':', '&']).chars() {
+    if ch.is_ascii_uppercase() {
+      if previous_was_lower_or_digit && !previous_was_separator {
+        normalized.push('-');
+      }
+      normalized.push(ch.to_ascii_lowercase());
+      previous_was_lower_or_digit = false;
+      previous_was_separator = false;
+    } else if ch.is_ascii_alphanumeric() || matches!(ch, '?' | '!') {
+      normalized.push(ch.to_ascii_lowercase());
+      previous_was_lower_or_digit = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+      previous_was_separator = false;
+    } else if !previous_was_separator && !normalized.is_empty() {
+      normalized.push('-');
+      previous_was_lower_or_digit = false;
+      previous_was_separator = true;
+    }
+  }
+  while normalized.ends_with('-') {
+    normalized.pop();
+  }
+  (!normalized.is_empty()).then_some(normalized)
+}
+
+/// Prefer the originating trait contract, then fall back to the evaluated Fn metadata.
+fn impl_method_schema(impl_value: &CalcitImpl, method_name: &str, fallback: &CalcitFn) -> Arc<CalcitTypeAnnotation> {
+  if let Some(trait_def) = impl_value.origin()
+    && let Some(method_idx) = trait_def.method_index(method_name)
+    && let Some(method_type) = trait_def.method_types.get(method_idx)
+  {
+    return method_type.clone();
+  }
+  Arc::new(CalcitTypeAnnotation::from_calcit_fn(fallback))
+}
+
+/// Rebuild compiler-owned function parameters while preserving markers and type evidence.
+fn synthetic_fn_args(info: &CalcitFn, schema: &CalcitTypeAnnotation, synthetic_name: &str) -> Calcit {
+  let schema_args = schema.resolve_to_fn().map(|annotation| annotation.arg_types.clone());
+  let mut parameter_index = 0usize;
+  let mut nodes = vec![];
+  let mut push_local = |idx: u16, nodes: &mut Vec<Calcit>| {
+    let type_info = schema_args
+      .as_ref()
+      .and_then(|types| types.get(parameter_index))
+      .cloned()
+      .or_else(|| info.arg_types.get(parameter_index).cloned())
+      .unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
+    parameter_index += 1;
+    nodes.push(Calcit::Local(CalcitLocal {
+      idx,
+      sym: Arc::from(CalcitLocal::read_name(idx)),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: info.def_ns.clone(),
+        at_def: Arc::from(synthetic_name),
+      }),
+      location: None,
+      type_info,
+    }));
+  };
+
+  match info.args.as_ref() {
+    CalcitFnArgs::Args(indices) => {
+      for idx in indices {
+        push_local(*idx, &mut nodes);
+      }
+    }
+    CalcitFnArgs::MarkedArgs(labels) => {
+      for label in labels {
+        match label {
+          CalcitArgLabel::Idx(idx) => push_local(*idx, &mut nodes),
+          CalcitArgLabel::OptionalMark => nodes.push(Calcit::Syntax(CalcitSyntax::ArgOptional, info.def_ns.clone())),
+          CalcitArgLabel::RestMark => nodes.push(Calcit::Syntax(CalcitSyntax::ArgSpread, info.def_ns.clone())),
+        }
+      }
+    }
+  }
+  Calcit::from(CalcitList::from(nodes.as_slice()))
+}
+
+/// Materialize a capture-free anonymous impl method as a deterministic compiled definition.
+fn synthesize_nominal_impl_callable(
+  info: &CalcitFn,
+  impl_value: &CalcitImpl,
+  receiver_type: &CalcitTypeAnnotation,
+  method_name: &str,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<Calcit, CalcitErr> {
+  let target_ns = info.def_ns.as_ref();
+  let Some(scope_name) = nominal_callable_scope_name(receiver_type, target_ns) else {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      format!("cannot create a static callable for `.{method_name}` without a nominal receiver type"),
+      "E_IMPL_CALLABLE_NOMINAL_RECEIVER_REQUIRED",
+      call_stack,
+      None,
+    ));
+  };
+  let method_segment = method_name.to_ascii_lowercase();
+  let synthetic_name = format!("&{scope_name}:{method_segment}");
+
+  if program::has_def_code(target_ns, &synthetic_name) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      format!(
+        "generated impl callable `{target_ns}/{synthetic_name}` conflicts with a source definition; use that named callable directly in the impl or rename the conflicting internal definition"
+      ),
+      "E_IMPL_CALLABLE_SYMBOL_COLLISION",
+      call_stack,
+      None,
+    ));
+  }
+
+  let schema = impl_method_schema(impl_value, method_name, info);
+  let mut nodes = vec![
+    Calcit::Syntax(CalcitSyntax::Defn, info.def_ns.clone()),
+    Calcit::Symbol {
+      sym: Arc::from(synthetic_name.as_str()),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: info.def_ns.clone(),
+        at_def: Arc::from(synthetic_name.as_str()),
+      }),
+      location: None,
+    },
+    synthetic_fn_args(info, schema.as_ref(), &synthetic_name),
+  ];
+  nodes.extend(info.body.iter().cloned());
+  let preprocessed_code = Calcit::from(CalcitList::from(nodes.as_slice()));
+  if let Some(existing) = program::lookup_compiled_def(target_ns, &synthetic_name)
+    && (existing.preprocessed_code != preprocessed_code || existing.schema != schema)
+  {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      format!(
+        "generated impl callable `{target_ns}/{synthetic_name}` collides with a different generated definition; rename one nominal type or provide an explicit named callable"
+      ),
+      "E_IMPL_CALLABLE_GENERATED_COLLISION",
+      call_stack,
+      None,
+    ));
+  }
+  let mut deps = program::collect_compiled_deps(&preprocessed_code);
+  if let Some(owner_def) = program::find_source_def_for_runtime_value(target_ns, &Calcit::Impl(impl_value.clone())) {
+    deps.push(program::ensure_def_id(target_ns, owner_def.as_ref()));
+    deps.sort();
+    deps.dedup();
+  }
+  program::store_compiled_output(
+    target_ns,
+    &synthetic_name,
+    program::CompiledDefPayload {
+      version_id: 0,
+      preprocessed_code: preprocessed_code.clone(),
+      codegen_form: preprocessed_code,
+      deps,
+      type_summary: Some(Arc::from(schema.to_brief_string())),
+      source_code: None,
+      schema,
+      doc: Arc::from(format!(
+        "Compiler-generated direct callable for nominal method `.{method_name}` from impl `{}`.",
+        impl_value.name()
+      )),
+      examples: vec![],
+    },
+  );
+
+  let def_id = program::ensure_def_id(target_ns, &synthetic_name).0;
+  let info = if target_ns == file_ns {
+    ImportInfo::SameFile {
+      at_def: Arc::from(synthetic_name.as_str()),
+    }
+  } else {
+    ImportInfo::NsReferDef {
+      at_ns: Arc::from(file_ns),
+      at_def: Arc::from(synthetic_name.as_str()),
+    }
+  };
+  Ok(Calcit::Import(CalcitImport {
+    ns: Arc::from(target_ns),
+    def: Arc::from(synthetic_name),
+    info: Arc::new(info),
+    def_id: Some(def_id),
+  }))
 }
 
 fn build_inlined_call(callable_head: Calcit, args: &CalcitList, scope_types: &ScopeTypes) -> Calcit {
@@ -6553,6 +6825,19 @@ pub fn preprocess_defn(
             body_defs.insert(sym.to_owned());
             Ok(())
           }
+          // Compiler-generated rewrites may reprocess a callback that has
+          // already passed through this function once. Preserve its typed
+          // Local parameter nodes so the second pass is idempotent instead of
+          // rejecting valid generated code as non-source syntax.
+          Calcit::Local(local) => {
+            param_symbols.push(local.sym.clone());
+            body_defs.insert(local.sym.clone());
+            if !matches!(local.type_info.as_ref(), CalcitTypeAnnotation::Dynamic) {
+              body_types.insert(local.sym.clone(), local.type_info.clone());
+            }
+            zs.push(Calcit::Local(local.clone()));
+            Ok(())
+          }
           _ => Err(CalcitErr::use_msg_stack_location(
             CalcitErrKind::Type,
             format!("expected defn args to be symbols, got: {y}"),
@@ -7548,8 +7833,8 @@ fn validate_def_schema_during_preprocess(
 mod tests {
   use super::*;
   use crate::calcit::{
-    CalcitEnumDef, CalcitFn, CalcitFnArgs, CalcitFnUsageMeta, CalcitImport, CalcitMacro, CalcitScope, CalcitStructDef,
-    CalcitStructValue, ImportInfo,
+    CalcitEnumDef, CalcitFn, CalcitFnArgs, CalcitFnCallShape, CalcitFnDefRef, CalcitFnUsageMeta, CalcitImport, CalcitMacro,
+    CalcitScope, CalcitStructDef, CalcitStructValue, ImportInfo,
   };
   use crate::data::cirru::code_to_calcit;
   use cirru_parser::Cirru;
@@ -8088,6 +8373,44 @@ mod tests {
       "path expressions are evaluated before the replacement"
     );
 
+    let updater = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("typed-path-updater-input")),
+      sym: Arc::from("typed-path-updater-input"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.typed-path"),
+        at_def: Arc::from("main"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::DynFn),
+    });
+    let update_args = CalcitList::from(&[typed_base.to_owned(), literal_path.to_owned(), updater] as &[Calcit]);
+    let expanded_update = try_expand_typed_literal_path_call(
+      &core_import("update-in", "tests.typed-path"),
+      &update_args,
+      &ScopeTypes::new(),
+      "tests.typed-path",
+      &stack,
+    )
+    .expect("build update-in expansion")
+    .expect("typed update-in expansion");
+    let update_code = expanded_update.lisp_str();
+    assert!(update_code.contains("match"), "updater receives the Option-producing lookup result");
+    assert!(update_code.contains("&map:assoc"));
+    assert!(!update_code.contains("calcit.core/update-in"));
+    assert_eq!(update_code.matches("typed-path-base").count(), 1, "caller base is evaluated once");
+    assert_eq!(update_code.matches(":user").count(), 1, "first path expression is evaluated once");
+    assert_eq!(update_code.matches(":score").count(), 1, "second path expression is evaluated once");
+    assert_eq!(
+      update_code.matches("typed-path-updater-input").count(),
+      1,
+      "updater expression is evaluated once"
+    );
+    assert!(
+      update_code.find(":score").expect("second path expression")
+        < update_code.find("typed-path-updater-input").expect("updater expression"),
+      "path expressions are evaluated before the updater"
+    );
+
     let dynamic_base = Calcit::Local(CalcitLocal {
       idx: CalcitLocal::track_sym(&Arc::from("dynamic-path-base")),
       sym: Arc::from("dynamic-path-base"),
@@ -8108,6 +8431,22 @@ mod tests {
         &stack,
       )
       .expect("dynamic path decision")
+      .is_none()
+    );
+    let dynamic_update_args = CalcitList::from(&[
+      dynamic_args.first().expect("dynamic base").to_owned(),
+      dynamic_args.get(1).expect("literal path").to_owned(),
+      test_symbol("dynamic-updater"),
+    ] as &[Calcit]);
+    assert!(
+      try_expand_typed_literal_path_call(
+        &core_import("update-in", "tests.typed-path"),
+        &dynamic_update_args,
+        &ScopeTypes::new(),
+        "tests.typed-path",
+        &stack,
+      )
+      .expect("dynamic update path decision")
       .is_none()
     );
   }
@@ -11245,6 +11584,194 @@ mod tests {
       "typed postfix method should expose the internal callable head: {nodes}"
     );
     assert!(warnings.borrow().is_empty());
+  }
+
+  #[test]
+  fn anonymous_nominal_impl_method_gets_a_stable_direct_callable() {
+    let _guard = lock_preprocess_test_state();
+    let impl_ns: Arc<str> = Arc::from("tests.nominal-impl");
+    let receiver_idx = CalcitLocal::track_sym(&Arc::from("self"));
+    let anonymous_method = Calcit::Fn {
+      id: calcit::gen_core_id(),
+      info: Arc::new(CalcitFn {
+        name: Arc::from("f%"),
+        def_ns: impl_ns.clone(),
+        def_ref: Some(CalcitFnDefRef {
+          def_ns: impl_ns.clone(),
+          def_name: Arc::from("f%"),
+          coord: None,
+          is_defn: true,
+          is_macro_gen: true,
+        }),
+        usage: CalcitFnUsageMeta { used_in_impl: true },
+        scope: Arc::new(CalcitScope::default()),
+        args: Arc::new(CalcitFnArgs::Args(vec![receiver_idx])),
+        call_shape: CalcitFnCallShape::fixed(1),
+        body: vec![Calcit::Str(Arc::from("cat"))],
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        return_type: Arc::new(CalcitTypeAnnotation::String),
+        arg_types: vec![calcit::DYNAMIC_TYPE.clone()],
+        rest_type: None,
+      }),
+    };
+    let display_impl = Arc::new(CalcitImpl {
+      name: EdnTag::new("CatDisplayImpl"),
+      origin: None,
+      fields: Arc::new(vec![EdnTag::new("display-name")]),
+      values: Arc::new(vec![anonymous_method.clone()]),
+    });
+    program::install_internal_source_namespace(
+      impl_ns.clone(),
+      program::ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([(
+          Arc::from("CatDisplayImpl"),
+          program::ProgramDefEntry {
+            code: Calcit::Nil,
+            schema: calcit::DYNAMIC_TYPE.clone(),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: None,
+          },
+        )]),
+      },
+    )
+    .expect("install impl source fixture");
+    program::write_runtime_ready(&impl_ns, "CatDisplayImpl", Calcit::Impl(display_impl.as_ref().clone()))
+      .expect("install evaluated impl fixture");
+    let mut cat_struct = CalcitStructDef::from_fields(EdnTag::from("CatProfile"), vec![EdnTag::from("name")]);
+    cat_struct.impls = vec![display_impl.clone()];
+    let receiver_type = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(cat_struct)));
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("kitty")),
+      sym: Arc::from("kitty"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.nominal-call"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: receiver_type.clone(),
+    });
+    let head = Calcit::Method(Arc::from("display-name"), calcit::MethodKind::Invoke(receiver_type.clone()));
+    let args = CalcitList::from(&[receiver] as &[Calcit]);
+
+    let lowered = try_inline_method_call(&head, &args, &ScopeTypes::new(), "tests.nominal-call", &CallStackList::default())
+      .expect("lower anonymous nominal impl")
+      .expect("anonymous nominal impl should get a direct callable");
+    let Calcit::List(call) = lowered else {
+      panic!("expected direct call")
+    };
+    assert!(matches!(
+      call.first(),
+      Some(Calcit::Import(CalcitImport { ns, def, .. }))
+        if ns.as_ref() == impl_ns.as_ref() && def.as_ref() == "&cat-profile:display-name"
+    ));
+
+    let compiled = program::lookup_compiled_def(&impl_ns, "&cat-profile:display-name")
+      .expect("stable callable should be registered as a compiled definition");
+    assert_eq!(compiled.kind, program::CompiledDefKind::Fn);
+    assert!(
+      compiled.deps.contains(&program::ensure_def_id(&impl_ns, "CatDisplayImpl")),
+      "changing the source defimpl must invalidate its generated callable"
+    );
+    assert!(matches!(
+      &compiled.preprocessed_code,
+      Calcit::List(items)
+        if matches!(items.get(1), Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "&cat-profile:display-name")
+    ));
+
+    let callable = runner::evaluate_symbol_from_program("&cat-profile:display-name", &impl_ns, None, &CallStackList::default())
+      .expect("evaluate generated callable");
+    let Calcit::Fn { info, .. } = callable else {
+      panic!("generated callable should evaluate to a function")
+    };
+    assert_eq!(
+      runner::run_fn(&[Calcit::Nil], &info, &CallStackList::default()).expect("invoke generated callable"),
+      Calcit::Str(Arc::from("cat"))
+    );
+
+    let Calcit::Fn { info: original_info, .. } = anonymous_method else {
+      panic!("fixture method should remain a function")
+    };
+    let mut conflicting_info = original_info.as_ref().clone();
+    conflicting_info.body = vec![Calcit::Str(Arc::from("different implementation"))];
+    let collision = synthesize_nominal_impl_callable(
+      &conflicting_info,
+      display_impl.as_ref(),
+      receiver_type.as_ref(),
+      "display-name",
+      "tests.nominal-call",
+      &CallStackList::default(),
+    )
+    .expect_err("different generated bodies must not silently overwrite the same callable symbol");
+    assert_eq!(collision.code(), Some("E_IMPL_CALLABLE_GENERATED_COLLISION"));
+    program::remove_internal_source_namespace(&impl_ns);
+  }
+
+  #[test]
+  fn nominal_callable_scope_qualifies_cross_namespace_type_refs() {
+    let receiver = CalcitTypeAnnotation::TypeRef(Arc::from("app.models/CatProfile"), Arc::new(vec![]));
+    assert_eq!(nominal_callable_scope_name(&receiver, "app.models").as_deref(), Some("cat-profile"));
+    assert_eq!(
+      nominal_callable_scope_name(&receiver, "app.impls").as_deref(),
+      Some("app-models-cat-profile")
+    );
+  }
+
+  #[test]
+  fn captured_impl_closure_stays_on_runtime_dispatch() {
+    let captured_idx = CalcitLocal::track_sym(&Arc::from("captured"));
+    let mut captured_scope = CalcitScope::default();
+    captured_scope.insert_mut(captured_idx, Calcit::Str(Arc::from("value")));
+    let method = Calcit::Fn {
+      id: calcit::gen_core_id(),
+      info: Arc::new(CalcitFn {
+        name: Arc::from("f%"),
+        def_ns: Arc::from("tests.captured-impl"),
+        def_ref: None,
+        usage: CalcitFnUsageMeta { used_in_impl: true },
+        scope: Arc::new(captured_scope),
+        args: Arc::new(CalcitFnArgs::Args(vec![])),
+        call_shape: CalcitFnCallShape::fixed(0),
+        body: vec![Calcit::Local(CalcitLocal {
+          idx: captured_idx,
+          sym: Arc::from("captured"),
+          info: Arc::new(CalcitSymbolInfo {
+            at_ns: Arc::from("tests.captured-impl"),
+            at_def: Arc::from("f%"),
+          }),
+          location: None,
+          type_info: Arc::new(CalcitTypeAnnotation::String),
+        })],
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        return_type: Arc::new(CalcitTypeAnnotation::String),
+        arg_types: vec![],
+        rest_type: None,
+      }),
+    };
+    let implementation = CalcitImpl {
+      name: EdnTag::new("CapturedImpl"),
+      origin: None,
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      values: Arc::new(vec![method.clone()]),
+    };
+    let receiver_type = CalcitTypeAnnotation::StructValue(Arc::new(CalcitStructDef::from_fields(EdnTag::new("CapturedBox"), vec![])));
+
+    assert!(
+      pick_callable_from_method_entry(
+        &method,
+        &implementation,
+        &receiver_type,
+        "value",
+        "tests.captured-call",
+        &CallStackList::default(),
+      )
+      .expect("captured closure is a supported runtime boundary")
+      .is_none()
+    );
+    assert!(program::lookup_compiled_def("tests.captured-impl", "&captured-box:value").is_none());
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5147,8 +5147,8 @@ fn pick_callable_from_method_entry(
         def_id: Some(program::ensure_def_id(def_ref.def_ns.as_ref(), def_ref.def_name.as_ref()).0),
       })))
     }
-    Calcit::Fn { info, .. } if info.scope.is_empty() => {
-      synthesize_nominal_impl_callable(info, impl_value, receiver_type, method_name, file_ns, call_stack).map(Some)
+    Calcit::Fn { info, .. } if info.scope.is_empty() && nominal_callable_scope_name(receiver_type, info.def_ns.as_ref()).is_some() => {
+      synthesize_nominal_impl_callable(info, impl_value, receiver_type, method_name, file_ns, call_stack)
     }
     // A closure that captures lexical state cannot be promoted to a top-level
     // callable without changing its semantics. It remains on the explicit
@@ -5253,6 +5253,32 @@ fn synthetic_fn_args(info: &CalcitFn, schema: &CalcitTypeAnnotation, synthetic_n
   Calcit::from(CalcitList::from(nodes.as_slice()))
 }
 
+/// Collect source owners that must invalidate a generated nominal callable.
+fn nominal_callable_owner_deps(target_ns: &str, impl_value: &CalcitImpl, receiver_type: &CalcitTypeAnnotation) -> Vec<program::DefId> {
+  let mut deps = vec![];
+  if let Some(owner_def) = program::find_source_def_for_runtime_value(target_ns, &Calcit::Impl(impl_value.clone())) {
+    deps.push(program::ensure_def_id(target_ns, owner_def.as_ref()));
+  }
+
+  let type_ref = match receiver_type {
+    CalcitTypeAnnotation::TypeRef(path, _) => Some(path.as_ref()),
+    CalcitTypeAnnotation::Optional(inner) => {
+      return nominal_callable_owner_deps(target_ns, impl_value, inner.as_ref());
+    }
+    _ => None,
+  };
+  if let Some(path) = type_ref {
+    let stripped = path.trim_start_matches(['\'', ':']);
+    let (type_ns, type_def) = stripped.rsplit_once('/').unwrap_or((target_ns, stripped));
+    if program::has_def_code(type_ns, type_def) {
+      deps.push(program::ensure_def_id(type_ns, type_def));
+    }
+  }
+  deps.sort();
+  deps.dedup();
+  deps
+}
+
 /// Materialize a capture-free anonymous impl method as a deterministic compiled definition.
 fn synthesize_nominal_impl_callable(
   info: &CalcitFn,
@@ -5261,19 +5287,21 @@ fn synthesize_nominal_impl_callable(
   method_name: &str,
   file_ns: &str,
   call_stack: &CallStackList,
-) -> Result<Calcit, CalcitErr> {
+) -> Result<Option<Calcit>, CalcitErr> {
   let target_ns = info.def_ns.as_ref();
   let Some(scope_name) = nominal_callable_scope_name(receiver_type, target_ns) else {
-    return Err(CalcitErr::use_msg_stack_location_with_code(
-      CalcitErrKind::Type,
-      format!("cannot create a static callable for `.{method_name}` without a nominal receiver type"),
-      "E_IMPL_CALLABLE_NOMINAL_RECEIVER_REQUIRED",
-      call_stack,
-      None,
-    ));
+    return Ok(None);
   };
   let method_segment = method_name.to_ascii_lowercase();
   let synthetic_name = format!("&{scope_name}:{method_segment}");
+
+  // A cacheable compiler-owned symbol must have at least one source owner.
+  // Otherwise retain runtime method dispatch so no stale generated definition
+  // can survive a source edit without an invalidation edge.
+  let owner_deps = nominal_callable_owner_deps(target_ns, impl_value, receiver_type);
+  if owner_deps.is_empty() {
+    return Ok(None);
+  }
 
   if program::has_def_code(target_ns, &synthetic_name) {
     return Err(CalcitErr::use_msg_stack_location_with_code(
@@ -5316,11 +5344,9 @@ fn synthesize_nominal_impl_callable(
     ));
   }
   let mut deps = program::collect_compiled_deps(&preprocessed_code);
-  if let Some(owner_def) = program::find_source_def_for_runtime_value(target_ns, &Calcit::Impl(impl_value.clone())) {
-    deps.push(program::ensure_def_id(target_ns, owner_def.as_ref()));
-    deps.sort();
-    deps.dedup();
-  }
+  deps.extend(owner_deps);
+  deps.sort();
+  deps.dedup();
   program::store_compiled_output(
     target_ns,
     &synthetic_name,
@@ -5351,12 +5377,12 @@ fn synthesize_nominal_impl_callable(
       at_def: Arc::from(synthetic_name.as_str()),
     }
   };
-  Ok(Calcit::Import(CalcitImport {
+  Ok(Some(Calcit::Import(CalcitImport {
     ns: Arc::from(target_ns),
     def: Arc::from(synthetic_name),
     info: Arc::new(info),
     def_id: Some(def_id),
-  }))
+  })))
 }
 
 fn build_inlined_call(callable_head: Calcit, args: &CalcitList, scope_types: &ScopeTypes) -> Calcit {
@@ -6834,6 +6860,8 @@ pub fn preprocess_defn(
             body_defs.insert(local.sym.clone());
             if !matches!(local.type_info.as_ref(), CalcitTypeAnnotation::Dynamic) {
               body_types.insert(local.sym.clone(), local.type_info.clone());
+            } else {
+              body_types.remove(&local.sym);
             }
             zs.push(Calcit::Local(local.clone()));
             Ok(())
@@ -11720,6 +11748,90 @@ mod tests {
   }
 
   #[test]
+  fn nominal_callable_tracks_inline_type_owner_or_falls_back_without_source() {
+    let _guard = lock_preprocess_test_state();
+    let owner_ns: Arc<str> = Arc::from("tests.inline-impl-owner");
+    program::install_internal_source_namespace(
+      owner_ns.clone(),
+      program::ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([(
+          Arc::from("CatProfile"),
+          program::ProgramDefEntry {
+            code: Calcit::Nil,
+            schema: calcit::DYNAMIC_TYPE.clone(),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: None,
+          },
+        )]),
+      },
+    )
+    .expect("install inline impl owner fixture");
+    let inline_impl = CalcitImpl {
+      name: EdnTag::new("InlineDisplayImpl"),
+      origin: None,
+      fields: Arc::new(vec![]),
+      values: Arc::new(vec![]),
+    };
+    let receiver = CalcitTypeAnnotation::TypeRef(Arc::from("tests.inline-impl-owner/CatProfile"), Arc::new(vec![]));
+    assert_eq!(
+      nominal_callable_owner_deps(&owner_ns, &inline_impl, &receiver),
+      vec![program::ensure_def_id(&owner_ns, "CatProfile")],
+      "inline impl-traits must be invalidated through the nominal type source"
+    );
+
+    let missing_receiver = CalcitTypeAnnotation::TypeRef(Arc::from("tests.missing/CatProfile"), Arc::new(vec![]));
+    assert!(
+      nominal_callable_owner_deps(&owner_ns, &inline_impl, &missing_receiver).is_empty(),
+      "callable synthesis must fall back when no source owner can invalidate it"
+    );
+    program::remove_internal_source_namespace(&owner_ns);
+  }
+
+  #[test]
+  fn capture_free_non_nominal_impl_method_stays_on_runtime_dispatch() {
+    let method = Calcit::Fn {
+      id: calcit::gen_core_id(),
+      info: Arc::new(CalcitFn {
+        name: Arc::from("f%"),
+        def_ns: Arc::from("tests.non-nominal-impl"),
+        def_ref: None,
+        usage: CalcitFnUsageMeta { used_in_impl: true },
+        scope: Arc::new(CalcitScope::default()),
+        args: Arc::new(CalcitFnArgs::Args(vec![])),
+        call_shape: CalcitFnCallShape::fixed(0),
+        body: vec![Calcit::Nil],
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        return_type: calcit::DYNAMIC_TYPE.clone(),
+        arg_types: vec![],
+        rest_type: None,
+      }),
+    };
+    let impl_value = CalcitImpl {
+      name: EdnTag::new("DynamicDisplayImpl"),
+      origin: None,
+      fields: Arc::new(vec![EdnTag::new("display")]),
+      values: Arc::new(vec![method.clone()]),
+    };
+    let receiver = CalcitTypeAnnotation::Custom(Arc::new(Calcit::tag("struct")));
+    assert!(
+      pick_callable_from_method_entry(
+        &method,
+        &impl_value,
+        &receiver,
+        "display",
+        "tests.non-nominal-impl",
+        &CallStackList::default(),
+      )
+      .expect("non-nominal method selection must remain valid")
+      .is_none(),
+      "a non-nominal receiver cannot safely own a generated callable"
+    );
+  }
+
+  #[test]
   fn captured_impl_closure_stays_on_runtime_dispatch() {
     let captured_idx = CalcitLocal::track_sym(&Arc::from("captured"));
     let mut captured_scope = CalcitScope::default();
@@ -13489,6 +13601,46 @@ mod tests {
       rest_type: has_rest.then(|| Arc::new(CalcitTypeAnnotation::Number)),
       features: Arc::new(HashSet::new()),
     })))
+  }
+
+  #[test]
+  fn reprocessed_dynamic_local_parameter_shadows_outer_type() {
+    let ns: Arc<str> = Arc::from("tests.local-shadow");
+    let symbol_info = Arc::new(CalcitSymbolInfo {
+      at_ns: ns.clone(),
+      at_def: Arc::from("demo"),
+    });
+    let parameter = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("value")),
+      sym: Arc::from("value"),
+      info: symbol_info.clone(),
+      location: None,
+      type_info: calcit::DYNAMIC_TYPE.clone(),
+    });
+    let code = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::Defn, ns.clone()),
+      Calcit::Symbol {
+        sym: Arc::from("demo"),
+        info: symbol_info.clone(),
+        location: None,
+      },
+      Calcit::from(vec![parameter]),
+      Calcit::Symbol {
+        sym: Arc::from("value"),
+        info: symbol_info,
+        location: None,
+      },
+    ]);
+    let scope_defs = HashSet::from([Arc::from("value")]);
+    let mut scope_types = ScopeTypes::from([(Arc::from("value"), Arc::new(CalcitTypeAnnotation::String))]);
+    let warnings = RefCell::new(vec![]);
+    let result = preprocess_expr(&code, &scope_defs, &mut scope_types, &ns, &warnings, &CallStackList::default())
+      .expect("reprocess defn with compiler-generated local parameter");
+    assert!(matches!(
+      result,
+      Calcit::List(items)
+        if matches!(items.iter().last(), Some(Calcit::Local(local)) if matches!(local.type_info.as_ref(), CalcitTypeAnnotation::Dynamic))
+    ));
   }
 
   #[test]


### PR DESCRIPTION
## English

### Summary

- Keep application source on receiver-style `.name` calls while promoting capture-free anonymous nominal impl methods to deterministic lowercase internal callables such as `&lagopus0:show`.
- Preserve named methods as direct imports and captured closures as an explicit runtime-dispatch boundary.
- Track the source `defimpl` as a compiled dependency, qualify cross-namespace symbols, and reject source/generated symbol collisions with stable diagnostics.
- Extend typed non-empty literal-path lowering from `get-in` and `assoc-in` to `update-in`, with Option-aware lookup, Map reconstruction, source-order evaluation, and single evaluation of every argument.
- Allow named `impl-traits` wrapper references to match their resolved concrete Struct/Enum values, enabling precise hook return schemas without erasing nominal method identity.
- Preserve legacy `?` optional-parameter evidence in callable metadata and method arity checks so valid omitted trailing arguments are not rejected during migration.

### Review hardening

- Prefer the canonical impl tag over aliases when identifying the source `defimpl`, including before the runtime owner is Ready.
- Make inline `impl-traits` callables depend on their nominal TypeRef source definition; if no reliable source owner exists, keep runtime dispatch instead of creating an untracked generated cache entry.
- Preserve runtime dispatch for non-nominal receivers and clear shadowed outer type evidence when reprocessing Dynamic Local parameters.

### Explicit boundaries

- Dynamic receivers, dynamic or mixed paths, and captured impl closures retain the compatibility/runtime path.
- This PR does not deprecate `get-in` yet; it establishes the typed lowering target required before phased diagnostics and ecosystem migration.
- Existing source keeps `.name`; generated `&scope:name` symbols remain compiler/backend ABI and are not a new application-facing naming convention.

### Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (643 library, 278 CLI, and 23 `cr-wasm` tests)
- `yarn check-all` (235 core definition tests, native/JS/IR/WASM, static lowering, quality gates, and benchmarks)
- `bash scripts/check-docs-md.sh` (67 files / 329 blocks)
- msg-buffer regression with `config modules` pointing directly at the local alerts checkout: all six broad hook-return warnings, the valid `.show d!` optional-arity warning, and the prior `E_DECODE` regression remain absent. The remaining 30 findings are separately inventoried Respo/Reel/JS-FFI migration debt, not nominal-dispatch regressions.

Refs #579 and #580.

## 中文

### 摘要

- 应用源码继续使用 receiver-style `.name`，将不捕获环境的匿名 nominal impl 方法提升为确定的小写内部 callable，例如 `&lagopus0:show`。
- 已命名方法保持直接 Import；捕获闭包明确保留为运行时 dispatch 边界。
- 将来源 `defimpl` 记录为编译依赖；跨命名空间符号自动限定；源码或生成符号冲突使用稳定诊断拒绝，不再静默覆盖。
- 将类型化非空字面量路径 lowering 从 `get-in`、`assoc-in` 扩展到 `update-in`，使用 Option 感知读取与 Map 重建，并保证所有参数按源码顺序且只求值一次。
- 允许命名的 `impl-traits` 包装引用与其解析得到的具体 Struct/Enum 值匹配，使 hook 可以声明精确返回类型而不丢失 nominal 方法身份。
- 在 callable metadata 与方法参数检查中保留旧式 `?` 可选参数证据，避免迁移期间合法的末尾省略调用被误报。

### Review 加固

- 识别来源 `defimpl` 时 canonical impl tag 优先于别名；runtime owner 尚未进入 Ready 状态时也能建立依赖。
- inline `impl-traits` callable 依赖 nominal TypeRef 的源码定义；找不到可靠源码 owner 时保留运行时分发，不创建无法追踪失效的生成缓存。
- 非 nominal 接收者继续使用运行时分发；重新处理 Dynamic Local 参数时清除被遮蔽的外层类型证据。

### 明确边界

- Dynamic receiver、动态或混合路径、捕获环境的 impl closure 继续使用兼容/运行时路径。
- 本 PR 尚不废弃 `get-in`；先建立后续分阶段诊断与生态迁移所需的类型化 lowering 目标。
- 现有源码仍写 `.name`；生成的 `&scope:name` 只属于 compiler/backend ABI，不成为新的应用层命名约定。

### 验证

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`（643 个 library、278 个 CLI、23 个 `cr-wasm` 测试）
- `yarn check-all`（235 个 core definition tests，覆盖 native/JS/IR/WASM、静态 lowering、质量门与 benchmark）
- `bash scripts/check-docs-md.sh`（67 个文件 / 329 个代码块）
- msg-buffer 通过 `config modules` 直接指向本地 alerts checkout 联动验证：六条宽泛 hook 返回类型误报、合法 `.show d!` 的可选参数误报和之前的 `E_DECODE` 均未回归。剩余 30 条属于已单独盘点的 Respo/Reel/JS-FFI 迁移债务，不是 nominal dispatch 回归。

关联 #579、#580。
