### PR TITLE
Repair agent lease mirrors during heartbeat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,8 @@ npm view @calcit/procs version
   scripts/agent-issue-lease.sh heartbeat <issue-number> <agent-id>
   ```
 
+  heartbeat 以远端 lock 为权威：确认 owner 匹配、Issue 仍开放且未显式标记 `agent:blocked` 后，会修复缺失或陈旧的 Issue 状态标签与租约评论。不要因为人类可读镜像短暂丢失而手工创建、覆盖或删除 lock 分支。
+
 - 在 Issue 的 `Owned scope` 范围内修改；新增仓库或路径前，先更新 Issue 并确认不与其他活跃 Issue 重叠。
 - 每个执行写入的 Agent 必须为当前认领的 Issue 使用独立 Git worktree，并使用独立分支 `agent/issue-<number>-<agent-id>`。不得让多个 Agent 共用同一个 checkout，不得直接在共享主 checkout、其他 Agent 的 worktree、其他 Agent 的分支或含有他人未提交改动的目录中实现功能。
 - 共享主 checkout 只用于认领、状态查询、只读检查和创建 worktree；实现、格式化、测试、提交及 push 必须在当前 Agent 自己的 worktree 中完成。创建 worktree 前先确认目标分支名和路径均未被其他 Agent 使用。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ npm view @calcit/procs version
   scripts/agent-issue-lease.sh heartbeat <issue-number> <agent-id>
   ```
 
-  heartbeat 以远端 lock 为权威：确认 owner 匹配、Issue 仍开放且未显式标记 `agent:blocked` 后，会修复缺失或陈旧的 Issue 状态标签与租约评论。不要因为人类可读镜像短暂丢失而手工创建、覆盖或删除 lock 分支。
+  heartbeat 以远端 lock 为权威：确认 owner 匹配、Issue 仍开放且未显式标记 `agent:blocked` 后，会修复缺失或陈旧的 Issue 状态标签与租约评论。`agent:blocked` 与其他状态标签异常共存时仍具有最高优先级，claim 与 heartbeat 都必须拒绝。不要因为人类可读镜像短暂丢失而手工创建、覆盖或删除 lock 分支。
 
 - 在 Issue 的 `Owned scope` 范围内修改；新增仓库或路径前，先更新 Issue 并确认不与其他活跃 Issue 重叠。
 - 每个执行写入的 Agent 必须为当前认领的 Issue 使用独立 Git worktree，并使用独立分支 `agent/issue-<number>-<agent-id>`。不得让多个 Agent 共用同一个 checkout，不得直接在共享主 checkout、其他 Agent 的 worktree、其他 Agent 的分支或含有他人未提交改动的目录中实现功能。

--- a/editing-history/202609041940-agent-lease-heartbeat-mirror-recovery.md
+++ b/editing-history/202609041940-agent-lease-heartbeat-mirror-recovery.md
@@ -6,10 +6,12 @@ UTC: 2026-09-04T19:40:45Z
 
 - Let `heartbeat` renew an owner-matching authoritative remote lease when the Issue state-label mirror is missing or stale.
 - Keep closed and explicitly `agent:blocked` Issues non-renewable.
+- Make `agent:blocked` dominant over conflicting claimable labels for both acquisition and renewal.
 - Add shell regression coverage for mirror repair and both protected terminal states.
 
 ## 中文
 
 - 当 Issue 状态标签镜像缺失或陈旧时，只要远端权威租约 owner 匹配，允许 `heartbeat` 续租并修复镜像。
 - 已关闭或显式标记 `agent:blocked` 的 Issue 仍禁止续租。
+- 即使可领取标签异常共存，`agent:blocked` 在领取与续租路径中都保持最高优先级。
 - 增加 shell 回归测试，覆盖镜像修复以及两种受保护状态。

--- a/editing-history/202609041940-agent-lease-heartbeat-mirror-recovery.md
+++ b/editing-history/202609041940-agent-lease-heartbeat-mirror-recovery.md
@@ -1,0 +1,15 @@
+# Agent lease heartbeat mirror recovery
+
+UTC: 2026-09-04T19:40:45Z
+
+## English
+
+- Let `heartbeat` renew an owner-matching authoritative remote lease when the Issue state-label mirror is missing or stale.
+- Keep closed and explicitly `agent:blocked` Issues non-renewable.
+- Add shell regression coverage for mirror repair and both protected terminal states.
+
+## 中文
+
+- 当 Issue 状态标签镜像缺失或陈旧时，只要远端权威租约 owner 匹配，允许 `heartbeat` 续租并修复镜像。
+- 已关闭或显式标记 `agent:blocked` 的 Issue 仍禁止续租。
+- 增加 shell 回归测试，覆盖镜像修复以及两种受保护状态。

