### PR TITLE
Harden agent lease follow-ups / 加固 Agent 租约后续路径

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ npm view @calcit/procs version
 
 - PR 必须关联主 Issue，并在 PR 或 Issue 中记录 PR URL、head commit、base commit、改动仓库与路径、验证命令和结果。
 - 一个主 Issue 涉及多个仓库时，每个有改动的仓库都必须创建各自的 PR，并在主 Issue 汇总全部 PR；不能只为其中一个仓库创建 PR。
-- GitHub Wiki 仓库没有 PR 审查界面，是上述规则的唯一文档例外：Wiki 修改仍需独立 checkout、独立 commit 并直接 push 到 `calcit.wiki.git`，随后在主 Issue 和主仓库 PR 中记录 Wiki commit 与页面 URL；Wiki 正文不得复制回主仓库规避此例外。
+- GitHub Wiki 仓库没有 PR 审查界面，是上述规则的唯一文档例外：Wiki 修改仍需独立 checkout、独立 commit 并直接 push 到 `calcit.wiki.git`，随后始终在主 Issue 中记录 Wiki commit 与页面 URL；只有任务同时存在主仓库 PR 时，才在该 PR 中重复记录。Wiki 正文不得复制回主仓库规避此例外。
 - 已合并或已关闭的 PR 不覆盖其 head 分支后来新增的提交。分支在 PR 合并或关闭后继续产生改动时，必须创建新的关联 PR；不得把旧 PR 当作这些提交已经 review 的证据。
 - 只有所需 PR 均已创建、最新提交均已推送且 Issue 已记录上述信息后，才能执行 `release ... review`。没有 PR 时，任务仍可交接则使用 `ready`；确实等待人员权限或外部依赖则使用 `blocked`，并说明分支、commit 和恢复方式。
 - 纯版本号 release commit 的直接 `main` 例外只适用于既有发布流程，不适用于夹带功能、修复、测试、CI 或文档改动的提交。

--- a/editing-history/202609042309-agent-issue-leases.md
+++ b/editing-history/202609042309-agent-issue-leases.md
@@ -10,6 +10,6 @@
 - 写入 Agent 必须按 Issue 使用独立分支和独立 worktree；共享 checkout 只做认领、查询和只读协调。除纯版本号发布提交外，所有实现、CI、测试和文档改动都必须有覆盖最新提交的 PR。
 - Agent ID 应包含足够长的任务/会话标识和随机后缀，避免多个任务共享短前缀时错误续租或释放彼此的锁。
 - 生态 Wiki 正文只维护在独立 `calcit-lang/calcit.wiki.git`，主仓库不保存 `docs/wiki/` 副本、同步 workflow 或发布脚本；主仓库仅链接 Wiki，并保留版本化契约文档作为 source of truth。
-- `release` 先原子删除权威 lock ref，再更新 Issue 标签；若标签更新中断，后续 claim 可修复无锁的陈旧 `agent:claimed` 状态，避免出现“已 review 但锁仍有效”的误导状态。
+- `release` 先原子删除权威 lock ref，再更新 Issue 标签；同步完成后重新读取 ref，若期间已有新 claim，则用新锁元数据修复 Issue 镜像。若标签更新中断，后续 claim 仍可修复无锁的陈旧 `agent:claimed` 状态，避免旧 release 覆盖新 owner 或出现“已 review 但锁仍有效”的误导状态。
 - Lease commit 使用稳定空 tree；首次 claim 创建无 parent 的 metadata-only 根提交，heartbeat 与过期接管才把前一 lock commit 作为唯一 parent。这样本地 dirty/unpublished HEAD 的 tree、commit 和 ancestor objects 都不会经 `agent-lock/*` ref 发布。
 - `status` 在格式化时间前验证 `claimed_at`、`heartbeat_at`、`expires_at`，损坏元数据会显示 `CORRUPT` 和原始字段并以非零状态退出，便于人工诊断。

--- a/editing-history/202609050130-lease-review-followup.md
+++ b/editing-history/202609050130-lease-review-followup.md
@@ -1,0 +1,15 @@
+# Lease review follow-up
+
+2026-09-05 01:30 CST
+
+## English
+
+- Revalidate an Issue before an existing lease is renewed, taken over, or heartbeated.
+- After release-side Issue synchronization, re-read the authoritative lock ref and repair the visible mirror if a newer claim won the race.
+- Record Wiki delivery evidence in the main Issue unconditionally and in a main-repository PR only when that PR exists.
+
+## 中文
+
+- 已有租约续期、过期接管或心跳前，重新校验 Issue 是否仍可认领。
+- release 同步 Issue 可见状态后重新读取权威 lock ref；若新 claim 赢得竞态，则自动修复可见镜像。
+- Wiki 交付证据始终记录在主 Issue；仅当存在主仓库 PR 时才在 PR 中重复记录。

