### PR TITLE
chore: release 0.13.76 / 发布 0.13.76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calcit"
-version = "0.13.75"
+version = "0.13.76"
 dependencies = [
  "argh",
  "bisection_key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "calcit"
 autobins = false
-version = "0.13.75"
+version = "0.13.76"
 authors = ["jiyinyiyong <jiyinyiyong@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/editing-history/202609031154-release-01376.md
+++ b/editing-history/202609031154-release-01376.md
@@ -1,0 +1,13 @@
+# Release 0.13.76
+
+2026-09-03 11:54 CST
+
+## English
+
+- Release the recursive generic-binding prevention from PR #597.
+- Prevent compiler stack overflows encountered while generating JavaScript for the typed Respo ecosystem.
+
+## 中文
+
+- 发布 PR #597 中防止递归泛型绑定的修复。
+- 避免在为类型化 Respo 生态生成 JavaScript 时触发编译器栈溢出。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcit/procs",
-  "version": "0.13.75",
+  "version": "0.13.76",
   "main": "./lib/calcit.procs.mjs",
   "devDependencies": {
     "@types/node": "^25.7.0",


### PR DESCRIPTION
Release the compiler fix from #597 as version 0.13.76.

This resolves the recursive generic binding that caused a stack overflow when Copycat #46 generates JavaScript through the typed Respo dependency graph.

Validation: cargo fmt, clippy with warnings denied, 949 Rust tests, yarn compile, agent interface smoke 18/18, yarn check-all, release build, and Copycat JS generation using the release binary.

仅升级版本和记录已合并的 #597 修复；不包含发布、打 tag 或合并操作。