### PR TITLE
Fix late Dynamic classification review gaps

### DIFF
--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -150,7 +150,9 @@ Option/Result nominal family additionally names the expected receiver family
 and its visible `option:*` / `result:*` helper. Compatibility mode retains the
 `P_DYNAMIC_*` inventory and `W_DYNAMIC_NOMINAL_METHOD_RECEIVER` while projects
 migrate. A concrete inferred type, trait constraint, or external-object trait
-remains statically dispatchable and does not trigger this rule.
+remains statically dispatchable and does not trigger this rule. An Optional
+chain over Dynamic is the legacy-optional cause, while `Optional<DynFn>` keeps
+the dynamic-callable cause.
 
 Strict project source also rejects hand-written representation primitives with
 `E_RAW_PRIMITIVE_IN_TYPED_CODE`: `&get-raw`, `record-get` / `&struct:get`, raw `&%{}`, and

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -128,7 +128,9 @@ missing schema, Dynamic value/callable, legacy Optional, unbound generic or
 type slot, or explicit `:js-ffi` Dynamic boundary. Add static nominal or trait
 evidence before method syntax. A JS boundary must convert the host value or
 attach an external-object trait inside its narrow adapter; `:js-ffi` alone does
-not authorize runtime method lookup.
+not authorize runtime method lookup. Legacy Optional means an Optional chain
+whose payload is an open Dynamic value; `Optional<DynFn>` is classified as a
+dynamic callable instead.
 
 `unsafe-coerce` is stricter still: in `--strict-types` it must appear inside
 the current function's structured `Fn` schema with `:features $ #{} :js-ffi`,
@@ -224,7 +226,9 @@ argument whose contract contains a closed Struct or Enum. Decode text with
 with `decode-map-as` / `try-decode-map-as`, or validate and narrow it inside a
 small typed FFI adapter. The diagnostic identifies the argument and target
 contract. It does not reject unrelated `Dynamic` to primitive calls, and
