### PR TITLE
Reject untyped JavaScript object access in strict source

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -21,6 +21,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-nominal-method-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-method-dispatch-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/raw-primitive-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/untyped-js-object-access-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/unsafe-coerce-unscoped-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
@@ -38,6 +39,7 @@
 - `dynamic-nominal-method-strict.cirru` 会验证 strict 模式拒绝 Dynamic receiver 上的 Option/Result nominal method dispatch，并报告稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `raw-primitive-strict.cirru` 会验证 strict 模式拒绝项目源码直接调用 `&get-raw`，并报告稳定的 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
+- `untyped-js-object-access-strict.cirru` 会验证 strict 模式拒绝裸 `JsObject` 上的静态成员访问，并报告稳定的 `E_UNTYPED_JS_OBJECT_ACCESS` 与 external-object trait 迁移建议。
 - `unsafe-coerce-unscoped-strict.cirru` 会验证 strict 模式拒绝未声明 `:js-ffi` 的 `unsafe-coerce`，并报告稳定的 `E_UNSCOPED_UNSAFE_COERCE`。
 - `unsafe-coerce-scoped-strict.cirru` 是 integration preprocessing 正例：标记 adapter 可使用 assertion，普通 typed caller 不继承也不需要该 capability；完整 strict quality gate 仍要求显式 `unsafeCoerce` baseline。
 - `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
@@ -54,6 +56,7 @@
 - strict Dynamic nominal-method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver schema 与低层 helper 迁移建议
 - strict general Dynamic method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver-loss 分类与 typed adapter 迁移建议
 - strict raw primitive fixture：断言错误文本包含 `E_RAW_PRIMITIVE_IN_TYPED_CODE`、primitive 名称与 typed public API 迁移建议
+- strict untyped JS object fixture：断言错误文本包含 `E_UNTYPED_JS_OBJECT_ACCESS`、成员名、receiver evidence 与 external-object trait 迁移建议
 - strict unsafe-coerce fixtures：断言未标记 adapter 报 `E_UNSCOPED_UNSAFE_COERCE`，而词法标记的 adapter 与普通 caller 可通过 preprocessing
 - strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
@@ -72,6 +75,7 @@
 - `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`：strict 模式下可达 function 或直接进入预处理的 programmatic macro 既没有结构化根 schema，也没有嵌入式结构化契约；普通 legacy Snapshot macro 会更早被 loader 拒绝
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
 - `E_RAW_PRIMITIVE_IN_TYPED_CODE`：strict 项目源码手写 raw constructor/lookup/index primitive，且没有 compiler/macro origin 或匹配的 nominal layout evidence
+- `E_UNTYPED_JS_OBJECT_ACCESS`：strict 项目源码在裸 `JsObject` 上以静态成员名执行读取、调用或写入，需在 lexical adapter 内绑定 external-object trait；动态 key 保留 raw lookup 语义
 - `E_UNSCOPED_UNSAFE_COERCE`：strict 项目源码在当前 definition 未声明 `:js-ffi` 时使用 `unsafe-coerce`
 - `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配

--- a/calcit/type-fail/untyped-js-object-access-strict.cirru
+++ b/calcit/type-fail/untyped-js-object-access-strict.cirru
@@ -1,0 +1,27 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-untyped-js-object-access-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for literal access on a bare JsObject.") (:init-fn 'type-fail-untyped-js-object-access-strict.main/main!) (:mode :js) (:reload-fn 'type-fail-untyped-js-object-access-strict.main/reload!) (:target :node)
+      :feature-policy $ {} (:js-ffi :error)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-untyped-js-object-access-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc "|A known member on a bare host object must use an external-object trait.")
+          :code $ quote
+            defn main! () $ let
+                host $ js-object
+              .-length host
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+              :features $ #{} :js-ffi
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict untyped JavaScript object access fixture.")
+        :code $ quote (ns type-fail-untyped-js-object-access-strict.main)

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -34,8 +34,9 @@ and portability rules that apply to every form.
 ## 1. Boundary model: opaque first, typed second
 
 Raw JavaScript values are not ordinary `Dynamic` Calcit values. Property reads,
