### PR TITLE
fix: detect partial Struct source heads

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -367,7 +367,7 @@ defstruct Profile (:name 'String) (:bio (:: 'Option 'String))
 Profile :name |Ada
 ```
 
-这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数只用于兼容已有的非类型化 API，其缺省值是 `nil`；`--strict-types` 会以 `E_LEGACY_OPTIONAL_PARAM` 拒绝它。`%{}?` 同样会隐式用 `nil` 补 Struct 字段，并在 strict 模式触发 `E_PARTIAL_STRUCT_NIL_FILL`。修改旧接口时迁移到 `Option` 和完整 `%{}` 构造；在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。`Nil` 与 `Unit` 是不同类型：声明返回 `Unit` 的函数应返回 `&unit` 或以 Unit effect 结束；strict 模式以 `E_NIL_FOR_UNIT` 拒绝返回位置的 `nil` / `;nil`。
+这项语法糖只处理**结尾连续的** `Option` 参数：位于必填参数之前的 `Option` 仍然必须显式传 `(%none)` 或 `(%some value)`，带 rest 参数的函数也不会自动补值。`?` 参数只用于兼容已有的非类型化 API，其缺省值是 `nil`；`--strict-types` 会以 `E_LEGACY_OPTIONAL_PARAM` 拒绝它。`%{}?` 及其底层写法 `&%{}?` 同样会隐式用 `nil` 补 Struct 字段，并在 strict 模式触发 `E_PARTIAL_STRUCT_NIL_FILL`。修改旧接口时迁移到 `Option` 和完整 `%{}` 构造；在 FFI 或非类型化边界之外，缺失值使用 `Option`，失败使用 `Result`，无有效返回值使用 `Unit`。`Nil` 与 `Unit` 是不同类型：声明返回 `Unit` 的函数应返回 `&unit` 或以 Unit effect 结束；strict 模式以 `E_NIL_FOR_UNIT` 拒绝返回位置的 `nil` / `;nil`。
 
 Option/Result 的级联优先使用接收者方法，不要在每一层都 `unwrap`：
 

--- a/docs/features/structs.md
+++ b/docs/features/structs.md
@@ -222,10 +222,11 @@ let
 ```
 
 This is a compatibility surface, not a typed construction pattern.
-`--strict-types` rejects it with `E_PARTIAL_STRUCT_NIL_FILL`. Migrate by using
-`%{}` with every field present, or change fields that are genuinely absent to
-`Option<T>` and provide `%none`. There is no automatic rewrite because omitted
-fields may require business defaults rather than absence.
+`--strict-types` rejects both `%{}?` and its low-level `&%{}?` spelling with
+`E_PARTIAL_STRUCT_NIL_FILL`. Migrate by using `%{}` with every field present, or
+change fields that are genuinely absent to `Option<T>` and provide `%none`.
+There is no automatic rewrite because omitted fields may require business
+defaults rather than absence.
 
 The low-level `&%{}` form accepts fields as flat keyword-value pairs (no type checking):
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -287,8 +287,8 @@ let
 
 - `defstruct` - define a struct type with typed fields
 - `%{}` - create a named struct value, or an anonymous value with `%{} _ ...`
-- `%{}?` - legacy partial Struct constructor (unset fields default to nil;
-  rejected by `--strict-types` with `E_PARTIAL_STRUCT_NIL_FILL`)
+- `%{}?`, `&%{}?` - legacy partial Struct constructors (unset fields default to
+  nil; both are rejected by `--strict-types` with `E_PARTIAL_STRUCT_NIL_FILL`)
 - `&%{}` - low-level struct constructor (flat key-value pairs, no type check)
 - `struct-with` - update multiple declared fields
 - `&struct:get` - internal/dynamic-boundary field lookup; normal typed code must use `(:field value)`

--- a/editing-history/202609050149-detect-partial-struct-source-heads.md
+++ b/editing-history/202609050149-detect-partial-struct-source-heads.md
@@ -1,0 +1,19 @@
+# Detect partial Struct source heads
+
+## Context
+
+The strict partial-Struct check used `grab_def_name` for symbolic call heads,
+but that helper returns the enclosing definition name rather than the called
+symbol. A source `%{}?` macro could therefore reach expansion before
+`E_PARTIAL_STRUCT_NIL_FILL`, while the already-lowered native form was caught.
+
+## Change
+
+- Reuse the resolved core-head identity check before macro expansion and match
+  both `%{}?` and `&%{}?` alongside the native partial-Struct proc.
+- Exercise both source spellings through the parser in strict mode.
+- Document both legacy spellings and the complete `%{}` / explicit `Option<T>`
+  migration in the agent guide, Struct guide, and quick reference.
+
+Compatibility mode keeps the legacy nil-filling behavior; strict mode changes
+only the previously missed source-head path.

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1833,9 +1833,16 @@ fn preprocess_list_call(
     call_location: call_location.clone(),
   };
 
+  let is_constructor_named = |name: &str| {
+    matches!(&head_form, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == name)
+      || matches!(&head_form, Calcit::Symbol { sym, .. } if sym.as_ref() == name)
+  };
+
   if strict_types_enabled()
     && should_emit_project_source_lint(file_ns)
-    && (matches!(def_name.as_ref(), "%{}?" | "&%{}?") || matches!(head_form, Calcit::Proc(CalcitProc::NativeStructPartial)))
+    && (is_constructor_named("%{}?")
+      || is_constructor_named("&%{}?")
+      || matches!(head_form, Calcit::Proc(CalcitProc::NativeStructPartial)))
   {
     return Err(CalcitErr::use_msg_stack_location_with_code(
       CalcitErrKind::Type,
@@ -1849,10 +1856,6 @@ fn preprocess_list_call(
   warn_on_removed_data_api_call(&head_form, call_location.clone(), file_ns, check_warnings);
 
   let has_anonymous_definition_marker = matches!(args.first(), Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "_");
-  let is_constructor_named = |name: &str| {
-    matches!(&head_form, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == name)
-      || matches!(&head_form, Calcit::Symbol { sym, .. } if sym.as_ref() == name)
-  };
 
   if strict_types_enabled()
     && should_emit_project_source_lint(file_ns)
@@ -11025,6 +11028,14 @@ mod tests {
     let error = preprocess_test_expr(&code).expect_err("strict mode should reject omitted Struct fields");
     assert_eq!(error.code.as_deref(), Some("E_PARTIAL_STRUCT_NIL_FILL"));
     assert!(error.msg.contains("%none"));
+
+    for constructor in ["%{}?", "&%{}?"] {
+      let source_call = Cirru::List(vec![Cirru::leaf(constructor), Cirru::leaf("Profile")]);
+      let source_code =
+        code_to_calcit(&source_call, "tests.strict-nil", "build-profile", vec![]).expect("parse source partial Struct constructor");
+      let source_error = preprocess_test_expr(&source_code).expect_err("strict mode should reject source constructor before expansion");
+      assert_eq!(source_error.code.as_deref(), Some("E_PARTIAL_STRUCT_NIL_FILL"));
+    }
   }
 
   #[test]


### PR DESCRIPTION
Closes #695

## Summary
- detect both `%{}?` and low-level `&%{}?` from the resolved source call head before macro expansion
- keep compatibility-mode nil filling unchanged while strict mode reports `E_PARTIAL_STRUCT_NIL_FILL`
- cover both parsed-source spellings and document the complete Struct / explicit Option migration

## Validation
- `cargo test strict_types_rejects_partial_struct_nil_fill_but_compat_mode_keeps_it --lib` (1 passed)
- docs checks: `docs/CalcitAgent.md` 9/9, `docs/features/structs.md` 29/29, `docs/quick-reference.md` 8/8
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (708 lib, 299 CLI, 23 WASM)
- `yarn check-all` (237 core tests plus JS/WASM and quality gates)