### PR TITLE
feat: require lexical FFI scope for unsafe coerce

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -22,6 +22,8 @@
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-method-dispatch-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/raw-primitive-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/untyped-js-object-access-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/js-nullish-dereference-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/js-nullish-predicate-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/unsafe-coerce-unscoped-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
@@ -40,6 +42,8 @@
 - `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `raw-primitive-strict.cirru` 会验证 strict 模式拒绝项目源码直接调用 `&get-raw`，并报告稳定的 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
 - `untyped-js-object-access-strict.cirru` 会验证 strict 模式拒绝裸 `JsObject` 上的静态成员访问，并报告稳定的 `E_UNTYPED_JS_OBJECT_ACCESS` 与 external-object trait 迁移建议。
+- `js-nullish-dereference-strict.cirru` 会验证 strict 模式拒绝直接解引用 `JsNullish<JsObject>`，并报告稳定的 `E_JS_FFI_NULLABLE_DEREF` 与显式 narrow/optional access 建议。
+- `js-nullish-predicate-strict.cirru` 会验证 strict 模式拒绝以 legacy `nil?`/`some?` 检查 `JsNullish<T>`，并报告稳定的 `E_JS_FFI_NULLABLE_PREDICATE` 与专用 predicate 建议。
 - `unsafe-coerce-unscoped-strict.cirru` 会验证 strict 模式拒绝未声明 `:js-ffi` 的 `unsafe-coerce`，并报告稳定的 `E_UNSCOPED_UNSAFE_COERCE`。
 - `unsafe-coerce-scoped-strict.cirru` 是 integration preprocessing 正例：标记 adapter 可使用 assertion，普通 typed caller 不继承也不需要该 capability；完整 strict quality gate 仍要求显式 `unsafeCoerce` baseline。
 - `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
@@ -57,6 +61,7 @@
 - strict general Dynamic method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver-loss 分类与 typed adapter 迁移建议
 - strict raw primitive fixture：断言错误文本包含 `E_RAW_PRIMITIVE_IN_TYPED_CODE`、primitive 名称与 typed public API 迁移建议
 - strict untyped JS object fixture：断言错误文本包含 `E_UNTYPED_JS_OBJECT_ACCESS`、成员名、receiver evidence 与 external-object trait 迁移建议
+- strict nullable JS fixtures：断言直接 dereference 报 `E_JS_FFI_NULLABLE_DEREF`，legacy predicate 报 `E_JS_FFI_NULLABLE_PREDICATE`，且两者都提供专用 host-nullability 迁移建议
 - strict unsafe-coerce fixtures：断言未标记 adapter 报 `E_UNSCOPED_UNSAFE_COERCE`，而词法标记的 adapter 与普通 caller 可通过 preprocessing
 - strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
@@ -76,6 +81,8 @@
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
 - `E_RAW_PRIMITIVE_IN_TYPED_CODE`：strict 项目源码手写 raw constructor/lookup/index primitive，且没有 compiler/macro origin 或匹配的 nominal layout evidence
 - `E_UNTYPED_JS_OBJECT_ACCESS`：strict 项目源码在裸 `JsObject` 上以静态成员名执行读取、调用或写入，需在 lexical adapter 内绑定 external-object trait；动态 key 保留 raw lookup 语义
+- `E_JS_FFI_NULLABLE_DEREF`：strict 项目源码未 narrow `JsNullish<JsObject>` 就直接读取或调用宿主成员
+- `E_JS_FFI_NULLABLE_PREDICATE`：strict 项目源码用 legacy `nil?`/`some?` 擦除 `JsNullish<T>` 的宿主空值语义
 - `E_UNSCOPED_UNSAFE_COERCE`：strict 项目源码在当前 definition 未声明 `:js-ffi` 时使用 `unsafe-coerce`
 - `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配

--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -21,6 +21,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-nominal-method-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-method-dispatch-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/raw-primitive-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/untyped-js-object-access-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/unsafe-coerce-unscoped-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
@@ -38,6 +39,7 @@
 - `dynamic-nominal-method-strict.cirru` 会验证 strict 模式拒绝 Dynamic receiver 上的 Option/Result nominal method dispatch，并报告稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `raw-primitive-strict.cirru` 会验证 strict 模式拒绝项目源码直接调用 `&get-raw`，并报告稳定的 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
+- `untyped-js-object-access-strict.cirru` 会验证 strict 模式拒绝裸 `JsObject` 上的静态成员访问，并报告稳定的 `E_UNTYPED_JS_OBJECT_ACCESS` 与 external-object trait 迁移建议。
 - `unsafe-coerce-unscoped-strict.cirru` 会验证 strict 模式拒绝未声明 `:js-ffi` 的 `unsafe-coerce`，并报告稳定的 `E_UNSCOPED_UNSAFE_COERCE`。
 - `unsafe-coerce-scoped-strict.cirru` 是 integration preprocessing 正例：标记 adapter 可使用 assertion，普通 typed caller 不继承也不需要该 capability；完整 strict quality gate 仍要求显式 `unsafeCoerce` baseline。
 - `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
@@ -54,6 +56,7 @@
 - strict Dynamic nominal-method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver schema 与低层 helper 迁移建议
 - strict general Dynamic method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver-loss 分类与 typed adapter 迁移建议
 - strict raw primitive fixture：断言错误文本包含 `E_RAW_PRIMITIVE_IN_TYPED_CODE`、primitive 名称与 typed public API 迁移建议
+- strict untyped JS object fixture：断言错误文本包含 `E_UNTYPED_JS_OBJECT_ACCESS`、成员名、receiver evidence 与 external-object trait 迁移建议
 - strict unsafe-coerce fixtures：断言未标记 adapter 报 `E_UNSCOPED_UNSAFE_COERCE`，而词法标记的 adapter 与普通 caller 可通过 preprocessing
 - strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
@@ -72,6 +75,7 @@
 - `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`：strict 模式下可达 function 或直接进入预处理的 programmatic macro 既没有结构化根 schema，也没有嵌入式结构化契约；普通 legacy Snapshot macro 会更早被 loader 拒绝
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
 - `E_RAW_PRIMITIVE_IN_TYPED_CODE`：strict 项目源码手写 raw constructor/lookup/index primitive，且没有 compiler/macro origin 或匹配的 nominal layout evidence
+- `E_UNTYPED_JS_OBJECT_ACCESS`：strict 项目源码在裸 `JsObject` 上以静态成员名执行读取、调用或写入，需在 lexical adapter 内绑定 external-object trait；动态 key 保留 raw lookup 语义
 - `E_UNSCOPED_UNSAFE_COERCE`：strict 项目源码在当前 definition 未声明 `:js-ffi` 时使用 `unsafe-coerce`
 - `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配

--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -21,6 +21,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-nominal-method-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-method-dispatch-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/raw-primitive-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/unsafe-coerce-unscoped-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
 其中：
@@ -37,6 +38,8 @@
 - `dynamic-nominal-method-strict.cirru` 会验证 strict 模式拒绝 Dynamic receiver 上的 Option/Result nominal method dispatch，并报告稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `raw-primitive-strict.cirru` 会验证 strict 模式拒绝项目源码直接调用 `&get-raw`，并报告稳定的 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
+- `unsafe-coerce-unscoped-strict.cirru` 会验证 strict 模式拒绝未声明 `:js-ffi` 的 `unsafe-coerce`，并报告稳定的 `E_UNSCOPED_UNSAFE_COERCE`。
+- `unsafe-coerce-scoped-strict.cirru` 是 integration preprocessing 正例：标记 adapter 可使用 assertion，普通 typed caller 不继承也不需要该 capability；完整 strict quality gate 仍要求显式 `unsafeCoerce` baseline。
 - `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
 
 ## 自动化测试
@@ -51,6 +54,7 @@
 - strict Dynamic nominal-method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver schema 与低层 helper 迁移建议
 - strict general Dynamic method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver-loss 分类与 typed adapter 迁移建议
 - strict raw primitive fixture：断言错误文本包含 `E_RAW_PRIMITIVE_IN_TYPED_CODE`、primitive 名称与 typed public API 迁移建议