--- a/scripts/agent-issue-lease.sh
+++ b/scripts/agent-issue-lease.sh
@@ -122,6 +122,15 @@ require_claimable_issue() {
   die "issue #$issue is neither agent:ready nor agent:review"
 }
 
+require_renewable_issue() {
+  local issue="$1" repo="$2" state
+  state="$(gh issue view "$issue" --repo "$repo" --json state --jq .state)"
+  [[ "$state" == "OPEN" ]] || die "issue #$issue is not open"
+  if issue_has_label "$issue" "$repo" agent:blocked; then
+    die "issue #$issue is explicitly agent:blocked"
+  fi
+}
+
 set_issue_state() {
   local issue="$1" repo="$2" target="$3"
   gh issue edit "$issue" --repo "$repo" \
@@ -234,8 +243,10 @@ command_heartbeat() {
   [[ "$old_agent" == "$agent" ]] || die "issue #$issue is held by $old_agent, not $agent"
   repo="$(repo_slug)"
   ensure_labels "$repo"
-  # Do not extend ownership after the Issue has been closed or blocked.
-  require_claimable_issue "$issue" "$repo"
+  # The remote lock is authoritative. A missing or stale state label is a
+  # recoverable mirror failure, but an explicit maintainer block or closure is
+  # still authoritative and must stop renewal.
+  require_renewable_issue "$issue" "$repo"
   claimed="$(field "$old_sha" claimed_at)"
   scope="$(field "$old_sha" scope)"
   now="$(date +%s)"

--- a/scripts/agent-issue-lease.sh
+++ b/scripts/agent-issue-lease.sh
@@ -103,10 +103,18 @@ issue_has_label() {
   gh issue view "$1" --repo "$2" --json labels --jq '.labels[].name' | grep -Fxq "$3"
 }
 
-require_claimable_issue() {
+require_open_unblocked_issue() {
   local issue="$1" repo="$2" state
   state="$(gh issue view "$issue" --repo "$repo" --json state --jq .state)"
   [[ "$state" == "OPEN" ]] || die "issue #$issue is not open"
+  if issue_has_label "$issue" "$repo" agent:blocked; then
+    die "issue #$issue is explicitly agent:blocked"
+  fi
+}
+
+require_claimable_issue() {
+  local issue="$1" repo="$2"
+  require_open_unblocked_issue "$issue" "$repo"
   if issue_has_label "$issue" "$repo" agent:ready; then
     return
   fi
@@ -123,12 +131,7 @@ require_claimable_issue() {
 }
 
 require_renewable_issue() {
-  local issue="$1" repo="$2" state
-  state="$(gh issue view "$issue" --repo "$repo" --json state --jq .state)"
-  [[ "$state" == "OPEN" ]] || die "issue #$issue is not open"
-  if issue_has_label "$issue" "$repo" agent:blocked; then
-    die "issue #$issue is explicitly agent:blocked"
-  fi
+  require_open_unblocked_issue "$1" "$2"
 }
 
 set_issue_state() {

--- a/scripts/test-agent-issue-lease.sh
+++ b/scripts/test-agent-issue-lease.sh
@@ -31,7 +31,11 @@ if [[ "$1 $2" == "repo view" ]]; then
 elif [[ "$1 $2" == "label create" ]]; then
   :
 elif [[ "$1 $2" == "issue view" ]]; then
-  if [[ "$*" == *"--json state"* ]]; then echo OPEN; else echo agent:ready; fi
+  if [[ "$*" == *"--json state"* ]]; then
+    echo "${LEASE_TEST_ISSUE_STATE:-OPEN}"
+  else
+    printf '%s\n' "${LEASE_TEST_ISSUE_LABELS-agent:ready}"
+  fi
 elif [[ "$1 $2" == "issue edit" ]]; then
   previous=""
   for arg in "$@"; do
@@ -95,6 +99,8 @@ export LEASE_TEST_REAL_GIT="$real_git"
 export LEASE_TEST_WORK_REPO="$work_repo"
 export LEASE_TEST_OLD_SHA="$old_sha"
 export LEASE_TEST_NEW_SHA="$new_sha"
+export LEASE_TEST_ISSUE_STATE=OPEN
+export LEASE_TEST_ISSUE_LABELS=agent:ready
 
 (
   cd "$work_repo"
@@ -126,4 +132,43 @@ if grep -Fq 'Agent: ``' "$log_file" || grep -Fq 'Scope: ``' "$log_file"; then
   exit 1
 fi
 
-echo "agent lease release race tests passed"
+# Heartbeat trusts the validated remote lock and repairs a missing Issue state
+# label instead of rejecting the current owner because its mirror disappeared.
+heartbeat_sha="$(make_test_lock heartbeat-owner heartbeat-scope 1700000040)"
+"$real_git" -C "$work_repo" push --quiet --force origin "$heartbeat_sha:refs/heads/agent-lock/issue-1"
+: >"$log_file"
+export LEASE_TEST_ISSUE_LABELS=""
+(
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" heartbeat 1 heartbeat-owner
+)
+[[ "$(grep '^MIRROR ' "$log_file" | tail -n 1)" == "MIRROR agent:claimed" ]]
+renewed_sha="$("$real_git" -C "$work_repo" ls-remote --heads origin refs/heads/agent-lock/issue-1 | awk 'NR == 1 { print $1 }')"
+[[ -n "$renewed_sha" && "$renewed_sha" != "$heartbeat_sha" ]]
+[[ "$("$real_git" -C "$work_repo" show -s --format=%B "$renewed_sha" | sed -n 's/^agent_id=//p')" == "heartbeat-owner" ]]
+
+# Explicit blocked and closed Issue states remain non-renewable, and neither
+# failure may advance the authoritative lock.
+"$real_git" -C "$work_repo" push --quiet --force origin "$heartbeat_sha:refs/heads/agent-lock/issue-1"
+export LEASE_TEST_ISSUE_LABELS=agent:blocked
+if (
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" heartbeat 1 heartbeat-owner
+); then
+  echo "blocked Issue heartbeat unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$("$real_git" -C "$work_repo" ls-remote --heads origin refs/heads/agent-lock/issue-1 | awk 'NR == 1 { print $1 }')" == "$heartbeat_sha" ]]
+
+export LEASE_TEST_ISSUE_STATE=CLOSED
+export LEASE_TEST_ISSUE_LABELS=""
+if (
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" heartbeat 1 heartbeat-owner
+); then
+  echo "closed Issue heartbeat unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$("$real_git" -C "$work_repo" ls-remote --heads origin refs/heads/agent-lock/issue-1 | awk 'NR == 1 { print $1 }')" == "$heartbeat_sha" ]]
+
+echo "agent lease release race and heartbeat recovery tests passed"

--- a/scripts/test-agent-issue-lease.sh
+++ b/scripts/test-agent-issue-lease.sh
@@ -171,4 +171,25 @@ if (
 fi
 [[ "$("$real_git" -C "$work_repo" ls-remote --heads origin refs/heads/agent-lock/issue-1 | awk 'NR == 1 { print $1 }')" == "$heartbeat_sha" ]]
 
+# agent:blocked dominates conflicting claimable mirror labels for both renewal
+# of an existing lock and acquisition of a new lock.
+export LEASE_TEST_ISSUE_STATE=OPEN
+export LEASE_TEST_ISSUE_LABELS=$'agent:ready\nagent:blocked'
+if (
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" claim 1 heartbeat-owner heartbeat-scope
+); then
+  echo "blocked existing-lock claim unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$("$real_git" -C "$work_repo" ls-remote --heads origin refs/heads/agent-lock/issue-1 | awk 'NR == 1 { print $1 }')" == "$heartbeat_sha" ]]
+if (
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" claim 2 new-owner new-scope
+); then
+  echo "blocked new-lock claim unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ -z "$("$real_git" -C "$work_repo" ls-remote --heads origin refs/heads/agent-lock/issue-2)" ]]
+
 echo "agent lease release race and heartbeat recovery tests passed"


### PR DESCRIPTION
Closes #764.

## Summary

- renew an owner-matching authoritative remote lock even when its Issue state-label mirror is missing or stale
- reject renewal when the Issue is closed or explicitly `agent:blocked`
- restore `agent:claimed` and the lease comment through the existing post-push mirror synchronization
- document the recovery rule and add regression coverage

## Local validation

- `bash -n scripts/agent-issue-lease.sh scripts/test-agent-issue-lease.sh`
- `scripts/test-agent-issue-lease.sh`
- `shellcheck scripts/agent-issue-lease.sh scripts/test-agent-issue-lease.sh`
- `git diff --check`

No Podman/container validation was run. GitHub Actions on Linux is the authoritative full check.