### PR TITLE
Prioritize oldest actionable PR notifications / 优先处理最早可执行 PR 通知

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,8 @@ scripts/agent-issue-lease.sh status <issue-number>
 - PR 创建、最新提交推送并记录验证结果后，立即 `release ... review` 释放写入租约。Actions 或 review bot 仍在运行且没有可执行反馈时，不原地等待，可以认领下一个不冲突的 `agent:ready` Issue。
 - 一个 Agent 可以维护多个待审 PR 的观察列表，但同一时间只能持有一个 Issue 的写入租约。开始新任务不解除原 PR 的跟进责任。
 - 在认领新 Issue 前、完成一个实现检查点后、准备 push 前，以及距上次检查达到 10–15 分钟时，批量检查所有观察中的 PR。不要为单个 pending check 使用紧密轮询，也不使用会阻塞脚本的 `gh run watch`。
+- 批量处理 GitHub notifications 时，默认按 `updated_at` 升序处理最早的可执行 PR 通知。只有安全风险、发布阻塞或 required check 新失败等明确高优先级变化可以越过时间顺序，并在关联 Issue 记录原因。
+- 通知对应的 Issue 若由其他有效租约持有，只做只读归因，不修改其分支、不把仍需 owner 行动的通知标记已读，随后继续下一个可执行通知。已完成、已失效或已有明确阻塞证据的通知，分类后再标记已读，使未来状态变化可以重新通知。
 - 至少使用 `gh pr checks <pr-number>` 检查 Actions，并用 `gh pr view <pr-number> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,reviews,comments` 查看总体状态；inline comments 另外通过 `gh api repos/{owner}/{repo}/pulls/<pr-number>/comments` 检查。
 - Actions 失败时先读取失败日志并判断是否由本 PR 引入；能修复的立即修复并重新验证，外部或偶发失败要在 PR 留下证据，不能只重跑后忽略。
 - 对每条有效 review 意见进行处理：修改代码或明确回复不修改的理由。不要只回复评论而遗漏对应代码、测试或文档更新。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,7 @@ scripts/agent-issue-lease.sh status <issue-number>
 - PR 创建、最新提交推送并记录验证结果后，立即 `release ... review` 释放写入租约。Actions 或 review bot 仍在运行且没有可执行反馈时，不原地等待，可以认领下一个不冲突的 `agent:ready` Issue。
 - 一个 Agent 可以维护多个待审 PR 的观察列表，但同一时间只能持有一个 Issue 的写入租约。开始新任务不解除原 PR 的跟进责任。
 - 在认领新 Issue 前、完成一个实现检查点后、准备 push 前，以及距上次检查达到 10–15 分钟时，批量检查所有观察中的 PR。不要为单个 pending check 使用紧密轮询，也不使用会阻塞脚本的 `gh run watch`。
-- 批量处理 GitHub notifications 时，默认按 `updated_at` 升序处理最早的可执行 PR 通知。只有安全风险、发布阻塞或 required check 新失败等明确高优先级变化可以越过时间顺序，并在关联 Issue 记录原因。
+- 批量处理 GitHub notifications 时使用唯一的全序：先按“安全风险 → 当前发布阻塞 → required check 新失败 → 其他”的优先级，再按 `updated_at` 升序，最后按数字 notification ID 升序；没有 ID 时用 canonical thread URL 的字典序作为 tie-breaker。前三类越过普通时间顺序时，在关联 Issue 记录原因。
 - 通知对应的 Issue 若由其他有效租约持有，只做只读归因，不修改其分支、不把仍需 owner 行动的通知标记已读，随后继续下一个可执行通知。已完成、已失效或已有明确阻塞证据的通知，分类后再标记已读，使未来状态变化可以重新通知。
 - 至少使用 `gh pr checks <pr-number>` 检查 Actions，并用 `gh pr view <pr-number> --json state,mergeStateStatus,reviewDecision,statusCheckRollup,reviews,comments` 查看总体状态；inline comments 另外通过 `gh api repos/{owner}/{repo}/pulls/<pr-number>/comments` 检查。
 - Actions 失败时先读取失败日志并判断是否由本 PR 引入；能修复的立即修复并重新验证，外部或偶发失败要在 PR 留下证据，不能只重跑后忽略。

