### PR TITLE
feat: expose typed preprocess lowering in type-at

### DIFF
--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -126,7 +126,7 @@ For `code-nil`, the report includes raw `nil` and the legacy `;nil` compatibilit
 
 For one definition, `calcit query context '<ns/def>' --format json` embeds the same distinction in its diagnostics and returns the definition revision together with Snapshot paths.
 
-For one expression, `calcit query type-at '<ns/def>' --path code@... --format json` preprocesses only static program metadata and returns inferred type, expected type, typed bindings, confidence, method candidates, and diagnostics. It does not run the application entry. Paths use the same stable Snapshot coordinates returned by structural query commands.
+For one expression, `calcit query type-at '<ns/def>' --path code@... --format json` preprocesses only static program metadata and returns inferred type, expected type, typed bindings, confidence, method candidates, preprocess lowering evidence, and diagnostics. Its v2 `data.lowering` object distinguishes type-selected primitives from ordinary static call resolution and remaining dynamic dispatch. It does not run the application entry. Paths use the same stable Snapshot coordinates returned by structural query commands.
 
 `check-types`, `weak-types`, `deprecated`, and `quality` run as static Snapshot readers: they load configured modules and core metadata but do not preprocess or execute the application entry. `dynamic-methods` preprocesses the selected entry's reachable definitions without executing them, because receiver inference and method specialization are preprocessing results. With `--format json`, stdout is one versioned JSON envelope containing a stable scope revision, filters, summary, and finding or definition rows; startup/command messages stay on stderr.
 

--- a/docs/run/query.md
+++ b/docs/run/query.md
@@ -176,9 +176,12 @@ calcit query type-at test-struct.main/sum-point --path code@3.1 --format json
 - the expected type supplied by a return schema, callable parameter, `if` condition, or `assert-type`;
 - relevant typed bindings and their Snapshot paths;
 - statically resolvable methods and implementation origins;
+- the source callable and its preprocess lowering status (`specialized`, `resolved`, `dynamic`, or `unavailable`), including the selected core primitive when type information changes the execution path;
 - evidence, diagnostics, definition revision, and follow-up commands.
 
 The command does not invoke the project init/reload function. A dynamic FFI boundary is labeled `intentional-js-ffi` when the enclosing schema declares `:features $ #{} :js-ffi`; unresolved expressions remain explicit rather than triggering a runtime fallback. Named `defstruct`/`defenum` values are retained as source-backed type references, so field and method metadata can be resolved without constructing application values.
+
+`type-at --format json` uses protocol `schema_version: 2`. Version 2 adds the required `data.lowering` object with `status`, `kind`, `source_head`, `lowered_head`, and `detail`. Tooling can use `status: specialized` to confirm that rich source syntax reached a type-selected primitive, and should treat `dynamic` or `unavailable` as a migration/checking signal rather than assuming that successful inference implies optimized execution.
 
 ### Gather Definition Context (`context`)
 

--- a/editing-history/202609031845-type-at-lowering-evidence.md
+++ b/editing-history/202609031845-type-at-lowering-evidence.md
@@ -1,0 +1,9 @@
+# Type-at preprocess lowering evidence
+
+`query type-at` previously exposed inferred types and method candidates, but it did not show whether preprocessing had actually converted rich source syntax into a direct core operation. This made type coverage an incomplete proxy for runtime dispatch cost and gave migration tools no stable way to distinguish successful specialization from an ordinary symbol lookup.
+
+The v2 response now includes `data.lowering` with a closed status, a lowering kind, source and lowered callable heads, and a human-readable explanation. The classifier deliberately separates type-directed collection specialization, nominal Struct/Enum construction and access, static methods, and typed external operations from ordinary static call resolution. A known receiver that still uses method dispatch is reported as `dynamic`, because type evidence alone does not prove direct execution.
+
+The report is derived from the source-correlated preprocessed node already used by type inference. It does not evaluate the application or add runtime instrumentation. A missing correlated node is explicit as `unavailable`, which is important for rewrites that fold an expression into a location-free value or for preprocessing failures.
+
+Validation covers synthetic generic-to-primitive lowering, direct primitive calls, unresolved dynamic methods, and a real typed Struct field compiled from `calcit/test.cirru`. The CLI output was also checked to report `:x -> &struct:nth` for `test-struct.main/sum-point`.

