### PR TITLE
Clarify host-managed FFI diagnostics

### DIFF
--- a/docs/installation/ffi-interface-ir.md
+++ b/docs/installation/ffi-interface-ir.md
@@ -103,6 +103,12 @@ wrong type-argument arity, trait-bounded declarations, `Dynamic`, callbacks,
 callable boundaries produce explicit diagnostics. A rejected signature is
 `null`; there is no Dynamic fallback or declaration-name guessing.
 
+The core `FfiTask` and `FfiResponse` capabilities are known host-managed types,
+not missing application declarations. Interface IR reports them with stable
+`E_FFI_IR_HOST_MANAGED_TYPE` diagnostics. Keep those lifecycle boundaries in a
+handwritten Calcit adapter and wrap opaque native tokens with `ffi:task` or
+`ffi:response`; generators must not copy or synthesize their representation.
+
 Declaration IDs follow the resolved nominal Struct/Enum name, not necessarily
 the snapshot binding that stores the base definition. This supports the normal
 top-level trait pattern `Foo0 = defstruct Foo ...` plus
@@ -116,6 +122,11 @@ Option/Result 使用明确类型节点；只纳入从 FFI signature 传递可达
 歧义、参数数量错误或无法表示的声明会产生结构化错误，不会按名称猜测或静默退化
 为动态调用。生成器必须先检查 interface `version`、definition `status` 和顶层
 `diagnostics`。
+
+core 的 `FfiTask` 与 `FfiResponse` 是已知的宿主管理 capability，并非应用声明
+遗漏。Interface IR 使用稳定的 `E_FFI_IR_HOST_MANAGED_TYPE` 诊断区分这类边界；
+应在手写 Calcit adapter 中用 `ffi:task` / `ffi:response` 包装不透明 native token，
+生成器不得复制或猜测其底层表示。
 
 Declaration ID 以解析出的 nominal Struct/Enum 名称为准，不强制等于保存 base
 definition 的 Snapshot binding 名称，因此支持顶层 `Foo0 = defstruct Foo ...` 与

--- a/editing-history/202609042143-classify-host-managed-ffi-types.md
+++ b/editing-history/202609042143-classify-host-managed-ffi-types.md
@@ -1,0 +1,9 @@
+# Classify host-managed FFI types
+
+- Give the core `FfiTask` and `FfiResponse` capabilities a stable
+  `E_FFI_IR_HOST_MANAGED_TYPE` diagnostic instead of misclassifying them as
+  missing local declarations.
+- Preserve local declaration precedence for an unqualified matching name, so
+  the diagnostic does not hide valid project-owned Struct/Enum shapes.
+- Document the handwritten adapter migration and cover deterministic qualified,
+  unqualified, parameter, result, and local-shadowing behavior.

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -244,6 +244,14 @@ fn explicit_builtin_type(name: &str) -> Option<&str> {
   }
 }
 
