### PR TITLE
feat: 拒绝 Dynamic 擦除泛型关系 / reject generic relations erased by Dynamic

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -19,6 +19,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-unbound-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/whole-dynamic-schema-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-nominal-method-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
 其中：
 
@@ -32,6 +33,7 @@
 - `type-slot-unbound-strict.cirru` 会验证 strict 模式拒绝可达定义中的未绑定 slot，并报告稳定的 `E_UNBOUND_TYPE_SLOT`。
 - `whole-dynamic-schema-strict.cirru` 会验证 strict 模式拒绝可达定义的 whole-Dynamic function contract，并报告稳定的 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`。
 - `dynamic-nominal-method-strict.cirru` 会验证 strict 模式拒绝 Dynamic receiver 上的 Option/Result nominal method dispatch，并报告稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
+- `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
 
 ## 自动化测试
 
@@ -43,6 +45,7 @@
 - strict type-slot fixture：断言错误文本包含 `E_UNBOUND_TYPE_SLOT`、slot 名称与 schema 路径
 - strict whole-Dynamic fixture：断言错误文本包含 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`、schema 根路径与 `Fn` 迁移建议
 - strict Dynamic nominal-method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver schema 与低层 helper 迁移建议
+- strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
 相关测试位于 [src/bin/calcit.rs](src/bin/calcit.rs)。
 
@@ -58,6 +61,7 @@
 - `E_UNBOUND_TYPE_SLOT`：strict 模式下可达定义的 schema 引用了未配置或未局部绑定的 type slot
 - `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`：strict 模式下可达 function/macro 既没有结构化根 schema，也没有嵌入式结构化契约
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 Dynamic receiver 使用需要静态 Option/Result nominal evidence 的 method
+- `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配
 - `W_METHOD_ARG_TYPE_MISMATCH`：静态方法调用参数类型不匹配
 - `W_DYNAMIC_NOMINAL_METHOD_RECEIVER`：Option/Result method 的接收者仍为 Dynamic，需先收窄或在明确边界使用函数形式

--- a/calcit/type-fail/erased-generic-relation-strict.cirru
+++ b/calcit/type-fail/erased-generic-relation-strict.cirru
@@ -1,12 +1,12 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-whole-dynamic-schema-strict)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-erased-generic-relation-strict)
   :entries $ {}