+- strict unsafe-coerce fixtures：断言未标记 adapter 报 `E_UNSCOPED_UNSAFE_COERCE`，而词法标记的 adapter 与普通 caller 可通过 preprocessing
 - strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
 相关测试位于 [src/bin/calcit.rs](src/bin/calcit.rs)。
@@ -68,6 +72,7 @@
 - `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`：strict 模式下可达 function 或直接进入预处理的 programmatic macro 既没有结构化根 schema，也没有嵌入式结构化契约；普通 legacy Snapshot macro 会更早被 loader 拒绝
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
 - `E_RAW_PRIMITIVE_IN_TYPED_CODE`：strict 项目源码手写 raw constructor/lookup/index primitive，且没有 compiler/macro origin 或匹配的 nominal layout evidence
+- `E_UNSCOPED_UNSAFE_COERCE`：strict 项目源码在当前 definition 未声明 `:js-ffi` 时使用 `unsafe-coerce`
 - `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配
 - `W_METHOD_ARG_TYPE_MISMATCH`：静态方法调用参数类型不匹配

--- a/calcit/type-fail/js-nullish-dereference-strict.cirru
+++ b/calcit/type-fail/js-nullish-dereference-strict.cirru
@@ -1,0 +1,27 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-js-nullish-dereference-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for direct dereference of a nullable JavaScript host value.") (:init-fn 'type-fail-js-nullish-dereference-strict.main/main!) (:mode :js) (:reload-fn 'type-fail-js-nullish-dereference-strict.main/reload!) (:target :node)
+      :feature-policy $ {} (:js-ffi :error)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-js-nullish-dereference-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc "|A nullable host value must be narrowed before member access.")
+          :code $ quote
+            defn main! () $ let
+                host $ js/process.argv
+              .-length host
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+              :features $ #{} :js-ffi
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict nullable JavaScript dereference fixture.")
+        :code $ quote (ns type-fail-js-nullish-dereference-strict.main)

--- a/calcit/type-fail/js-nullish-predicate-strict.cirru
+++ b/calcit/type-fail/js-nullish-predicate-strict.cirru
@@ -1,0 +1,27 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-js-nullish-predicate-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for a legacy nil predicate on a nullable JavaScript host value.") (:init-fn 'type-fail-js-nullish-predicate-strict.main/main!) (:mode :js) (:reload-fn 'type-fail-js-nullish-predicate-strict.main/reload!) (:target :node)
+      :feature-policy $ {} (:js-ffi :error)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-js-nullish-predicate-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc "|A nullable host value must use a JavaScript-specific presence predicate.")
+          :code $ quote
+            defn main! () $ let
+                host $ js/process.argv
+              nil? host
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ []
+              :features $ #{} :js-ffi
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict nullable JavaScript predicate fixture.")
+        :code $ quote (ns type-fail-js-nullish-predicate-strict.main)

--- a/calcit/type-fail/unsafe-coerce-scoped-strict.cirru
+++ b/calcit/type-fail/unsafe-coerce-scoped-strict.cirru
@@ -1,0 +1,32 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-unsafe-coerce-scoped-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for a lexically scoped unsafe host assertion.") (:init-fn 'type-fail-unsafe-coerce-scoped-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-unsafe-coerce-scoped-strict.main/reload!)
+      :feature-policy $ {}
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-unsafe-coerce-scoped-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'coerce-host $ %{} 'CodeEntry (:doc "|The same assertion is allowed only in this marked adapter body.")
+          :code $ quote
+            defn coerce-host (value) (unsafe-coerce value 'String)
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Dynamic
+              :features $ #{} :js-ffi
+              :return 'String
+        'main! $ %{} 'CodeEntry (:doc "|Typed callers do not inherit or need the adapter capability.")
+          :code $ quote (defn main! () (coerce-host 1))
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ []
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict scoped unsafe-coerce fixture.")
+        :code $ quote (ns type-fail-unsafe-coerce-scoped-strict.main)

--- a/calcit/type-fail/unsafe-coerce-unscoped-strict.cirru
+++ b/calcit/type-fail/unsafe-coerce-unscoped-strict.cirru
@@ -1,0 +1,30 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-unsafe-coerce-unscoped-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for an unscoped unsafe host assertion.") (:init-fn 'type-fail-unsafe-coerce-unscoped-strict.main/main!) (:mode :native) (:reload-fn 'type-fail-unsafe-coerce-unscoped-strict.main/reload!)
+      :feature-policy $ {}
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-unsafe-coerce-unscoped-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'coerce-host $ %{} 'CodeEntry (:doc "|An unsafe assertion without lexical FFI capability must fail.")
+          :code $ quote
+            defn coerce-host (value) (unsafe-coerce value 'String)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ [] 'Dynamic
+        'main! $ %{} 'CodeEntry (:doc "|Entry that makes coerce-host reachable.")
+          :code $ quote (defn main! () (coerce-host 1))
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ []
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict unscoped unsafe-coerce fixture.")
+        :code $ quote (ns type-fail-unsafe-coerce-unscoped-strict.main)

--- a/calcit/type-fail/untyped-js-object-access-strict.cirru
+++ b/calcit/type-fail/untyped-js-object-access-strict.cirru
@@ -1,0 +1,27 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-untyped-js-object-access-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for literal access on a bare JsObject.") (:init-fn 'type-fail-untyped-js-object-access-strict.main/main!) (:mode :js) (:reload-fn 'type-fail-untyped-js-object-access-strict.main/reload!) (:target :node)
+      :feature-policy $ {} (:js-ffi :error)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-untyped-js-object-access-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc "|A known member on a bare host object must use an external-object trait.")
+          :code $ quote
+            defn main! () $ let
+                host $ js-object
+              .-length host
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+              :features $ #{} :js-ffi
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict untyped JavaScript object access fixture.")
+        :code $ quote (ns type-fail-untyped-js-object-access-strict.main)

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -34,8 +34,9 @@ and portability rules that apply to every form.
 ## 1. Boundary model: opaque first, typed second
 
 Raw JavaScript values are not ordinary `Dynamic` Calcit values. Property reads,
-native method calls, `aget`, untyped `js-get`, and `js/...` calls are
-conservatively inferred as `JsNullish<JsObject>`:
+native method calls, `aget`, untyped `js-get`, and arbitrary `js/...` calls are
+conservatively inferred as `JsNullish<JsObject>`. The deliberate exception is
+`js/typeof`, whose JavaScript-language result is always inferred as `String`:
 
 - `JsNullish` is reserved for the actual JavaScript `null`/`undefined` boundary;
   it is deliberately distinct from legacy `Optional` and nominal `Option`.

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -103,7 +103,7 @@ legacy projects and disables this target-specific check.
 
 ### 2.3 Audit untyped access points
 
-`.-name`, `.!name`, `aget`, `aset`, `js-get`, and `js-set` against a bare
+`.-name`, `.!name`, `.?-name`, `.?!name`, `aget`, `aset`, `js-get`, and `js-set` against a bare
 `JsObject` receiver have no field or method contract. When the member key is a
 literal, strict project source rejects the access with
 `E_UNTYPED_JS_OBJECT_ACCESS`; declare the smallest external-object trait and

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -47,18 +47,22 @@ conservatively inferred as `JsNullish<JsObject>`. The deliberate exception is
   with a boundary decoder. `unsafe-coerce` is available only when an external
   API contract is trusted and the unchecked conversion is intentional.
 
-Plain `.-name` and `.!name` dereference their receiver. If the receiver is an
-`JsNullish<JsObject>`, preprocessing reports `W_JS_FFI_NULLABLE_DEREF`. Use
-`.?-name`/`.?!name`, or narrow the receiver before dereferencing it.
+Plain `.-name` and `.!name` dereference their receiver. If the receiver is a
+`JsNullish<JsObject>`, strict project source fails with
+`E_JS_FFI_NULLABLE_DEREF`; compatibility mode reports
+`W_JS_FFI_NULLABLE_DEREF`. Use `.?-name`/`.?!name`, or narrow the receiver
+before dereferencing it.
 
 Functions containing raw interop should declare `:features $ #{} :js-ffi` in
 their schema. The feature identifies the boundary but does not suppress
 nullable dereference or strong-type mismatch diagnostics.
 
 Use `js-nullish?` and `js-present?` to narrow a JavaScript boundary. Applying
