### PR TITLE
Cover complete heartbeat mirror recovery / 覆盖完整 heartbeat 镜像修复

### DIFF
--- a/editing-history/202609050846-heartbeat-mirror-test-coverage.md
+++ b/editing-history/202609050846-heartbeat-mirror-test-coverage.md
@@ -1,0 +1,13 @@
+# Complete heartbeat mirror test coverage / 补齐 heartbeat 镜像测试覆盖
+
+## English
+
+- Assert that heartbeat recovery restores the `agent-lease:<issue>` comment marker as well as the `agent:claimed` label.
+- Exercise repair from a stale `agent:review` mirror while the authoritative remote lease remains valid.
+- Preserve the existing blocked and closed Issue exception coverage.
+
+## 中文
+
+- 断言 heartbeat 修复会同时恢复 `agent-lease:<issue>` 评论标记和 `agent:claimed` 标签。
+- 覆盖远端权威租约仍有效、Issue 镜像却停留在旧 `agent:review` 标签时的自动修复。
+- 保留已有的 blocked 与 closed Issue 异常路径覆盖。

--- a/scripts/test-agent-issue-lease.sh
+++ b/scripts/test-agent-issue-lease.sh
@@ -143,9 +143,21 @@ export LEASE_TEST_ISSUE_LABELS=""
   PATH="$fake_bin:$PATH" "$lease_script" heartbeat 1 heartbeat-owner
 )
 [[ "$(grep '^MIRROR ' "$log_file" | tail -n 1)" == "MIRROR agent:claimed" ]]
+grep -Fq '<!-- agent-lease:1 -->' "$log_file"
 renewed_sha="$("$real_git" -C "$work_repo" ls-remote --heads origin refs/heads/agent-lock/issue-1 | awk 'NR == 1 { print $1 }')"
 [[ -n "$renewed_sha" && "$renewed_sha" != "$heartbeat_sha" ]]
 [[ "$("$real_git" -C "$work_repo" show -s --format=%B "$renewed_sha" | sed -n 's/^agent_id=//p')" == "heartbeat-owner" ]]
+
+# A stale claimable state is repaired just like a missing state: the
+# authoritative lock wins, and both the label and lease comment are restored.
+: >"$log_file"
+export LEASE_TEST_ISSUE_LABELS=agent:review
+(
+  cd "$work_repo"
+  PATH="$fake_bin:$PATH" "$lease_script" heartbeat 1 heartbeat-owner
+)
+[[ "$(grep '^MIRROR ' "$log_file" | tail -n 1)" == "MIRROR agent:claimed" ]]
+grep -Fq '<!-- agent-lease:1 -->' "$log_file"
 
 # Explicit blocked and closed Issue states remain non-renewable, and neither
 # failure may advance the authoritative lock.


### PR DESCRIPTION
Closes #787
Follow-up to merged PR #766.

## Summary / 摘要

- assert that normal heartbeat mirror recovery restores the `agent-lease:1` comment marker
- cover recovery from a stale `agent:review` label while the authoritative lock remains valid
- preserve the blocked and closed exception-path tests

- 断言正常 heartbeat 镜像修复会恢复 `agent-lease:1` 评论标记
- 覆盖权威锁有效但 Issue 残留 `agent:review` 标签的修复
- 保留 blocked/closed 异常路径测试

## Validation / 验证

- `bash -n scripts/agent-issue-lease.sh scripts/test-agent-issue-lease.sh`
- `scripts/test-agent-issue-lease.sh`
- `git diff --check`

All passed locally.