### PR TITLE
feat: default strict JS FFI policy to error

### DIFF
--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -77,6 +77,18 @@ or `:error` to reject them during preprocessing:
   :js-ffi :error
 ```
 
+When `--strict-types` is present and the selected entry omits `:js-ffi`, the
+effective in-memory default is `:error`; running the check never rewrites the
+Snapshot. An explicitly configured `:allow` or `:warn` remains available while
+migrating an older entry. Inspect and update the selected entry without hand
+editing the Snapshot:
+
+```bash
+calcit config show
+calcit config set feature-policy.js-ffi error
+calcit config set --entry browser feature-policy.js-ffi warn
+```
+
 The gate applies to `js/...`, JavaScript syntax such as `new` and `js-await`,
 native `.-`/`.!` access, typed external-object access, and host
 `unsafe-coerce`. It is lexical: a normal function may call a typed FFI wrapper

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -149,6 +149,12 @@ calcit --check-only --strict-types
 calcit --strict-types js
 ```
 
+If the selected entry omits `:feature-policy :js-ffi`, strict mode uses
+`:error` as its effective in-memory default without rewriting the Snapshot.
+Older entries may opt into a staged migration explicitly with
+`calcit config set feature-policy.js-ffi warn` (or `allow`); use
+`calcit config show` to audit the selected policy.
+
 The flag enables the location-aware untyped JS FFI diagnostics from
 `--warn-dyn-method`, then runs the zero-baseline static quality gate before
 execution or code generation. It rejects unresolved or schema `Dynamic`, code

--- a/editing-history/202609041625-strict-js-ffi-policy.md
+++ b/editing-history/202609041625-strict-js-ffi-policy.md
@@ -1,0 +1,6 @@
+# Strict JS FFI feature-policy default
+
+- `--strict-types` now gives a selected entry with no explicit `js-ffi` feature policy an in-memory `Error` default. It does not rewrite the project Snapshot.
+- Explicit `allow`, `warn`, and `error` values remain intact, so existing projects can make their migration choice visible instead of depending on the compatibility default.
+- `calcit config show` now displays feature policies deterministically, and `calcit config set feature-policy.<name> allow|warn|error` validates and persists a selected entry policy.
+- Focused tests cover compatibility behavior, strict defaulting, explicit-policy preservation, deterministic display, persistence, and rejection without partial writes.

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -62,6 +62,15 @@ fn format_type_slots(type_slots: &std::collections::HashMap<String, String>) -> 
   format!("{{{}}}", pairs.join(", "))
 }
 
+fn format_feature_policy(feature_policy: &HashMap<String, snapshot::FeaturePolicy>) -> String {
+  let mut pairs = feature_policy
+    .iter()
+    .map(|(feature, policy)| format!(":{feature} -> :{}", policy.as_str()))
+    .collect::<Vec<_>>();
+  pairs.sort();
+  format!("{{{}}}", pairs.join(", "))
+}
+
 fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String> {
   let snapshot = load_snapshot_for_display(input_path)?;
 
@@ -79,6 +88,7 @@ fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String>
     println!("  {}: {}", "description".cyan(), entry.description);
     println!("  {}: {:?}", "modules".cyan(), entry.modules);
     println!("  {}: {}", "type_slots".cyan(), format_type_slots(&entry.type_slots));
+    println!("  {}: {}", "feature_policy".cyan(), format_feature_policy(&entry.feature_policy));
     return Ok(());
   }
 
@@ -103,6 +113,7 @@ fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String>
     println!("    {}: {}", "description".cyan(), entry.description);
     println!("    {}: {:?}", "modules".cyan(), entry.modules);
     println!("    {}: {}", "type_slots".cyan(), format_type_slots(&entry.type_slots));
+    println!("    {}: {}", "feature_policy".cyan(), format_feature_policy(&entry.feature_policy));
   }
 
   Ok(())
@@ -250,9 +261,28 @@ fn handle_set(opts: &ConfigSetCommand, snapshot_file: &str) -> Result<(), String
       entry.description = opts.value.clone();
       format!("{} Set [{entry_label}] description = '{}'", "✓".green(), opts.value)
     }
