### PR TITLE
Prevent recursive generic bindings / 防止递归泛型绑定

### DIFF
--- a/editing-history/202609030325-prevent-recursive-generic-bindings.md
+++ b/editing-history/202609030325-prevent-recursive-generic-bindings.md
@@ -1,0 +1,36 @@
+# Prevent recursive generic bindings
+
+## Context / 背景
+
+While rebuilding `Cumulo/cumulo-reel.calcit` with Calcit 0.13.75, JS codegen
+overflowed its 64 MiB worker stack while preprocessing
+`recollect.wasm-test/probe-map-keys`. The minimal trigger combines nested generic
+collection access with homogeneous equality:
+
+```cirru
+= (&list:first (&list:first (&map:to-list ({} (:score 1))))) :score
+```
+
+在 Calcit 0.13.75 下重新编译 `Cumulo/cumulo-reel.calcit` 时，JS codegen 在补全
+`recollect.wasm-test/probe-map-keys` 的预处理结果时耗尽 64 MiB worker stack。
+
+## Root cause / 根因
+
+Generic matching could bind `T` to a type that recursively contains `T`, such
+as `Optional<T>`. When a later argument reused `T`, matching repeatedly followed
+the cyclic binding and never terminated.
+
+泛型匹配此前可能记录 `T = Optional<T>` 一类包含自身的绑定；后续参数再次使用
+`T` 时会无限递归解析。
+
+## Change / 修改
+
+- Add a named type-variable occurs-check across container, function, nominal,
+  optional/nullish and variadic annotations.
+- If a candidate contains the variable being bound, keep the unresolved
+  generic match permissive without storing the recursive binding. Later
+  concrete arguments can still bind the variable normally.
+- Cover the nested binding explicitly and confirm the original minimal case now
+  reports its ordinary type warning instead of aborting.
+
+Tracking: calcit-lang/calcit#596.

--- a/editing-history/202609030325-prevent-recursive-generic-bindings.md
+++ b/editing-history/202609030325-prevent-recursive-generic-bindings.md
@@ -27,6 +27,8 @@ the cyclic binding and never terminated.
 
 - Add a named type-variable occurs-check across container, function, nominal,
   optional/nullish and variadic annotations.
+- Follow aliases already present in the binding graph so indirect cycles such
+  as `T = U` followed by `U = Optional<T>` are rejected as well.
 - If a candidate contains the variable being bound, keep the unresolved
   generic match permissive without storing the recursive binding. Later
   concrete arguments can still bind the variable normally.

--- a/editing-history/202609030351-follow-generic-aliases-in-occurs-check.md
+++ b/editing-history/202609030351-follow-generic-aliases-in-occurs-check.md
@@ -1,0 +1,21 @@
+# Follow generic aliases in the occurs-check
+
+## Context / 背景
+
+Review of calcit-lang/calcit#597 identified that checking only the candidate
+annotation catches direct bindings such as `T = Optional<T>`, but not indirect
+cycles through existing aliases.
+
+对 calcit-lang/calcit#597 的 review 指出，仅检查候选 annotation 能阻止直接
+递归绑定，但仍可能通过已有别名形成间接环。
+
+## Change / 修改
+
+- Make the occurs-check traverse existing generic bindings with a visited set.
+- Keep the permissive unresolved match while refusing to store cyclic edges.
+- Cover `T = U` followed by a rejected `U = Optional<T>` edge.
+- Cover the reverse `T` versus `Optional<T>` matching direction and verify a
+  later concrete binding still succeeds.
+
+Validation: `cargo fmt`, strict Clippy, `yarn compile`, full Rust tests,
+`yarn check-all`, and `yarn check-agent-interface`.

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2721,6 +2721,32 @@ impl CalcitTypeAnnotation {
     }
   }
 
