### PR TITLE
fix: preserve nominal generic order / 保留具名类型泛型顺序

### DIFF
--- a/calcit/test-types-inference.cirru
+++ b/calcit/test-types-inference.cirru
@@ -108,6 +108,14 @@
               assert-type applied-string 'String
               &inspect-type n
               &inspect-type s
+              match (parse-float |41)
+                (:ok value)
+                  assert= 42 $ + value 1
+                (:err error) (raise error)
+              match (parse-float |bad)
+                (:ok _) (raise |Expected-parse-error)
+                (:err error)
+                  assert= true $ starts-with? error |b
           :examples $ []
           :schema $ :: 'Dynamic
         'test-list-inference $ %{} 'CodeEntry (:doc |)

--- a/editing-history/202609060230-generic-declaration-order.md
+++ b/editing-history/202609060230-generic-declaration-order.md
@@ -1,0 +1,27 @@
+# Preserve positional nominal generic parameters / 保留具名类型泛型声明顺序
+
+Issue: #877. Base: dd8138aa2f41d213544453fbbf5ca618ea1996c7.
+
+- Static Struct/Enum parsing and runtime definition constructors sorted explicit
+  generic names, changing Result<T,E> into positional [E,T]. Keep declaration
+  order with stable first-occurrence deduplication; field/variant sorting stays.
+- 静态解析和运行时构造原先按字母排序泛型参数，破坏 Result 成功值/错误的类型
+  对应关系。保留原声明顺序及去重语义，不改变字段与变体排序。
+- Added static/runtime nominal metadata agreement (including a non-adjacent
+  duplicate), Result ok/err type-checking, and native/JS integration assertions.
+- `parse-float |41` followed by ok arithmetic now evaluates to 42. Rust tests:
+  712 library + 300 CLI + 23 integration pass; native suite passes.
+- Initial generated-JS execution lacked the repository-local @calcit/procs
+  self-link; use the existing yarn procs-link setup before repeating it.
+- Full yarn check-all (including JS, Agent interface 18/18, core tests 237,
+  WASM and lowering checks) and all-target Clippy pass. Added negative Result
+  payload misuse checks after the full run; rerun the focused Rust test.
+- Calcium local regression using this unreleased debug compiler: restored the
+  canonical Result<Value,Error> in patch validation and four message decoder
+  schemas previously written against sorted [E,T]. Normal client/server
+  preprocessing, 21 tests, JS codegen and Session/User JS suite pass. Published
+  dependency pins and the globally installed compiler remain unchanged.
+- Calcium 本地回归恢复标准 Result 顺序后通过；未发布的本地编译器仅用于验证，
+  不替代正式版本依赖。草稿 PR #47 仍需完成其他严格边界验收。
+- Latest-head review and Actions remain required. No release/version changes
+  or merge-completion claim.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -135,6 +135,23 @@ fn load_fixture_entries(path: &str) -> ProgramEntries {
 }
 
 #[test]
