### PR TITLE
fix: match nominal trait references across strict schemas / 修复严格 schema 中的 nominal trait 引用匹配

### DIFF
--- a/editing-history/202609022025-trait-type-ref-matching.md
+++ b/editing-history/202609022025-trait-type-ref-matching.md
@@ -1,0 +1,19 @@
+# Nominal Trait and TypeRef matching
+
+2026-09-02 20:25 CST
+
+## English
+
+- Match a resolved nominal `Trait` annotation with the corresponding qualified `TypeRef` retained by strict function schemas.
+- Preserve qualified source identity when a strict generic `:where` bound resolves directly to a trait value, and allow a value represented by that same nominal trait annotation to satisfy the bound.
+- Keep traits with identical short names in different namespaces distinct, and add regression coverage for both matching paths.
+- Retain the documented compatibility behavior for an explicitly bare legacy trait placeholder while keeping qualified references nominal.
+- This closes the false-positive `DomElement` argument and generic-bound warnings found while validating Respo against Calcit 0.13.74.
+
+## 中文
+
+- 让已解析的 nominal `Trait` annotation 与严格函数 schema 保留的对应限定名 `TypeRef` 正确匹配。
+- 当严格泛型 `:where` bound 直接解析为 trait value 时保留限定 source identity，并允许由同一 nominal trait annotation 表示的 value 满足该 bound。
+- 对不同 namespace 中短名称相同的 trait 继续保持 nominal 区分，并为两条匹配路径增加回归测试。
+- 对显式 bare legacy trait placeholder 保留已有兼容匹配行为，同时继续保证限定名引用的 nominal 区分。
+- 修复 Respo 使用 Calcit 0.13.74 验证时出现的 `DomElement` 参数与泛型约束误报。

