### PR TITLE
Correct string character-count documentation / 修正字符串字符计数文档

### DIFF
--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -1058,7 +1058,7 @@
             defn test-str-compare-lt () $ &str:compare |abc |abd
           :examples $ []
           :schema $ :: 'Dynamic
-        'test-str-concat $ %{} 'CodeEntry (:doc "|concat two strings and return byte count")
+        'test-str-concat $ %{} 'CodeEntry (:doc "|concat two strings and return character count")
           :code $ quote
             defn test-str-concat () $ &str:count (&str:concat |foo |bar)
           :examples $ []
@@ -1073,7 +1073,7 @@
             defn test-str-contains-true () $ &str:contains? |hello 1
           :examples $ []
           :schema $ :: 'Dynamic
-        'test-str-count $ %{} 'CodeEntry (:doc "|string byte length")
+        'test-str-count $ %{} 'CodeEntry (:doc "|string character count")
           :code $ quote
             defn test-str-count () $ &str:count |hello
           :examples $ []
@@ -1083,7 +1083,7 @@
             defn test-str-empty-false () $ &= (&str:count |hi) 0
           :examples $ []
           :schema $ :: 'Dynamic
-        'test-str-empty-true $ %{} 'CodeEntry (:doc "|rest of 1-char string has 0 bytes")
+        'test-str-empty-true $ %{} 'CodeEntry (:doc "|rest of 1-char string has 0 characters")
           :code $ quote
             defn test-str-empty-true () $ &=
               &str:count $ &str:rest |a
@@ -1137,12 +1137,12 @@
             defn test-str-pad-right () $ &str:count (&str:pad-right |hi 5 |-)
           :examples $ []
           :schema $ :: 'Dynamic
-        'test-str-rest $ %{} 'CodeEntry (:doc "|rest of hello has 4 bytes")
+        'test-str-rest $ %{} 'CodeEntry (:doc "|rest of hello has 4 characters")
           :code $ quote
             defn test-str-rest () $ &str:count (&str:rest |hello)
           :examples $ []
           :schema $ :: 'Dynamic
-        'test-str-slice $ %{} 'CodeEntry (:doc "|slice bytes 1..4 from abcde = 3 bytes (bcd)")
+        'test-str-slice $ %{} 'CodeEntry (:doc "|slice 1..4 from abcde = 3 characters (bcd)")
           :code $ quote
             defn test-str-slice () $ &str:count (&str:slice |abcde 1 4)
           :examples $ []

--- a/docs/data/string.md
+++ b/docs/data/string.md
@@ -14,7 +14,7 @@ The way strings are represented in Calcit is a bit unique. Strings are distingui
 
 This somewhat unusual design exists because the structural editor naturally wraps strings in double quotes. When writing with indentation-based syntax, the outermost double quotes can be omitted for convenience.
 
-### Character count and wire size
+## Character count and wire size
 
 String `.count` returns the number of Unicode scalar values consistently on the native, JavaScript, and WASM backends. Use `.utf8-byte-count` when a protocol, queue, file, or metric needs the encoded UTF-8 byte length:
 
@@ -25,6 +25,6 @@ assert= 5 $ "|A😀".utf8-byte-count
 
 Keep these operations distinct: character count describes Calcit text indexing semantics, while UTF-8 byte count describes storage and wire budgets. The latter is O(1) on the native and WASM representations and uses one allocation-free linear pass in generated JavaScript.
 
-### Tag
+## Tag
 
 Calcit also provides the Tag type, written with a leading `:` such as `:demo`. Tags are interned immutable identifiers with consistent Calcit semantics across the Rust interpreter and JavaScript output. They are commonly used for struct fields, enum variants, map keys, and protocol labels; ordinary user-facing text should remain a String.

--- a/editing-history/202609041734-string-character-count-docs.md
+++ b/editing-history/202609041734-string-character-count-docs.md
@@ -1,0 +1,9 @@
+# Correct string character-count documentation
+
+- Updated WASM string test descriptions to use Unicode character-count semantics instead of byte-count wording.
+- Made the character-count and Tag sections peer level-2 headings in the String guide.
+
+# 修正字符串字符计数文档
+
+- 更新 WASM 字符串测试描述，使用 Unicode 字符计数语义，避免误写为字节计数。
+- 将字符串指南中的字符计数与 Tag 调整为同级二级标题。


### PR DESCRIPTION
Closes #696

## Summary / 概要

- describe the five affected WASM string `.count` checks as Unicode character counts rather than byte counts
- make `Character count and wire size` and `Tag` peer level-2 sections under the String guide title
- preserve runtime behavior; this is documentation and test-description correction only

## Validation / 验证

- Calcit 0.13.77 canonical Snapshot format: no additional diff
- Calcit 0.13.77 `calcit/test-wasm.cirru --check-only`: passed
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`: all WASM checks passed locally
- `bash scripts/check-docs-md.sh`: 68 files / 329 blocks passed locally
- GitHub Actions Ubuntu result is the required acceptance evidence; local macOS results are supplementary
