### PR TITLE
Fix FFI declarations stored behind nominal aliases

### DIFF
--- a/docs/installation/ffi-interface-ir.md
+++ b/docs/installation/ffi-interface-ir.md
@@ -103,12 +103,24 @@ wrong type-argument arity, trait-bounded declarations, `Dynamic`, callbacks,
 callable boundaries produce explicit diagnostics. A rejected signature is
 `null`; there is no Dynamic fallback or declaration-name guessing.
 
+Declaration IDs follow the resolved nominal Struct/Enum name, not necessarily
+the snapshot binding that stores the base definition. This supports the normal
+top-level trait pattern `Foo0 = defstruct Foo ...` plus
+`Foo = impl-traits Foo0 FooImpl`. If multiple bindings define the same nominal
+ID, export rejects the reference as ambiguous and reports the source bindings
+in deterministic order.
+
 当前 v2 只导出带有效 lowering 字段的本地 raw binding，忽略 snapshot 中普通
 定义的空 `:ffi {}` 占位。Struct/Enum 使用 namespace-qualified declaration ID，
 Option/Result 使用明确类型节点；只纳入从 FFI signature 传递可达的声明。缺失、
 歧义、参数数量错误或无法表示的声明会产生结构化错误，不会按名称猜测或静默退化
 为动态调用。生成器必须先检查 interface `version`、definition `status` 和顶层
 `diagnostics`。
+
+Declaration ID 以解析出的 nominal Struct/Enum 名称为准，不强制等于保存 base
+definition 的 Snapshot binding 名称，因此支持顶层 `Foo0 = defstruct Foo ...` 与
+`Foo = impl-traits Foo0 FooImpl` 模式。多个 binding 声明同一 nominal ID 时会以
+稳定顺序报告歧义，不会随机选择一个形状。
 
 `package_version` 读取相邻 `deps.cirru` 的 `:version`，与当前项目发版流程保持
 同一事实来源；尚未迁移版本字段的旧项目才回退到 snapshot 兼容值。

