### PR TITLE
docs: align type-slot diagnostic examples

### DIFF
--- a/RFCs/04-13-type-slot-mechanism-rfc.md
+++ b/RFCs/04-13-type-slot-mechanism-rfc.md
@@ -381,9 +381,10 @@ preprocessing 已实现以下规则：
 示例诊断：
 
 ```text
-E_UNBOUND_TYPE_SLOT: `respo.schema/dispatch-op` is required by
-respo.schema/EventHandler but is not bound for entry `app.main/main!`.
-Bind it in :type-slots or explicitly select :dynamic.
+[E_UNBOUND_TYPE_SLOT] respo.schema/EventHandler uses unbound type slot
+`*dispatch-op` at schema.args.0; bind it for the selected entry with
+`calcit config set-type-slot :dispatch-op namespace/definition`, or explicitly
+select `:dynamic` only for a reviewed open boundary.
 ```
 
 ### 8.7 阶段 B 的证据门槛

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -168,7 +168,7 @@ from accidental omission.
 
 `E_UNBOUND_TYPE_SLOT` rejects a reachable function or macro contract that uses
 `*slot` without a binding in the selected entry. Bind a concrete nominal type
-with `calcit config set-type-slot :slot namespace/Definition`. When the entry
+with `calcit config set-type-slot :slot namespace/definition`. When the entry
 deliberately opts out of static checking at that boundary, bind `:dynamic`
 explicitly; it remains visible to `analyze weak-types` and quality baselines but
 is no longer confused with an omitted configuration. Compatibility mode keeps

--- a/editing-history/202609032245-align-type-slot-doc-examples.md
+++ b/editing-history/202609032245-align-type-slot-doc-examples.md
@@ -1,0 +1,7 @@
+# Align type-slot diagnostic documentation
+
+- Updated the type-slot RFC example to match the implemented
+  `E_UNBOUND_TYPE_SLOT` diagnostic, including the schema path and concrete
+  `set-type-slot` migration command.
+- Normalized the CLI placeholder to `namespace/definition` to match the
+  surrounding documentation.


### PR DESCRIPTION
## Summary

Follow up on review comments from #608.

- update the RFC `E_UNBOUND_TYPE_SLOT` example to show the implemented diagnostic code, nested schema path, and `set-type-slot` remediation
- normalize the CLI placeholder to `namespace/definition`

## Validation

- `git diff --check`

Refs #608