--- a/src/calcit/calcit_trait.rs
+++ b/src/calcit/calcit_trait.rs
@@ -187,6 +187,9 @@ impl CalcitTrait {
   /// references use runtime identity, source references use their qualified
   /// definition, and legacy bare placeholders fall back to shape or name.
   pub fn matches_reference(&self, expected: &Self) -> bool {
+    if expected.runtime_id.is_none() && expected.definition_ref.is_none() && expected.methods.is_empty() {
+      return self.name == expected.name;
+    }
     if expected.runtime_id.is_some() {
       return self == expected;
     }
@@ -339,12 +342,15 @@ mod tests {
     let user = CalcitTrait::new(EdnTag::new("Show"), vec![], vec![]).with_definition_ref("app.main", "Show");
     let same_core = CalcitTrait::new_reference("calcit.core/Show");
     let runtime_core = CalcitTrait::new_runtime(EdnTag::new("Show"), vec![], vec![]).with_definition_ref("calcit.core", "Show");
+    let legacy_placeholder = CalcitTrait::new_reference("Show");
 
     assert_eq!(core, same_core);
     assert_eq!(hash_trait(&core), hash_trait(&same_core));
     assert_ne!(core, user);
     assert!(!core.matches_reference(&user));
     assert!(runtime_core.matches_reference(&same_core));
+    assert!(core.matches_reference(&legacy_placeholder));
+    assert!(user.matches_reference(&legacy_placeholder));
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -972,6 +972,24 @@ impl CalcitTypeAnnotation {
       .is_some_and(|resolved| resolved.name().ref_str() == target)
   }
 
+  fn type_ref_matches_trait(name: &str, target: &CalcitTrait) -> bool {
+    let stripped = name.trim_start_matches('\'').trim_start_matches(':');
+    if target
+      .definition_ref
+      .as_deref()
+      .is_some_and(|definition_ref| definition_ref == stripped)
+    {
+      return true;
+    }
+    if resolve_type_ref_as_schema(stripped).is_some_and(|resolved| {
+      matches!(resolved.as_ref(), Self::Trait(resolved_trait) if resolved_trait.matches_reference(target) || target.matches_reference(resolved_trait))
+    })
+    {
+      return true;
+    }
+    target.definition_ref.is_none() && target.runtime_id.is_none() && Self::type_ref_name_matches(stripped, target.name.ref_str())
+  }
+
   fn is_hint_fn_form(list: &CalcitList) -> bool {
     match list.first() {
       Some(Calcit::Syntax(CalcitSyntax::HintFn, _)) => true,
@@ -1245,6 +1263,22 @@ impl CalcitTypeAnnotation {
     }
   }
 
+  fn trait_bound_with_source_ref(form: &Calcit, trait_def: &Arc<CalcitTrait>) -> Arc<CalcitTrait> {
+    if trait_def.definition_ref.is_some() {
+      return trait_def.clone();
+    }
+    let Some(source_name) = Self::extract_type_ref_name(form) else {
+      return trait_def.clone();
+    };
+    let Some((ns, def)) = source_name.rsplit_once('/') else {
+      return trait_def.clone();
+    };
+    if def != trait_def.name.ref_str() {
+      return trait_def.clone();
+    }
+    Arc::new(trait_def.as_ref().clone().with_definition_ref(ns, def))
+  }
+
   fn parse_trait_bounds_value(form: &Calcit, generics: &[Arc<str>], strict_named_refs: bool) -> Option<Vec<Arc<CalcitTrait>>> {
     if let Calcit::List(items) = form {
       let start = if items.first().map(Self::is_args_list_head).unwrap_or(false) {
@@ -1256,7 +1290,7 @@ impl CalcitTypeAnnotation {
       for item in items.iter().skip(start) {
         let parsed = Self::parse_type_annotation_form_inner(item, generics, strict_named_refs);
         match parsed.as_ref() {
-          CalcitTypeAnnotation::Trait(trait_def) => traits.push(trait_def.clone()),
+          CalcitTypeAnnotation::Trait(trait_def) => traits.push(Self::trait_bound_with_source_ref(item, trait_def)),
           CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => {
             traits.push(Arc::new(CalcitTrait::new_reference(name)))
           }
@@ -1269,7 +1303,7 @@ impl CalcitTypeAnnotation {
     }
 
     match Self::parse_type_annotation_form_inner(form, generics, strict_named_refs).as_ref() {
-      CalcitTypeAnnotation::Trait(trait_def) => Some(vec![trait_def.clone()]),
+      CalcitTypeAnnotation::Trait(trait_def) => Some(vec![Self::trait_bound_with_source_ref(form, trait_def)]),
       CalcitTypeAnnotation::TypeRef(name, args) if strict_named_refs && args.is_empty() => {
         Some(vec![Arc::new(CalcitTrait::new_reference(name))])
       }
@@ -2895,6 +2929,19 @@ impl CalcitTypeAnnotation {
   }
 
   fn satisfies_trait_bound(&self, expected_trait: &CalcitTrait) -> bool {
+    match self {
+      Self::Trait(actual_trait) if actual_trait.matches_reference(expected_trait) || expected_trait.matches_reference(actual_trait) => {
+        return true;
+      }
+      Self::TraitSet(actual_traits)
+        if actual_traits
+          .iter()
+          .any(|actual_trait| actual_trait.matches_reference(expected_trait) || expected_trait.matches_reference(actual_trait)) =>
+      {
+        return true;
+      }
+      _ => {}
+    }
     if let Some(impls) = self.collect_static_impls() {
       if impls.iter().any(|imp| Self::impl_matches_trait(imp, expected_trait)) {
         return true;
@@ -3118,10 +3165,24 @@ impl CalcitTypeAnnotation {
         }
         a_args.len() == b_args.len() && a_args.iter().zip(b_args.iter()).all(|(x, y)| x.matches_with_bindings(y, bindings))
       }
-      (Self::Trait(a), Self::Trait(b)) => a == b,
-      (Self::TraitSet(actual), Self::Trait(expected)) => actual.iter().any(|t| t == expected),
-      (Self::Trait(actual), Self::TraitSet(expected)) => expected.len() == 1 && expected.iter().any(|t| t == actual),
-      (Self::TraitSet(actual), Self::TraitSet(expected)) => expected.iter().all(|t| actual.iter().any(|a| a == t)),
+      (Self::TypeRef(name, args), Self::Trait(trait_def)) | (Self::Trait(trait_def), Self::TypeRef(name, args)) => {
+        args.is_empty() && Self::type_ref_matches_trait(name, trait_def.as_ref())
+      }
+      (Self::Trait(a), Self::Trait(b)) => a.matches_reference(b) || b.matches_reference(a),
+      (Self::TraitSet(actual), Self::Trait(expected)) => actual
+        .iter()
+        .any(|trait_def| trait_def.matches_reference(expected) || expected.matches_reference(trait_def)),
+      (Self::Trait(actual), Self::TraitSet(expected)) => {
+        expected.len() == 1
+          && expected
+            .iter()
+            .any(|trait_def| actual.matches_reference(trait_def) || trait_def.matches_reference(actual))
+      }
+      (Self::TraitSet(actual), Self::TraitSet(expected)) => expected.iter().all(|expected_trait| {
+        actual
+          .iter()
+          .any(|actual_trait| actual_trait.matches_reference(expected_trait) || expected_trait.matches_reference(actual_trait))
+      }),
       (actual, Self::Trait(expected)) => actual.satisfies_trait_bound(expected.as_ref()),
       (actual, Self::TraitSet(expected)) => actual.satisfies_trait_bounds(expected.as_ref()),
       (Self::Struct(_, _), Self::Custom(expected))
@@ -4239,6 +4300,24 @@ mod tests {
     assert!(!number.matches_annotation(&CalcitTypeAnnotation::Trait(runtime_user_debug)));
   }
 
+  #[test]
+  fn nominal_trait_annotations_match_their_type_refs_and_own_bounds() {
+    let dom_element = Arc::new(CalcitTrait::new_reference("respo.dom/DomElement"));
+    let other_dom_element = Arc::new(CalcitTrait::new_reference("other.dom/DomElement"));
+    let mut evaluated_dom_element = CalcitTrait::new_reference("respo.dom/DomElement");
+    evaluated_dom_element.runtime_id = Some(7);
+    let annotation = CalcitTypeAnnotation::Trait(Arc::new(evaluated_dom_element));
+
+    assert!(annotation.matches_annotation(&CalcitTypeAnnotation::TypeRef(Arc::from("respo.dom/DomElement"), Arc::new(vec![]),)));
+    assert!(!annotation.matches_annotation(&CalcitTypeAnnotation::TypeRef(Arc::from("other.dom/DomElement"), Arc::new(vec![]),)));
+    assert!(annotation.satisfies_trait_bound(dom_element.as_ref()));
+    assert!(!annotation.satisfies_trait_bound(other_dom_element.as_ref()));
+    let CalcitTypeAnnotation::Trait(evaluated_dom_element) = &annotation else {
+      unreachable!();
+    };
+    assert!(CalcitTypeAnnotation::Trait(dom_element).satisfies_trait_bound(evaluated_dom_element));
+  }
+
   fn symbol(name: &str) -> Calcit {
     Calcit::Symbol {
       sym: Arc::from(name),
@@ -4890,6 +4969,16 @@ mod tests {
       bounds[0].traits[0].methods.is_empty(),
       "source resolution happens during preprocessing"
     );
+  }
+
+  #[test]
+  fn qualified_trait_bounds_keep_their_nominal_source_reference() {
+    let source_form = symbol("respo.dom/DomElement");
+    let trait_def = Arc::new(CalcitTrait::new(EdnTag::new("DomElement"), vec![], vec![]));
+
+    let qualified = CalcitTypeAnnotation::trait_bound_with_source_ref(&source_form, &trait_def);
+
+    assert_eq!(qualified.definition_ref.as_deref(), Some("respo.dom/DomElement"));
   }
 
   #[test]


### PR DESCRIPTION
## English

### Background

Ecosystem validation after Calcit 0.13.74 exposed a nominal matching gap: the same external-object trait can be inferred as a resolved `Trait`, while strict schemas retain it as a qualified `TypeRef` or a source-backed generic trait bound. This caused valid Respo `DomElement` values to be rejected at strict DOM boundaries.

### Changes

- Match a resolved nominal `Trait` with its corresponding qualified `TypeRef`.
- Preserve qualified source identity when parsing strict generic `:where` trait bounds.
- Allow a value represented by the same nominal trait annotation to satisfy that bound.
- Keep traits with the same short name in different namespaces distinct.
- Retain the documented compatibility behavior for explicitly bare legacy trait placeholders.
- Add regression coverage for direct annotations, generic bounds, qualified identity, and legacy placeholders.

### Validation

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1` (646 library, 278 CLI, and 23 WASM tests)
- `corepack yarn check-all` (native, JS, WASM, quality gates, and benchmarks)
- Respo downstream strict check: zero warnings after the separate real boundary migrations

This removes eight false-positive `DomElement` diagnostics found during downstream validation. The genuine Respo state, optional-value, and DOM-nullability migrations remain in a separate PR.

## 中文

### 背景

在 Calcit 0.13.74 的生态验证中发现一处 nominal 匹配缺口：同一个外部对象 trait 在推导结果中可能表示为已解析的 `Trait`，而严格 schema 会将它保留为限定名 `TypeRef` 或带 source identity 的泛型 trait bound。这会让合法的 Respo `DomElement` 值在严格 DOM 边界被错误拒绝。

### 修改

- 让已解析的 nominal `Trait` 与对应的限定名 `TypeRef` 正确匹配。
- 解析严格泛型 `:where` trait bound 时保留限定 source identity。
- 允许由同一 nominal trait annotation 表示的值满足该约束。
- 对不同 namespace 中短名称相同的 trait 继续保持区分。
- 对显式 bare legacy trait placeholder 保留已有的兼容行为。
- 增加直接 annotation、泛型约束、限定 identity 与 legacy placeholder 的回归测试。

### 验证

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`（646 个 library、278 个 CLI、23 个 WASM 测试）
- `corepack yarn check-all`（native、JS、WASM、质量门槛与 benchmark）
- Respo 下游严格检查：在独立修复真实边界问题后为零 warning

该修复消除了下游验证中发现的 8 个 `DomElement` 误报。Respo 中真实存在的状态、可空值和 DOM nullability 迁移会放在独立 PR 中处理。
