### PR TITLE
feat: reject unspecialized method dispatch in strict mode

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -19,6 +19,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-unbound-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/whole-dynamic-schema-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-nominal-method-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/dynamic-method-dispatch-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
 其中：
@@ -33,6 +34,7 @@
 - `type-slot-unbound-strict.cirru` 会验证 strict 模式拒绝可达定义中的未绑定 slot，并报告稳定的 `E_UNBOUND_TYPE_SLOT`。
 - `whole-dynamic-schema-strict.cirru` 会验证 strict 模式拒绝可达定义的 whole-Dynamic function contract，并报告稳定的 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`。
 - `dynamic-nominal-method-strict.cirru` 会验证 strict 模式拒绝 Dynamic receiver 上的 Option/Result nominal method dispatch，并报告稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
+- `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
 
 ## 自动化测试
@@ -45,6 +47,7 @@
 - strict type-slot fixture：断言错误文本包含 `E_UNBOUND_TYPE_SLOT`、slot 名称与 schema 路径
 - strict whole-Dynamic fixture：断言错误文本包含 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`、schema 根路径与 `Fn` 迁移建议
 - strict Dynamic nominal-method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver schema 与低层 helper 迁移建议
+- strict general Dynamic method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver-loss 分类与 typed adapter 迁移建议
 - strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
 相关测试位于 [src/bin/calcit.rs](src/bin/calcit.rs)。
@@ -60,7 +63,7 @@
 - `E_SCHEMA_DEF_MISMATCH`：定义与 `:schema` 的 `:kind` / `:args` / `:rest` 不匹配
 - `E_UNBOUND_TYPE_SLOT`：strict 模式下可达定义的 schema 引用了未配置或未局部绑定的 type slot
 - `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`：strict 模式下可达 function 或直接进入预处理的 programmatic macro 既没有结构化根 schema，也没有嵌入式结构化契约；普通 legacy Snapshot macro 会更早被 loader 拒绝
-- `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 Dynamic receiver 使用需要静态 Option/Result nominal evidence 的 method
+- `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
 - `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配
 - `W_METHOD_ARG_TYPE_MISMATCH`：静态方法调用参数类型不匹配

