### PR TITLE
fix: align filter-map-kv drop contracts

### DIFF
--- a/editing-history/202609050144-align-filter-map-kv-drop-contract.md
+++ b/editing-history/202609050144-align-filter-map-kv-drop-contract.md
@@ -1,0 +1,18 @@
+# Align filter-map-kv drop contracts
+
+## Context
+
+`filter-map-kv` already models its callback with the nominal
+`MapEntryDecision<K, V>` enum, but the Calcit implementation wrapped the
+unchanged accumulator in a redundant `identity` call. The shared WASM emitter
+also described both callback results as pair lists even though the filtering
+variant consumes the enum layout.
+
+## Change
+
+- Return the accumulator directly from the `:drop` branch.
+- Document the pair-list and `MapEntryDecision` layouts separately at the
+  shared WASM lowering boundary.
+
+Existing core and WASM regressions exercise both transformed `:keep` entries
+and omitted `:drop` entries; no runtime behavior or schema changes are intended.

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -5000,7 +5000,7 @@
                       decision $ f key value
                     match decision
                       (:keep next-key next-value) (&map:assoc acc next-key next-value)
-                      (:drop) (identity acc)
+                      (:drop) acc
           :examples $ []
           :schema $ :: 'Fn
             {}

--- a/src/codegen/emit_wasm/hof.rs
+++ b/src/codegen/emit_wasm/hof.rs
@@ -1046,7 +1046,8 @@ fn emit_map_kv_impl(ctx: &mut WasmGenCtx, args: &[Calcit], uses_decision: bool) 
     _ => unreachable!(),
   }
 
-  // result is [k', v'] list on stack; get its pointer
+  // `map-kv` returns a [k', v'] pair list, while `filter-map-kv` returns a
+  // MapEntryDecision enum. Both are heap values whose pointer is on the stack.
   ctx.emit(Instruction::I32TruncF64U);
   ctx.emit(Instruction::LocalSet(result_ptr));
 


### PR DESCRIPTION
Closes #693
Child of #678

## Change

- Return the accumulator directly from the Calcit `filter-map-kv` `:drop` branch instead of calling `identity`.
- Correct the shared WASM emitter comment: `map-kv` consumes a pair list while `filter-map-kv` consumes `MapEntryDecision`.
- Keep the nominal schema and runtime behavior unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --all-features -- --test-threads=1` (706 lib, 299 CLI, 23 WASM)
- `cargo run --bin calcit -- src/cirru/calcit-core.cirru test --name transforms-and-drops --summary-only` (1/1)
- `cargo run --bin calcit -- src/cirru/calcit-core.cirru test --tag unit --summary-only` (237/237)
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh` (all checks passed; `test-filter-map-kv() = 32`)
- `git diff --check`

Base: `1ac0d7cf`
Head: `67c80cbce0cf2b56c36360836e74924484b0ead8`
Milestone: **0.13.78 — Strict-boundary completion / 严格边界收口**