-    :default $ {} (:description "|Strict preprocessing fixture for a generic relation erased by Dynamic.") (:init-fn 'type-fail-whole-dynamic-schema-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-whole-dynamic-schema-strict.main/reload!)
+    :default $ {} (:description "|Strict preprocessing fixture for a generic relation erased by Dynamic.") (:init-fn 'type-fail-erased-generic-relation-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-erased-generic-relation-strict.main/reload!)
       :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    'type-fail-whole-dynamic-schema-strict.main $ %{} 'FileEntry
+    'type-fail-erased-generic-relation-strict.main $ %{} 'FileEntry
       :defs $ {}
         'compare-open $ %{} 'CodeEntry (:doc "|Dynamic input must be narrowed before entering the homogeneous generic equality relation.")
           :code $ quote
@@ -30,4 +30,4 @@
             {} (:return 'Unit)
               :args $ []
       :ns $ %{} 'NsEntry (:doc "|Strict erased-generic-relation fixture.")
-        :code $ quote (ns type-fail-whole-dynamic-schema-strict.main)
+        :code $ quote (ns type-fail-erased-generic-relation-strict.main)

--- a/calcit/type-fail/erased-generic-relation-strict.cirru
+++ b/calcit/type-fail/erased-generic-relation-strict.cirru
@@ -1,0 +1,33 @@
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-whole-dynamic-schema-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for a generic relation erased by Dynamic.") (:init-fn 'type-fail-whole-dynamic-schema-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-whole-dynamic-schema-strict.main/reload!)
+      :feature-policy $ {}
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-whole-dynamic-schema-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'compare-open $ %{} 'CodeEntry (:doc "|Dynamic input must be narrowed before entering the homogeneous generic equality relation.")
+          :code $ quote
+            defn compare-open (value) (= value 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'Dynamic
+        'main! $ %{} 'CodeEntry (:doc "|Entry that makes the erased generic relation reachable.")
+          :code $ quote
+            defn main! () $ compare-open 1
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ []
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote
+            defn reload! () &unit
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict erased-generic-relation fixture.")
+        :code $ quote (ns type-fail-whole-dynamic-schema-strict.main)

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -112,6 +112,16 @@ calcit query type-at app.main/calculate-total --path code@3.2 --format json
 
 `check-types` treats nested dynamic slots such as bare `:ref`, `:list`, or `:map` as partial coverage and includes actionable `[W_SCHEMA_DYNAMIC]` entries in `schema_issues`. An unbound `*type-slot` is also partial and emits `[W_UNRESOLVED_TYPE_SLOT]`; bind it in the selected entry or explicitly choose `:dynamic` for a documented boundary. When partial/none definitions exist, human output adds an `agent-note` and JSON emits `W_TYPE_COVERAGE_GAPS`. Strict preprocessing reports `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA` when a reachable project function has neither a structured root schema nor an embedded structured `Fn` hint; replace a missing or whole-Dynamic root with a structured `Fn` contract and keep any reviewed `Dynamic` at an exact nested position. Existing embedded hints remain valid contract evidence during Snapshot migration. Macro contracts are stricter at Snapshot load time: an old runtime `Fn` or whole-`Dynamic` macro schema is rejected with its definition path before static analysis starts. Migrate it with the final compatible Calcit 0.13.51 release, then declare `Macro` fields explicitly; the analyzer never guesses `Syntax`, `Expr<T>`, or expansion contracts. Use `--deps`: release audits must inspect resolved module artifacts, not only each dependency's current source branch. `weak-types --format json` reports the exact Snapshot/schema path plus an `impact` and `suggestion` for every occurrence; unresolved dynamic debt emits `W_DYNAMIC_TYPE_DEBT`, unbound slots emit `W_UNRESOLVED_TYPE_SLOT`, while unresolved or compatibility-Optional nil debt emits `W_NIL_TYPE_DEBT`. Definitions marked with the explicit `:js-ffi` feature remain classified as intentional boundaries rather than ordinary unresolved dynamic debt.
 
+Strict call preprocessing also reports `E_ERASED_GENERIC_RELATION` when an
+argument still contains `Dynamic` at a position tied to another occurrence of
+a declared generic. This includes input/output relations such as
+`Fn<T>(T) -> T`, homogeneous variadic calls, and nested container or callback
+positions. A standalone reviewed `Dynamic` position is not rejected merely
+because the same contract declares an unrelated generic. Narrow or validate
+the argument before the relational call, or isolate genuinely open behavior in
+an adapter whose contract does not claim that relationship. Compatibility mode
+keeps accepting the call while projects migrate.
+
 For a strict-only release check, load every resolved dependency with `--deps`; loader acceptance proves that no legacy macro schema remains:
 
 ```bash
@@ -397,6 +407,12 @@ If the body only needs a capability, add a trait bound rather than replacing `'T
 ```
 
 The same rule applies inside containers and callbacks: `:: :list 'T` preserves a homogeneous item relationship, while bare `:list` means `list<dynamic>`; a complete `:: :fn` callback schema preserves argument/return checking, while bare `:fn` does not.
+
+With `--strict-types`, the relationship must also survive each call site. A
+`Dynamic` value cannot be passed directly into one of these related generic
+positions, because accepting it would make the declared relationship
+uncheckable. First decode, validate, pattern-match, or otherwise narrow the
+value to a concrete or nominal type.
 
 #### Struct and Enum Types
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -190,6 +190,15 @@ only in the specific argument, return, or `Expr<Dynamic>` position so `analyze
 weak-types` can report and baseline that exact decision. Compatibility mode
 continues to inventory these definitions while the schema is migrated.
 
+`E_ERASED_GENERIC_RELATION` rejects a project call when a `Dynamic` argument
+occupies a declared generic position that is related to another argument,
+variadic item, nested type, or return position. For example, passing `Dynamic`
+to `Fn<T>(T) -> T` prevents strict preprocessing from proving the promised
+input/output relationship. Narrow or validate the value before the call. If
+the callee is intentionally open, put that operation behind a small adapter
+whose structured contract does not claim the generic relationship. Outside
+`--strict-types`, the existing compatibility behavior is unchanged.
+
 `--strict-types` also rejects hand-written runtime Struct index operations such
 as `&struct:nth` without matching nominal type evidence. Use `(:field value)` with a concrete nominal Struct; generic
 helpers need a typed trait/accessor or a deliberately open Map boundary.

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -532,6 +532,12 @@ strict mode 还会以 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA` 拒绝既没有结构化�
 中已有的嵌入式 `Fn` hint 仍可作为契约证据。若参数、返回值或宏表达式确实开放，只在对应位置写
 `Dynamic` / `Expr<Dynamic>`，不要用根 `Dynamic` 擦除整个契约。
 
+当 `Dynamic` 实参进入重复出现的泛型位置时，strict mode 会进一步报告
+`E_ERASED_GENERIC_RELATION`。例如 `Fn<T>(T) -> T`、同类型比较或参数化容器转换都依赖调用点保留
+`T` 的关系；把未知值直接传入会让返回值或其他参数无法再被静态关联。应先 narrow/validate 成具体
+类型，再调用泛型 API。确实开放的操作应收拢到一个小型 adapter，并让 adapter 的结构化契约明确
+不承诺该泛型关系。非 strict 模式保持原有兼容行为，便于渐进迁移。
+
 再对每个 entry 运行独立的动态方法报告；已有项目可以先记录非零上限，再逐步降低：
 
 ```bash

--- a/editing-history/202609040101-reject-erased-generic-relations.md
+++ b/editing-history/202609040101-reject-erased-generic-relations.md
@@ -1,0 +1,15 @@
+# Reject generic relations erased by Dynamic
+
+- Added strict `E_ERASED_GENERIC_RELATION` call-site validation for declared
+  type variables that relate multiple argument, nested, variadic, or return
+  positions.
+- Match expected and actual schemas structurally: `List<T>` against
+  `List<Dynamic>` loses the item relationship, while binding an entire `T` to
+  `List<Dynamic>` still preserves `T -> T` and must not be rejected.
+- Kept compatibility mode and dependency source unchanged. A genuinely open
+  operation belongs behind a structured adapter that does not claim the erased
+  generic relation.
+- Covered user/imported and local function calls with unit tests and a real
+  Snapshot CLI fixture. Verified with `cargo clippy -- -D warnings`,
+  `cargo test`, `yarn compile`, `yarn check-agent-interface`, `yarn check-all`,
+  and a globally installed `calcit` check against Respo.

--- a/editing-history/202609040110-align-erased-generic-fixture-identity.md
+++ b/editing-history/202609040110-align-erased-generic-fixture-identity.md
@@ -1,0 +1,10 @@
+# Align erased-generic fixture identity
+
+- Renamed the strict fixture package, namespace, and entry references to match
+  `erased-generic-relation-strict.cirru` so diagnostic stacks and preprocessing
+  cache keys cannot collide with the whole-Dynamic fixture.
+- Ran `calcit edit format` to validate canonical Snapshot structure and reran
+  the focused CLI regression test.
+- Kept the original `202609040101` editing-history timestamp: repository
+  timestamps use the configured Asia/Shanghai local time, and the associated
+  commit was created at `2026-09-04T01:03:08+08:00`.

--- a/editing-history/202609040118-preserve-type-slot-struct-arguments.md
+++ b/editing-history/202609040118-preserve-type-slot-struct-arguments.md
@@ -1,0 +1,11 @@
+# Preserve generic Struct arguments across type-slot bindings
+
+- Reused one Struct-value annotation helper from ordinary static inference and
+  `with-type-slot`, preventing generic Struct instances from degrading to an
+  argument-free `StructValue` annotation.
+- Added a regression showing that a `Struct<T>` contract still detects a
+  nested Dynamic applied argument after the type-slot conversion path.
+- Strengthened the CLI fixture assertions for both rendered actual and expected
+  type fragments in `E_ERASED_GENERIC_RELATION`.
+- Verified the review fix with Clippy, focused tests, full `cargo test`, and
+  `yarn check-all`.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -242,6 +242,8 @@ fn strict_type_fail_erased_generic_relation_reports_stable_error_code() {
     );
     assert!(err.contains("call to `calcit.core/=`"), "callee should be explicit: {err}");
     assert!(err.contains("argument 1"), "erased argument should be identified: {err}");
+    assert!(err.contains("passes `dynamic`"), "actual type should be rendered: {err}");
+    assert!(err.contains("required by `'T`"), "expected type should be rendered: {err}");
     assert!(err.contains("generic relation `'T`"), "generic relation should be named: {err}");
     assert!(
       err.contains("narrow or validate the value"),

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -229,6 +229,28 @@ fn strict_type_fail_dynamic_nominal_method_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_erased_generic_relation_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/erased-generic-relation-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let strict_entries = load_fixture_entries(fixture);
+    let err = run_check_only(&strict_entries).expect_err("Dynamic must not erase a generic call relation in strict mode");
+
+    assert!(
+      err.contains("E_ERASED_GENERIC_RELATION"),
+      "unexpected strict generic-relation error: {err}"
+    );
+    assert!(err.contains("call to `calcit.core/=`"), "callee should be explicit: {err}");
+    assert!(err.contains("argument 1"), "erased argument should be identified: {err}");
+    assert!(err.contains("generic relation `'T`"), "generic relation should be named: {err}");
+    assert!(
+      err.contains("narrow or validate the value"),
+      "migration should be actionable: {err}"
+    );
+  });
+}
+
+#[test]
 fn type_fail_call_arg_fixture_reports_warning_code() {
   run_with_large_stack(|| {
     let fixtures = [

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2321,6 +2321,14 @@ fn preprocess_list_call(
           call_location.clone(),
           check_warnings,
         );
+        reject_strict_erased_generic_relation(
+          &head_form,
+          &current_args,
+          effective_user_call_schema(info.as_ref()).as_ref(),
+          scope_types,
+          file_ns,
+          call_stack,
+        )?;
         check_user_fn_arg_types(info.as_ref(), &head_form, &current_args, scope_types, &call_info, check_warnings);
       }
       if has_spread {
@@ -2832,6 +2840,16 @@ fn preprocess_list_call(
           }
           if let Some(Calcit::Local(local)) = ys.first() {
             let updated_args = CalcitList::from(ys.drop_left());
+            let local_type = if matches!(*local.type_info, CalcitTypeAnnotation::Dynamic) {
+              scope_types.get(&local.sym).cloned()
+            } else {
+              Some(local.type_info.clone())
+            };
+            if let Some(local_type) = local_type
+              && let CalcitTypeAnnotation::Fn(signature) = local_type.as_ref()
+            {
+              reject_strict_erased_generic_relation(&head_form, &updated_args, signature, scope_types, file_ns, call_stack)?;
+            }
             check_local_fn_call_arg_types(&head_form, local, &updated_args, scope_types, &call_info, check_warnings);
           }
         }
@@ -8262,6 +8280,250 @@ fn find_unbound_type_slot_schema(annotation: &Arc<CalcitTypeAnnotation>, path: &
     }
     _ => None,
   })
+}
+
+/// Count one named type variable through a schema tree.
+///
+/// A variadic position counts twice because one annotation relates every
+/// runtime rest argument to the same type variable even when it occurs only
+/// once in serialized schema syntax.
+fn count_named_type_var(annotation: &CalcitTypeAnnotation, name: &str) -> usize {
+  match annotation {
+    CalcitTypeAnnotation::TypeVar(current) => usize::from(current.as_ref() == name),
+    CalcitTypeAnnotation::List(inner)
+    | CalcitTypeAnnotation::Set(inner)
+    | CalcitTypeAnnotation::Ref(inner)
+    | CalcitTypeAnnotation::Optional(inner)
+    | CalcitTypeAnnotation::JsNullish(inner) => count_named_type_var(inner, name),
+    CalcitTypeAnnotation::Variadic(inner) => count_named_type_var(inner, name).saturating_mul(2),
+    CalcitTypeAnnotation::Map(key, value) => count_named_type_var(key, name) + count_named_type_var(value, name),
+    CalcitTypeAnnotation::Fn(signature) => {
+      signature
+        .arg_types
+        .iter()
+        .map(|item| count_named_type_var(item, name))
+        .sum::<usize>()
+        + count_named_type_var(&signature.return_type, name)
+        + signature
+          .rest_type
+          .as_ref()
+          .map_or(0, |item| count_named_type_var(&CalcitTypeAnnotation::Variadic(item.clone()), name))
+    }
+    CalcitTypeAnnotation::Macro(signature) => {
+      let count_contract = |contract: &MacroSyntaxType| match contract {
+        MacroSyntaxType::Expr(semantic) => count_named_type_var(semantic, name),
+        MacroSyntaxType::Syntax | MacroSyntaxType::SyntaxSymbol | MacroSyntaxType::SyntaxList => 0,
+      };
+      signature
+        .required_inputs
+        .iter()
+        .chain(signature.optional_inputs.iter())
+        .map(count_contract)
+        .sum::<usize>()
+        + signature.rest_input.as_ref().map_or(0, count_contract)
+        + match &signature.expansion {
+          MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => count_named_type_var(semantic, name),
+          MacroExpansionType::Dynamic | MacroExpansionType::Declarations => 0,
+        }
+    }
+    CalcitTypeAnnotation::Syntax(contract) => match contract.as_ref() {
+      MacroSyntaxType::Expr(semantic) => count_named_type_var(semantic, name),
+      MacroSyntaxType::Syntax | MacroSyntaxType::SyntaxSymbol | MacroSyntaxType::SyntaxList => 0,
+    },
+    CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => {
+      args.iter().map(|item| count_named_type_var(item, name)).sum()
+    }
+    _ => 0,
+  }
+}
+
+fn related_generic_names(signature: &CalcitFnTypeAnnotation) -> Vec<Arc<str>> {
+  signature
+    .generics
+    .iter()
+    .filter(|name| {
+      let fixed = signature
+        .arg_types
+        .iter()
+        .map(|item| count_named_type_var(item, name))
+        .sum::<usize>();
+      let returned = count_named_type_var(&signature.return_type, name);
+      let rest = signature
+        .rest_type
+        .as_ref()
+        .map_or(0, |item| count_named_type_var(&CalcitTypeAnnotation::Variadic(item.clone()), name));
+      fixed + returned + rest >= 2
+    })
+    .cloned()
+    .collect()
+}
+
+/// Whether Dynamic in the actual type occupies the exact structural position
+/// represented by `name` in the expected type. Binding `T` to
+/// `List<Dynamic>` still preserves a `T -> T` relation, while matching
+/// `List<T>` against `List<Dynamic>` erases its item relation.
+fn generic_is_erased_at(expected: &CalcitTypeAnnotation, actual: &CalcitTypeAnnotation, name: &str) -> bool {
+  if matches!(actual, CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn) {
+    return count_named_type_var(expected, name) > 0;
+  }
+  if let CalcitTypeAnnotation::TypeSlot(slot) = actual {
+    return calcit::resolve_type_slot(slot)
+      .as_ref()
+      .is_none_or(|resolved| generic_is_erased_at(expected, resolved, name));
+  }
+
+  match (expected, actual) {
+    // A concrete structured type, even one with an open nested position, can
+    // bind an entire T without losing the outer generic relationship.
+    (CalcitTypeAnnotation::TypeVar(_), _) => false,
+    (CalcitTypeAnnotation::List(expected), CalcitTypeAnnotation::List(actual))
+    | (CalcitTypeAnnotation::Set(expected), CalcitTypeAnnotation::Set(actual))
+    | (CalcitTypeAnnotation::Ref(expected), CalcitTypeAnnotation::Ref(actual))
+    | (CalcitTypeAnnotation::Optional(expected), CalcitTypeAnnotation::Optional(actual))
+    | (CalcitTypeAnnotation::JsNullish(expected), CalcitTypeAnnotation::JsNullish(actual))
+    | (CalcitTypeAnnotation::Variadic(expected), CalcitTypeAnnotation::Variadic(actual)) => {
+      generic_is_erased_at(expected, actual, name)
+    }
+    (CalcitTypeAnnotation::Map(expected_key, expected_value), CalcitTypeAnnotation::Map(actual_key, actual_value)) => {
+      generic_is_erased_at(expected_key, actual_key, name) || generic_is_erased_at(expected_value, actual_value, name)
+    }
+    (CalcitTypeAnnotation::Fn(expected), CalcitTypeAnnotation::Fn(actual)) => {
+      expected
+        .arg_types
+        .iter()
+        .zip(actual.arg_types.iter())
+        .any(|(expected, actual)| generic_is_erased_at(expected, actual, name))
+        || generic_is_erased_at(&expected.return_type, &actual.return_type, name)
+        || expected.rest_type.as_ref().is_some_and(|expected| {
+          actual
+            .rest_type
+            .as_ref()
+            .is_some_and(|actual| generic_is_erased_at(expected, actual, name))
+        })
+    }
+    (CalcitTypeAnnotation::Struct(expected_def, expected_args), CalcitTypeAnnotation::Struct(actual_def, actual_args))
+      if expected_def.name == actual_def.name =>
+    {
+      expected_args
+        .iter()
+        .zip(actual_args.iter())
+        .any(|(expected, actual)| generic_is_erased_at(expected, actual, name))
+    }
+    (CalcitTypeAnnotation::Enum(expected_def, expected_args), CalcitTypeAnnotation::Enum(actual_def, actual_args))
+      if expected_def.name() == actual_def.name() =>
+    {
+      expected_args
+        .iter()
+        .zip(actual_args.iter())
+        .any(|(expected, actual)| generic_is_erased_at(expected, actual, name))
+    }
+    (CalcitTypeAnnotation::TypeRef(expected_ref, expected_args), CalcitTypeAnnotation::TypeRef(actual_ref, actual_args))
+      if expected_ref == actual_ref =>
+    {
+      expected_args
+        .iter()
+        .zip(actual_args.iter())
+        .any(|(expected, actual)| generic_is_erased_at(expected, actual, name))
+    }
+    _ => false,
+  }
+}
+
+#[derive(Debug, PartialEq)]
+struct ErasedGenericArgument {
+  index: usize,
+  expected: Arc<CalcitTypeAnnotation>,
+  actual: Arc<CalcitTypeAnnotation>,
+  generics: Vec<Arc<str>>,
+}
+
+fn find_erased_generic_argument(
+  signature: &CalcitFnTypeAnnotation,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+) -> Option<ErasedGenericArgument> {
+  let related = related_generic_names(signature);
+  if related.is_empty() || args.iter().any(|arg| matches!(arg, Calcit::Syntax(CalcitSyntax::ArgSpread, _))) {
+    return None;
+  }
+
+  let inspect = |index: usize, arg: &Calcit, expected: &Arc<CalcitTypeAnnotation>| {
+    let actual = resolve_type_value(arg, scope_types).or_else(|| match arg {
+      Calcit::Local(local) => Some(local.type_info.clone()),
+      _ => None,
+    })?;
+    let erased = related
+      .iter()
+      .filter(|name| generic_is_erased_at(expected, &actual, name))
+      .cloned()
+      .collect::<Vec<_>>();
+    (!erased.is_empty()).then(|| ErasedGenericArgument {
+      index,
+      expected: expected.clone(),
+      actual,
+      generics: erased,
+    })
+  };
+
+  for (index, (arg, expected)) in args.iter().zip(signature.arg_types.iter()).enumerate() {
+    if let Some(found) = inspect(index, arg, expected) {
+      return Some(found);
+    }
+  }
+  if let Some(rest) = &signature.rest_type {
+    for (index, arg) in args.iter().enumerate().skip(signature.arg_types.len()) {
+      if let Some(found) = inspect(index, arg, rest) {
+        return Some(found);
+      }
+    }
+  }
+  None
+}
+
+fn reject_strict_erased_generic_relation(
+  head: &Calcit,
+  args: &CalcitList,
+  signature: &CalcitFnTypeAnnotation,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled() || !should_emit_project_source_lint(file_ns) {
+    return Ok(());
+  }
+  let Some(ErasedGenericArgument {
+    index,
+    expected,
+    actual,
+    generics,
+  }) = find_erased_generic_argument(signature, args, scope_types)
+  else {
+    return Ok(());
+  };
+  let names = generics.iter().map(|name| format!("`'{name}`")).collect::<Vec<_>>().join(", ");
+  let argument = args.get(index);
+  Err(CalcitErr::use_msg_stack_location_with_code(
+    CalcitErrKind::Type,
+    format!(
+      "call to `{head}` passes `{}` at argument {}, so Dynamic erases generic relation {names} required by `{}`; narrow or validate the value before this call, or use an explicit open adapter whose contract does not claim that generic relation",
+      actual.to_brief_string(),
+      index + 1,
+      expected.to_brief_string(),
+    ),
+    "E_ERASED_GENERIC_RELATION",
+    call_stack,
+    argument.and_then(Calcit::get_location).or_else(|| head.get_location()),
+  ))
+}
+
+fn effective_user_call_schema(info: &CalcitFn) -> Arc<CalcitFnTypeAnnotation> {
+  if let CalcitTypeAnnotation::Fn(signature) = program::lookup_def_schema(&info.def_ns, &info.name).as_ref() {
+    return signature.clone();
+  }
+  let CalcitTypeAnnotation::Fn(signature) = CalcitTypeAnnotation::from_calcit_fn(info) else {
+    unreachable!("CalcitTypeAnnotation::from_calcit_fn always returns Fn")
+  };
+  signature
 }
 
 fn reject_strict_whole_dynamic_public_schema(
@@ -14814,6 +15076,121 @@ mod tests {
       None,
     )
     .expect("an embedded structured Fn hint is valid static contract evidence");
+  }
+
+  fn generic_relation_test_signature(
+    arg_types: Vec<Arc<CalcitTypeAnnotation>>,
+    return_type: Arc<CalcitTypeAnnotation>,
+    rest_type: Option<Arc<CalcitTypeAnnotation>>,
+  ) -> CalcitFnTypeAnnotation {
+    CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      arg_types,
+      return_type,
+      fn_kind: SchemaKind::Fn,
+      rest_type,
+      features: Arc::new(HashSet::new()),
+    }
+  }
+
+  fn generic_relation_test_local(name: &str, annotation: Arc<CalcitTypeAnnotation>) -> Calcit {
+    Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from(name)),
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.generic-relation"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: annotation,
+    })
+  }
+
+  #[test]
+  fn identifies_repeated_generic_contract_relations() {
+    let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let identity = generic_relation_test_signature(vec![type_var.clone()], type_var.clone(), None);
+    assert_eq!(related_generic_names(&identity), vec![Arc::from("T")]);
+
+    let variadic_equality =
+      generic_relation_test_signature(vec![type_var.clone()], Arc::new(CalcitTypeAnnotation::Bool), Some(type_var.clone()));
+    assert_eq!(related_generic_names(&variadic_equality), vec![Arc::from("T")]);
+
+    let unrelated = generic_relation_test_signature(vec![type_var], Arc::new(CalcitTypeAnnotation::Bool), None);
+    assert!(related_generic_names(&unrelated).is_empty());
+  }
+
+  #[test]
+  fn detects_only_dynamic_arguments_that_erase_generic_relations() {
+    let _state = lock_preprocess_test_state();
+    let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let identity = generic_relation_test_signature(vec![type_var.clone()], type_var.clone(), None);
+    let dynamic = calcit::DYNAMIC_TYPE.clone();
+    let value = generic_relation_test_local("value", dynamic.clone());
+    let scope_types = ScopeTypes::from([(Arc::from("value"), dynamic.clone())]);
+    let dynamic_args = CalcitList::from(&[value.clone()][..]);
+
+    {
+      let _compat = StrictTypesGuard::new(false);
+      reject_strict_erased_generic_relation(
+        &test_symbol("identity"),
+        &dynamic_args,
+        &identity,
+        &scope_types,
+        "tests.generic-relation",
+        &CallStackList::default(),
+      )
+      .expect("compatibility mode should keep accepting erased generic relations during migration");
+    }
+    let _strict = StrictTypesGuard::new(true);
+    let error = reject_strict_erased_generic_relation(
+      &test_symbol("identity"),
+      &dynamic_args,
+      &identity,
+      &scope_types,
+      "tests.generic-relation",
+      &CallStackList::default(),
+    )
+    .expect_err("strict mode should reject an erased generic relation");
+    assert_eq!(error.code.as_deref(), Some("E_ERASED_GENERIC_RELATION"));
+
+    let erased = find_erased_generic_argument(&identity, &dynamic_args, &scope_types).expect("Dynamic should erase T -> T");
+    assert_eq!(erased.index, 0);
+    assert_eq!(erased.expected.as_ref(), type_var.as_ref());
+    assert!(matches!(erased.actual.as_ref(), CalcitTypeAnnotation::Dynamic));
+    assert_eq!(erased.generics, vec![Arc::from("T")]);
+
+    let concrete_args = CalcitList::from(&[Calcit::Number(1.0)][..]);
+    assert!(find_erased_generic_argument(&identity, &concrete_args, &ScopeTypes::new()).is_none());
+
+    let open_list = Arc::new(CalcitTypeAnnotation::List(dynamic.clone()));
+    let list_value = generic_relation_test_local("list-value", open_list.clone());
+    let list_scope = ScopeTypes::from([(Arc::from("list-value"), open_list.clone())]);
+    let list_args = CalcitList::from(&[list_value][..]);
+    assert!(
+      find_erased_generic_argument(&identity, &list_args, &list_scope).is_none(),
+      "T can bind to the complete List<Dynamic> type without losing T -> T"
+    );
+
+    let related_list = Arc::new(CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))));
+    let list_identity = generic_relation_test_signature(vec![related_list.clone()], related_list, None);
+    assert!(
+      find_erased_generic_argument(&list_identity, &list_args, &list_scope).is_some(),
+      "List<T> against List<Dynamic> loses the item relationship"
+    );
+
+    let reviewed_open_position = generic_relation_test_signature(vec![type_var], Arc::new(CalcitTypeAnnotation::Dynamic), None);
+    assert!(related_generic_names(&reviewed_open_position).is_empty());
+    assert!(find_erased_generic_argument(&reviewed_open_position, &dynamic_args, &scope_types).is_none());
+
+    let relation_plus_open_boundary = generic_relation_test_signature(
+      vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))), dynamic.clone()],
+      Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))),
+      None,
+    );
+    let args = CalcitList::from(&[Calcit::Number(1.0), value][..]);
+    assert!(find_erased_generic_argument(&relation_plus_open_boundary, &args, &scope_types).is_none());
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -22,7 +22,8 @@ use type_checking::{
 pub use type_inference::infer_static_type_from_expr;
 use type_inference::{
   extract_literal_list_items, find_struct_lookup_in_literal_path, fully_typed_literal_assoc_path, fully_typed_literal_lookup_path,
-  infer_struct_field_type, infer_type_from_expr, resolve_enum_value, resolve_program_value_for_preprocess, resolve_type_value,
+  infer_struct_field_type, infer_struct_value_annotation, infer_type_from_expr, resolve_enum_value,
+  resolve_program_value_for_preprocess, resolve_type_value,
 };
 use type_rewriting::{
   build_enum_ref_node, build_struct_ref_node, try_rewrite_enum_args_to_named_enums, try_rewrite_local_fn_enum_args_to_named_enums,
@@ -475,7 +476,7 @@ fn preprocess_with_type_slot_block(
       Calcit::EnumDef(_) | Calcit::StructDef(_) => {
         Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), Arc::new(vec![])))
       }
