### PR TITLE
feat: reject raw primitives in strict project source

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -20,6 +20,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/whole-dynamic-schema-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-nominal-method-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-method-dispatch-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/raw-primitive-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
 其中：
@@ -35,6 +36,7 @@
 - `whole-dynamic-schema-strict.cirru` 会验证 strict 模式拒绝可达定义的 whole-Dynamic function contract，并报告稳定的 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`。
 - `dynamic-nominal-method-strict.cirru` 会验证 strict 模式拒绝 Dynamic receiver 上的 Option/Result nominal method dispatch，并报告稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
+- `raw-primitive-strict.cirru` 会验证 strict 模式拒绝项目源码直接调用 `&get-raw`，并报告稳定的 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
 - `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
 
 ## 自动化测试
@@ -48,6 +50,7 @@
 - strict whole-Dynamic fixture：断言错误文本包含 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`、schema 根路径与 `Fn` 迁移建议
 - strict Dynamic nominal-method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver schema 与低层 helper 迁移建议
 - strict general Dynamic method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver-loss 分类与 typed adapter 迁移建议
+- strict raw primitive fixture：断言错误文本包含 `E_RAW_PRIMITIVE_IN_TYPED_CODE`、primitive 名称与 typed public API 迁移建议
 - strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
 相关测试位于 [src/bin/calcit.rs](src/bin/calcit.rs)。
@@ -64,6 +67,7 @@
 - `E_UNBOUND_TYPE_SLOT`：strict 模式下可达定义的 schema 引用了未配置或未局部绑定的 type slot
 - `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`：strict 模式下可达 function 或直接进入预处理的 programmatic macro 既没有结构化根 schema，也没有嵌入式结构化契约；普通 legacy Snapshot macro 会更早被 loader 拒绝
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
+- `E_RAW_PRIMITIVE_IN_TYPED_CODE`：strict 项目源码手写 raw constructor/lookup/index primitive，且没有 compiler/macro origin 或匹配的 nominal layout evidence
 - `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配
 - `W_METHOD_ARG_TYPE_MISMATCH`：静态方法调用参数类型不匹配