--- a/editing-history/202609050130-lease-review-followup.md
+++ b/editing-history/202609050130-lease-review-followup.md
@@ -6,10 +6,12 @@
 
 - Revalidate an Issue before an existing lease is renewed, taken over, or heartbeated.
 - After release-side Issue synchronization, re-read the authoritative lock ref and repair the visible mirror if a newer claim won the race.
+- Refresh replacement metadata from the commit actually fetched, reject missing owner/scope fields, and fail safely when a still-present ref cannot be fetched.
 - Record Wiki delivery evidence in the main Issue unconditionally and in a main-repository PR only when that PR exists.
 
 ## 中文
 
 - 已有租约续期、过期接管或心跳前，重新校验 Issue 是否仍可认领。
 - release 同步 Issue 可见状态后重新读取权威 lock ref；若新 claim 赢得竞态，则自动修复可见镜像。
+- replacement 元数据取自实际 fetch 到的 commit；缺少 owner/scope 时保留 claimed 状态，ref 仍存在但 fetch 失败时安全报错。
 - Wiki 交付证据始终记录在主 Issue；仅当存在主仓库 PR 时才在 PR 中重复记录。

--- a/scripts/agent-issue-lease.sh
+++ b/scripts/agent-issue-lease.sh
@@ -117,7 +117,6 @@ require_claimable_issue() {
   # A claimed label without a lock is a recoverable partial update from an
   # interrupted release. The Git ref remains the ownership authority.
   if issue_has_label "$issue" "$repo" agent:claimed; then
-    echo "WARN: repairing stale agent:claimed label without a lock" >&2
     return
   fi
   die "issue #$issue is neither agent:ready nor agent:review"
@@ -212,6 +211,9 @@ command_claim() {
     die "issue #$issue is held by $old_agent until $(iso_time "$old_expires")"
   fi
 
+  # A maintainer may close or block an Issue while its prior lease is still
+  # present. Revalidate immediately before renewing or taking it over.
+  require_claimable_issue "$issue" "$repo"
   new_sha="$(make_lock_commit "$issue" "$agent" "$claimed" "$expires" "$scope" "$old_sha")"
   git push --force-with-lease="$ref:$old_sha" "$remote" "$new_sha:$ref" >/dev/null
   sync_claimed_issue "$issue" "$repo" "$agent" "$claimed" "$now" "$expires" "$scope" "$new_sha"
@@ -230,14 +232,16 @@ command_heartbeat() {
   fetch_lock "$ref"
   old_agent="$(field "$old_sha" agent_id)"
   [[ "$old_agent" == "$agent" ]] || die "issue #$issue is held by $old_agent, not $agent"
+  repo="$(repo_slug)"
+  ensure_labels "$repo"
+  # Do not extend ownership after the Issue has been closed or blocked.
+  require_claimable_issue "$issue" "$repo"
   claimed="$(field "$old_sha" claimed_at)"
   scope="$(field "$old_sha" scope)"
   now="$(date +%s)"
   expires="$((now + ttl * 60))"
   new_sha="$(make_lock_commit "$issue" "$agent" "$claimed" "$expires" "$scope" "$old_sha")"
   git push --force-with-lease="$ref:$old_sha" "$remote" "$new_sha:$ref" >/dev/null
-  repo="$(repo_slug)"
-  ensure_labels "$repo"
   sync_claimed_issue "$issue" "$repo" "$agent" "$claimed" "$now" "$expires" "$scope" "$new_sha"
   echo "HEARTBEAT issue #$issue by $agent until $(iso_time "$expires")"
 }
@@ -271,6 +275,33 @@ command_release() {
 
 The issue currently has no active write lease."
   upsert_comment "$issue" "$repo" "$body"
+  # A new claim may land after the authoritative ref deletion but before the
+  # human-readable Issue mirror above is complete. Re-read the ref last and
+  # repair the mirror when that race occurred; if a claim starts after this
+  # check, its own synchronization naturally wins.
+  local replacement_sha replacement_agent replacement_claimed replacement_heartbeat replacement_expires replacement_scope
+  replacement_sha="$(remote_sha "$ref")"
+  if [[ -n "$replacement_sha" ]]; then
+    if ! fetch_lock "$ref"; then
+      echo "WARN: the newer lease disappeared during mirror repair; its release owns the final Issue state" >&2
+      echo "RELEASED issue #$issue by $agent to agent:$target"
+      return
+    fi
+    replacement_agent="$(field "$replacement_sha" agent_id)"
+    replacement_claimed="$(field "$replacement_sha" claimed_at)"
+    replacement_heartbeat="$(field "$replacement_sha" heartbeat_at)"
+    replacement_expires="$(field "$replacement_sha" expires_at)"
+    replacement_scope="$(field "$replacement_sha" scope)"
+    if [[ "$replacement_claimed" =~ ^[0-9]+$ && "$replacement_heartbeat" =~ ^[0-9]+$ && "$replacement_expires" =~ ^[0-9]+$ ]]; then
+      sync_claimed_issue \
+        "$issue" "$repo" "$replacement_agent" "$replacement_claimed" "$replacement_heartbeat" \
+        "$replacement_expires" "$replacement_scope" "$replacement_sha"
+      echo "WARN: a newer lease appeared during release; repaired the Issue mirror from $replacement_sha" >&2
+    else
+      set_issue_state "$issue" "$repo" claimed
+      echo "WARN: a newer lease appeared during release with invalid metadata; preserved agent:claimed for human repair" >&2
+    fi
+  fi
   echo "RELEASED issue #$issue by $agent to agent:$target"
 }
 

--- a/scripts/agent-issue-lease.sh
+++ b/scripts/agent-issue-lease.sh
@@ -283,16 +283,23 @@ The issue currently has no active write lease."
   replacement_sha="$(remote_sha "$ref")"
   if [[ -n "$replacement_sha" ]]; then
     if ! fetch_lock "$ref"; then
-      echo "WARN: the newer lease disappeared during mirror repair; its release owns the final Issue state" >&2
-      echo "RELEASED issue #$issue by $agent to agent:$target"
-      return
+      replacement_sha="$(remote_sha "$ref")"
+      if [[ -z "$replacement_sha" ]]; then
+        echo "WARN: the newer lease disappeared during mirror repair; its release owns the final Issue state" >&2
+        echo "RELEASED issue #$issue by $agent to agent:$target"
+        return
+      fi
+      die "newer lease $replacement_sha still exists but could not be fetched for mirror repair"
     fi
+    # The ref may advance after the initial ls-remote. Read metadata from the
+    # commit that fetch_lock actually fetched, never from the stale observation.
+    replacement_sha="$(git rev-parse FETCH_HEAD)"
     replacement_agent="$(field "$replacement_sha" agent_id)"
     replacement_claimed="$(field "$replacement_sha" claimed_at)"
     replacement_heartbeat="$(field "$replacement_sha" heartbeat_at)"
     replacement_expires="$(field "$replacement_sha" expires_at)"
     replacement_scope="$(field "$replacement_sha" scope)"
-    if [[ "$replacement_claimed" =~ ^[0-9]+$ && "$replacement_heartbeat" =~ ^[0-9]+$ && "$replacement_expires" =~ ^[0-9]+$ ]]; then
+    if [[ -n "$replacement_agent" && -n "$replacement_scope" && "$replacement_claimed" =~ ^[0-9]+$ && "$replacement_heartbeat" =~ ^[0-9]+$ && "$replacement_expires" =~ ^[0-9]+$ ]]; then
       sync_claimed_issue \
         "$issue" "$repo" "$replacement_agent" "$replacement_claimed" "$replacement_heartbeat" \
         "$replacement_expires" "$replacement_scope" "$replacement_sha"

--- a/scripts/test-agent-issue-lease.sh
+++ b/scripts/test-agent-issue-lease.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+lease_script="$repo_root/scripts/agent-issue-lease.sh"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/calcit-agent-lease-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+
+real_git="$(command -v git)"
+remote_repo="$test_root/remote.git"
+work_repo="$test_root/work"
+fake_bin="$test_root/bin"
+log_file="$test_root/gh.log"
+race_marker="$test_root/race-created"
+advance_marker="$test_root/race-advanced"
+fetch_arm="$test_root/arm-fetch"
+mkdir -p "$fake_bin"
+
+"$real_git" init --bare --quiet "$remote_repo"
+"$real_git" init --quiet "$work_repo"
+"$real_git" -C "$work_repo" config user.name "Lease test"
+"$real_git" -C "$work_repo" config user.email "lease-test@calcit-lang.invalid"
+"$real_git" -C "$work_repo" remote add origin "$remote_repo"
+
+cat >"$fake_bin/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$LEASE_TEST_LOG"
+if [[ "$1 $2" == "repo view" ]]; then
+  echo "calcit-lang/calcit"
+elif [[ "$1 $2" == "label create" ]]; then
+  :
+elif [[ "$1 $2" == "issue view" ]]; then
+  if [[ "$*" == *"--json state"* ]]; then echo OPEN; else echo agent:ready; fi
+elif [[ "$1 $2" == "issue edit" ]]; then
+  previous=""
+  for arg in "$@"; do
+    if [[ "$previous" == "--add-label" ]]; then
+      printf 'MIRROR %s\n' "$arg" >>"$LEASE_TEST_LOG"
+      if [[ "$arg" == "agent:review" && ! -e "$LEASE_TEST_RACE_MARKER" ]]; then
+        touch "$LEASE_TEST_RACE_MARKER"
+        "$LEASE_TEST_REAL_GIT" -C "$LEASE_TEST_WORK_REPO" push --quiet origin "$LEASE_TEST_OLD_SHA:refs/heads/agent-lock/issue-1"
+      fi
+      break
+    fi
+    previous="$arg"
+  done
+elif [[ "$1" == "api" ]]; then
+  if [[ "$*" == *"--method POST"* && "$*" == *"Agent lease released"* ]]; then
+    touch "$LEASE_TEST_FETCH_ARM"
+  fi
+else
+  echo "unexpected fake gh invocation: $*" >&2
+  exit 2
+fi
+FAKE_GH
+
+cat >"$fake_bin/git" <<'FAKE_GIT'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "fetch" && -e "$LEASE_TEST_FETCH_ARM" && ! -e "$LEASE_TEST_ADVANCE_MARKER" ]]; then
+  touch "$LEASE_TEST_ADVANCE_MARKER"
+  "$LEASE_TEST_REAL_GIT" -C "$LEASE_TEST_WORK_REPO" push --quiet --force origin "$LEASE_TEST_NEW_SHA:refs/heads/agent-lock/issue-1"
+fi
+exec "$LEASE_TEST_REAL_GIT" "$@"
+FAKE_GIT
+chmod +x "$fake_bin/gh" "$fake_bin/git"
+
+empty_tree="$("$real_git" -C "$work_repo" mktree </dev/null)"
+make_test_lock() {
+  local agent="$1" scope="$2" heartbeat="$3"
+  local message
+  message="agent-lease-v1
+issue=1
+agent_id=$agent
+claimed_at=1700000000
+heartbeat_at=$heartbeat
+expires_at=2000000000
+scope=$scope"
+  GIT_AUTHOR_NAME="Lease test" GIT_AUTHOR_EMAIL="lease-test@calcit-lang.invalid" \
+  GIT_COMMITTER_NAME="Lease test" GIT_COMMITTER_EMAIL="lease-test@calcit-lang.invalid" \
+    "$real_git" -C "$work_repo" commit-tree "$empty_tree" <<<"$message"
+}
+
+old_sha="$(make_test_lock old-owner old-scope 1700000010)"
+new_sha="$(make_test_lock new-owner new-scope 1700000020)"
+release_sha="$(make_test_lock releasing-owner release-scope 1700000005)"
+"$real_git" -C "$work_repo" push --quiet origin "$release_sha:refs/heads/agent-lock/issue-1"
+
+export LEASE_TEST_LOG="$log_file"
+export LEASE_TEST_RACE_MARKER="$race_marker"
+export LEASE_TEST_ADVANCE_MARKER="$advance_marker"
+export LEASE_TEST_FETCH_ARM="$fetch_arm"
+export LEASE_TEST_REAL_GIT="$real_git"
+export LEASE_TEST_WORK_REPO="$work_repo"
+export LEASE_TEST_OLD_SHA="$old_sha"
+export LEASE_TEST_NEW_SHA="$new_sha"
+
+(
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" release 1 releasing-owner review
+)
+
+grep -Fq 'Agent: `new-owner`' "$log_file"
+grep -Fq 'Scope: `new-scope`' "$log_file"
+if grep -Fq 'Agent: `old-owner`' "$log_file"; then
+  echo "stale replacement metadata reached the Issue mirror" >&2
+  exit 1
+fi
+
+# A replacement with missing required identity fields must retain the claimed
+# label for human repair rather than publishing a blank owner or scope.
+corrupt_sha="$(make_test_lock '' '' 1700000030)"
+"$real_git" -C "$work_repo" push --quiet --force origin "$release_sha:refs/heads/agent-lock/issue-1"
+rm -f "$race_marker" "$advance_marker" "$fetch_arm"
+: >"$log_file"
+export LEASE_TEST_OLD_SHA="$corrupt_sha"
+export LEASE_TEST_NEW_SHA="$corrupt_sha"
+(
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" release 1 releasing-owner review
+)
+[[ "$(grep '^MIRROR ' "$log_file" | tail -n 1)" == "MIRROR agent:claimed" ]]
+if grep -Fq 'Agent: ``' "$log_file" || grep -Fq 'Scope: ``' "$log_file"; then
+  echo "blank replacement identity reached the Issue mirror" >&2
+  exit 1
+fi
+
+echo "agent lease release race tests passed"


### PR DESCRIPTION
Closes #691
Part of #678

Focused scope: AGENTS.md Wiki-only evidence rule; Issue lease renewal and heartbeat revalidation; release-side mirror repair after a newer claim; lease editing history.

Base: d21c2280d989a098f1d65ae3aa7166897bc69560
Head: cced2c8b

Validation: git diff --check; bash syntax check; prior identical aggregate patch passed local bare-remote failure injection for closed-Issue renewal and heartbeat plus release/new-claim race repair.