### PR TITLE
Formalize multi-agent delivery and externalize Wiki / 固化多 Agent 交付并外置 Wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,75 @@
+name: Agent-ready task
+description: A scoped task that may be claimed by a human or coding agent
+title: "[Task] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This repository is the coordination source of truth, including for work implemented in related Calcit repositories. A maintainer adds `agent:ready` after the scope and dependencies are clear.
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome / 预期结果
+      description: Describe observable completion, not implementation details. 请描述可验证的完成结果。
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Owned scope / 修改范围
+      description: List every repository and path this task may modify. One task owns these paths while leased.
+      placeholder: |
+        calcit-lang/calcit: src/codegen/**, calcit/**
+        calcit-lang/calcit-bindgen: tests/**
+    validations:
+      required: true
+
+  - type: textarea
+    id: exclusions
+    attributes:
+      label: Out of scope / 不修改范围
+      description: State nearby code or behavior that must remain untouched.
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and related Issues / 依赖与关联 Issue
+      description: Link blockers, umbrella/child Issues, and potentially overlapping active work.
+      placeholder: "Blocked by #123; related to calcit-lang/calcit-bindgen#45"
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance checks / 验收方式
+      description: Commands or observations that prove the task is complete.
+      placeholder: |
+        - cargo test ...
+        - yarn check-...
+        - Cross-repository smoke test ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Validation evidence / 验证证据
+      description: Update this field or add an Issue comment before review with commands run, results, commits, and PR URLs. 进入 review 前请补充命令、结果、提交和 PR 链接。
+      placeholder: |
+        Planned: cargo test ...
+        Completed: command, result, commit SHA, PR URL
+
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Readiness checklist
+      options:
+        - label: The owned scope does not overlap another open `agent:claimed` Issue.
+          required: true
+        - label: Dependencies and related repositories are recorded above.
+          required: true
+        - label: Implementation will use an Issue-scoped branch and a dedicated worktree for every modified repository.
+          required: true
+        - label: Every non-release change will be delivered through a PR; a pushed branch alone is not completion.
+          required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 
 - **主仓库边界**：parser/source model、Snapshot、preprocess/type system、runtime、JS/WASM/Calx backend 语义、`@calcit/procs`、`calcit` CLI/Agent interface 以及权威 RFC/离线文档留在本仓库。短期不规划 LSP，不为假设中的 LSP consumer 拆独立 analysis 仓库。
 - **拆分总索引**：跨仓库职责和迁移顺序由 [calcit#549](https://github.com/calcit-lang/calcit/issues/549) 追踪；bindgen、caps、Calx benchmark 和 native ABI 的具体任务使用总索引中的 child Issues，避免重复立项。
+- **生态 Wiki 外置**：生态目录、边界、依赖层次和批量演进说明只维护在独立的 [`calcit-lang/calcit` GitHub Wiki](https://github.com/calcit-lang/calcit/wiki)，不在主仓库保存正文副本或自动镜像脚本。Wiki 用于发现和导航，各模块仓库 README/AGENTS.md、主仓库版本化文档与测试仍是具体契约的 source of truth。
 - **状态必须可发现**：每个拆出或供多个仓库复用的模块，都必须在自己的 README 或 AGENTS.md 说明状态（production / experimental / template / internal）、职责与非职责、上游/下游契约和 source of truth、兼容矩阵、版本与发布策略、迁移/验证命令以及关联 umbrella/child Issues。
 - **模板不冒充产品**：workflow/template 仓库必须明确标记用途及“不随业务功能迭代版本”；实验性 benchmark 也必须明确结果可比性和非生产定位。
 - **Calx profile 证据**：机器相关的 Calx 采样策略、raw reports 与性能 provenance 由 [`calcit-lang/calcit-calx-bench`](https://github.com/calcit-lang/calcit-calx-bench) 独立维护；core 的 `docs/run/calx-compile-cache.md` 只拥有 cache/runtime 语义与设计约束。报告必须记录干净 commit、环境、命令、迭代数、原始文件哈希与 inclusive-stack 限制，不把原始 profiler 资产提交回 core。
@@ -174,3 +175,100 @@ npm view @calcit/procs version
 ### 编辑历史
 
 每次 commit 之前, 都产生一个时间戳(年月日时分)开头的文件, 记录本次修改的知识点和概要, 方便未来修改类似功能时查阅. 统一存储在 `editing-history/` 目录.
+
+## 多 Agent Issue 协作
+
+`calcit-lang/calcit` 的 GitHub Issues 是 Calcit 主项目及关联仓库工作的唯一协调状态源。即使代码实际修改在 `calcit-bindgen`、`calcit-calx-bench` 等关联仓库，也必须先在本仓库建立或关联一个主 Issue，并在其中写明所有目标仓库和路径。
+
+### Release manager / 协调 Agent
+
+每轮发布指定一个 release manager 负责协调，不直接认领或实现普通 `agent:ready` Issue，不进入实现 Agent 的 worktree，也不修改 Issue `Owned scope` 中的源码。release manager 的职责是维护 GitHub Issues、PR 状态、依赖关系、milestones、优先级和发布门槛，并推动其他 Agent 在各自 worktree 中完成工作。
+
+- 所有开放 Issue 都必须归入一个 milestone；新 Issue 出现后立即判断属于当前版本、后续版本或无截止日期的长期迭代，不能长期处于无 milestone 状态。
+- 每个 milestone 必须有双语目标、截止日期（长期迭代可省略）和可验证的退出条件。当前版本只包含确实阻塞该版本的工作；未完成事项在发版前移动到下一 milestone，并在 Issue 留言说明理由，不得为清空 milestone 而虚假关闭。
+- release manager 维护状态一致性：只有依赖满足且范围可执行的 Issue 使用 `agent:ready`；持有有效租约时使用 `agent:claimed`；已有覆盖最新提交的 PR 时才使用 `agent:review`；等待明确依赖、权限或人工决策时使用 `agent:blocked`。
+- release manager 定期检查当前 milestone 的开放 PR、required checks、review threads、mergeability 和依赖变化。只在状态变化、失败、冲突或需要行动时更新 Issue，状态不变时不重复留言或紧密轮询。
+- 当前版本建立独立的 release Issue，并标记 `priority:p0`。依赖未完成时保持 `agent:blocked`；所有版本内实现 Issue 已关闭或明确移出、required PR 已合并且 release 验收条件满足后，release manager 才把它切换为 `agent:ready`，交给另一个 Agent 认领和执行发布。
+- release manager 不用实现租约来修改 GitHub milestone、Issue 标签、依赖、状态和协调评论；但任何仓库文件改动（包括已经合入后的 `AGENTS.md`、workflow 或 release script）仍必须建立 Issue，由实现 Agent 认领、在独立 worktree 修改并创建 PR。
+- release manager 不把“分支已 push”视为进度完成。发现分支有新提交但没有覆盖该提交的开放 PR 时，将对应 Issue 退回 `agent:ready` 或标记 `agent:blocked`，并要求实现 Agent 创建 PR；release manager 自己不接管该分支补实现。
+- tag、GitHub release、crates.io/npm 发布均验证成功后才能关闭 release Issue 和对应 milestone，并立即确认下一 milestone 成为唯一的当前迭代。
+
+仓库维护者首次启用时执行 `scripts/agent-issue-lease.sh init` 创建四个状态标签。执行认领的环境必须具备可 push `agent-lock/*` 分支、编辑 Issue 和标签的 `git`/`gh` 权限。
+
+### 开始写入前
+
+1. 只处理开放且带 `agent:ready` 标签的 Issue；先阅读 Issue、依赖项和关联 Issue。
+2. 为本次运行选择全局唯一且不易碰撞的 ID，建议包含客户端、完整任务/会话标识和随机后缀，例如 `codex-01a06d08-654-a91f`。不得只截取很短的公共前缀（如 `codex-01a06d`），也不要复用其他正在运行的 ID。
+3. 在本仓库执行：
+
+   ```bash
+   scripts/agent-issue-lease.sh claim <issue-number> <agent-id> '<repo:path, repo:path>'
+   ```
+
+4. 只有命令显示 `CLAIMED` 或 `RENEWED` 后才能修改文件。认领失败时立即停止，不得绕过锁。
+5. 每个 Agent 同时只持有一个写入租约，但可以跟踪多个已进入 `agent:review` 的 Issue/PR。不同 Issue 的修改范围如果重叠，也不得并行写入；在两个 Issue 留言说明冲突后等待拆分或释放。
+
+远端 `agent-lock/issue-<number>` 分支是认领权的权威来源；Issue 标签与租约评论用于人员和 Agent 查看。不要手工创建、覆盖或删除该分支。脚本使用原子 Git ref 更新防止同时认领，并能在租约过期后安全接管。
+
+### 工作期间
+
+- 默认租约为 45 分钟。长时间工作至少每 15 分钟续租一次：
+
+  ```bash
+  scripts/agent-issue-lease.sh heartbeat <issue-number> <agent-id>
+  ```
+
+- 在 Issue 的 `Owned scope` 范围内修改；新增仓库或路径前，先更新 Issue 并确认不与其他活跃 Issue 重叠。
+- 每个执行写入的 Agent 必须为当前认领的 Issue 使用独立 Git worktree，并使用独立分支 `agent/issue-<number>-<agent-id>`。不得让多个 Agent 共用同一个 checkout，不得直接在共享主 checkout、其他 Agent 的 worktree、其他 Agent 的分支或含有他人未提交改动的目录中实现功能。
+- 共享主 checkout 只用于认领、状态查询、只读检查和创建 worktree；实现、格式化、测试、提交及 push 必须在当前 Agent 自己的 worktree 中完成。创建 worktree 前先确认目标分支名和路径均未被其他 Agent 使用。
+- 推荐在认领成功后从最新目标分支创建 worktree：
+
+  ```bash
+  git fetch origin main
+  git worktree add ../calcit-issue-<number>-<agent-id> -b agent/issue-<number>-<agent-id> origin/main
+  ```
+
+  若 Issue 指定其他 base branch，使用 Issue 明确记录的 base；不得自行猜测。一个 Issue 修改多个仓库时，每个被修改仓库都建立独立 worktree，并在 Issue 的 `Owned scope` 中记录路径和分支。
+- 一个 worktree 在同一时间只服务一个 Issue 和一个 Agent。切换 Issue、租约转交或恢复旧任务时，不复用仍含另一任务状态的 worktree；先确认原任务已提交、推送并记录，或为新任务创建新的 worktree。
+- 不得删除、移动、清理或重置其他 Agent 的 worktree。当前 Agent 的 worktree 只有在关联 PR 已合并或关闭、Issue 已记录最终状态且确认没有未提交或未推送成果后才能清理。
+- 发现租约丢失、远端锁所有者改变或 Issue 被关闭时，立即停止写入并保留本地成果，不得强推。
+- 只读调查可以并行，但不得借只读任务修改代码、格式化文件或生成构建产物。
+
+### 完成、PR 与租约释放
+
+除“发布流程规范”中明确允许直接提交 `main` 的纯版本号 release commit 外，所有由 Issue 驱动的功能、修复、重构、测试、CI、文档和跨仓库改动，完成验证后都必须推送独立分支并创建关联 PR。仅推送分支、记录 commit URL 或在 Issue 留言都不能替代 PR，也不算进入 review。
+
+- PR 必须关联主 Issue，并在 PR 或 Issue 中记录 PR URL、head commit、base commit、改动仓库与路径、验证命令和结果。
+- 一个主 Issue 涉及多个仓库时，每个有改动的仓库都必须创建各自的 PR，并在主 Issue 汇总全部 PR；不能只为其中一个仓库创建 PR。
+- GitHub Wiki 仓库没有 PR 审查界面，是上述规则的唯一文档例外：Wiki 修改仍需独立 checkout、独立 commit 并直接 push 到 `calcit.wiki.git`，随后在主 Issue 和主仓库 PR 中记录 Wiki commit 与页面 URL；Wiki 正文不得复制回主仓库规避此例外。
+- 已合并或已关闭的 PR 不覆盖其 head 分支后来新增的提交。分支在 PR 合并或关闭后继续产生改动时，必须创建新的关联 PR；不得把旧 PR 当作这些提交已经 review 的证据。
+- 只有所需 PR 均已创建、最新提交均已推送且 Issue 已记录上述信息后，才能执行 `release ... review`。没有 PR 时，任务仍可交接则使用 `ready`；确实等待人员权限或外部依赖则使用 `blocked`，并说明分支、commit 和恢复方式。
+- 纯版本号 release commit 的直接 `main` 例外只适用于既有发布流程，不适用于夹带功能、修复、测试、CI 或文档改动的提交。
+
+满足以上条件后执行：
+
+```bash
+scripts/agent-issue-lease.sh release <issue-number> <agent-id> review
+```
+
+若任务仍可由其他 Agent 继续，使用 `ready`；若必须等待人或外部依赖，使用 `blocked`。Agent 异常退出后不需要人工删锁：租约过期时，下一个 `claim` 会用 compare-and-swap 接管，并在 Issue 中更新所有者。查看权威状态使用：
+
+```bash
+scripts/agent-issue-lease.sh status <issue-number>
+```
+
+### PR 创建后的持续跟进
+
+发出 PR 不代表任务结束。创建 PR 的 Agent 继续负责该 PR，直到合并、关闭或在 Issue 中明确完成交接：
+
+- PR 创建、最新提交推送并记录验证结果后，立即 `release ... review` 释放写入租约。Actions 或 review bot 仍在运行且没有可执行反馈时，不原地等待，可以认领下一个不冲突的 `agent:ready` Issue。
+- 一个 Agent 可以维护多个待审 PR 的观察列表，但同一时间只能持有一个 Issue 的写入租约。开始新任务不解除原 PR 的跟进责任。
+- 在认领新 Issue 前、完成一个实现检查点后、准备 push 前，以及距上次检查达到 10–15 分钟时，批量检查所有观察中的 PR。不要为单个 pending check 使用紧密轮询，也不使用会阻塞脚本的 `gh run watch`。
+- 至少使用 `gh pr checks <pr-number>` 检查 Actions，并用 `gh pr view <pr-number> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,reviews,comments` 查看总体状态；inline comments 另外通过 `gh api repos/{owner}/{repo}/pulls/<pr-number>/comments` 检查。
+- Actions 失败时先读取失败日志并判断是否由本 PR 引入；能修复的立即修复并重新验证，外部或偶发失败要在 PR 留下证据，不能只重跑后忽略。
+- 对每条有效 review 意见进行处理：修改代码或明确回复不修改的理由。不要只回复评论而遗漏对应代码、测试或文档更新。
+- Issue 处于 `agent:review` 且出现失败或修改请求时，优先于认领新的普通任务处理。若当前正持有另一个 Issue 的租约，先做到安全检查点并执行 `release ... ready`，再重新 `claim` 待审 Issue；不得同时持有两个写入租约。修复完成、推送并记录验证结果后，再 `release ... review`，随后可恢复之前释放的任务。
+- 所有必需 checks 成功且 review 意见已处理后，在 Issue/PR 留下最终状态。若暂时无法继续，标记 `agent:blocked` 并写清阻塞条件和恢复方式。
+- PR 合并或关闭后，确认没有残留的 `agent-lock/issue-<number>` 远端锁分支，再关闭或更新主 Issue；涉及关联仓库的 PR 必须逐个记录和确认。
+
+推荐调度优先级为：需要修改的既有 PR → 已认领且未完成的当前 Issue → 新的 `agent:ready` Issue → 仅等待中的 PR。等待中的 PR 只需要周期性批量巡检，不应占用 Agent 的主要执行时间。

--- a/editing-history/202609042309-agent-issue-leases.md
+++ b/editing-history/202609042309-agent-issue-leases.md
@@ -11,3 +11,5 @@
 - Agent ID 应包含足够长的任务/会话标识和随机后缀，避免多个任务共享短前缀时错误续租或释放彼此的锁。
 - 生态 Wiki 正文只维护在独立 `calcit-lang/calcit.wiki.git`，主仓库不保存 `docs/wiki/` 副本、同步 workflow 或发布脚本；主仓库仅链接 Wiki，并保留版本化契约文档作为 source of truth。
 - `release` 先原子删除权威 lock ref，再更新 Issue 标签；若标签更新中断，后续 claim 可修复无锁的陈旧 `agent:claimed` 状态，避免出现“已 review 但锁仍有效”的误导状态。
+- Lease commit 使用稳定空 tree；首次 claim 创建无 parent 的 metadata-only 根提交，heartbeat 与过期接管才把前一 lock commit 作为唯一 parent。这样本地 dirty/unpublished HEAD 的 tree、commit 和 ancestor objects 都不会经 `agent-lock/*` ref 发布。
+- `status` 在格式化时间前验证 `claimed_at`、`heartbeat_at`、`expires_at`，损坏元数据会显示 `CORRUPT` 和原始字段并以非零状态退出，便于人工诊断。

--- a/editing-history/202609042309-agent-issue-leases.md
+++ b/editing-history/202609042309-agent-issue-leases.md
@@ -1,0 +1,13 @@
+# Agent Issue leases
+
+- 将 `calcit-lang/calcit` Issues 定义为主项目和所有关联仓库工作的唯一协调状态源。
+- 使用远端 `agent-lock/issue-<number>` Git ref 提供原子认领；Issue 标签与单条可更新评论只作为可见镜像。
+- 租约默认 45 分钟，支持心跳、过期后的 `--force-with-lease` 原子接管，以及 `ready`、`review`、`blocked` 三种释放结果。
+- Issue 表单要求预先声明跨仓库修改范围、排除项、依赖关系和验收命令，以便并行 Agent 在写入前发现范围冲突。
+- 仓库只需一次 `init` 创建状态标签；后续认领、心跳和释放都会修复标签与锁不一致的常见中断状态。
+- PR 创建后仍由发起 Agent 持续关注 Actions、review 和 inline comments；需要修改时可从 `agent:review` 重新认领，修复推送后再释放回 review。
+- 调度采用“单写锁、多 PR 观察”：CI/bot review 等待期立即释放租约并领取下一任务，在任务检查点批量巡检待审 PR；出现可执行反馈时再安全切换回原 Issue。
+- 写入 Agent 必须按 Issue 使用独立分支和独立 worktree；共享 checkout 只做认领、查询和只读协调。除纯版本号发布提交外，所有实现、CI、测试和文档改动都必须有覆盖最新提交的 PR。
+- Agent ID 应包含足够长的任务/会话标识和随机后缀，避免多个任务共享短前缀时错误续租或释放彼此的锁。
+- 生态 Wiki 正文只维护在独立 `calcit-lang/calcit.wiki.git`，主仓库不保存 `docs/wiki/` 副本、同步 workflow 或发布脚本；主仓库仅链接 Wiki，并保留版本化契约文档作为 source of truth。
+- `release` 先原子删除权威 lock ref，再更新 Issue 标签；若标签更新中断，后续 claim 可修复无锁的陈旧 `agent:claimed` 状态，避免出现“已 review 但锁仍有效”的误导状态。

--- a/scripts/agent-issue-lease.sh
+++ b/scripts/agent-issue-lease.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+remote="${AGENT_LEASE_REMOTE:-origin}"
+default_ttl="${AGENT_LEASE_TTL_MINUTES:-45}"
+lock_prefix="refs/heads/agent-lock/issue-"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/agent-issue-lease.sh init
+  scripts/agent-issue-lease.sh claim ISSUE AGENT_ID [SCOPE] [TTL_MINUTES]
+  scripts/agent-issue-lease.sh heartbeat ISSUE AGENT_ID [TTL_MINUTES]
+  scripts/agent-issue-lease.sh release ISSUE AGENT_ID [ready|review|blocked]
+  scripts/agent-issue-lease.sh status ISSUE
+
+The remote agent-lock branch is the ownership source of truth. GitHub Issue
+labels and the lease comment are a human-readable mirror of that lock.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+validate_issue() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]] || die "ISSUE must be a positive integer"
+}
+
+validate_agent() {
+  [[ "${1:-}" =~ ^[A-Za-z0-9._-]+$ ]] || die "AGENT_ID may contain only letters, digits, dot, underscore, and dash"
+}
+
+validate_ttl() {
+  [[ "${1:-}" =~ ^[0-9]+$ ]] || die "TTL_MINUTES must be an integer"
+  (( $1 >= 5 && $1 <= 240 )) || die "TTL_MINUTES must be between 5 and 240"
+}
+
+iso_time() {
+  if date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
+  else
+    date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ'
+  fi
+}
+
+remote_sha() {
+  git ls-remote --heads "$remote" "$1" | awk 'NR == 1 { print $1 }'
+}
+
+fetch_lock() {
+  git fetch --quiet "$remote" "$1"
+}
+
+field() {
+  git show -s --format=%B "$1" | sed -n "s/^$2=//p" | head -n 1
+}
+
+make_lock_commit() {
+  local issue="$1" agent="$2" claimed="$3" expires="$4" scope="$5" parent="$6"
+  local tree message
+  tree="$(git rev-parse HEAD^{tree})"
+  message="agent-lease-v1
+issue=$issue
+agent_id=$agent
+claimed_at=$claimed
+heartbeat_at=$(date +%s)
+expires_at=$expires
+scope=$scope"
+
+  GIT_AUTHOR_NAME="Calcit Agent Lease" \
+  GIT_AUTHOR_EMAIL="agent-lease@calcit-lang.invalid" \
+  GIT_COMMITTER_NAME="Calcit Agent Lease" \
+  GIT_COMMITTER_EMAIL="agent-lease@calcit-lang.invalid" \
+    git commit-tree "$tree" -p "$parent" <<<"$message"
+}
+
+repo_slug() {
+  gh repo view --json nameWithOwner --jq .nameWithOwner
+}
+
+ensure_labels() {
+  local repo="$1"
+  gh label create agent:ready --repo "$repo" --color 1D76DB --description "Available for an agent" --force >/dev/null
+  gh label create agent:claimed --repo "$repo" --color FBCA04 --description "Held by an active agent lease" --force >/dev/null
+  gh label create agent:review --repo "$repo" --color 0E8A16 --description "Implementation ready for review" --force >/dev/null
+  gh label create agent:blocked --repo "$repo" --color D93F0B --description "Waiting for human input or a dependency" --force >/dev/null
+}
+
+issue_has_label() {
+  gh issue view "$1" --repo "$2" --json labels --jq '.labels[].name' | grep -Fxq "$3"
+}
+
+require_claimable_issue() {
+  local issue="$1" repo="$2" state
+  state="$(gh issue view "$issue" --repo "$repo" --json state --jq .state)"
+  [[ "$state" == "OPEN" ]] || die "issue #$issue is not open"
+  if issue_has_label "$issue" "$repo" agent:ready; then
+    return
+  fi
+  # A review Issue may be reclaimed to address failed checks or feedback.
+  if issue_has_label "$issue" "$repo" agent:review; then
+    return
+  fi
+  # A claimed label without a lock is a recoverable partial update from an
+  # interrupted release. The Git ref remains the ownership authority.
+  if issue_has_label "$issue" "$repo" agent:claimed; then
+    echo "WARN: repairing stale agent:claimed label without a lock" >&2
+    return
+  fi
+  die "issue #$issue is neither agent:ready nor agent:review"
+}
+
+set_issue_state() {
+  local issue="$1" repo="$2" target="$3"
+  gh issue edit "$issue" --repo "$repo" \
+    --remove-label agent:ready --remove-label agent:claimed \
+    --remove-label agent:review --remove-label agent:blocked \
+    --add-label "agent:$target" >/dev/null
+}
+
+upsert_comment() {
+  local issue="$1" repo="$2" body="$3" marker comment_id endpoint
+  marker="<!-- agent-lease:$issue -->"
+  endpoint="repos/$repo/issues/$issue/comments"
+  comment_id="$(gh api "$endpoint" --paginate --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n 1)"
+  if [[ -n "$comment_id" ]]; then
+    gh api --method PATCH "repos/$repo/issues/comments/$comment_id" -f body="$body" >/dev/null
+  else
+    gh api --method POST "$endpoint" -f body="$body" >/dev/null
+  fi
+}
+
+sync_claimed_issue() {
+  local issue="$1" repo="$2" agent="$3" claimed="$4" heartbeat="$5" expires="$6" scope="$7" sha="$8"
+  local body
+  set_issue_state "$issue" "$repo" claimed
+  body="<!-- agent-lease:$issue -->
+### Active agent lease
+
+- Agent: \`$agent\`
+- Claimed: $(iso_time "$claimed")
+- Heartbeat: $(iso_time "$heartbeat")
+- Expires: $(iso_time "$expires")
+- Scope: \`$scope\`
+- Lock: \`${sha:0:12}\`
+
+This comment is maintained by \`scripts/agent-issue-lease.sh\`. The remote lock branch is authoritative."
+  upsert_comment "$issue" "$repo" "$body"
+}
+
+command_init() {
+  local repo
+  repo="$(repo_slug)"
+  ensure_labels "$repo"
+  echo "INITIALIZED $repo agent labels"
+}
+
+command_claim() {
+  local issue="$1" agent="$2" scope="${3:-repository scope declared in issue}" ttl="${4:-$default_ttl}"
+  local ref old_sha now expires claimed old_agent old_expires new_sha repo result
+  validate_issue "$issue"
+  validate_agent "$agent"
+  validate_ttl "$ttl"
+  [[ "$scope" != *$'\n'* ]] || die "SCOPE must be one line"
+  git rev-parse --is-inside-work-tree >/dev/null
+  git remote get-url "$remote" >/dev/null
+
+  ref="${lock_prefix}${issue}"
+  old_sha="$(remote_sha "$ref")"
+  now="$(date +%s)"
+  expires="$((now + ttl * 60))"
+  repo="$(repo_slug)"
+  ensure_labels "$repo"
+
+  if [[ -z "$old_sha" ]]; then
+    require_claimable_issue "$issue" "$repo"
+    claimed="$now"
+    new_sha="$(make_lock_commit "$issue" "$agent" "$claimed" "$expires" "$scope" "$(git rev-parse HEAD)")"
+    if ! result="$(git push "$remote" "$new_sha:$ref" 2>&1)"; then
+      echo "$result" >&2
+      die "claim race lost; inspect the current owner with: $0 status $issue"
+    fi
+    sync_claimed_issue "$issue" "$repo" "$agent" "$claimed" "$now" "$expires" "$scope" "$new_sha"
+    echo "CLAIMED issue #$issue by $agent until $(iso_time "$expires")"
+    return
+  fi
+
+  fetch_lock "$ref"
+  old_agent="$(field "$old_sha" agent_id)"
+  old_expires="$(field "$old_sha" expires_at)"
+  [[ "$old_expires" =~ ^[0-9]+$ ]] || die "remote lock has invalid metadata; human repair required"
+
+  if [[ "$old_agent" == "$agent" ]]; then
+    claimed="$(field "$old_sha" claimed_at)"
+  elif (( old_expires <= now )); then
+    claimed="$now"
+    echo "WARN: taking over expired lease from $old_agent" >&2
+  else
+    die "issue #$issue is held by $old_agent until $(iso_time "$old_expires")"
+  fi
+
+  new_sha="$(make_lock_commit "$issue" "$agent" "$claimed" "$expires" "$scope" "$old_sha")"
+  git push --force-with-lease="$ref:$old_sha" "$remote" "$new_sha:$ref" >/dev/null
+  sync_claimed_issue "$issue" "$repo" "$agent" "$claimed" "$now" "$expires" "$scope" "$new_sha"
+  echo "RENEWED issue #$issue by $agent until $(iso_time "$expires")"
+}
+
+command_heartbeat() {
+  local issue="$1" agent="$2" ttl="${3:-$default_ttl}"
+  local ref old_sha old_agent claimed scope now expires new_sha repo
+  validate_issue "$issue"
+  validate_agent "$agent"
+  validate_ttl "$ttl"
+  ref="${lock_prefix}${issue}"
+  old_sha="$(remote_sha "$ref")"
+  [[ -n "$old_sha" ]] || die "issue #$issue has no active lock"
+  fetch_lock "$ref"
+  old_agent="$(field "$old_sha" agent_id)"
+  [[ "$old_agent" == "$agent" ]] || die "issue #$issue is held by $old_agent, not $agent"
+  claimed="$(field "$old_sha" claimed_at)"
+  scope="$(field "$old_sha" scope)"
+  now="$(date +%s)"
+  expires="$((now + ttl * 60))"
+  new_sha="$(make_lock_commit "$issue" "$agent" "$claimed" "$expires" "$scope" "$old_sha")"
+  git push --force-with-lease="$ref:$old_sha" "$remote" "$new_sha:$ref" >/dev/null
+  repo="$(repo_slug)"
+  ensure_labels "$repo"
+  sync_claimed_issue "$issue" "$repo" "$agent" "$claimed" "$now" "$expires" "$scope" "$new_sha"
+  echo "HEARTBEAT issue #$issue by $agent until $(iso_time "$expires")"
+}
+
+command_release() {
+  local issue="$1" agent="$2" target="${3:-review}"
+  local ref old_sha old_agent repo body
+  validate_issue "$issue"
+  validate_agent "$agent"
+  [[ "$target" =~ ^(ready|review|blocked)$ ]] || die "release state must be ready, review, or blocked"
+  ref="${lock_prefix}${issue}"
+  old_sha="$(remote_sha "$ref")"
+  [[ -n "$old_sha" ]] || die "issue #$issue has no active lock"
+  fetch_lock "$ref"
+  old_agent="$(field "$old_sha" agent_id)"
+  [[ "$old_agent" == "$agent" ]] || die "issue #$issue is held by $old_agent, not $agent"
+
+  repo="$(repo_slug)"
+  ensure_labels "$repo"
+  git push --force-with-lease="$ref:$old_sha" "$remote" ":$ref" >/dev/null
+  # Delete the authoritative lock before updating its human-readable mirror.
+  # If the Issue update is interrupted, the next claim can repair a stale label;
+  # the inverse ordering could advertise review while a write lease still exists.
+  set_issue_state "$issue" "$repo" "$target"
+  body="<!-- agent-lease:$issue -->
+### Agent lease released
+
+- Last agent: \`$agent\`
+- Released: $(iso_time "$(date +%s)")
+- Resulting state: \`agent:$target\`
+
+The issue currently has no active write lease."
+  upsert_comment "$issue" "$repo" "$body"
+  echo "RELEASED issue #$issue by $agent to agent:$target"
+}
+
+command_status() {
+  local issue="$1" ref sha now agent expires claimed heartbeat scope state
+  validate_issue "$issue"
+  ref="${lock_prefix}${issue}"
+  sha="$(remote_sha "$ref")"
+  if [[ -z "$sha" ]]; then
+    echo "UNLOCKED issue #$issue"
+    return
+  fi
+  fetch_lock "$ref"
+  agent="$(field "$sha" agent_id)"
+  expires="$(field "$sha" expires_at)"
+  claimed="$(field "$sha" claimed_at)"
+  heartbeat="$(field "$sha" heartbeat_at)"
+  scope="$(field "$sha" scope)"
+  now="$(date +%s)"
+  state="ACTIVE"
+  if [[ "$expires" =~ ^[0-9]+$ ]] && (( expires <= now )); then
+    state="EXPIRED"
+  fi
+  printf '%s issue #%s\nagent=%s\nclaimed=%s\nheartbeat=%s\nexpires=%s\nscope=%s\nlock=%s\n' \
+    "$state" "$issue" "$agent" "$(iso_time "$claimed")" "$(iso_time "$heartbeat")" \
+    "$(iso_time "$expires")" "$scope" "$sha"
+}
+
+command="${1:-}"
+case "$command" in
+  init)
+    [[ $# -eq 1 ]] || { usage >&2; exit 2; }
+    command_init
+    ;;
+  claim)
+    (( $# >= 3 && $# <= 5 )) || { usage >&2; exit 2; }
+    command_claim "$2" "$3" "${4:-}" "${5:-$default_ttl}"
+    ;;
+  heartbeat)
+    (( $# >= 3 && $# <= 4 )) || { usage >&2; exit 2; }
+    command_heartbeat "$2" "$3" "${4:-$default_ttl}"
+    ;;
+  release)
+    (( $# >= 3 && $# <= 4 )) || { usage >&2; exit 2; }
+    command_release "$2" "$3" "${4:-review}"
+    ;;
+  status)
+    [[ $# -eq 2 ]] || { usage >&2; exit 2; }
+    command_status "$2"
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/agent-issue-lease.sh
+++ b/scripts/agent-issue-lease.sh
@@ -59,9 +59,11 @@ field() {
 }
 
 make_lock_commit() {
-  local issue="$1" agent="$2" claimed="$3" expires="$4" scope="$5" parent="$6"
+  local issue="$1" agent="$2" claimed="$3" expires="$4" scope="$5" parent="${6:-}"
   local tree message
-  tree="$(git rev-parse HEAD^{tree})"
+  # Lease refs must never publish the caller's repository tree or HEAD ancestry.
+  # `git mktree` with empty input produces Git's stable empty tree object.
+  tree="$(git mktree </dev/null)"
   message="agent-lease-v1
 issue=$issue
 agent_id=$agent
@@ -70,11 +72,19 @@ heartbeat_at=$(date +%s)
 expires_at=$expires
 scope=$scope"
 
-  GIT_AUTHOR_NAME="Calcit Agent Lease" \
-  GIT_AUTHOR_EMAIL="agent-lease@calcit-lang.invalid" \
-  GIT_COMMITTER_NAME="Calcit Agent Lease" \
-  GIT_COMMITTER_EMAIL="agent-lease@calcit-lang.invalid" \
-    git commit-tree "$tree" -p "$parent" <<<"$message"
+  if [[ -n "$parent" ]]; then
+    GIT_AUTHOR_NAME="Calcit Agent Lease" \
+    GIT_AUTHOR_EMAIL="agent-lease@calcit-lang.invalid" \
+    GIT_COMMITTER_NAME="Calcit Agent Lease" \
+    GIT_COMMITTER_EMAIL="agent-lease@calcit-lang.invalid" \
+      git commit-tree "$tree" -p "$parent" <<<"$message"
+  else
+    GIT_AUTHOR_NAME="Calcit Agent Lease" \
+    GIT_AUTHOR_EMAIL="agent-lease@calcit-lang.invalid" \
+    GIT_COMMITTER_NAME="Calcit Agent Lease" \
+    GIT_COMMITTER_EMAIL="agent-lease@calcit-lang.invalid" \
+      git commit-tree "$tree" <<<"$message"
+  fi
 }
 
 repo_slug() {
@@ -178,7 +188,7 @@ command_claim() {
   if [[ -z "$old_sha" ]]; then
     require_claimable_issue "$issue" "$repo"
     claimed="$now"
-    new_sha="$(make_lock_commit "$issue" "$agent" "$claimed" "$expires" "$scope" "$(git rev-parse HEAD)")"
+    new_sha="$(make_lock_commit "$issue" "$agent" "$claimed" "$expires" "$scope")"
     if ! result="$(git push "$remote" "$new_sha:$ref" 2>&1)"; then
       echo "$result" >&2
       die "claim race lost; inspect the current owner with: $0 status $issue"
@@ -279,6 +289,11 @@ command_status() {
   claimed="$(field "$sha" claimed_at)"
   heartbeat="$(field "$sha" heartbeat_at)"
   scope="$(field "$sha" scope)"
+  if [[ ! "$claimed" =~ ^[0-9]+$ || ! "$heartbeat" =~ ^[0-9]+$ || ! "$expires" =~ ^[0-9]+$ ]]; then
+    printf 'CORRUPT issue #%s\nagent=%s\nclaimed_at=%s\nheartbeat_at=%s\nexpires_at=%s\nscope=%s\nlock=%s\n' \
+      "$issue" "$agent" "$claimed" "$heartbeat" "$expires" "$scope" "$sha"
+    return 1
+  fi
   now="$(date +%s)"
   state="ACTIVE"
   if [[ "$expires" =~ ^[0-9]+$ ]] && (( expires <= now )); then


### PR DESCRIPTION
## Outcome / 结果

- Formalize Issue leasing, dedicated worktrees, mandatory non-release PR delivery, release-manager responsibilities, and PR follow-up in `AGENTS.md`.
- Add an Agent-ready Issue Form with owned scope, dependencies, acceptance checks, validation evidence, dedicated-worktree, and PR requirements.
- Add the atomic `agent-lock/issue-*` lease helper and its editing history.
- Keep ecosystem Wiki bodies outside the main repository. This PR intentionally excludes `docs/wiki/**`, `publish-wiki.yml`, and `publish-ecosystem-wiki.sh`.

## Repository boundary / 仓库边界

The Wiki pages are prepared in an independent `calcit.wiki.git` checkout. GitHub has not materialized that remote because its first page must be created on the signed-in web UI; Wiki commit and page URLs will be added to #654 after that initialization. No Wiki body or mirroring automation is included here.

## Validation / 验证

- `bash -n scripts/agent-issue-lease.sh`
- usage path: exits 2 and prints `Usage` plus all commands
- `scripts/agent-issue-lease.sh status 654`: active lease metadata parsed successfully
- Ruby/Psych YAML parse: Issue Form fields present and IDs unique
- `git diff --check`
- excluded Wiki paths absent from this branch

Head: `69c13053ef93081c2f9725105e52f3932dde2090`  
Base: `50971e23ffffab83957d189543d6c2fe971bdd8d`

Relates to #654.
