### PR TITLE
Classify Dynamic and callback FFI boundaries

### DIFF
--- a/docs/installation/ffi-interface-ir.md
+++ b/docs/installation/ffi-interface-ir.md
@@ -112,9 +112,12 @@ handwritten Calcit adapter and wrap opaque native tokens with `ffi:task` or
 Unsupported signatures distinguish two other common handwritten boundaries.
 `E_FFI_IR_DYNAMIC_TYPE` identifies an open `Dynamic` position that must become a
 concrete raw type or be validated/decoded by an adapter.
-`E_FFI_IR_CALLBACK_TYPE` identifies typed and untyped callbacks because v2 does
-not define their ownership, thread-affinity, or lifetime contract. Other types
-outside the portable subset continue to use `E_FFI_IR_UNSUPPORTED_TYPE`.
+`E_FFI_IR_CALLBACK_TYPE` identifies typed runtime function and untyped `DynFn`
+callbacks because v2 does not define their ownership, thread-affinity, or
+lifetime contract. A nested macro-kind function annotation is not a runtime
+callback and continues to use `E_FFI_IR_UNSUPPORTED_TYPE`; a macro raw binding
+uses `E_FFI_IR_UNSUPPORTED_SCHEMA`. Other types outside the portable subset
+continue to use `E_FFI_IR_UNSUPPORTED_TYPE`.
 
 Declaration IDs follow the resolved nominal Struct/Enum name, not necessarily
 the snapshot binding that stores the base definition. This supports the normal
@@ -137,9 +140,12 @@ core 的 `FfiTask` 与 `FfiResponse` 是已知的宿主管理 capability，并�
 
 unsupported signature 还会区分另外两类常见手写边界：
 `E_FFI_IR_DYNAMIC_TYPE` 表示开放的 `Dynamic` 位置，必须改成具体 raw type，或在
-adapter 中验证/解码；`E_FFI_IR_CALLBACK_TYPE` 表示 typed/untyped callback，因为
-v2 尚未定义 ownership、线程亲和性与生命周期契约。其他超出 portable subset 的
-类型仍使用 `E_FFI_IR_UNSUPPORTED_TYPE`。
+adapter 中验证/解码；`E_FFI_IR_CALLBACK_TYPE` 表示 typed runtime function 与
+untyped `DynFn` callback，因为 v2 尚未定义 ownership、线程亲和性与生命周期契约。
+嵌套的 macro-kind function annotation 不是 runtime callback，仍使用
+`E_FFI_IR_UNSUPPORTED_TYPE`；macro raw binding 使用
+`E_FFI_IR_UNSUPPORTED_SCHEMA`。其他超出 portable subset 的类型仍使用
+`E_FFI_IR_UNSUPPORTED_TYPE`。
 
 Declaration ID 以解析出的 nominal Struct/Enum 名称为准，不强制等于保存 base
 definition 的 Snapshot binding 名称，因此支持顶层 `Foo0 = defstruct Foo ...` 与

--- a/docs/installation/ffi-interface-ir.md
+++ b/docs/installation/ffi-interface-ir.md
@@ -109,6 +109,13 @@ not missing application declarations. Interface IR reports them with stable
 handwritten Calcit adapter and wrap opaque native tokens with `ffi:task` or
 `ffi:response`; generators must not copy or synthesize their representation.
 
+Unsupported signatures distinguish two other common handwritten boundaries.
+`E_FFI_IR_DYNAMIC_TYPE` identifies an open `Dynamic` position that must become a
+concrete raw type or be validated/decoded by an adapter.
+`E_FFI_IR_CALLBACK_TYPE` identifies typed and untyped callbacks because v2 does
+not define their ownership, thread-affinity, or lifetime contract. Other types
+outside the portable subset continue to use `E_FFI_IR_UNSUPPORTED_TYPE`.
+
 Declaration IDs follow the resolved nominal Struct/Enum name, not necessarily
 the snapshot binding that stores the base definition. This supports the normal
 top-level trait pattern `Foo0 = defstruct Foo ...` plus