-legacy `nil?`/`some?` reports `W_JS_FFI_NULLABLE_PREDICATE`. Convert explicitly
-with `js-nullish->option` only after accepting the opaque payload contract;
-generic `optionally` does not accept `JsNullish<T>`.
+legacy `nil?`/`some?` fails strict project source with
+`E_JS_FFI_NULLABLE_PREDICATE`; compatibility mode reports
+`W_JS_FFI_NULLABLE_PREDICATE`. Convert explicitly with
+`js-nullish->option` only after accepting the opaque payload contract; generic
+`optionally` does not accept `JsNullish<T>`.
 
 ## 2. Capability and target policy
 
@@ -449,5 +453,8 @@ Common diagnostics:
 | `E_UNSCOPED_UNSAFE_COERCE` | Strict preprocessing finds `unsafe-coerce` outside the current function's lexical FFI scope. | Move it into a small structured `Fn` adapter declaring `:js-ffi`; validate/convert there and return typed data. |
 | `E_JS_FFI_TARGET_MISMATCH` | The selected entry targets another host. | Correct the entry `:target` or use the matching adapter. |
 | `W_JS_FFI_NULLABLE_DEREF` | A nullable host value is dereferenced directly. | Use optional access or narrow with `js-present?`. |
+| `W_JS_FFI_NULLABLE_PREDICATE` | Compatibility source applies legacy `nil?`/`some?` to a host-nullish value. | Use `js-nullish?`/`js-present?` so host semantics remain visible. |
+| `E_JS_FFI_NULLABLE_DEREF` | Strict project source dereferences `JsNullish<JsObject>` directly. | Use optional access or narrow with a dedicated JS predicate. |
+| `E_JS_FFI_NULLABLE_PREDICATE` | Strict project source applies legacy `nil?`/`some?` to `JsNullish<T>`. | Use `js-nullish?`/`js-present?`, then convert explicitly if needed. |
 | `E_JS_FFI_FIELD_READONLY` | A typed external field is written without permission. | Add the field to `:ffi :writable` only if the host API permits it. |
 ```

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -79,6 +79,13 @@ without declaring `:js-ffi`; only the wrapper's own implementation body needs
 the feature. An anonymous function uses the feature declared in its own
 `hint-fn` schema.
 
+In `--strict-types`, `unsafe-coerce` has an additional backend-independent
+gate: the current function's structured schema must declare `:js-ffi`, or
+preprocessing fails with `E_UNSCOPED_UNSAFE_COERCE`. An adapter-like namespace
+name is inventory evidence, not authorization. A scoped assertion remains in
+the `unsafeCoerce` quality metric and therefore needs an explicitly reviewed
+baseline before a full strict quality gate can pass.
+
 ### 2.2 Host target policy
 
 Entries can additionally declare an explicit host target:
@@ -436,6 +443,7 @@ Common diagnostics:
 | Code | Meaning | Typical fix |
 | --- | --- | --- |
 | `E_JS_FFI_FEATURE_REQUIRED` | A host operation is outside a marked adapter body. | Add `:js-ffi` to that implementation schema or move the operation into a wrapper. |
+| `E_UNSCOPED_UNSAFE_COERCE` | Strict preprocessing finds `unsafe-coerce` outside the current function's lexical FFI scope. | Move it into a small structured `Fn` adapter declaring `:js-ffi`; validate/convert there and return typed data. |
 | `E_JS_FFI_TARGET_MISMATCH` | The selected entry targets another host. | Correct the entry `:target` or use the matching adapter. |
 | `W_JS_FFI_NULLABLE_DEREF` | A nullable host value is dereferenced directly. | Use optional access or narrow with `js-present?`. |
 | `E_JS_FFI_FIELD_READONLY` | A typed external field is written without permission. | Add the field to `:ffi :writable` only if the host API permits it. |

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -104,12 +104,14 @@ legacy projects and disables this target-specific check.
 ### 2.3 Audit untyped access points
 
 `.-name`, `.!name`, `aget`, `aset`, `js-get`, and `js-set` against a bare
-`JsObject` receiver (no external-object trait attached) still work, but nothing
-about the field is checked. Running with `--warn-dyn-method` additionally
-reports `W_JS_FFI_UNTYPED_ACCESS` for these calls whenever the field key is a
-literal tag/string, since that is the case where declaring a trait for the
-receiver is directly actionable. A dynamic (non-literal) key, or a receiver
-that already carries trait or nullable evidence, does not trigger it.
+`JsObject` receiver have no field or method contract. When the member key is a
+literal, strict project source rejects the access with
+`E_UNTYPED_JS_OBJECT_ACCESS`; declare the smallest external-object trait and
+coerce the host value to that trait inside the lexical adapter. Compatibility
+mode can inventory the same sites as `W_JS_FFI_UNTYPED_ACCESS` with
+`--warn-dyn-method`. A dynamic (non-literal) key retains explicit raw lookup
+semantics, while receivers that already carry trait or nullable evidence are
+handled by their dedicated checks.
 
 ## 3. Typed adapters and external objects
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -134,6 +134,13 @@ For `code-nil`, the report includes raw `nil` and the legacy `;nil` compatibilit
 
 `unsafe-coerce` is reported separately as `unsafe-coerce` with the explicit `explicit-unsafe` intent, its exact `code@...` path, and the asserted target schema. JSON occurrence rows add an `evidence` object with the static input form, whether the containing definition declares `:js-ffi`, and whether the namespace follows the `js-ffi.raw.*` adapter convention. This is static source evidence, not a claimed runtime proof of the host value. JSON adds `W_JS_FFI_UNCHECKED_COERCE` whenever the selected scope contains one or more assertions. Keep each assertion in a narrow adapter and cover both accepted and rejected host values with runtime-contract tests.
 
+Under `--strict-types`, this inventory is also enforced lexically before any
+backend is selected. `unsafe-coerce` outside a current structured function
+schema declaring `:js-ffi` fails with `E_UNSCOPED_UNSAFE_COERCE`; an adapter
+namespace convention never grants permission. A correctly scoped occurrence
+still contributes to `unsafeCoerce`, so a release must keep it inside an
+explicitly reviewed per-definition baseline.
+
 For one definition, `calcit query context '<ns/def>' --format json` embeds the same distinction in its diagnostics and returns the definition revision together with Snapshot paths.
 
 For one expression, `calcit query type-at '<ns/def>' --path code@... --format json` preprocesses only static program metadata and returns inferred type, expected type, typed bindings, confidence, method candidates, preprocess lowering evidence, and diagnostics. Its v2 `data.lowering` object distinguishes type-selected primitives from ordinary static call resolution and remaining dynamic dispatch. It does not run the application entry. Paths use the same stable Snapshot coordinates returned by structural query commands.

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -130,6 +130,13 @@ evidence before method syntax. A JS boundary must convert the host value or
 attach an external-object trait inside its narrow adapter; `:js-ffi` alone does
 not authorize runtime method lookup.
 
+`unsafe-coerce` is stricter still: in `--strict-types` it must appear inside
+the current function's structured `Fn` schema with `:features $ #{} :js-ffi`,
+independent of codegen mode or the compatibility feature policy. Otherwise
+preprocessing reports `E_UNSCOPED_UNSAFE_COERCE`. Namespace naming does not
+grant an exemption, and scoped assertions remain subject to the
+per-definition `unsafeCoerce` quality baseline.
+
 ### Strict type preflight (`--strict-types`)
 
 Use `--strict-types` for new or fully migrated modules that must carry no local

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -454,6 +454,12 @@ compiler/macro lowering、core internals、可复用 `defimpl`，以及 evidence
 已持久化的 `&%{}` IR 也可以保留，但必须能解析到具体 `defstruct`，并且每个声明字段恰好出现一次；
 缺字段、重复字段或未知字段仍会被拒绝。
 
