### PR TITLE
Specialize collection key and mutation contracts / 专门化集合键与修改契约

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -34,7 +34,7 @@
 - `generic-where-bound-mismatch.cirru` 会触发 `W_GENERIC_WHERE_BOUND_MISMATCH`，验证泛型 `:where` 约束在调用点能被发现，并在 `--check-only` 下被当作错误处理。
 - `slice-receiver-trait-mismatch.cirru` 会验证 `slice` 只接受实现 `Sliceable` 的 receiver，拒绝用 `C -> C` 泛型伪装不可切片的值。
 - `update-collection-contract-mismatch.cirru` 会验证已知 `List<T>` / `Map<K,V>` receiver 将索引/键与 `T -> T` / `V -> V` updater contract 带到调用点。
-- `collection-member-contract-mismatch.cirru` 会验证已知 collection receiver 将 `get` / `contains?` 的索引或键、`includes?` 的成员，以及 `assoc` 的键和值类型带到调用点。
+- `collection-member-contract-mismatch.cirru` 会验证已知 collection receiver 将 `get` / `contains?` 的索引或键、`includes?` 的成员，以及 `assoc` 的索引、键和值类型带到调用点，包括 Enum 的 Number payload index。
 - `type-slot-record-call-arg-type-mismatch.cirru` 会验证 `bind-type` 绑定 struct 实例后，`*slot` 参与调用点类型检查。
 - `type-slot-bind-unknown.cirru` 会验证未声明 slot 的 `bind-type` 会直接失败。
 - `type-slot-bind-duplicate.cirru` 会验证同一个 slot 重复绑定会直接失败。

--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -34,7 +34,7 @@
 - `generic-where-bound-mismatch.cirru` 会触发 `W_GENERIC_WHERE_BOUND_MISMATCH`，验证泛型 `:where` 约束在调用点能被发现，并在 `--check-only` 下被当作错误处理。
 - `slice-receiver-trait-mismatch.cirru` 会验证 `slice` 只接受实现 `Sliceable` 的 receiver，拒绝用 `C -> C` 泛型伪装不可切片的值。
 - `update-collection-contract-mismatch.cirru` 会验证已知 `List<T>` / `Map<K,V>` receiver 将索引/键与 `T -> T` / `V -> V` updater contract 带到调用点。
-- `collection-member-contract-mismatch.cirru` 会验证已知 collection receiver 将 `get` 的索引/键和 `includes?` 的成员类型带到调用点。
+- `collection-member-contract-mismatch.cirru` 会验证已知 collection receiver 将 `get` / `contains?` 的索引或键、`includes?` 的成员，以及 `assoc` 的键和值类型带到调用点。
 - `type-slot-record-call-arg-type-mismatch.cirru` 会验证 `bind-type` 绑定 struct 实例后，`*slot` 参与调用点类型检查。
 - `type-slot-bind-unknown.cirru` 会验证未声明 slot 的 `bind-type` 会直接失败。
 - `type-slot-bind-duplicate.cirru` 会验证同一个 slot 重复绑定会直接失败。

--- a/calcit/type-fail/collection-member-contract-mismatch.cirru
+++ b/calcit/type-fail/collection-member-contract-mismatch.cirru
@@ -23,6 +23,8 @@
               assoc ([] 1 2) 0 :bad
               assoc (&{} :a 1) 0 2
               assoc (&{} :a 1) :a :bad
+              contains? (:: :ok 1) :bad
+              assoc (:: :ok 1) :bad 2
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/calcit/type-fail/collection-member-contract-mismatch.cirru
+++ b/calcit/type-fail/collection-member-contract-mismatch.cirru
@@ -1,12 +1,14 @@
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |type-fail-collection-member-contract) (:version |0.0.0)
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |type-fail-collection-member-contract)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'type-fail-collection-member-contract.main/main!) (:mode :native) (:reload-fn 'type-fail-collection-member-contract.main/reload!)
+      :feature-policy $ {}
       :modules $ []
       :type-slots $ {}
   :files $ {}
-    |type-fail-collection-member-contract.main $ %{} 'FileEntry
+    'type-fail-collection-member-contract.main $ %{} 'FileEntry
       :defs $ {}
-        |main! $ %{} 'CodeEntry (:doc "|Reject mismatched collection lookup and membership arguments")
+        'main! $ %{} 'CodeEntry (:doc "|Reject mismatched collection lookup, membership, key, and association arguments")
           :code $ quote
             defn main! ()
               get ([] 1 2) :bad