--- a/calcit/type-fail/dynamic-method-dispatch-strict.cirru
+++ b/calcit/type-fail/dynamic-method-dispatch-strict.cirru
@@ -1,0 +1,34 @@
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-dynamic-method-dispatch-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for an unspecialized Dynamic method receiver.") (:init-fn 'type-fail-dynamic-method-dispatch-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-dynamic-method-dispatch-strict.main/reload!)
+      :feature-policy $ {}
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-dynamic-method-dispatch-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'run-open $ %{} 'CodeEntry (:doc "|Dynamic input must be narrowed before ordinary method syntax.")
+          :code $ quote
+            defn run-open (value)
+              value .custom
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] 'Dynamic
+        'main! $ %{} 'CodeEntry (:doc "|Entry that makes run-open reachable.")
+          :code $ quote
+            defn main! () $ run-open 1
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote
+            defn reload! () &unit
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict dynamic-method-dispatch fixture.")
+        :code $ quote (ns type-fail-dynamic-method-dispatch-strict.main)

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -142,14 +142,15 @@ For one expression, `calcit query type-at '<ns/def>' --path code@... --format js
 
 `analyze dynamic-methods` reports only `P_DYNAMIC_METHOD_DISPATCH` and `P_DYNAMIC_POSTFIX_METHOD`; ordinary type warnings and JS FFI diagnostics do not contaminate its count. Project namespaces are the default scope, while `--deps` includes reachable modules. `--summary-only` omits individual findings. `--max <count>` turns the report into a focused CI policy and emits `E_DYNAMIC_METHOD_POLICY` with a non-zero status when the count grows beyond the reviewed budget. A receiver made concrete by normal inference, a trait constraint, or an explicit reviewed `unsafe-coerce` boundary is not unresolved dispatch.
 
-The Option/Result nominal family is stricter than the general compatibility
-inventory. Under `--strict-types`, `.unwrap-or`, `.fold`, `.and-then`, and the
-other documented nominal operations reject a Dynamic receiver immediately with
-`E_DYNAMIC_METHOD_DISPATCH` or `E_DYNAMIC_POSTFIX_METHOD`. Narrow the receiver
-to its nominal type, or isolate the intentionally open call behind the matching
-visible `option:*` / `result:*` helper. Other unknown method families remain in
-the dynamic-method inventory until their receiver-loss classification is
-complete.
+Under `--strict-types`, every unspecialized project method is rejected with
+`E_DYNAMIC_METHOD_DISPATCH` or `E_DYNAMIC_POSTFIX_METHOD`. Diagnostics classify
+the receiver loss as a missing schema, Dynamic value/callable, legacy Optional,
+unbound generic/type slot, or explicit `:js-ffi` Dynamic boundary. The
+Option/Result nominal family additionally names the expected receiver family
+and its visible `option:*` / `result:*` helper. Compatibility mode retains the
+`P_DYNAMIC_*` inventory and `W_DYNAMIC_NOMINAL_METHOD_RECEIVER` while projects
+migrate. A concrete inferred type, trait constraint, or external-object trait
+remains statically dispatchable and does not trigger this rule.
 
 `analyze quality` combines the release-facing metrics from `check-types`, `weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic,code-nil,unsafe-coerce --intent unresolved,intentional-macro-syntax,declared-unit,declared-optional,explicit-unsafe`, and `deprecated`. Intentional macro syntax remains in the `schemaDynamic` budget so new open macro positions cannot bypass review, while only unresolved positions increment the `unresolved` budget. `unsafeCoerce` is an independent budget for explicit host assertions; it is not folded into unresolved Dynamic debt. With no baseline it is a zero-debt gate. `--baseline <file>` compares against a committed baseline and exits non-zero on regression; `--write-baseline <file>` atomically writes a reviewed native baseline. Native v2 baselines keep budgets per definition, so improving one definition cannot hide new debt in another. Native v1 and the older flat eight-metric shape remain readable and preserve their original eight-metric enforcement; v1 is reported as `native-baseline-v1` and does not claim an `unsafeCoerce` delta. Regenerate a reviewed baseline to adopt that budget. Scope flags (`--ns`, `--ns-prefix`, `--deps`) are recorded in native baselines and must match when they are enforced.
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -122,6 +122,14 @@ or `E_DYNAMIC_POSTFIX_METHOD` for postfix calls. Give the receiver a concrete
 `Option<T>` / `Result<T, E>` schema, or use the matching visible `option:*` /
 `result:*` function inside an explicitly reviewed open adapter.
 
+Strict mode also promotes every remaining unspecialized project method to the
+same stable prefix/postfix errors. The diagnostic classifies the receiver as a
+missing schema, Dynamic value/callable, legacy Optional, unbound generic or
+type slot, or explicit `:js-ffi` Dynamic boundary. Add static nominal or trait
+evidence before method syntax. A JS boundary must convert the host value or
+attach an external-object trait inside its narrow adapter; `:js-ffi` alone does
+not authorize runtime method lookup.
+
 ### Strict type preflight (`--strict-types`)
 
 Use `--strict-types` for new or fully migrated modules that must carry no local

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -441,6 +441,12 @@ Dynamic 时，使用明确的函数形式，例如 `option:unwrap-or (get config
 `Option<T>` / `Result<T, E>` receiver schema，或者把开放边界收拢到显式 `option:*` / `result:*`
 adapter；不要用 `unsafe-coerce` 批量压制。
 
+其他无法静态 specialization 的项目 method 也会在 strict mode 使用相同的 prefix/postfix error。
+诊断会区分缺失 schema、Dynamic value/callable、legacy Optional、未绑定 generic/type-slot，以及显式
+`:js-ffi` Dynamic boundary。按分类补 concrete/nominal schema、trait `:where` 或 entry slot binding。
+`:js-ffi` 只声明 host capability，不授权运行时 method lookup；adapter 必须在返回业务层前转换 host
+值或附加 external-object trait。
+
 #### `.trim` / `.blank?` 接收者迁移
 
 `.trim` 与 `.blank?` 只对静态推断为 String 的接收者可用。若错误写成 `unknown method .trim for map`，

--- a/editing-history/202609040908-reject-general-dynamic-method-dispatch.md
+++ b/editing-history/202609040908-reject-general-dynamic-method-dispatch.md
@@ -1,0 +1,16 @@
+# Reject general Dynamic method dispatch in strict mode
+
+- Promoted every remaining unspecialized project prefix/postfix method call to
+  `E_DYNAMIC_METHOD_DISPATCH` or `E_DYNAMIC_POSTFIX_METHOD` in strict mode.
+- Classified receiver loss as missing schema, Dynamic value/callable, legacy
+  Optional, unbound generic/type slot, or explicit `:js-ffi` Dynamic boundary.
+- Kept compatibility warnings and `analyze dynamic-methods` inventory intact;
+  dependency namespaces and statically dispatchable nominal/trait receivers are
+  unchanged.
+- Added unit and real Snapshot CLI coverage with migration guidance that favors
+  concrete schemas, trait constraints, slot bindings, and narrow typed adapters
+  instead of broad coercion.
+- Regressed against `respo.calcit`: compatibility analysis reports three
+  actionable `.to-list` dispatch sites. Its full strict preflight still stops
+  earlier at the existing `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA` macro boundary, so no
+  external source was changed to hide the new inventory.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -229,6 +229,27 @@ fn strict_type_fail_dynamic_nominal_method_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_general_dynamic_method_reports_receiver_source() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/dynamic-method-dispatch-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("ordinary method dispatch on Dynamic must fail strict check-only");
+
+    assert!(err.contains("E_DYNAMIC_POSTFIX_METHOD"), "unexpected strict dispatch error: {err}");
+    assert!(err.contains("`.custom`"), "method should be explicit: {err}");
+    assert!(
+      err.contains("missing static receiver schema"),
+      "receiver source should be classified: {err}"
+    );
+    assert!(
+      err.contains("add a structured receiver schema"),
+      "migration should be actionable: {err}"
+    );
+  });
+}
+
+#[test]
 fn strict_type_fail_erased_generic_relation_reports_stable_error_code() {
   run_with_large_stack(|| {
     let fixture = "calcit/type-fail/erased-generic-relation-strict.cirru";

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2042,40 +2042,61 @@ fn preprocess_list_call(
           // For non-struct/trait types (Dynamic, Fn, etc.), silently fall through —
           // `.method` is a normal argument.
         }
-        if file_ns != calcit::CORE_NS
-          && resolve_type_value(&head_form, scope_types).is_none_or(|type_info| is_dynamic_annotation(type_info.as_ref()))
-        {
-          let location = head_form.get_location().or_else(|| first_arg.get_location());
-          if matches!(method_kind, calcit::MethodKind::Invoke(_))
-            && let Some((receiver_requirement, helper_hint)) = dynamic_nominal_method_requirement(method_name.as_ref())
-          {
-            if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
-              return Err(CalcitErr::use_msg_stack_location_with_code(
-                CalcitErrKind::Type,
-                format!(
-                  "postfix nominal method `.{method_name}` cannot dispatch on a Dynamic receiver; provide a statically known {receiver_requirement} schema or call {helper_hint} at an explicit open boundary"
-                ),
-                "E_DYNAMIC_POSTFIX_METHOD",
-                call_stack,
-                location.clone(),
-              ));
-            }
-            let message = format!(
-              "[Warn] postfix nominal method `.{method_name}` requires a statically known {receiver_requirement} receiver in {file_ns}/{def_name}, but the receiver is Dynamic; narrow it with a schema/assertion before using method syntax, or call {helper_hint} at an intentional Dynamic boundary"
-            );
-            if let Some(loc) = location {
-              gen_check_warning_with_location_code(message, "W_DYNAMIC_NOMINAL_METHOD_RECEIVER", loc, check_warnings);
+        if file_ns != calcit::CORE_NS {
+          let receiver_type = resolve_type_value(&head_form, scope_types);
+          let receiver_cause = classify_dynamic_dispatch_receiver(receiver_type.as_deref(), current_function_has_js_ffi_feature());
+          if let Some(receiver_cause) = receiver_cause {
+            let location = head_form.get_location().or_else(|| first_arg.get_location());
+            if matches!(method_kind, calcit::MethodKind::Invoke(_))
+              && let Some((receiver_requirement, helper_hint)) = dynamic_nominal_method_requirement(method_name.as_ref())
+            {
+              if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+                return Err(CalcitErr::use_msg_stack_location_with_code(
+                  CalcitErrKind::Type,
+                  format!(
+                    "postfix nominal method `.{method_name}` cannot be statically specialized because its receiver source is {}; provide a statically known {receiver_requirement} schema or call {helper_hint} at an explicit open boundary",
+                    receiver_cause.label(),
+                  ),
+                  "E_DYNAMIC_POSTFIX_METHOD",
+                  call_stack,
+                  location.clone(),
+                ));
+              }
+              let message = format!(
+                "[Warn] postfix nominal method `.{method_name}` requires a statically known {receiver_requirement} receiver in {file_ns}/{def_name}, but its receiver source is {}; narrow it with a schema/assertion before using method syntax, or call {helper_hint} at an intentional Dynamic boundary",
+                receiver_cause.label(),
+              );
+              if let Some(loc) = location {
+                gen_check_warning_with_location_code(message, "W_DYNAMIC_NOMINAL_METHOD_RECEIVER", loc, check_warnings);
+              } else {
+                gen_check_warning_code(message, "W_DYNAMIC_NOMINAL_METHOD_RECEIVER", file_ns, check_warnings);
+              }
             } else {
-              gen_check_warning_code(message, "W_DYNAMIC_NOMINAL_METHOD_RECEIVER", file_ns, check_warnings);
-            }
-          } else if warn_dyn_method_enabled() {
-            let message = format!(
-              "[Warn] postfix method `.{method_name}` has a dynamic receiver in {file_ns}/{def_name}; use prefix syntax `(.{method_name} receiver ...)`, assert-traits, or unsafe-coerce at an FFI boundary"
-            );
-            if let Some(loc) = location {
-              gen_check_warning_with_location_code(message, "P_DYNAMIC_POSTFIX_METHOD", loc, check_warnings);
-            } else {
-              gen_check_warning_code(message, "P_DYNAMIC_POSTFIX_METHOD", file_ns, check_warnings);
+              if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+                return Err(CalcitErr::use_msg_stack_location_with_code(
+                  CalcitErrKind::Type,
+                  format!(
+                    "postfix method `.{method_name}` cannot be statically specialized because its receiver source is {}; {}",
+                    receiver_cause.label(),
+                    receiver_cause.migration(),
+                  ),
+                  "E_DYNAMIC_POSTFIX_METHOD",
+                  call_stack,
+                  location.clone(),
+                ));
+              }
+              if warn_dyn_method_enabled() {
+                let message = format!(
+                  "[Warn] postfix method `.{method_name}` cannot be statically specialized in {file_ns}/{def_name} because its receiver source is {}; {}",
+                  receiver_cause.label(),
+                  receiver_cause.migration(),
+                );
+                if let Some(loc) = location {
+                  gen_check_warning_with_location_code(message, "P_DYNAMIC_POSTFIX_METHOD", loc, check_warnings);
+                } else {
+                  gen_check_warning_code(message, "P_DYNAMIC_POSTFIX_METHOD", file_ns, check_warnings);
+                }
+              }
             }
           }
         }
@@ -4569,15 +4590,9 @@ fn reject_or_warn_on_dynamic_trait_call(
   };
 
   let receiver_type = resolve_type_value(receiver, scope_types);
-  let warn = match receiver_type.as_ref().map(|value| value.as_ref()) {
-    None => true,
-    Some(ann) if is_trait_annotation(ann) => false,
-    Some(ann) => is_dynamic_annotation(ann),
-  };
-
-  if !warn {
+  let Some(receiver_cause) = classify_dynamic_dispatch_receiver(receiver_type.as_deref(), current_function_has_js_ffi_feature()) else {
     return Ok(());
-  }
+  };
 
   if strict_types_enabled()
     && should_emit_project_source_lint(file_ns)
@@ -4586,7 +4601,22 @@ fn reject_or_warn_on_dynamic_trait_call(
     return Err(CalcitErr::use_msg_stack_location_with_code(
       CalcitErrKind::Type,
       format!(
-        "nominal method `.{method_name}` cannot dispatch on a Dynamic receiver; provide a statically known {receiver_requirement} schema or call {helper_hint} at an explicit open boundary"
+        "nominal method `.{method_name}` cannot be statically specialized because its receiver source is {}; provide a statically known {receiver_requirement} schema or call {helper_hint} at an explicit open boundary",
+        receiver_cause.label(),
+      ),
+      "E_DYNAMIC_METHOD_DISPATCH",
+      call_stack,
+      head.get_location().or_else(|| receiver.get_location()),
+    ));
+  }
+
+  if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      format!(
+        "method `.{method_name}` cannot be statically specialized because its receiver source is {}; {}",
+        receiver_cause.label(),
+        receiver_cause.migration(),
       ),
       "E_DYNAMIC_METHOD_DISPATCH",
       call_stack,
@@ -4599,7 +4629,9 @@ fn reject_or_warn_on_dynamic_trait_call(
   }
 
   let message = format!(
-    "[Warn] dynamic trait call `.{method_name}` cannot be monomorphized in {file_ns}/{def_name}; add assert-traits, or use unsafe-coerce only at a trusted FFI boundary"
+    "[Warn] method `.{method_name}` cannot be statically specialized in {file_ns}/{def_name} because its receiver source is {}; {}",
+    receiver_cause.label(),
+    receiver_cause.migration(),
   );
 
   if let Some(loc) = head.get_location().or_else(|| receiver.get_location()) {
@@ -6340,6 +6372,76 @@ fn is_trait_annotation(type_value: &CalcitTypeAnnotation) -> bool {
 fn is_dynamic_annotation(type_value: &CalcitTypeAnnotation) -> bool {
   matches!(type_value, CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn)
     || matches!(type_value, CalcitTypeAnnotation::Optional(inner) if is_dynamic_annotation(inner.as_ref()))
+}
+
+#[derive(Debug, PartialEq)]
+enum DynamicDispatchReceiverCause {
+  MissingSchema,
+  DynamicSchema,
+  DynamicCallable,
+  LegacyOptional,
+  UnboundGeneric(Arc<str>),
+  UnboundTypeSlot(Arc<str>),
+  ExplicitJsFfiBoundary,
+}
+
+impl DynamicDispatchReceiverCause {
+  fn label(&self) -> String {
+    match self {
+      Self::MissingSchema => "a missing static receiver schema".to_owned(),
+      Self::DynamicSchema => "a receiver schema that resolves to Dynamic".to_owned(),
+      Self::DynamicCallable => "a receiver schema that resolves to a dynamic callable".to_owned(),
+      Self::LegacyOptional => "a legacy Optional receiver whose payload is Dynamic".to_owned(),
+      Self::UnboundGeneric(name) => format!("unbound generic `'{name}` without a trait constraint"),
+      Self::UnboundTypeSlot(name) => format!("unbound type slot `*{name}`"),
+      Self::ExplicitJsFfiBoundary => "an explicit `:js-ffi` Dynamic boundary".to_owned(),
+    }
+  }
+
+  fn migration(&self) -> &'static str {
+    match self {
+      Self::MissingSchema => "add a structured receiver schema or infer a concrete nominal type before method syntax",
+      Self::DynamicSchema | Self::DynamicCallable | Self::LegacyOptional => {
+        "narrow or validate the receiver before method syntax, or isolate runtime lookup in a typed adapter"
+      }
+      Self::UnboundGeneric(_) => "add a trait `:where` bound or replace the erased generic with a concrete nominal type",
+      Self::UnboundTypeSlot(_) => "bind the slot to a concrete type for this entry before method syntax",
+      Self::ExplicitJsFfiBoundary => {
+        "declare an external-object trait or convert the host value inside the narrow `:js-ffi` adapter before returning it"
+      }
+    }
+  }
+}
+
+fn current_function_has_js_ffi_feature() -> bool {
+  CURRENT_FN_FEATURES.with(|cell| {
+    cell
+      .borrow()
+      .as_ref()
+      .is_some_and(|features| features.iter().any(|feature| feature.ref_str() == "js-ffi"))
+  })
+}
+
+fn classify_dynamic_dispatch_receiver(
+  type_value: Option<&CalcitTypeAnnotation>,
+  inside_js_ffi_boundary: bool,
+) -> Option<DynamicDispatchReceiverCause> {
+  let Some(type_value) = type_value else {
+    return Some(DynamicDispatchReceiverCause::MissingSchema);
+  };
+  match type_value {
+    CalcitTypeAnnotation::Dynamic if inside_js_ffi_boundary => Some(DynamicDispatchReceiverCause::ExplicitJsFfiBoundary),
+    CalcitTypeAnnotation::Dynamic => Some(DynamicDispatchReceiverCause::DynamicSchema),
+    CalcitTypeAnnotation::DynFn => Some(DynamicDispatchReceiverCause::DynamicCallable),
+    CalcitTypeAnnotation::Optional(inner) if is_dynamic_annotation(inner) => Some(DynamicDispatchReceiverCause::LegacyOptional),
+    CalcitTypeAnnotation::Optional(inner) => classify_dynamic_dispatch_receiver(Some(inner), inside_js_ffi_boundary),
+    CalcitTypeAnnotation::TypeVar(name) => Some(DynamicDispatchReceiverCause::UnboundGeneric(name.clone())),
+    CalcitTypeAnnotation::TypeSlot(name) => match calcit::resolve_type_slot(name) {
+      Some(resolved) => classify_dynamic_dispatch_receiver(Some(resolved.as_ref()), inside_js_ffi_boundary),
+      None => Some(DynamicDispatchReceiverCause::UnboundTypeSlot(name.clone())),
+    },
+    _ => None,
+  }
 }
 
 fn dynamic_nominal_method_requirement(method_name: &str) -> Option<(&'static str, &'static str)> {
@@ -10469,7 +10571,87 @@ mod tests {
       .filter(|warning| warning.code() == Some("P_DYNAMIC_POSTFIX_METHOD"))
       .collect::<Vec<_>>();
     assert_eq!(matched.len(), 1, "expected one dynamic postfix warning, got: {warnings:?}");
-    assert!(matched[0].message().contains("unsafe-coerce"));
+    assert!(matched[0].message().contains("missing static receiver schema"));
+    assert!(matched[0].message().contains("add a structured receiver schema"));
+  }
+
+  #[test]
+  fn classifies_dynamic_dispatch_receiver_sources() {
+    let _slots = TypeSlotsGuard::cleared();
+    let dynamic = calcit::DYNAMIC_TYPE.clone();
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(None, false),
+      Some(DynamicDispatchReceiverCause::MissingSchema)
+    );
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(Some(dynamic.as_ref()), false),
+      Some(DynamicDispatchReceiverCause::DynamicSchema)
+    );
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(Some(dynamic.as_ref()), true),
+      Some(DynamicDispatchReceiverCause::ExplicitJsFfiBoundary)
+    );
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::DynFn), false),
+      Some(DynamicDispatchReceiverCause::DynamicCallable)
+    );
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::Optional(dynamic)), false),
+      Some(DynamicDispatchReceiverCause::LegacyOptional)
+    );
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::TypeVar(Arc::from("T"))), false),
+      Some(DynamicDispatchReceiverCause::UnboundGeneric(Arc::from("T")))
+    );
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::TypeSlot(Arc::from("receiver"))), false),
+      Some(DynamicDispatchReceiverCause::UnboundTypeSlot(Arc::from("receiver")))
+    );
+    assert_eq!(classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::Number), false), None);
+  }
+
+  #[test]
+  fn strict_types_reject_general_dynamic_dispatch_in_both_call_forms() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let _warn_guard = WarnDynMethodGuard::new(false);
+
+    for (expr, expected_code) in [
+      (
+        Cirru::List(vec![Cirru::leaf("receiver"), Cirru::leaf(".custom")]),
+        "E_DYNAMIC_POSTFIX_METHOD",
+      ),
+      (
+        Cirru::List(vec![Cirru::leaf(".custom"), Cirru::leaf("receiver")]),
+        "E_DYNAMIC_METHOD_DISPATCH",
+      ),
+    ] {
+      let code = code_to_calcit(&expr, "tests.dynamic-general-strict", "main", vec![]).expect("parse dynamic method call");
+      let mut scope_defs: HashSet<Arc<str>> = HashSet::new();
+      scope_defs.insert(Arc::from("receiver"));
+      let mut scope_types = ScopeTypes::from([(Arc::from("receiver"), calcit::DYNAMIC_TYPE.clone())]);
+      let warnings = RefCell::new(vec![]);
+
+      let error = preprocess_expr(
+        &code,
+        &scope_defs,
+        &mut scope_types,
+        "tests.dynamic-general-strict",
+        &warnings,
+        &CallStackList::default(),
+      )
+      .expect_err("strict mode should reject a method call that still needs runtime receiver dispatch");
+      assert_eq!(error.code.as_deref(), Some(expected_code));
+      assert!(error.msg.contains("`.custom`"), "method should be named: {error:?}");
+      assert!(
+        error.msg.contains("resolves to Dynamic"),
+        "receiver source should be classified: {error:?}"
+      );
+      assert!(
+        error.msg.contains("narrow or validate"),
+        "migration should be actionable: {error:?}"
+      );
+    }
   }
 
   #[test]
