### PR TITLE
feat: reject unsupported indexed receivers in strict mode

### DIFF
--- a/calcit/type-fail/README.md
+++ b/calcit/type-fail/README.md
@@ -47,6 +47,7 @@
 - `dynamic-nominal-method-strict.cirru` 会验证 strict 模式拒绝 Dynamic receiver 上的 Option/Result nominal method dispatch，并报告稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `dynamic-method-dispatch-strict.cirru` 会验证 strict 模式拒绝普通 Dynamic receiver method，并报告 receiver source 与稳定的 `E_DYNAMIC_POSTFIX_METHOD`。
 - `raw-primitive-strict.cirru` 会验证 strict 模式拒绝项目源码直接调用 `&get-raw`，并报告稳定的 `E_RAW_PRIMITIVE_IN_TYPED_CODE`。
+- strict indexed-access integration 会验证完整预处理路径拒绝 Number 等静态不支持的 `first` / `last` / `nth` / `get` receiver，并报告稳定的 `E_UNSUPPORTED_INDEXED_RECEIVER`；该检查属于 native/JS 共用的前端语义。
 - `untyped-js-object-access-strict.cirru` 会验证 strict 模式拒绝裸 `JsObject` 上的静态成员访问，并报告稳定的 `E_UNTYPED_JS_OBJECT_ACCESS` 与 external-object trait 迁移建议。
 - `js-nullish-dereference-strict.cirru` 会验证 strict 模式拒绝直接解引用 `JsNullish<JsObject>`，并报告稳定的 `E_JS_FFI_NULLABLE_DEREF` 与显式 narrow/optional access 建议。
 - `js-nullish-predicate-strict.cirru` 会验证 strict 模式拒绝以 legacy `nil?`/`some?` 检查 `JsNullish<T>`，并报告稳定的 `E_JS_FFI_NULLABLE_PREDICATE` 与专用 predicate 建议。
@@ -86,6 +87,7 @@
 - `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`：strict 模式下可达 function 或直接进入预处理的 programmatic macro 既没有结构化根 schema，也没有嵌入式结构化契约；普通 legacy Snapshot macro 会更早被 loader 拒绝
 - `E_DYNAMIC_METHOD_DISPATCH` / `E_DYNAMIC_POSTFIX_METHOD`：strict 模式下 method receiver 缺少可静态 specialization 的 schema、generic/slot 绑定或 typed FFI evidence
 - `E_RAW_PRIMITIVE_IN_TYPED_CODE`：strict 项目源码手写 raw constructor/lookup/index primitive，且没有 compiler/macro origin 或匹配的 nominal layout evidence
+- `E_UNSUPPORTED_INDEXED_RECEIVER`：strict 项目源码把静态可解析但不支持的具体类型传给 `first`、`last`、`nth` 或 `get`；应转换到支持的 collection、先 narrow optional/FFI value，或对 Struct 使用字段访问
 - `E_UNTYPED_JS_OBJECT_ACCESS`：strict 项目源码在裸 `JsObject` 上以静态成员名执行读取、调用或写入，需在 lexical adapter 内绑定 external-object trait；动态 key 保留 raw lookup 语义
 - `E_JS_FFI_NULLABLE_DEREF`：strict 项目源码未 narrow `JsNullish<JsObject>` 就直接读取或调用宿主成员
 - `E_JS_FFI_NULLABLE_PREDICATE`：strict 项目源码用 legacy `nil?`/`some?` 擦除 `JsNullish<T>` 的宿主空值语义

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -397,6 +397,13 @@ Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field`
 | `get-in` | `Option<T>`（开放动态路径常为 `Option<Dynamic>`） | 任一路径缺失都是 `%none` |
 | `get-env` | `Option<String>` | 未设置的环境变量是 `%none` |
 
+`--strict-types` 还会检查这些访问 API 的接收者能力。`first`、`last`、`nth` 只接受可静态确认的
+`List<T>`、`String` 或 `Enum`，`get` 另外接受 `Map<K,V>`；把 Number、Set、Struct、函数或未收窄的
+optional/FFI host value 传入时会报告 `E_UNSUPPORTED_INDEXED_RECEIVER`，而不是把 core schema 中保留的
+Dynamic 接收者位置当成任意值逃生口。Struct 字段改用 `(:field value)`，optional receiver 先 match/unwrap，
+FFI value 在 adapter 边界完成 validate/convert。普通兼容模式和显式声明的 `Dynamic` receiver 仍保留原运行时路径，
+便于按边界渐进迁移。
+
 ```cirru
 let
     xs $ [] 1 2 3