+    key if key.starts_with("feature-policy.") => {
+      let feature = key.trim_start_matches("feature-policy.").trim().trim_start_matches(':');
+      if feature.is_empty() {
+        return Err("Feature policy key must name a feature, for example `feature-policy.js-ffi`".to_owned());
+      }
+      let policy = match opts.value.trim().trim_start_matches(':') {
+        "allow" => snapshot::FeaturePolicy::Allow,
+        "warn" => snapshot::FeaturePolicy::Warn,
+        "error" => snapshot::FeaturePolicy::Error,
+        value => return Err(format!("Unknown feature policy '{value}'. Valid policies: allow, warn, error")),
+      };
+      entry.feature_policy.insert(feature.to_owned(), policy);
+      format!(
+        "{} Set [{entry_label}] feature policy ':{}' = ':{}'",
+        "✓".green(),
+        feature.cyan(),
+        policy.as_str()
+      )
+    }
     _ => {
       return Err(format!(
-        "Unknown config key '{}'. Valid keys: mode, init-fn, reload-fn, description, version (accepts semver string or patch|minor|major)",
+        "Unknown config key '{}'. Valid keys: mode, init-fn, reload-fn, description, feature-policy.<name>, version (accepts semver string or patch|minor|major)",
         opts.key
       ));
     }
@@ -491,6 +521,53 @@ mod tests {
       err.contains("caps version bump patch /missing-project/deps.cirru"),
       "unexpected error: {err}"
     );
+  }
+
+  #[test]
+  fn config_set_feature_policy_validates_and_persists_the_selected_entry() {
+    let source = "{} (:package |demo)\n  :entries $ {}\n    :default $ {} (:mode :js) (:init-fn |app.main/main!) (:reload-fn |app.main/reload!)\n      :modules $ []\n      :feature-policy $ {}\n  :files $ {}\n";
+    let temp_path = std::env::temp_dir().join(format!("calcit-feature-policy-{}.cirru", std::process::id()));
+    fs::write(&temp_path, source).expect("write fixture");
+    let path = temp_path.to_string_lossy();
+
+    handle_set(
+      &ConfigSetCommand {
+        entry: None,
+        key: "feature-policy.js-ffi".to_owned(),
+        value: ":warn".to_owned(),
+      },
+      &path,
+    )
+    .expect("set JS FFI policy");
+    let saved = load_snapshot_for_display(&path).expect("reload configured snapshot");
+    assert_eq!(
+      saved.active_entry().unwrap().feature_policy.get("js-ffi"),
+      Some(&snapshot::FeaturePolicy::Warn)
+    );
+
+    let before_invalid = fs::read_to_string(&temp_path).expect("read configured fixture");
+    let error = handle_set(
+      &ConfigSetCommand {
+        entry: None,
+        key: "feature-policy.js-ffi".to_owned(),
+        value: "maybe".to_owned(),
+      },
+      &path,
+    )
+    .expect_err("unknown policy should fail before writing");
+    assert!(error.contains("Valid policies: allow, warn, error"));
+    assert_eq!(fs::read_to_string(&temp_path).expect("read unchanged fixture"), before_invalid);
+
+    fs::remove_file(temp_path).expect("remove fixture");
+  }
+
+  #[test]
+  fn feature_policy_display_is_deterministic() {
+    let policies = HashMap::from([
+      ("zeta".to_owned(), snapshot::FeaturePolicy::Warn),
+      ("js-ffi".to_owned(), snapshot::FeaturePolicy::Error),
+    ]);
+    assert_eq!(format_feature_policy(&policies), "{:js-ffi -> :error, :zeta -> :warn}");
   }
 
   #[test]

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -464,6 +464,7 @@ fn run_cli() -> Result<(), String> {
       calcit::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
     }
   }
+  apply_strict_feature_policy_defaults(&mut snapshot, cli_args.strict_types)?;
   let selected_entry = snapshot.active_entry()?.clone();
   let configured_run_mode = selected_entry.mode;
   let config_init = selected_entry.init_fn;
