### PR TITLE
feat: reject legacy Optional schemas in strict mode / strict 模式拒绝 legacy Optional schema

### DIFF
--- a/RFCs/08-05-systematic-nil-reduction-rfc.md
+++ b/RFCs/08-05-systematic-nil-reduction-rfc.md
@@ -21,7 +21,7 @@
 下一版本是 nil 迁移的最终 breaking window。该版本合并、升级并发布后，以下规则进入兼容性承诺：
 
 - 公开缺失统一返回 `Option<T>`，公开可恢复失败统一返回 `Result<T,E>`，副作用返回 `Unit`；
-- 公开 schema 不得出现 `Optional<T>`。预处理器会发出 `W_LEGACY_OPTIONAL_SCHEMA`，该规则同样约束 `calcit.core` 的公开定义；
+- 公开 schema 不得出现 `Optional<T>`。`--strict-types` 会发出 `E_LEGACY_OPTIONAL_SCHEMA`，普通模式保留迁移警告；该规则同样约束 `calcit.core` 的公开定义；
 - 名称以 `&` 开头的 raw primitive 属于 semver-private 实现细节，允许在内部使用 nullable 表示，但不得直接挂入公开方法表；
 - 已生成 JS bundle 引用的 npm runtime export 属于 codegen ABI：typed wrapper/raw proc 改名时必须保留兼容 export，并由 runtime identity test 覆盖；类型系统负责阻断重新编译的旧 FFI 源码，但不能替代旧 bundle 的装载兼容性；
 - 新增查询 API 不得先返回 nil、再在后续版本改成 Option。类型和所有后端实现必须在首次发布时一致；

--- a/docs/run/strict-nil-migration.md
+++ b/docs/run/strict-nil-migration.md
@@ -13,6 +13,7 @@ keeps the legacy runtime behavior during migration.
 | `E_PARTIAL_STRUCT_NIL_FILL` | `%{}? Struct ...` and `&%{}? Struct ...` | Use `%{}` with every field present. Change genuinely absent fields to `Option<T>` and provide `%none`. Do not infer business defaults automatically. |
 | `E_NIL_FOR_UNIT` | A function declared to return `Unit` whose returned expression has static type `Nil`, including legacy `;nil` | Return `&unit`, or end the body with an effect that already returns `Unit`. Intermediate nil values are not treated as the function return. |
 | `E_NIL_CALLBACK_SENTINEL` | An inline `map-kv` callback has a return path that uses `nil` to drop an entry, including an `if` without an else branch | Use `filter-map-kv`; return `MapEntryDecision :keep key value` or `MapEntryDecision :drop` on every path. A `nil` nested inside the returned key/value pair remains ordinary data and is not rejected. |
+| `E_LEGACY_OPTIONAL_SCHEMA` | A public function schema contains legacy `Optional<T>`, which conflates a nominal API with runtime nil | Use `Option<T>` for Calcit absence, `JsNullish<T>` only at JS FFI boundaries, `Result<T,E>` for failures, or `Unit` for effects. Raw core `&...` primitives and the `optionally` bridge remain internal compatibility boundaries. |
 
 The runtime `nil` value, Cirru EDN nil, and explicit untyped/FFI boundaries are
 not removed. The strict errors only close constructs that silently manufacture

--- a/editing-history/202609031741-strict-legacy-optional-schema.md
+++ b/editing-history/202609031741-strict-legacy-optional-schema.md
@@ -1,0 +1,5 @@
+# Reject legacy Optional schemas in strict mode
+
+- Promote public `Optional<T>` schemas from a migration warning to the strict-mode `E_LEGACY_OPTIONAL_SCHEMA` error.
+- Keep compatibility mode warning-only, and preserve raw core `&...` primitives plus `optionally` as explicit internal nullable bridges.
+- Require public APIs to choose `Option`, `Result`, `Unit`, or `JsNullish` according to the actual absence, failure, effect, or JavaScript-boundary semantics.

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6952,13 +6952,20 @@ pub fn preprocess_defn(
           )),
         ));
       }
-      warn_on_legacy_optional_public_schema(ctx.file_ns, def_name.as_ref(), &def_schema, ctx.check_warnings);
-      let schema_issues = validate_def_schema_during_preprocess(head, ctx.file_ns, def_name.as_ref(), ys, &def_schema);
       let definition_location = NodeLocation::new(
         info.at_ns.to_owned(),
         info.at_def.to_owned(),
         location.to_owned().unwrap_or_default(),
       );