--- a/editing-history/202609041750-fix-ffi-nominal-alias.md
+++ b/editing-history/202609041750-fix-ffi-nominal-alias.md
@@ -1,0 +1,29 @@
+# Resolve FFI declarations by nominal name / 按 nominal 名称解析 FFI 声明
+
+- Index local Interface IR Struct/Enum declarations by the resolved nominal
+  name instead of the Snapshot binding that stores the definition.
+- Support the standard top-level `Foo0 = defstruct Foo` plus
+  `Foo = impl-traits Foo0 FooImpl` pattern used by typed modules.
+- Reject duplicate nominal declarations as deterministic ambiguity diagnostics
+  that name the conflicting source bindings.
+- Add unit regressions and validate the fix against the real calcit-regex
+  `Regex0`/`Regex` consumer from calcit#634.
+
+- Interface IR 的本地 Struct/Enum declaration 改为按解析后的 nominal 名称建索引，
+  不再误用保存定义的 Snapshot binding 名称。
+- 支持类型化模块常用的顶层 `Foo0 = defstruct Foo` 加
+  `Foo = impl-traits Foo0 FooImpl` 模式。
+- 多个 binding 声明同一 nominal 类型时，以包含冲突 source binding 的稳定歧义
+  diagnostic 拒绝，不随机选择。
+- 添加单元回归，并使用 calcit#634 的真实 calcit-regex `Regex0`/`Regex` 消费者验证。
+
+## Validation / 验证
+
+- `cargo test ffi_interface_ir::tests::` (21 passed)
+- rebuilt `cargo build --bin calcit`
+- real calcit-regex `ffi export`: no declaration-missing diagnostic; exact
+  `declarations.regex.core/Regex.fields.0.type` unsupported resource boundary
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test -- --test-threads=1` (all passed)
+- `yarn check-all` (all passed)

--- a/editing-history/202609041756-clarify-ffi-ambiguity-guidance.md
+++ b/editing-history/202609041756-clarify-ffi-ambiguity-guidance.md
@@ -1,0 +1,18 @@
+# Clarify FFI ambiguity guidance / 澄清 FFI 歧义指引
+
+- Correct the duplicate nominal declaration diagnostic so it remains useful
+  when the callable schema already uses a namespace-qualified ID.
+- Tell authors to keep one local declaration source per nominal type, while
+  retaining namespace-qualified IDs as the general FFI contract rule.
+- Add a regression assertion for the actionable suggestion text.
+
+- 修正重复 nominal declaration 的诊断建议，使 callable schema 已使用 namespace
+  限定 ID 时仍然可操作。
+- 明确每个 nominal 类型只保留一个本地声明源，同时继续要求 FFI contract 使用
+  namespace-qualified ID。
+- 为建议文案添加回归断言。
+
+## Validation / 验证
+
+- `cargo fmt --check`
+- `cargo test ffi_interface_ir::tests:: -- --test-threads=1`

--- a/editing-history/202609041802-tailor-ffi-ambiguity-guidance.md
+++ b/editing-history/202609041802-tailor-ffi-ambiguity-guidance.md
@@ -1,0 +1,17 @@
+# Tailor FFI ambiguity guidance / 按限定状态细化 FFI 歧义指引
+
+- Tailor duplicate declaration guidance based on whether the referenced type ID
+  is already namespace-qualified.
+- Qualified references now point directly to removing duplicate local sources;
+  unqualified references first recommend qualification, then deduplication.
+- Cover both diagnostic branches with regression assertions.
+
+- 根据被引用类型 ID 是否已包含 namespace，分别生成重复声明修复建议。
+- 已限定引用直接要求移除重复本地声明源；未限定引用先建议补全 namespace，再
+  在仍有歧义时去重。
+- 为两条诊断分支分别添加回归断言。
+
+## Validation / 验证
+
+- `cargo fmt --check`
+- `cargo test ffi_interface_ir::tests:: -- --test-threads=1`

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -265,8 +265,9 @@ fn resolve_local_declaration<'a>(
   context: &'a TypeConversionContext<'_>,
 ) -> Result<&'a LocalTypeDeclaration, Box<FfiInterfaceDiagnostic>> {
   let name = normalized_type_name(name);
+  let name_is_qualified = name.contains('/');
   let mut candidates = Vec::new();
-  if name.contains('/') {
+  if name_is_qualified {
     if let Some(found) = context.declarations.get(name) {
       candidates.extend(found);
     }
@@ -290,16 +291,23 @@ fn resolve_local_declaration<'a>(
       format!("FFI Interface IR v{FFI_INTERFACE_IR_VERSION} cannot resolve local type declaration `{name}` at `{path}`."),
       "Use a namespace-qualified local defstruct/defenum reference, or keep dependency/resource/host types behind a handwritten adapter until declarations can be included explicitly.",
     ))),
-    many => Err(Box::new(diagnostic(
-      definition,
-      path,
-      "E_FFI_IR_DECLARATION_AMBIGUOUS",
-      format!(
-        "FFI Interface IR v{FFI_INTERFACE_IR_VERSION} found multiple local declarations for `{name}` at `{path}`: {}.",
-        many.iter().map(|candidate| candidate.source_id()).collect::<Vec<_>>().join(", ")
-      ),
-      "Use namespace-qualified declaration IDs and keep exactly one local defstruct/defenum source for each nominal type.",
-    ))),
+    many => {
+      let suggestion = if name_is_qualified {
+        "Keep exactly one local defstruct/defenum source for this namespace-qualified nominal type."
+      } else {
+        "Use a namespace-qualified declaration ID; if it remains ambiguous, keep exactly one local defstruct/defenum source for that nominal type."
+      };
+      Err(Box::new(diagnostic(
+        definition,
+        path,
+        "E_FFI_IR_DECLARATION_AMBIGUOUS",
+        format!(
+          "FFI Interface IR v{FFI_INTERFACE_IR_VERSION} found multiple local declarations for `{name}` at `{path}`: {}.",
+          many.iter().map(|candidate| candidate.source_id()).collect::<Vec<_>>().join(", ")
+        ),
+        suggestion,
+      )))
+    }
   }
 }
 
@@ -1357,7 +1365,7 @@ mod tests {
 
   #[test]
   fn duplicate_nominal_declaration_bindings_are_ambiguous_and_deterministic() {
-    let export = || {
+    let export = |type_name: &str| {
       export_snapshot(
         &snapshot(vec![
           ("PersonText", data_entry("defstruct Person (:value 'String)")),
@@ -1365,10 +1373,7 @@ mod tests {
           (
             "read-person",
             function_entry(
-              vec![Arc::new(CalcitTypeAnnotation::TypeRef(
-                Arc::from("test.ffi/Person"),
-                Arc::new(vec![]),
-              ))],
+              vec![Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from(type_name), Arc::new(vec![])))],
               Arc::new(CalcitTypeAnnotation::Unit),
               native_metadata("read_person"),
             ),
@@ -1378,7 +1383,7 @@ mod tests {
       )
       .expect("inventory duplicate nominal declarations")
     };
-    let report = export();
+    let report = export("test.ffi/Person");
 
     assert_eq!(report.summary.unsupported, 1);
     assert!(report.interface.definitions[0].signature.is_none());
@@ -1390,9 +1395,24 @@ mod tests {
     assert!(ambiguity.message.contains("test.ffi/PersonNumber, test.ffi/PersonText"));
     assert_eq!(
       ambiguity.suggestion,
-      "Use namespace-qualified declaration IDs and keep exactly one local defstruct/defenum source for each nominal type."
+      "Keep exactly one local defstruct/defenum source for this namespace-qualified nominal type."
     );
-    assert_eq!(report, export(), "duplicate declaration diagnostics must be deterministic");
+    assert_eq!(
+      report,
+      export("test.ffi/Person"),
+      "duplicate declaration diagnostics must be deterministic"
+    );
+
+    let unqualified = export("Person");
+    let unqualified_ambiguity = unqualified
+      .diagnostics
+      .iter()
+      .find(|diagnostic| diagnostic.code == "E_FFI_IR_DECLARATION_AMBIGUOUS")
+      .expect("unqualified duplicate nominal declarations must be rejected");
+    assert_eq!(
+      unqualified_ambiguity.suggestion,
+      "Use a namespace-qualified declaration ID; if it remains ambiguous, keep exactly one local defstruct/defenum source for that nominal type."
+    );
   }
 
   #[test]

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -298,7 +298,7 @@ fn resolve_local_declaration<'a>(
         "FFI Interface IR v{FFI_INTERFACE_IR_VERSION} found multiple local declarations for `{name}` at `{path}`: {}.",
         many.iter().map(|candidate| candidate.source_id()).collect::<Vec<_>>().join(", ")
       ),
-      "Use the namespace-qualified declaration ID in the callable schema so bindgen never guesses between same-name types.",
+      "Use namespace-qualified declaration IDs and keep exactly one local defstruct/defenum source for each nominal type.",
     ))),
   }
 }
@@ -1388,6 +1388,10 @@ mod tests {
       .find(|diagnostic| diagnostic.code == "E_FFI_IR_DECLARATION_AMBIGUOUS")
       .expect("duplicate nominal declarations must be rejected");
     assert!(ambiguity.message.contains("test.ffi/PersonNumber, test.ffi/PersonText"));
+    assert_eq!(
+      ambiguity.suggestion,
+      "Use namespace-qualified declaration IDs and keep exactly one local defstruct/defenum source for each nominal type."
+    );
     assert_eq!(report, export(), "duplicate declaration diagnostics must be deterministic");
   }
 

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -171,11 +171,13 @@ fn diagnostic(
 enum LocalTypeDeclaration {
   Struct {
     id: String,
+    source_id: String,
     namespace: String,
     nominal: CalcitStructDef,
   },
   Enum {
     id: String,
+    source_id: String,
     namespace: String,
     nominal: CalcitEnumDef,
   },
@@ -200,6 +202,12 @@ impl LocalTypeDeclaration {
     }
   }
 
+  fn source_id(&self) -> &str {
+    match self {
+      Self::Struct { source_id, .. } | Self::Enum { source_id, .. } => source_id,
+    }
+  }
+
   fn kind(&self) -> LocalTypeDeclarationKind {
     match self {
       Self::Struct { .. } => LocalTypeDeclarationKind::Struct,
@@ -215,8 +223,10 @@ impl LocalTypeDeclaration {
   }
 }
 
+type LocalTypeDeclarations = BTreeMap<String, Vec<LocalTypeDeclaration>>;
+
 struct TypeConversionContext<'a> {
-  declarations: &'a BTreeMap<String, LocalTypeDeclaration>,
+  declarations: &'a LocalTypeDeclarations,
   required: &'a mut BTreeSet<String>,
   current_namespace: &'a str,
   type_parameters: &'a BTreeSet<String>,
@@ -257,20 +267,19 @@ fn resolve_local_declaration<'a>(
   let name = normalized_type_name(name);
   let mut candidates = Vec::new();
   if name.contains('/') {
-    if let Some(candidate) = context.declarations.get(name) {
-      candidates.push(candidate);
+    if let Some(found) = context.declarations.get(name) {
+      candidates.extend(found);
     }
   } else {
     let local_id = format!("{}/{name}", context.current_namespace);
-    if let Some(candidate) = context.declarations.get(&local_id) {
-      candidates.push(candidate);
+    if let Some(found) = context.declarations.get(&local_id) {
+      candidates.extend(found);
     }
   }
   if let Some(kind) = expected_kind {
     candidates.retain(|candidate| candidate.kind() == kind);
   }
-  candidates.sort_unstable_by_key(|candidate| candidate.id());
-  candidates.dedup_by_key(|candidate| candidate.id());
+  candidates.sort_unstable_by_key(|candidate| candidate.source_id());
 
   match candidates.as_slice() {
     [declaration] => Ok(*declaration),
@@ -287,7 +296,7 @@ fn resolve_local_declaration<'a>(
       "E_FFI_IR_DECLARATION_AMBIGUOUS",
       format!(
         "FFI Interface IR v{FFI_INTERFACE_IR_VERSION} found multiple local declarations for `{name}` at `{path}`: {}.",
-        many.iter().map(|candidate| candidate.id()).collect::<Vec<_>>().join(", ")
+        many.iter().map(|candidate| candidate.source_id()).collect::<Vec<_>>().join(", ")
       ),
       "Use the namespace-qualified declaration ID in the callable schema so bindgen never guesses between same-name types.",
     ))),
@@ -423,7 +432,7 @@ fn convert_signature(
   entry: &CodeEntry,
   definition: &str,
   namespace: &str,
-  declarations: &BTreeMap<String, LocalTypeDeclaration>,
+  declarations: &LocalTypeDeclarations,
   required: &mut BTreeSet<String>,
 ) -> Result<FfiFunctionSignatureIr, Vec<FfiInterfaceDiagnostic>> {
   let CalcitTypeAnnotation::Fn(signature) = entry.schema.as_ref() else {
@@ -521,7 +530,16 @@ fn cirru_may_define_nominal_type(code: &Cirru) -> bool {
   }
 }
 
-fn collect_local_type_declarations(snapshot: &Snapshot) -> BTreeMap<String, LocalTypeDeclaration> {
+fn local_nominal_id(namespace: &str, name: &str) -> String {
+  let name = normalized_type_name(name);
+  if name.contains('/') {
+    name.to_owned()
+  } else {
+    format!("{namespace}/{name}")
+  }
+}
+
+fn collect_local_type_declarations(snapshot: &Snapshot) -> LocalTypeDeclarations {
   let mut declarations = BTreeMap::new();
   for (namespace, file) in &snapshot.files {
     for (definition, entry) in &file.defs {
@@ -534,22 +552,33 @@ fn collect_local_type_declarations(snapshot: &Snapshot) -> BTreeMap<String, Loca
       let Some(declaration) = crate::calcit::type_annotation::resolve_type_def_from_code(&code) else {
         continue;
       };
-      let id = format!("{namespace}/{definition}");
+      let source_id = format!("{namespace}/{definition}");
       let source = match declaration {
-        Calcit::StructDef(nominal) => LocalTypeDeclaration::Struct {
-          id: id.clone(),
-          namespace: namespace.clone(),
-          nominal,
-        },
-        Calcit::EnumDef(nominal) => LocalTypeDeclaration::Enum {
-          id: id.clone(),
-          namespace: namespace.clone(),
-          nominal,
-        },
+        Calcit::StructDef(nominal) => {
+          let id = local_nominal_id(namespace, nominal.name.ref_str());
+          LocalTypeDeclaration::Struct {
+            id,
+            source_id,
+            namespace: namespace.clone(),
+            nominal,
+          }
+        }
+        Calcit::EnumDef(nominal) => {
+          let id = local_nominal_id(namespace, nominal.name().ref_str());
+          LocalTypeDeclaration::Enum {
+            id,
+            source_id,
+            namespace: namespace.clone(),
+            nominal,
+          }
+        }
         _ => continue,
       };
-      declarations.insert(id, source);
+      declarations.entry(source.id().to_owned()).or_insert_with(Vec::new).push(source);
     }
+  }
+  for candidates in declarations.values_mut() {
+    candidates.sort_unstable_by(|left, right| left.source_id().cmp(right.source_id()));
   }
   declarations
 }
@@ -565,7 +594,7 @@ fn declaration_type_parameters(source: &LocalTypeDeclaration) -> Vec<String> {
 fn convert_declaration(
   source: &LocalTypeDeclaration,
   owner_definition: &str,
-  declarations: &BTreeMap<String, LocalTypeDeclaration>,
+  declarations: &LocalTypeDeclarations,
   required: &mut BTreeSet<String>,
 ) -> Result<FfiTypeDeclarationIr, Vec<FfiInterfaceDiagnostic>> {
   let mut diagnostics = Vec::new();
@@ -579,7 +608,9 @@ fn convert_declaration(
   };
 
   match source {
-    LocalTypeDeclaration::Struct { id, namespace, nominal } => {
+    LocalTypeDeclaration::Struct {
+      id, namespace, nominal, ..
+    } => {
       if !nominal.where_bounds.is_empty() {
         diagnostics.push(diagnostic(
           owner_definition,
@@ -616,7 +647,9 @@ fn convert_declaration(
         Err(diagnostics)
       }
     }
-    LocalTypeDeclaration::Enum { id, namespace, nominal } => {
+    LocalTypeDeclaration::Enum {
+      id, namespace, nominal, ..
+    } => {
       if !nominal.where_bounds().is_empty() {
         diagnostics.push(diagnostic(
           owner_definition,
@@ -662,7 +695,7 @@ fn convert_declaration(
 
 fn convert_reachable_declarations(
   owner_definition: &str,
-  declarations: &BTreeMap<String, LocalTypeDeclaration>,
+  declarations: &LocalTypeDeclarations,
   required: &mut BTreeSet<String>,
 ) -> (Vec<FfiTypeDeclarationIr>, Vec<FfiInterfaceDiagnostic>) {
   let mut pending = required.iter().cloned().collect::<VecDeque<_>>();
@@ -674,13 +707,30 @@ fn convert_reachable_declarations(
     if !visited.insert(id.clone()) {
       continue;
     }
-    let Some(source) = declarations.get(&id) else {
+    let Some(candidates) = declarations.get(&id) else {
       diagnostics.push(diagnostic(
         owner_definition,
         format!("declarations.{id}"),
         "E_FFI_IR_DECLARATION_MISSING",
         format!("Required declaration `{id}` disappeared while building Interface IR v{FFI_INTERFACE_IR_VERSION}."),
         "Keep the namespace-qualified local declaration in the same snapshot as its FFI signature.",
+      ));
+      continue;
+    };
+    let [source] = candidates.as_slice() else {
+      diagnostics.push(diagnostic(
+        owner_definition,
+        format!("declarations.{id}"),
+        "E_FFI_IR_DECLARATION_AMBIGUOUS",
+        format!(
+          "Required declaration `{id}` resolves to multiple snapshot definitions: {}.",
+          candidates
+            .iter()
+            .map(LocalTypeDeclaration::source_id)
+            .collect::<Vec<_>>()
+            .join(", ")
+        ),
+        "Keep one local defstruct/defenum source for each namespace-qualified nominal type.",
       ));
       continue;
     };
@@ -1276,6 +1326,69 @@ mod tests {
       FfiTypeDeclarationIr::Struct { fields, .. }
         if matches!(fields[1].type_ir, FfiTypeIr::Option { ref item } if matches!(item.as_ref(), FfiTypeIr::String))
     ));
+  }
+
+  #[test]
+  fn indexes_local_declarations_by_nominal_name_instead_of_binding_name() {
+    let person = Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("test.ffi/Person"), Arc::new(vec![])));
+    let report = export_snapshot(
+      &snapshot(vec![
+        ("PersonShape", data_entry("defstruct Person (:name 'String)")),
+        (
+          "read-person",
+          function_entry(vec![person], Arc::new(CalcitTypeAnnotation::String), native_metadata("read_person")),
+        ),
+      ]),
+      None,
+    )
+    .expect("export nominal declaration stored behind a differently named binding");
+
+    assert_eq!(report.summary.supported, 1);
+    assert!(report.diagnostics.is_empty());
+    assert!(matches!(
+      report.interface.declarations.as_slice(),
+      [FfiTypeDeclarationIr::Struct { id, name, .. }] if id == "test.ffi/Person" && name == "Person"
+    ));
+    assert!(matches!(
+      report.interface.definitions[0].signature.as_ref().expect("supported signature").parameters[0].type_ir,
+      FfiTypeIr::Struct { ref id, ref arguments } if id == "test.ffi/Person" && arguments.is_empty()
+    ));
+  }
+
+  #[test]
+  fn duplicate_nominal_declaration_bindings_are_ambiguous_and_deterministic() {
+    let export = || {
+      export_snapshot(
+        &snapshot(vec![
+          ("PersonText", data_entry("defstruct Person (:value 'String)")),
+          ("PersonNumber", data_entry("defstruct Person (:value 'Number)")),
+          (
+            "read-person",
+            function_entry(
+              vec![Arc::new(CalcitTypeAnnotation::TypeRef(
+                Arc::from("test.ffi/Person"),
+                Arc::new(vec![]),
+              ))],
+              Arc::new(CalcitTypeAnnotation::Unit),
+              native_metadata("read_person"),
+            ),
+          ),
+        ]),
+        None,
+      )
+      .expect("inventory duplicate nominal declarations")
+    };
+    let report = export();
+
+    assert_eq!(report.summary.unsupported, 1);
+    assert!(report.interface.definitions[0].signature.is_none());
+    let ambiguity = report
+      .diagnostics
+      .iter()
+      .find(|diagnostic| diagnostic.code == "E_FFI_IR_DECLARATION_AMBIGUOUS")
+      .expect("duplicate nominal declarations must be rejected");
+    assert!(ambiguity.message.contains("test.ffi/PersonNumber, test.ffi/PersonText"));
+    assert_eq!(report, export(), "duplicate declaration diagnostics must be deterministic");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- index Interface IR Struct/Enum declarations by their resolved nominal names instead of snapshot binding names
- support the standard `Foo0 = defstruct Foo` plus `Foo = impl-traits Foo0 FooImpl` pattern
- reject duplicate bindings for one nominal declaration deterministically
- document the nominal declaration-ID rule and add regression coverage

Fixes #634.

## Consumer validation

Rebuilt `calcit` and exported the real `calcit-regex` Interface IR. `regex.core/Regex` now resolves to its `Regex0` base definition; the previous `E_FFI_IR_DECLARATION_MISSING` is gone, and export proceeds to the expected explicit Dynamic resource-boundary diagnostic.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn check-all`