### PR TITLE
feat: infer JavaScript typeof as String

### DIFF
--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -34,8 +34,9 @@ and portability rules that apply to every form.
 ## 1. Boundary model: opaque first, typed second
 
 Raw JavaScript values are not ordinary `Dynamic` Calcit values. Property reads,
-native method calls, `aget`, untyped `js-get`, and `js/...` calls are
-conservatively inferred as `JsNullish<JsObject>`:
+native method calls, `aget`, untyped `js-get`, and arbitrary `js/...` calls are
+conservatively inferred as `JsNullish<JsObject>`. The deliberate exception is
+`js/typeof`, whose JavaScript-language result is always inferred as `String`:
 
 - `JsNullish` is reserved for the actual JavaScript `null`/`undefined` boundary;
   it is deliberately distinct from legacy `Optional` and nominal `Option`.

--- a/editing-history/202609041050-type-js-typeof-result.md
+++ b/editing-history/202609041050-type-js-typeof-result.md
@@ -1,0 +1,12 @@
+# Type the JavaScript `typeof` result
+
+- Infer `js/typeof` as concrete `String` before and after raw JavaScript
+  lowering; arbitrary `js/...` operations remain opaque
+  `JsNullish<JsObject>` boundaries.
+- Added focused inference coverage for source and preprocessed forms and
+  documented the single language-defined exception in the JS interop guide.
+- Revalidated the unchanged `calcit-lang/js-ffi` default, Node, and browser
+  entries with the strict raw-primitive and lexical `unsafe-coerce` stack.
+  Its existing quality baseline remains at zero Dynamic/unresolved debt and
+  30 reviewed coercions, while all Node/browser contract tests and the Vite
+  production build pass.

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -549,6 +549,10 @@ fn infer_external_field_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&
 
 fn infer_js_ffi_call_return_type(name: &str, call_expr: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
   match name {
+    // JavaScript's `typeof` operator always produces one of the specified
+    // string tags. Unlike arbitrary host calls, its result is neither opaque
+    // nor nullish, even when the inspected value is null or undefined.
+    "js/typeof" => Some(tag_annotation("string")),
     // JavaScript indexed/property reads may yield `undefined` or `null`. Keep
     // the raw host value opaque as well as nullable so a nil check alone does
     // not silently prove that it is a Calcit Number/String/etc.
@@ -763,6 +767,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           None
         }
 
+        Calcit::RawCode(calcit::RawCodeType::Js, code) if code.as_ref() == "typeof" => Some(tag_annotation("string")),
         Calcit::RawCode(..) => Some(js_nullish_host_value_type()),
 
         // Direct Fn call: return the function's return type
@@ -2173,6 +2178,23 @@ mod tests {
     assert!(opaque.matches_annotation(&CalcitTypeAnnotation::JsObject));
     assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::String));
     assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::Number));
+  }
+
+  #[test]
+  fn js_typeof_has_a_concrete_string_result() {
+    let value = local("host", js_nullish_host_value_type());
+    let typeof_call = Calcit::from(vec![symbol("js/typeof"), value]);
+    let processed_typeof_call = Calcit::from(vec![
+      Calcit::RawCode(calcit::RawCodeType::Js, Arc::from("typeof")),
+      local("host", js_nullish_host_value_type()),
+    ]);
+
+    for expression in [typeof_call, processed_typeof_call] {
+      assert!(matches!(
+        infer_static_type_from_expr(&expression).as_deref(),
+        Some(CalcitTypeAnnotation::String)
+      ));
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- infer `js/typeof` as concrete `String` in both source and preprocessed raw-JS forms
- keep every arbitrary `js/...` operation conservatively typed as `JsNullish<JsObject>`
- document the language-defined exception and add focused inference coverage

This is stacked on #616 so it is validated together with the raw-primitive and lexical unsafe-coerce policies.

## Ecosystem evidence

The unchanged `calcit-lang/js-ffi` repository now passes strict preprocessing for its default, Node, and browser entries. This removes the previous `E_ERASED_GENERIC_RELATION` at `js-ffi.contract/expect-string` without adding an `unsafe-coerce` or changing its baseline:

- Dynamic/unresolved/incomplete debt remains 0
- reviewed `unsafeCoerce` inventory remains 30
- Node contract test passes
- browser-in-Node contract test passes
- Vite 8 production build passes under Node 24

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (669 lib, 288 CLI, 23 WASM)
- `yarn compile`
- `yarn test-fail` (25/25)
- `yarn check-agent-interface` (18/18)
- `yarn check-all`
- bundled core tests (236/236)