@@ -127,6 +134,12 @@ core 的 `FfiTask` 与 `FfiResponse` 是已知的宿主管理 capability，并�
 遗漏。Interface IR 使用稳定的 `E_FFI_IR_HOST_MANAGED_TYPE` 诊断区分这类边界；
 应在手写 Calcit adapter 中用 `ffi:task` / `ffi:response` 包装不透明 native token，
 生成器不得复制或猜测其底层表示。
+
+unsupported signature 还会区分另外两类常见手写边界：
+`E_FFI_IR_DYNAMIC_TYPE` 表示开放的 `Dynamic` 位置，必须改成具体 raw type，或在
+adapter 中验证/解码；`E_FFI_IR_CALLBACK_TYPE` 表示 typed/untyped callback，因为
+v2 尚未定义 ownership、线程亲和性与生命周期契约。其他超出 portable subset 的
+类型仍使用 `E_FFI_IR_UNSUPPORTED_TYPE`。
 
 Declaration ID 以解析出的 nominal Struct/Enum 名称为准，不强制等于保存 base
 definition 的 Snapshot binding 名称，因此支持顶层 `Foo0 = defstruct Foo ...` 与

--- a/editing-history/202609042155-classify-ffi-dynamic-and-callback-types.md
+++ b/editing-history/202609042155-classify-ffi-dynamic-and-callback-types.md
@@ -1,0 +1,9 @@
+# Classify FFI Dynamic and callback types
+
+- Split open `Dynamic` positions into stable `E_FFI_IR_DYNAMIC_TYPE`
+  diagnostics with concrete decode-or-adapt migration guidance.
+- Split typed and untyped callbacks into stable `E_FFI_IR_CALLBACK_TYPE`
+  diagnostics that name the missing ownership, thread-affinity, and lifetime
+  contract.
+- Preserve the generic unsupported code for the remaining portable-subset gaps
+  and cover deterministic codes and nested paths.

--- a/editing-history/202609042204-align-generic-ffi-suggestion.md
+++ b/editing-history/202609042204-align-generic-ffi-suggestion.md
@@ -1,0 +1,6 @@
+# Align the generic FFI suggestion
+
+- Remove Dynamic and callbacks from the generic unsupported-type suggestion now
+  that each has a dedicated diagnostic and migration path.
+- Keep the fallback guidance focused on the remaining non-portable types such as
+  Map/Set, Ref, resources, and host objects.

--- a/editing-history/202609042213-preserve-macro-ffi-classification.md
+++ b/editing-history/202609042213-preserve-macro-ffi-classification.md
@@ -1,0 +1,8 @@
+# Preserve macro FFI classification
+
+- Inspect `SchemaKind` before classifying a nested function annotation as a
+  callback boundary.
+- Keep macro-kind annotations on the unsupported-type path, with guidance that
+  distinguishes compile-time macros from runtime callbacks.
+- Add deterministic regression coverage and document the distinction between
+  nested macro annotations and macro raw bindings.

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -465,7 +465,7 @@ fn convert_type(
         "FFI Interface IR v{FFI_INTERFACE_IR_VERSION} cannot represent Calcit type `{}` at `{path}`.",
         unsupported.to_brief_string()
       ),
-      "Use Unit, Bool, Number, String, Buffer, List, Option, Result, or an explicitly declared local Struct/Enum; keep Dynamic, callbacks, Map/Set, Ref, resources, and host objects behind a handwritten adapter.",
+      "Use Unit, Bool, Number, String, Buffer, List, Option, Result, or an explicitly declared local Struct/Enum; keep Map/Set, Ref, resources, host objects, and other non-portable values behind a handwritten adapter.",
     ))),
   }
 }

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -447,6 +447,13 @@ fn convert_type(
       format!("FFI Interface IR v{FFI_INTERFACE_IR_VERSION} cannot generate an open Dynamic type at `{path}`."),
       "Replace Dynamic at the raw binding with a concrete generator-safe type or a declared local Struct/Enum. If the payload is intentionally open, keep it behind a handwritten adapter and validate or decode it before entering typed business code.",
     ))),