+fn result_generic_declaration_order_preserves_ok_and_err_payload_types() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries(
+      "do\n  match (parse-float |41)\n    (:ok value) (+ value 1)\n    (:err error) (str error |!)\n  match (parse-float |bad)\n    (:ok value) (+ value 1)\n    (:err error) (starts-with? error |b)",
+    );
+    run_check_only(&entries).expect("Result<Number,String> must bind ok to Number and err to String");
+    for snippet in [
+      "match (parse-float |41)\n  (:ok value) (starts-with? value |4)\n  (:err _) false",
+      "match (parse-float |bad)\n  (:ok _) 0\n  (:err error) (+ error 1)",
+    ] {
+      let entries = load_snippet_entries(snippet);
+      run_check_only(&entries).expect_err("Result payloads must not accept operations for the opposite type");
+    }
+  });
+}
+
+#[test]
 fn type_fail_schema_mismatch_fixtures_report_error_code() {
   run_with_large_stack(|| {
     let fixtures = [

--- a/src/builtins/structs.rs
+++ b/src/builtins/structs.rs
@@ -6,7 +6,7 @@ use cirru_edn::EdnTag;
 
 use crate::builtins::meta::type_of;
 use crate::calcit::CORE_NS;
-use crate::calcit::type_annotation::{collect_runtime_type_bindings, validate_runtime_generic_where_bounds};
+use crate::calcit::type_annotation::{collect_runtime_type_bindings, dedup_generic_names, validate_runtime_generic_where_bounds};
 use crate::calcit::{
   Calcit, CalcitEnumDef, CalcitErr, CalcitErrKind, CalcitImpl, CalcitImport, CalcitList, CalcitProc, CalcitStructDef,
   CalcitStructValue, CalcitSyntax, CalcitTypeAnnotation, brief_type_of_value, format_proc_examples_hint, value_matches_type_annotation,
@@ -377,8 +377,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
   }
 
-  generics.sort();
-  generics.dedup();
+  dedup_generic_names(&mut generics);
 
   let field_names: Vec<EdnTag> = fields.iter().map(|(name, _)| name.to_owned()).collect();
   let field_types: Vec<Arc<CalcitTypeAnnotation>> = fields.iter().map(|(_, t)| t.to_owned()).collect();
@@ -477,8 +476,7 @@ pub fn new_enum(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let values: Vec<Calcit> = variants.iter().map(|(_, value)| value.to_owned()).collect();
 
   let mut struct_ref = CalcitStructDef::from_fields(name_id, fields);
-  generics.sort();
-  generics.dedup();
+  dedup_generic_names(&mut generics);
   struct_ref.generics = Arc::new(generics);
   struct_ref.where_bounds = Arc::new(where_bounds);
   struct_ref.impls = vec![Arc::new(enum_prototype_marker())];

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -4055,6 +4055,12 @@ fn is_list_literal_head(head: &Calcit) -> bool {
     || matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if &**ns == CORE_NS && &**def == "[]")
 }
 
+/// Generic arguments are positional: deduplicate without changing declaration order.
+pub(crate) fn dedup_generic_names(generics: &mut Vec<Arc<str>>) {
+  let mut seen = HashSet::with_capacity(generics.len());
+  generics.retain(|name| seen.insert(name.clone()));
+}
+
 fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStructDef> {
   let forms = normalized_data_definition_forms(items);
   let name_form = forms.get(1)?;
@@ -4102,8 +4108,7 @@ fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStructDef> {
     }
   }
 
-  generics.sort();
-  generics.dedup();
+  dedup_generic_names(&mut generics);
 
   let field_names: Vec<EdnTag> = fields.iter().map(|(name, _)| name.to_owned()).collect();
   let field_types: Vec<Arc<CalcitTypeAnnotation>> = fields.iter().map(|(_, t)| t.to_owned()).collect();
@@ -4168,8 +4173,7 @@ fn parse_defenum_code(items: &CalcitList) -> Option<CalcitEnumDef> {
 
   let fields: Vec<EdnTag> = variants.iter().map(|(tag, _)| tag.to_owned()).collect();
   let values: Vec<Calcit> = variants.iter().map(|(_, value)| value.to_owned()).collect();
-  generics.sort();
-  generics.dedup();
+  dedup_generic_names(&mut generics);
   let mut struct_ref = CalcitStructDef::from_fields(name, fields);
   struct_ref.generics = Arc::new(generics);
   struct_ref.where_bounds = Arc::new(where_bounds);
@@ -4492,6 +4496,35 @@ mod tests {
     let enum_def = parse_defenum_code(&enum_code).expect("map-wrapped enum definition");
     assert!(enum_def.find_variant_by_name("some").is_some());
     assert!(enum_def.find_variant_by_name("none").is_some());
+  }
+
+  #[test]
+  fn nominal_generic_declaration_order_matches_static_and_runtime_paths() {
+    let quoted = |name: &str| Calcit::from(vec![symbol("quote"), symbol(name)]);
+    // Include a non-adjacent duplicate to preserve the previous deduplication behavior.
+    let generics = Calcit::from(vec![Calcit::Proc(CalcitProc::List), quoted("T"), quoted("E"), quoted("T")]);
+    let fields = [
+      Calcit::from(vec![Calcit::tag("value"), quoted("T")]),
+      Calcit::from(vec![Calcit::tag("error"), quoted("E")]),
+    ];
+    let expected = vec![Arc::<str>::from("T"), Arc::<str>::from("E")];
+    let args = vec![symbol("Ordered"), generics, fields[0].clone(), fields[1].clone()];
+    let struct_code = CalcitList::from(&[vec![symbol("defstruct")], args.clone()].concat()[..]);
+    let enum_code = CalcitList::from(&[vec![symbol("defenum")], args.clone()].concat()[..]);
+    let static_struct = parse_defstruct_code(&struct_code).expect("static struct");
+    let static_enum = parse_defenum_code(&enum_code).expect("static enum");
+    let Calcit::StructDef(runtime_struct) = crate::builtins::structs::new_struct(&args).expect("runtime struct") else {
+      panic!("expected StructDef");
+    };
+    let Calcit::EnumDef(runtime_enum) = crate::builtins::structs::new_enum(&args).expect("runtime enum") else {
+      panic!("expected EnumDef");
+    };
+    assert_eq!(static_struct.generics.as_ref(), &expected);
+    assert_eq!(runtime_struct.generics.as_ref(), &expected);
+    assert_eq!(static_enum.generics(), expected.as_slice());
+    assert_eq!(runtime_enum.generics(), expected.as_slice());
+    // Field/variant sorting is independent of generic parameter order.
+    assert_eq!(static_struct.fields.as_ref(), &[EdnTag::new("error"), EdnTag::new("value")]);
   }
 
   fn generic_result_enum() -> Arc<CalcitEnumDef> {


### PR DESCRIPTION
Closes #877.

## Fix / 修复

Explicit nominal generic parameters are positional. Four static/runtime Struct/Enum constructor paths sorted names, so Result<T,E> became [E,T] and `parse-float`'s ok payload was inferred as String.

Keep declaration order with stable first-occurrence deduplication. Preserve existing field/variant sorting, duplicate-name behavior, and generic bounds. No dependency/version changes.

显式泛型参数的声明顺序决定类型实参绑定，不能按字母重排。静态解析和运行时 Struct/Enum 构造现在保持顺序；字段/变体排序与原去重行为不变。

## Verification / 验证

- Rust: 712 library + 300 CLI + 23 integration tests passed.
- Added static/runtime Struct/Enum metadata agreement, non-alphabetical and non-adjacent duplicate generic names; Result positive and negative payload checks.
- Native/JS integration assertions cover parse success arithmetic and error String use.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, Node 24 `yarn compile`, full `yarn check-all` passed. Agent interface 18/18 and core tests 237 passed within check-all.
- The final added negative checks passed in the focused Result Rust regression after the full run.
- Local Calcium regression using this unreleased debug compiler: canonical Result<Value,Error> declarations restored in patch validator and four decoder schemas; normal client/server preprocessing, 21 tests, JS codegen and Session/User JS regressions pass. Global compiler and published dependency pins unchanged.

Calcium 的部分声明先前依赖错误的排序行为，已在隔离工作树恢复标准顺序并验证；Cumulo/calcium-workflow#47 仍是草稿，其他 strict-nil 验收未完成。

Require latest-head bot/user review, resolve valid findings, and all Actions green/CLEAN before merging. No release is included.