-native method calls, `aget`, untyped `js-get`, and `js/...` calls are
-conservatively inferred as `JsNullish<JsObject>`:
+native method calls, `aget`, untyped `js-get`, and arbitrary `js/...` calls are
+conservatively inferred as `JsNullish<JsObject>`. The deliberate exception is
+`js/typeof`, whose JavaScript-language result is always inferred as `String`:
 
 - `JsNullish` is reserved for the actual JavaScript `null`/`undefined` boundary;
   it is deliberately distinct from legacy `Optional` and nominal `Option`.

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -104,12 +104,14 @@ legacy projects and disables this target-specific check.
 ### 2.3 Audit untyped access points
 
 `.-name`, `.!name`, `aget`, `aset`, `js-get`, and `js-set` against a bare
-`JsObject` receiver (no external-object trait attached) still work, but nothing
-about the field is checked. Running with `--warn-dyn-method` additionally
-reports `W_JS_FFI_UNTYPED_ACCESS` for these calls whenever the field key is a
-literal tag/string, since that is the case where declaring a trait for the
-receiver is directly actionable. A dynamic (non-literal) key, or a receiver
-that already carries trait or nullable evidence, does not trigger it.
+`JsObject` receiver have no field or method contract. When the member key is a
+literal, strict project source rejects the access with
+`E_UNTYPED_JS_OBJECT_ACCESS`; declare the smallest external-object trait and
+coerce the host value to that trait inside the lexical adapter. Compatibility
+mode can inventory the same sites as `W_JS_FFI_UNTYPED_ACCESS` with
+`--warn-dyn-method`. A dynamic (non-literal) key retains explicit raw lookup
+semantics, while receivers that already carry trait or nullable evidence are
+handled by their dedicated checks.
 
 ## 3. Typed adapters and external objects
 

--- a/editing-history/202609041050-type-js-typeof-result.md
+++ b/editing-history/202609041050-type-js-typeof-result.md
@@ -1,0 +1,12 @@
+# Type the JavaScript `typeof` result
+
+- Infer `js/typeof` as concrete `String` before and after raw JavaScript
+  lowering; arbitrary `js/...` operations remain opaque
+  `JsNullish<JsObject>` boundaries.
+- Added focused inference coverage for source and preprocessed forms and
+  documented the single language-defined exception in the JS interop guide.
+- Revalidated the unchanged `calcit-lang/js-ffi` default, Node, and browser
+  entries with the strict raw-primitive and lexical `unsafe-coerce` stack.
+  Its existing quality baseline remains at zero Dynamic/unresolved debt and
+  30 reviewed coercions, while all Node/browser contract tests and the Vite
+  production build pass.

--- a/editing-history/202609041106-reject-untyped-js-object-access.md
+++ b/editing-history/202609041106-reject-untyped-js-object-access.md
@@ -1,0 +1,13 @@
+# Reject untyped JavaScript object access in strict source
+
+- Promote literal member reads, calls, and writes on a bare `JsObject` from the
+  opt-in `W_JS_FFI_UNTYPED_ACCESS` inventory warning to the stable strict error
+  `E_UNTYPED_JS_OBJECT_ACCESS` for project source.
+- Keep compatibility-mode inventory warnings and dynamic-key raw lookup
+  semantics, while typed external-object and nullable receivers continue
+  through their dedicated checks.
+- Add unit and type-fail coverage plus migration guidance toward minimal
+  external-object traits inside lexical `:js-ffi` adapters.
+- Validate the migration against `calcit-lang/js-ffi`: `process.argv` now uses a
+  `ProcessArgvHost` capability and retains runtime `length` validation without
+  increasing its existing explicit-unsafe quality baseline.