+  /// Check whether this annotation recursively contains one named `TypeVar`.
+  ///
+  /// Generic matching uses this as an occurs-check before recording a binding,
+  /// so a value such as `Optional<T>` cannot bind `T` to a type containing
+  /// itself and make later comparisons recurse forever.
+  fn contains_type_var_named(&self, name: &str) -> bool {
+    match self {
+      Self::TypeVar(current) => current.as_ref() == name,
+      Self::TypeRef(_, args) => args.iter().any(|arg| arg.contains_type_var_named(name)),
+      Self::List(inner)
+      | Self::Set(inner)
+      | Self::Ref(inner)
+      | Self::Optional(inner)
+      | Self::JsNullish(inner)
+      | Self::Variadic(inner) => inner.contains_type_var_named(name),
+      Self::Map(key, value) => key.contains_type_var_named(name) || value.contains_type_var_named(name),
+      Self::Fn(signature) => {
+        signature.arg_types.iter().any(|arg| arg.contains_type_var_named(name))
+          || signature.return_type.contains_type_var_named(name)
+          || signature.rest_type.as_ref().is_some_and(|rest| rest.contains_type_var_named(name))
+      }
+      Self::Struct(_, args) | Self::Enum(_, args) => args.iter().any(|arg| arg.contains_type_var_named(name)),
+      _ => false,
+    }
+  }
+
   /// Try to resolve this type annotation to a concrete `CalcitStructDef` definition.
   /// Works for `Struct(def, _)`, `StructValue(def)`, and `TypeRef("ns/name", _)` that can be
   /// looked up from the program registry.
@@ -3022,6 +3048,7 @@ impl CalcitTypeAnnotation {
           let bound = bound.clone();
           actual.matches_with_bindings(bound.as_ref(), bindings)
         }
+        None if actual.contains_type_var_named(var) => true,
         None => {
           bindings.insert(var.to_owned(), Arc::new(actual.to_owned()));
           true
@@ -3074,6 +3101,7 @@ impl CalcitTypeAnnotation {
           let bound = bound.clone();
           bound.as_ref().matches_with_bindings(expected_type, bindings)
         }
+        None if expected_type.contains_type_var_named(var) => true,
         None => {
           bindings.insert(var.to_owned(), Arc::new(expected_type.to_owned()));
           true
@@ -4529,6 +4557,20 @@ mod tests {
     assert!(type_var.matches_with_bindings(&type_var, &mut bindings));
     assert!(type_var.matches_with_bindings(&type_var, &mut bindings));
     assert!(bindings.is_empty(), "an identical type variable needs no self-binding");
+  }
+
+  #[test]
+  fn nested_type_vars_do_not_create_recursive_occurs_bindings() {
+    let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let optional_type_var = CalcitTypeAnnotation::Optional(type_var);
+    let expected_type_var = CalcitTypeAnnotation::TypeVar(Arc::from("T"));
+    let mut bindings = TypeBindings::new();
+
+    assert!(optional_type_var.matches_with_bindings(&expected_type_var, &mut bindings));
+    assert!(bindings.is_empty(), "T must not be bound to Optional<T>");
+
+    assert!(CalcitTypeAnnotation::Tag.matches_with_bindings(&expected_type_var, &mut bindings));
+    assert_eq!(bindings.get("T").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::Tag));
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2747,6 +2747,56 @@ impl CalcitTypeAnnotation {
     }
   }
 
+  /// Binding-aware occurs-check used before inserting a generic binding.
+  ///
+  /// Following existing aliases is necessary to reject indirect cycles such
+  /// as `T = U` followed by `U = Optional<T>`. `visiting` also keeps this
+  /// defensive check finite if it receives an already-cyclic binding graph.
+  fn contains_type_var_named_with_bindings(&self, name: &str, bindings: &TypeBindings) -> bool {
+    if self.contains_type_var_named(name) {
+      return true;
+    }
+
+    fn walk(annotation: &CalcitTypeAnnotation, name: &str, bindings: &TypeBindings, visiting: &mut HashSet<Arc<str>>) -> bool {
+      match annotation {
+        CalcitTypeAnnotation::TypeVar(current) => {
+          if current.as_ref() == name {
+            return true;
+          }
+          if !visiting.insert(current.clone()) {
+            return false;
+          }
+          let found = bindings
+            .get(current)
+            .is_some_and(|bound| walk(bound.as_ref(), name, bindings, visiting));
+          visiting.remove(current);
+          found
+        }
+        CalcitTypeAnnotation::TypeRef(_, args) | CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) => {
+          args.iter().any(|arg| walk(arg, name, bindings, visiting))
+        }
+        CalcitTypeAnnotation::List(inner)
+        | CalcitTypeAnnotation::Set(inner)
+        | CalcitTypeAnnotation::Ref(inner)
+        | CalcitTypeAnnotation::Optional(inner)
+        | CalcitTypeAnnotation::JsNullish(inner)
+        | CalcitTypeAnnotation::Variadic(inner) => walk(inner, name, bindings, visiting),
+        CalcitTypeAnnotation::Map(key, value) => walk(key, name, bindings, visiting) || walk(value, name, bindings, visiting),
+        CalcitTypeAnnotation::Fn(signature) => {
+          signature.arg_types.iter().any(|arg| walk(arg, name, bindings, visiting))
+            || walk(&signature.return_type, name, bindings, visiting)
+            || signature
+              .rest_type
+              .as_ref()
+              .is_some_and(|rest| walk(rest, name, bindings, visiting))
+        }
+        _ => false,
+      }
+    }
+
+    walk(self, name, bindings, &mut HashSet::new())
+  }
+
   /// Try to resolve this type annotation to a concrete `CalcitStructDef` definition.
   /// Works for `Struct(def, _)`, `StructValue(def)`, and `TypeRef("ns/name", _)` that can be
   /// looked up from the program registry.