@@ -14646,7 +14828,7 @@ mod tests {
   }
 
   #[test]
-  fn warns_on_dynamic_trait_call() {
+  fn warns_on_unspecialized_dynamic_method_call() {
     let _lock = lock_preprocess_test_state();
     let _guard = WarnDynMethodGuard::new(true);
 
@@ -14663,12 +14845,12 @@ mod tests {
       preprocess_expr(&code, &scope_defs, &mut scope_types, "tests.trait", &warnings, &stack).expect("preprocess method call");
 
     let warnings_vec = warnings.borrow();
-    assert!(!warnings_vec.is_empty(), "should warn on dynamic trait call");
+    assert!(!warnings_vec.is_empty(), "should warn on dynamic method dispatch");
     assert_eq!(warnings_vec[0].code(), Some("P_DYNAMIC_METHOD_DISPATCH"));
     let warning_msg = warnings_vec[0].to_string();
     assert!(
-      warning_msg.contains("dynamic trait call") && warning_msg.contains(".greet"),
-      "warning should mention method: {warning_msg}"
+      warning_msg.contains("missing static receiver schema") && warning_msg.contains(".greet"),
+      "warning should mention the method and receiver source: {warning_msg}"
     );
   }
 


### PR DESCRIPTION
## Summary / 概要

- promote every remaining unspecialized project prefix/postfix method call to stable strict errors
- classify receiver evidence loss: missing schema, Dynamic value/callable, legacy Optional, unbound generic/type slot, and explicit `:js-ffi` Dynamic boundary
- retain compatibility-mode inventory and add a real type-fail Snapshot plus migration documentation

- 将所有仍未静态专化的项目 prefix/postfix method 调用提升为稳定 strict error
- 区分 receiver 证据丢失来源：缺失 schema、Dynamic value/callable、legacy Optional、未绑定 generic/type slot、显式 `:js-ffi` Dynamic boundary
- 保留兼容模式 inventory，并补充真实 type-fail Snapshot 与迁移文档

## Validation / 验证

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn test-fail` (23/23)
- `yarn check-agent-interface` (18/18)
- `yarn check-all`
- external `respo.calcit analyze dynamic-methods --format json`: 3 actionable `.to-list` sites; external tree remains clean

Closes part of #580.
Progresses #577.