--- a/editing-history/202609050858-oldest-actionable-notifications.md
+++ b/editing-history/202609050858-oldest-actionable-notifications.md
@@ -2,12 +2,12 @@
 
 ## English
 
-- Sort batched GitHub notifications by ascending `updated_at` and handle the oldest actionable PR first.
+- Apply one total order: security risk, current release blocker, newly failing required check, then other notifications; within each class sort by ascending `updated_at`, then numeric notification ID or canonical thread URL.
 - Leave actionable notifications unread when another valid Issue lease owns the work; inspect them read-only and continue with the next available item.
-- Permit explicit security, release-blocker, and newly failing required-check exceptions, with the reason recorded on the coordinating Issue.
+- Record the reason when one of the first three priority classes precedes an otherwise older notification.
 
 ## 中文
 
-- 批量拉取 GitHub notifications 后按 `updated_at` 升序排列，优先处理最早且可执行的 PR。
+- 使用唯一全序：安全风险、当前发布阻塞、required check 新失败、其他通知；每类再按 `updated_at` 升序，最后按数字 notification ID 或 canonical thread URL 排序。
 - 其他有效 Issue 租约持有的工作只读检查，并保留其待处理通知未读，再继续下一个可执行项。
-- 安全风险、发布阻塞与 required check 新失败可以明确越序，但要在协调 Issue 记录原因。
+- 前三类优先于时间更早的普通通知时，要在协调 Issue 记录原因。

--- a/editing-history/202609050858-oldest-actionable-notifications.md
+++ b/editing-history/202609050858-oldest-actionable-notifications.md
@@ -1,0 +1,13 @@
+# Oldest actionable notifications first / 优先处理最早可执行通知
+
+## English
+
+- Sort batched GitHub notifications by ascending `updated_at` and handle the oldest actionable PR first.
+- Leave actionable notifications unread when another valid Issue lease owns the work; inspect them read-only and continue with the next available item.
+- Permit explicit security, release-blocker, and newly failing required-check exceptions, with the reason recorded on the coordinating Issue.
+
+## 中文
+
+- 批量拉取 GitHub notifications 后按 `updated_at` 升序排列，优先处理最早且可执行的 PR。
+- 其他有效 Issue 租约持有的工作只读检查，并保留其待处理通知未读，再继续下一个可执行项。
+- 安全风险、发布阻塞与 required check 新失败可以明确越序，但要在协调 Issue 记录原因。

--- a/editing-history/202609050904-total-notification-order.md
+++ b/editing-history/202609050904-total-notification-order.md
@@ -1,0 +1,11 @@
+# Total notification order / 通知全序规则
+
+## English
+
+- Resolve competing priority exceptions before comparing notification timestamps.
+- Use numeric notification ID, or canonical thread URL when no ID exists, as the stable final tie-breaker.
+
+## 中文
+
+- 多个优先级例外同时出现时，先确定优先级，再比较通知时间。
+- 最后使用数字 notification ID；没有 ID 时使用 canonical thread URL，保证排序稳定。


### PR DESCRIPTION
Closes #807

## Summary / 摘要

- process batched GitHub PR notifications in ascending `updated_at` order
- inspect notifications owned by another valid Issue lease read-only and leave actionable items unread
- allow documented security, release-blocker, and newly failing required-check exceptions

- 按 `updated_at` 升序处理批量 PR 通知
- 对其他有效租约持有的通知只读检查，并保留仍需 owner 处理的通知未读
- 允许有记录的安全、发布阻塞和 required check 新失败例外

## Validation / 验证

- `git diff --check`
- focused review of the PR follow-up scheduling rules