+    CalcitTypeAnnotation::Fn(signature) if signature.fn_kind == SchemaKind::Macro => Err(Box::new(diagnostic(
+      definition,
+      path,
+      "E_FFI_IR_UNSUPPORTED_TYPE",
+      format!("FFI Interface IR v{FFI_INTERFACE_IR_VERSION} cannot represent a macro schema at `{path}`."),
+      "Keep macros outside runtime FFI signatures. Expose a runtime Fn only when it is an actual callback boundary, or move compile-time orchestration into handwritten Calcit code.",
+    ))),
     CalcitTypeAnnotation::Fn(_) | CalcitTypeAnnotation::DynFn => Err(Box::new(diagnostic(
       definition,
       path,
@@ -1770,6 +1777,39 @@ mod tests {
       ["signature.parameters.0.type", "signature.parameters.1.type"]
     );
     assert_eq!(report, export(), "callback diagnostics must be deterministic");
+  }
+
+  #[test]
+  fn preserves_macro_kind_when_classifying_nested_function_annotations() {
+    let macro_schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![DYNAMIC_TYPE.clone()],
+      return_type: DYNAMIC_TYPE.clone(),
+      fn_kind: SchemaKind::Macro,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    let report = export_snapshot(
+      &snapshot(vec![(
+        "expand",
+        function_entry(vec![macro_schema], Arc::new(CalcitTypeAnnotation::Unit), native_metadata("expand")),
+      )]),
+      None,
+    )
+    .expect("inventory nested macro schema");
+
+    assert_eq!(report.summary.supported, 0);
+    assert_eq!(report.summary.unsupported, 1);
+    assert_eq!(report.summary.diagnostics, 1);
+    assert_eq!(report.diagnostics[0].code, "E_FFI_IR_UNSUPPORTED_TYPE");
+    assert_eq!(report.diagnostics[0].path, "signature.parameters.0.type");
+    assert!(report.diagnostics[0].message.contains("macro schema"));
+    assert!(
+      report.diagnostics[0]
+        .suggestion
+        .contains("Keep macros outside runtime FFI signatures")
+    );
   }
 
   #[test]

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -440,6 +440,23 @@ fn convert_type(
     CalcitTypeAnnotation::TypeVar(name) if context.type_parameters.contains(name.as_ref()) => Ok(FfiTypeIr::TypeParameter {
       name: name.trim_start_matches('\'').to_owned(),
     }),
+    CalcitTypeAnnotation::Dynamic => Err(Box::new(diagnostic(
+      definition,
+      path,
+      "E_FFI_IR_DYNAMIC_TYPE",
+      format!("FFI Interface IR v{FFI_INTERFACE_IR_VERSION} cannot generate an open Dynamic type at `{path}`."),
+      "Replace Dynamic at the raw binding with a concrete generator-safe type or a declared local Struct/Enum. If the payload is intentionally open, keep it behind a handwritten adapter and validate or decode it before entering typed business code.",
+    ))),
+    CalcitTypeAnnotation::Fn(_) | CalcitTypeAnnotation::DynFn => Err(Box::new(diagnostic(
+      definition,
+      path,
+      "E_FFI_IR_CALLBACK_TYPE",
+      format!(
+        "FFI Interface IR v{FFI_INTERFACE_IR_VERSION} does not model callback type `{}` at `{path}`.",
+        annotation.to_brief_string()
+      ),
+      "Keep callback ownership, thread affinity, and lifetime orchestration in a handwritten adapter. Expose only generator-safe request and result values across generated raw bindings.",
+    ))),
     unsupported => Err(Box::new(diagnostic(
       definition,
       path,
@@ -1678,7 +1695,7 @@ mod tests {
       &snapshot(vec![(
         "dynamic-call",
         function_entry(
-          vec![DYNAMIC_TYPE.clone()],
+          vec![DYNAMIC_TYPE.clone(), Arc::new(CalcitTypeAnnotation::List(DYNAMIC_TYPE.clone()))],
           DYNAMIC_TYPE.clone(),
           Edn::map_from_iter([(Edn::tag("symbol"), Edn::str("dynamic_call"))]),
         ),
@@ -1691,8 +1708,68 @@ mod tests {
     assert_eq!(report.summary.unsupported, 1);
     assert!(report.interface.definitions[0].signature.is_none());
     let codes = diagnostic_codes(&report);
-    assert!(codes.contains("E_FFI_IR_UNSUPPORTED_TYPE"));
+    assert!(codes.contains("E_FFI_IR_DYNAMIC_TYPE"));
     assert!(codes.contains("E_FFI_IR_BACKEND_REQUIRED"));
+    assert_eq!(
+      report
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "E_FFI_IR_DYNAMIC_TYPE")
+        .map(|diagnostic| diagnostic.path.as_str())
+        .collect::<Vec<_>>(),
+      [
+        "signature.parameters.0.type",
+        "signature.parameters.1.type.item",
+        "signature.result"
+      ]
+    );
+  }
+
+  #[test]
+  fn classifies_typed_and_untyped_callbacks_with_stable_paths() {
+    let callback = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![Arc::new(CalcitTypeAnnotation::String)],
+      return_type: Arc::new(CalcitTypeAnnotation::Unit),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    let export = || {
+      export_snapshot(
+        &snapshot(vec![(
+          "watch",
+          function_entry(
+            vec![callback.clone(), Arc::new(CalcitTypeAnnotation::DynFn)],
+            Arc::new(CalcitTypeAnnotation::Unit),
+            native_metadata("watch"),
+          ),
+        )]),
+        None,
+      )
+      .expect("inventory callback boundaries")
+    };
+    let report = export();
+
+    assert_eq!(report.summary.supported, 0);
+    assert_eq!(report.summary.unsupported, 1);
+    assert_eq!(report.summary.diagnostics, 2);
+    assert!(
+      report
+        .diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.code == "E_FFI_IR_CALLBACK_TYPE")
+    );
+    assert_eq!(
+      report
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.path.as_str())
+        .collect::<Vec<_>>(),
+      ["signature.parameters.0.type", "signature.parameters.1.type"]
+    );
+    assert_eq!(report, export(), "callback diagnostics must be deterministic");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- report open `Dynamic` positions as stable `E_FFI_IR_DYNAMIC_TYPE`
- report typed and untyped callbacks as stable `E_FFI_IR_CALLBACK_TYPE`
- provide separate concrete migration guidance for decode/adapt and callback lifecycle boundaries
- retain `E_FFI_IR_UNSUPPORTED_TYPE` for other types outside the v2 portable subset

## Stack

This is one commit stacked on #642 because both slices refine the same Interface IR conversion path. The diff against this PR's base contains only Dynamic/callback classification. After #642 lands, this PR can be retargeted or GitHub can follow the updated branch ancestry.

## Real-module evidence

- Fetch remains 1 unsupported definition / 3 diagnostics: Dynamic options, callback, host-managed result now each have a distinct code
- WSS remains 2 supported / 2 unsupported / 4 diagnostics: callbacks receive the dedicated code, Map remains generic unsupported, and the host-managed result retains #642's code
- paths and summary counts do not change

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (702 lib, 295 CLI, 23 WASM)
- `yarn check-all` (237 core tests, agent interface 18/18, Dynamic classification 277/277, JS/IR/WASM/performance)
- focused deterministic coverage includes root and nested Dynamic paths plus typed and untyped callbacks

Related to #581 and #577.
