### PR TITLE
Specialize collection update contracts / 专门化集合 update 契约

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -14,6 +14,7 @@
 - `cargo run --bin calcit -- calcit/type-fail/trait-method-generic-receiver-mismatch.cirru --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/generic-where-bound-mismatch.cirru --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/slice-receiver-trait-mismatch.cirru --check-only`
+- `cargo run --bin calcit -- calcit/type-fail/update-collection-contract-mismatch.cirru --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-record-call-arg-type-mismatch.cirru --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-bind-unknown.cirru --check-only`
 - `cargo run --bin calcit -- calcit/type-fail/type-slot-bind-duplicate.cirru --check-only`
@@ -31,6 +32,7 @@
 - `trait-method-generic-receiver-mismatch.cirru` 会验证泛型方法根据 receiver 的 `Option<String>` 绑定其 fallback 类型，并拒绝 `Number` fallback；同时验证 `.and-then` callback 不能返回裸 payload。
 - `generic-where-bound-mismatch.cirru` 会触发 `W_GENERIC_WHERE_BOUND_MISMATCH`，验证泛型 `:where` 约束在调用点能被发现，并在 `--check-only` 下被当作错误处理。
 - `slice-receiver-trait-mismatch.cirru` 会验证 `slice` 只接受实现 `Sliceable` 的 receiver，拒绝用 `C -> C` 泛型伪装不可切片的值。
+- `update-collection-contract-mismatch.cirru` 会验证已知 `List<T>` / `Map<K,V>` receiver 将索引/键与 `T -> T` / `V -> V` updater contract 带到调用点。
 - `type-slot-record-call-arg-type-mismatch.cirru` 会验证 `bind-type` 绑定 struct 实例后，`*slot` 参与调用点类型检查。
 - `type-slot-bind-unknown.cirru` 会验证未声明 slot 的 `bind-type` 会直接失败。
 - `type-slot-bind-duplicate.cirru` 会验证同一个 slot 重复绑定会直接失败。

