### PR TITLE
Reject unsafe JavaScript nullish use in strict source

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -22,6 +22,8 @@
 - `cargo run --bin calcit -- calcit/type-fail/dynamic-method-dispatch-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/raw-primitive-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/untyped-js-object-access-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/js-nullish-dereference-strict.cirru --strict-types --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/js-nullish-predicate-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/unsafe-coerce-unscoped-strict.cirru --strict-types --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/erased-generic-relation-strict.cirru --strict-types --check-only`
 
@@ -40,6 +42,8 @@
 - `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `raw-primitive-strict.cirru` 会验证 strict 模式拒绝项目源码直接调用 `&get-raw`，并报告稳定的 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
 - `untyped-js-object-access-strict.cirru` 会验证 strict 模式拒绝裸 `JsObject` 上的静态成员访问，并报告稳定的 `E_UNTYPED_JS_OBJECT_ACCESS` 与 external-object trait 迁移建议。
+- `js-nullish-dereference-strict.cirru` 会验证 strict 模式拒绝直接解引用 `JsNullish<JsObject>`，并报告稳定的 `E_JS_FFI_NULLABLE_DEREF` 与显式 narrow/optional access 建议。
+- `js-nullish-predicate-strict.cirru` 会验证 strict 模式拒绝以 legacy `nil?`/`some?` 检查 `JsNullish<T>`，并报告稳定的 `E_JS_FFI_NULLABLE_PREDICATE` 与专用 predicate 建议。
 - `unsafe-coerce-unscoped-strict.cirru` 会验证 strict 模式拒绝未声明 `:js-ffi` 的 `unsafe-coerce`，并报告稳定的 `E_UNSCOPED_UNSAFE_COERCE`。
 - `unsafe-coerce-scoped-strict.cirru` 是 integration preprocessing 正例：标记 adapter 可使用 assertion，普通 typed caller 不继承也不需要该 capability；完整 strict quality gate 仍要求显式 `unsafeCoerce` baseline。
 - `erased-generic-relation-strict.cirru` 会验证 strict 模式拒绝把 Dynamic 实参传入重复泛型关系，并报告稳定的 `E_ERASED_GENERIC_RELATION`。
@@ -57,6 +61,7 @@
 - strict general Dynamic method fixture：断言错误文本包含 `E_DYNAMIC_POSTFIX_METHOD`、method 名称、receiver-loss 分类与 typed adapter 迁移建议
 - strict raw primitive fixture：断言错误文本包含 `E_RAW_PRIMITIVE_IN_TYPED_CODE`、primitive 名称与 typed public API 迁移建议
 - strict untyped JS object fixture：断言错误文本包含 `E_UNTYPED_JS_OBJECT_ACCESS`、成员名、receiver evidence 与 external-object trait 迁移建议
+- strict nullable JS fixtures：断言直接 dereference 报 `E_JS_FFI_NULLABLE_DEREF`，legacy predicate 报 `E_JS_FFI_NULLABLE_PREDICATE`，且两者都提供专用 host-nullability 迁移建议
 - strict unsafe-coerce fixtures：断言未标记 adapter 报 `E_UNSCOPED_UNSAFE_COERCE`，而词法标记的 adapter 与普通 caller 可通过 preprocessing
 - strict erased-generic fixture：断言错误文本包含 `E_ERASED_GENERIC_RELATION`、callee、参数位置、泛型变量与 narrow/adapter 迁移建议
 
@@ -76,6 +81,8 @@
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
 - `E_RAW_PRIMITIVE_IN_TYPED_CODE`：strict 项目源码手写 raw constructor/lookup/index primitive，且没有 compiler/macro origin 或匹配的 nominal layout evidence
 - `E_UNTYPED_JS_OBJECT_ACCESS`：strict 项目源码在裸 `JsObject` 上以静态成员名执行读取、调用或写入，需在 lexical adapter 内绑定 external-object trait；动态 key 保留 raw lookup 语义
+- `E_JS_FFI_NULLABLE_DEREF`：strict 项目源码未 narrow `JsNullish<JsObject>` 就直接读取或调用宿主成员
+- `E_JS_FFI_NULLABLE_PREDICATE`：strict 项目源码用 legacy `nil?`/`some?` 擦除 `JsNullish<T>` 的宿主空值语义
 - `E_UNSCOPED_UNSAFE_COERCE`：strict 项目源码在当前 definition 未声明 `:js-ffi` 时使用 `unsafe-coerce`
 - `E_ERASED_GENERIC_RELATION`：strict 模式下 Dynamic 实参擦除了 callee 声明的重复泛型关系
 - `W_FN_ARG_TYPE_MISMATCH`：用户函数调用参数类型不匹配

--- a/calcit/type-fail/js-nullish-dereference-strict.cirru
+++ b/calcit/type-fail/js-nullish-dereference-strict.cirru
@@ -1,0 +1,27 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-js-nullish-dereference-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for direct dereference of a nullable JavaScript host value.") (:init-fn 'type-fail-js-nullish-dereference-strict.main/main!) (:mode :js) (:reload-fn 'type-fail-js-nullish-dereference-strict.main/reload!) (:target :node)
+      :feature-policy $ {} (:js-ffi :error)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-js-nullish-dereference-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc "|A nullable host value must be narrowed before member access.")
+          :code $ quote
+            defn main! () $ let
+                host $ js/process.argv
+              .-length host
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'JsObject)
+              :args $ []
+              :features $ #{} :js-ffi
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict nullable JavaScript dereference fixture.")
+        :code $ quote (ns type-fail-js-nullish-dereference-strict.main)

--- a/calcit/type-fail/js-nullish-dereference-strict.cirru
+++ b/calcit/type-fail/js-nullish-dereference-strict.cirru
@@ -14,7 +14,7 @@
               .-length host
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'JsObject)
+            {} (:return 'Number)
               :args $ []
               :features $ #{} :js-ffi
         'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")

--- a/calcit/type-fail/js-nullish-predicate-strict.cirru
+++ b/calcit/type-fail/js-nullish-predicate-strict.cirru
@@ -1,0 +1,27 @@
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-js-nullish-predicate-strict)
+  :entries $ {}
+    :default $ {} (:description "|Strict preprocessing fixture for a legacy nil predicate on a nullable JavaScript host value.") (:init-fn 'type-fail-js-nullish-predicate-strict.main/main!) (:mode :js) (:reload-fn 'type-fail-js-nullish-predicate-strict.main/reload!) (:target :node)
+      :feature-policy $ {} (:js-ffi :error)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'type-fail-js-nullish-predicate-strict.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc "|A nullable host value must use a JavaScript-specific presence predicate.")
+          :code $ quote
+            defn main! () $ let
+                host $ js/process.argv
+              nil? host
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ []
+              :features $ #{} :js-ffi
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote (defn reload! () &unit)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+      :ns $ %{} 'NsEntry (:doc "|Strict nullable JavaScript predicate fixture.")
+        :code $ quote (ns type-fail-js-nullish-predicate-strict.main)

--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -47,18 +47,22 @@ conservatively inferred as `JsNullish<JsObject>`. The deliberate exception is
   with a boundary decoder. `unsafe-coerce` is available only when an external
   API contract is trusted and the unchecked conversion is intentional.
 
-Plain `.-name` and `.!name` dereference their receiver. If the receiver is an
-`JsNullish<JsObject>`, preprocessing reports `W_JS_FFI_NULLABLE_DEREF`. Use
-`.?-name`/`.?!name`, or narrow the receiver before dereferencing it.
+Plain `.-name` and `.!name` dereference their receiver. If the receiver is a
+`JsNullish<JsObject>`, strict project source fails with
+`E_JS_FFI_NULLABLE_DEREF`; compatibility mode reports
+`W_JS_FFI_NULLABLE_DEREF`. Use `.?-name`/`.?!name`, or narrow the receiver
+before dereferencing it.
 
 Functions containing raw interop should declare `:features $ #{} :js-ffi` in
 their schema. The feature identifies the boundary but does not suppress
 nullable dereference or strong-type mismatch diagnostics.
 
 Use `js-nullish?` and `js-present?` to narrow a JavaScript boundary. Applying