--- a/calcit/type-fail/raw-primitive-strict.cirru
+++ b/calcit/type-fail/raw-primitive-strict.cirru
@@ -1,0 +1,32 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-raw-primitive-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for a hand-written raw collection primitive.") (:init-fn 'type-fail-raw-primitive-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-raw-primitive-strict.main/reload!)
+      :feature-policy $ {}
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-raw-primitive-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'read-raw $ %{} 'CodeEntry (:doc "|Typed collection code must use an Option-returning public lookup.")
+          :code $ quote
+            defn read-raw (value) (&get-raw value :x)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ [] (:: 'Map 'Tag 'Number)
+        'main! $ %{} 'CodeEntry (:doc "|Entry that makes read-raw reachable.")
+          :code $ quote
+            defn main! ()
+              read-raw $ {} (:x 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict raw-primitive fixture.")
+        :code $ quote (ns type-fail-raw-primitive-strict.main)

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -414,7 +414,7 @@ update-in data ([] :profile :visits)
 
 这样可以让缺失、默认值和失败在类型上分开，而不是继续依赖 `nil` 或组件临时的 `read-field` 函数。
 
-已知具名 Struct 的字段读取一律写成 `(:field value)`（接收者优先的 invoke 简写为 `value.:field`），不要在应用代码中生成 `&struct:get`。检查器会验证字段、返回声明类型，并把读取自动降为 `&struct:nth value <index>`；直接写低层 primitive 会隐藏源码中的类型意图，并触发 `W_STRUCT_RAW_ACCESS`。如果 `(:field value)` 报 `W_REQUIRED_STRUCT_FIELD_TYPE`，应补全 schema、先 narrow/unwrap，不能改写成 `&struct:get` 绕过分析。若诊断中的接收者只剩未限定的 `'Router` 一类 nominal TypeRef，应恢复或显式写成 `'app.schema/Router`，并检查声明所在依赖是否正确加载；嵌套字段声明中的同 namespace 短类型会由检查器自动保留声明 namespace。只有可复用 `defimpl` 尚未绑定具体 Struct 的实现体以及 core/runtime 底层代码，才把 `&struct:get` 作为明确的动态边界。`W_STRUCT_*` 属于项目源码迁移提示，不会要求调用方修改已安装依赖中的旧实现。
+已知具名 Struct 的字段读取一律写成 `(:field value)`（接收者优先的 invoke 简写为 `value.:field`），不要在应用代码中生成 `&struct:get`。检查器会验证字段、返回声明类型，并把读取自动降为 `&struct:nth value <index>`；兼容模式直接写低层 primitive 会触发 `W_STRUCT_RAW_ACCESS`，strict mode 会报告 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。如果 `(:field value)` 报 `W_REQUIRED_STRUCT_FIELD_TYPE`，应补全 schema、先 narrow/unwrap，不能改写成 `&struct:get` 绕过分析。若诊断中的接收者只剩未限定的 `'Router` 一类 nominal TypeRef，应恢复或显式写成 `'app.schema/Router`，并检查声明所在依赖是否正确加载；嵌套字段声明中的同 namespace 短类型会由检查器自动保留声明 namespace。只有可复用 `defimpl` 尚未绑定具体 Struct 的实现体以及 core/runtime 底层代码，才把 `&struct:get` 作为明确的动态边界。`W_STRUCT_*` 属于项目源码迁移提示，不会要求调用方修改已安装依赖中的旧实现。
 
 ### 5.4 CLI 的 `quote` 是代码/数据边界
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -157,8 +157,9 @@ Strict project source also rejects hand-written representation primitives with
 `&struct:nth` without an exact nominal layout/index/tag proof. Prefer public
 typed lookup, named Struct field syntax, and `%{}` construction. The check is
 evidence based: compiler or reviewed macro lowering, core internals, reusable
-`defimpl` access, and persisted indexed IR with a matching concrete layout are
-preserved.
+`defimpl` access, persisted constructors that name a concrete Struct and contain
+every declared field exactly once, and indexed IR with a matching concrete layout
+are preserved. Missing, duplicate, or unknown constructor fields do not qualify.
 
 `analyze quality` combines the release-facing metrics from `check-types`, `weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic,code-nil,unsafe-coerce --intent unresolved,intentional-macro-syntax,declared-unit,declared-optional,explicit-unsafe`, and `deprecated`. Intentional macro syntax remains in the `schemaDynamic` budget so new open macro positions cannot bypass review, while only unresolved positions increment the `unresolved` budget. `unsafeCoerce` is an independent budget for explicit host assertions; it is not folded into unresolved Dynamic debt. With no baseline it is a zero-debt gate. `--baseline <file>` compares against a committed baseline and exits non-zero on regression; `--write-baseline <file>` atomically writes a reviewed native baseline. Native v2 baselines keep budgets per definition, so improving one definition cannot hide new debt in another. Native v1 and the older flat eight-metric shape remain readable and preserve their original eight-metric enforcement; v1 is reported as `native-baseline-v1` and does not claim an `unsafeCoerce` delta. Regenerate a reviewed baseline to adopt that budget. Scope flags (`--ns`, `--ns-prefix`, `--deps`) are recorded in native baselines and must match when they are enforced.
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -152,6 +152,14 @@ and its visible `option:*` / `result:*` helper. Compatibility mode retains the
 migrate. A concrete inferred type, trait constraint, or external-object trait
 remains statically dispatchable and does not trigger this rule.
 
+Strict project source also rejects hand-written representation primitives with
+`E_RAW_PRIMITIVE_IN_TYPED_CODE`: `&get-raw`, `&struct:get`, raw `&%{}`, and
+`&struct:nth` without an exact nominal layout/index/tag proof. Prefer public
+typed lookup, named Struct field syntax, and `%{}` construction. The check is
+evidence based: compiler or reviewed macro lowering, core internals, reusable
+`defimpl` access, and persisted indexed IR with a matching concrete layout are
+preserved.
+
 `analyze quality` combines the release-facing metrics from `check-types`, `weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic,code-nil,unsafe-coerce --intent unresolved,intentional-macro-syntax,declared-unit,declared-optional,explicit-unsafe`, and `deprecated`. Intentional macro syntax remains in the `schemaDynamic` budget so new open macro positions cannot bypass review, while only unresolved positions increment the `unresolved` budget. `unsafeCoerce` is an independent budget for explicit host assertions; it is not folded into unresolved Dynamic debt. With no baseline it is a zero-debt gate. `--baseline <file>` compares against a committed baseline and exits non-zero on regression; `--write-baseline <file>` atomically writes a reviewed native baseline. Native v2 baselines keep budgets per definition, so improving one definition cannot hide new debt in another. Native v1 and the older flat eight-metric shape remain readable and preserve their original eight-metric enforcement; v1 is reported as `native-baseline-v1` and does not claim an `unsafeCoerce` delta. Regenerate a reviewed baseline to adopt that budget. Scope flags (`--ns`, `--ns-prefix`, `--deps`) are recorded in native baselines and must match when they are enforced.
 
 Calcit's bundled Cirru core uses `config/calcit-core-quality.cirru` as a per-definition Cirru EDN migration baseline. `yarn check-core-quality`, the pull-request workflow, and the release workflow reject new or increased Dynamic/type-coverage debt while existing contracts are migrated incrementally. After a reviewed cleanup, regenerate the baseline with `calcit src/cirru/calcit-core.cirru analyze quality --write-baseline config/calcit-core-quality.cirru --format json`; never regenerate it merely to make an unexplained regression pass. A `.json` output path remains available only for external tooling that explicitly requires JSON. Track retained open boundaries and cleanup batches in [calcit#579](https://github.com/calcit-lang/calcit/issues/579).

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -153,7 +153,7 @@ migrate. A concrete inferred type, trait constraint, or external-object trait
 remains statically dispatchable and does not trigger this rule.
 
 Strict project source also rejects hand-written representation primitives with
-`E_RAW_PRIMITIVE_IN_TYPED_CODE`: `&get-raw`, `&struct:get`, raw `&%{}`, and
+`E_RAW_PRIMITIVE_IN_TYPED_CODE`: `&get-raw`, `record-get` / `&struct:get`, raw `&%{}`, and
 `&struct:nth` without an exact nominal layout/index/tag proof. Prefer public
 typed lookup, named Struct field syntax, and `%{}` construction. The check is
 evidence based: compiler or reviewed macro lowering, core internals, reusable

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -214,8 +214,9 @@ whose structured contract does not claim the generic relationship. Outside
 `&get-raw`, `record-get` / `&struct:get`, raw `&%{}`, and `&struct:nth` without matching
 nominal layout evidence. Use Option-returning collection lookup, named Struct
 field syntax, and the public `%{}` constructor. Core/reviewed macro lowering,
-reusable `defimpl` access, and indexed IR whose index/tag agrees with the
-concrete receiver layout remain valid.
+reusable `defimpl` access, evidence-complete persisted constructors whose fields
+exactly match one concrete Struct, and indexed IR whose index/tag agrees with
+the concrete receiver layout remain valid.
 
 For a focused, machine-readable inventory that excludes unrelated type and FFI warnings, use the dedicated analysis command:
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -211,7 +211,7 @@ whose structured contract does not claim the generic relationship. Outside
 `--strict-types`, the existing compatibility behavior is unchanged.
 
 `--strict-types` reports `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written
-`&get-raw`, `&struct:get`, raw `&%{}`, and `&struct:nth` without matching
+`&get-raw`, `record-get` / `&struct:get`, raw `&%{}`, and `&struct:nth` without matching
 nominal layout evidence. Use Option-returning collection lookup, named Struct
 field syntax, and the public `%{}` constructor. Core/reviewed macro lowering,
 reusable `defimpl` access, and indexed IR whose index/tag agrees with the

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -210,9 +210,12 @@ the callee is intentionally open, put that operation behind a small adapter
 whose structured contract does not claim the generic relationship. Outside
 `--strict-types`, the existing compatibility behavior is unchanged.
 
-`--strict-types` also rejects hand-written runtime Struct index operations such
-as `&struct:nth` without matching nominal type evidence. Use `(:field value)` with a concrete nominal Struct; generic
-helpers need a typed trait/accessor or a deliberately open Map boundary.
+`--strict-types` reports `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written
+`&get-raw`, `&struct:get`, raw `&%{}`, and `&struct:nth` without matching
+nominal layout evidence. Use Option-returning collection lookup, named Struct
+field syntax, and the public `%{}` constructor. Core/reviewed macro lowering,
+reusable `defimpl` access, and indexed IR whose index/tag agrees with the
+concrete receiver layout remain valid.
 
 For a focused, machine-readable inventory that excludes unrelated type and FFI warnings, use the dedicated analysis command:
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -447,7 +447,7 @@ adapter；不要用 `unsafe-coerce` 批量压制。
 `:js-ffi` 只声明 host capability，不授权运行时 method lookup；adapter 必须在返回业务层前转换 host
 值或附加 external-object trait。
 
-strict 项目源码也不能直接依赖 `&get-raw`、`&struct:get`、手写 `&%{}`，或缺少匹配 nominal
+strict 项目源码也不能直接依赖 `&get-raw`、`record-get` / `&struct:get`、手写 `&%{}`，或缺少匹配 nominal
 layout/index/tag evidence 的 `&struct:nth`。这些形式会报告 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
 collection lookup 改用返回 `Option<T>` 的公开 API，Struct 字段改用 `(:field value)`，构造改用 `%{}`。
 compiler/macro lowering、core internals、可复用 `defimpl`，以及 evidence 完整的 persisted indexed IR 保持可用。

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -451,6 +451,8 @@ strict 项目源码也不能直接依赖 `&get-raw`、`record-get` / `&struct:ge
 layout/index/tag evidence 的 `&struct:nth`。这些形式会报告 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
 collection lookup 改用返回 `Option<T>` 的公开 API，Struct 字段改用 `(:field value)`，构造改用 `%{}`。
 compiler/macro lowering、core internals、可复用 `defimpl`，以及 evidence 完整的 persisted indexed IR 保持可用。
+已持久化的 `&%{}` IR 也可以保留，但必须能解析到具体 `defstruct`，并且每个声明字段恰好出现一次；
+缺字段、重复字段或未知字段仍会被拒绝。
 
 #### `.trim` / `.blank?` 接收者迁移
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -447,6 +447,11 @@ adapter；不要用 `unsafe-coerce` 批量压制。
 `:js-ffi` 只声明 host capability，不授权运行时 method lookup；adapter 必须在返回业务层前转换 host
 值或附加 external-object trait。
 
+strict 项目源码也不能直接依赖 `&get-raw`、`&struct:get`、手写 `&%{}`，或缺少匹配 nominal
+layout/index/tag evidence 的 `&struct:nth`。这些形式会报告 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
+collection lookup 改用返回 `Option<T>` 的公开 API，Struct 字段改用 `(:field value)`，构造改用 `%{}`。
+compiler/macro lowering、core internals、可复用 `defimpl`，以及 evidence 完整的 persisted indexed IR 保持可用。
+
 #### `.trim` / `.blank?` 接收者迁移
 
 `.trim` 与 `.blank?` 只对静态推断为 String 的接收者可用。若错误写成 `unknown method .trim for map`，

--- a/editing-history/202609040932-reject-raw-primitives-in-strict-source.md
+++ b/editing-history/202609040932-reject-raw-primitives-in-strict-source.md
@@ -1,0 +1,14 @@
+# Reject raw primitives in strict project source
+
+- Added `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written `&get-raw`,
+  `&struct:get`, raw `&%{}`, and `&struct:nth` without matching nominal layout
+  evidence.
+- Preserved public `%{}` macro lowering, reviewed macro/core internals, reusable
+  `defimpl` access, and persisted indexed Struct IR whose index/tag pair agrees
+  with the concrete receiver layout.
+- Added unit and real Snapshot CLI coverage with migrations toward typed
+  Option-returning lookups, named Struct fields, and public constructors.
+- Regressed the external `reel-strict` Respo application: compatibility
+  check-only still passes and the tree stays clean. Its strict preflight still
+  stops earlier at the existing `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA` boundary in
+  `render-app!`, rather than at the new raw-primitive policy.

--- a/editing-history/202609040932-reject-raw-primitives-in-strict-source.md
+++ b/editing-history/202609040932-reject-raw-primitives-in-strict-source.md
@@ -1,7 +1,7 @@
 # Reject raw primitives in strict project source
 
-- Added `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written `&get-raw`,
-  `&struct:get`, raw `&%{}`, and `&struct:nth` without matching nominal layout
+- Added `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written `&get-raw`, legacy
+  `record-get` / `&struct:get`, raw `&%{}`, and `&struct:nth` without matching nominal layout
   evidence.
 - Preserved public `%{}` macro lowering, reviewed macro/core internals, reusable
   `defimpl` access, and persisted indexed Struct IR whose index/tag pair agrees

--- a/editing-history/202609040934-address-pr-615-review.md
+++ b/editing-history/202609040934-address-pr-615-review.md
@@ -1,0 +1,6 @@
+# Address PR 615 raw diagnostic review
+
+- Split legacy `record-get` from the `&get-raw` diagnostic so the reported
+  primitive and migration guidance match the actual Struct field operation.
+- Added direct regression coverage and documented `record-get` alongside
+  `&struct:get` in the strict raw-primitive policy.

--- a/editing-history/202609040953-preserve-evidence-complete-raw-constructors.md
+++ b/editing-history/202609040953-preserve-evidence-complete-raw-constructors.md
@@ -1,0 +1,12 @@
+# Preserve evidence-complete raw Struct constructors
+
+- Refined strict `&%{}` handling so persisted Snapshot IR remains valid when
+  the constructor resolves to one concrete `defstruct` and provides every
+  declared field exactly once.
+- Kept missing, duplicate, unknown, and unresolved raw constructors behind
+  `E_RAW_PRIMITIVE_IN_TYPED_CODE`.
+- Added focused coverage for embedded definitions, namespace-local Snapshot
+  symbols, reordered complete fields, and each rejected shape.
+- Regressed the external `js-ffi` project: raw Struct construction now passes;
+  its strict preflight advances to the independently tracked
+  `E_ERASED_GENERIC_RELATION` boundary in `js-ffi.contract/expect-string`.

--- a/editing-history/202609041012-reject-shadowed-raw-struct-definitions.md
+++ b/editing-history/202609041012-reject-shadowed-raw-struct-definitions.md
@@ -1,0 +1,7 @@
+# Reject shadowed raw Struct definitions
+
+- Made evidence-complete persisted `&%{}` checks consult lexical scope before
+  resolving a namespace-local constructor symbol.
+- A local binding that shadows a global `defstruct` can no longer borrow the
+  global layout as proof for raw constructor IR.
+- Added a focused strict regression alongside the valid Snapshot symbol case.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -250,6 +250,23 @@ fn strict_type_fail_general_dynamic_method_reports_receiver_source() {
 }
 
 #[test]
+fn strict_type_fail_raw_primitive_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/raw-primitive-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("hand-written raw primitive must fail strict check-only");
+
+    assert!(err.contains("E_RAW_PRIMITIVE_IN_TYPED_CODE"), "unexpected strict raw error: {err}");
+    assert!(err.contains("`&get-raw`"), "primitive should be explicit: {err}");
+    assert!(
+      err.contains("typed collection lookup returning Option<T>"),
+      "migration should point to the typed public API: {err}"
+    );
+  });
+}
+
+#[test]
 fn strict_type_fail_erased_generic_relation_reports_stable_error_code() {
   run_with_large_stack(|| {
     let fixture = "calcit/type-fail/erased-generic-relation-strict.cirru";

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3934,12 +3934,18 @@ fn reject_raw_primitive_in_strict_source(
         "use named field syntax on a concrete Struct; only indexed IR with a matching nominal layout and field tag is accepted",
       ))
     }
-    Calcit::Import(CalcitImport { ns, def, .. })
-      if ns.as_ref() == calcit::CORE_NS && matches!(def.as_ref(), "&get-raw" | "record-get") && !inside_defimpl =>
-    {
+    Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "&get-raw" && !inside_defimpl => {
       Some((
         "`&get-raw`",
         "use typed collection lookup returning Option<T>, or named Struct field syntax after narrowing the receiver",
+      ))
+    }
+    Calcit::Import(CalcitImport { ns, def, .. })
+      if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "record-get" && !inside_defimpl =>
+    {
+      Some((
+        "`record-get`",
+        "use `(:field value)` or `value.:field` on a concrete Struct so the compiler validates and lowers the access",
       ))
     }
     Calcit::Symbol { sym, .. } if sym.as_ref() == "&get-raw" && !inside_defimpl => Some((
@@ -11850,6 +11856,26 @@ mod tests {
       assert_eq!(error.code.as_deref(), Some("E_RAW_PRIMITIVE_IN_TYPED_CODE"));
       assert!(error.msg.contains(primitive), "diagnostic must name {primitive}: {error:?}");
     }
+
+    let record_get = Calcit::Import(CalcitImport {
+      ns: Arc::from(calcit::CORE_NS),
+      def: Arc::from("record-get"),
+      info: Arc::new(ImportInfo::Core {
+        at_ns: Arc::from("tests.raw-strict"),
+      }),
+      def_id: None,
+    });
+    let record_error = reject_raw_primitive_in_strict_source(
+      &record_get,
+      &CalcitList::default(),
+      &ScopeTypes::new(),
+      "tests.raw-strict",
+      &CallStackList::default(),
+      None,
+    )
+    .expect_err("legacy record-get must receive its own Struct-access diagnostic");
+    assert!(record_error.msg.contains("`record-get`"));
+    assert!(record_error.msg.contains("`(:field value)`"));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1799,6 +1799,7 @@ fn preprocess_list_call(
       call_location,
     ));
   }
+  reject_raw_primitive_in_strict_source(&head_form, &args, scope_types, file_ns, call_stack, call_location.clone())?;
   warn_on_removed_data_api_call(&head_form, call_location.clone(), file_ns, check_warnings);
 
   let has_anonymous_definition_marker = matches!(args.first(), Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "_");
@@ -3895,6 +3896,92 @@ fn check_struct_field_access(
   }
 }
 
+fn reject_raw_primitive_in_strict_source(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  call_stack: &CallStackList,
+  location: Option<NodeLocation>,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled() || !should_emit_project_source_lint(file_ns) || file_ns == calcit::CORE_NS {
+    return Ok(());
+  }
+
+  let public_struct_constructor_origin = call_stack
+    .0
+    .iter()
+    .any(|frame| matches!(frame.kind, StackKind::Macro) && frame.ns.as_ref() == calcit::CORE_NS && frame.def.as_ref() == "%{}");
+  let inside_defimpl = call_stack
+    .0
+    .iter()
+    .any(|frame| matches!(frame.kind, StackKind::Macro) && frame.ns.as_ref() == calcit::CORE_NS && frame.def.as_ref() == "defimpl");
+
+  let violation = match head {
+    Calcit::Proc(CalcitProc::NativeStruct) if !public_struct_constructor_origin => Some((
+      "`&%{}`",
+      "use the public `%{}` constructor so field names and declared field types are validated before lowering",
+    )),
+    Calcit::Proc(CalcitProc::NativeStructGet) if !inside_defimpl => Some((
+      "`&struct:get`",
+      "use `(:field value)` or `value.:field` on a concrete Struct so the compiler validates and lowers the access",
+    )),
+    Calcit::Proc(CalcitProc::NativeStructNth)
+      if !inside_defimpl && !raw_struct_index_matches_known_layout(args.first(), args.get(1), args.get(2), scope_types) =>
+    {
+      Some((
+        "`&struct:nth`",
+        "use named field syntax on a concrete Struct; only indexed IR with a matching nominal layout and field tag is accepted",
+      ))
+    }
+    Calcit::Import(CalcitImport { ns, def, .. })
+      if ns.as_ref() == calcit::CORE_NS && matches!(def.as_ref(), "&get-raw" | "record-get") && !inside_defimpl =>
+    {
+      Some((
+        "`&get-raw`",
+        "use typed collection lookup returning Option<T>, or named Struct field syntax after narrowing the receiver",
+      ))
+    }
+    Calcit::Symbol { sym, .. } if sym.as_ref() == "&get-raw" && !inside_defimpl => Some((
+      "`&get-raw`",
+      "use typed collection lookup returning Option<T>, or named Struct field syntax after narrowing the receiver",
+    )),
+    _ => None,
+  };
+
+  let Some((primitive, migration)) = violation else {
+    return Ok(());
+  };
+  Err(CalcitErr::use_msg_stack_location_with_code(
+    CalcitErrKind::Type,
+    format!("raw primitive {primitive} is not allowed in strict project source; {migration}"),
+    "E_RAW_PRIMITIVE_IN_TYPED_CODE",
+    call_stack,
+    location,
+  ))
+}
+
+fn raw_struct_index_matches_known_layout(
+  receiver: Option<&Calcit>,
+  index: Option<&Calcit>,
+  field: Option<&Calcit>,
+  scope_types: &ScopeTypes,
+) -> bool {
+  let (Some(receiver), Some(Calcit::Number(raw_index)), Some(Calcit::Tag(field_tag))) = (receiver, index, field) else {
+    return false;
+  };
+  resolve_type_value(receiver, scope_types)
+    .as_deref()
+    .and_then(CalcitTypeAnnotation::resolve_to_struct)
+    .is_some_and(|struct_def| {
+      *raw_index >= 0.0
+        && raw_index.fract() == 0.0
+        && struct_def
+          .index_of(field_tag.ref_str())
+          .is_some_and(|field_index| field_index == *raw_index as usize)
+    })
+}
+
 fn warn_on_raw_struct_index_access(
   receiver: &Calcit,
   index: &Calcit,
@@ -3919,22 +4006,7 @@ fn warn_on_raw_struct_index_access(
   // Snapshot IR. Accept that representation when the receiver still proves the
   // exact nominal layout and the embedded index/tag pair agrees with it. Raw
   // indexed access is hazardous only when that proof is absent or stale.
-  let matches_known_layout = resolve_type_value(receiver, scope_types)
-    .as_deref()
-    .and_then(CalcitTypeAnnotation::resolve_to_struct)
-    .is_some_and(|struct_def| {
-      let Calcit::Number(raw_index) = index else {
-        return false;
-      };
-      let Some(Calcit::Tag(field_tag)) = field else {
-        return false;
-      };
-      *raw_index >= 0.0
-        && raw_index.fract() == 0.0
-        && struct_def
-          .index_of(field_tag.ref_str())
-          .is_some_and(|field_index| field_index == *raw_index as usize)
-    });
+  let matches_known_layout = raw_struct_index_matches_known_layout(Some(receiver), Some(index), field, scope_types);
   if matches_known_layout {
     return;
   }
@@ -11729,6 +11801,74 @@ mod tests {
   }
 
   #[test]
+  fn strict_types_reject_handwritten_raw_primitives() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+
+    for (expr, primitive) in [
+      (
+        Cirru::List(vec![Cirru::leaf("&struct:get"), Cirru::leaf("store"), Cirru::leaf(":states")]),
+        "&struct:get",
+      ),
+      (
+        Cirru::List(vec![
+          Cirru::leaf("&struct:nth"),
+          Cirru::leaf("store"),
+          Cirru::leaf("1"),
+          Cirru::leaf(":states"),
+        ]),
+        "&struct:nth",
+      ),
+      (
+        Cirru::List(vec![Cirru::leaf("&get-raw"), Cirru::leaf("store"), Cirru::leaf(":states")]),
+        "&get-raw",
+      ),
+      (
+        Cirru::List(vec![
+          Cirru::leaf("&%{}"),
+          Cirru::leaf("Store"),
+          Cirru::leaf(":states"),
+          Cirru::leaf("1"),
+        ]),
+        "&%{}",
+      ),
+    ] {
+      let code = code_to_calcit(&expr, "tests.raw-strict", "demo", vec![]).expect("parse raw primitive");
+      let scope_defs = HashSet::from([Arc::from("store"), Arc::from("Store")]);
+      let mut scope_types = ScopeTypes::from([(Arc::from("store"), Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))))]);
+      let warnings = RefCell::new(vec![]);
+
+      let error = preprocess_expr(
+        &code,
+        &scope_defs,
+        &mut scope_types,
+        "tests.raw-strict",
+        &warnings,
+        &CallStackList::default(),
+      )
+      .expect_err("strict project source must reject a hand-written raw primitive");
+      assert_eq!(error.code.as_deref(), Some("E_RAW_PRIMITIVE_IN_TYPED_CODE"));
+      assert!(error.msg.contains(primitive), "diagnostic must name {primitive}: {error:?}");
+    }
+  }
+
+  #[test]
+  fn strict_raw_policy_only_accepts_the_core_public_constructor_macro() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let head = Calcit::Proc(CalcitProc::NativeStruct);
+    let args = CalcitList::default();
+    let core_origin = CallStackList::default().extend(calcit::CORE_NS, "%{}", StackKind::Macro, &Calcit::Nil, &[]);
+    reject_raw_primitive_in_strict_source(&head, &args, &ScopeTypes::new(), "tests.raw-strict", &core_origin, None)
+      .expect("the public core constructor macro may lower to &%{}");
+
+    let project_origin = CallStackList::default().extend("tests.raw-strict", "%{}", StackKind::Macro, &Calcit::Nil, &[]);
+    let error = reject_raw_primitive_in_strict_source(&head, &args, &ScopeTypes::new(), "tests.raw-strict", &project_origin, None)
+      .expect_err("a project macro with the same name must not grant a raw-constructor exemption");
+    assert_eq!(error.code.as_deref(), Some("E_RAW_PRIMITIVE_IN_TYPED_CODE"));
+  }
+
+  #[test]
   fn rejects_source_struct_index_access_in_generic_helpers() {
     let _guard = WarnDynMethodGuard::new(true);
     let expr = Cirru::List(vec![
@@ -11763,6 +11903,8 @@ mod tests {
 
   #[test]
   fn accepts_persisted_struct_index_ir_with_matching_nominal_layout() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
     let _guard = WarnDynMethodGuard::new(true);
     let expr = Cirru::List(vec![
       Cirru::leaf("&struct:nth"),

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3919,7 +3919,7 @@ fn reject_raw_primitive_in_strict_source(
 
   let violation = match head {
     Calcit::Proc(CalcitProc::NativeStruct)
-      if !public_struct_constructor_origin && !raw_struct_constructor_matches_known_layout(args) =>
+      if !public_struct_constructor_origin && !raw_struct_constructor_matches_known_layout(args, scope_types) =>
     {
       Some((
         "`&%{}`",
@@ -3971,7 +3971,7 @@ fn reject_raw_primitive_in_strict_source(
   ))
 }
 
-fn raw_struct_constructor_matches_known_layout(args: &CalcitList) -> bool {
+fn raw_struct_constructor_matches_known_layout(args: &CalcitList, scope_types: &ScopeTypes) -> bool {
   let Some(definition) = args.first() else {
     return false;
   };
@@ -3980,7 +3980,9 @@ fn raw_struct_constructor_matches_known_layout(args: &CalcitList) -> bool {
     Calcit::Import(CalcitImport { ns, def, .. }) if data_definition_kind(ns, def) == Some("defstruct") => {
       CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), Arc::new(vec![])).resolve_to_struct()
     }
-    Calcit::Symbol { sym, info, .. } if data_definition_kind(&info.at_ns, sym) == Some("defstruct") => {
+    Calcit::Symbol { sym, info, .. }
+      if !scope_types.contains_key(sym) && data_definition_kind(&info.at_ns, sym) == Some("defstruct") =>
+    {
       CalcitTypeAnnotation::TypeRef(Arc::from(format!("{}/{sym}", info.at_ns)), Arc::new(vec![])).resolve_to_struct()
     }
     _ => None,
@@ -12000,6 +12002,15 @@ mod tests {
       None,
     )
     .expect("namespace-local Snapshot symbols must resolve back to their concrete defstruct layout");
+
+    let shadowed_scope = ScopeTypes::from([(
+      Arc::from("Person"),
+      Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(person.clone()))),
+    )]);
+    let shadowed_error =
+      reject_raw_primitive_in_strict_source(&head, &snapshot_args, &shadowed_scope, snapshot_ns, &CallStackList::default(), None)
+        .expect_err("a lexical binding must not borrow evidence from a shadowed global defstruct");
+    assert_eq!(shadowed_error.code.as_deref(), Some("E_RAW_PRIMITIVE_IN_TYPED_CODE"));
 
     for invalid_args in [
       list(vec![

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3918,10 +3918,14 @@ fn reject_raw_primitive_in_strict_source(
     .any(|frame| matches!(frame.kind, StackKind::Macro) && frame.ns.as_ref() == calcit::CORE_NS && frame.def.as_ref() == "defimpl");
 
   let violation = match head {
-    Calcit::Proc(CalcitProc::NativeStruct) if !public_struct_constructor_origin => Some((
-      "`&%{}`",
-      "use the public `%{}` constructor so field names and declared field types are validated before lowering",
-    )),
+    Calcit::Proc(CalcitProc::NativeStruct)
+      if !public_struct_constructor_origin && !raw_struct_constructor_matches_known_layout(args) =>
+    {
+      Some((
+        "`&%{}`",
+        "use the public `%{}` constructor so field names and declared field types are validated before lowering; persisted raw constructor IR is accepted only when it names one concrete Struct and provides every declared field exactly once",
+      ))
+    }
     Calcit::Proc(CalcitProc::NativeStructGet) if !inside_defimpl => Some((
       "`&struct:get`",
       "use `(:field value)` or `value.:field` on a concrete Struct so the compiler validates and lowers the access",
@@ -3965,6 +3969,40 @@ fn reject_raw_primitive_in_strict_source(
     call_stack,
     location,
   ))
+}
+
+fn raw_struct_constructor_matches_known_layout(args: &CalcitList) -> bool {
+  let Some(definition) = args.first() else {
+    return false;
+  };
+  let resolved_struct_def = match definition {
+    Calcit::StructDef(struct_def) => Some(struct_def.to_owned()),
+    Calcit::Import(CalcitImport { ns, def, .. }) if data_definition_kind(ns, def) == Some("defstruct") => {
+      CalcitTypeAnnotation::TypeRef(Arc::from(format!("{ns}/{def}")), Arc::new(vec![])).resolve_to_struct()
+    }
+    Calcit::Symbol { sym, info, .. } if data_definition_kind(&info.at_ns, sym) == Some("defstruct") => {
+      CalcitTypeAnnotation::TypeRef(Arc::from(format!("{}/{sym}", info.at_ns)), Arc::new(vec![])).resolve_to_struct()
+    }
+    _ => None,
+  };
+  let Some(struct_def) = resolved_struct_def else {
+    return false;
+  };
+  if args.len() != 1 + struct_def.fields.len() * 2 {
+    return false;
+  }
+
+  let mut provided_fields = HashSet::with_capacity(struct_def.fields.len());
+  let items = args.to_vec();
+  for pair in items[1..].chunks_exact(2) {
+    let Calcit::Tag(field) = &pair[0] else {
+      return false;
+    };
+    if !struct_def.fields.iter().any(|declared| declared == field) || !provided_fields.insert(field.to_owned()) {
+      return false;
+    }
+  }
+  provided_fields.len() == struct_def.fields.len()
 }
 
 fn raw_struct_index_matches_known_layout(
@@ -11879,7 +11917,7 @@ mod tests {
   }
 
   #[test]
-  fn strict_raw_policy_only_accepts_the_core_public_constructor_macro() {
+  fn strict_raw_policy_accepts_public_or_evidence_complete_struct_constructors() {
     let _lock = lock_preprocess_test_state();
     let _strict = StrictTypesGuard::new(true);
     let head = Calcit::Proc(CalcitProc::NativeStruct);
@@ -11892,6 +11930,109 @@ mod tests {
     let error = reject_raw_primitive_in_strict_source(&head, &args, &ScopeTypes::new(), "tests.raw-strict", &project_origin, None)
       .expect_err("a project macro with the same name must not grant a raw-constructor exemption");
     assert_eq!(error.code.as_deref(), Some("E_RAW_PRIMITIVE_IN_TYPED_CODE"));
+
+    let person = CalcitStructDef::from_fields(EdnTag::from("Person"), vec![EdnTag::from("age"), EdnTag::from("name")]);
+    let list = |items: Vec<Calcit>| CalcitList::from(items.as_slice());
+    let complete_args = list(vec![
+      Calcit::StructDef(person.clone()),
+      Calcit::Tag(EdnTag::from("name")),
+      Calcit::Str(Arc::from("Alice")),
+      Calcit::Tag(EdnTag::from("age")),
+      Calcit::Number(20.0),
+    ]);
+    reject_raw_primitive_in_strict_source(
+      &head,
+      &complete_args,
+      &ScopeTypes::new(),
+      "tests.raw-strict",
+      &CallStackList::default(),
+      None,
+    )
+    .expect("persisted raw IR may reorder fields when its concrete Struct layout remains exact");
+
+    calcit::register_program_lookups(program::lookup_runtime_ready, program::lookup_def_code, program::lookup_def_schema);
+    let snapshot_ns = "tests.raw-constructor-snapshot";
+    let struct_source_marker = Calcit::from(vec![Calcit::Symbol {
+      sym: Arc::from("defstruct"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from(snapshot_ns),
+        at_def: Arc::from("Person"),
+      }),
+      location: None,
+    }]);
+    program::PROGRAM_CODE_DATA.write().expect("open program code").insert(
+      Arc::from(snapshot_ns),
+      program::ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([(
+          Arc::from("Person"),
+          program::ProgramDefEntry {
+            code: struct_source_marker,
+            schema: calcit::DYNAMIC_TYPE.clone(),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: None,
+          },
+        )]),
+      },
+    );
+    program::write_runtime_ready(snapshot_ns, "Person", Calcit::StructDef(person.clone())).expect("register Snapshot Struct metadata");
+    let snapshot_args = list(vec![
+      Calcit::Symbol {
+        sym: Arc::from("Person"),
+        info: Arc::new(CalcitSymbolInfo {
+          at_ns: Arc::from(snapshot_ns),
+          at_def: Arc::from("make-person"),
+        }),
+        location: None,
+      },
+      Calcit::Tag(EdnTag::from("age")),
+      Calcit::Number(20.0),
+      Calcit::Tag(EdnTag::from("name")),
+      Calcit::Str(Arc::from("Alice")),
+    ]);
+    reject_raw_primitive_in_strict_source(
+      &head,
+      &snapshot_args,
+      &ScopeTypes::new(),
+      snapshot_ns,
+      &CallStackList::default(),
+      None,
+    )
+    .expect("namespace-local Snapshot symbols must resolve back to their concrete defstruct layout");
+
+    for invalid_args in [
+      list(vec![
+        Calcit::StructDef(person.clone()),
+        Calcit::Tag(EdnTag::from("name")),
+        Calcit::Str(Arc::from("Alice")),
+      ]),
+      list(vec![
+        Calcit::StructDef(person.clone()),
+        Calcit::Tag(EdnTag::from("name")),
+        Calcit::Str(Arc::from("Alice")),
+        Calcit::Tag(EdnTag::from("name")),
+        Calcit::Str(Arc::from("duplicate")),
+      ]),
+      list(vec![
+        Calcit::StructDef(person.clone()),
+        Calcit::Tag(EdnTag::from("name")),
+        Calcit::Str(Arc::from("Alice")),
+        Calcit::Tag(EdnTag::from("unknown")),
+        Calcit::Number(20.0),
+      ]),
+    ] {
+      let error = reject_raw_primitive_in_strict_source(
+        &head,
+        &invalid_args,
+        &ScopeTypes::new(),
+        "tests.raw-strict",
+        &CallStackList::default(),
+        None,
+      )
+      .expect_err("missing, duplicate, or unknown fields must not count as exact constructor evidence");
+      assert_eq!(error.code.as_deref(), Some("E_RAW_PRIMITIVE_IN_TYPED_CODE"));
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Summary / 概要

- add stable `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written `&get-raw`, `&struct:get`, raw `&%{}`, and `&struct:nth` without matching nominal layout evidence
- preserve the core `%{}` macro lowering, reviewed `defimpl`/core internals, and persisted indexed Struct IR with an exact index/tag/layout proof
- add unit and real Snapshot type-fail coverage plus migration guidance

- 为手写 `&get-raw`、`&struct:get`、raw `&%{}`，以及缺少 nominal layout evidence 的 `&struct:nth` 增加稳定 strict error
- 保留 core `%{}` lowering、审核过的 `defimpl`/core internal，以及 index/tag/layout 完全匹配的 persisted Struct IR
- 增加 unit、真实 Snapshot type-fail 与迁移文档

## Validation / 验证

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (667 lib / 287 CLI / 23 wasm)
- `yarn compile`
- `yarn test-fail` (24/24)
- `yarn check-agent-interface` (18/18)
- `yarn check-all`
- external `reel-strict`: compatibility check-only passes and repository stays clean; strict preflight still stops earlier at its existing whole-Dynamic schema boundary

Closes the raw-primitive policy slice of #580.
Progresses #577.