### PR TITLE
ci: 在 Linux 发版路径锁定 Dynamic 分类 / gate Dynamic classification on Linux

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: "prevent bundled core type-debt regressions"
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json
       - name: "prevent bundled core Dynamic classification drift"
-        run: node scripts/core-dynamic-classification.mjs --check
+        run: cargo build --bin calcit && node scripts/core-dynamic-classification.mjs --check
       - run: cargo run --bin calcit -- calcit/test.cirru
 
       - name: "verify WASM exports and FFI"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,6 +43,8 @@ jobs:
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru test --tag unit
       - name: "prevent bundled core type-debt regressions"
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json
+      - name: "prevent bundled core Dynamic classification drift"
+        run: node scripts/core-dynamic-classification.mjs --check
       - run: cargo run --bin calcit -- calcit/test.cirru
 
       - name: "verify WASM exports and FFI"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,8 @@ jobs:
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru test --tag unit
       - name: "prevent bundled core type-debt regressions"
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json
+      - name: "prevent bundled core Dynamic classification drift"
+        run: node scripts/core-dynamic-classification.mjs --check
       - run: cargo run --bin calcit -- calcit/test.cirru
 
       - name: "verify WASM exports and FFI"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: "prevent bundled core type-debt regressions"
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json
       - name: "prevent bundled core Dynamic classification drift"
-        run: node scripts/core-dynamic-classification.mjs --check
+        run: cargo build --bin calcit && node scripts/core-dynamic-classification.mjs --check
       - run: cargo run --bin calcit -- calcit/test.cirru
 
       - name: "verify WASM exports and FFI"

--- a/editing-history/202609042316-gate-core-dynamic-classification-on-linux.md
+++ b/editing-history/202609042316-gate-core-dynamic-classification-on-linux.md
@@ -1,0 +1,19 @@
+# Gate core Dynamic classification on Linux
+
+## Context
+
+The bundled-core Dynamic classification is checked in and locally verified by
+`yarn check-all`, but the GitHub pull-request and release workflows did not run
+the classifier drift check. A stale inventory could therefore pass the primary
+Linux release path even while its owner or migrate/retain decisions no longer
+matched the compiler report.
+
+## Change
+
+- Run `node scripts/core-dynamic-classification.mjs --check` in the
+  `ubuntu-latest` pull-request job after the core quality baseline check.
+- Run the same check in the `ubuntu-latest` publish job before release build and
+  publication.
+
+This keeps the generated inventory, report revision, owners, and migration
+decisions tied to the same Linux-tested compiler used by CI and releases.

--- a/editing-history/202609042324-make-linux-classification-gates-self-contained.md
+++ b/editing-history/202609042324-make-linux-classification-gates-self-contained.md
@@ -1,0 +1,7 @@
+# Make Linux classification gates self-contained
+
+Review identified that the new workflow steps depended on an earlier `cargo
+run` leaving `target/debug/calcit` behind. Each pull-request and publish gate
+now explicitly runs `cargo build --bin calcit` before checking the generated
+Dynamic classification, so reordering or conditionally skipping unrelated
+steps cannot silently break the gate.


### PR DESCRIPTION
## 中文

- 在 `ubuntu-latest` PR job 中校验 bundled core Dynamic 分类清单没有漂移
- 在 `ubuntu-latest` publish job 中运行同一门槛，防止过期 owner 或 migrate/retain 决策进入发版
- 每个 gate 显式构建其检查所需的 `calcit` binary，不依赖前序步骤的副作用
- 保持现有 macOS main-thread stack 检查作为补充平台验证

关闭 #647；关联 #579。

## English

- Check the bundled-core Dynamic classification for drift in the `ubuntu-latest` pull-request job.
- Run the same gate in the `ubuntu-latest` publish job so stale owners or migrate/retain decisions cannot reach a release.
- Explicitly build the `calcit` binary used by each gate instead of relying on a preceding step's side effect.
- Keep the existing macOS main-thread stack check as supplemental platform coverage.

Closes #647; related to #579.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1`
- `yarn check-all`
- `cargo build --bin calcit && node scripts/core-dynamic-classification.mjs --check` (277 positions)
