### PR TITLE
test: 隔离进程级程序状态 / isolate process-wide program state

### DIFF
--- a/editing-history/202609042333-isolate-program-test-state.md
+++ b/editing-history/202609042333-isolate-program-test-state.md
@@ -1,0 +1,45 @@
+# Isolate process-wide program state in Rust tests
+
+## Problem
+
+Default-parallel Rust tests used separate module-local mutexes while sharing the
+same process-wide program registries. A `program` test could therefore replace
+source or compiled data while a `preprocess` or Snapshot schema test resolved a
+type through the registered program lookup callbacks. The resulting failures
+were order-dependent and ranged from qualified type-reference drift to stack
+overflow.
+
+## State inventory
+
+The shared test guard covers all mutable process-wide state owned by
+`program.rs`:
+
+- source definitions (`PROGRAM_CODE_DATA`);
+- runtime cells (`PROGRAM_RUNTIME_DATA_STATE`);
+- compiled definitions (`PROGRAM_COMPILED_DATA_STATE`);
+- stable definition IDs (`PROGRAM_DEF_ID_INDEX`);
+- active entry feature policy (`ACTIVE_FEATURE_POLICY`);
+- active compilation target (`ACTIVE_TARGET`).
+
+Type-slot bindings and warning/import-resolution stacks are thread-local, so
+they do not need cross-thread serialization. Preprocess project namespaces
+already use their own scoped restoration guard.
+
+## Isolation contract
+
+Tests that read or mutate process-wide program state acquire
+`program::lock_program_test_state`. The guard snapshots the registries while
+holding one cross-module mutex and restores them in `Drop`, including panic
+unwinding. Program and preprocess tests no longer use independent locks, and
+the Snapshot schema regressions join the same isolation domain.
+
+Tests that only use local values remain parallel. New tests that install source
+definitions, compile into the global registry, or resolve schemas through the
+registered lookup callbacks must acquire the shared guard for their full
+critical section.
+
+## Verification
+
+- focused panic-restoration, Snapshot schema, and preprocess regressions;
+- five consecutive default-parallel `cargo test` runs;
+- serial full-suite, formatting, Clippy, and repository integration gates.

--- a/src/program.rs
+++ b/src/program.rs
@@ -9,6 +9,9 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::RwLock;
 
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard};
+
 use cirru_parser::Cirru;
 
 use crate::calcit::data_shape::DataShapeGraph;
