### PR TITLE
Enforce strict Dynamic nominal boundaries

### DIFF
--- a/docs/data/edn.md
+++ b/docs/data/edn.md
@@ -39,6 +39,13 @@ The available methods are `.parse-cirru`, `.parse-cirru-list`, `.parse-cirru-edn
 
 Cirru syntax has a closed result type, while Cirru EDN and JSON remain `Result<Dynamic,String>` because their data shapes are open. Use `parse-cirru-edn-as` or `decode-map-as` after the boundary when application code needs a closed nominal type. The original parser procedures remain available for compatibility and still raise on malformed input.
 
+Under `--strict-types`, passing that open `Dynamic` result directly to a
+function argument whose contract contains a Struct or Enum is
+`E_DYNAMIC_NOMINAL_ARGUMENT`. This also covers matching containers such as
+`List<Dynamic>` entering `List<Person>`. Decode at the boundary instead of
+letting application code accidentally treat an open map as a nominal value;
+non-strict mode remains compatible while a codebase migrates.
+
 These Result-returning parser methods currently run on the native and JavaScript backends. The WASM backend does not yet support the underlying parser procedures or `try`-based wrappers; the standard WASM validation suite confirms that unsupported parser definitions are skipped without affecting supported exports.
 
 ## Strict typed decoding

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -217,6 +217,15 @@ the callee is intentionally open, put that operation behind a small adapter
 whose structured contract does not claim the generic relationship. Outside
 `--strict-types`, the existing compatibility behavior is unchanged.
 
+`E_DYNAMIC_NOMINAL_ARGUMENT` rejects a project call when an explicitly open
+`Dynamic` value, or a matching container with a `Dynamic` member, enters an
+argument whose contract contains a closed Struct or Enum. Decode text with
+`parse-cirru-edn-as` / `try-parse-cirru-edn-as`, decode an evaluated host value
+with `decode-map-as` / `try-decode-map-as`, or validate and narrow it inside a
+small typed FFI adapter. The diagnostic identifies the argument and target
+contract. It does not reject unrelated `Dynamic` to primitive calls, and
+compatibility mode keeps the existing gradual migration behavior.
+
 `--strict-types` reports `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written
 `&get-raw`, `record-get` / `&struct:get`, raw `&%{}`, and `&struct:nth` without matching
 nominal layout evidence. Use Option-returning collection lookup, named Struct

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -559,6 +559,12 @@ strict mode 还会以 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA` 拒绝既没有结构化�
 类型，再调用泛型 API。确实开放的操作应收拢到一个小型 adapter，并让 adapter 的结构化契约明确
 不承诺该泛型关系。非 strict 模式保持原有兼容行为，便于渐进迁移。
 
+当开放 `Dynamic`（或同形容器中的 `Dynamic` 成员）进入包含 Struct / Enum 的封闭参数契约时，
+strict mode 报告 `E_DYNAMIC_NOMINAL_ARGUMENT`，并指出参数位置和目标契约。文本边界使用
+`parse-cirru-edn-as` / `try-parse-cirru-edn-as`，已求值的 host/FFI 数据使用 `decode-map-as` /
+`try-decode-map-as`；更复杂的 host 值在小型 typed FFI adapter 内完成验证和收窄。该规则不扩大为
+所有 `Dynamic` 到 primitive 的调用，非 strict 模式也继续支持渐进迁移。
+
 再对每个 entry 运行独立的动态方法报告；已有项目可以先记录非零上限，再逐步降低：
 
 ```bash