--- a/editing-history/202609042355-strict-indexed-access-receivers.md
+++ b/editing-history/202609042355-strict-indexed-access-receivers.md
@@ -1,0 +1,7 @@
+# Strict indexed-access receivers
+
+- Strict typed preprocessing now rejects concrete unsupported receivers for public `first`, `last`, `nth`, and `get` calls with `E_UNSUPPORTED_INDEXED_RECEIVER`.
+- The check runs only after arity and static receiver resolution are available. Supported List/String/Enum receivers and Map `get` continue through the existing Option-returning specialization.
+- Compatibility mode and deliberately explicit Dynamic/unresolved boundaries remain on the runtime path, preserving incremental migration.
+- Diagnostics point Struct callers to `(:field value)`, optional callers to narrowing/unwrapping, and `JsObject` callers to FFI validation/conversion.
+- Rust regression coverage locks shared preprocessing state and verifies helper-level compatibility, strict rejection, explicit Dynamic behavior, and the complete backend-independent check-only preprocessing path shared by native and JS.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -325,6 +325,51 @@ fn strict_type_fail_raw_primitive_reports_stable_error_code() {
 }
 
 #[test]
+fn strict_type_fail_unsupported_indexed_receiver_reports_stable_error_code() {
+  run_with_large_stack(|| {
+    builtins::effects::init_effects_states();
+    let mut snapshot = snapshot::Snapshot::default();
+    let mut file = snapshot::create_file_from_snippet(concat!(
+      "defn read-first (value)\n  first value\n\n",
+      "defn main! ()\n  read-first 1\n\n",
+      "defn reload! () $ identity &unit",
+    ))
+    .expect("unsupported indexed receiver snippet should parse");
+    let fn_schema = |args, return_type| {
+      Arc::new(CalcitTypeAnnotation::Fn(Arc::new(calcit::calcit::CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: args,
+        return_type,
+        fn_kind: calcit::calcit::SchemaKind::Fn,
+        rest_type: None,
+        features: Arc::new(HashSet::new()),
+      })))
+    };
+    file.defs.get_mut("read-first").expect("read-first entry").schema =
+      fn_schema(vec![Arc::new(CalcitTypeAnnotation::Number)], calcit::calcit::DYNAMIC_TYPE.clone());
+    file.defs.get_mut("main!").expect("main entry").schema = fn_schema(vec![], calcit::calcit::DYNAMIC_TYPE.clone());
+    file.defs.get_mut("reload!").expect("reload entry").schema = fn_schema(vec![], Arc::new(CalcitTypeAnnotation::Unit));
+    snapshot.files.insert("app.main".to_owned(), file);
+
+    let entries = prepare_snapshot_entries(snapshot);
+    let _strict = StrictTypesReset::enabled();
+    let err = run_check_only(&entries).expect_err("Number receiver must fail strict indexed access during full preprocessing");
+
+    assert!(
+      err.contains("E_UNSUPPORTED_INDEXED_RECEIVER"),
+      "unexpected strict indexed receiver error: {err}"
+    );
+    assert!(err.contains("`first`"), "operation should be explicit: {err}");
+    assert!(err.contains("`:number`"), "resolved receiver type should be explicit: {err}");
+    assert!(
+      err.contains("List<T>, String, or Enum"),
+      "supported receivers should be named: {err}"
+    );
+  });
+}
+
+#[test]
 fn strict_type_fail_untyped_js_object_access_reports_stable_error_code() {
   run_with_large_stack(|| {
     let fixture = "calcit/type-fail/untyped-js-object-access-strict.cirru";

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1404,6 +1404,12 @@ fn try_expand_typed_optional_access_call(
     _ => None,
   };
 
+  let receiver_is_open = match receiver_type.as_ref() {
+    T::Dynamic | T::Custom(_) | T::TypeVar(_) | T::Trait(_) | T::TraitSet(_) | T::TypeSlot(_) => true,
+    value @ T::TypeRef(_, _) => value.resolve_to_enum().is_none() && value.resolve_to_struct().is_none(),
+    _ => false,
+  };
+
   match (fn_def, args.len(), receiver_type.as_ref()) {
     ("get", 2, T::Map(_, _)) => {
       let receiver = generated_path_symbol("typed_get_receiver", file_ns, call_stack)?;
@@ -1460,6 +1466,36 @@ fn try_expand_typed_optional_access_call(
       let body = generated_optional_last_access(receiver.to_owned(), receiver_type.as_ref(), file_ns, call_stack)?
         .expect("guarded typed last receiver");
       Ok(Some(generated_let(receiver, receiver_expr.to_owned(), body, file_ns)))
+    }
+    _ if strict_types_enabled()
+      && should_emit_project_source_lint(file_ns)
+      && matches!((fn_def, args.len()), ("first" | "last", 1) | ("get" | "nth", 2))
+      && !receiver_is_open =>
+    {
+      let supported = if fn_def == "get" {
+        "Map<K,V>, List<T>, String, or Enum"
+      } else {
+        "List<T>, String, or Enum"
+      };
+      let migration = if fn_def == "get" && receiver_type.resolve_to_struct().is_some() {
+        "use `(:field value)` for a Struct field so its declared type is checked"
+      } else if matches!(receiver_type.as_ref(), T::Optional(_) | T::JsNullish(_)) || receiver_type.is_option_type() {
+        "narrow or unwrap the optional receiver before access"
+      } else if matches!(receiver_type.as_ref(), T::JsObject) {
+        "validate or convert the FFI value at its boundary before access"
+      } else {
+        "convert the value to a supported collection or choose an operation for its concrete type"
+      };
+      Err(CalcitErr::use_msg_stack_location_with_code(
+        CalcitErrKind::Type,
+        format!(
+          "`{fn_def}` cannot use statically resolved receiver `{}`; strict indexed access supports {supported}; {migration}",
+          receiver_type.to_brief_string()
+        ),
+        "E_UNSUPPORTED_INDEXED_RECEIVER",
+        call_stack,
+        receiver_expr.get_location(),
+      ))
     }
     _ => Ok(None),
   }
@@ -9852,6 +9888,7 @@ mod tests {
 
   #[test]
   fn leaves_dynamic_optional_access_on_the_compatibility_path() {
+    let _guard = lock_preprocess_test_state();
     let dynamic_receiver = Calcit::Local(CalcitLocal {
       idx: CalcitLocal::track_sym(&Arc::from("dynamic-source")),
       sym: Arc::from("dynamic-source"),
@@ -9873,6 +9910,91 @@ mod tests {
         &CallStackList::default(),
       )
       .expect("dynamic access should remain valid")
+      .is_none()
+    );
+  }
+
+  #[test]
+  fn strict_types_reject_concrete_unsupported_optional_access_receivers() {
+    let _guard = lock_preprocess_test_state();
+    let stack = CallStackList::default();
+
+    {
+      let _compat = StrictTypesGuard::new(false);
+      let args = CalcitList::from(&[Calcit::Number(1.0)] as &[Calcit]);
+      assert!(
+        try_expand_typed_optional_access_call(calcit::CORE_NS, "first", &args, &ScopeTypes::new(), "tests.typed-access", &stack)
+          .expect("compatibility mode keeps runtime dispatch")
+          .is_none()
+      );
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    for (fn_def, args) in [
+      ("first", CalcitList::from(&[Calcit::Number(1.0)] as &[Calcit])),
+      ("last", CalcitList::from(&[Calcit::Bool(true)] as &[Calcit])),
+      (
+        "nth",
+        CalcitList::from(&[Calcit::Tag(EdnTag::new("not-indexed")), Calcit::Number(0.0)] as &[Calcit]),
+      ),
+      (
+        "get",
+        CalcitList::from(&[Calcit::Number(1.0), Calcit::Tag(EdnTag::new("field"))] as &[Calcit]),
+      ),
+    ] {
+      let error =
+        try_expand_typed_optional_access_call(calcit::CORE_NS, fn_def, &args, &ScopeTypes::new(), "tests.typed-access", &stack)
+          .expect_err("strict mode should reject a concrete unsupported receiver");
+      assert_eq!(error.code.as_deref(), Some("E_UNSUPPORTED_INDEXED_RECEIVER"));
+      assert!(error.msg.contains(fn_def));
+      assert!(error.msg.contains("strict indexed access supports"));
+    }
+
+    let struct_def = Arc::new(CalcitStructDef {
+      name: EdnTag::new("Task"),
+      fields: Arc::new(vec![EdnTag::new("done?")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::Bool)]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    let struct_args = CalcitList::from(&[
+      generic_relation_test_local("task", Arc::new(CalcitTypeAnnotation::StructValue(struct_def))),
+      Calcit::Tag(EdnTag::new("done?")),
+    ] as &[Calcit]);
+    let struct_error = try_expand_typed_optional_access_call(
+      calcit::CORE_NS,
+      "get",
+      &struct_args,
+      &ScopeTypes::new(),
+      "tests.typed-access",
+      &stack,
+    )
+    .expect_err("strict mode should direct Struct lookup to declared field access");
+    assert_eq!(struct_error.code.as_deref(), Some("E_UNSUPPORTED_INDEXED_RECEIVER"));
+    assert!(struct_error.msg.contains("use `(:field value)`"));
+
+    let dynamic_receiver = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("reviewed-open-source")),
+      sym: Arc::from("reviewed-open-source"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.typed-access"),
+        at_def: Arc::from("main"),
+      }),
+      location: None,
+      type_info: calcit::DYNAMIC_TYPE.clone(),
+    });
+    let dynamic_args = CalcitList::from(&[dynamic_receiver, Calcit::Number(0.0)] as &[Calcit]);
+    assert!(
+      try_expand_typed_optional_access_call(
+        calcit::CORE_NS,
+        "get",
+        &dynamic_args,
+        &ScopeTypes::new(),
+        "tests.typed-access",
+        &stack,
+      )
+      .expect("an explicitly Dynamic receiver remains a reviewed open boundary")
       .is_none()
     );
   }


### PR DESCRIPTION
## Summary / 概要

- reject statically resolved unsupported receivers for `first`, `last`, `nth`, and `get` under `--strict-types`
- preserve supported List/String/Enum and Map `get` specialization, compatibility mode, and explicit Dynamic/unresolved boundaries
- add stable `E_UNSUPPORTED_INDEXED_RECEIVER` diagnostics with Struct, optional, and FFI migration guidance
- add helper-level and complete check-only preprocessing coverage plus migration documentation

Closes #652
Advances #579

## Validation / 验证

Local macOS regression (secondary evidence):
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` — 705 + 296 + 23 passed before the release-only rebase
- focused tests repeated after rebasing onto 0.13.77
- `yarn check-all` — passed, including shared JS and WASM paths

Primary acceptance evidence:
- GitHub Actions `Test` on `ubuntu-latest` must pass before merge.

## Scope / 范围

This is post-0.13.77 strict-boundary work. It does not modify release/version/tag/publish files.