@@ -3048,7 +3098,7 @@ impl CalcitTypeAnnotation {
           let bound = bound.clone();
           actual.matches_with_bindings(bound.as_ref(), bindings)
         }
-        None if actual.contains_type_var_named(var) => true,
+        None if actual.contains_type_var_named_with_bindings(var, bindings) => true,
         None => {
           bindings.insert(var.to_owned(), Arc::new(actual.to_owned()));
           true
@@ -3101,7 +3151,7 @@ impl CalcitTypeAnnotation {
           let bound = bound.clone();
           bound.as_ref().matches_with_bindings(expected_type, bindings)
         }
-        None if expected_type.contains_type_var_named(var) => true,
+        None if expected_type.contains_type_var_named_with_bindings(var, bindings) => true,
         None => {
           bindings.insert(var.to_owned(), Arc::new(expected_type.to_owned()));
           true
@@ -4571,6 +4621,37 @@ mod tests {
 
     assert!(CalcitTypeAnnotation::Tag.matches_with_bindings(&expected_type_var, &mut bindings));
     assert_eq!(bindings.get("T").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::Tag));
+
+    let reverse_type_var = CalcitTypeAnnotation::TypeVar(Arc::from("T"));
+    let reverse_optional = CalcitTypeAnnotation::Optional(Arc::new(reverse_type_var.clone()));
+    let mut reverse_bindings = TypeBindings::new();
+    assert!(reverse_type_var.matches_with_bindings(&reverse_optional, &mut reverse_bindings));
+    assert!(
+      reverse_bindings.is_empty(),
+      "T must not be bound to Optional<T> in the reverse direction"
+    );
+    assert!(reverse_type_var.matches_with_bindings(&CalcitTypeAnnotation::String, &mut reverse_bindings));
+    assert_eq!(reverse_bindings.get("T").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::String));
+  }
+
+  #[test]
+  fn generic_occurs_check_follows_existing_alias_bindings() {
+    let generic_t = CalcitTypeAnnotation::TypeVar(Arc::from("T"));
+    let generic_u = CalcitTypeAnnotation::TypeVar(Arc::from("U"));
+    let optional_t = CalcitTypeAnnotation::Optional(Arc::new(generic_t.clone()));
+    let mut bindings = TypeBindings::new();
+
+    assert!(generic_u.matches_with_bindings(&generic_t, &mut bindings));
+    assert_eq!(bindings.get("T").map(AsRef::as_ref), Some(&generic_u));
+
+    assert!(optional_t.matches_with_bindings(&generic_t, &mut bindings));
+    assert!(
+      bindings.get("U").is_none(),
+      "U must not be bound to Optional<T> through the T -> U alias"
+    );
+
+    assert!(CalcitTypeAnnotation::Tag.matches_with_bindings(&generic_t, &mut bindings));
+    assert_eq!(bindings.get("U").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::Tag));
   }
 
   #[test]


### PR DESCRIPTION
## English

- add a named type-variable occurs-check before generic bindings are recorded
- leave self-containing candidates unresolved so later concrete arguments can still bind the variable
- cover `T` versus `Optional<T>` and subsequent concrete binding
- verify the original nested collection/equality reproducer no longer aborts
- verify Cumulo Reel server and client JS codegen against the stacked ecosystem fixes

## 中文

- 在记录泛型绑定前增加具名类型变量 occurs-check
- 候选类型包含自身变量时不写入递归绑定，保留后续具体参数完成绑定的机会
- 覆盖 `T` 与 `Optional<T>` 以及后续具体绑定
- 验证原始嵌套集合/相等判断复现不再导致进程崩溃
- 使用叠加的生态修复验证 Cumulo Reel 服务端与客户端 JS codegen

## Validation / 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `cargo test`
- `yarn check-all`
- `yarn check-agent-interface`
- Cumulo Reel server/client JS codegen with local fixed dependency branches

Closes #596