@@ -165,7 +168,7 @@ impl CompiledFileData {
 
 pub type CompiledProgram = HashMap<Arc<str>, CompiledFileData>;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 struct ProgramDefIdIndex {
   next_id: u32,
   by_ns: HashMap<Arc<str>, HashMap<Arc<str>, DefId>>,
@@ -210,6 +213,55 @@ static PROGRAM_COMPILED_DATA_STATE: LazyLock<RwLock<ProgramCompiledData>> = Lazy
 /// raw code information before program running
 pub static PROGRAM_CODE_DATA: LazyLock<RwLock<ProgramCodeData>> = LazyLock::new(|| RwLock::new(HashMap::new()));
 static PROGRAM_DEF_ID_INDEX: LazyLock<RwLock<ProgramDefIdIndex>> = LazyLock::new(|| RwLock::new(ProgramDefIdIndex::default()));
+
+/// Serializes Rust tests that temporarily replace process-wide program state.
+///
+/// The guard snapshots every registry owned by this module and restores it on
+/// drop, including during panic unwinding. Tests in other modules must use this
+/// guard instead of defining a module-local mutex when they read or mutate
+/// program state.
+#[cfg(test)]
+static PROGRAM_TEST_STATE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[cfg(test)]
+pub(crate) struct ProgramTestStateGuard {
+  _lock: MutexGuard<'static, ()>,
+  runtime_data: ProgramRuntimeData,
+  compiled_data: ProgramCompiledData,
+  code_data: ProgramCodeData,
+  def_id_index: ProgramDefIdIndex,
+  feature_policy: HashMap<String, snapshot::FeaturePolicy>,
+  target: Option<snapshot::SnapshotTarget>,
+}
+
+#[cfg(test)]
+impl Drop for ProgramTestStateGuard {
+  fn drop(&mut self) {
+    *PROGRAM_RUNTIME_DATA_STATE.write().unwrap_or_else(|error| error.into_inner()) = std::mem::take(&mut self.runtime_data);
+    *PROGRAM_COMPILED_DATA_STATE.write().unwrap_or_else(|error| error.into_inner()) = std::mem::take(&mut self.compiled_data);
+    *PROGRAM_CODE_DATA.write().unwrap_or_else(|error| error.into_inner()) = std::mem::take(&mut self.code_data);
+    *PROGRAM_DEF_ID_INDEX.write().unwrap_or_else(|error| error.into_inner()) = std::mem::take(&mut self.def_id_index);
+    *ACTIVE_FEATURE_POLICY.write().unwrap_or_else(|error| error.into_inner()) = std::mem::take(&mut self.feature_policy);
+    *ACTIVE_TARGET.write().unwrap_or_else(|error| error.into_inner()) = self.target;
+  }
+}
+
+#[cfg(test)]
+pub(crate) fn lock_program_test_state() -> ProgramTestStateGuard {
+  let lock = PROGRAM_TEST_STATE_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+  ProgramTestStateGuard {
+    _lock: lock,
+    runtime_data: PROGRAM_RUNTIME_DATA_STATE.read().unwrap_or_else(|error| error.into_inner()).clone(),
+    compiled_data: PROGRAM_COMPILED_DATA_STATE
+      .read()
+      .unwrap_or_else(|error| error.into_inner())
+      .clone(),
+    code_data: PROGRAM_CODE_DATA.read().unwrap_or_else(|error| error.into_inner()).clone(),
+    def_id_index: PROGRAM_DEF_ID_INDEX.read().unwrap_or_else(|error| error.into_inner()).clone(),
+    feature_policy: ACTIVE_FEATURE_POLICY.read().unwrap_or_else(|error| error.into_inner()).clone(),
+    target: *ACTIVE_TARGET.read().unwrap_or_else(|error| error.into_inner()),
+  }
+}
 
 fn ensure_runtime_capacity(runtime: &mut ProgramRuntimeData, def_id: DefId) {
   let idx = def_id.0 as usize;

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -12,9 +12,6 @@ use crate::run_program_with_docs;
 use cirru_edn::EdnTag;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{LazyLock, Mutex};
-
-static PROGRAM_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 static CALX_VOID_IMPORT_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 fn cirru_leaf(value: &str) -> Cirru {
@@ -299,8 +296,8 @@ fn namespace_validation_accepts_legacy_colon_ns_form() {
   assert!(imports.is_empty());
 }
 
-fn lock_program_test_state() -> std::sync::MutexGuard<'static, ()> {
-  PROGRAM_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+fn lock_program_test_state() -> ProgramTestStateGuard {
+  super::lock_program_test_state()
 }
 
 fn reset_program_test_state() {
@@ -308,6 +305,32 @@ fn reset_program_test_state() {
   PROGRAM_COMPILED_DATA_STATE.write().expect("reset compiled data").clear();
   PROGRAM_CODE_DATA.write().expect("reset program code").clear();
   *PROGRAM_DEF_ID_INDEX.write().expect("reset def id index") = ProgramDefIdIndex::default();
+}
+
+#[test]
+fn program_test_state_guard_restores_registry_after_panic() {
+  let namespace: Arc<str> = Arc::from("tests.guard-panic-restoration");
+  let result = std::panic::catch_unwind(|| {
+    let _guard = lock_program_test_state();
+    reset_program_test_state();
+    PROGRAM_CODE_DATA.write().unwrap_or_else(|error| error.into_inner()).insert(
+      namespace.clone(),
+      ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::new(),
+      },
+    );
+    panic!("exercise panic restoration");
+  });
+  assert!(result.is_err());
+
+  let _guard = lock_program_test_state();
+  assert!(
+    !PROGRAM_CODE_DATA
+      .read()
+      .unwrap_or_else(|error| error.into_inner())
+      .contains_key(namespace.as_ref())
+  );
 }
 
 fn calx_test_fn_schema(arg_types: Vec<CalcitTypeAnnotation>, return_type: CalcitTypeAnnotation) -> Arc<CalcitTypeAnnotation> {

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -9271,9 +9271,6 @@ mod tests {
   };
   use crate::data::cirru::code_to_calcit;
   use cirru_parser::Cirru;
-  use std::sync::{LazyLock, Mutex};
-
-  static PREPROCESS_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
   fn strict_macro_signature(
     required_inputs: Vec<MacroSyntaxType>,
@@ -9496,8 +9493,8 @@ mod tests {
     assert_eq!(err.code.as_deref(), Some("E_MACRO_EXPANSION_DECLARATIONS"));
   }
 
-  fn lock_preprocess_test_state() -> std::sync::MutexGuard<'static, ()> {
-    PREPROCESS_TEST_LOCK.lock().unwrap_or_else(|err| err.into_inner())
+  fn lock_preprocess_test_state() -> crate::program::ProgramTestStateGuard {
+    crate::program::lock_program_test_state()
   }
 
   #[test]
@@ -11574,6 +11571,7 @@ mod tests {
 
   #[test]
   fn passes_assert_traits_expression_without_local_binding() {
+    let _guard = lock_preprocess_test_state();
     let expr = Cirru::List(vec![
       Cirru::leaf("assert-traits"),
       Cirru::List(vec![Cirru::leaf("&+"), Cirru::leaf("1"), Cirru::leaf("2")]),

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -3707,6 +3707,7 @@ mod tests {
 
   #[test]
   fn test_schema_named_type_refs_round_trip_without_becoming_type_vars() {
+    let _guard = crate::program::lock_program_test_state();
     let schema_text = "{} (:kind :fn) (:generics ([] 'T 'E)) (:args ([] 'T)) (:return (:: 'Result 'T 'E))";
     let schema_cirru = cirru_parser::parse(schema_text)
       .expect("should parse")
@@ -4163,6 +4164,7 @@ mod tests {
 
   #[test]
   fn test_load_snapshot_preserves_selected_real_world_schemas() {
+    let _guard = crate::program::lock_program_test_state();
     let core_file_content = fs::read_to_string("src/cirru/calcit-core.cirru").expect("Failed to read calcit-core.cirru");
     let edn_data = cirru_edn::parse(&core_file_content).expect("Failed to parse cirru content as EDN");
     let snapshot = load_snapshot_data(&edn_data, "src/cirru/calcit-core.cirru").expect("Failed to parse snapshot");
@@ -4720,6 +4722,7 @@ mod tests {
 
   #[test]
   fn optionally_schema_bridges_nullable_values_to_nominal_option() {
+    let _guard = crate::program::lock_program_test_state();
     let core_file_content = fs::read_to_string("src/cirru/calcit-core.cirru").expect("Failed to read calcit-core.cirru");
     let edn_data = cirru_edn::parse(&core_file_content).expect("Failed to parse cirru content as EDN");
     let snapshot = load_snapshot_data(&edn_data, "src/cirru/calcit-core.cirru").expect("Failed to parse snapshot");


### PR DESCRIPTION
## 中文

统一 program 与 preprocess Rust tests 使用的进程级状态锁，并通过 RAII guard 快照/恢复 program source、runtime、compiled、def-id、feature policy 与 target。受影响的 Snapshot schema tests 加入同一隔离域；新增 panic unwind 恢复回归。

验证：
- cargo fmt --all -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test 默认并行连续 5 轮
- cargo test -- --test-threads=1
- yarn check-all
- rebase 最新 main 后 cargo test --quiet

Closes #592
Related #588