+`--strict-types` 下，`unsafe-coerce` 还必须位于当前 definition 的结构化 `Fn` schema 所声明的
+`:features $ #{} :js-ffi` 词法范围内，否则报告 `E_UNSCOPED_UNSAFE_COERCE`。`js-ffi.raw.*`
+一类 namespace 约定只用于 inventory，不授予权限。迁移时把 assertion 收拢到小 adapter，完成 host
+value 的 validate/convert 后只返回 typed Calcit data；即使已正确标记，release quality gate 仍需审核
+对应的 per-definition `unsafeCoerce` baseline。
+
 #### `.trim` / `.blank?` 接收者迁移
 
 `.trim` 与 `.blank?` 只对静态推断为 String 的接收者可用。若错误写成 `unknown method .trim for map`，

--- a/editing-history/202609040948-scope-unsafe-coerce-to-ffi-functions.md
+++ b/editing-history/202609040948-scope-unsafe-coerce-to-ffi-functions.md
@@ -1,0 +1,15 @@
+# Scope unsafe-coerce to lexical FFI functions
+
+- Added backend-independent `E_UNSCOPED_UNSAFE_COERCE` enforcement in strict
+  project preprocessing. The current structured function schema must declare
+  `:js-ffi`; an adapter-like namespace does not grant permission.
+- Kept compatibility mode and the existing entry feature policy unchanged.
+  Correctly scoped assertions remain visible in the per-definition
+  `unsafeCoerce` quality budget.
+- Added unit and Snapshot integration coverage for both the rejected unmarked
+  adapter and the accepted marked adapter with an ordinary typed caller.
+- Regressed the external `js-ffi` browser entry against the marked `random`
+  adapter: preprocessing passes, then the existing project-wide strict-zero
+  quality gate reports only its reviewed migration debt (`unsafeCoerce: 30`).
+  The default Node entry still stops earlier at the independently tracked
+  `E_ERASED_GENERIC_RELATION` in `js-ffi.contract/expect-string`.

--- a/editing-history/202609041050-type-js-typeof-result.md
+++ b/editing-history/202609041050-type-js-typeof-result.md
@@ -1,0 +1,12 @@
+# Type the JavaScript `typeof` result
+
+- Infer `js/typeof` as concrete `String` before and after raw JavaScript
+  lowering; arbitrary `js/...` operations remain opaque
+  `JsNullish<JsObject>` boundaries.
+- Added focused inference coverage for source and preprocessed forms and
+  documented the single language-defined exception in the JS interop guide.
+- Revalidated the unchanged `calcit-lang/js-ffi` default, Node, and browser
+  entries with the strict raw-primitive and lexical `unsafe-coerce` stack.
+  Its existing quality baseline remains at zero Dynamic/unresolved debt and
+  30 reviewed coercions, while all Node/browser contract tests and the Vite
+  production build pass.

--- a/editing-history/202609041106-reject-untyped-js-object-access.md
+++ b/editing-history/202609041106-reject-untyped-js-object-access.md
@@ -1,0 +1,13 @@
+# Reject untyped JavaScript object access in strict source
+
+- Promote literal member reads, calls, and writes on a bare `JsObject` from the
+  opt-in `W_JS_FFI_UNTYPED_ACCESS` inventory warning to the stable strict error
+  `E_UNTYPED_JS_OBJECT_ACCESS` for project source.
+- Keep compatibility-mode inventory warnings and dynamic-key raw lookup
+  semantics, while typed external-object and nullable receivers continue
+  through their dedicated checks.
+- Add unit and type-fail coverage plus migration guidance toward minimal
+  external-object traits inside lexical `:js-ffi` adapters.
+- Validate the migration against `calcit-lang/js-ffi`: `process.argv` now uses a
+  `ProcessArgvHost` capability and retains runtime `length` validation without
+  increasing its existing explicit-unsafe quality baseline.

--- a/editing-history/202609041114-preserve-opt-in-js-object-inventory.md
+++ b/editing-history/202609041114-preserve-opt-in-js-object-inventory.md
@@ -1,0 +1,9 @@
+# Preserve opt-in JavaScript object inventory outside project source
+
+- Keep `W_JS_FFI_UNTYPED_ACCESS` behind `--warn-dyn-method` when strict
+  preprocessing visits dependency namespaces outside the project-source lint
+  scope.
+- Retain `E_UNTYPED_JS_OBJECT_ACCESS` for strict project source and add a
+  serialized regression test that configures project namespaces explicitly.
+- This addresses the focused review finding on PR #620 without broadening the
+  hard-error boundary or changing dynamic-key semantics.

--- a/editing-history/202609041127-reject-unsafe-js-nullish-use.md
+++ b/editing-history/202609041127-reject-unsafe-js-nullish-use.md
@@ -1,0 +1,14 @@
+# Reject unsafe JavaScript nullish use in strict source
+
+- Promote direct member dereference of `JsNullish<JsObject>` to
+  `E_JS_FFI_NULLABLE_DEREF` for strict project source; optional access and
+  explicit `js-present?`/`js-nullish?` narrowing remain supported.
+- Promote legacy `nil?`/`some?` checks on `JsNullish<T>` to
+  `E_JS_FFI_NULLABLE_PREDICATE`, preserving the distinction between host
+  `null`/`undefined` and Calcit absence.
+- Keep both established warnings in compatibility mode and outside the strict
+  project-source scope.
+- Add unit and type-fail coverage for both stable error codes and document the
+  migration paths.
+- Revalidate `calcit-lang/js-ffi` Node and browser entries against the combined
+  strict stack with no new nullable-boundary failures or quality debt.

--- a/editing-history/202609041150-cover-optional-untyped-js-access.md
+++ b/editing-history/202609041150-cover-optional-untyped-js-access.md
@@ -1,0 +1,8 @@
+# Cover optional untyped JavaScript access
+
+- Extend strict `E_UNTYPED_JS_OBJECT_ACCESS` enforcement and compatibility
+  inventory to optional property access (`.?-`) and optional native invocation
+  (`.?!`) on bare `JsObject` receivers.
+- Exercise all four native member operation kinds in the strict regression test
+  and document the complete audited syntax family.
+- This closes the optional-operation bypass identified during review of PR #616.