--- a/editing-history/202609031907-recognize-postfix-lowering-head.md
+++ b/editing-history/202609031907-recognize-postfix-lowering-head.md
@@ -1,0 +1,5 @@
+# Recognize postfix method heads in lowering evidence
+
+Review found that `query type-at` treated the first item of every list as its callable head. In postfix source syntax such as `receiver .method`, however, the second item is the method head. That mismatch could label the receiver as the source/lowered callable and misclassify remaining dynamic dispatch.
+
+The lowering classifier now selects a Method in either of the two legal head positions, preferring the ordinary leading position when present. A regression test covers unchanged postfix dynamic dispatch and verifies that both reported heads remain `.show`.

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -61,6 +61,7 @@ struct SearchCommonOpts<'a> {
 }
 
 const DETAILED_RESULTS_WINDOW: usize = 3;
+const TYPE_AT_SCHEMA_VERSION: u32 = 2;
 
 struct SpecialBuiltinQueryMeta {
   doc: &'static str,
@@ -132,6 +133,15 @@ struct TypeAtBinding {
   path: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct TypeAtLowering {
+  status: &'static str,
+  kind: &'static str,
+  source_head: Option<String>,
+  lowered_head: Option<String>,
+  detail: String,
+}
+
 #[derive(Debug, Serialize)]
 struct TypeAtData {
   id: String,
@@ -147,6 +157,7 @@ struct TypeAtData {
   bindings: Vec<TypeAtBinding>,
   bindings_complete: bool,
   static_methods: Option<Vec<ContextMethod>>,
+  lowering: TypeAtLowering,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1207,6 +1218,12 @@ mod type_query_tests {
       matches!(field_access.first(), Some(Calcit::Proc(calcit::CalcitProc::NativeStructNth))),
       "typed tag access should specialize to struct nth, got {target}"
     );
+    let source = parse_query_test_expression(":x p");
+    let lowering = type_at_lowering(&source, Some(target));
+    assert_eq!(lowering.status, "specialized");
+    assert_eq!(lowering.kind, "nominal-struct-field");
+    assert_eq!(lowering.source_head.as_deref(), Some(":x"));
+    assert_eq!(lowering.lowered_head.as_deref(), Some("&struct:nth"));
   }
 
   #[test]
@@ -1214,6 +1231,45 @@ mod type_query_tests {
     assert_eq!(parse_type_at_path("code@3.2"), Ok(vec![3, 2]));
     assert_eq!(parse_type_at_path("@3.2"), Ok(vec![3, 2]));
     assert_eq!(parse_type_at_path("3.2"), Ok(vec![3, 2]));
+  }
+
+  fn parse_query_test_expression(source: &str) -> Calcit {
+    let mut nodes = cirru_parser::parse(source).expect("test expression should parse");
+    assert_eq!(nodes.len(), 1);
+    code_to_calcit(&nodes.remove(0), "tests.type-at", "demo", vec![]).expect("test expression should convert")
+  }
+
+  #[test]
+  fn type_at_lowering_distinguishes_typed_specialization_from_direct_primitives() {
+    let source = parse_query_test_expression("count xs");
+    let processed = Calcit::from(vec![Calcit::Proc(calcit::CalcitProc::NativeListCount), Calcit::Number(1.0)]);
+    assert_eq!(
+      type_at_lowering(&source, Some(&processed)),
+      TypeAtLowering {
+        status: "specialized",
+        kind: "typed-polymorphic-call",
+        source_head: Some("count".to_owned()),
+        lowered_head: Some("&list:count".to_owned()),
+        detail:
+          "Static receiver type selected a collection-specific primitive or core implementation, removing generic runtime dispatch."
+            .to_owned(),
+      }
+    );
+
+    let direct = Calcit::from(vec![Calcit::Proc(calcit::CalcitProc::NativeListCount), Calcit::Number(1.0)]);
+    let lowering = type_at_lowering(&direct, Some(&direct));
+    assert_eq!(lowering.status, "unchanged");
+    assert_eq!(lowering.kind, "core-expression");
+  }
+
+  #[test]
+  fn type_at_lowering_exposes_dynamic_method_dispatch() {
+    let source = parse_query_test_expression(".show value");
+    let lowering = type_at_lowering(&source, Some(&source));
+    assert_eq!(lowering.status, "dynamic");
+    assert_eq!(lowering.kind, "dynamic-method-dispatch");
+    assert_eq!(lowering.source_head.as_deref(), Some(".show"));
+    assert_eq!(lowering.lowered_head.as_deref(), Some(".show"));
   }
 
   #[test]
@@ -1631,6 +1687,164 @@ fn type_at_evidence(node: &Calcit, path: &str, used_preprocessed: bool) -> TypeA
   }
 }
 
+fn type_at_call_head(node: &Calcit) -> Option<&Calcit> {
+  match node {
+    Calcit::List(items) => items.first(),
+    _ => None,
+  }
+}
+
+fn type_at_head_label(head: &Calcit) -> Option<String> {
+  match head {
+    Calcit::Proc(proc) => Some(proc.to_string()),
+    Calcit::Import(import) => Some(format!("{}/{}", import.ns, import.def)),
+    Calcit::Symbol { sym, .. } | Calcit::Local(calcit::calcit::CalcitLocal { sym, .. }) => Some(sym.to_string()),
+    Calcit::Method(..) => Some(head.turn_string()),
+    Calcit::Tag(tag) => Some(format!(":{tag}")),
+    Calcit::Syntax(syntax, _) => Some(syntax.to_string()),
+    Calcit::StructDef(definition) => Some(definition.name.to_string()),
+    Calcit::EnumDef(definition) => Some(definition.name().to_string()),
+    Calcit::Fn { info, .. } => Some(info.name.to_string()),
+    Calcit::Registered(name) => Some(name.to_string()),
+    _ => None,
+  }
+}
+
+fn type_at_source_method(node: &Calcit) -> Option<String> {
+  let Calcit::List(items) = node else {
+    return None;
+  };
+  items.iter().take(2).find_map(|item| match item {
+    Calcit::Method(name, calcit::calcit::MethodKind::Invoke(_)) => Some(format!(".{name}")),
+    _ => None,
+  })
+}
+
+fn is_typed_collection_target(head: &Calcit) -> bool {
+  match head {
+    Calcit::Proc(proc) => {
+      let name = proc.as_ref();
+      name.starts_with("&list:")
+        || name.starts_with("&map:")
+        || name.starts_with("&set:")
+        || name.starts_with("&str:")
+        || name.starts_with("&enum:")
+    }
+    Calcit::Import(import) if import.ns.as_ref() == calcit::calcit::CORE_NS => {
+      let name = import.def.as_ref();
+      name.starts_with("&list:") || name.starts_with("&map:") || name.starts_with("&set:")
+    }
+    _ => false,
+  }
+}
+
+fn type_at_lowering(source: &Calcit, processed: Option<&Calcit>) -> TypeAtLowering {
+  let source_head = type_at_call_head(source).and_then(type_at_head_label);
+  let Some(processed) = processed else {
+    return TypeAtLowering {
+      status: "unavailable",
+      kind: "preprocess-unavailable",
+      source_head,
+      lowered_head: None,
+      detail: "No source-correlated preprocessed node was produced; inspect diagnostics before relying on runtime dispatch.".to_owned(),
+    };
+  };
+  let processed_head = type_at_call_head(processed);
+  let lowered_head = processed_head.and_then(type_at_head_label);
+  let source_method = type_at_source_method(source);
+
+  let (status, kind, detail) = match processed_head {
+    Some(Calcit::Proc(calcit::CalcitProc::NativeStructNth)) => (
+      "specialized",
+      "nominal-struct-field",
+      "The typed Struct field access was validated and lowered to indexed field access.",
+    ),
+    Some(Calcit::Proc(calcit::CalcitProc::NativeStructGet)) => (
+      "specialized",
+      "struct-field",
+      "The Struct field access was lowered to the core Struct primitive; indexed access needs a resolved nominal field layout.",
+    ),
+    Some(Calcit::Proc(calcit::CalcitProc::NativeStruct)) => (
+      "specialized",
+      "nominal-struct-constructor",
+      "The Struct constructor was checked against its nominal definition and lowered to the core constructor primitive.",
+    ),
+    Some(Calcit::Proc(calcit::CalcitProc::NativeNamedEnumNew)) => (
+      "specialized",
+      "nominal-enum-constructor",
+      "The Enum variant and payload were checked against the nominal definition and lowered to the core constructor primitive.",
+    ),
+    Some(Calcit::Proc(calcit::CalcitProc::NativeEnum)) => (
+      "specialized",
+      "anonymous-enum-constructor",
+      "The anonymous Enum constructor was lowered to the core constructor primitive.",
+    ),
+    Some(head) if is_typed_collection_target(head) && source_head != lowered_head => (
+      "specialized",
+      "typed-polymorphic-call",
+      "Static receiver type selected a collection-specific primitive or core implementation, removing generic runtime dispatch.",
+    ),
+    Some(Calcit::Method(
+      _,
+      calcit::calcit::MethodKind::ExternalAccess(_)
+      | calcit::calcit::MethodKind::ExternalGet(_)
+      | calcit::calcit::MethodKind::ExternalSet(_)
+      | calcit::calcit::MethodKind::ExternalInvoke(_),
+    )) => (
+      "specialized",
+      "typed-external-operation",
+      "Static external-object type selected a backend-native property or method operation.",
+    ),
+    Some(Calcit::Method(_, calcit::calcit::MethodKind::Invoke(receiver)))
+      if matches!(receiver.as_ref(), CalcitTypeAnnotation::Dynamic) =>
+    {
+      (
+        "dynamic",
+        "dynamic-method-dispatch",
+        "The receiver type is still Dynamic, so the method cannot be lowered to a direct callable.",
+      )
+    }
+    Some(Calcit::Method(_, calcit::calcit::MethodKind::Invoke(_))) => (
+      "dynamic",
+      "typed-method-dispatch",
+      "The receiver type is known, but this method remains on the explicit dispatch path because no stable direct callable was selected.",
+    ),
+    Some(_) if source_method.is_some() && source_head != lowered_head => (
+      "specialized",
+      "static-method-call",
+      "The typed method was resolved during preprocessing and lowered to a direct callable.",
+    ),
+    Some(_) if source_head != lowered_head => (
+      "resolved",
+      "static-call-resolution",
+      "Preprocessing resolved the callable head, but no type-directed specialization was identified.",
+    ),
+    Some(_) => (
+      "unchanged",
+      "core-expression",
+      "The expression already uses its final callable shape; no additional type-directed lowering was needed.",
+    ),
+    None if source_method.is_some() => (
+      "specialized",
+      "static-method-call",
+      "The typed method was resolved and folded into a non-call expression during preprocessing.",
+    ),
+    None => (
+      "resolved",
+      "preprocessed-value",
+      "Preprocessing produced a value rather than a callable expression.",
+    ),
+  };
+
+  TypeAtLowering {
+    status,
+    kind,
+    source_head: source_method.or(source_head),
+    lowered_head,
+    detail: detail.to_owned(),
+  }
+}
+
 fn collect_type_at_bindings(node: &Calcit, values: &mut BTreeMap<String, (Arc<CalcitTypeAnnotation>, Option<String>)>) {
   match node {
     Calcit::Local(local) => {
@@ -1759,6 +1973,11 @@ fn render_type_at_human(envelope: &SemanticQueryEnvelope<TypeAtData>) -> String 
   if let Some(intent) = data.dynamic_intent {
     let _ = writeln!(&mut out, "Dynamic intent: {intent}");
   }
+  let _ = writeln!(&mut out, "Lowering: {} ({})", data.lowering.status, data.lowering.kind);
+  let source_head = data.lowering.source_head.as_deref().unwrap_or("value");
+  let lowered_head = data.lowering.lowered_head.as_deref().unwrap_or("value");
+  let _ = writeln!(&mut out, "  {source_head} -> {lowered_head}");
+  let _ = writeln!(&mut out, "  {}", data.lowering.detail);
   let _ = writeln!(&mut out, "Evidence:");
   for evidence in &data.evidence {
     let _ = writeln!(&mut out, "  - {}: {}", evidence.kind, evidence.detail);
@@ -1933,6 +2152,7 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
   }
   let bindings = format_type_at_bindings(processed_root, processed_target)?;
   let confidence = type_at_confidence(inferred.as_deref());
+  let lowering = type_at_lowering(&source_target, processed_target);
   let data = TypeAtData {
     id: format!("{namespace}/{definition}"),
     path: semantic_path.clone(),
@@ -1947,6 +2167,7 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
     bindings,
     bindings_complete: false,
     static_methods: methods,
+    lowering,
   };
   let mut next = vec![format!("calcit tree show '{namespace}/{definition}' --path '{semantic_path}'")];
   if confidence != "exact" {
@@ -1956,7 +2177,7 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
     ));
   }
   let envelope = SemanticQueryEnvelope {
-    schema_version: 1,
+    schema_version: TYPE_AT_SCHEMA_VERSION,
     command: "query.type-at",
     revision,
     data,

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -1273,6 +1273,16 @@ mod type_query_tests {
   }
 
   #[test]
+  fn type_at_lowering_recognizes_postfix_method_heads() {
+    let source = parse_query_test_expression("value .show");
+    let lowering = type_at_lowering(&source, Some(&source));
+    assert_eq!(lowering.status, "dynamic");
+    assert_eq!(lowering.kind, "dynamic-method-dispatch");
+    assert_eq!(lowering.source_head.as_deref(), Some(".show"));
+    assert_eq!(lowering.lowered_head.as_deref(), Some(".show"));
+  }
+
+  #[test]
   fn definition_return_schema_does_not_leak_into_nested_functions() {
     let mut nodes = cirru_parser::parse("fn ()\n  fn () 1").expect("test function should parse");
     let mut entry = snapshot::CodeEntry::from_code(nodes.remove(0));
@@ -1689,7 +1699,11 @@ fn type_at_evidence(node: &Calcit, path: &str, used_preprocessed: bool) -> TypeA
 
 fn type_at_call_head(node: &Calcit) -> Option<&Calcit> {
   match node {
-    Calcit::List(items) => items.first(),
+    Calcit::List(items) => match (items.first(), items.get(1)) {
+      (Some(head @ Calcit::Method(..)), _) => Some(head),
+      (_, Some(head @ Calcit::Method(..))) => Some(head),
+      (head, _) => head,
+    },
     _ => None,
   }
 }


### PR DESCRIPTION
Refs #579
Refs #580

## Summary
- add a versioned `data.lowering` object to `query type-at`
- distinguish type-selected Struct/Enum/collection/method lowering from ordinary static resolution and remaining dynamic dispatch
- render source head -> lowered primitive in human output so migration tools and application authors can verify the execution path

## Architecture
This makes the source surface -> typed preprocess lowering -> runtime primitive boundary observable without running the application. The report treats known type information as insufficient by itself: a method that still needs dispatch is reported as `dynamic`, while `specialized` is reserved for a direct type-selected operation.

## Validation
- `cargo fmt --check`
- `cargo test --bin calcit` (280 passed)
- `cargo clippy --bin calcit -- -D warnings`
- real Snapshot query reports `:x -> &struct:nth` for `test-struct.main/sum-point`

`cargo clippy --all-targets --all-features -- -D warnings` is currently blocked by an existing test-only warning at `src/calcit/type_annotation.rs:4649` (`get(...).is_none()`); production binary Clippy is clean.