### PR TITLE
Document readable dependency version policy / 记录可读依赖版本规则

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@
 - **一致性**：复用现有模式，保持日志和错误信息风格统一。
 - **测试覆盖**：新功能必须补齐正常路径与异常分支的测试用例。
 
+### 依赖版本引用
+
+- **版本号是 source of truth**：正式依赖、CLI 和 GitHub Actions 必须优先使用明确、已发布的精确版本或 release tag（例如 `v1.4.0`）。不要在版本位置使用裸 commit hash 代替版本号，也不要用 `@<sha> # v1.4.0` 这类注释让 hash 代理版本语义。
+- **hash 只表示 revision 或完整性**：仅在上游尚未发布、复现/二分问题，或已有明确供应链策略要求不可变 revision 时使用完整 commit hash；必须在 Issue/PR 中说明原因，并另外记录对应的正式版本/tag（没有则明确写 `unreleased`）。hash/checksum 可以作为版本之外的完整性证据，不能冒充版本本身。
+- **避免可移动版本**：工具支持时使用精确 release tag（如 `v1.4.0`），不使用会随发布移动的宽泛 tag（如 `v1`）。升级时直接更新可读版本，并按仓库门禁重新验证。
+
 ### 语言定位与文档一致性
 
 - **以 Calcit 自身为中心**：文档直接介绍 nominal struct/enum、traits 与方法、Option/Result、静态分析、typed FFI、Cirru source model 和跨 backend 语义，不再以 “ClojureScript dialect” 或其他语言类比作为主要解释框架。

--- a/editing-history/202609050942-readable-dependency-versions.md
+++ b/editing-history/202609050942-readable-dependency-versions.md
@@ -1,0 +1,13 @@
+# Keep dependency versions readable / 保持依赖版本可读
+
+## 中文
+
+- 在全局 Agent 规则中明确：正式依赖、CLI 与 GitHub Actions 使用精确 release 版本/tag 作为版本 source of truth。
+- 禁止用裸 commit hash 或附带版本注释的 hash 代理版本号；精确 release tag 优先于可移动的 major tag。
+- 保留少量明确例外：未发布源码验证、问题复现/二分，或已有供应链策略要求时可以固定完整 hash，但必须记录原因及对应版本，且只把它视作 revision/完整性证据。
+
+## English
+
+- Make exact released versions or tags the source of truth for dependencies, CLIs, and GitHub Actions.
+- Do not use a raw commit hash, even with a version comment, as a proxy version number; prefer an exact release tag over a moving major tag.
+- Allow full commit pins only for documented unreleased-source work, reproduction/bisection, or an explicit immutable-revision policy, with the canonical release version recorded separately.


### PR DESCRIPTION
Follow-up for #658, prompted by calcit-lang/calcit.std#61.

## English

- Make exact released versions or tags the source of truth for dependencies, CLIs, and GitHub Actions.
- Explicitly reject a raw commit SHA plus a version comment as a proxy version number.
- Prefer exact release tags over moving major tags.
- Keep narrow, documented exceptions for unreleased-source work, reproduction/bisection, or an explicit immutable-revision policy; in those cases the SHA is revision/integrity evidence and the canonical version is recorded separately.

Validation: `git diff --check`; documentation-only change.

## 中文

- 明确正式依赖、CLI 与 GitHub Actions 以精确 release 版本/tag 作为版本 source of truth。
- 明确禁止使用“裸 commit SHA + 版本注释”代理版本号。
- 精确 release tag 优先于可移动的 major tag。
- 仅为未发布源码验证、问题复现/二分或明确的不可变 revision 策略保留窄例外；此时 SHA 只是 revision/完整性证据，正式版本需另外记录。

验证：`git diff --check`；仅文档修改。