### PR TITLE
feat: strict 模式拒绝未绑定 type slot

### DIFF
--- a/RFCs/04-13-type-slot-mechanism-rfc.md
+++ b/RFCs/04-13-type-slot-mechanism-rfc.md
@@ -365,15 +365,18 @@ compiled definition 记录环境 ID。遇到不同环境时：
 
 这避免在尚未设计稳定符号命名和共享策略前，暗中生成多份 specialized JS definitions。
 
-### 8.6 未绑定行为（当前保持兼容）
+### 8.6 未绑定行为（strict 已拒绝）
 
 当前未绑定 slot 静默退化为 `:dynamic`，很容易让用户误以为检查已经生效。
 
-当前未绑定 slot 仍退化为 `:dynamic`；配置也允许显式写 `:dynamic`。是否升级诊断继续保留以下建议规则：
+普通兼容模式下，未绑定 slot 仍退化为 `:dynamic` 并进入
+`unresolved-type-slot` inventory；配置也允许显式写 `:dynamic`。strict
+preprocessing 已实现以下规则：
 
 - 可达 schema 引用了已声明 slot，但 entry 未绑定：默认 hard error；
 - 应用确实希望关闭检查时，在 entry 中显式绑定为 `:dynamic`，让意图可见；
-- 迁移期可先发结构化 warning，再在下一个 breaking release 升级为 error。
+- 非 strict 迁移期继续使用结构化 warning/inventory；breaking release 翻转由
+  #582 跟踪。
 
 示例诊断：
 