@@ -1124,6 +1125,25 @@ fn compiled_test_depends_on(
 
 fn should_emit_js(subcommand: &Option<CalcitCommand>, configured_run_mode: snapshot::SnapshotRunMode) -> bool {
   matches!(subcommand, Some(CalcitCommand::EmitJs(_))) || (subcommand.is_none() && configured_run_mode == snapshot::SnapshotRunMode::Js)
+}
+
+/// Strict mode is an explicit opt-in, so a missing JS FFI policy can safely
+/// become an in-memory error default without rewriting an existing Snapshot.
+/// An entry that deliberately declares allow/warn/error keeps that choice.
+fn apply_strict_feature_policy_defaults(snapshot: &mut snapshot::Snapshot, strict_types: bool) -> Result<(), String> {
+  if !strict_types {
+    return Ok(());
+  }
+  let entry_name = snapshot.active_entry_name().to_owned();
+  let entry = snapshot
+    .entries
+    .get_mut(&entry_name)
+    .ok_or_else(|| format!("Entry '{entry_name}' not found"))?;
+  entry
+    .feature_policy
+    .entry("js-ffi".to_owned())
+    .or_insert(snapshot::FeaturePolicy::Error);
+  Ok(())
 }
 
 fn run_js_escape(symbol: &str) -> Result<(), String> {
@@ -1949,6 +1969,36 @@ mod tests {
       })),
       snapshot::SnapshotRunMode::Js,
     ));
+  }
+
+  #[test]
+  fn strict_types_default_missing_js_ffi_policy_to_error_without_overriding_explicit_choices() {
+    let mut compatibility = snapshot::Snapshot::default();
+    apply_strict_feature_policy_defaults(&mut compatibility, false).expect("compatibility policy");
+    assert!(!compatibility.active_entry().unwrap().feature_policy.contains_key("js-ffi"));
+
+    let mut strict_default = snapshot::Snapshot::default();
+    apply_strict_feature_policy_defaults(&mut strict_default, true).expect("strict policy");
+    assert_eq!(
+      strict_default.active_entry().unwrap().feature_policy.get("js-ffi"),
+      Some(&snapshot::FeaturePolicy::Error)
+    );
+
+    for policy in [
+      snapshot::FeaturePolicy::Allow,
+      snapshot::FeaturePolicy::Warn,
+      snapshot::FeaturePolicy::Error,
+    ] {
+      let mut configured = snapshot::Snapshot::default();
+      configured
+        .entries
+        .get_mut(snapshot::DEFAULT_ENTRY_NAME)
+        .unwrap()
+        .feature_policy
+        .insert("js-ffi".to_owned(), policy);
+      apply_strict_feature_policy_defaults(&mut configured, true).expect("explicit policy");
+      assert_eq!(configured.active_entry().unwrap().feature_policy.get("js-ffi"), Some(&policy));
+    }
   }
 
   #[test]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -2474,7 +2474,7 @@ pub enum ConfigSubcommand {
   /// show or bump the project version (omit value to show; use patch|minor|major to bump; or pass a semver string)
   /// [Deprecated] prefer `caps version get/set/bump` which manages `deps.cirru :version`
   Version(ConfigVersionCommand),
-  /// set a configuration key to a value (mode, init-fn, reload-fn, description, version)
+  /// set a configuration key to a value (mode, init-fn, reload-fn, description, feature-policy.<name>, version)
   Set(ConfigSetCommand),
   /// add a module path to an entry's modules
   AddModule(ConfigAddModuleCommand),
@@ -2524,12 +2524,12 @@ pub struct ConfigVersionCommand {
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 #[argh(subcommand, name = "set")]
-/// set a configuration key (mode, init-fn, reload-fn, description, version)
+/// set a configuration key (mode, init-fn, reload-fn, description, feature-policy.<name>, version)
 pub struct ConfigSetCommand {
   /// apply to a named entry (e.g. "test"); defaults to "default" (version is always project-level)
   #[argh(option)]
   pub entry: Option<String>,
-  /// config key: mode, init-fn, reload-fn, description, version ([Deprecated] prefer `caps version`)
+  /// config key: mode, init-fn, reload-fn, description, feature-policy.<name>, version ([Deprecated] prefer `caps version`)
   #[argh(positional)]
   pub key: String,
   /// config value; for "version" accepts semver string or patch|minor|major


### PR DESCRIPTION
## Summary

- default a missing `js-ffi` feature policy to `error` in memory when `--strict-types` is active
- preserve explicit `allow`, `warn`, and `error` choices for staged migration
- expose deterministic feature-policy output and `config set feature-policy.<name>` controls
- document strict defaults and migration commands

## Validation

Local macOS checks are supplemental only:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -- --test-threads=1` (705 lib + 298 CLI + 23 WASM)
- `yarn check-all`

Primary acceptance: GitHub Actions `Test` on `ubuntu-latest`.

Closes #659
Advances #581