@@ -14,11 +16,18 @@
               includes? (#{} 1 2) :bad
               includes? (&{} :a 1) :a
               includes? |abc 1
+              contains? ([] 1 2) :bad
+              contains? (&{} :a 1) 0
+              contains? (#{} 1 2) :bad
+              assoc ([] 1 2) :bad 3
+              assoc ([] 1 2) 0 :bad
+              assoc (&{} :a 1) 0 2
+              assoc (&{} :a 1) :a :bad
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
               :args $ []
-        |reload! $ %{} 'CodeEntry (:doc "|Reload handler")
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler")
           :code $ quote
             defn reload! () nil
           :examples $ []

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -25,7 +25,7 @@ calcit analyze check-types --summary-only
 calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved --format json
 ```
 
-兼容性的多态 collection facade 可能仍在 core schema 中保留局部 `Dynamic`，但已知 receiver 会在预处理阶段专门化。例如 `update` 对 `List<T>` 要求 `Number` 索引和 `T -> T` updater，对 `Map<K,V>` 要求 `K` 键和 `V -> V` updater；Struct 则按静态字段类型检查。`get` 同样要求 List/String/Enum 的 `Number` 索引或 Map 的 `K` 键，`includes?` 则要求 List/Set 的成员 `T`、Map 的值 `V` 或 String substring。未标注的 inline callback 若能从函数体恢复返回类型，也会参与这项检查。不要把 receiver 擦除为 `Dynamic` 来绕过这些关系：在 FFI/open-data adapter 中先校验或转换，再进入集合操作。
+兼容性的多态 collection facade 可能仍在 core schema 中保留局部 `Dynamic`，或者使用彼此独立、无法表达容器成员关系的泛型，但已知 receiver 会在预处理阶段专门化。例如 `update` 对 `List<T>` 要求 `Number` 索引和 `T -> T` updater，对 `Map<K,V>` 要求 `K` 键和 `V -> V` updater；Struct 则按静态字段类型检查。`get` 同样要求 List/String/Enum 的 `Number` 索引或 Map 的 `K` 键，`includes?` 要求 List/Set 的成员 `T`、Map 的值 `V` 或 String substring；`contains?` 要求 List/String 的 `Number` 索引、Map 的键 `K` 或 Set 的成员 `T`。`assoc` 会同时约束 List 的索引/成员、Map 的键/值，以及静态 Struct 字段的值类型。未标注的 inline callback 若能从函数体恢复返回类型，也会参与这项检查。不要把 receiver 擦除为 `Dynamic` 来绕过这些关系：在 FFI/open-data adapter 中先校验或转换，再进入集合操作。
 
 ## 用原生 quality gate 阻止类型债务回归
 

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -25,7 +25,7 @@ calcit analyze check-types --summary-only
 calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved --format json
 ```
 
-兼容性的多态 collection facade 可能仍在 core schema 中保留局部 `Dynamic`，或者使用彼此独立、无法表达容器成员关系的泛型，但已知 receiver 会在预处理阶段专门化。例如 `update` 对 `List<T>` 要求 `Number` 索引和 `T -> T` updater，对 `Map<K,V>` 要求 `K` 键和 `V -> V` updater；Struct 则按静态字段类型检查。`get` 同样要求 List/String/Enum 的 `Number` 索引或 Map 的 `K` 键，`includes?` 要求 List/Set 的成员 `T`、Map 的值 `V` 或 String substring；`contains?` 要求 List/String 的 `Number` 索引、Map 的键 `K` 或 Set 的成员 `T`。`assoc` 会同时约束 List 的索引/成员、Map 的键/值，以及静态 Struct 字段的值类型。未标注的 inline callback 若能从函数体恢复返回类型，也会参与这项检查。不要把 receiver 擦除为 `Dynamic` 来绕过这些关系：在 FFI/open-data adapter 中先校验或转换，再进入集合操作。
+兼容性的多态 collection facade 可能仍在 core schema 中保留局部 `Dynamic`，或者使用彼此独立、无法表达容器成员关系的泛型，但已知 receiver 会在预处理阶段专门化。例如 `update` 对 `List<T>` 要求 `Number` 索引和 `T -> T` updater，对 `Map<K,V>` 要求 `K` 键和 `V -> V` updater；Struct 则按静态字段类型检查。`get` 同样要求 List/String/Enum 的 `Number` 索引或 Map 的 `K` 键，`includes?` 要求 List/Set 的成员 `T`、Map 的值 `V` 或 String substring；`contains?` 要求 List/String/Enum 的 `Number` 索引、Map 的键 `K` 或 Set 的成员 `T`。`assoc` 会同时约束 List 的索引/成员、Map 的键/值、静态 Struct 字段的值类型，以及 Enum 的 `Number` payload index；Enum payload 可以异构，因此新值在没有精确 variant/slot evidence 时仍保持开放。未标注的 inline callback 若能从函数体恢复返回类型，也会参与这项检查。不要把 receiver 擦除为 `Dynamic` 来绕过这些关系：在 FFI/open-data adapter 中先校验或转换，再进入集合操作。
 
 ## 用原生 quality gate 阻止类型债务回归
 

--- a/editing-history/202609041342-specialize-collection-key-mutation-contracts.md
+++ b/editing-history/202609041342-specialize-collection-key-mutation-contracts.md
@@ -1,0 +1,30 @@
+# Specialize collection key and mutation contracts / 专门化集合键与修改契约
+
+## Context / 背景
+
+The public `contains?` and `assoc` facades used independent generic variables for their receiver, key, and value. Those annotations looked typed but did not express that a `Map<K,V>` must receive `K`/`V`, that a List uses Number indices and preserves its item type, or that Set containment uses its member type. Invalid calls therefore passed preprocessing even when the receiver already provided exact evidence.
+
+公共 `contains?` 与 `assoc` facade 为 receiver、key 和 value 使用彼此独立的泛型变量。它们表面上已有类型，却没有表达 `Map<K,V>` 必须接收 `K`/`V`、List 使用 Number 索引并保持成员类型，或者 Set containment 使用自身成员类型；因此即使 receiver 已提供精确证据，错误调用仍会通过预处理。
+
+## Change / 修改
+
+- Extend core call-site specialization to recover `contains?` contracts for List/String indices, Map keys, and Set members.
+- Recover `assoc` contracts for List indices/items, Map keys/values, and statically known Struct field values.
+- Preserve the compatibility path for Dynamic or unsupported receivers, including heterogeneous Enum payload updates that cannot yet be represented honestly.
+- Align Rust primitive metadata so native Map association carries `Map<K,V>`, `K`, and `V`, while native Set membership carries `Set<T>` and `T`.
+- Expand the existing Snapshot fixture from five to twelve mismatch cases and add unit assertions for the recovered relationships.
+- Keep the bundled-core Dynamic inventory unchanged at `schemaDynamic=278`, `unresolved=184`, and `typeNotFull=134`; this tranche enforces erased relationships rather than rewriting schemas cosmetically.
+
+- 扩展 core 调用点专门化：`contains?` 对 List/String 恢复索引类型，对 Map 恢复键类型，对 Set 恢复成员类型。
+- `assoc` 对 List 恢复索引/成员关系，对 Map 恢复键/值关系，并按静态 Struct 字段约束新值。
+- Dynamic 或当前无法可靠表示的 receiver（包括异构 Enum payload 更新）继续保留兼容路径。
+- 同步 Rust primitive metadata：native Map assoc 携带 `Map<K,V>`、`K`、`V`，native Set membership 携带 `Set<T>`、`T`。
+- 将既有 Snapshot fixture 从五类错误扩展到十二类，并增加关系恢复的单元断言。
+- bundled-core Dynamic inventory 保持 `schemaDynamic=278`、`unresolved=184`、`typeNotFull=134`；本批目标是执行被擦除的关系，而不是装饰性改写 schema。
+
+## Validation / 验证
+
+- `cargo fmt --all`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test` (672 lib, 290 CLI, 23 WASM)
+- `yarn check-all` (Agent interface 18/18, bundled core 237/237, classification 278/278, native/JS/IR/WASM/performance)

--- a/editing-history/202609041342-specialize-collection-key-mutation-contracts.md
+++ b/editing-history/202609041342-specialize-collection-key-mutation-contracts.md
@@ -8,18 +8,18 @@ The public `contains?` and `assoc` facades used independent generic variables fo
 
 ## Change / 修改
 
-- Extend core call-site specialization to recover `contains?` contracts for List/String indices, Map keys, and Set members.
-- Recover `assoc` contracts for List indices/items, Map keys/values, and statically known Struct field values.
-- Preserve the compatibility path for Dynamic or unsupported receivers, including heterogeneous Enum payload updates that cannot yet be represented honestly.
+- Extend core call-site specialization to recover `contains?` contracts for List/String/Enum indices, Map keys, and Set members.
+- Recover `assoc` contracts for List indices/items, Map keys/values, statically known Struct field values, and Enum payload indices. Enum replacement values remain open when no precise variant/slot evidence exists because payloads may be heterogeneous.
+- Preserve the compatibility path for Dynamic or unsupported receivers rather than inventing unavailable relationships.
 - Align Rust primitive metadata so native Map association carries `Map<K,V>`, `K`, and `V`, while native Set membership carries `Set<T>` and `T`.
-- Expand the existing Snapshot fixture from five to twelve mismatch cases and add unit assertions for the recovered relationships.
+- Expand the existing Snapshot fixture from five to fourteen mismatch cases and add unit assertions for the recovered relationships.
 - Keep the bundled-core Dynamic inventory unchanged at `schemaDynamic=278`, `unresolved=184`, and `typeNotFull=134`; this tranche enforces erased relationships rather than rewriting schemas cosmetically.
 
-- 扩展 core 调用点专门化：`contains?` 对 List/String 恢复索引类型，对 Map 恢复键类型，对 Set 恢复成员类型。
-- `assoc` 对 List 恢复索引/成员关系，对 Map 恢复键/值关系，并按静态 Struct 字段约束新值。
-- Dynamic 或当前无法可靠表示的 receiver（包括异构 Enum payload 更新）继续保留兼容路径。
+- 扩展 core 调用点专门化：`contains?` 对 List/String/Enum 恢复索引类型，对 Map 恢复键类型，对 Set 恢复成员类型。
+- `assoc` 对 List 恢复索引/成员关系，对 Map 恢复键/值关系，按静态 Struct 字段约束新值，并要求 Enum payload index 为 Number。Enum payload 可异构，因此缺少精确 variant/slot evidence 时 replacement value 仍保持开放。
+- Dynamic 或当前无法可靠表示的 receiver 继续保留兼容路径，不虚构缺失的关系。
 - 同步 Rust primitive metadata：native Map assoc 携带 `Map<K,V>`、`K`、`V`，native Set membership 携带 `Set<T>`、`T`。
-- 将既有 Snapshot fixture 从五类错误扩展到十二类，并增加关系恢复的单元断言。
+- 将既有 Snapshot fixture 从五类错误扩展到十四类，并增加关系恢复的单元断言。
 - bundled-core Dynamic inventory 保持 `schemaDynamic=278`、`unresolved=184`、`typeNotFull=134`；本批目标是执行被擦除的关系，而不是装饰性改写 schema。
 
 ## Validation / 验证

--- a/editing-history/202609041352-cover-enum-key-specialization.md
+++ b/editing-history/202609041352-cover-enum-key-specialization.md
@@ -1,0 +1,9 @@
+# Cover Enum key specialization / 覆盖 Enum 键专门化
+
+Copilot review identified that the initial `contains?` and `assoc` extension omitted concrete Enum receivers even though both operations require a numeric payload index at runtime. The specializer now treats anonymous, value, and resolvable nominal Enum annotations like the existing typed `get` path: `contains?` and `assoc` both require `Number` for the index.
+
+The `assoc` replacement value remains deliberately open when there is no precise variant/slot evidence because Enum payload positions may be heterogeneous. Unit tests and the real Snapshot fixture now cover the Enum index mismatch, bringing the fixture to fourteen focused warnings.
+
+Copilot review 指出首版 `contains?` 与 `assoc` 扩展遗漏了 concrete Enum receiver，而两项运行时操作都要求数值 payload index。specializer 现在与既有 typed `get` 路径一致，对 anonymous、value 及可解析 nominal Enum annotation 强制 `Number` index。
+
+在缺少精确 variant/slot evidence 时，`assoc` replacement value 仍保持开放，因为 Enum payload 位置可以异构。单元测试与真实 Snapshot fixture 均增加 Enum index 错配覆盖，fixture 总计十四条聚焦告警。

--- a/editing-history/202609041403-resolve-nominal-struct-specialization.md
+++ b/editing-history/202609041403-resolve-nominal-struct-specialization.md
@@ -1,0 +1,9 @@
+# Resolve nominal Struct specialization / 解析 nominal Struct 专门化
+
+Copilot's follow-up review noted that direct `TypeRef` annotations resolving to a Struct were excluded by the `assoc` specialization gate even though the shared field inference helper already supports them. The gate now accepts direct Struct annotations, Struct values, and resolvable direct TypeRefs. The same correction applies to `update`, which shared the narrower condition.
+
+`Optional<Struct>` is deliberately not treated as a Struct receiver: Option is a nominal Enum wrapper at runtime and must be narrowed before `assoc` or `update` can target a Struct field. A regression assertion preserves that boundary so convenient type unwrapping does not create an unsound runtime dispatch assumption.
+
+Copilot follow-up review 指出，能够解析为 Struct 的直接 `TypeRef` annotation 被 `assoc` specialization gate 排除，尽管共享字段推断 helper 已经支持它。gate 现在接受直接 Struct annotation、Struct value 以及可解析的直接 TypeRef；共享相同窄条件的 `update` 也同步修正。
+
+`Optional<Struct>` 不会被当作 Struct receiver：Option 在运行时是 nominal Enum wrapper，必须先 narrow，`assoc` 或 `update` 才能针对 Struct 字段。新增回归断言固定该边界，避免便利性的类型解包制造不可靠的 runtime dispatch 假设。

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -791,7 +791,7 @@ fn type_fail_collection_member_contract_fixture_reports_warning_codes() {
       .collect();
     assert_eq!(
       matched.len(),
-      12,
+      14,
       "expected lookup, membership, key, and association warnings, got: {warnings:?}"
     );
     assert!(
@@ -839,8 +839,8 @@ fn type_fail_collection_member_contract_fixture_reports_warning_codes() {
             && warning.message().contains("got `:tag`")
         })
         .count(),
-      2,
-      "List indices and Set members should both preserve their Number contract: {matched:?}"
+      3,
+      "List and Enum indices plus Set members should preserve their Number contract: {matched:?}"
     );
     assert!(
       matched.iter().any(|warning| {
@@ -850,13 +850,17 @@ fn type_fail_collection_member_contract_fixture_reports_warning_codes() {
       }),
       "Map containment should require its key type: {matched:?}"
     );
-    assert!(
-      matched.iter().any(|warning| {
-        warning.message().contains("calcit.core/assoc")
-          && warning.message().contains("arg 2 expects type `:number`")
-          && warning.message().contains("got `:tag`")
-      }),
-      "List association should require a Number index: {matched:?}"
+    assert_eq!(
+      matched
+        .iter()
+        .filter(|warning| {
+          warning.message().contains("calcit.core/assoc")
+            && warning.message().contains("arg 2 expects type `:number`")
+            && warning.message().contains("got `:tag`")
+        })
+        .count(),
+      2,
+      "List and Enum association should require a Number index: {matched:?}"
     );
     assert_eq!(
       matched

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -783,10 +783,17 @@ fn type_fail_collection_member_contract_fixture_reports_warning_codes() {
       .iter()
       .filter(|warning| {
         warning.code() == Some("W_FN_ARG_TYPE_MISMATCH")
-          && (warning.message().contains("calcit.core/get") || warning.message().contains("calcit.core/includes?"))
+          && (warning.message().contains("calcit.core/get")
+            || warning.message().contains("calcit.core/includes?")
+            || warning.message().contains("calcit.core/contains?")
+            || warning.message().contains("calcit.core/assoc"))
       })
       .collect();
-    assert_eq!(matched.len(), 5, "expected lookup and membership warnings, got: {warnings:?}");
+    assert_eq!(
+      matched.len(),
+      12,
+      "expected lookup, membership, key, and association warnings, got: {warnings:?}"
+    );
     assert!(
       matched.iter().any(|warning| {
         warning.message().contains("calcit.core/get")
@@ -822,6 +829,62 @@ fn type_fail_collection_member_contract_fixture_reports_warning_codes() {
           && warning.message().contains("got `:number`")
       }),
       "String membership should require a String substring: {matched:?}"
+    );
+    assert_eq!(
+      matched
+        .iter()
+        .filter(|warning| {
+          warning.message().contains("calcit.core/contains?")
+            && warning.message().contains("arg 2 expects type `:number`")
+            && warning.message().contains("got `:tag`")
+        })
+        .count(),
+      2,
+      "List indices and Set members should both preserve their Number contract: {matched:?}"
+    );
+    assert!(
+      matched.iter().any(|warning| {
+        warning.message().contains("calcit.core/contains?")
+          && warning.message().contains("arg 2 expects type `:tag`")
+          && warning.message().contains("got `:number`")
+      }),
+      "Map containment should require its key type: {matched:?}"
+    );
+    assert!(
+      matched.iter().any(|warning| {
+        warning.message().contains("calcit.core/assoc")
+          && warning.message().contains("arg 2 expects type `:number`")
+          && warning.message().contains("got `:tag`")
+      }),
+      "List association should require a Number index: {matched:?}"
+    );
+    assert_eq!(
+      matched
+        .iter()
+        .filter(|warning| {
+          warning.message().contains("calcit.core/assoc")
+            && warning.message().contains("arg 3 expects type `:number`")
+            && warning.message().contains("got `:tag`")
+        })
+        .count(),
+      2,
+      "List and Map association should preserve their Number member/value type: {matched:?}"
+    );
+    assert!(
+      matched.iter().any(|warning| {
+        warning.message().contains("calcit.core/assoc")
+          && warning.message().contains("arg 2 expects type `:tag`")
+          && warning.message().contains("got `:number`")
+      }),
+      "Map association should require its key type: {matched:?}"
+    );
+    assert!(
+      matched.iter().any(|warning| {
+        warning.message().contains("calcit.core/assoc")
+          && warning.message().contains("arg 3 expects type `:number`")
+          && warning.message().contains("got `:tag`")
+      }),
+      "Map association should require its value type: {matched:?}"
     );
   });
 }

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -1078,8 +1078,13 @@ impl CalcitProc {
         arg_types: vec![map_of(type_var("K"), type_var("V")), type_var("V")],
       }),
       NativeMapAssoc => Some(ProcTypeSignature {
-        return_type: some_tag("map"),
-        arg_types: vec![some_tag("map"), dynamic_tag(), dynamic_tag(), variadic_dynamic()],
+        return_type: map_of(type_var("K"), type_var("V")),
+        arg_types: vec![
+          map_of(type_var("K"), type_var("V")),
+          type_var("K"),
+          type_var("V"),
+          variadic_dynamic(),
+        ],
       }),
       NativeMapDiffNew => Some(ProcTypeSignature {
         return_type: map_of(type_var("K"), type_var("W")),
@@ -1133,7 +1138,7 @@ impl CalcitProc {
       }),
       NativeSetIncludes => Some(ProcTypeSignature {
         return_type: some_tag("bool"),
-        arg_types: vec![some_set(), dynamic_tag()],
+        arg_types: vec![set_of(type_var("T")), type_var("T")],
       }),
       NativeSetDestruct => Some(ProcTypeSignature {
         return_type: optional_tag("list"),
@@ -1582,6 +1587,31 @@ mod tests {
     assert!(matches!(
       map_includes.arg_types.get(1).map(AsRef::as_ref),
       Some(CalcitTypeAnnotation::TypeVar(name)) if name.as_ref() == "V"
+    ));
+    let map_assoc = CalcitProc::NativeMapAssoc.get_type_signature().expect("map assoc signature");
+    assert!(matches!(
+      map_assoc.return_type.as_ref(),
+      CalcitTypeAnnotation::Map(key, value)
+        if matches!(key.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "K")
+          && matches!(value.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "V")
+    ));
+    assert!(matches!(
+      map_assoc.arg_types.get(1).map(AsRef::as_ref),
+      Some(CalcitTypeAnnotation::TypeVar(name)) if name.as_ref() == "K"
+    ));
+    assert!(matches!(
+      map_assoc.arg_types.get(2).map(AsRef::as_ref),
+      Some(CalcitTypeAnnotation::TypeVar(name)) if name.as_ref() == "V"
+    ));
+    let set_includes = CalcitProc::NativeSetIncludes.get_type_signature().expect("set includes signature");
+    assert!(matches!(
+      set_includes.arg_types.first().map(AsRef::as_ref),
+      Some(CalcitTypeAnnotation::Set(inner))
+        if matches!(inner.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "T")
+    ));
+    assert!(matches!(
+      set_includes.arg_types.get(1).map(AsRef::as_ref),
+      Some(CalcitTypeAnnotation::TypeVar(name)) if name.as_ref() == "T"
     ));
 
     let atom = CalcitProc::Atom.get_type_signature().expect("atom signature");

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -209,7 +209,7 @@ fn specialize_assoc_expected_types(
     value if value.resolve_to_enum().is_some() => {
       specialized[1] = Arc::new(CalcitTypeAnnotation::Number);
     }
-    CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::StructValue(_) => {
+    value if is_direct_struct_receiver(value) => {
       let field_name = match args.get(1)? {
         Calcit::Tag(tag) => tag.ref_str(),
         Calcit::Str(text) => text.as_ref(),
@@ -221,6 +221,11 @@ fn specialize_assoc_expected_types(
     _ => return None,
   }
   Some(specialized)
+}
+
+fn is_direct_struct_receiver(value: &CalcitTypeAnnotation) -> bool {
+  matches!(value, CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::StructValue(_))
+    || matches!(value, CalcitTypeAnnotation::TypeRef(_, _)) && value.resolve_to_struct().is_some()
 }
 
 fn specialize_update_expected_types(
@@ -240,7 +245,7 @@ fn specialize_update_expected_types(
       specialized[1] = key_type.clone();
       value_type.clone()
     }
-    CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::StructValue(_) => {
+    value if is_direct_struct_receiver(value) => {
       let field_name = match args.get(1)? {
         Calcit::Tag(tag) => tag.ref_str(),
         Calcit::Str(text) => text.as_ref(),
@@ -1082,13 +1087,28 @@ mod tests {
       impls: vec![],
     });
     let struct_args = CalcitList::from(&[
-      make_local("task", Arc::new(CalcitTypeAnnotation::StructValue(task_struct))),
+      make_local("task", Arc::new(CalcitTypeAnnotation::StructValue(task_struct.clone()))),
       Calcit::Tag(EdnTag::new("done?")),
       Calcit::Number(0.0),
     ]);
     let struct_specialized = specialize_core_expected_types(&fn_info, &struct_args, &ScopeTypes::new(), &fn_info.arg_types)
       .expect("struct association should specialize from field evidence");
     assert!(matches!(struct_specialized[2].as_ref(), CalcitTypeAnnotation::Bool));
+
+    let optional_struct_args = CalcitList::from(&[
+      make_local(
+        "maybe-task",
+        Arc::new(CalcitTypeAnnotation::Optional(Arc::new(CalcitTypeAnnotation::StructValue(
+          task_struct,
+        )))),
+      ),
+      Calcit::Tag(EdnTag::new("done?")),
+      Calcit::Bool(false),
+    ]);
+    assert!(
+      specialize_core_expected_types(&fn_info, &optional_struct_args, &ScopeTypes::new(), &fn_info.arg_types).is_none(),
+      "Option<Struct> is an Enum wrapper and must be narrowed before Struct association"
+    );
 
     let enum_args = CalcitList::from(&[
       make_local("result", Arc::new(CalcitTypeAnnotation::AnonymousEnum)),

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -150,7 +150,11 @@ fn specialize_core_expected_types(
       specialized[1] = match receiver_type.as_ref() {
         CalcitTypeAnnotation::Map(key_type, _) => key_type.clone(),
         CalcitTypeAnnotation::Set(item_type) => item_type.clone(),
-        CalcitTypeAnnotation::List(_) | CalcitTypeAnnotation::String => Arc::new(CalcitTypeAnnotation::Number),
+        CalcitTypeAnnotation::List(_)
+        | CalcitTypeAnnotation::String
+        | CalcitTypeAnnotation::EnumValue(_)
+        | CalcitTypeAnnotation::AnonymousEnum => Arc::new(CalcitTypeAnnotation::Number),
+        value if value.resolve_to_enum().is_some() => Arc::new(CalcitTypeAnnotation::Number),
         _ => return None,
       };
       Some(specialized)
@@ -198,6 +202,12 @@ fn specialize_assoc_expected_types(
     CalcitTypeAnnotation::Map(key_type, value_type) => {
       specialized[1] = key_type.clone();
       specialized[2] = value_type.clone();
+    }
+    CalcitTypeAnnotation::EnumValue(_) | CalcitTypeAnnotation::AnonymousEnum => {
+      specialized[1] = Arc::new(CalcitTypeAnnotation::Number);
+    }
+    value if value.resolve_to_enum().is_some() => {
+      specialized[1] = Arc::new(CalcitTypeAnnotation::Number);
     }
     CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::StructValue(_) => {
       let field_name = match args.get(1)? {
@@ -1020,6 +1030,14 @@ mod tests {
     let set_specialized = specialize_core_expected_types(&fn_info, &set_args, &ScopeTypes::new(), &fn_info.arg_types)
       .expect("set membership should specialize");
     assert_eq!(set_specialized[1], number);
+
+    let enum_args = CalcitList::from(&[
+      make_local("result", Arc::new(CalcitTypeAnnotation::AnonymousEnum)),
+      Calcit::Tag(EdnTag::new("bad")),
+    ]);
+    let enum_specialized = specialize_core_expected_types(&fn_info, &enum_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("enum index lookup should specialize");
+    assert!(matches!(enum_specialized[1].as_ref(), CalcitTypeAnnotation::Number));
   }
 
   #[test]
@@ -1071,5 +1089,14 @@ mod tests {
     let struct_specialized = specialize_core_expected_types(&fn_info, &struct_args, &ScopeTypes::new(), &fn_info.arg_types)
       .expect("struct association should specialize from field evidence");
     assert!(matches!(struct_specialized[2].as_ref(), CalcitTypeAnnotation::Bool));
+
+    let enum_args = CalcitList::from(&[
+      make_local("result", Arc::new(CalcitTypeAnnotation::AnonymousEnum)),
+      Calcit::Tag(EdnTag::new("bad")),
+      Calcit::Number(0.0),
+    ]);
+    let enum_specialized = specialize_core_expected_types(&fn_info, &enum_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("enum association should specialize its payload index");
+    assert!(matches!(enum_specialized[1].as_ref(), CalcitTypeAnnotation::Number));
   }
 }

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -134,8 +134,8 @@ fn specialize_core_expected_types(
     return None;
   }
   let required_arity = match fn_info.name.as_ref() {
-    "get" | "includes?" => 2,
-    "update" => 3,
+    "contains?" | "get" | "includes?" => 2,
+    "assoc" | "update" => 3,
     _ => return None,
   };
   if expected_types.len() < required_arity || args.len() < required_arity {
@@ -145,6 +145,16 @@ fn specialize_core_expected_types(
   let receiver_type = resolve_type_value(receiver, scope_types)?;
 
   match fn_info.name.as_ref() {
+    "contains?" => {
+      let mut specialized = expected_types.to_vec();
+      specialized[1] = match receiver_type.as_ref() {
+        CalcitTypeAnnotation::Map(key_type, _) => key_type.clone(),
+        CalcitTypeAnnotation::Set(item_type) => item_type.clone(),
+        CalcitTypeAnnotation::List(_) | CalcitTypeAnnotation::String => Arc::new(CalcitTypeAnnotation::Number),
+        _ => return None,
+      };
+      Some(specialized)
+    }
     "get" => {
       let mut specialized = expected_types.to_vec();
       specialized[1] = match receiver_type.as_ref() {
@@ -166,9 +176,41 @@ fn specialize_core_expected_types(
       };
       Some(specialized)
     }
+    "assoc" => specialize_assoc_expected_types(args, receiver_type.as_ref(), scope_types, expected_types),
     "update" => specialize_update_expected_types(args, receiver_type.as_ref(), scope_types, expected_types),
     _ => None,
   }
+}
+
+fn specialize_assoc_expected_types(
+  args: &CalcitList,
+  receiver_type: &CalcitTypeAnnotation,
+  scope_types: &ScopeTypes,
+  expected_types: &[Arc<CalcitTypeAnnotation>],
+) -> Option<Vec<Arc<CalcitTypeAnnotation>>> {
+  let receiver = args.first()?;
+  let mut specialized = expected_types.to_vec();
+  match receiver_type {
+    CalcitTypeAnnotation::List(item_type) => {
+      specialized[1] = Arc::new(CalcitTypeAnnotation::Number);
+      specialized[2] = item_type.clone();
+    }
+    CalcitTypeAnnotation::Map(key_type, value_type) => {
+      specialized[1] = key_type.clone();
+      specialized[2] = value_type.clone();
+    }
+    CalcitTypeAnnotation::Struct(_, _) | CalcitTypeAnnotation::StructValue(_) => {
+      let field_name = match args.get(1)? {
+        Calcit::Tag(tag) => tag.ref_str(),
+        Calcit::Str(text) => text.as_ref(),
+        Calcit::Symbol { sym, .. } => sym.as_ref(),
+        _ => return None,
+      };
+      specialized[2] = infer_struct_field_type(receiver, field_name, scope_types)?;
+    }
+    _ => return None,
+  }
+  Some(specialized)
 }
 
 fn specialize_update_expected_types(
@@ -944,5 +986,90 @@ mod tests {
     let map_specialized = specialize_core_expected_types(&fn_info, &map_args, &ScopeTypes::new(), &fn_info.arg_types)
       .expect("map value membership should specialize");
     assert_eq!(map_specialized[1], number);
+  }
+
+  #[test]
+  fn specialize_contains_uses_collection_key_or_member_type() {
+    let fn_info = make_core_fn(
+      "contains?",
+      vec![crate::calcit::DYNAMIC_TYPE.clone(), crate::calcit::DYNAMIC_TYPE.clone()],
+    );
+    let number = Arc::new(CalcitTypeAnnotation::Number);
+    let string = Arc::new(CalcitTypeAnnotation::String);
+
+    let list_args = CalcitList::from(&[
+      make_local("items", Arc::new(CalcitTypeAnnotation::List(string.clone()))),
+      Calcit::Tag(EdnTag::new("bad")),
+    ]);
+    let list_specialized = specialize_core_expected_types(&fn_info, &list_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("list key lookup should specialize");
+    assert_eq!(list_specialized[1], number);
+
+    let map_args = CalcitList::from(&[
+      make_local("counts", Arc::new(CalcitTypeAnnotation::Map(string.clone(), number.clone()))),
+      Calcit::Number(0.0),
+    ]);
+    let map_specialized = specialize_core_expected_types(&fn_info, &map_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("map key lookup should specialize");
+    assert_eq!(map_specialized[1], string);
+
+    let set_args = CalcitList::from(&[
+      make_local("ids", Arc::new(CalcitTypeAnnotation::Set(number.clone()))),
+      Calcit::Tag(EdnTag::new("bad")),
+    ]);
+    let set_specialized = specialize_core_expected_types(&fn_info, &set_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("set membership should specialize");
+    assert_eq!(set_specialized[1], number);
+  }
+
+  #[test]
+  fn specialize_assoc_uses_collection_key_and_value_types() {
+    let fn_info = make_core_fn(
+      "assoc",
+      vec![
+        crate::calcit::DYNAMIC_TYPE.clone(),
+        crate::calcit::DYNAMIC_TYPE.clone(),
+        crate::calcit::DYNAMIC_TYPE.clone(),
+      ],
+    );
+    let number = Arc::new(CalcitTypeAnnotation::Number);
+    let string = Arc::new(CalcitTypeAnnotation::String);
+
+    let list_args = CalcitList::from(&[
+      make_local("items", Arc::new(CalcitTypeAnnotation::List(string.clone()))),
+      Calcit::Tag(EdnTag::new("bad")),
+      Calcit::Number(0.0),
+    ]);
+    let list_specialized = specialize_core_expected_types(&fn_info, &list_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("list association should specialize");
+    assert_eq!(list_specialized[1], number);
+    assert_eq!(list_specialized[2], string);
+
+    let map_args = CalcitList::from(&[
+      make_local("counts", Arc::new(CalcitTypeAnnotation::Map(string.clone(), number.clone()))),
+      Calcit::Number(0.0),
+      Calcit::Tag(EdnTag::new("bad")),
+    ]);
+    let map_specialized = specialize_core_expected_types(&fn_info, &map_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("map association should specialize");
+    assert_eq!(map_specialized[1], string);
+    assert_eq!(map_specialized[2], number);
+
+    let task_struct = Arc::new(CalcitStructDef {
+      name: EdnTag::new("Task"),
+      fields: Arc::new(vec![EdnTag::new("done?")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::Bool)]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    let struct_args = CalcitList::from(&[
+      make_local("task", Arc::new(CalcitTypeAnnotation::StructValue(task_struct))),
+      Calcit::Tag(EdnTag::new("done?")),
+      Calcit::Number(0.0),
+    ]);
+    let struct_specialized = specialize_core_expected_types(&fn_info, &struct_args, &ScopeTypes::new(), &fn_info.arg_types)
+      .expect("struct association should specialize from field evidence");
+    assert!(matches!(struct_specialized[2].as_ref(), CalcitTypeAnnotation::Bool));
   }
 }


### PR DESCRIPTION
## 中文

### 背景

公共 `contains?` 与 `assoc` 使用彼此独立的 receiver/key/value 泛型，schema 表面上有类型，却无法表达容器与索引、键、成员和值之间的关系。即使 receiver 已经是具体的 `List<T>`、`Map<K,V>`、`Set<T>`、Enum 或 Struct，错误参数此前仍可能通过预处理。

### 修改

- 在 core 调用点 specializer 中加入 `contains?`：
  - List/String/Enum 要求 `Number` 索引；
  - Map 要求键 `K`；
  - Set 要求成员 `T`。
- 加入 `assoc`：
  - List 要求 `Number` 索引与成员 `T`；
  - Map 要求键 `K` 与值 `V`；
  - Struct 根据静态字段恢复新值类型；
  - Enum 要求 `Number` payload index；缺少精确 variant/slot evidence 时 replacement value 保持开放，因为 payload 可以异构。
- Dynamic 或无法可靠表达的 receiver 保持兼容路径，不虚构缺失关系。
- Rust primitive metadata 同步为 native Map assoc 的 `Map<K,V>` / `K` / `V`，以及 native Set membership 的 `Set<T>` / `T`。
- 将真实 Snapshot type-fail fixture 从 5 类扩展到 14 类，并增加 Rust 单元覆盖与迁移文档。

### 结果

本批执行之前被独立泛型擦除的关系，不宣称装饰性的 inventory 下降：`schemaDynamic=278`、`unresolved=184`、`typeNotFull=134` 保持不变。

Copilot 首轮 review 指出的两个 Enum index 遗漏已在 `50bd1a33` 修正，threads 已回复并 resolved。

这是堆叠在 #624 上的 PR；#624 及其父 PR 合并前，本 PR 不计作 landed。

## English

### Context

The public `contains?` and `assoc` facades used independent receiver/key/value generics. Their schemas looked typed but could not express the relationship between a concrete container and its index, key, member, or value, so invalid arguments could pass preprocessing despite exact receiver evidence.

### Changes

- Specialize `contains?` at call sites:
  - List/String/Enum require a `Number` index;
  - Map requires key `K`;
  - Set requires member `T`.
- Specialize `assoc`:
  - List requires a `Number` index and member `T`;
  - Map requires key `K` and value `V`;
  - Struct recovers the statically declared field value type;
  - Enum requires a `Number` payload index, while the replacement value remains open without precise variant/slot evidence because payloads may be heterogeneous.
- Preserve the compatibility path for Dynamic or unsupported receivers instead of inventing unavailable relationships.
- Align Rust primitive metadata for native Map association (`Map<K,V>`, `K`, `V`) and native Set membership (`Set<T>`, `T`).
- Expand the real Snapshot type-fail fixture from 5 to 14 cases, with Rust unit coverage and migration guidance.

### Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`: 672 lib, 290 CLI, 23 WASM
- `yarn check-all`: Agent interface 18/18, bundled core 237/237, classification 278/278, native/JS/IR/WASM/performance

Both Enum-index findings from the first Copilot review were fixed in `50bd1a33`; the threads were replied to and resolved.

This PR is stacked on #624. It is not counted as landed until #624 and its parent stack merge.
