### PR TITLE
fix: omit JS match wildcard bindings / 修复 JS match 通配符绑定

### DIFF
--- a/editing-history/202609031805-js-match-wildcards.md
+++ b/editing-history/202609031805-js-match-wildcards.md
@@ -1,0 +1,5 @@
+# Omit match wildcard bindings in JavaScript output
+
+- Treat `_` in enum match payload positions as a true wildcard in both generic and indexed JavaScript match emitters.
+- Do not emit a JavaScript `let` declaration or add `_` to the lexical scope for wildcard positions.
+- Cover repeated wildcards so generated modules remain parseable by Vite, Rollup, and native JavaScript engines.

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -1380,6 +1380,9 @@ fn gen_match_code(
         // Generate binding code
         let mut scoped_defs = local_defs.to_owned();
         for (i, binding) in pat_xs.iter().skip(1).enumerate() {
+          if matches!(binding, Calcit::Local(CalcitLocal { sym, .. }) | Calcit::Symbol { sym, .. } if sym.as_ref() == "_") {
+            continue;
+          }
           let bind_name = match binding {
             Calcit::Local(CalcitLocal { sym, .. }) => escape_var(sym),
             Calcit::Symbol { sym, .. } => escape_var(sym),
@@ -1469,6 +1472,9 @@ fn gen_indexed_match_code(
 
     let mut scoped_defs = local_defs.to_owned();
     for (idx, binding) in pattern.iter().skip(1).enumerate() {
+      if matches!(binding, Calcit::Local(CalcitLocal { sym, .. }) | Calcit::Symbol { sym, .. } if sym.as_ref() == "_") {
+        continue;
+      }
       let bind_name = match binding {
         Calcit::Local(CalcitLocal { sym, .. }) | Calcit::Symbol { sym, .. } => {
           scoped_defs.insert(sym.to_owned());
@@ -2350,6 +2356,40 @@ mod tests {
     assert!(code.contains("case _t_.running.idx:"), "{code}");
     assert!(code.contains("case _t_.done.idx:"), "{code}");
     assert!(!code.contains(" else if "), "{code}");
+  }
+
+  #[test]
+  fn enum_match_codegen_does_not_bind_repeated_wildcards() {
+    let pattern = Calcit::from(vec![Calcit::Tag(EdnTag::from("states")), symbol("_"), symbol("_")]);
+    let branch = Calcit::from(vec![pattern, Calcit::Number(0.0)]);
+    let fallback = Calcit::from(vec![symbol("_"), Calcit::Number(-1.0)]);
+    let body = CalcitList::Vector(vec![symbol("state"), branch, fallback]);
+    let local_defs = HashSet::from([Arc::from("state")]);
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+
+    let code = gen_match_code(&body, &local_defs, &Calcit::Nil, "tests.emit-js", &file_imports, &tags, None)
+      .expect("match codegen should support repeated wildcards");
+
+    assert!(!code.contains("let _ ="), "wildcards must not create JS bindings: {code}");
+    assert!(code.contains("_t_.states"), "{code}");
+  }
+
+  #[test]
+  fn indexed_enum_match_codegen_does_not_bind_repeated_wildcards() {
+    let pattern = Calcit::from(vec![Calcit::Tag(EdnTag::from("states")), symbol("_"), symbol("_")]);
+    let branch = Calcit::from(vec![pattern, Calcit::Number(0.0)]);
+    let wildcard = Calcit::from(vec![symbol("_"), Calcit::Number(-1.0)]);
+    let table = CalcitList::Vector(vec![branch, wildcard]);
+    let local_defs = HashSet::from([Arc::from("state")]);
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+
+    let code = gen_indexed_match_code(&symbol("state"), &table, &local_defs, "tests.emit-js", &file_imports, &tags, None)
+      .expect("indexed match codegen should support repeated wildcards");
+
+    assert!(!code.contains("let _ ="), "wildcards must not create JS bindings: {code}");
+    assert!(code.contains("case _t_.states.idx:"), "{code}");
   }
 
   #[test]


### PR DESCRIPTION
Fixes #598.

- Treat `_` in enum match payload positions as a no-binding wildcard in both JavaScript emitters.
- Prevent duplicate `let _` declarations from making generated modules unparsable.
- Add regression coverage for generic and indexed enum match codegen.

验证：`cargo fmt`、`cargo test`（650/651 一次性通过；唯一 effects-graph 初始化时序用例单独重跑通过）、`cargo clippy -- -D warnings`、`yarn compile`、`yarn check-agent-interface`、`yarn check-all`。