-      Calcit::Struct(struct_value) => Arc::new(CalcitTypeAnnotation::StructValue(struct_value.struct_ref.clone())),
+      Calcit::Struct(struct_value) => infer_struct_value_annotation(struct_value, scope_types),
       other => {
         return Err(CalcitErr::use_msg_stack_location(
           CalcitErrKind::Unexpected,
@@ -492,7 +493,7 @@ fn preprocess_with_type_slot_block(
     match &resolved {
       Calcit::EnumDef(enum_def) => Arc::new(CalcitTypeAnnotation::Enum(Arc::new(enum_def.to_owned()), Arc::new(vec![]))),
       Calcit::StructDef(struct_def) => Arc::new(CalcitTypeAnnotation::Struct(Arc::new(struct_def.to_owned()), Arc::new(vec![]))),
-      Calcit::Struct(struct_value) => Arc::new(CalcitTypeAnnotation::StructValue(struct_value.struct_ref.clone())),
+      Calcit::Struct(struct_value) => infer_struct_value_annotation(struct_value, scope_types),
       other => match infer_type_from_expr(other, scope_types) {
         Some(inferred)
           if matches!(
@@ -15191,6 +15192,45 @@ mod tests {
     );
     let args = CalcitList::from(&[Calcit::Number(1.0), value][..]);
     assert!(find_erased_generic_argument(&relation_plus_open_boundary, &args, &scope_types).is_none());
+  }
+
+  #[test]
+  fn type_slot_struct_annotations_preserve_generic_arguments_for_erasure_checks() {
+    let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let box_def = Arc::new(CalcitStructDef {
+      name: EdnTag::new("Box"),
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      field_types: Arc::new(vec![type_var.clone()]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    let dynamic = calcit::DYNAMIC_TYPE.clone();
+    let dynamic_value = generic_relation_test_local("dynamic-value", dynamic.clone());
+    let value_scope = ScopeTypes::from([(Arc::from("dynamic-value"), dynamic.clone())]);
+    let box_value = CalcitStructValue {
+      struct_ref: box_def.clone(),
+      values: Arc::new(vec![dynamic_value]),
+    };
+
+    let inferred = infer_struct_value_annotation(&box_value, &value_scope);
+    assert!(
+      matches!(
+        inferred.as_ref(),
+        CalcitTypeAnnotation::Struct(_, args)
+          if matches!(args.as_slice(), [argument] if matches!(argument.as_ref(), CalcitTypeAnnotation::Dynamic))
+      ),
+      "a generic Struct value used by with-type-slot must retain its applied Dynamic argument: {inferred:?}"
+    );
+
+    let expected_box = Arc::new(CalcitTypeAnnotation::Struct(box_def, Arc::new(vec![type_var])));
+    let signature = generic_relation_test_signature(vec![expected_box.clone()], expected_box, None);
+    let box_local = generic_relation_test_local("box-value", inferred.clone());
+    let box_scope = ScopeTypes::from([(Arc::from("box-value"), inferred)]);
+    let args = CalcitList::from(&[box_local][..]);
+    let erased = find_erased_generic_argument(&signature, &args, &box_scope)
+      .expect("Struct<T> against Struct<Dynamic> should erase the nested generic relation");
+    assert_eq!(erased.generics, vec![Arc::from("T")]);
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -625,17 +625,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
       Some(enum_def) => Some(Arc::new(CalcitTypeAnnotation::EnumValue(enum_def.clone()))),
       None => Some(Arc::new(CalcitTypeAnnotation::AnonymousEnum)),
     },
-    Calcit::Struct(struct_value) => {
-      if struct_value.struct_ref.generics.is_empty() {
-        Some(Arc::new(CalcitTypeAnnotation::StructValue(struct_value.struct_ref.clone())))
-      } else {
-        let applied_args = infer_struct_applied_args(struct_value.struct_ref.as_ref(), struct_value.values.iter(), scope_types);
-        Some(Arc::new(CalcitTypeAnnotation::Struct(
-          struct_value.struct_ref.clone(),
-          Arc::new(applied_args),
-        )))
-      }
-    }
+    Calcit::Struct(struct_value) => Some(infer_struct_value_annotation(struct_value, scope_types)),
     Calcit::StructDef(struct_def) => Some(Arc::new(CalcitTypeAnnotation::StructDef(Arc::new(struct_def.to_owned())))),
     Calcit::EnumDef(enum_def) => Some(Arc::new(CalcitTypeAnnotation::EnumDef(Arc::new(enum_def.to_owned())))),
     Calcit::Trait(trait_def) => Some(Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def.to_owned())))),
@@ -1708,6 +1698,18 @@ fn infer_struct_applied_args<'a>(
     .iter()
     .map(|name| bindings.get(name).cloned().unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone()))
     .collect()
+}
+
+pub(super) fn infer_struct_value_annotation(struct_value: &CalcitStructValue, scope_types: &ScopeTypes) -> Arc<CalcitTypeAnnotation> {
+  if struct_value.struct_ref.generics.is_empty() {
+    Arc::new(CalcitTypeAnnotation::StructValue(struct_value.struct_ref.clone()))
+  } else {
+    let applied_args = infer_struct_applied_args(struct_value.struct_ref.as_ref(), struct_value.values.iter(), scope_types);
+    Arc::new(CalcitTypeAnnotation::Struct(
+      struct_value.struct_ref.clone(),
+      Arc::new(applied_args),
+    ))
+  }
 }
 
 fn collect_struct_literal_values(xs: &CalcitList, struct_value: &CalcitStructValue) -> Option<Vec<Calcit>> {


### PR DESCRIPTION
## 中文

### 背景

继续推进 #579 的最后一个建议诊断。结构化 schema 已能声明泛型关系，但 strict preprocessing 此前仍允许 Dynamic 实参进入这些位置，使输入、输出或多个参数之间的关系在调用点失去静态证据。

### 改动

- 新增稳定错误码 `E_ERASED_GENERIC_RELATION`，只在 `--strict-types` 的项目源码调用中生效。
- 覆盖用户/导入函数与已知类型的局部函数；依赖源码、兼容模式和 spread 调用保持原有行为。
- 仅检查在函数契约中重复出现的已声明泛型，包括参数、返回值、variadic、容器和 callback 内部位置。
- 按 expected/actual 类型结构对齐 Dynamic：`List<T>` 对 `List<Dynamic>` 会失败；`T -> T` 把整个 `List<Dynamic>` 绑定为 T 时仍保留关系，不会误报。
- 错误信息包含 callee、参数序号、实际/期望类型、被擦除的泛型名，以及 narrow/validate 或显式开放 adapter 的迁移建议。
- 增加 Rust 单元测试、真实 Snapshot CLI fixture、CLI/静态分析/升级文档和 editing history。

### 验证

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`（18/18）
- `yarn check-all`
- 用全局安装的当前构建在 Respo 运行 `analyze check-types --summary-only --format json` 和 `--check-only`，均通过且仓库保持干净。

关联 #579
关联 #577

## English

### Context

This completes the final proposed diagnostic slice in #579. Structured schemas can already declare generic relationships, but strict preprocessing previously allowed a Dynamic argument to enter those positions and remove call-site evidence connecting inputs, outputs, or multiple arguments.

### Changes

- Add stable `E_ERASED_GENERIC_RELATION`, active only for project-source calls under `--strict-types`.
- Cover user/imported functions and statically typed local functions; dependency source, compatibility mode, and spread calls keep their existing behavior.
- Inspect only declared generics that occur more than once across arguments, returns, variadic positions, containers, or callbacks.
- Align expected and actual schemas structurally: `List<T>` against `List<Dynamic>` fails, while binding an entire `T` to `List<Dynamic>` still preserves `T -> T` and is accepted.
- Report the callee, argument index, actual/expected types, erased generic names, and actionable narrow/validate or explicit-open-adapter guidance.
- Add Rust unit coverage, a real Snapshot CLI fixture, CLI/static-analysis/upgrade documentation, and editing history.

### Verification

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (18/18)
- `yarn check-all`
- Ran the globally installed current build against Respo with `analyze check-types --summary-only --format json` and `--check-only`; both passed and the external worktree remained clean.

Refs #579
Refs #577