-legacy `nil?`/`some?` reports `W_JS_FFI_NULLABLE_PREDICATE`. Convert explicitly
-with `js-nullish->option` only after accepting the opaque payload contract;
-generic `optionally` does not accept `JsNullish<T>`.
+legacy `nil?`/`some?` fails strict project source with
+`E_JS_FFI_NULLABLE_PREDICATE`; compatibility mode reports
+`W_JS_FFI_NULLABLE_PREDICATE`. Convert explicitly with
+`js-nullish->option` only after accepting the opaque payload contract; generic
+`optionally` does not accept `JsNullish<T>`.
 
 ## 2. Capability and target policy
 
@@ -449,5 +453,8 @@ Common diagnostics:
 | `E_UNSCOPED_UNSAFE_COERCE` | Strict preprocessing finds `unsafe-coerce` outside the current function's lexical FFI scope. | Move it into a small structured `Fn` adapter declaring `:js-ffi`; validate/convert there and return typed data. |
 | `E_JS_FFI_TARGET_MISMATCH` | The selected entry targets another host. | Correct the entry `:target` or use the matching adapter. |
 | `W_JS_FFI_NULLABLE_DEREF` | A nullable host value is dereferenced directly. | Use optional access or narrow with `js-present?`. |
+| `W_JS_FFI_NULLABLE_PREDICATE` | Compatibility source applies legacy `nil?`/`some?` to a host-nullish value. | Use `js-nullish?`/`js-present?` so host semantics remain visible. |
+| `E_JS_FFI_NULLABLE_DEREF` | Strict project source dereferences `JsNullish<JsObject>` directly. | Use optional access or narrow with a dedicated JS predicate. |
+| `E_JS_FFI_NULLABLE_PREDICATE` | Strict project source applies legacy `nil?`/`some?` to `JsNullish<T>`. | Use `js-nullish?`/`js-present?`, then convert explicitly if needed. |
 | `E_JS_FFI_FIELD_READONLY` | A typed external field is written without permission. | Add the field to `:ffi :writable` only if the host API permits it. |
 ```

--- a/editing-history/202609041127-reject-unsafe-js-nullish-use.md
+++ b/editing-history/202609041127-reject-unsafe-js-nullish-use.md
@@ -1,0 +1,14 @@
+# Reject unsafe JavaScript nullish use in strict source
+
+- Promote direct member dereference of `JsNullish<JsObject>` to
+  `E_JS_FFI_NULLABLE_DEREF` for strict project source; optional access and
+  explicit `js-present?`/`js-nullish?` narrowing remain supported.
+- Promote legacy `nil?`/`some?` checks on `JsNullish<T>` to
+  `E_JS_FFI_NULLABLE_PREDICATE`, preserving the distinction between host
+  `null`/`undefined` and Calcit absence.
+- Keep both established warnings in compatibility mode and outside the strict
+  project-source scope.
+- Add unit and type-fail coverage for both stable error codes and document the
+  migration paths.
+- Revalidate `calcit-lang/js-ffi` Node and browser entries against the combined
+  strict stack with no new nullable-boundary failures or quality debt.

--- a/editing-history/202609041157-focus-js-nullish-fixture.md
+++ b/editing-history/202609041157-focus-js-nullish-fixture.md
@@ -1,0 +1,7 @@
+# Focus the strict JavaScript nullish fixture
+
+- Correct the nullable-dereference fixture return schema from `JsObject` to
+  `Number`, matching the result of `.-length`.
+- Keep the type-fail fixture focused on `E_JS_FFI_NULLABLE_DEREF` so unrelated
+  return-type validation cannot mask the intended diagnostic.
+- This addresses the focused review finding on PR #621.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -285,6 +285,40 @@ fn strict_type_fail_untyped_js_object_access_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_js_nullish_dereference_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/js-nullish-dereference-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("direct dereference of a JsNullish host value must fail strict check-only");
+
+    assert!(
+      err.contains("E_JS_FFI_NULLABLE_DEREF"),
+      "unexpected nullable dereference error: {err}"
+    );
+    assert!(err.contains(".-length"), "operation should be explicit: {err}");
+    assert!(err.contains("js-present?"), "narrowing migration should be actionable: {err}");
+  });
+}
+
+#[test]
+fn strict_type_fail_js_nullish_predicate_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    let fixture = "calcit/type-fail/js-nullish-predicate-strict.cirru";
+    let _strict = StrictTypesReset::enabled();
+    let entries = load_fixture_entries(fixture);
+    let err = run_check_only(&entries).expect_err("legacy nil? on a JsNullish host value must fail strict check-only");
+
+    assert!(
+      err.contains("E_JS_FFI_NULLABLE_PREDICATE"),
+      "unexpected nullable predicate error: {err}"
+    );
+    assert!(err.contains("`nil?`"), "legacy predicate should be explicit: {err}");
+    assert!(err.contains("js-nullish?"), "predicate migration should be actionable: {err}");
+  });
+}
+
+#[test]
 fn strict_type_fail_unsafe_coerce_requires_lexical_ffi_scope() {
   run_with_large_stack(|| {
     let _strict = StrictTypesReset::enabled();

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2307,7 +2307,15 @@ fn preprocess_list_call(
         // their statically known struct fields in this branch as well.
         check_struct_field_access(&head_form, &current_args, scope_types, file_ns, call_stack, check_warnings);
         warn_on_nominal_enum_legacy_absence_use(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-        warn_on_legacy_js_nullish_predicate(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+        reject_or_warn_on_legacy_js_nullish_predicate(
+          &head_form,
+          &current_args,
+          scope_types,
+          file_ns,
+          def_name.as_ref(),
+          check_warnings,
+          call_stack,
+        )?;
         let mut any_rewritten = false;
         // Rewrite hashmap literal args to struct literals when the expected type is a struct
         if let Some(rewritten) = try_rewrite_map_args_to_structs(info.as_ref(), &current_args, file_ns, &def_name, check_warnings) {
@@ -2765,7 +2773,15 @@ fn preprocess_list_call(
           // Recompute processed_args from ys after optimization rewrites (e.g. struct:get→nth, assoc→assoc-at)
           let processed_args = CalcitList::from(ys.drop_left());
           require_js_ffi_feature_for_operation(call_head, file_ns, def_name.as_ref(), check_warnings, call_stack)?;
-          warn_on_nullable_js_ffi_dereference(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          reject_or_warn_on_nullable_js_ffi_dereference(
+            call_head,
+            &processed_args,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
+            check_warnings,
+            call_stack,
+          )?;
           reject_or_warn_on_untyped_js_ffi_field_access(
             call_head,
             &processed_args,
@@ -2776,7 +2792,15 @@ fn preprocess_list_call(
             call_stack,
           )?;
           warn_on_nominal_enum_legacy_absence_use(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
-          warn_on_legacy_js_nullish_predicate(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
+          reject_or_warn_on_legacy_js_nullish_predicate(
+            call_head,
+            &processed_args,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
+            check_warnings,
+            call_stack,
+          )?;
           reject_or_warn_on_dynamic_trait_call(
             call_head,
             &processed_args,
@@ -4768,16 +4792,17 @@ fn reject_or_warn_on_dynamic_trait_call(
   Ok(())
 }
 
-fn warn_on_nullable_js_ffi_dereference(
+fn reject_or_warn_on_nullable_js_ffi_dereference(
   head: &Calcit,
   args: &CalcitList,
   scope_types: &ScopeTypes,
   file_ns: &str,
   def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
-) {
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
   if file_ns == calcit::CORE_NS {
-    return;
+    return Ok(());
   }
 
   let is_raw_dereference = matches!(
@@ -4785,20 +4810,20 @@ fn warn_on_nullable_js_ffi_dereference(
     Calcit::Method(_, calcit::MethodKind::Access | calcit::MethodKind::InvokeNative)
   ) || matches!(head, Calcit::Symbol { sym, .. } if matches!(sym.as_ref(), "aget" | "js-get"));
   if !is_raw_dereference {
-    return;
+    return Ok(());
   }
 
   let Some(receiver) = args.first() else {
-    return;
+    return Ok(());
   };
   let Some(receiver_type) = resolve_type_value(receiver, scope_types) else {
-    return;
+    return Ok(());
   };
   let CalcitTypeAnnotation::JsNullish(inner) = receiver_type.as_ref() else {
-    return;
+    return Ok(());
   };
   if !matches!(inner.as_ref(), CalcitTypeAnnotation::JsObject) {
-    return;
+    return Ok(());
   }
 
   let operation = match head {
@@ -4812,11 +4837,23 @@ fn warn_on_nullable_js_ffi_dereference(
     "[Warn] JsNullish FFI value is dereferenced by `{operation}` in {file_ns}/{def_name}; use optional access, narrow with `js-present?`/`js-nullish?`, then validate or explicitly `unsafe-coerce` the opaque JsObject value"
   );
 
-  if let Some(location) = head.get_location().or_else(|| receiver.get_location()) {
+  let location = head.get_location().or_else(|| receiver.get_location());
+  if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      message.replacen("[Warn]", "[Error]", 1),
+      "E_JS_FFI_NULLABLE_DEREF",
+      call_stack,
+      location,
+    ));
+  }
+
+  if let Some(location) = location {
     gen_check_warning_with_location_code(message, "W_JS_FFI_NULLABLE_DEREF", location, check_warnings);
   } else {
     gen_check_warning_code(message, "W_JS_FFI_NULLABLE_DEREF", file_ns, check_warnings);
   }
+  Ok(())
 }
 
 fn static_js_field_name(form: &Calcit) -> Option<&str> {
@@ -5014,41 +5051,54 @@ fn reject_or_warn_on_untyped_js_ffi_field_access(
   Ok(())
 }
 
-fn warn_on_legacy_js_nullish_predicate(
+fn reject_or_warn_on_legacy_js_nullish_predicate(
   head: &Calcit,
   args: &CalcitList,
   scope_types: &ScopeTypes,
   file_ns: &str,
   def_name: &str,
   check_warnings: &RefCell<Vec<LocatedWarning>>,
-) {
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
   if file_ns == calcit::CORE_NS {
-    return;
+    return Ok(());
   }
   let Some(operation) = canonical_absence_operation_name(head) else {
-    return;
+    return Ok(());
   };
   if !matches!(operation, "nil?" | "some?") {
-    return;
+    return Ok(());
   }
   let Some(value) = args.first() else {
-    return;
+    return Ok(());
   };
   let Some(value_type) = resolve_type_value(value, scope_types) else {
-    return;
+    return Ok(());
   };
   if !matches!(value_type.as_ref(), CalcitTypeAnnotation::JsNullish(_)) {
-    return;
+    return Ok(());
   }
 
   let message = format!(
     "[Warn] `{operation}` consumes a JsNullish FFI value in {file_ns}/{def_name}; use `js-nullish?` or `js-present?` so host nullability stays explicit"
   );
-  if let Some(location) = head.get_location().or_else(|| value.get_location()) {
+  let location = head.get_location().or_else(|| value.get_location());
+  if strict_types_enabled() && should_emit_project_source_lint(file_ns) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      message.replacen("[Warn]", "[Error]", 1),
+      "E_JS_FFI_NULLABLE_PREDICATE",
+      call_stack,
+      location,
+    ));
+  }
+
+  if let Some(location) = location {
     gen_check_warning_with_location_code(message, "W_JS_FFI_NULLABLE_PREDICATE", location, check_warnings);
   } else {
     gen_check_warning_code(message, "W_JS_FFI_NULLABLE_PREDICATE", file_ns, check_warnings);
   }
+  Ok(())
 }
 
 fn canonical_absence_operation_name(head: &Calcit) -> Option<&str> {
@@ -9794,6 +9844,8 @@ mod tests {
 
   #[test]
   fn js_nullish_ffi_values_require_safe_dereference_and_dedicated_predicates() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(false);
     let sym: Arc<str> = Arc::from("host");
     let receiver = Calcit::Local(CalcitLocal {
       idx: CalcitLocal::track_sym(&sym),
@@ -9808,37 +9860,43 @@ mod tests {
     let args = CalcitList::from(std::slice::from_ref(&receiver));
     let warnings = RefCell::new(vec![]);
 
-    warn_on_nullable_js_ffi_dereference(
+    reject_or_warn_on_nullable_js_ffi_dereference(
       &Calcit::Method(Arc::from("read"), calcit::MethodKind::InvokeNative),
       &args,
       &ScopeTypes::new(),
       "tests.js-ffi",
       "demo",
       &warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("compatibility mode should retain the nullable dereference warning");
     assert_eq!(warnings.borrow().len(), 1);
     assert_eq!(warnings.borrow()[0].code(), Some("W_JS_FFI_NULLABLE_DEREF"));
 
     let optional_warnings = RefCell::new(vec![]);
-    warn_on_nullable_js_ffi_dereference(
+    reject_or_warn_on_nullable_js_ffi_dereference(
       &Calcit::Method(Arc::from("read"), calcit::MethodKind::InvokeNativeOptional),
       &args,
       &ScopeTypes::new(),
       "tests.js-ffi",
       "demo",
       &optional_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("optional host access remains valid");
     assert!(optional_warnings.borrow().is_empty());
 
     let predicate_warnings = RefCell::new(vec![]);
-    warn_on_legacy_js_nullish_predicate(
+    reject_or_warn_on_legacy_js_nullish_predicate(
       &Calcit::Proc(CalcitProc::NilQuestion),
       &args,
       &ScopeTypes::new(),
       "tests.js-ffi",
       "demo",
       &predicate_warnings,
-    );
+      &CallStackList::default(),
+    )
+    .expect("compatibility mode should retain the legacy predicate warning");
     assert_eq!(predicate_warnings.borrow().len(), 1);
     assert_eq!(predicate_warnings.borrow()[0].code(), Some("W_JS_FFI_NULLABLE_PREDICATE"));
 
@@ -9863,6 +9921,50 @@ mod tests {
       narrowing.true_binding,
       Some((name, inferred)) if name.as_ref() == "host" && matches!(inferred.as_ref(), CalcitTypeAnnotation::JsObject)
     ));
+  }
+
+  #[test]
+  fn strict_types_reject_nullable_js_ffi_dereference_and_legacy_predicates() {
+    let _lock = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let sym: Arc<str> = Arc::from("host");
+    let receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&sym),
+      sym,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.js-ffi-strict"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info: Arc::new(CalcitTypeAnnotation::JsNullish(Arc::new(CalcitTypeAnnotation::JsObject))),
+    });
+    let args = CalcitList::from(std::slice::from_ref(&receiver));
+
+    let dereference_error = reject_or_warn_on_nullable_js_ffi_dereference(
+      &Calcit::Method(Arc::from("read"), calcit::MethodKind::InvokeNative),
+      &args,
+      &ScopeTypes::new(),
+      "tests.js-ffi-strict",
+      "demo",
+      &RefCell::new(vec![]),
+      &CallStackList::default(),
+    )
+    .expect_err("strict project source must narrow a JsNullish receiver before dereferencing it");
+    assert_eq!(dereference_error.code.as_deref(), Some("E_JS_FFI_NULLABLE_DEREF"));
+    assert!(dereference_error.msg.contains("js-present?"));
+
+    let predicate_error = reject_or_warn_on_legacy_js_nullish_predicate(
+      &Calcit::Proc(CalcitProc::NilQuestion),
+      &args,
+      &ScopeTypes::new(),
+      "tests.js-ffi-strict",
+      "demo",
+      &RefCell::new(vec![]),
+      &CallStackList::default(),
+    )
+    .expect_err("strict project source must use a dedicated JavaScript nullish predicate");
+    assert_eq!(predicate_error.code.as_deref(), Some("E_JS_FFI_NULLABLE_PREDICATE"));
+    assert!(predicate_error.msg.contains("js-nullish?"));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- promote direct JsNullish<JsObject> member dereference to E_JS_FFI_NULLABLE_DEREF in strict project source
- promote legacy nil?/some? checks on JsNullish<T> to E_JS_FFI_NULLABLE_PREDICATE
- preserve compatibility warnings, optional access, dedicated JavaScript predicates, and explicit conversion paths
- add independent unit and type-fail coverage for both diagnostics

Stacked on #616, whose branch now contains merged #619 and #620. Together these close the lexical-scope, concrete typeof, bare-host-member, and host-nullability slices of #581. Real calcit-lang/js-ffi Node/browser entries pass the combined strict stack with zero Dynamic/unresolved/incomplete debt and the unchanged 30-site explicit-unsafe baseline.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all (672 lib, 291 CLI, 23 WASM)
- yarn compile
- yarn test-fail (28/28)
- yarn check-agent-interface (18/18)
- yarn check-all (core 236/236 plus native/JS/IR/WASM/performance checks)
- js-ffi Node/browser strict quality validation