+fn core_host_managed_type(name: &str) -> Option<&str> {
+  match normalized_type_name(name) {
+    "FfiTask" | "calcit.core/FfiTask" => Some("FfiTask"),
+    "FfiResponse" | "calcit.core/FfiResponse" => Some("FfiResponse"),
+    _ => None,
+  }
+}
+
 fn convert_type_arguments(
   arguments: &[std::sync::Arc<CalcitTypeAnnotation>],
   definition: &str,
@@ -284,6 +292,15 @@ fn resolve_local_declaration<'a>(
 
   match candidates.as_slice() {
     [declaration] => Ok(*declaration),
+    [] if let Some(capability) = core_host_managed_type(name) => Err(Box::new(diagnostic(
+      definition,
+      path,
+      "E_FFI_IR_HOST_MANAGED_TYPE",
+      format!(
+        "FFI Interface IR v{FFI_INTERFACE_IR_VERSION} deliberately does not represent host-managed core capability `{capability}` at `{path}`."
+      ),
+      "Keep this capability boundary handwritten: wrap opaque native task/response tokens with `ffi:task` or `ffi:response` inside the Calcit adapter, and do not expose their representation to generated bindings.",
+    ))),
     [] => Err(Box::new(diagnostic(
       definition,
       path,
@@ -1440,6 +1457,73 @@ mod tests {
     assert!(report.interface.definitions[0].signature.is_none());
     assert!(diagnostic_codes(&report).contains("E_FFI_IR_DECLARATION_MISSING"));
     assert_eq!(report, export(), "unresolved declaration diagnostics must be deterministic");
+  }
+
+  #[test]
+  fn classifies_core_host_managed_capabilities_separately_from_missing_declarations() {
+    let export = || {
+      export_snapshot(
+        &snapshot(vec![(
+          "serve",
+          function_entry(
+            vec![Arc::new(CalcitTypeAnnotation::TypeRef(
+              Arc::from("calcit.core/FfiResponse"),
+              Arc::new(vec![]),
+            ))],
+            Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("FfiTask"), Arc::new(vec![]))),
+            native_metadata("serve"),
+          ),
+        )]),
+        None,
+      )
+      .expect("inventory host-managed core capabilities")
+    };
+    let report = export();
+
+    assert_eq!(report.summary.unsupported, 1);
+    assert_eq!(report.summary.diagnostics, 2);
+    assert!(report.interface.definitions[0].signature.is_none());
+    assert!(
+      report
+        .diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.code == "E_FFI_IR_HOST_MANAGED_TYPE")
+    );
+    assert_eq!(
+      report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.path.as_str())
+        .collect::<Vec<_>>(),
+      ["signature.parameters.0.type", "signature.result"]
+    );
+    assert_eq!(report, export(), "host-managed capability diagnostics must be deterministic");
+  }
+
+  #[test]
+  fn prefers_a_local_declaration_over_the_unqualified_core_capability_name() {
+    let report = export_snapshot(
+      &snapshot(vec![
+        ("FfiTask", data_entry("defstruct FfiTask (:id 'String)")),
+        (
+          "read-task",
+          function_entry(
+            vec![],
+            Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("FfiTask"), Arc::new(vec![]))),
+            native_metadata("read_task"),
+          ),
+        ),
+      ]),
+      None,
+    )
+    .expect("export local declaration shadowing a core capability name");
+
+    assert_eq!(report.summary.supported, 1);
+    assert!(report.diagnostics.is_empty());
+    assert!(matches!(
+      report.interface.definitions[0].signature.as_ref().expect("supported signature").result,
+      FfiTypeIr::Struct { ref id, ref arguments } if id == "test.ffi/FfiTask" && arguments.is_empty()
+    ));
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- classify core `FfiTask` and `FfiResponse` as known host-managed capabilities
- emit stable `E_FFI_IR_HOST_MANAGED_TYPE` instead of the misleading local-declaration-missing diagnostic
- preserve local Struct/Enum precedence for an unqualified matching name
- document the handwritten `ffi:task` / `ffi:response` adapter migration

## Why

Current Interface IR v2 intentionally leaves lifecycle capabilities behind handwritten adapters. Real Fetch and WSS exports nevertheless report `FfiTask` as `E_FFI_IR_DECLARATION_MISSING`, which suggests that adding a declaration could make the boundary generator-safe. The new code identifies the actual policy without changing support status or erasing the boundary.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (701 lib, 295 CLI, 23 WASM)
- `yarn check-all` (237 core tests, agent interface 18/18, Dynamic classification 277/277, JS/IR/WASM/performance)
- real `calcit-fetch` export: still 1 unsupported definition / 3 diagnostics; only `signature.result` changes to the new code
- real `calcit-wss` export: still 2 supported / 2 unsupported / 4 diagnostics; only `wss-serve!` `signature.result` changes to the new code

Related to #581 and #577.
