### PR TITLE
修复 F64Buffer 长度的跨平台检查

### DIFF
--- a/editing-history/202609030453-address-f64-buffer-review.md
+++ b/editing-history/202609030453-address-f64-buffer-review.md
@@ -1,0 +1,11 @@
+# Address F64Buffer portability review / 处理 F64Buffer 可移植性评审
+
+## 中文
+
+- 修正文档中的“比较现在先将”为“比较时先将”。
+- 长度上限直接引用 `i64::MAX`，避免硬编码位移，同时保持“无法装入 signed i64 时拒绝”的边界语义。
+
+## English
+
+- Fix the Chinese wording typo in the original portability note.
+- Reference `i64::MAX` directly for the upper bound instead of spelling it as a bit shift, while preserving the same signed-i64 fit rule.

--- a/editing-history/202609030900-f64-buffer-length-portability.md
+++ b/editing-history/202609030900-f64-buffer-length-portability.md
@@ -5,7 +5,7 @@
 `F64Buffer` 的 strict length boundary 需要表达“长度必须小于 `2^63`”。此前使用
 `1usize << 63`，在 32-bit target 上该常量本身不可表示，可能在用户还未运行程序前就导致编译失败。
 
-比较现在先将 `usize` 长度提升为 `u64`，再与 `1u64 << 63` 比较。语义不变：64-bit target 仍拒绝
+比较时先将 `usize` 长度提升为 `u64`，再与 `i64::MAX` 的 `u64` 表示比较。语义不变：64-bit target 仍拒绝
 无法装入 signed i64 的长度；32-bit target 的所有可表示 `usize` 长度自然低于该上限。这个修复不改变
 F64Buffer ABI、Nil/Dynamic policy 或 runtime allocation。
 
@@ -15,7 +15,7 @@ The strict `F64Buffer` length boundary must express that a length is smaller tha
 `1usize << 63` expression is not representable on a 32-bit target and can fail compilation before a user
 runs their program.
 
-The comparison now widens the `usize` length to `u64` and compares it with `1u64 << 63`. Semantics are
+The comparison now widens the `usize` length to `u64` and compares it with `i64::MAX` represented as `u64`. Semantics are
 unchanged: 64-bit targets still reject lengths that cannot fit in signed i64, while every representable
 32-bit `usize` length is naturally below that limit. This does not change the F64Buffer ABI, Nil/Dynamic
 policy, or runtime allocation.

--- a/editing-history/202609030900-f64-buffer-length-portability.md
+++ b/editing-history/202609030900-f64-buffer-length-portability.md
@@ -1,0 +1,21 @@
+# F64Buffer length portability / F64Buffer 长度可移植性
+
+## 中文
+
+`F64Buffer` 的 strict length boundary 需要表达“长度必须小于 `2^63`”。此前使用
+`1usize << 63`，在 32-bit target 上该常量本身不可表示，可能在用户还未运行程序前就导致编译失败。
+
+比较现在先将 `usize` 长度提升为 `u64`，再与 `1u64 << 63` 比较。语义不变：64-bit target 仍拒绝
+无法装入 signed i64 的长度；32-bit target 的所有可表示 `usize` 长度自然低于该上限。这个修复不改变
+F64Buffer ABI、Nil/Dynamic policy 或 runtime allocation。
+
+## English
+
+The strict `F64Buffer` length boundary must express that a length is smaller than `2^63`. The previous
+`1usize << 63` expression is not representable on a 32-bit target and can fail compilation before a user
+runs their program.
+
+The comparison now widens the `usize` length to `u64` and compares it with `1u64 << 63`. Semantics are
+unchanged: 64-bit targets still reject lengths that cannot fit in signed i64, while every representable
+32-bit `usize` length is naturally below that limit. This does not change the F64Buffer ABI, Nil/Dynamic
+policy, or runtime allocation.

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -1907,7 +1907,7 @@ pub fn f64_buffer_len(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let [Calcit::F64Buffer(values)] = xs else {
     return CalcitErr::err_nodes(CalcitErrKind::Type, "f64-buffer.len expected one F64Buffer:", xs);
   };
-  if (values.len() as u64) >= (1u64 << 63) {
+  if values.len() as u64 > i64::MAX as u64 {
     return CalcitErr::err_str(
       CalcitErrKind::Unexpected,
       format!("f64-buffer.len length {} does not fit i64", values.len()),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -1907,7 +1907,7 @@ pub fn f64_buffer_len(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let [Calcit::F64Buffer(values)] = xs else {
     return CalcitErr::err_nodes(CalcitErrKind::Type, "f64-buffer.len expected one F64Buffer:", xs);
   };
-  if values.len() >= (1usize << 63) {
+  if (values.len() as u64) >= (1u64 << 63) {
     return CalcitErr::err_str(
       CalcitErrKind::Unexpected,
       format!("f64-buffer.len length {} does not fit i64", values.len()),


### PR DESCRIPTION
## 中文

关联已合并的 [calcit#573](https://github.com/calcit-lang/calcit/pull/573) review comment。

将 F64Buffer 长度上限从依赖 target-width 的 `1usize << 63` 改为 `(len as u64) >= (1u64 << 63)`。这样 32-bit target 可以编译；64-bit 运行时语义保持不变。

本 PR 不改变 ABI、buffer ownership、Nil/Dynamic policy 或运行时分配。

验证：

- `cargo fmt --check`
- `cargo test`（646 tests）
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn compile`
- `yarn check-agent-interface`（18/18）
- `yarn check-all`

## English

Addresses the review comment on merged [calcit#573](https://github.com/calcit-lang/calcit/pull/573).

Changes the F64Buffer length limit from target-width-dependent `1usize << 63` to `(len as u64) >= (1u64 << 63)`. This permits 32-bit targets to compile while preserving the 64-bit runtime semantics.

This PR does not change ABI, buffer ownership, Nil/Dynamic policy, or runtime allocation.

Validation:

- `cargo fmt --check`
- `cargo test` (646 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn compile`
- `yarn check-agent-interface` (18/18)
- `yarn check-all`