--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -16,6 +16,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-record-call-arg-type-mismatch.cirru --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-bind-unknown.cirru --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-bind-duplicate.cirru --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/type-slot-unbound-strict.cirru --strict-types --check-only`
 
 其中：
 
@@ -26,6 +27,7 @@
 - `type-slot-record-call-arg-type-mismatch.cirru` 会验证 `bind-type` 绑定 struct 实例后，`*slot` 参与调用点类型检查。
 - `type-slot-bind-unknown.cirru` 会验证未声明 slot 的 `bind-type` 会直接失败。
 - `type-slot-bind-duplicate.cirru` 会验证同一个 slot 重复绑定会直接失败。
+- `type-slot-unbound-strict.cirru` 会验证 strict 模式拒绝可达定义中的未绑定 slot，并报告稳定的 `E_UNBOUND_TYPE_SLOT`。
 
 ## 自动化测试
 
@@ -34,6 +36,7 @@
 - schema mismatch fixtures：断言最终错误文本包含 `E_SCHEMA_DEF_MISMATCH`
 - call-site arg mismatch fixtures：断言产生 `W_FN_ARG_TYPE_MISMATCH` / `W_GENERIC_WHERE_BOUND_MISMATCH`
 - type-slot hard-fail fixtures：断言错误文本包含具体 slot 绑定失败原因
+- strict type-slot fixture：断言错误文本包含 `E_UNBOUND_TYPE_SLOT`、slot 名称与 schema 路径
 
 相关测试位于 [src/bin/calcit.rs](src/bin/calcit.rs)。
 
@@ -46,6 +49,7 @@
 ## 当前相关 code
 
 - `E_SCHEMA_DEF_MISMATCH`：定义与 `:schema` 的 `:kind` / `:args` / `:rest` 不匹配
+- `E_UNBOUND_TYPE_SLOT`：strict 模式下可达定义的 schema 引用了未配置或未局部绑定的 type slot
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配
 - `W_METHOD_ARG_TYPE_MISMATCH`：静态方法调用参数类型不匹配
 - `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`：Option/Result method 的接收者仍为 Dynamic，需先收窄或在明确边界使用函数形式
@@ -53,4 +57,4 @@
 - `W_CORE_FN_ARG_TYPE_MISMATCH`：`calcit.core` 函数参数类型不匹配
 - `W_FN_RETURN_TYPE_MISMATCH`：函数声明返回类型与函数体实际返回类型不匹配
 - `W_GENERIC_WHERE_BOUND_MISMATCH`：泛型绑定后的实际类型不满足 `:where` trait 约束
-- type-slot fixture 额外覆盖：struct 绑定、未知 slot 绑定、重复绑定、跨程序加载的 slot 状态清理
+- type-slot fixture 额外覆盖：struct 绑定、未知 slot 绑定、重复绑定、strict 未绑定拒绝、跨程序加载的 slot 状态清理

--- a/calcit/type-fail/type-slot-unbound-strict.cirru
+++ b/calcit/type-fail/type-slot-unbound-strict.cirru
@@ -1,0 +1,33 @@
+
+{} (:about "|Strict preprocessing fixture for a reachable unbound type slot.") (:package |type-fail-type-slot-unbound-strict) (:version |0.0.0)
+  :entries $ {}
+    :default $ {} (:description |) (:init-fn 'type-fail-type-slot-unbound-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-type-slot-unbound-strict.main/reload!)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    |type-fail-type-slot-unbound-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        |accept-payload $ %{} 'CodeEntry (:doc "|Reachable definition whose payload slot must be bound by the selected entry.")
+          :code $ quote
+            defn accept-payload (payload) payload
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return '*payload)
+              :args $ [] '*payload
+        |main! $ %{} 'CodeEntry (:doc "|Entry that makes accept-payload reachable.")
+          :code $ quote
+            defn main! ()
+              accept-payload 1
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote
+            defn reload! () &unit
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict unbound type-slot fixture.")
+        :code $ quote (ns type-fail-type-slot-unbound-strict.main)

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -790,7 +790,10 @@ Entries do not inherit `entries.default.type-slots`. Bind every slot needed by e
 ### Constraints
 
 - Configuration values must be `:dynamic` or a full `namespace/definition` path that exists after modules are loaded.
-- An unbound slot currently falls back to `:dynamic`; bind it explicitly when static checking is expected.
+- In compatibility mode an unbound slot falls back to `:dynamic` and remains an
+  `unresolved-type-slot` finding. Strict preprocessing rejects a slot used by a
+  reachable function or macro with `E_UNBOUND_TYPE_SLOT`, including its precise
+  schema path.
 - `:dynamic` is an explicit opt-out for an entry that intentionally disables the slot check.
 - The slot name is currently project-wide within one compilation. Libraries should choose stable, specific names to avoid accidental collisions.
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -166,6 +166,14 @@ example, migrate `List` to `(:: List T)` with `:generics ([] T)`; an intentional
 open boundary is written `(:: List Dynamic)` so analysis can distinguish it
 from accidental omission.
 
+`E_UNBOUND_TYPE_SLOT` rejects a reachable function or macro contract that uses
+`*slot` without a binding in the selected entry. Bind a concrete nominal type
+with `calcit config set-type-slot :slot namespace/Definition`. When the entry
+deliberately opts out of static checking at that boundary, bind `:dynamic`
+explicitly; it remains visible to `analyze weak-types` and quality baselines but
+is no longer confused with an omitted configuration. Compatibility mode keeps
+the existing warning/inventory behavior while projects migrate.
+
 `--strict-types` also rejects hand-written runtime Struct index operations such
 as `&struct:nth` without matching nominal type evidence. Use `(:field value)` with a concrete nominal Struct; generic
 helpers need a typed trait/accessor or a deliberately open Map boundary.

--- a/editing-history/202609032215-reject-unbound-type-slots.md
+++ b/editing-history/202609032215-reject-unbound-type-slots.md
@@ -1,0 +1,13 @@
+# Reject reachable unbound type slots in strict mode
+
+- Added `E_UNBOUND_TYPE_SLOT` during strict preprocessing of reachable function
+  and macro definitions.
+- Reused one recursive schema walker for bare-container and type-slot checks so
+  nested argument, return, rest, macro, and nominal type-argument paths remain
+  consistent.
+- Kept compatibility mode unchanged: unresolved slots still participate in
+  `analyze weak-types` and quality baselines.
+- Preserved entry-level `:dynamic` as an explicit, inventoried opt-out rather
+  than treating it as a missing binding.
+- Added regression coverage for nested schema paths, source location, migration
+  guidance, compatibility mode, and explicit Dynamic binding.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -9,6 +9,24 @@ fn lock_fixture_tests() -> std::sync::MutexGuard<'static, ()> {
   super::GLOBAL_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
 }
 
+struct StrictTypesReset {
+  previous: bool,
+}
+
+impl StrictTypesReset {
+  fn enabled() -> Self {
+    let previous = runner::preprocess::is_strict_types_enabled();
+    runner::preprocess::set_strict_types(true);
+    Self { previous }
+  }
+}
+
+impl Drop for StrictTypesReset {
+  fn drop(&mut self) {
+    runner::preprocess::set_strict_types(self.previous);
+  }
+}
+
 /// Run a test body in a dedicated thread with a 32 MiB stack.
 /// The suite lock is acquired inside the spawned thread so it is held for the
 /// duration of the run and dropped before the thread exits.
@@ -72,11 +90,13 @@ fn load_snippet_entries(snippet: &str) -> ProgramEntries {
 }
 
 fn prepare_snapshot_entries(mut snapshot: snapshot::Snapshot) -> ProgramEntries {
+  let project_namespaces: HashSet<String> = snapshot.files.keys().cloned().collect();
   let core_snapshot = calcit::load_core_snapshot().expect("load core snapshot");
 
   for (k, v) in core_snapshot.files {
     snapshot.files.insert(k.to_owned(), v.to_owned());
   }
+  runner::preprocess::set_project_namespaces(&project_namespaces);
 
   {
     let mut prgm = program::PROGRAM_CODE_DATA.write().expect("open program data");
@@ -146,6 +166,22 @@ fn type_fail_schema_mismatch_fixtures_report_error_code() {
       );
       assert!(err.contains(expected_msg), "fixture {path} msg was: {err}");
     }
+  });
+}
+
+#[test]
+fn strict_type_fail_reachable_unbound_slot_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let entries = load_fixture_entries("calcit/type-fail/type-slot-unbound-strict.cirru");
+    let _strict = StrictTypesReset::enabled();
+    let err = run_check_only(&entries).expect_err("reachable unbound type slot should fail strict check-only");
+
+    assert!(err.contains("E_UNBOUND_TYPE_SLOT"), "unexpected strict type-slot error: {err}");
+    assert!(err.contains("*payload"), "slot name should be actionable: {err}");
+    assert!(
+      err.contains("schema.args.0"),
+      "schema path should identify the unresolved slot: {err}"
+    );
   });
 }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -7215,6 +7215,13 @@ pub fn preprocess_defn(
         info.at_def.to_owned(),
         location.to_owned().unwrap_or_default(),
       );
+      reject_strict_unbound_type_slot_schema(
+        ctx.file_ns,
+        def_name.as_ref(),
+        &def_schema,
+        ctx.call_stack,
+        Some(definition_location.clone()),
+      )?;
       reject_strict_bare_container_public_schema(
         ctx.file_ns,
         def_name.as_ref(),
@@ -8101,40 +8108,38 @@ fn contains_legacy_optional(annotation: &CalcitTypeAnnotation) -> bool {
   }
 }
 
-fn find_bare_container_schema(annotation: &Arc<CalcitTypeAnnotation>, path: &str) -> Option<(String, &'static str)> {
-  let find_inner = |inner: &Arc<CalcitTypeAnnotation>, inner_path: String, container: &'static str| {
-    if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic) && Arc::ptr_eq(inner, &calcit::DYNAMIC_TYPE) {
-      Some((inner_path, container))
-    } else {
-      find_bare_container_schema(inner, &inner_path)
-    }
-  };
-
+fn find_schema_annotation<T>(
+  annotation: &Arc<CalcitTypeAnnotation>,
+  path: &str,
+  predicate: &mut impl FnMut(&Arc<CalcitTypeAnnotation>, &str) -> Option<T>,
+) -> Option<T> {
+  if let Some(found) = predicate(annotation, path) {
+    return Some(found);
+  }
   match annotation.as_ref() {
-    CalcitTypeAnnotation::List(inner) => find_inner(inner, format!("{path}.item"), "List"),
-    CalcitTypeAnnotation::Set(inner) => find_inner(inner, format!("{path}.item"), "Set"),
-    CalcitTypeAnnotation::Ref(inner) => find_inner(inner, format!("{path}.item"), "Ref"),
-    CalcitTypeAnnotation::Map(key, value) => {
-      find_inner(key, format!("{path}.key"), "Map").or_else(|| find_inner(value, format!("{path}.value"), "Map"))
+    CalcitTypeAnnotation::List(inner) | CalcitTypeAnnotation::Set(inner) | CalcitTypeAnnotation::Ref(inner) => {
+      find_schema_annotation(inner, &format!("{path}.item"), predicate)
     }
     CalcitTypeAnnotation::Variadic(inner) | CalcitTypeAnnotation::Optional(inner) | CalcitTypeAnnotation::JsNullish(inner) => {
-      find_bare_container_schema(inner, path)
+      find_schema_annotation(inner, path, predicate)
     }
+    CalcitTypeAnnotation::Map(key, value) => find_schema_annotation(key, &format!("{path}.key"), predicate)
+      .or_else(|| find_schema_annotation(value, &format!("{path}.value"), predicate)),
     CalcitTypeAnnotation::Fn(info) => info
       .arg_types
       .iter()
       .enumerate()
-      .find_map(|(idx, item)| find_bare_container_schema(item, &format!("{path}.args.{idx}")))
+      .find_map(|(idx, item)| find_schema_annotation(item, &format!("{path}.args.{idx}"), predicate))
       .or_else(|| {
         info
           .rest_type
           .as_ref()
-          .and_then(|item| find_bare_container_schema(item, &format!("{path}.rest")))
+          .and_then(|item| find_schema_annotation(item, &format!("{path}.rest"), predicate))
       })
-      .or_else(|| find_bare_container_schema(&info.return_type, &format!("{path}.return"))),
+      .or_else(|| find_schema_annotation(&info.return_type, &format!("{path}.return"), predicate)),
     CalcitTypeAnnotation::Macro(signature) => {
-      let find_contract = |contract: &MacroSyntaxType, contract_path: String| match contract {
-        MacroSyntaxType::Expr(semantic) => find_bare_container_schema(semantic, &contract_path),
+      let mut find_contract = |contract: &MacroSyntaxType, contract_path: String| match contract {
+        MacroSyntaxType::Expr(semantic) => find_schema_annotation(semantic, &contract_path, predicate),
         MacroSyntaxType::Syntax | MacroSyntaxType::SyntaxSymbol | MacroSyntaxType::SyntaxList => None,
       };
       signature
@@ -8157,21 +8162,85 @@ fn find_bare_container_schema(annotation: &Arc<CalcitTypeAnnotation>, path: &str
         })
         .or_else(|| match &signature.expansion {
           MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => {
-            find_bare_container_schema(semantic, &format!("{path}.expansion"))
+            find_schema_annotation(semantic, &format!("{path}.expansion"), predicate)
           }
           MacroExpansionType::Dynamic | MacroExpansionType::Declarations => None,
         })
     }
     CalcitTypeAnnotation::Syntax(contract) => match contract.as_ref() {
-      MacroSyntaxType::Expr(semantic) => find_bare_container_schema(semantic, path),
+      MacroSyntaxType::Expr(semantic) => find_schema_annotation(semantic, &format!("{path}.expr"), predicate),
       MacroSyntaxType::Syntax | MacroSyntaxType::SyntaxSymbol | MacroSyntaxType::SyntaxList => None,
     },
     CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => args
       .iter()
       .enumerate()
-      .find_map(|(idx, item)| find_bare_container_schema(item, &format!("{path}.type-arg.{idx}"))),
+      .find_map(|(idx, item)| find_schema_annotation(item, &format!("{path}.type-arg.{idx}"), predicate)),
     _ => None,
   }
+}
+
+fn find_bare_container_schema(annotation: &Arc<CalcitTypeAnnotation>, path: &str) -> Option<(String, &'static str)> {
+  find_schema_annotation(annotation, path, &mut |candidate, candidate_path| match candidate.as_ref() {
+    CalcitTypeAnnotation::List(inner)
+      if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic) && Arc::ptr_eq(inner, &calcit::DYNAMIC_TYPE) =>
+    {
+      Some((format!("{candidate_path}.item"), "List"))
+    }
+    CalcitTypeAnnotation::Set(inner)
+      if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic) && Arc::ptr_eq(inner, &calcit::DYNAMIC_TYPE) =>
+    {
+      Some((format!("{candidate_path}.item"), "Set"))
+    }
+    CalcitTypeAnnotation::Ref(inner)
+      if matches!(inner.as_ref(), CalcitTypeAnnotation::Dynamic) && Arc::ptr_eq(inner, &calcit::DYNAMIC_TYPE) =>
+    {
+      Some((format!("{candidate_path}.item"), "Ref"))
+    }
+    CalcitTypeAnnotation::Map(key, _)
+      if matches!(key.as_ref(), CalcitTypeAnnotation::Dynamic) && Arc::ptr_eq(key, &calcit::DYNAMIC_TYPE) =>
+    {
+      Some((format!("{candidate_path}.key"), "Map"))
+    }
+    CalcitTypeAnnotation::Map(_, value)
+      if matches!(value.as_ref(), CalcitTypeAnnotation::Dynamic) && Arc::ptr_eq(value, &calcit::DYNAMIC_TYPE) =>
+    {
+      Some((format!("{candidate_path}.value"), "Map"))
+    }
+    _ => None,
+  })
+}
+
+fn find_unbound_type_slot_schema(annotation: &Arc<CalcitTypeAnnotation>, path: &str) -> Option<(String, Arc<str>)> {
+  find_schema_annotation(annotation, path, &mut |candidate, candidate_path| match candidate.as_ref() {
+    CalcitTypeAnnotation::TypeSlot(name) if calcit::resolve_type_slot(name).is_none() => {
+      Some((candidate_path.to_owned(), name.clone()))
+    }
+    _ => None,
+  })
+}
+
+fn reject_strict_unbound_type_slot_schema(
+  ns: &str,
+  def_name: &str,
+  schema: &Arc<CalcitTypeAnnotation>,
+  call_stack: &CallStackList,
+  definition_location: Option<NodeLocation>,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled() || !should_emit_project_source_lint(ns) {
+    return Ok(());
+  }
+  let Some((path, slot)) = find_unbound_type_slot_schema(schema, "schema") else {
+    return Ok(());
+  };
+  Err(CalcitErr::use_msg_stack_location_with_code(
+    CalcitErrKind::Type,
+    format!(
+      "{ns}/{def_name} uses unbound type slot `*{slot}` at {path}; bind it for the selected entry with `calcit config set-type-slot :{slot} namespace/definition`, or explicitly select `:dynamic` only for a reviewed open boundary"
+    ),
+    "E_UNBOUND_TYPE_SLOT",
+    call_stack,
+    find_preferred_macro_location(call_stack).or(definition_location),
+  ))
 }
 
 fn reject_strict_bare_container_public_schema(
@@ -9606,6 +9675,21 @@ mod tests {
   impl Drop for StrictTypesGuard {
     fn drop(&mut self) {
       set_strict_types(self.prev);
+    }
+  }
+
+  struct TypeSlotsGuard;
+
+  impl TypeSlotsGuard {
+    fn cleared() -> Self {
+      calcit::clear_type_slots();
+      Self
+    }
+  }
+
+  impl Drop for TypeSlotsGuard {
+    fn drop(&mut self) {
+      calcit::clear_type_slots();
     }
   }
 
@@ -14461,6 +14545,53 @@ mod tests {
     let _strict = StrictTypesGuard::new(true);
     reject_strict_bare_container_public_schema("tests.schema", "open-values", &schema, &CallStackList::default(), None)
       .expect("an explicitly written List<Dynamic> remains an auditable open boundary");
+  }
+
+  #[test]
+  fn strict_types_reject_reachable_unbound_type_slots_and_allow_explicit_entry_opt_out() {
+    let _state = lock_preprocess_test_state();
+    let _slots = TypeSlotsGuard::cleared();
+    let schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![Arc::new(CalcitTypeAnnotation::Map(
+        Arc::new(CalcitTypeAnnotation::Tag),
+        Arc::new(CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::TypeSlot(Arc::from(
+          "payload",
+        ))))),
+      ))],
+      return_type: Arc::new(CalcitTypeAnnotation::Unit),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    let location = NodeLocation::new("tests.schema".into(), "dispatch".into(), Arc::new(vec![4]));
+
+    {
+      let _compat = StrictTypesGuard::new(false);
+      reject_strict_unbound_type_slot_schema(
+        "tests.schema",
+        "dispatch",
+        &schema,
+        &CallStackList::default(),
+        Some(location.clone()),
+      )
+      .expect("compatibility mode should retain the existing unresolved-slot analysis path");
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    let error = reject_strict_unbound_type_slot_schema("tests.schema", "dispatch", &schema, &CallStackList::default(), Some(location))
+      .expect_err("strict mode should reject an unbound slot in a reachable definition");
+    assert_eq!(error.code.as_deref(), Some("E_UNBOUND_TYPE_SLOT"));
+    assert!(error.msg.contains("*payload"));
+    assert!(error.msg.contains("schema.args.0.value.item"));
+    assert!(error.msg.contains("calcit config set-type-slot :payload namespace/definition"));
+    assert!(error.location.is_some());
+
+    calcit::configure_entry_type_slots(&HashMap::from([("payload".to_owned(), ":dynamic".to_owned())]))
+      .expect("explicit Dynamic type-slot opt-out should be accepted");
+    reject_strict_unbound_type_slot_schema("tests.schema", "dispatch", &schema, &CallStackList::default(), None)
+      .expect("an explicit entry-level Dynamic binding remains visible to quality inventory without an unbound-slot error");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- add stable `E_UNBOUND_TYPE_SLOT` for reachable project definitions under `--strict-types`
- report the exact nested schema path and an actionable `config set-type-slot` command
- preserve compatibility mode and explicit `:dynamic` as an inventoried migration escape hatch
- add unit and CLI fixture coverage, and update the RFC and user docs

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`
- direct strict fixture confirms nonzero exit with `E_UNBOUND_TYPE_SLOT`

Refs #579