--- a/editing-history/202609041114-preserve-opt-in-js-object-inventory.md
+++ b/editing-history/202609041114-preserve-opt-in-js-object-inventory.md
@@ -1,0 +1,9 @@
+# Preserve opt-in JavaScript object inventory outside project source
+
+- Keep `W_JS_FFI_UNTYPED_ACCESS` behind `--warn-dyn-method` when strict
+  preprocessing visits dependency namespaces outside the project-source lint
+  scope.
+- Retain `E_UNTYPED_JS_OBJECT_ACCESS` for strict project source and add a
+  serialized regression test that configures project namespaces explicitly.
+- This addresses the focused review finding on PR #620 without broadening the
+  hard-error boundary or changing dynamic-key semantics.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -267,6 +267,24 @@ fn strict_type_fail_raw_primitive_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_untyped_js_object_access_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/untyped-js-object-access-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("literal access on a bare JsObject must fail strict check-only");
+
+    assert!(
+      err.contains("E_UNTYPED_JS_OBJECT_ACCESS"),
+      "unexpected strict JS object access error: {err}"
+    );
+    assert!(err.contains(".-length"), "operation should be explicit: {err}");
+    assert!(err.contains("inferred `JsObject`"), "receiver evidence should be explicit: {err}");
+    assert!(err.contains("external-object trait"), "migration should be actionable: {err}");
+  });
+}
+
+#[test]
 fn strict_type_fail_unsafe_coerce_requires_lexical_ffi_scope() {
   run_with_large_stack(|| {
     let _strict = StrictTypesReset::enabled();

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -5006,7 +5006,9 @@ fn reject_or_warn_on_untyped_js_ffi_field_access(
     ));
   }
 
-  gen_check_warning_code_at(message, "W_JS_FFI_UNTYPED_ACCESS", file_ns, location, check_warnings);
+  if warn_dyn_method_enabled() {
+    gen_check_warning_code_at(message, "W_JS_FFI_UNTYPED_ACCESS", file_ns, location, check_warnings);
+  }
   Ok(())
 }
 
@@ -10275,6 +10277,24 @@ mod tests {
     }
   }
 
+  struct ProjectNamespacesGuard {
+    previous: HashSet<Arc<str>>,
+  }
+
+  impl ProjectNamespacesGuard {
+    fn new(namespaces: &[&str]) -> Self {
+      let mut current = PROJECT_NAMESPACES.write().expect("write project namespaces");
+      let previous = std::mem::replace(&mut *current, namespaces.iter().map(|ns| Arc::from(*ns)).collect());
+      Self { previous }
+    }
+  }
+
+  impl Drop for ProjectNamespacesGuard {
+    fn drop(&mut self) {
+      *PROJECT_NAMESPACES.write().expect("restore project namespaces") = std::mem::take(&mut self.previous);
+    }
+  }
+
   struct CurrentFnFeaturesGuard {
     previous: Option<Arc<HashSet<EdnTag>>>,
   }
