### PR TITLE
Detect partial Struct heads before expansion / 展开前识别 partial Struct 调用

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -367,7 +367,7 @@ defstruct Profile (:name 'String) (:bio (:: 'Option 'String))
 Profile :name |Ada
 ```
 
-这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数只用于兼容已有的非类型化 API，其缺省值是 `nil`；`--strict-types` 会以 `E_LEGACY_OPTIONAL_PARAM` 拒绝它。`%{}?` 同样会隐式用 `nil` 补 Struct 字段，并在 strict 模式触发 `E_PARTIAL_STRUCT_NIL_FILL`。修改旧接口时迁移到 `Option` 和完整 `%{}` 构造；在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。`Nil` 与 `Unit` 是不同类型：声明返回 `Unit` 的函数应返回 `&unit` 或以 Unit effect 结束；strict 模式以 `E_NIL_FOR_UNIT` 拒绝返回位置的 `nil` / `;nil`。
+这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数只用于兼容已有的非类型化 API，其缺省值是 `nil`；`--strict-types` 会以 `E_LEGACY_OPTIONAL_PARAM` 拒绝它。`%{}?` 及其底层写法 `&%{}?` 同样会隐式用 `nil` 补 Struct 字段，并在 strict 模式触发 `E_PARTIAL_STRUCT_NIL_FILL`。修改旧接口时迁移到 `Option` 和完整 `%{}` 构造；在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。`Nil` 与 `Unit` 是不同类型：声明返回 `Unit` 的函数应返回 `&unit` 或以 Unit effect 结束；strict 模式以 `E_NIL_FOR_UNIT` 拒绝返回位置的 `nil` / `;nil`。
 
 Option/Result 的级联优先使用接收者方法，不要在每一层都 `unwrap`：
 

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -222,10 +222,11 @@ let
 ```
 
 This is a compatibility surface, not a typed construction pattern.
-`--strict-types` rejects it with `E_PARTIAL_STRUCT_NIL_FILL`. Migrate by using
-`%{}` with every field present, or change fields that are genuinely absent to
-`Option<T>` and provide `%none`. There is no automatic rewrite because omitted
-fields may require business defaults rather than absence.
+`--strict-types` rejects both `%{}?` and its low-level `&%{}?` spelling with
+`E_PARTIAL_STRUCT_NIL_FILL`. Migrate by using `%{}` with every field present, or
+change fields that are genuinely absent to `Option<T>` and provide `%none`.
+There is no automatic rewrite because omitted fields may require business
+defaults rather than absence.
 
 The low-level `&%{}` form accepts fields as flat keyword-value pairs (no type checking):
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -287,8 +287,8 @@ let
 
 - `defstruct` - define a struct type with typed fields
 - `%{}` - create a named struct value, or an anonymous value with `%{} _ ...`
-- `%{}?` - legacy partial Struct constructor (unset fields default to nil;
-  rejected by `--strict-types` with `E_PARTIAL_STRUCT_NIL_FILL`)
+- `%{}?`, `&%{}?` - legacy partial Struct constructors (unset fields default to
+  nil; both are rejected by `--strict-types` with `E_PARTIAL_STRUCT_NIL_FILL`)
 - `&%{}` - low-level struct constructor (flat key-value pairs, no type check)
 - `struct-with` - update multiple declared fields
 - `&struct:get` - internal/dynamic-boundary field lookup; normal typed code must use `(:field value)`

--- a/editing-history/202609050240-partial-struct-head.md
+++ b/editing-history/202609050240-partial-struct-head.md
@@ -1,0 +1,15 @@
+# Detect partial Struct constructors before expansion
+
+2026-09-05 02:40 CST
+
+## English
+
+- Identify both partial Struct constructor spellings from the resolved call head before macro expansion.
+- Do not use the enclosing definition name as call identity.
+- Document both spellings and their complete-Struct or Option-field migration path.
+
+## 中文
+
+- 在宏展开前，从已解析调用头识别两种 partial Struct 构造写法。
+- 不再误用外围 definition name 作为被调用对象身份。
+- 文档同时列出两种写法，以及迁移到完整 Struct 或 Option 字段的路径。

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1823,9 +1823,16 @@ fn preprocess_list_call(
     call_location: call_location.clone(),
   };
 
+  let is_constructor_named = |name: &str| {
+    matches!(&head_form, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == name)
+      || matches!(&head_form, Calcit::Symbol { sym, .. } if sym.as_ref() == name)
+  };
+
   if strict_types_enabled()
     && should_emit_project_source_lint(file_ns)
-    && (matches!(def_name.as_ref(), "%{}?" | "&%{}?") || matches!(head_form, Calcit::Proc(CalcitProc::NativeStructPartial)))
+    && (is_constructor_named("%{}?")
+      || is_constructor_named("&%{}?")
+      || matches!(head_form, Calcit::Proc(CalcitProc::NativeStructPartial)))
   {
     return Err(CalcitErr::use_msg_stack_location_with_code(
       CalcitErrKind::Type,
@@ -1839,11 +1846,6 @@ fn preprocess_list_call(
   warn_on_removed_data_api_call(&head_form, call_location.clone(), file_ns, check_warnings);
 
   let has_anonymous_definition_marker = matches!(args.first(), Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "_");
-  let is_constructor_named = |name: &str| {
-    matches!(&head_form, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == name)
-      || matches!(&head_form, Calcit::Symbol { sym, .. } if sym.as_ref() == name)
-  };
-
   if strict_types_enabled()
     && should_emit_project_source_lint(file_ns)
     && is_constructor_named("map-kv")
@@ -10929,6 +10931,12 @@ mod tests {
     let error = preprocess_test_expr(&code).expect_err("strict mode should reject omitted Struct fields");
     assert_eq!(error.code.as_deref(), Some("E_PARTIAL_STRUCT_NIL_FILL"));
     assert!(error.msg.contains("%none"));
+
+    let source_call = Cirru::List(vec![Cirru::leaf("%{}?"), Cirru::leaf("Profile")]);
+    let source_code =
+      code_to_calcit(&source_call, "tests.strict-nil", "build-profile", vec![]).expect("parse source partial Struct constructor");
+    let source_error = preprocess_test_expr(&source_code).expect_err("strict mode should reject the core %{}? macro before expansion");
+    assert_eq!(source_error.code.as_deref(), Some("E_PARTIAL_STRUCT_NIL_FILL"));
   }
 
   #[test]


### PR DESCRIPTION
Closes #695
Part of #678

Focused change: identify both partial Struct constructor spellings from the resolved call head before macro expansion, add a parsed-source regression, and document the same migration in the three directly related guides.

Validation: cargo fmt; focused regression passed; cargo test --lib (706 passed); Clippy with warnings denied; 46 focused Markdown code blocks passed; git diff check.