### PR TITLE
Fix final strict Dynamic boundary gaps

### DIFF
--- a/editing-history/202609042003-make-dynamic-generic-binding-transactional.md
+++ b/editing-history/202609042003-make-dynamic-generic-binding-transactional.md
@@ -1,0 +1,22 @@
+# Make Dynamic generic binding transactional
+
+## Context
+
+Final review of PR #638 identified two remaining consistency gaps: Variadic
+containers were classified as open but not compared recursively, and a failed
+non-Dynamic match could leave partial generic bindings that misclassified a
+later Dynamic argument.
+
+## Changes
+
+- Compare matching `Variadic` contracts recursively.
+- Collect each argument's generic bindings in a candidate map and commit them
+  only when the complete argument type matches its expected contract.
+- Cover `Variadic<Dynamic>` and a Map mismatch that must not leak a partially
+  bound nominal generic into the following Dynamic argument.
+
+## Validation
+
+- Focused strict boundary regression passes.
+- Clippy with warnings denied passes.
+- Full repository gates are rerun before push.

--- a/editing-history/202609042013-skip-static-dynamic-boundary-bindings.md
+++ b/editing-history/202609042013-skip-static-dynamic-boundary-bindings.md
@@ -1,0 +1,19 @@
+# Skip static Dynamic boundary bindings
+
+## Context
+
+Review of PR #639 noted that strict boundary checking cloned the generic
+binding map and walked every non-Dynamic argument, including contracts that
+cannot bind any type variables.
+
+## Changes
+
+- Skip the transactional generic-binding pass when the expected argument type
+  contains no type variables.
+- Preserve the existing transactional behavior for generic contracts, where a
+  failed match must not leak partial bindings.
+
+## Validation
+
+- Formatting, clippy, focused tests, serial Rust tests, and repository gates
+  are rerun before push.

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8879,7 +8879,8 @@ fn dynamic_erases_nominal_contract(actual: &CalcitTypeAnnotation, expected: &Cal
     | (CalcitTypeAnnotation::Set(actual), CalcitTypeAnnotation::Set(expected))
     | (CalcitTypeAnnotation::Ref(actual), CalcitTypeAnnotation::Ref(expected))
     | (CalcitTypeAnnotation::Optional(actual), CalcitTypeAnnotation::Optional(expected))
-    | (CalcitTypeAnnotation::JsNullish(actual), CalcitTypeAnnotation::JsNullish(expected)) => {
+    | (CalcitTypeAnnotation::JsNullish(actual), CalcitTypeAnnotation::JsNullish(expected))
+    | (CalcitTypeAnnotation::Variadic(actual), CalcitTypeAnnotation::Variadic(expected)) => {
       dynamic_erases_nominal_contract(actual.as_ref(), expected.as_ref())
     }
     (CalcitTypeAnnotation::Map(actual_key, actual_value), CalcitTypeAnnotation::Map(expected_key, expected_value)) => {
@@ -8996,7 +8997,10 @@ fn reject_strict_dynamic_nominal_argument(
     if let Some(actual) = actual
       && !contains_dynamic_type(actual.as_ref())
     {
-      actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings);
+      let mut candidate = bindings.clone();
+      if actual.as_ref().matches_with_bindings(expected.as_ref(), &mut candidate) {
+        bindings = candidate;
+      }
     }
   }
   for (index, ((arg, actual), expected)) in args.iter().zip(actual_types).zip(expected_types).enumerate() {
@@ -16315,8 +16319,48 @@ mod tests {
     ));
     assert!(contains_nominal_contract(&CalcitTypeAnnotation::TypeRef(
       Arc::from("tests/Envelope"),
-      Arc::new(vec![person_type]),
+      Arc::new(vec![person_type.clone()]),
     )));
+    assert!(dynamic_erases_nominal_contract(
+      &CalcitTypeAnnotation::Variadic(calcit::DYNAMIC_TYPE.clone()),
+      &CalcitTypeAnnotation::Variadic(person_type.clone()),
+    ));
+
+    let partial_generic = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let partial_signature = generic_relation_test_signature(
+      vec![
+        Arc::new(CalcitTypeAnnotation::Map(
+          partial_generic.clone(),
+          Arc::new(CalcitTypeAnnotation::Number),
+        )),
+        partial_generic,
+      ],
+      Arc::new(CalcitTypeAnnotation::Unit),
+      None,
+    );
+    let mismatched_map = Arc::new(CalcitTypeAnnotation::Map(
+      person_type.clone(),
+      Arc::new(CalcitTypeAnnotation::String),
+    ));
+    let partial_scope = ScopeTypes::from([
+      (Arc::from("bad-map"), mismatched_map.clone()),
+      (Arc::from("open-value"), calcit::DYNAMIC_TYPE.clone()),
+    ]);
+    let partial_args = CalcitList::from(
+      &[
+        generic_relation_test_local("bad-map", mismatched_map),
+        generic_relation_test_local("open-value", calcit::DYNAMIC_TYPE.clone()),
+      ][..],
+    );
+    reject_strict_dynamic_nominal_argument(
+      &test_symbol("partial-binding"),
+      &partial_args,
+      &partial_signature,
+      &partial_scope,
+      "tests.dynamic-boundary",
+      &CallStackList::default(),
+    )
+    .expect("a mismatching argument must not commit its partial nominal generic binding");
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8996,6 +8996,7 @@ fn reject_strict_dynamic_nominal_argument(
   for (actual, expected) in actual_types.iter().zip(expected_types.iter()) {
     if let Some(actual) = actual
       && !contains_dynamic_type(actual.as_ref())
+      && expected.contains_type_var()
     {
       let mut candidate = bindings.clone();
       if actual.as_ref().matches_with_bindings(expected.as_ref(), &mut candidate) {


### PR DESCRIPTION
Follow-up to #638, which merged before the final review feedback was incorporated.

This patch closes the remaining strict Dynamic boundary gaps:

- recursively compares `Variadic<Dynamic>` against nominal variadic contracts
- makes first-pass generic inference transactional, so a mismatching argument cannot leak partial bindings and produce a misleading `E_DYNAMIC_NOMINAL_ARGUMENT` on a later argument
- adds focused regression coverage for both cases

Validation:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn check-all`