@@ -11649,6 +11669,33 @@ mod tests {
     assert!(error.msg.contains("external-object trait"));
     assert!(error.msg.contains("lexical `:js-ffi` adapter"));
     assert!(warnings.borrow().is_empty());
+  }
+
+  #[test]
+  fn strict_types_keep_dependency_untyped_access_inventory_opt_in() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let _warn_guard = WarnDynMethodGuard::new(false);
+    let _project_namespaces = ProjectNamespacesGuard::new(&["app.main"]);
+    let receiver = untyped_js_ffi_test_receiver();
+    let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
+    let warnings = RefCell::new(vec![]);
+
+    reject_or_warn_on_untyped_js_ffi_field_access(
+      &head,
+      &CalcitList::from(std::slice::from_ref(&receiver)),
+      &ScopeTypes::new(),
+      "dependency.host",
+      "demo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect("strict dependency access stays outside project-source hard errors");
+
+    assert!(
+      warnings.borrow().is_empty(),
+      "dependency inventory remains behind --warn-dyn-method"
+    );
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2766,7 +2766,15 @@ fn preprocess_list_call(
           let processed_args = CalcitList::from(ys.drop_left());
           require_js_ffi_feature_for_operation(call_head, file_ns, def_name.as_ref(), check_warnings, call_stack)?;
           warn_on_nullable_js_ffi_dereference(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-          warn_on_untyped_js_ffi_field_access(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          reject_or_warn_on_untyped_js_ffi_field_access(
+            call_head,
+            &processed_args,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
+            check_warnings,
+            call_stack,
+          )?;
           warn_on_nominal_enum_legacy_absence_use(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           warn_on_legacy_js_nullish_predicate(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           reject_or_warn_on_dynamic_trait_call(
@@ -4935,22 +4943,24 @@ fn check_typed_js_field_operation(
 
 /// Raw `.-`/`.!`/`aget`/`aset`/`js-get`/`js-set` on a bare `JsObject` receiver
 /// (no external-object trait attached) has nothing left to check statically.
-/// This is opt-in (behind `--warn-dyn-method`) since it fires on any untyped
-/// FFI touch point, including code that intentionally stays dynamic.
-fn warn_on_untyped_js_ffi_field_access(
+/// Strict project source must attach an external-object trait when the key is
+/// statically known. Compatibility mode keeps the opt-in inventory warning;
+/// dynamic keys retain explicit raw JavaScript semantics.
+fn reject_or_warn_on_untyped_js_ffi_field_access(
   head: &Calcit,
   args: &CalcitList,
   scope_types: &ScopeTypes,
   file_ns: &str,
   def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
-) {
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
   if file_ns == calcit::CORE_NS {
-    return;
+    return Ok(());
   }
 
-  if !warn_dyn_method_enabled() {
-    return;
+  if !strict_types_enabled() && !warn_dyn_method_enabled() {
+    return Ok(());
   }
 
   let (operation, field_name) = match head {
@@ -4960,38 +4970,44 @@ fn warn_on_untyped_js_ffi_field_access(
       let Some(field_name) = args.get(1).and_then(static_js_field_name) else {
         // A dynamic (non-literal) key cannot be described by a trait field
         // either, so there is no actionable next step to suggest here.
-        return;
+        return Ok(());
       };
       (sym.to_string(), field_name.to_owned())
     }
-    _ => return,
+    _ => return Ok(()),
   };
 
   let Some(receiver) = args.first() else {
-    return;
+    return Ok(());
   };
   let Some(receiver_type) = resolve_type_value(receiver, scope_types) else {
-    return;
+    return Ok(());
   };
   // Only the bare, non-nullable `JsObject` case is targeted here: it already
   // proves the value is a raw host object, and the key is a literal the
   // developer already knows, so declaring a trait is directly actionable.
   // Nullable receivers and declared traits are covered by other diagnostics.
   if !matches!(receiver_type.as_ref(), CalcitTypeAnnotation::JsObject) {
-    return;
+    return Ok(());
   }
 
   let message = format!(
-    "[Warn] `{operation}` accesses untyped JS field `:{field_name}` in {file_ns}/{def_name}; still permitted, but declaring an external-object trait (`deftrait ... :ffi {{:kind :external-object ...}}`) for the receiver unlocks static field/method checking and `:names` mapping"
+    "[Warn] `{operation}` accesses untyped JS field `:{field_name}` on inferred `JsObject` in {file_ns}/{def_name}; declare an external-object trait (`deftrait ... :ffi {{:kind :external-object ...}}`) containing that field or method, then coerce the host value to the trait inside the lexical `:js-ffi` adapter; use a dynamic key only when raw lookup semantics are intentional"
   );
 
-  gen_check_warning_code_at(
-    message,
-    "W_JS_FFI_UNTYPED_ACCESS",
-    file_ns,
-    head.get_location().or_else(|| receiver.get_location()),
-    check_warnings,
-  );
+  let location = head.get_location().or_else(|| receiver.get_location());
+  if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      message.replacen("[Warn]", "[Error]", 1),
+      "E_UNTYPED_JS_OBJECT_ACCESS",
+      call_stack,
+      location,
+    ));
+  }
+
+  gen_check_warning_code_at(message, "W_JS_FFI_UNTYPED_ACCESS", file_ns, location, check_warnings);
+  Ok(())
 }
 
 fn warn_on_legacy_js_nullish_predicate(
@@ -11595,16 +11611,44 @@ mod tests {
     let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
     let warnings = RefCell::new(vec![]);
 
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &head,
       &CalcitList::from(std::slice::from_ref(&receiver)),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("compatibility inventory should remain a warning");
 
     assert_eq!(warnings.borrow()[0].code(), Some("W_JS_FFI_UNTYPED_ACCESS"));
+  }
+
+  #[test]
+  fn strict_types_reject_untyped_js_object_access_with_a_static_field() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let receiver = untyped_js_ffi_test_receiver();
+    let head = Calcit::Method(Arc::from("value"), calcit::MethodKind::Access);
+    let warnings = RefCell::new(vec![]);
+
+    let error = reject_or_warn_on_untyped_js_ffi_field_access(
+      &head,
+      &CalcitList::from(std::slice::from_ref(&receiver)),
+      &ScopeTypes::new(),
+      "tests.untyped-ffi",
+      "demo",
+      &warnings,
+      &CallStackList::default(),
+    )
+    .expect_err("strict project source must attach an external-object trait");
+
+    assert_eq!(error.code.as_deref(), Some("E_UNTYPED_JS_OBJECT_ACCESS"));
+    assert!(error.msg.contains("inferred `JsObject`"));
+    assert!(error.msg.contains("external-object trait"));
+    assert!(error.msg.contains("lexical `:js-ffi` adapter"));
+    assert!(warnings.borrow().is_empty());
   }
 
   #[test]
@@ -11615,41 +11659,47 @@ mod tests {
 
     // Disabled by default: the flag must be explicitly turned on.
     let disabled_warnings = RefCell::new(vec![]);
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &head,
       &CalcitList::from(std::slice::from_ref(&receiver)),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &disabled_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("disabled compatibility inventory should accept raw access");
     assert!(disabled_warnings.borrow().is_empty());
 
     let _warn_guard = WarnDynMethodGuard::new(true);
 
     // A dynamic (non-literal) key gives no actionable static field to suggest.
     let dynamic_key_warnings = RefCell::new(vec![]);
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &external_field_test_symbol("aget"),
       &CalcitList::from(&[receiver.clone(), external_field_test_symbol("k")]),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &dynamic_key_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("dynamic keys retain explicit raw lookup semantics");
     assert!(dynamic_key_warnings.borrow().is_empty());
 
     // Already-typed external-object receivers are covered by other diagnostics.
     let typed_receiver = external_field_test_receiver(seed_external_field_trait(true));
     let typed_warnings = RefCell::new(vec![]);
-    warn_on_untyped_js_ffi_field_access(
+    reject_or_warn_on_untyped_js_ffi_field_access(
       &external_field_test_symbol("aget"),
       &CalcitList::from(&[typed_receiver, Calcit::Tag(EdnTag::new("value"))]),
       &ScopeTypes::new(),
       "tests.untyped-ffi",
       "demo",
       &typed_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("external-object traits remain statically checked");
     assert!(typed_warnings.borrow().is_empty());
   }
 

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -549,6 +549,10 @@ fn infer_external_field_type(base_type: &CalcitTypeAnnotation, key_arg: Option<&
 
 fn infer_js_ffi_call_return_type(name: &str, call_expr: &CalcitList, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
   match name {
+    // JavaScript's `typeof` operator always produces one of the specified
+    // string tags. Unlike arbitrary host calls, its result is neither opaque
+    // nor nullish, even when the inspected value is null or undefined.
+    "js/typeof" => Some(tag_annotation("string")),
     // JavaScript indexed/property reads may yield `undefined` or `null`. Keep
     // the raw host value opaque as well as nullable so a nil check alone does
     // not silently prove that it is a Calcit Number/String/etc.
@@ -763,6 +767,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           None
         }
 
+        Calcit::RawCode(calcit::RawCodeType::Js, code) if code.as_ref() == "typeof" => Some(tag_annotation("string")),
         Calcit::RawCode(..) => Some(js_nullish_host_value_type()),
 
         // Direct Fn call: return the function's return type
@@ -2173,6 +2178,23 @@ mod tests {
     assert!(opaque.matches_annotation(&CalcitTypeAnnotation::JsObject));
     assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::String));
     assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::Number));
+  }
+
+  #[test]
+  fn js_typeof_has_a_concrete_string_result() {
+    let value = local("host", js_nullish_host_value_type());
+    let typeof_call = Calcit::from(vec![symbol("js/typeof"), value]);
+    let processed_typeof_call = Calcit::from(vec![
+      Calcit::RawCode(calcit::RawCodeType::Js, Arc::from("typeof")),
+      local("host", js_nullish_host_value_type()),
+    ]);
+
+    for expression in [typeof_call, processed_typeof_call] {
+      assert!(matches!(
+        infer_static_type_from_expr(&expression).as_deref(),
+        Some(CalcitTypeAnnotation::String)
+      ));
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- promote literal member reads, calls, and writes on bare JsObject to E_UNTYPED_JS_OBJECT_ACCESS in strict project source
- preserve compatibility-mode W_JS_FFI_UNTYPED_ACCESS inventory and dynamic-key raw lookup semantics
- add stable type-fail coverage and external-object trait migration guidance

Stacked on #619 because JavaScript typeof must retain its concrete String result before this stricter boundary is enabled. Ecosystem migration: calcit-lang/js-ffi#11. Tracks #581.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all (670 lib, 289 CLI, 23 WASM)
- yarn compile
- yarn test-fail (26/26)
- yarn check-agent-interface (18/18)
- yarn check-all (core 236/236, native/JS/IR/WASM and performance checks)
- js-ffi default, Node, browser, runtime contract, and production build validation