--- a/editing-history/202609041157-focus-js-nullish-fixture.md
+++ b/editing-history/202609041157-focus-js-nullish-fixture.md
@@ -1,0 +1,7 @@
+# Focus the strict JavaScript nullish fixture
+
+- Correct the nullable-dereference fixture return schema from `JsObject` to
+  `Number`, matching the result of `.-length`.
+- Keep the type-fail fixture focused on `E_JS_FFI_NULLABLE_DEREF` so unrelated
+  return-type validation cannot mask the intended diagnostic.
+- This addresses the focused review finding on PR #621.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -267,6 +267,24 @@ fn strict_type_fail_raw_primitive_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_untyped_js_object_access_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/untyped-js-object-access-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("literal access on a bare JsObject must fail strict check-only");
+
+    assert!(
+      err.contains("E_UNTYPED_JS_OBJECT_ACCESS"),
+      "unexpected strict JS object access error: {err}"
+    );
+    assert!(err.contains(".-length"), "operation should be explicit: {err}");
+    assert!(err.contains("inferred `JsObject`"), "receiver evidence should be explicit: {err}");
+    assert!(err.contains("external-object trait"), "migration should be actionable: {err}");
+  });
+}
+
+#[test]
 fn strict_type_fail_unsafe_coerce_requires_lexical_ffi_scope() {
   run_with_large_stack(|| {
     let _strict = StrictTypesReset::enabled();

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -285,6 +285,40 @@ fn strict_type_fail_untyped_js_object_access_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_js_nullish_dereference_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/js-nullish-dereference-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("direct dereference of a JsNullish host value must fail strict check-only");
+
+    assert!(
+      err.contains("E_JS_FFI_NULLABLE_DEREF"),
+      "unexpected nullable dereference error: {err}"
+    );
+    assert!(err.contains(".-length"), "operation should be explicit: {err}");
+    assert!(err.contains("js-present?"), "narrowing migration should be actionable: {err}");
+  });
+}
+
+#[test]
+fn strict_type_fail_js_nullish_predicate_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/js-nullish-predicate-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("legacy nil? on a JsNullish host value must fail strict check-only");
+
+    assert!(
+      err.contains("E_JS_FFI_NULLABLE_PREDICATE"),
+      "unexpected nullable predicate error: {err}"
+    );
+    assert!(err.contains("`nil?`"), "legacy predicate should be explicit: {err}");
+    assert!(err.contains("js-nullish?"), "predicate migration should be actionable: {err}");
+  });
+}
+
+#[test]
 fn strict_type_fail_unsafe_coerce_requires_lexical_ffi_scope() {
   run_with_large_stack(|| {
     let _strict = StrictTypesReset::enabled();

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -267,6 +267,20 @@ fn strict_type_fail_raw_primitive_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_unsafe_coerce_requires_lexical_ffi_scope() {
+  run_with_large_stack(|| {
+    let _strict = StrictTypesReset::enabled();
+    let unscoped = load_fixture_entries("calcit/type-fail/unsafe-coerce-unscoped-strict.cirru");
+    let err = run_check_only(&unscoped).expect_err("unscoped unsafe-coerce must fail strict check-only");
+    assert!(err.contains("E_UNSCOPED_UNSAFE_COERCE"), "unexpected strict FFI error: {err}");
+    assert!(err.contains("`:js-ffi` boundary"), "missing lexical-boundary guidance: {err}");
+
+    let scoped = load_fixture_entries("calcit/type-fail/unsafe-coerce-scoped-strict.cirru");
+    run_check_only(&scoped).expect("a marked adapter may contain unsafe-coerce without leaking capability to its caller");
+  });
+}
+
+#[test]
 fn strict_type_fail_erased_generic_relation_reports_stable_error_code() {
   run_with_large_stack(|| {
     let fixture = "calcit/type-fail/erased-generic-relation-strict.cirru";

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -4941,7 +4941,7 @@ fn check_typed_js_field_operation(
   Ok(())
 }
 
-/// Raw `.-`/`.!`/`aget`/`aset`/`js-get`/`js-set` on a bare `JsObject` receiver
+/// Raw `.-`/`.!`/`.?-`/`.?!`/`aget`/`aset`/`js-get`/`js-set` on a bare `JsObject` receiver
 /// (no external-object trait attached) has nothing left to check statically.
 /// Strict project source must attach an external-object trait when the key is
 /// statically known. Compatibility mode keeps the opt-in inventory warning;
@@ -4965,7 +4965,9 @@ fn reject_or_warn_on_untyped_js_ffi_field_access(
 
   let (operation, field_name) = match head {
     Calcit::Method(name, calcit::MethodKind::Access) => (format!(".-{name}"), name.to_string()),
+    Calcit::Method(name, calcit::MethodKind::AccessOptional) => (format!(".?-{name}"), name.to_string()),
     Calcit::Method(name, calcit::MethodKind::InvokeNative) => (format!(".!{name}"), name.to_string()),
+    Calcit::Method(name, calcit::MethodKind::InvokeNativeOptional) => (format!(".?!{name}"), name.to_string()),
     Calcit::Symbol { sym, .. } if matches!(sym.as_ref(), "aget" | "js-get" | "aset" | "js-set") => {
       let Some(field_name) = args.get(1).and_then(static_js_field_name) else {
         // A dynamic (non-literal) key cannot be described by a trait field
@@ -11646,29 +11648,36 @@ mod tests {
   }
 
   #[test]
-  fn strict_types_reject_untyped_js_object_access_with_a_static_field() {
+  fn strict_types_reject_all_untyped_js_object_method_access_with_a_static_field() {
     let _lock = lock_preprocess_test_state();
     let _strict = StrictTypesGuard::new(true);
     let receiver = untyped_js_ffi_test_receiver();
-    let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
-    let warnings = RefCell::new(vec![]);
+    for (kind, operation) in [
+      (calcit::MethodKind::Access, ".-value"),
+      (calcit::MethodKind::AccessOptional, ".?-value"),
+      (calcit::MethodKind::InvokeNative, ".!value"),
+      (calcit::MethodKind::InvokeNativeOptional, ".?!value"),
+    ] {
+      let head = Calcit::Method(Arc::from("value"), kind);
+      let warnings = RefCell::new(vec![]);
+      let error = reject_or_warn_on_untyped_js_ffi_field_access(
+        &head,
+        &CalcitList::from(std::slice::from_ref(&receiver)),
+        &ScopeTypes::new(),
+        "tests.untyped-ffi",
+        "demo",
+        &warnings,
+        &CallStackList::default(),
+      )
+      .expect_err("strict project source must attach an external-object trait");
 
-    let error = reject_or_warn_on_untyped_js_ffi_field_access(
-      &head,
-      &CalcitList::from(std::slice::from_ref(&receiver)),
-      &ScopeTypes::new(),
-      "tests.untyped-ffi",
-      "demo",
-      &warnings,
-      &CallStackList::default(),
-    )
-    .expect_err("strict project source must attach an external-object trait");
-
-    assert_eq!(error.code.as_deref(), Some("E_UNTYPED_JS_OBJECT_ACCESS"));
-    assert!(error.msg.contains("inferred `JsObject`"));
-    assert!(error.msg.contains("external-object trait"));
-    assert!(error.msg.contains("lexical `:js-ffi` adapter"));
-    assert!(warnings.borrow().is_empty());
+      assert_eq!(error.code.as_deref(), Some("E_UNTYPED_JS_OBJECT_ACCESS"));
+      assert!(error.msg.contains(operation));
+      assert!(error.msg.contains("inferred `JsObject`"));
+      assert!(error.msg.contains("external-object trait"));
+      assert!(error.msg.contains("lexical `:js-ffi` adapter"));
+      assert!(warnings.borrow().is_empty());
+    }
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2307,7 +2307,15 @@ fn preprocess_list_call(
         // their statically known struct fields in this branch as well.
         check_struct_field_access(&head_form, &current_args, scope_types, file_ns, call_stack, check_warnings);
         warn_on_nominal_enum_legacy_absence_use(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-        warn_on_legacy_js_nullish_predicate(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+        reject_or_warn_on_legacy_js_nullish_predicate(
+          &head_form,
+          &current_args,
+          scope_types,
+          file_ns,
+          def_name.as_ref(),
+          check_warnings,
+          call_stack,
+        )?;
         let mut any_rewritten = false;
         // Rewrite hashmap literal args to struct literals when the expected type is a struct
         if let Some(rewritten) = try_rewrite_map_args_to_structs(info.as_ref(), &current_args, file_ns, &def_name, check_warnings) {
@@ -2765,7 +2773,15 @@ fn preprocess_list_call(
           // Recompute processed_args from ys after optimization rewrites (e.g. struct:get→nth, assoc→assoc-at)
           let processed_args = CalcitList::from(ys.drop_left());
           require_js_ffi_feature_for_operation(call_head, file_ns, def_name.as_ref(), check_warnings, call_stack)?;
-          warn_on_nullable_js_ffi_dereference(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          reject_or_warn_on_nullable_js_ffi_dereference(
+            call_head,
+            &processed_args,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
+            check_warnings,
+            call_stack,
+          )?;
           reject_or_warn_on_untyped_js_ffi_field_access(
             call_head,
             &processed_args,
@@ -2776,7 +2792,15 @@ fn preprocess_list_call(
             call_stack,
           )?;
           warn_on_nominal_enum_legacy_absence_use(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-          warn_on_legacy_js_nullish_predicate(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          reject_or_warn_on_legacy_js_nullish_predicate(
+            call_head,
+            &processed_args,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
+            check_warnings,
+            call_stack,
+          )?;
           reject_or_warn_on_dynamic_trait_call(
             call_head,
             &processed_args,
@@ -4768,16 +4792,17 @@ fn reject_or_warn_on_dynamic_trait_call(
   Ok(())
 }
 
-fn warn_on_nullable_js_ffi_dereference(
+fn reject_or_warn_on_nullable_js_ffi_dereference(
   head: &Calcit,
   args: &CalcitList,
   scope_types: &ScopeTypes,
   file_ns: &str,
   def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
-) {
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
   if file_ns == calcit::CORE_NS {
-    return;
+    return Ok(());
   }
 
   let is_raw_dereference = matches!(
@@ -4785,20 +4810,20 @@ fn warn_on_nullable_js_ffi_dereference(
     Calcit::Method(_, calcit::MethodKind::Access | calcit::MethodKind::InvokeNative)
   ) || matches!(head, Calcit::Symbol { sym, .. } if matches!(sym.as_ref(), "aget" | "js-get"));
   if !is_raw_dereference {
-    return;
+    return Ok(());
   }
 
   let Some(receiver) = args.first() else {
-    return;
+    return Ok(());
   };
   let Some(receiver_type) = resolve_type_value(receiver, scope_types) else {
-    return;
+    return Ok(());
   };
   let CalcitTypeAnnotation::JsNullish(inner) = receiver_type.as_ref() else {
-    return;
+    return Ok(());
   };
   if !matches!(inner.as_ref(), CalcitTypeAnnotation::JsObject) {
-    return;
+    return Ok(());
   }
 
   let operation = match head {
@@ -4812,11 +4837,23 @@ fn warn_on_nullable_js_ffi_dereference(
     "[Warn] JsNullish FFI value is dereferenced by `{operation}` in {file_ns}/{def_name}; use optional access, narrow with `js-present?`/`js-nullish?`, then validate or explicitly `unsafe-coerce` the opaque JsObject value"
   );
 
-  if let Some(location) = head.get_location().or_else(|| receiver.get_location()) {
+  let location = head.get_location().or_else(|| receiver.get_location());
+  if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      message.replacen("[Warn]", "[Error]", 1),
+      "E_JS_FFI_NULLABLE_DEREF",
+      call_stack,
+      location,
+    ));
+  }
+
+  if let Some(location) = location {
     gen_check_warning_with_location_code(message, "W_JS_FFI_NULLABLE_DEREF", location, check_warnings);
   } else {
     gen_check_warning_code(message, "W_JS_FFI_NULLABLE_DEREF", file_ns, check_warnings);
   }
+  Ok(())
 }
 
 fn static_js_field_name(form: &Calcit) -> Option<&str> {
@@ -5014,41 +5051,54 @@ fn reject_or_warn_on_untyped_js_ffi_field_access(
   Ok(())
 }
 
-fn warn_on_legacy_js_nullish_predicate(
+fn reject_or_warn_on_legacy_js_nullish_predicate(
   head: &Calcit,
   args: &CalcitList,
   scope_types: &ScopeTypes,
   file_ns: &str,
   def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
-) {
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
   if file_ns == calcit::CORE_NS {
-    return;
+    return Ok(());
   }
   let Some(operation) = canonical_absence_operation_name(head) else {
-    return;
+    return Ok(());
   };
   if !matches!(operation, "nil?" | "some?") {
-    return;
+    return Ok(());
   }
   let Some(value) = args.first() else {
-    return;
+    return Ok(());
   };
   let Some(value_type) = resolve_type_value(value, scope_types) else {
-    return;
+    return Ok(());
   };
   if !matches!(value_type.as_ref(), CalcitTypeAnnotation::JsNullish(_)) {
-    return;
+    return Ok(());
   }
 
   let message = format!(
     "[Warn] `{operation}` consumes a JsNullish FFI value in {file_ns}/{def_name}; use `js-nullish?` or `js-present?` so host nullability stays explicit"
   );
-  if let Some(location) = head.get_location().or_else(|| value.get_location()) {
+  let location = head.get_location().or_else(|| value.get_location());
+  if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      message.replacen("[Warn]", "[Error]", 1),
+      "E_JS_FFI_NULLABLE_PREDICATE",
+      call_stack,
+      location,
+    ));
+  }
+
+  if let Some(location) = location {
     gen_check_warning_with_location_code(message, "W_JS_FFI_NULLABLE_PREDICATE", location, check_warnings);
   } else {
     gen_check_warning_code(message, "W_JS_FFI_NULLABLE_PREDICATE", file_ns, check_warnings);
   }
+  Ok(())
 }
 
 fn canonical_absence_operation_name(head: &Calcit) -> Option<&str> {
@@ -9794,6 +9844,8 @@ mod tests {
 
   #[test]
   fn js_nullish_ffi_values_require_safe_dereference_and_dedicated_predicates() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(false);
     let sym: Arc<str> = Arc::from("host");
     let receiver = Calcit::Local(CalcitLocal {
       idx: CalcitLocal::track_sym(&sym),
@@ -9808,37 +9860,43 @@ mod tests {
     let args = CalcitList::from(std::slice::from_ref(&receiver));
     let warnings = RefCell::new(vec![]);
 
-    warn_on_nullable_js_ffi_dereference(
+    reject_or_warn_on_nullable_js_ffi_dereference(
       &Calcit::Method(Arc::from("read"), calcit::MethodKind::InvokeNative),
       &args,
       &ScopeTypes::new(),
       "tests.js-ffi",
       "demo",
       &warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("compatibility mode should retain the nullable dereference warning");
     assert_eq!(warnings.borrow().len(), 1);
     assert_eq!(warnings.borrow()[0].code(), Some("W_JS_FFI_NULLABLE_DEREF"));
 
     let optional_warnings = RefCell::new(vec![]);
-    warn_on_nullable_js_ffi_dereference(
+    reject_or_warn_on_nullable_js_ffi_dereference(
       &Calcit::Method(Arc::from("read"), calcit::MethodKind::InvokeNativeOptional),
       &args,
       &ScopeTypes::new(),
       "tests.js-ffi",
       "demo",
       &optional_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("optional host access remains valid");
     assert!(optional_warnings.borrow().is_empty());
 
     let predicate_warnings = RefCell::new(vec![]);
-    warn_on_legacy_js_nullish_predicate(
+    reject_or_warn_on_legacy_js_nullish_predicate(
       &Calcit::Proc(CalcitProc::NilQuestion),
       &args,
       &ScopeTypes::new(),
       "tests.js-ffi",
       "demo",
       &predicate_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("compatibility mode should retain the legacy predicate warning");
     assert_eq!(predicate_warnings.borrow().len(), 1);
     assert_eq!(predicate_warnings.borrow()[0].code(), Some("W_JS_FFI_NULLABLE_PREDICATE"));
 
@@ -9863,6 +9921,50 @@ mod tests {
       narrowing.true_binding,
       Some((name, inferred)) if name.as_ref() == "host" && matches!(inferred.as_ref(), CalcitTypeAnnotation::JsObject)
     ));
+  }
+
+  #[test]
+  fn strict_types_reject_nullable_js_ffi_dereference_and_legacy_predicates() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let sym: Arc<str> = Arc::from("host");
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&sym),
+      sym,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.js-ffi-strict"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::JsNullish(Arc::new(CalcitTypeAnnotation::JsObject))),
+    });
+    let args = CalcitList::from(std::slice::from_ref(&receiver));
+
+    let dereference_error = reject_or_warn_on_nullable_js_ffi_dereference(
+      &Calcit::Method(Arc::from("read"), calcit::MethodKind::InvokeNative),
+      &args,
+      &ScopeTypes::new(),
+      "tests.js-ffi-strict",
+      "demo",
+      &RefCell::new(vec![]),
+      &CallStackList::default(),
+    )
+    .expect_err("strict project source must narrow a JsNullish receiver before dereferencing it");
+    assert_eq!(dereference_error.code.as_deref(), Some("E_JS_FFI_NULLABLE_DEREF"));
+    assert!(dereference_error.msg.contains("js-present?"));
+
+    let predicate_error = reject_or_warn_on_legacy_js_nullish_predicate(
+      &Calcit::Proc(CalcitProc::NilQuestion),
+      &args,
+      &ScopeTypes::new(),
+      "tests.js-ffi-strict",
+      "demo",
+      &RefCell::new(vec![]),
+      &CallStackList::default(),
+    )
+    .expect_err("strict project source must use a dedicated JavaScript nullish predicate");
+    assert_eq!(predicate_error.code.as_deref(), Some("E_JS_FFI_NULLABLE_PREDICATE"));
+    assert!(predicate_error.msg.contains("js-nullish?"));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2766,7 +2766,15 @@ fn preprocess_list_call(
           let processed_args = CalcitList::from(ys.drop_left());
           require_js_ffi_feature_for_operation(call_head, file_ns, def_name.as_ref(), check_warnings, call_stack)?;
           warn_on_nullable_js_ffi_dereference(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-          warn_on_untyped_js_ffi_field_access(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          reject_or_warn_on_untyped_js_ffi_field_access(
+            call_head,
+            &processed_args,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
+            check_warnings,
+            call_stack,
+          )?;
           warn_on_nominal_enum_legacy_absence_use(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_legacy_js_nullish_predicate(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           reject_or_warn_on_dynamic_trait_call(
@@ -4935,22 +4943,24 @@ fn check_typed_js_field_operation(
 
 /// Raw `.-`/`.!`/`aget`/`aset`/`js-get`/`js-set` on a bare `JsObject` receiver
 /// (no external-object trait attached) has nothing left to check statically.
-/// This is opt-in (behind `--warn-dyn-method`) since it fires on any untyped
-/// FFI touch point, including code that intentionally stays dynamic.
-fn warn_on_untyped_js_ffi_field_access(
+/// Strict project source must attach an external-object trait when the key is
+/// statically known. Compatibility mode keeps the opt-in inventory warning;
+/// dynamic keys retain explicit raw JavaScript semantics.
+fn reject_or_warn_on_untyped_js_ffi_field_access(
   head: &Calcit,
   args: &CalcitList,
   scope_types: &ScopeTypes,
   file_ns: &str,
   def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
-) {
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
   if file_ns == calcit::CORE_NS {
-    return;
+    return Ok(());
   }
 
-  if !warn_dyn_method_enabled() {
-    return;
+  if !strict_types_enabled() && !warn_dyn_method_enabled() {
+    return Ok(());
   }
 
   let (operation, field_name) = match head {
@@ -4960,38 +4970,46 @@ fn warn_on_untyped_js_ffi_field_access(
       let Some(field_name) = args.get(1).and_then(static_js_field_name) else {
         // A dynamic (non-literal) key cannot be described by a trait field
         // either, so there is no actionable next step to suggest here.
-        return;
+        return Ok(());
       };
       (sym.to_string(), field_name.to_owned())
     }
-    _ => return,
+    _ => return Ok(()),
   };
 
   let Some(receiver) = args.first() else {
-    return;
+    return Ok(());
   };
   let Some(receiver_type) = resolve_type_value(receiver, scope_types) else {
-    return;
+    return Ok(());
   };
   // Only the bare, non-nullable `JsObject` case is targeted here: it already
   // proves the value is a raw host object, and the key is a literal the
   // developer already knows, so declaring a trait is directly actionable.
   // Nullable receivers and declared traits are covered by other diagnostics.
   if !matches!(receiver_type.as_ref(), CalcitTypeAnnotation::JsObject) {
-    return;
+    return Ok(());
   }
 
   let message = format!(
-    "[Warn] `{operation}` accesses untyped JS field `:{field_name}` in {file_ns}/{def_name}; still permitted, but declaring an external-object trait (`deftrait ... :ffi {{:kind :external-object ...}}`) for the receiver unlocks static field/method checking and `:names` mapping"
+    "[Warn] `{operation}` accesses untyped JS field `:{field_name}` on inferred `JsObject` in {file_ns}/{def_name}; declare an external-object trait (`deftrait ... :ffi {{:kind :external-object ...}}`) containing that field or method, then coerce the host value to the trait inside the lexical `:js-ffi` adapter; use a dynamic key only when raw lookup semantics are intentional"
   );
 
-  gen_check_warning_code_at(
-    message,
-    "W_JS_FFI_UNTYPED_ACCESS",
-    file_ns,
-    head.get_location().or_else(|| receiver.get_location()),
-    check_warnings,
-  );
+  let location = head.get_location().or_else(|| receiver.get_location());
+  if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      message.replacen("[Warn]", "[Error]", 1),
+      "E_UNTYPED_JS_OBJECT_ACCESS",
+      call_stack,
+      location,
+    ));
+  }
+
+  if warn_dyn_method_enabled() {
+    gen_check_warning_code_at(message, "W_JS_FFI_UNTYPED_ACCESS", file_ns, location, check_warnings);
+  }
+  Ok(())
 }
 
 fn warn_on_legacy_js_nullish_predicate(
@@ -10259,6 +10277,24 @@ mod tests {
     }
   }
 
+  struct ProjectNamespacesGuard {
+    previous: HashSet<Arc<str>>,
+  }
+
+  impl ProjectNamespacesGuard {
+    fn new(namespaces: &[&str]) -> Self {
+      let mut current = PROJECT_NAMESPACES.write().expect("write project namespaces");
+      let previous = std::mem::replace(&mut *current, namespaces.iter().map(|ns| Arc::from(*ns)).collect());
+      Self { previous }
+    }
+  }
+
+  impl Drop for ProjectNamespacesGuard {
+    fn drop(&mut self) {
+      *PROJECT_NAMESPACES.write().expect("restore project namespaces") = std::mem::take(&mut self.previous);
+    }
+  }
+
   struct CurrentFnFeaturesGuard {
     previous: Option<Arc<HashSet<EdnTag>>>,
   }
@@ -11595,16 +11631,71 @@ mod tests {
     let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
     let warnings = RefCell::new(vec![]);
 
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &head,
       &CalcitList::from(std::slice::from_ref(&receiver)),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("compatibility inventory should remain a warning");
 
     assert_eq!(warnings.borrow()[0].code(), Some("W_JS_FFI_UNTYPED_ACCESS"));
+  }
+
+  #[test]
+  fn strict_types_reject_untyped_js_object_access_with_a_static_field() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let receiver = untyped_js_ffi_test_receiver();
+    let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
+    let warnings = RefCell::new(vec![]);
+
+    let error = reject_or_warn_on_untyped_js_ffi_field_access(
+      &head,
+      &CalcitList::from(std::slice::from_ref(&receiver)),
+      &ScopeTypes::new(),
+      "tests.untyped-ffi",
+      "demo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect_err("strict project source must attach an external-object trait");
+
+    assert_eq!(error.code.as_deref(), Some("E_UNTYPED_JS_OBJECT_ACCESS"));
+    assert!(error.msg.contains("inferred `JsObject`"));
+    assert!(error.msg.contains("external-object trait"));
+    assert!(error.msg.contains("lexical `:js-ffi` adapter"));
+    assert!(warnings.borrow().is_empty());
+  }
+
+  #[test]
+  fn strict_types_keep_dependency_untyped_access_inventory_opt_in() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let _warn_guard = WarnDynMethodGuard::new(false);
+    let _project_namespaces = ProjectNamespacesGuard::new(&["app.main"]);
+    let receiver = untyped_js_ffi_test_receiver();
+    let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
+    let warnings = RefCell::new(vec![]);
+
+    reject_or_warn_on_untyped_js_ffi_field_access(
+      &head,
+      &CalcitList::from(std::slice::from_ref(&receiver)),
+      &ScopeTypes::new(),
+      "dependency.host",
+      "demo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("strict dependency access stays outside project-source hard errors");
+
+    assert!(
+      warnings.borrow().is_empty(),
+      "dependency inventory remains behind --warn-dyn-method"
+    );
   }
 
   #[test]
@@ -11615,41 +11706,47 @@ mod tests {
 
     // Disabled by default: the flag must be explicitly turned on.
     let disabled_warnings = RefCell::new(vec![]);
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &head,
       &CalcitList::from(std::slice::from_ref(&receiver)),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &disabled_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("disabled compatibility inventory should accept raw access");
     assert!(disabled_warnings.borrow().is_empty());
 
     let _warn_guard = WarnDynMethodGuard::new(true);
 
     // A dynamic (non-literal) key gives no actionable static field to suggest.
     let dynamic_key_warnings = RefCell::new(vec![]);
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &external_field_test_symbol("aget"),
       &CalcitList::from(&[receiver.clone(), external_field_test_symbol("k")]),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &dynamic_key_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("dynamic keys retain explicit raw lookup semantics");
     assert!(dynamic_key_warnings.borrow().is_empty());
 
     // Already-typed external-object receivers are covered by other diagnostics.
     let typed_receiver = external_field_test_receiver(seed_external_field_trait(true));
     let typed_warnings = RefCell::new(vec![]);
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &external_field_test_symbol("aget"),
       &CalcitList::from(&[typed_receiver, Calcit::Tag(EdnTag::new("value"))]),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &typed_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("external-object traits remain statically checked");
     assert!(typed_warnings.borrow().is_empty());
   }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8075,6 +8075,20 @@ pub fn preprocess_unsafe_coerce(
     ));
   }
 
+  if strict_types_enabled()
+    && should_emit_project_source_lint(ctx.file_ns)
+    && ctx.file_ns != calcit::CORE_NS
+    && !current_function_has_js_ffi_feature()
+  {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      "`unsafe-coerce` is outside a lexical `:js-ffi` boundary; move the host assertion into a small adapter function whose structured `Fn` schema declares `:features $ #{} :js-ffi`, validate or convert the host value there, and return typed Calcit data",
+      "E_UNSCOPED_UNSAFE_COERCE",
+      ctx.call_stack,
+      args.first().and_then(Calcit::get_location),
+    ));
+  }
+
   let target_form = preprocess_expr(
     args.first().expect("validated unsafe-coerce target"),
     ctx.scope_defs,
@@ -10245,6 +10259,23 @@ mod tests {
     }
   }
 
+  struct CurrentFnFeaturesGuard {
+    previous: Option<Arc<HashSet<EdnTag>>>,
+  }
+
+  impl CurrentFnFeaturesGuard {
+    fn js_ffi() -> Self {
+      let previous = CURRENT_FN_FEATURES.with(|cell| cell.borrow_mut().replace(Arc::new(HashSet::from([EdnTag::new("js-ffi")]))));
+      Self { previous }
+    }
+  }
+
+  impl Drop for CurrentFnFeaturesGuard {
+    fn drop(&mut self) {
+      CURRENT_FN_FEATURES.with(|cell| *cell.borrow_mut() = self.previous.take());
+    }
+  }
+
   struct TypeSlotsGuard;
 
   impl TypeSlotsGuard {
@@ -10603,6 +10634,44 @@ mod tests {
       "coercing one expression must not retype every later use of the local"
     );
     assert!(warnings.borrow().is_empty());
+  }
+
+  #[test]
+  fn strict_types_require_a_lexical_js_ffi_feature_for_unsafe_coerce() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let expr = Cirru::List(vec![Cirru::leaf("unsafe-coerce"), Cirru::leaf("host"), Cirru::leaf("'String")]);
+    let code = code_to_calcit(&expr, "js-ffi.raw.ids", "make-id", vec![]).expect("parse unsafe host assertion");
+    let scope_defs = HashSet::from([Arc::from("host")]);
+    let warnings = RefCell::new(vec![]);
+
+    let error = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut ScopeTypes::new(),
+      "js-ffi.raw.ids",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect_err("adapter-like namespace naming must not grant an unsafe-coerce exemption");
+    assert_eq!(error.code.as_deref(), Some("E_UNSCOPED_UNSAFE_COERCE"));
+    assert!(error.msg.contains("`:js-ffi` boundary"));
+    assert!(error.msg.contains("structured `Fn` schema"));
+
+    let _features = CurrentFnFeaturesGuard::js_ffi();
+    let resolved = preprocess_expr(
+      &code,
+      &scope_defs,
+      &mut ScopeTypes::new(),
+      "js-ffi.raw.ids",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("the same assertion is allowed inside the lexically marked adapter");
+    assert!(matches!(
+      resolved,
+      Calcit::List(nodes) if matches!(nodes.first(), Some(Calcit::Syntax(CalcitSyntax::UnsafeCoerce, _)))
+    ));
   }
 
   #[test]

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -549,6 +549,10 @@ fn infer_external_field_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&
 
 fn infer_js_ffi_call_return_type(name: &str, call_expr: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
   match name {
+    // JavaScript's `typeof` operator always produces one of the specified
+    // string tags. Unlike arbitrary host calls, its result is neither opaque
+    // nor nullish, even when the inspected value is null or undefined.
+    "js/typeof" => Some(tag_annotation("string")),
     // JavaScript indexed/property reads may yield `undefined` or `null`. Keep
     // the raw host value opaque as well as nullable so a nil check alone does
     // not silently prove that it is a Calcit Number/String/etc.
@@ -763,6 +767,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           None
         }
 
+        Calcit::RawCode(calcit::RawCodeType::Js, code) if code.as_ref() == "typeof" => Some(tag_annotation("string")),
         Calcit::RawCode(..) => Some(js_nullish_host_value_type()),
 
         // Direct Fn call: return the function's return type
@@ -2173,6 +2178,23 @@ mod tests {
     assert!(opaque.matches_annotation(&CalcitTypeAnnotation::JsObject));
     assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::String));
     assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::Number));
+  }
+
+  #[test]
+  fn js_typeof_has_a_concrete_string_result() {
+    let value = local("host", js_nullish_host_value_type());
+    let typeof_call = Calcit::from(vec![symbol("js/typeof"), value]);
+    let processed_typeof_call = Calcit::from(vec![
+      Calcit::RawCode(calcit::RawCodeType::Js, Arc::from("typeof")),
+      local("host", js_nullish_host_value_type()),
+    ]);
+
+    for expression in [typeof_call, processed_typeof_call] {
+      assert!(matches!(
+        infer_static_type_from_expr(&expression).as_deref(),
+        Some(CalcitTypeAnnotation::String)
+      ));
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Summary / 摘要

- reject strict project-source `unsafe-coerce` outside the current function schema’s lexical `:js-ffi` feature
- keep the capability local to the adapter: namespace naming and callers do not inherit it
- add stable `E_UNSCOPED_UNSAFE_COERCE`, focused unit and Snapshot integration coverage, and migration guidance
- keep correctly scoped assertions visible in the existing per-definition `unsafeCoerce` quality budget

## Validation / 验证

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (668 lib, 288 CLI, 23 wasm)
- `yarn compile`
- `yarn test-fail` (25)
- `yarn check-agent-interface` (18/18)
- `yarn check-all`
- external `calcit-lang/js-ffi`, browser entry + `js-ffi.browser/random`: lexical preprocessing passes; the existing project-level strict-zero gate then reports only `unsafeCoerce: 30`
- external default Node entry currently stops earlier at the independently tracked `E_ERASED_GENERIC_RELATION` in `js-ffi.contract/expect-string`

## Stack / 堆叠关系

This PR is intentionally based on #615 (`codex/strict-raw-primitives-20260904`). After #615 lands, the base can be retargeted to `main` without changing this patch.

Advances #581 and #577.