--- a/editing-history/202609041925-reject-open-dynamic-nominal-arguments.md
+++ b/editing-history/202609041925-reject-open-dynamic-nominal-arguments.md
@@ -1,0 +1,27 @@
+# Reject open Dynamic nominal arguments in strict mode
+
+## Context
+
+An explicitly open `Dynamic` value could still flow directly into a function
+argument whose contract required a Struct or Enum. General inference may look
+through a Dynamic return contract to support gradual migration, so strict
+checking needs to retain the explicit boundary evidence without changing
+compatibility-mode inference.
+
+## Changes
+
+- Add strict project-source diagnostic `E_DYNAMIC_NOMINAL_ARGUMENT` for root
+  `Dynamic` and matching containers whose Dynamic member erases a closed
+  Struct/Enum argument contract.
+- Preserve an explicitly declared Dynamic return as boundary evidence for this
+  check while leaving missing-schema and compatibility behavior unchanged.
+- Cover direct and local calls, generic substitution, rest arguments, nested
+  containers, compatibility mode, and the decoder migration message.
+- Document typed Cirru EDN, runtime-map, and typed FFI adapter migration paths.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test -- --test-threads=1`
+- `yarn check-all`

--- a/editing-history/202609041939-bind-nominal-generics-before-dynamic-check.md
+++ b/editing-history/202609041939-bind-nominal-generics-before-dynamic-check.md
@@ -1,0 +1,21 @@
+# Bind nominal generics before Dynamic boundary checks
+
+## Context
+
+Review of PR #638 identified an order-dependent false negative: for
+`Fn<T>(T, T)`, a leading Dynamic argument was checked before a later Person
+argument could bind `T` to the nominal type.
+
+## Changes
+
+- Resolve argument types once and collect generic bindings from every fully
+  non-Dynamic argument before enforcing the open-to-nominal boundary.
+- Treat Dynamic nested in containers, nominal type arguments, named refs, and
+  function contracts as open evidence that must not supply a generic binding.
+- Add a regression where argument 2 binds `T` to Person and argument 1 must then
+  fail with `E_DYNAMIC_NOMINAL_ARGUMENT`.
+
+## Validation
+
+- Focused unit and end-to-end strict boundary tests pass.
+- Full repository gates are rerun before push.

--- a/editing-history/202609041949-recurse-applied-nominal-dynamic-arguments.md
+++ b/editing-history/202609041949-recurse-applied-nominal-dynamic-arguments.md
@@ -1,0 +1,20 @@
+# Recurse through applied nominal Dynamic arguments
+
+## Context
+
+Incremental review of PR #638 found that open type arguments on an otherwise
+matching nominal base, such as `Box<Dynamic>` entering `Box<Person>`, were
+classified as open but not rejected by the boundary comparison.
+
+## Changes
+
+- Recurse through applied arguments when Struct definitions, Enum definitions,
+  or TypeRef names match and have the same arity.
+- Keep different nominal bases outside this focused rule; ordinary type
+  mismatch diagnostics continue to own those cases.
+- Cover Struct, Enum, and TypeRef applied Dynamic arguments.
+
+## Validation
+
+- Focused strict Dynamic nominal boundary regression passes.
+- Full repository gates are rerun before push.

--- a/editing-history/202609041955-recurse-function-nominal-contracts.md
+++ b/editing-history/202609041955-recurse-function-nominal-contracts.md
@@ -1,0 +1,20 @@
+# Recurse through function nominal contracts
+
+## Context
+
+Follow-up review of PR #638 noted that nominal types nested in callback
+contracts were not included in the open-to-closed boundary comparison.
+
+## Changes
+
+- Detect nominal contracts inside TypeRef arguments and function required,
+  rest, and return positions.
+- Compare matching function contracts recursively so
+  `Fn(Dynamic)->Unit` cannot enter `Fn(Person)->Unit` in strict project source.
+- Cover callback and unresolved TypeRef nominal nesting in the focused test.
+
+## Validation
+
+- Focused strict boundary regression passes.
+- Clippy with warnings denied passes.
+- Full repository gates are rerun before push.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -209,6 +209,64 @@ fn strict_type_fail_reachable_whole_dynamic_schema_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_dynamic_nominal_argument_reports_decoder_migration() {
+  run_with_large_stack(|| {
+    builtins::effects::init_effects_states();
+    let mut snapshot = snapshot::Snapshot::default();
+    let mut file = snapshot::create_file_from_snippet(concat!(
+      "defstruct Person $ :name 'String\n\n",
+      "defn open-value () $ {} (:name |Ada)\n\n",
+      "defn consume-person (person)\n  :name person\n\n",
+      "defn main! ()\n  consume-person\n    open-value\n\n",
+      "defn reload! () $ identity &unit",
+    ))
+    .expect("dynamic nominal boundary snippet should parse");
+    let person = Arc::new(calcit::calcit::CalcitStructDef {
+      name: cirru_edn::EdnTag::new("Person"),
+      fields: Arc::new(vec![cirru_edn::EdnTag::new("name")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    let fn_schema = |args, return_type| {
+      Arc::new(CalcitTypeAnnotation::Fn(Arc::new(calcit::calcit::CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: args,
+        return_type,
+        fn_kind: calcit::calcit::SchemaKind::Fn,
+        rest_type: None,
+        features: Arc::new(HashSet::new()),
+      })))
+    };
+    file.defs.get_mut("open-value").expect("open-value entry").schema = fn_schema(vec![], Arc::new(CalcitTypeAnnotation::Dynamic));
+    file.defs.get_mut("consume-person").expect("consume-person entry").schema = fn_schema(
+      vec![Arc::new(CalcitTypeAnnotation::Struct(person, Arc::new(vec![])))],
+      Arc::new(CalcitTypeAnnotation::String),
+    );
+    file.defs.get_mut("main!").expect("main entry").schema = fn_schema(vec![], Arc::new(CalcitTypeAnnotation::String));
+    file.defs.get_mut("reload!").expect("reload entry").schema = fn_schema(vec![], Arc::new(CalcitTypeAnnotation::Unit));
+    snapshot.files.insert("app.main".to_owned(), file);
+    let entries = prepare_snapshot_entries(snapshot);
+    let _strict = StrictTypesReset::enabled();
+    let err = run_check_only(&entries).expect_err("Dynamic data must not enter a closed nominal argument in strict mode");
+
+    assert!(
+      err.contains("E_DYNAMIC_NOMINAL_ARGUMENT"),
+      "unexpected strict boundary error: {err}"
+    );
+    assert!(err.contains("argument 1"), "argument position should be actionable: {err}");
+    assert!(err.contains("struct Person"), "closed nominal target should be explicit: {err}");
+    assert!(err.contains("parse-cirru-edn-as"), "text decoder migration should be named: {err}");
+    assert!(
+      err.contains("decode-map-as"),
+      "evaluated-value decoder migration should be named: {err}"
+    );
+  });
+}
+
+#[test]
 fn strict_type_fail_dynamic_nominal_method_reports_stable_error_code() {
   run_with_large_stack(|| {
     let entries = load_fixture_entries("calcit/type-fail/dynamic-nominal-method-strict.cirru");

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8868,6 +8868,31 @@ fn dynamic_erases_nominal_contract(actual: &CalcitTypeAnnotation, expected: &Cal
   }
 }
 
+fn contains_dynamic_type(annotation: &CalcitTypeAnnotation) -> bool {
+  match annotation {
+    CalcitTypeAnnotation::Dynamic => true,
+    CalcitTypeAnnotation::List(inner)
+    | CalcitTypeAnnotation::Set(inner)
+    | CalcitTypeAnnotation::Ref(inner)
+    | CalcitTypeAnnotation::Optional(inner)
+    | CalcitTypeAnnotation::JsNullish(inner)
+    | CalcitTypeAnnotation::Variadic(inner) => contains_dynamic_type(inner.as_ref()),
+    CalcitTypeAnnotation::Map(key, value) => contains_dynamic_type(key.as_ref()) || contains_dynamic_type(value.as_ref()),
+    CalcitTypeAnnotation::Struct(_, args) | CalcitTypeAnnotation::Enum(_, args) | CalcitTypeAnnotation::TypeRef(_, args) => {
+      args.iter().any(|arg| contains_dynamic_type(arg.as_ref()))
+    }
+    CalcitTypeAnnotation::Fn(signature) => {
+      signature.arg_types.iter().any(|arg| contains_dynamic_type(arg.as_ref()))
+        || signature
+          .rest_type
+          .as_ref()
+          .is_some_and(|rest| contains_dynamic_type(rest.as_ref()))
+        || contains_dynamic_type(signature.return_type.as_ref())
+    }
+    _ => false,
+  }
+}
+
 fn resolve_strict_boundary_argument_type(arg: &Calcit, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
   let Calcit::List(items) = arg else {
     return resolve_type_value(arg, scope_types);
@@ -8904,11 +8929,20 @@ fn reject_strict_dynamic_nominal_argument(
   if let Some(rest) = signature.rest_type.as_ref() {
     expected_types.extend(std::iter::repeat_n(rest, args.len().saturating_sub(expected_types.len())));
   }
+  let actual_types = args
+    .iter()
+    .map(|arg| resolve_strict_boundary_argument_type(arg, scope_types))
+    .collect::<Vec<_>>();
   let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
-  for (index, (arg, expected)) in args.iter().zip(expected_types).enumerate() {
-    let Some(actual) = resolve_strict_boundary_argument_type(arg, scope_types) else {
-      continue;
-    };
+  for (actual, expected) in actual_types.iter().zip(expected_types.iter()) {
+    if let Some(actual) = actual
+      && !contains_dynamic_type(actual.as_ref())
+    {
+      actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings);
+    }
+  }
+  for (index, ((arg, actual), expected)) in args.iter().zip(actual_types).zip(expected_types).enumerate() {
+    let Some(actual) = actual else { continue };
     let resolved_expected = expected.substitute_type_vars(&bindings);
     if dynamic_erases_nominal_contract(actual.as_ref(), resolved_expected.as_ref()) {
       return Err(CalcitErr::use_msg_stack_location_with_code(
@@ -8924,7 +8958,6 @@ fn reject_strict_dynamic_nominal_argument(
         arg.get_location().or_else(|| head.get_location()),
       ));
     }
-    actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings);
   }
   Ok(())
 }
@@ -16156,12 +16189,38 @@ mod tests {
     assert!(error.msg.contains("decode-map-as"));
 
     let open_list = CalcitTypeAnnotation::List(calcit::DYNAMIC_TYPE.clone());
-    let people = CalcitTypeAnnotation::List(person_type);
+    let people = CalcitTypeAnnotation::List(person_type.clone());
     assert!(dynamic_erases_nominal_contract(&open_list, &people));
     assert!(!dynamic_erases_nominal_contract(
       &CalcitTypeAnnotation::Dynamic,
       &CalcitTypeAnnotation::Number
     ));
+
+    let generic = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let related_signature = generic_relation_test_signature(vec![generic.clone(), generic], Arc::new(CalcitTypeAnnotation::Unit), None);
+    let person_value = generic_relation_test_local("person", person_type.clone());
+    let related_scope = ScopeTypes::from([
+      (Arc::from("open-value"), calcit::DYNAMIC_TYPE.clone()),
+      (Arc::from("person"), person_type.clone()),
+    ]);
+    let related_args = CalcitList::from(
+      &[
+        generic_relation_test_local("open-value", calcit::DYNAMIC_TYPE.clone()),
+        person_value,
+      ][..],
+    );
+    let related_error = reject_strict_dynamic_nominal_argument(
+      &test_symbol("same-type"),
+      &related_args,
+      &related_signature,
+      &related_scope,
+      "tests.dynamic-boundary",
+      &CallStackList::default(),
+    )
+    .expect_err("later nominal arguments should bind generics before earlier Dynamic arguments are checked");
+    assert_eq!(related_error.code.as_deref(), Some("E_DYNAMIC_NOMINAL_ARGUMENT"));
+    assert!(related_error.msg.contains("argument 1"));
+    assert!(related_error.msg.contains("struct Person"));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8864,6 +8864,30 @@ fn dynamic_erases_nominal_contract(actual: &CalcitTypeAnnotation, expected: &Cal
       dynamic_erases_nominal_contract(actual_key.as_ref(), expected_key.as_ref())
         || dynamic_erases_nominal_contract(actual_value.as_ref(), expected_value.as_ref())
     }
+    (CalcitTypeAnnotation::Struct(actual_def, actual_args), CalcitTypeAnnotation::Struct(expected_def, expected_args))
+      if actual_def == expected_def && actual_args.len() == expected_args.len() =>
+    {
+      actual_args
+        .iter()
+        .zip(expected_args.iter())
+        .any(|(actual, expected)| dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref()))
+    }
+    (CalcitTypeAnnotation::Enum(actual_def, actual_args), CalcitTypeAnnotation::Enum(expected_def, expected_args))
+      if actual_def == expected_def && actual_args.len() == expected_args.len() =>
+    {
+      actual_args
+        .iter()
+        .zip(expected_args.iter())
+        .any(|(actual, expected)| dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref()))
+    }
+    (CalcitTypeAnnotation::TypeRef(actual_name, actual_args), CalcitTypeAnnotation::TypeRef(expected_name, expected_args))
+      if actual_name == expected_name && actual_args.len() == expected_args.len() =>
+    {
+      actual_args
+        .iter()
+        .zip(expected_args.iter())
+        .any(|(actual, expected)| dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref()))
+    }
     _ => false,
   }
 }
@@ -16221,6 +16245,30 @@ mod tests {
     assert_eq!(related_error.code.as_deref(), Some("E_DYNAMIC_NOMINAL_ARGUMENT"));
     assert!(related_error.msg.contains("argument 1"));
     assert!(related_error.msg.contains("struct Person"));
+
+    let box_def = Arc::new(CalcitStructDef {
+      name: EdnTag::new("Box"),
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    assert!(dynamic_erases_nominal_contract(
+      &CalcitTypeAnnotation::Struct(box_def.clone(), Arc::new(vec![calcit::DYNAMIC_TYPE.clone()])),
+      &CalcitTypeAnnotation::Struct(box_def, Arc::new(vec![person_type.clone()])),
+    ));
+
+    let wrapper_def = Arc::new(indexed_match_enum());
+    assert!(dynamic_erases_nominal_contract(
+      &CalcitTypeAnnotation::Enum(wrapper_def.clone(), Arc::new(vec![calcit::DYNAMIC_TYPE.clone()])),
+      &CalcitTypeAnnotation::Enum(wrapper_def, Arc::new(vec![person_type.clone()])),
+    ));
+
+    assert!(dynamic_erases_nominal_contract(
+      &CalcitTypeAnnotation::TypeRef(Arc::from("tests/Box"), Arc::new(vec![calcit::DYNAMIC_TYPE.clone()])),
+      &CalcitTypeAnnotation::TypeRef(Arc::from("tests/Box"), Arc::new(vec![person_type])),
+    ));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2352,10 +2352,19 @@ fn preprocess_list_call(
           call_location.clone(),
           check_warnings,
         );
+        let effective_schema = effective_user_call_schema(info.as_ref());
+        reject_strict_dynamic_nominal_argument(
+          &head_form,
+          &current_args,
+          effective_schema.as_ref(),
+          scope_types,
+          file_ns,
+          call_stack,
+        )?;
         reject_strict_erased_generic_relation(
           &head_form,
           &current_args,
-          effective_user_call_schema(info.as_ref()).as_ref(),
+          effective_schema.as_ref(),
           scope_types,
           file_ns,
           call_stack,
@@ -2903,6 +2912,7 @@ fn preprocess_list_call(
             if let Some(local_type) = local_type
               && let CalcitTypeAnnotation::Fn(signature) = local_type.as_ref()
             {
+              reject_strict_dynamic_nominal_argument(&head_form, &updated_args, signature, scope_types, file_ns, call_stack)?;
               reject_strict_erased_generic_relation(&head_form, &updated_args, signature, scope_types, file_ns, call_stack)?;
             }
             check_local_fn_call_arg_types(&head_form, local, &updated_args, scope_types, &call_info, check_warnings);
@@ -8820,6 +8830,103 @@ fn reject_strict_erased_generic_relation(
     call_stack,
     argument.and_then(Calcit::get_location).or_else(|| head.get_location()),
   ))
+}
+
+fn contains_nominal_contract(annotation: &CalcitTypeAnnotation) -> bool {
+  if annotation.resolve_to_struct_with_ref().is_some() || annotation.resolve_to_enum().is_some() {
+    return true;
+  }
+  match annotation {
+    CalcitTypeAnnotation::List(inner)
+    | CalcitTypeAnnotation::Set(inner)
+    | CalcitTypeAnnotation::Ref(inner)
+    | CalcitTypeAnnotation::Optional(inner)
+    | CalcitTypeAnnotation::JsNullish(inner)
+    | CalcitTypeAnnotation::Variadic(inner) => contains_nominal_contract(inner.as_ref()),
+    CalcitTypeAnnotation::Map(key, value) => contains_nominal_contract(key.as_ref()) || contains_nominal_contract(value.as_ref()),
+    _ => false,
+  }
+}
+
+fn dynamic_erases_nominal_contract(actual: &CalcitTypeAnnotation, expected: &CalcitTypeAnnotation) -> bool {
+  if matches!(actual, CalcitTypeAnnotation::Dynamic) {
+    return contains_nominal_contract(expected);
+  }
+  match (actual, expected) {
+    (CalcitTypeAnnotation::List(actual), CalcitTypeAnnotation::List(expected))
+    | (CalcitTypeAnnotation::Set(actual), CalcitTypeAnnotation::Set(expected))
+    | (CalcitTypeAnnotation::Ref(actual), CalcitTypeAnnotation::Ref(expected))
+    | (CalcitTypeAnnotation::Optional(actual), CalcitTypeAnnotation::Optional(expected))
+    | (CalcitTypeAnnotation::JsNullish(actual), CalcitTypeAnnotation::JsNullish(expected)) => {
+      dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref())
+    }
+    (CalcitTypeAnnotation::Map(actual_key, actual_value), CalcitTypeAnnotation::Map(expected_key, expected_value)) => {
+      dynamic_erases_nominal_contract(actual_key.as_ref(), expected_key.as_ref())
+        || dynamic_erases_nominal_contract(actual_value.as_ref(), expected_value.as_ref())
+    }
+    _ => false,
+  }
+}
+
+fn resolve_strict_boundary_argument_type(arg: &Calcit, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
+  let Calcit::List(items) = arg else {
+    return resolve_type_value(arg, scope_types);
+  };
+  let declared_schema = match items.first() {
+    Some(Calcit::Import(CalcitImport { ns, def, .. })) => Some(program::lookup_def_schema(ns, def)),
+    Some(Calcit::Fn { info, .. }) => Some(program::lookup_def_schema(&info.def_ns, &info.name)),
+    Some(Calcit::Symbol { sym, info, .. }) => Some(program::lookup_def_schema(&info.at_ns, sym)),
+    _ => None,
+  };
+  if let Some(schema) = declared_schema
+    && !crate::snapshot::schema_annotation_is_missing(&schema)
+    && let CalcitTypeAnnotation::Fn(signature) = schema.as_ref()
+    && matches!(signature.return_type.as_ref(), CalcitTypeAnnotation::Dynamic)
+  {
+    return Some(signature.return_type.clone());
+  }
+  resolve_type_value(arg, scope_types)
+}
+
+fn reject_strict_dynamic_nominal_argument(
+  head: &Calcit,
+  args: &CalcitList,
+  signature: &CalcitFnTypeAnnotation,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled() || !should_emit_project_source_lint(file_ns) {
+    return Ok(());
+  }
+
+  let mut expected_types = signature.arg_types.iter().collect::<Vec<_>>();
+  if let Some(rest) = signature.rest_type.as_ref() {
+    expected_types.extend(std::iter::repeat_n(rest, args.len().saturating_sub(expected_types.len())));
+  }
+  let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
+  for (index, (arg, expected)) in args.iter().zip(expected_types).enumerate() {
+    let Some(actual) = resolve_strict_boundary_argument_type(arg, scope_types) else {
+      continue;
+    };
+    let resolved_expected = expected.substitute_type_vars(&bindings);
+    if dynamic_erases_nominal_contract(actual.as_ref(), resolved_expected.as_ref()) {
+      return Err(CalcitErr::use_msg_stack_location_with_code(
+        CalcitErrKind::Type,
+        format!(
+          "call to `{head}` passes open `{}` data at argument {} into closed nominal contract `{}`; decode JSON/Cirru EDN with `parse-cirru-edn-as` or `try-parse-cirru-edn-as`, decode an evaluated host value with `decode-map-as` or `try-decode-map-as`, or validate and narrow it inside a typed FFI adapter before this call",
+          actual.describe(),
+          index + 1,
+          resolved_expected.describe(),
+        ),
+        "E_DYNAMIC_NOMINAL_ARGUMENT",
+        call_stack,
+        arg.get_location().or_else(|| head.get_location()),
+      ));
+    }
+    actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings);
+  }
+  Ok(())
 }
 
 fn effective_user_call_schema(info: &CalcitFn) -> Arc<CalcitFnTypeAnnotation> {
@@ -15999,6 +16106,62 @@ mod tests {
     );
     let args = CalcitList::from(&[Calcit::Number(1.0), value][..]);
     assert!(find_erased_generic_argument(&relation_plus_open_boundary, &args, &scope_types).is_none());
+  }
+
+  #[test]
+  fn strict_types_reject_dynamic_values_crossing_into_nominal_arguments() {
+    let _state = lock_preprocess_test_state();
+    let person_def = Arc::new(CalcitStructDef {
+      name: EdnTag::new("Person"),
+      fields: Arc::new(vec![EdnTag::new("name")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    let person_type = Arc::new(CalcitTypeAnnotation::Struct(person_def, Arc::new(vec![])));
+    let signature = generic_relation_test_signature(vec![person_type.clone()], Arc::new(CalcitTypeAnnotation::Unit), None);
+    let dynamic = calcit::DYNAMIC_TYPE.clone();
+    let open_value = generic_relation_test_local("open-value", dynamic.clone());
+    let scope_types = ScopeTypes::from([(Arc::from("open-value"), dynamic)]);
+    let args = CalcitList::from(&[open_value][..]);
+
+    {
+      let _compat = StrictTypesGuard::new(false);
+      reject_strict_dynamic_nominal_argument(
+        &test_symbol("consume-person"),
+        &args,
+        &signature,
+        &scope_types,
+        "tests.dynamic-boundary",
+        &CallStackList::default(),
+      )
+      .expect("compatibility mode should preserve the existing Dynamic boundary during migration");
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    let error = reject_strict_dynamic_nominal_argument(
+      &test_symbol("consume-person"),
+      &args,
+      &signature,
+      &scope_types,
+      "tests.dynamic-boundary",
+      &CallStackList::default(),
+    )
+    .expect_err("strict mode should reject Dynamic entering a closed nominal argument");
+    assert_eq!(error.code.as_deref(), Some("E_DYNAMIC_NOMINAL_ARGUMENT"));
+    assert!(error.msg.contains("open `dynamic` data at argument 1"));
+    assert!(error.msg.contains("closed nominal contract `struct Person`"));
+    assert!(error.msg.contains("parse-cirru-edn-as"));
+    assert!(error.msg.contains("decode-map-as"));
+
+    let open_list = CalcitTypeAnnotation::List(calcit::DYNAMIC_TYPE.clone());
+    let people = CalcitTypeAnnotation::List(person_type);
+    assert!(dynamic_erases_nominal_contract(&open_list, &people));
+    assert!(!dynamic_erases_nominal_contract(
+      &CalcitTypeAnnotation::Dynamic,
+      &CalcitTypeAnnotation::Number
+    ));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8844,6 +8844,15 @@ fn contains_nominal_contract(annotation: &CalcitTypeAnnotation) -> bool {
     | CalcitTypeAnnotation::JsNullish(inner)
     | CalcitTypeAnnotation::Variadic(inner) => contains_nominal_contract(inner.as_ref()),
     CalcitTypeAnnotation::Map(key, value) => contains_nominal_contract(key.as_ref()) || contains_nominal_contract(value.as_ref()),
+    CalcitTypeAnnotation::TypeRef(_, args) => args.iter().any(|arg| contains_nominal_contract(arg.as_ref())),
+    CalcitTypeAnnotation::Fn(signature) => {
+      signature.arg_types.iter().any(|arg| contains_nominal_contract(arg.as_ref()))
+        || signature
+          .rest_type
+          .as_ref()
+          .is_some_and(|rest| contains_nominal_contract(rest.as_ref()))
+        || contains_nominal_contract(signature.return_type.as_ref())
+    }
     _ => false,
   }
 }
@@ -8887,6 +8896,18 @@ fn dynamic_erases_nominal_contract(actual: &CalcitTypeAnnotation, expected: &Cal
         .iter()
         .zip(expected_args.iter())
         .any(|(actual, expected)| dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref()))
+    }
+    (CalcitTypeAnnotation::Fn(actual), CalcitTypeAnnotation::Fn(expected)) if actual.arg_types.len() == expected.arg_types.len() => {
+      actual
+        .arg_types
+        .iter()
+        .zip(expected.arg_types.iter())
+        .any(|(actual, expected)| dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref()))
+        || match (actual.rest_type.as_ref(), expected.rest_type.as_ref()) {
+          (Some(actual), Some(expected)) => dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref()),
+          _ => false,
+        }
+        || dynamic_erases_nominal_contract(actual.return_type.as_ref(), expected.return_type.as_ref())
     }
     _ => false,
   }
@@ -16267,8 +16288,22 @@ mod tests {
 
     assert!(dynamic_erases_nominal_contract(
       &CalcitTypeAnnotation::TypeRef(Arc::from("tests/Box"), Arc::new(vec![calcit::DYNAMIC_TYPE.clone()])),
-      &CalcitTypeAnnotation::TypeRef(Arc::from("tests/Box"), Arc::new(vec![person_type])),
+      &CalcitTypeAnnotation::TypeRef(Arc::from("tests/Box"), Arc::new(vec![person_type.clone()])),
     ));
+
+    let open_callback = generic_relation_test_signature(vec![calcit::DYNAMIC_TYPE.clone()], Arc::new(CalcitTypeAnnotation::Unit), None);
+    let person_callback = generic_relation_test_signature(vec![person_type.clone()], Arc::new(CalcitTypeAnnotation::Unit), None);
+    assert!(contains_nominal_contract(&CalcitTypeAnnotation::Fn(Arc::new(
+      person_callback.clone()
+    ))));
+    assert!(dynamic_erases_nominal_contract(
+      &CalcitTypeAnnotation::Fn(Arc::new(open_callback)),
+      &CalcitTypeAnnotation::Fn(Arc::new(person_callback)),
+    ));
+    assert!(contains_nominal_contract(&CalcitTypeAnnotation::TypeRef(
+      Arc::from("tests/Envelope"),
+      Arc::new(vec![person_type]),
+    )));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- reject explicit `Dynamic` and matching nested Dynamic containers when they enter closed Struct/Enum arguments under `--strict-types`
- preserve explicit Dynamic return-contract evidence for this boundary check without changing gradual inference or compatibility mode
- report stable `E_DYNAMIC_NOMINAL_ARGUMENT` diagnostics with typed decoder and FFI adapter migration paths
- document the strict boundary and cover direct/local calls, generics, rest arguments, nesting, and compatibility behavior

## Motivation

Open JSON, Cirru EDN, and host values could previously flow into nominal business APIs while general inference looked through the open return contract to the implementation. That is useful during gradual migration, but a strict module must not silently treat an open map as a Struct or Enum.

This change intentionally remains narrower than a blanket Dynamic ban: it targets nominal contracts and their matching containers, while unrelated Dynamic-to-primitive calls keep their existing behavior.

Closes part of #581.
Advances #579.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn check-all`
