### PR TITLE
Exclude external-object contracts from callable FFI exports

### DIFF
--- a/docs/installation/ffi-interface-ir.md
+++ b/docs/installation/ffi-interface-ir.md
@@ -47,9 +47,17 @@ fall back to the compatibility version retained in the snapshot.
 Version 2 selects local definitions whose `:ffi` metadata contains at least
 one lowering field: `:backend`, `:target`, `:kind`, `:symbol`, `:invoke`, or
 `:transport`. Empty `:ffi {}` placeholders and capability-only metadata such
-as `:features` do not declare a raw binding. Malformed non-container metadata
-remains visible as a diagnostic instead of disappearing. Dependencies are
-excluded; run the command in each module that owns a boundary.
+as `:features` do not declare a raw binding. A typed external-object trait with
+`:kind :external-object` is also a static host capability contract rather than
+a callable lowering entry; inspect it with `calcit query def`, not `ffi export`.
+Other callable kinds, incomplete lowering, and malformed non-container metadata
+remain visible instead of disappearing. Dependencies are excluded; run the
+command in each module that owns a boundary.
+
+V2 会忽略 `:kind :external-object` 的 typed host capability trait：它用于静态
+成员检查，不是 callable lowering；请用 `calcit query def` 审计其 schema 与 FFI
+metadata。其他 callable kind、字段不完整的 lowering 以及 malformed metadata
+仍会进入 inventory 并产生诊断，不能借此静默绕过 bindgen 检查。
 
 Both layers remain visible:
 

--- a/editing-history/202609042224-exclude-external-object-callable-inventory.md
+++ b/editing-history/202609042224-exclude-external-object-callable-inventory.md
@@ -1,0 +1,11 @@
+# Exclude external-object contracts from callable FFI inventory
+
+- Treat `:ffi :kind :external-object` traits as static host capability
+  contracts, not callable Interface IR lowering entries.
+- Preserve inventory and diagnostics for every other callable kind, incomplete
+  lowering contract, and malformed metadata shape.
+- Cover realistic backend, target, and member-name metadata and document the
+  separate `query def` inspection path.
+- Current-main ecosystem audit: js-ffi drops from 30 definitions / 21
+  diagnostics to 10 / 1, and gen-code-strict drops from 2 / 2 to 0 / 0;
+  calcit-wss, calcit-json, and regex callable inventories remain unchanged.

--- a/src/ffi_interface_ir.rs
+++ b/src/ffi_interface_ir.rs
@@ -879,8 +879,19 @@ fn canonical_edn_display(value: &Edn) -> String {
   }
 }
 
+/// External-object traits describe host capabilities for static member checks;
+/// they are not callable lowering entries for Interface IR.
+fn is_external_object_contract(metadata: &Edn) -> bool {
+  match metadata_value(metadata, "kind") {
+    Some(Edn::Tag(value)) => value.ref_str() == "external-object",
+    Some(Edn::Str(value) | Edn::Symbol(value)) => value.trim_start_matches(':') == "external-object",
+    _ => false,
+  }
+}
+
 fn is_ffi_boundary_candidate(metadata: &Edn) -> bool {
   match metadata {
+    Edn::Map(_) | Edn::Struct(_) if is_external_object_contract(metadata) => false,
     Edn::Map(_) | Edn::Struct(_) => ["backend", "target", "kind", "symbol", "invoke", "transport"]
       .iter()
       .any(|key| metadata_value(metadata, key).is_some()),
@@ -1832,10 +1843,23 @@ mod tests {
             Edn::map_from_iter([(Edn::tag("features"), Edn::tag("js-ffi"))]),
           ),
         ),
+        (
+          "external-object-contract",
+          function_entry(
+            vec![],
+            Arc::new(CalcitTypeAnnotation::Unit),
+            Edn::map_from_iter([
+              (Edn::tag("backend"), Edn::tag("js")),
+              (Edn::tag("kind"), Edn::tag("external-object")),
+              (Edn::tag("target"), Edn::tag("browser")),
+              (Edn::tag("names"), Edn::map_from_iter([(Edn::tag("read"), Edn::str("readValue"))])),
+            ]),
+          ),
+        ),
       ]),
       None,
     )
-    .expect("ignore non-lowering FFI metadata");
+    .expect("ignore non-lowering and external-object FFI metadata");
 
     assert_eq!(report.summary.definitions, 0);
     assert!(report.diagnostics.is_empty());


### PR DESCRIPTION
## Summary

- exclude FFI metadata with kind external-object from Interface IR v2 callable selection
- keep all other callable kinds, incomplete lowerings, and malformed metadata visible to diagnostics
- document that external-object traits are inspected through query def
- add regression coverage for realistic JS backend, target, and member-name metadata

## Why

Current-main ecosystem auditing found that typed external-object traits were being mistaken for callable raw bindings because they carry backend, kind, and target metadata. This produced 20 false unsupported schemas in js-ffi and 2 in gen-code-strict.

With this change:

- js-ffi: 30 definitions / 21 diagnostics becomes 10 / 1; its remaining diagnostic is the real set-timeout callback boundary
- gen-code-strict: 2 / 2 becomes 0 / 0
- calcit-wss, calcit-json, and regex callable inventories and diagnostics remain unchanged

## Validation

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test -- --test-threads=1 (703 lib / 295 CLI / 23 WASM)
- yarn check-all (Agent interface 18/18, core 237/237, Dynamic classification 277/277, native/JS/IR/WASM/performance)
- exact current-main exports for js-ffi, gen-code-strict, calcit-wss, calcit-json, and regex

Related to #581.