### PR TITLE
Enforce typed Ref watcher contracts

### DIFF
--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -480,7 +480,8 @@
               let
                   *b $ atom 0
                   *c $ atom 0
-                add-watch *b :change $ fn (current prev) (reset! *c current)
+                add-watch *b :change $ fn (current prev)
+                  do (reset! *c current) &unit
                 reset! *b 1
                 assert= 1 @*b
                 assert= 1 @*c

--- a/calcit/test.cirru
+++ b/calcit/test.cirru
@@ -466,6 +466,8 @@
                 fn (current prev) (println "|change happened:" prev current)
               assert= 2 $ reset! *ref-demo 2
               assert= &unit $ remove-watch *ref-demo :change
+              assert= "|remove-watch failed: listener with key `missing` not found" $ try (remove-watch *ref-demo :missing)
+                fn (error) error
               assert= 2 @*ref-demo
               assert= :ref $ type-of *ref-demo
               let

--- a/calcit/type-fail/collection-member-contract-mismatch.cirru
+++ b/calcit/type-fail/collection-member-contract-mismatch.cirru
@@ -48,6 +48,8 @@
               &list:sort ([] |a |b) +
               sort ([] |a |b) inc
               &list:sort-by ([] |a |b) inc
+              add-watch (atom |x) |change inc
+              remove-watch (atom 1) |change
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -228,6 +228,10 @@ let
   ; => 11
 ```
 
+Watcher keys are Tags. A watcher on `Ref<T>` receives the new and previous
+values as `(T, T)` and must return `Unit`; finish side-effect-only callbacks
+with `&unit`. `remove-watch` requires the same Tag key used at registration.
+
 ### Managing Collections in State
 
 ```cirru