+      reject_strict_legacy_optional_public_schema(
+        ctx.file_ns,
+        def_name.as_ref(),
+        &def_schema,
+        ctx.call_stack,
+        Some(definition_location.clone()),
+      )?;
+      warn_on_legacy_optional_public_schema(ctx.file_ns, def_name.as_ref(), &def_schema, ctx.check_warnings);
+      let schema_issues = validate_def_schema_during_preprocess(head, ctx.file_ns, def_name.as_ref(), ys, &def_schema);
       if !schema_issues.is_empty() {
         let details = schema_issues.join("\n  - ");
         return Err(CalcitErr::use_msg_stack_location_with_code(
@@ -7829,20 +7836,48 @@ fn contains_legacy_optional(annotation: &CalcitTypeAnnotation) -> bool {
   }
 }
 
+fn legacy_optional_public_schema_requires_migration(ns: &str, def_name: &str, schema: &CalcitTypeAnnotation) -> bool {
+  if !contains_legacy_optional(schema) {
+    return false;
+  }
+  // Core `&` definitions are semver-private primitives and may still model
+  // nullable host/runtime values. Public core wrappers must obey the same
+  // nominal absence rule as application code. `optionally` is the one explicit
+  // bridge from an internal Optional<T> value to Option<T>.
+  !(ns == calcit::CORE_NS && (def_name.starts_with('&') || def_name == "optionally"))
+}
+
+fn reject_strict_legacy_optional_public_schema(
+  ns: &str,
+  def_name: &str,
+  schema: &CalcitTypeAnnotation,
+  call_stack: &CallStackList,
+  definition_location: Option<NodeLocation>,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled()
+    || !should_emit_project_source_lint(ns)
+    || !legacy_optional_public_schema_requires_migration(ns, def_name, schema)
+  {
+    return Ok(());
+  }
+  Err(CalcitErr::use_msg_stack_location_with_code(
+    CalcitErrKind::Type,
+    format!(
+      "{ns}/{def_name} exposes legacy Optional<T> in its public schema; use Option<T> for Calcit absence, JsNullish<T> only for JavaScript FFI, Result<T,E> for failures, or Unit for effects"
+    ),
+    "E_LEGACY_OPTIONAL_SCHEMA",
+    call_stack,
+    find_preferred_macro_location(call_stack).or(definition_location),
+  ))
+}
+
 fn warn_on_legacy_optional_public_schema(
   ns: &str,
   def_name: &str,
   schema: &CalcitTypeAnnotation,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
 ) {
-  if !contains_legacy_optional(schema) {
-    return;
-  }
-  // Core `&` definitions are semver-private primitives and may still model
-  // nullable host/runtime values. Public core wrappers must obey the same
-  // nominal absence rule as application code. `optionally` is the one explicit
-  // bridge from an internal Optional<T> value to Option<T>.
-  if ns == calcit::CORE_NS && (def_name.starts_with('&') || def_name == "optionally") {
+  if !legacy_optional_public_schema_requires_migration(ns, def_name, schema) {
     return;
   }
   gen_check_warning_code(
@@ -13852,6 +13887,39 @@ mod tests {
       bridge_warnings.borrow().is_empty(),
       "optionally is the explicit nullable-to-nominal bridge"
     );
+  }
+
+  #[test]
+  fn strict_types_reject_legacy_optional_public_schemas_but_keep_internal_bridges() {
+    let _state = lock_preprocess_test_state();
+    let schema = CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![Arc::new(CalcitTypeAnnotation::Number)],
+      return_type: Arc::new(CalcitTypeAnnotation::Optional(Arc::new(CalcitTypeAnnotation::Number))),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    }));
+    let location = NodeLocation::new("tests.schema".into(), "demo".into(), Arc::new(vec![4]));
+
+    {
+      let _compat = StrictTypesGuard::new(false);
+      reject_strict_legacy_optional_public_schema("tests.schema", "demo", &schema, &CallStackList::default(), Some(location.clone()))
+        .expect("compatibility mode should preserve the warning-only migration path");
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    let error = reject_strict_legacy_optional_public_schema("tests.schema", "demo", &schema, &CallStackList::default(), Some(location))
+      .expect_err("strict mode should reject public Optional<T> schemas");
+    assert_eq!(error.code.as_deref(), Some("E_LEGACY_OPTIONAL_SCHEMA"));
+    assert!(error.msg.contains("Option<T>"));
+    assert!(error.location.is_some());
+
+    reject_strict_legacy_optional_public_schema(calcit::CORE_NS, "&raw-lookup", &schema, &CallStackList::default(), None)
+      .expect("raw core primitives remain explicit nullable implementation boundaries");
+    reject_strict_legacy_optional_public_schema(calcit::CORE_NS, "optionally", &schema, &CallStackList::default(), None)
+      .expect("the explicit Optional-to-Option bridge remains available");
   }
 
   #[test]


### PR DESCRIPTION
## Summary / 概要

- `--strict-types` now rejects public `Optional<T>` schemas with `E_LEGACY_OPTIONAL_SCHEMA`.
- Ordinary mode keeps `W_LEGACY_OPTIONAL_SCHEMA` during the migration window.
- Raw core `&...` primitives and `optionally` remain explicit internal nullable bridges.

`--strict-types` 现以 `E_LEGACY_OPTIONAL_SCHEMA` 拒绝公开 `Optional<T>` schema；普通模式继续保留迁移警告。core 的 raw `&...` primitive 与 `optionally` 仍是明确的内部 nullable bridge。

## Validation / 验证

- `cargo test`
- `cargo clippy -- -D warnings`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`