--- a/calcit/type-fail/update-collection-contract-mismatch.cirru
+++ b/calcit/type-fail/update-collection-contract-mismatch.cirru
@@ -1,0 +1,36 @@
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |type-fail-update-collection-contract) (:version |0.0.0)
+  :entries $ {}
+    :default $ {} (:description |) (:init-fn 'type-fail-update-collection-contract.main/main!) (:mode :native) (:reload-fn 'type-fail-update-collection-contract.main/reload!)
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    |type-fail-update-collection-contract.main $ %{} 'FileEntry
+      :defs $ {}
+        |main! $ %{} 'CodeEntry (:doc "|Reject mismatched List/Map update keys and callbacks")
+          :code $ quote
+            defn main! ()
+              update ([] 1 2) :bad inc
+              update (&{} :a 1) :a string-id
+              update ([] 1 2) 0 $ fn (x)
+                str x
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
+        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
+          :code $ quote
+            defn reload! () nil
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Dynamic)
+              :args $ []
+        |string-id $ %{} 'CodeEntry (:doc "|Deliberately incompatible updater")
+          :code $ quote
+            defn string-id (x) x
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ [] 'String
+      :ns $ %{} 'NsEntry (:doc "|Namespace for update collection contract mismatch")
+        :code $ quote (ns type-fail-update-collection-contract.main)

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -25,6 +25,8 @@ calcit analyze check-types --summary-only
 calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved --format json
 ```
 
+兼容性的多态 collection facade 可能仍在 core schema 中保留局部 `Dynamic`，但已知 receiver 会在预处理阶段专门化。例如 `update` 对 `List<T>` 要求 `Number` 索引和 `T -> T` updater，对 `Map<K,V>` 要求 `K` 键和 `V -> V` updater；Struct 则按静态字段类型检查。未标注的 inline callback 若能从函数体恢复返回类型，也会参与这项检查。不要把 receiver 擦除为 `Dynamic` 来绕过这些关系：在 FFI/open-data adapter 中先校验或转换，再进入集合操作。
+
 ## 用原生 quality gate 阻止类型债务回归
 
 新项目直接要求所有发布指标归零：

--- a/editing-history/202609041248-specialize-update-collection-contracts.md
+++ b/editing-history/202609041248-specialize-update-collection-contracts.md
@@ -1,0 +1,23 @@
+# Specialize collection `update` contracts / 专门化集合 `update` 契约
+
+## Context / 背景
+
+The public compatibility schema for `update` must remain open because one signature cannot encode List, Map, Enum, and Struct member relationships. Return-type inference already preserved a statically known receiver, but argument checking only specialized Struct fields. As a result, known `List<T>` and `Map<K,V>` calls could still pass incompatible keys or updater functions.
+
+`update` 的公共兼容 schema 需要同时覆盖 List、Map、Enum、Struct，单一签名无法表达全部成员关系。返回类型推断已能保留静态 receiver，但参数检查此前只专门化 Struct 字段，因此已知 `List<T>` / `Map<K,V>` 调用仍可能接受错误的键或 updater。
+
+## Change / 修改
+
+- Derive `Number` plus `T -> T` for `List<T>` update calls.
+- Derive `K` plus `V -> V` for `Map<K,V>` update calls.
+- Preserve the existing literal-field specialization for Struct values.
+- Recover the statically inferable return type of fixed-arity inline callbacks whenever an expected `Fn` contract is available, rather than limiting that check to `option:fold`.
+- Skip optional/rest callbacks because the current function annotation does not retain their call-shape semantics; this avoids treating valid shorthand lambdas as fixed arity.
+- Add a type-fail fixture covering a bad List index, a named Map updater mismatch, and an inline updater with the wrong return type.
+
+- `List<T>` 的 `update` 调用推导出 `Number` 索引与 `T -> T` updater。
+- `Map<K,V>` 的 `update` 调用推导出 `K` 键与 `V -> V` updater。
+- 保留已有的 Struct 字面字段专门化。
+- 当调用点存在期望 `Fn` contract 时，恢复固定参数 inline callback 可静态推断的返回类型，不再只对 `option:fold` 生效。
+- 对 optional/rest callback 保持原行为，因为当前函数 annotation 不保留其 call-shape 语义，避免把合法 shorthand lambda 错当成固定参数函数。
+- 新增 type-fail fixture，覆盖错误 List 索引、具名 Map updater 类型不匹配，以及 inline updater 返回类型错误。

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -732,6 +732,44 @@ fn type_fail_slice_receiver_trait_fixture_reports_warning_code() {
 }
 
 #[test]
+fn type_fail_update_collection_contract_fixture_reports_warning_codes() {
+  run_with_large_stack(|| {
+    let entries = load_fixture_entries("calcit/type-fail/update-collection-contract-mismatch.cirru");
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("collection update mismatches should preprocess with warnings");
+
+    let warnings = warnings.borrow();
+    let matched: Vec<&LocatedWarning> = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_FN_ARG_TYPE_MISMATCH") && warning.message().contains("calcit.core/update"))
+      .collect();
+    assert_eq!(matched.len(), 3, "expected update key and callback warnings, got: {warnings:?}");
+    assert!(
+      matched
+        .iter()
+        .any(|warning| { warning.message().contains("arg 2 expects type `:number`") && warning.message().contains("got `:tag`") }),
+      "List update should require a Number index: {matched:?}"
+    );
+    assert!(
+      matched.iter().any(|warning| {
+        warning.message().contains("arg 3 expects type `fn(:number) -> :number`")
+          && warning.message().contains("got `fn(:string) -> :string`")
+      }),
+      "Map update should bind the updater to its value type: {matched:?}"
+    );
+    assert!(
+      matched.iter().any(|warning| {
+        warning.message().contains("arg 3 expects type `fn(:number) -> :number`")
+          && warning.message().contains("got `fn('T) -> :string`")
+      }),
+      "inline update callbacks should validate their inferred return type: {matched:?}"
+    );
+  });
+}
+
+#[test]
 fn type_fail_type_slot_enum_invalid_variant() {
   run_with_large_stack(|| {
     let entries = load_fixture_entries("calcit/type-fail/type-slot-enum-invalid-variant.cirru");

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -138,16 +138,29 @@ fn specialize_update_expected_types(
   }
 
   let receiver = args.first()?;
-  let field_name = match args.get(1)? {
-    Calcit::Tag(tag) => tag.ref_str(),
-    Calcit::Str(text) => text.as_ref(),
-    Calcit::Symbol { sym, .. } => sym.as_ref(),
+  let receiver_type = resolve_type_value(receiver, scope_types)?;
+  let mut specialized = expected_types.to_vec();
+  let value_type = match receiver_type.as_ref() {
+    CalcitTypeAnnotation::List(item_type) => {
+      specialized[1] = Arc::new(CalcitTypeAnnotation::Number);
+      item_type.clone()
+    }
+    CalcitTypeAnnotation::Map(key_type, value_type) => {
+      specialized[1] = key_type.clone();
+      value_type.clone()
+    }
+    CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::StructValue(_) => {
+      let field_name = match args.get(1)? {
+        Calcit::Tag(tag) => tag.ref_str(),
+        Calcit::Str(text) => text.as_ref(),
+        Calcit::Symbol { sym, .. } => sym.as_ref(),
+        _ => return None,
+      };
+      infer_struct_field_type(receiver, field_name, scope_types)?
+    }
     _ => return None,
   };
-
-  let field_type = infer_struct_field_type(receiver, field_name, scope_types)?;
-  let mut specialized = expected_types.to_vec();
-  specialized[2] = Arc::new(CalcitTypeAnnotation::from_function_parts(vec![field_type.clone()], field_type));
+  specialized[2] = Arc::new(CalcitTypeAnnotation::from_function_parts(vec![value_type.clone()], value_type));
   Some(specialized)
 }
 
@@ -206,11 +219,6 @@ where
   }
 
   let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
-  let is_option_fold = matches!(
-    ctx.head_form,
-    Calcit::Import(import) if import.ns.as_ref() == calcit::CORE_NS && import.def.as_ref() == "option:fold"
-  );
-
   for (idx, (arg, expected_type)) in ctx.args.iter().zip(ctx.expected_types.iter()).enumerate() {
     if matches!(expected_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
       continue;
@@ -229,8 +237,9 @@ where
     }
 
     if let Some(actual_type) = resolve_type_value(arg, ctx.scope_types) {
-      let actual_type = if is_option_fold
-        && matches!(actual_type.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn)
+      let callback_needs_inference = matches!(actual_type.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn)
+        || matches!(actual_type.as_ref(), CalcitTypeAnnotation::Fn(signature) if matches!(signature.return_type.as_ref(), CalcitTypeAnnotation::Dynamic) || signature.return_type.contains_type_var());
+      let actual_type = if callback_needs_inference
         && matches!(expected_type.as_ref(), CalcitTypeAnnotation::Fn(_))
         && let Calcit::List(callback) = arg
       {
@@ -748,5 +757,63 @@ mod tests {
     };
     assert!(matches!(callback.arg_types.as_slice(), [arg] if matches!(arg.as_ref(), CalcitTypeAnnotation::Bool)));
     assert!(matches!(callback.return_type.as_ref(), CalcitTypeAnnotation::Bool));
+  }
+
+  #[test]
+  fn specialize_update_uses_collection_key_and_value_types() {
+    let generic = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let fn_info = CalcitFn {
+      name: Arc::from("update"),
+      def_ns: Arc::from(calcit::CORE_NS),
+      def_ref: None,
+      usage: Default::default(),
+      scope: Arc::new(Default::default()),
+      args: Arc::new(crate::calcit::CalcitFnArgs::Args(vec![])),
+      call_shape: crate::calcit::CalcitFnCallShape::fixed(0),
+      body: vec![],
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      return_type: crate::calcit::DYNAMIC_TYPE.clone(),
+      arg_types: vec![
+        crate::calcit::DYNAMIC_TYPE.clone(),
+        crate::calcit::DYNAMIC_TYPE.clone(),
+        Arc::new(CalcitTypeAnnotation::from_function_parts(vec![generic.clone()], generic)),
+      ],
+      rest_type: None,
+    };
+    let number = Arc::new(CalcitTypeAnnotation::Number);
+    let string = Arc::new(CalcitTypeAnnotation::String);
+    let callback = make_local(
+      "identity",
+      Arc::new(CalcitTypeAnnotation::from_function_parts(vec![number.clone()], number.clone())),
+    );
+
+    let list_args = CalcitList::from(&[
+      make_local("items", Arc::new(CalcitTypeAnnotation::List(string.clone()))),
+      Calcit::Number(0.0),
+      callback.clone(),
+    ]);
+    let list_specialized = specialize_update_expected_types(&fn_info, &list_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("list update should specialize");
+    assert!(matches!(list_specialized[1].as_ref(), CalcitTypeAnnotation::Number));
+    let CalcitTypeAnnotation::Fn(list_callback) = list_specialized[2].as_ref() else {
+      panic!("list updater should be a function");
+    };
+    assert!(matches!(list_callback.arg_types.as_slice(), [arg] if arg == &string));
+    assert_eq!(list_callback.return_type, string);
+
+    let map_args = CalcitList::from(&[
+      make_local("counts", Arc::new(CalcitTypeAnnotation::Map(string.clone(), number.clone()))),
+      Calcit::Str(Arc::from("a")),
+      callback,
+    ]);
+    let map_specialized = specialize_update_expected_types(&fn_info, &map_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("map update should specialize");
+    assert_eq!(map_specialized[1], string);
+    let CalcitTypeAnnotation::Fn(map_callback) = map_specialized[2].as_ref() else {
+      panic!("map updater should be a function");
+    };
+    assert!(matches!(map_callback.arg_types.as_slice(), [arg] if arg == &number));
+    assert_eq!(map_callback.return_type, number);
   }
 }

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -942,6 +942,16 @@ pub(crate) fn infer_unhinted_callback_signature(xs: &CalcitList, scope_types: &S
   {
     return None;
   }
+  if let Some(Calcit::List(params)) = xs.get(2)
+    && params
+      .iter()
+      .any(|param| matches!(param, Calcit::Syntax(CalcitSyntax::ArgOptional | CalcitSyntax::ArgSpread, _)))
+  {
+    // Function annotations do not retain optional-parameter call shapes.
+    // Recovering these callbacks as fixed arity would reject valid shorthand
+    // lambdas that accept an optional second argument.
+    return None;
+  }
   let (arg_types, rest_type) = infer_preprocessed_function_parameters(xs.get(2));
   let return_type = infer_type_from_expr(xs.get(xs.len() - 1)?, scope_types)
     .filter(|annotation| !matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::DynFn))?;


### PR DESCRIPTION
## Summary / 摘要

- specialize `update` call-site contracts for known `List<T>` receivers as `Number` plus `T -> T`
- specialize known `Map<K,V>` receivers as `K` plus `V -> V`, while retaining Struct literal-field specialization
- recover inferable fixed-arity inline callback returns whenever a concrete expected `Fn` is available; optional/rest callbacks keep the compatibility path
- add a negative fixture for invalid List keys, named Map updaters, and inline updater returns

- 对已知 `List<T>` receiver，将 `update` 调用点契约专门化为 `Number` 索引与 `T -> T` updater
- 对已知 `Map<K,V>` receiver，将契约专门化为 `K` 键与 `V -> V` updater，同时保留 Struct 字面字段专门化
- 在存在具体期望 `Fn` 时恢复可推断的固定参数 inline callback 返回类型；optional/rest callback 继续走兼容路径
- 新增负向 fixture，覆盖错误 List key、具名 Map updater 和 inline updater 返回值

The global compatibility schema stays intentionally open: one signature cannot honestly encode the member relationships of List, Map, Enum, and Struct. This PR strengthens known call sites without hiding residual dynamic boundaries. The inventory therefore remains `schemaDynamic=278`, `unresolved=184`, `typeNotFull=134`.

全局兼容 schema 有意保持开放：单一签名无法诚实表达 List、Map、Enum、Struct 的成员关系。本 PR 强化已知调用点，而不隐藏残留动态边界，因此 inventory 保持 `schemaDynamic=278`、`unresolved=184`、`typeNotFull=134`。

Stacked on #622.

## Validation / 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` — 668 lib, 289 CLI, 23 WASM tests
- `yarn check-all`
  - agent interface: 18/18
  - core suite: 237/237
  - weak-type classification: 278/278 current
  - native, JavaScript, IR, WASM, and performance checks passed