--- a/editing-history/202609041814-type-ref-watcher-contracts.md
+++ b/editing-history/202609041814-type-ref-watcher-contracts.md
@@ -1,0 +1,28 @@
+# Type Ref watcher contracts / 收紧 Ref watcher 类型契约
+
+- Align native `add-watch` with the public `Ref<T>, Tag, Fn(T, T) -> Unit`
+  contract instead of erasing all three arguments to Dynamic.
+- Require a Tag key for both `add-watch` and `remove-watch`; remove the
+  unrelated public key generic from `remove-watch`.
+- Substitute already-bound proc type variables before diagnostics so callback
+  errors name the concrete Ref payload type.
+- Migrate the bundled watcher callback to explicit Unit, add negative
+  key/callback fixtures, and document the contract.
+
+- 将 native `add-watch` 与公开的 `Ref<T>, Tag, Fn(T, T) -> Unit` 契约对齐，
+  不再把三个参数都擦除为 Dynamic。
+- `add-watch` 与 `remove-watch` 均要求 Tag key，并移除 `remove-watch` 无关的
+  public key 泛型。
+- diagnostic 生成前替换已绑定的 proc 类型变量，使 callback 错误展示具体 Ref
+  payload 类型。
+- 将 bundled watcher callback 迁移为显式 Unit，增加 key/callback 负向 fixture，
+  并补充文档。
+
+## Validation / 验证
+
+- targeted proc-signature and type-fail regression tests
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test -- --test-threads=1` (all passed)
+- `yarn check-all` (all passed; core quality inventory unchanged at
+  278 schema-Dynamic / 184 unresolved / 134 not-full)

--- a/editing-history/202609041838-align-js-remove-watch-errors.md
+++ b/editing-history/202609041838-align-js-remove-watch-errors.md
@@ -1,0 +1,7 @@
+# Align JavaScript remove-watch errors
+
+PR review identified a backend mismatch after the watcher type contracts were tightened. Native `remove-watch` raises when the requested tag is absent, while the JavaScript implementation ignored the boolean result from `Map.delete`.
+
+The JavaScript backend now raises the same stable missing-key message when deletion returns false. The shared Calcit ref test covers the absent-key path, so both native and generated JavaScript execute the same assertion.
+
+Validation for this follow-up includes formatting, TypeScript compilation, native core execution, generated JavaScript execution, strict Clippy, serialized Rust tests, and the repository-wide `check-all` gate.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -1184,6 +1184,39 @@ fn type_fail_collection_member_contract_fixture_reports_warning_codes() {
         && sort_by_warnings[0].message().contains("got `fn(:number) -> :number`"),
       "sort-by should preserve the String member type while leaving its key type generic: {sort_by_warnings:?}"
     );
+    let watch_warnings = warnings
+      .iter()
+      .filter(|warning| {
+        warning.code() == Some("W_PROC_ARG_TYPE_MISMATCH")
+          && (warning.message().contains("Proc `add-watch`") || warning.message().contains("Proc `remove-watch`"))
+      })
+      .collect::<Vec<_>>();
+    assert_eq!(
+      watch_warnings.len(),
+      3,
+      "Ref watcher calls should validate keys and callbacks: {warnings:?}"
+    );
+    assert!(
+      watch_warnings.iter().any(|warning| {
+        warning.message().contains("Proc `add-watch` arg 2 expects type `:tag`") && warning.message().contains("got `:string`")
+      }),
+      "add-watch should require a Tag key: {watch_warnings:?}"
+    );
+    assert!(
+      watch_warnings.iter().any(|warning| {
+        warning
+          .message()
+          .contains("Proc `add-watch` arg 3 expects type `fn(:string, :string) -> :unit`")
+          && warning.message().contains("got `fn(:number) -> :number`")
+      }),
+      "add-watch should bind both callback inputs to the Ref payload and require Unit: {watch_warnings:?}"
+    );
+    assert!(
+      watch_warnings.iter().any(|warning| {
+        warning.message().contains("Proc `remove-watch` arg 2 expects type `:tag`") && warning.message().contains("got `:string`")
+      }),
+      "remove-watch should require a Tag key: {watch_warnings:?}"
+    );
   });
 }
 

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -1347,11 +1347,18 @@ impl CalcitProc {
       }),
       AddWatch => Some(ProcTypeSignature {
         return_type: some_tag("unit"),
-        arg_types: vec![some_tag("ref"), dynamic_tag(), dynamic_tag()],
+        arg_types: vec![
+          ref_of(type_var("T")),
+          some_tag("tag"),
+          Arc::new(CalcitTypeAnnotation::from_function_parts(
+            vec![type_var("T"), type_var("T")],
+            some_tag("unit"),
+          )),
+        ],
       }),
       RemoveWatch => Some(ProcTypeSignature {
         return_type: some_tag("unit"),
-        arg_types: vec![some_tag("ref"), dynamic_tag()],
+        arg_types: vec![ref_of(type_var("T")), some_tag("tag")],
       }),
 
       // === I/O operations ===
@@ -1668,6 +1675,29 @@ mod tests {
     assert!(matches!(
       atom.arg_types.first().map(AsRef::as_ref),
       Some(CalcitTypeAnnotation::TypeVar(name)) if name.as_ref() == "T"
+    ));
+
+    let add_watch = CalcitProc::AddWatch.get_type_signature().expect("add-watch signature");
+    assert!(matches!(
+      add_watch.arg_types.as_slice(),
+      [reference, key, callback]
+        if matches!(reference.as_ref(), CalcitTypeAnnotation::Ref(inner)
+          if matches!(inner.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "T"))
+          && matches!(key.as_ref(), CalcitTypeAnnotation::Tag)
+          && matches!(callback.as_ref(), CalcitTypeAnnotation::Fn(signature)
+            if matches!(signature.arg_types.as_slice(), [current, previous]
+              if matches!(current.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "T")
+                && matches!(previous.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "T"))
+              && matches!(signature.return_type.as_ref(), CalcitTypeAnnotation::Unit))
+    ));
+
+    let remove_watch = CalcitProc::RemoveWatch.get_type_signature().expect("remove-watch signature");
+    assert!(matches!(
+      remove_watch.arg_types.as_slice(),
+      [reference, key]
+        if matches!(reference.as_ref(), CalcitTypeAnnotation::Ref(inner)
+          if matches!(inner.as_ref(), CalcitTypeAnnotation::TypeVar(name) if name.as_ref() == "T"))
+          && matches!(key.as_ref(), CalcitTypeAnnotation::Tag)
     ));
   }
 

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -7232,13 +7232,13 @@
               :args $ [] 'T
               :generics $ [] 'T
           :tags $ #{} :builtin :internal :state
-        'remove-watch $ %{} 'CodeEntry (:doc "|internal function for removing atom watchers\nSyntax: (remove-watch atom key)\nParams: atom (atom), key (any)\nReturns: &unit\nRemoves watcher with specified key from atom")
+        'remove-watch $ %{} 'CodeEntry (:doc "|Remove a watcher from a Ref<T>. Syntax: (remove-watch ref tag-key). The key must be a Tag. Returns Unit; reports an error when the key is absent.")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
-              :args $ [] (:: 'Ref 'T) 'K
-              :generics $ [] 'T 'K
+              :args $ [] (:: 'Ref 'T) 'Tag
+              :generics $ [] 'T
           :tags $ #{} :builtin :internal :state :watch
         'repeat $ %{} 'CodeEntry (:doc |)
           :code $ quote

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -659,6 +659,7 @@ pub(crate) fn check_proc_arg_types(
       break;
     }
 
+    let expected_type = expected_type.substitute_type_vars(&bindings);
     if matches!(expected_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
       continue;
     }

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -930,7 +930,9 @@ export let add_watch = (a: CalcitRef, k: CalcitTag, f: CalcitFn): void => {
 };
 
 export let remove_watch = (a: CalcitRef, k: CalcitTag): void => {
-  a.listeners.delete(k);
+  if (!a.listeners.delete(k)) {
+    throw new Error(`remove-watch failed: listener with key \`${k.value}\` not found`);
+  }
 };
 
 const MAX_RANGE_LENGTH = 0xffff_ffff;


### PR DESCRIPTION
## Summary

- enforce the native `add-watch` contract as `Ref<T>, Tag, Fn(T, T) -> Unit`
- require Tag keys for `remove-watch` and remove its unrelated key generic
- substitute already-bound proc type variables before diagnostics, so callback mismatches show the concrete Ref payload
- migrate the bundled callback to explicit Unit and add negative key/callback regressions plus docs

Progresses #579.

This branch is based directly on current `main` and does not depend on #635.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn check-all`
- core quality remains 278 schema-Dynamic / 184 unresolved / 134 not-full, with no regression