-compatibility mode keeps the existing gradual migration behavior.
+compatibility mode keeps the existing gradual migration behavior. A type slot
+bound to a Struct/Enum contract is resolved before this check, so entry-level
+and scoped slot configuration cannot erase the nominal boundary.
 
 `--strict-types` reports `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written
 `&get-raw`, `record-get` / `&struct:get`, raw `&%{}`, and `&struct:nth` without matching

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -228,7 +228,9 @@ small typed FFI adapter. The diagnostic identifies the argument and target
 contract. It does not reject unrelated `Dynamic` to primitive calls, and
 compatibility mode keeps the existing gradual migration behavior. A type slot
 bound to a Struct/Enum contract is resolved before this check, so entry-level
-and scoped slot configuration cannot erase the nominal boundary.
+and scoped slot configuration cannot erase the nominal boundary. Cyclic slot
+bindings are treated conservatively as protected boundaries instead of being
+followed recursively or allowed to bypass the strict check.
 
 `--strict-types` reports `E_RAW_PRIMITIVE_IN_TYPED_CODE` for hand-written
 `&get-raw`, `record-get` / `&struct:get`, raw `&%{}`, and `&struct:nth` without matching

--- a/editing-history/202609042235-close-review-classification-gaps.md
+++ b/editing-history/202609042235-close-review-classification-gaps.md
@@ -1,0 +1,8 @@
+# Close review classification gaps
+
+- Preserve the dynamic-callable cause for `Optional<DynFn>` instead of
+  describing its payload as a Dynamic value.
+- Resolve bound type slots while detecting nominal Struct/Enum argument
+  contracts, so Dynamic cannot bypass the strict nominal boundary.
+- Add focused regression coverage and align the migration documentation with
+  both classifications.

--- a/editing-history/202609042235-close-review-classification-gaps.md
+++ b/editing-history/202609042235-close-review-classification-gaps.md
@@ -3,6 +3,8 @@
 - Preserve the dynamic-callable cause for `Optional<DynFn>` instead of
   describing its payload as a Dynamic value.
 - Resolve bound type slots while detecting nominal Struct/Enum argument
-  contracts, so Dynamic cannot bypass the strict nominal boundary.
+  contracts, so Dynamic cannot bypass the strict nominal boundary. Track slot
+  resolution cycles and conservatively protect cyclic contracts rather than
+  recursing without a bound.
 - Add focused regression coverage and align the migration documentation with
   both classifications.

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6586,6 +6586,11 @@ fn is_dynamic_annotation(type_value: &CalcitTypeAnnotation) -> bool {
     || matches!(type_value, CalcitTypeAnnotation::Optional(inner) if is_dynamic_annotation(inner.as_ref()))
 }
 
+fn is_legacy_optional_dynamic_payload(type_value: &CalcitTypeAnnotation) -> bool {
+  matches!(type_value, CalcitTypeAnnotation::Dynamic)
+    || matches!(type_value, CalcitTypeAnnotation::Optional(inner) if is_legacy_optional_dynamic_payload(inner.as_ref()))
+}
+
 #[derive(Debug, PartialEq)]
 enum DynamicDispatchReceiverCause {
   MissingSchema,
@@ -6645,7 +6650,9 @@ fn classify_dynamic_dispatch_receiver(
     CalcitTypeAnnotation::Dynamic if inside_js_ffi_boundary => Some(DynamicDispatchReceiverCause::ExplicitJsFfiBoundary),
     CalcitTypeAnnotation::Dynamic => Some(DynamicDispatchReceiverCause::DynamicSchema),
     CalcitTypeAnnotation::DynFn => Some(DynamicDispatchReceiverCause::DynamicCallable),
-    CalcitTypeAnnotation::Optional(inner) if is_dynamic_annotation(inner) => Some(DynamicDispatchReceiverCause::LegacyOptional),
+    CalcitTypeAnnotation::Optional(inner) if is_legacy_optional_dynamic_payload(inner) => {
+      Some(DynamicDispatchReceiverCause::LegacyOptional)
+    }
     CalcitTypeAnnotation::Optional(inner) => classify_dynamic_dispatch_receiver(Some(inner), inside_js_ffi_boundary),
     CalcitTypeAnnotation::TypeVar(name) => Some(DynamicDispatchReceiverCause::UnboundGeneric(name.clone())),
     CalcitTypeAnnotation::TypeSlot(name) => match calcit::resolve_type_slot(name) {
@@ -8865,6 +8872,9 @@ fn contains_nominal_contract(annotation: &CalcitTypeAnnotation) -> bool {
           .as_ref()
           .is_some_and(|rest| contains_nominal_contract(rest.as_ref()))
         || contains_nominal_contract(signature.return_type.as_ref())
+    }
+    CalcitTypeAnnotation::TypeSlot(name) => {
+      calcit::resolve_type_slot(name).is_some_and(|resolved| contains_nominal_contract(resolved.as_ref()))
     }
     _ => false,
   }
@@ -11156,6 +11166,10 @@ mod tests {
     assert_eq!(
       classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::Optional(dynamic)), false),
       Some(DynamicDispatchReceiverCause::LegacyOptional)
+    );
+    assert_eq!(
+      classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::Optional(Arc::new(CalcitTypeAnnotation::DynFn))), false,),
+      Some(DynamicDispatchReceiverCause::DynamicCallable)
     );
     assert_eq!(
       classify_dynamic_dispatch_receiver(Some(&CalcitTypeAnnotation::TypeVar(Arc::from("T"))), false),
@@ -16207,6 +16221,7 @@ mod tests {
   #[test]
   fn strict_types_reject_dynamic_values_crossing_into_nominal_arguments() {
     let _state = lock_preprocess_test_state();
+    let _slots = TypeSlotsGuard::cleared();
     let person_def = Arc::new(CalcitStructDef {
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("name")]),
@@ -16216,6 +16231,11 @@ mod tests {
       impls: vec![],
     });
     let person_type = Arc::new(CalcitTypeAnnotation::Struct(person_def, Arc::new(vec![])));
+    calcit::push_type_slot_override(Arc::from("payload"), person_type.clone());
+    let nominal_slot = CalcitTypeAnnotation::TypeSlot(Arc::from("payload"));
+    assert!(contains_nominal_contract(&nominal_slot));
+    assert!(dynamic_erases_nominal_contract(&CalcitTypeAnnotation::Dynamic, &nominal_slot));
+    calcit::pop_type_slot_override("payload");
     let signature = generic_relation_test_signature(vec![person_type.clone()], Arc::new(CalcitTypeAnnotation::Unit), None);
     let dynamic = calcit::DYNAMIC_TYPE.clone();
     let open_value = generic_relation_test_local("open-value", dynamic.clone());

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8853,31 +8853,40 @@ fn reject_strict_erased_generic_relation(
 }
 
 fn contains_nominal_contract(annotation: &CalcitTypeAnnotation) -> bool {
-  if annotation.resolve_to_struct_with_ref().is_some() || annotation.resolve_to_enum().is_some() {
-    return true;
-  }
-  match annotation {
-    CalcitTypeAnnotation::List(inner)
-    | CalcitTypeAnnotation::Set(inner)
-    | CalcitTypeAnnotation::Ref(inner)
-    | CalcitTypeAnnotation::Optional(inner)
-    | CalcitTypeAnnotation::JsNullish(inner)
-    | CalcitTypeAnnotation::Variadic(inner) => contains_nominal_contract(inner.as_ref()),
-    CalcitTypeAnnotation::Map(key, value) => contains_nominal_contract(key.as_ref()) || contains_nominal_contract(value.as_ref()),
-    CalcitTypeAnnotation::TypeRef(_, args) => args.iter().any(|arg| contains_nominal_contract(arg.as_ref())),
-    CalcitTypeAnnotation::Fn(signature) => {
-      signature.arg_types.iter().any(|arg| contains_nominal_contract(arg.as_ref()))
-        || signature
-          .rest_type
-          .as_ref()
-          .is_some_and(|rest| contains_nominal_contract(rest.as_ref()))
-        || contains_nominal_contract(signature.return_type.as_ref())
+  fn walk(annotation: &CalcitTypeAnnotation, resolving_slots: &mut HashSet<Arc<str>>) -> bool {
+    if let CalcitTypeAnnotation::TypeSlot(name) = annotation {
+      if !resolving_slots.insert(name.clone()) {
+        return true;
+      }
+      let contains_nominal = calcit::resolve_type_slot(name).is_some_and(|resolved| walk(resolved.as_ref(), resolving_slots));
+      resolving_slots.remove(name);
+      return contains_nominal;
     }
-    CalcitTypeAnnotation::TypeSlot(name) => {
-      calcit::resolve_type_slot(name).is_some_and(|resolved| contains_nominal_contract(resolved.as_ref()))
+    if annotation.resolve_to_struct_with_ref().is_some() || annotation.resolve_to_enum().is_some() {
+      return true;
     }
-    _ => false,
+    match annotation {
+      CalcitTypeAnnotation::List(inner)
+      | CalcitTypeAnnotation::Set(inner)
+      | CalcitTypeAnnotation::Ref(inner)
+      | CalcitTypeAnnotation::Optional(inner)
+      | CalcitTypeAnnotation::JsNullish(inner)
+      | CalcitTypeAnnotation::Variadic(inner) => walk(inner.as_ref(), resolving_slots),
+      CalcitTypeAnnotation::Map(key, value) => walk(key.as_ref(), resolving_slots) || walk(value.as_ref(), resolving_slots),
+      CalcitTypeAnnotation::TypeRef(_, args) => args.iter().any(|arg| walk(arg.as_ref(), resolving_slots)),
+      CalcitTypeAnnotation::Fn(signature) => {
+        signature.arg_types.iter().any(|arg| walk(arg.as_ref(), resolving_slots))
+          || signature
+            .rest_type
+            .as_ref()
+            .is_some_and(|rest| walk(rest.as_ref(), resolving_slots))
+          || walk(signature.return_type.as_ref(), resolving_slots)
+      }
+      _ => false,
+    }
   }
+
+  walk(annotation, &mut HashSet::new())
 }
 
 fn dynamic_erases_nominal_contract(actual: &CalcitTypeAnnotation, expected: &CalcitTypeAnnotation) -> bool {
@@ -16236,6 +16245,19 @@ mod tests {
     assert!(contains_nominal_contract(&nominal_slot));
     assert!(dynamic_erases_nominal_contract(&CalcitTypeAnnotation::Dynamic, &nominal_slot));
     calcit::pop_type_slot_override("payload");
+    calcit::push_type_slot_override(
+      Arc::from("direct-cycle"),
+      Arc::new(CalcitTypeAnnotation::TypeSlot(Arc::from("direct-cycle"))),
+    );
+    assert!(contains_nominal_contract(&CalcitTypeAnnotation::TypeSlot(Arc::from(
+      "direct-cycle"
+    ))));
+    calcit::pop_type_slot_override("direct-cycle");
+    calcit::push_type_slot_override(Arc::from("cycle-a"), Arc::new(CalcitTypeAnnotation::TypeSlot(Arc::from("cycle-b"))));
+    calcit::push_type_slot_override(Arc::from("cycle-b"), Arc::new(CalcitTypeAnnotation::TypeSlot(Arc::from("cycle-a"))));
+    assert!(contains_nominal_contract(&CalcitTypeAnnotation::TypeSlot(Arc::from("cycle-a"))));
+    calcit::pop_type_slot_override("cycle-b");
+    calcit::pop_type_slot_override("cycle-a");
     let signature = generic_relation_test_signature(vec![person_type.clone()], Arc::new(CalcitTypeAnnotation::Unit), None);
     let dynamic = calcit::DYNAMIC_TYPE.clone();
     let open_value = generic_relation_test_local("open-value", dynamic.clone());


### PR DESCRIPTION
## Summary

- preserve `DynamicCallable` for `Optional<DynFn>` receivers instead of reporting `LegacyOptional`
- resolve bound `TypeSlot` contracts before checking whether Dynamic erases a Struct/Enum boundary
- add focused regressions and document both migration classifications

This follows up late review comments on #614 and #638.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (703 lib, 295 CLI, 23 WASM)
- `yarn check-all` (agent interface, core, quality, Dynamic classification, native/JS/IR/WASM, literal paths, performance)