### PR TITLE
fix: validate Ref writes / 校验引用写入类型

### DIFF
--- a/editing-history/202609060306-ref-write-boundary.md
+++ b/editing-history/202609060306-ref-write-boundary.md
@@ -1,0 +1,138 @@
+# Ref write boundary / 可变引用写入边界
+
+Issue: https://github.com/calcit-lang/calcit/issues/879
+
+Current handoff: the checkpoints below are chronological. Public issue creation
+was subsequently explicitly approved by the user and #879 is now in milestone 2.
+The generic, outer-unknown and nested-constructor gaps below have been addressed.
+Calcium integration with separately owned local ws-edn/cumulo-util fixes passes
+client/server preprocessing, all 23 native tests, generated-JS projection and
+serialized snapshot/patch regressions, production build and browser style smoke.
+Those provider fixes are unreleased; formal dependencies remain unchanged, and
+whole strict client/server still stop at cursor Map / parsed-database boundaries.
+The candidate binary was invoked explicitly; no global toolchain was replaced.
+Reel remains owned by other PRs. No merge or release is claimed by this record.
+
+用户批准后已公开创建 #879；下文保留早期失败和逐步修复记录。真实应用本地联调
+通过，但未发布 provider、正式依赖和全项目 strict 验收仍需单独推进。
+
+During Calcium strict migration, a full-state assertion passed while a literal
+get-in traversal returned none. A dependency-free reproduction on published
+0.13.77 and unreleased main 74420e5d confirms the difference only after mutating
+an atom to an incompatible nested Map payload. An immutable Map works.
+
+Atom inference retains Ref<T> from its initializer and deref restores T. Reset
+previously only preprocessed arguments, so subsequent typed reads could trust
+evidence invalidated by a write. The local candidate routes reset! through the
+existing argument checker with the target Ref's payload as its expected type.
+It does not widen declared types or disable literal-path optimization.
+
+Regressions cover scalar and nested Map mismatches, a non-Ref target, compatible
+scalar/Map writes, declared Ref<Number> acceptance/rejection, and an explicit
+Ref<Dynamic> boundary. The initial full cargo test run passed; subsequently
+added declared/open-reference cases passed in a focused rerun. cargo fmt --check,
+git diff --check and all-target clippy with -D warnings pass. Generated-JS and
+application validation, plus a final full run on the exact final patch, remain
+required; this checkpoint is not a release or merge claim.
+
+在真实应用回归中发现引用写入缺少校验，已缩小为无依赖合成复现。修复候选复用
+现有参数检查器，禁止不兼容写入破坏后续类型化读取的依据，不通过降低类型要求
+或关闭优化规避问题。Reel 及其工作区未修改。
+
+An issue draft is local under .calcit/snippets/atom-reset-issue.md. Public issue
+creation was rejected by permission review; no issue was created, and publishing
+this diagnostic requires explicit user approval. Do not retry indirectly.
+
+## Consumer and full-suite checkpoint
+
+The exact current patch passes cargo test (712 library, 301 CLI, 23 integration)
+and Node 24 yarn check-all, including Agent interface 18/18, native/JS suites,
+WASM, literal-path and typed-method checks. Calcium server preprocessing passes.
+Calcium client preprocessing now reports three genuine boundary disagreements:
+two ws-edn timer-ref writes claim Option<Number> but receive Option<JsNullish<JsObject>>;
+cumulo-util.activity's touch timer claims Number but receives JsNullish<JsObject>.
+These are not suppressed and no installed provider was edited.
+
+A further synthetic probe remains accepted and prevents treating this candidate
+as complete: a function with args Ref<T>, T can reset its reference to a fixed
+String. The shared generic argument matcher specializes T at the write instead
+of treating the reference's T as fixed. Next work must distinguish a reference's
+existing generic contract from fresh call-site inference, test accepted same-T
+writes and rejected unrelated writes, and audit Dynamic-to-concrete writes.
+
+完整检查通过但泛型引用反例仍未阻止，因此当前候选不能合并或发版。真实应用
+新增的三个 timer 边界告警保留，后续需由其所属模块补齐真实宿主类型契约。
+
+## Rigid generic write follow-up
+
+The generic counterexample above is now rejected. The write check uses a fresh
+binding probe and rejects writes that would specialize existing type variables.
+Regressions reject String into Ref<T>, unrelated T into Ref<Number>, and List<U>
+into Ref<List<T>>; same-T scalar and List writes continue to pass. Full Rust
+tests pass (712/301/23). Clippy's needless closure borrow was fixed, not allowed
+away; clippy and check-all are being rerun on that exact patch.
+
+Dynamic-to-concrete Ref writes still require a focused strict fixture. A direct
+strict exec probe stopped earlier at its synthetic entry's undeclared schema,
+so it supplies no evidence about that write boundary. Do not treat this gap as
+resolved or publish/merge the current candidate yet.
+
+泛型反例已补齐正反回归，拒绝写入时重新绑定已有类型参数；全量 Rust 测试通过。
+仍需单独验证 Dynamic 写入边界，不能把提前失败的 strict 入口当作验收证据。
+
+The generic follow-up's clippy and full check-all reruns completed successfully.
+A subsequent strict probe adds an explicit Unit entry hint: main preprocessing
+accepts a local `(Ref<Number>, Dynamic) -> Unit` function that resets the reference
+from that Dynamic argument; the default synthetic reload entry then fails its
+unrelated missing-schema gate. This narrows the next investigation to unknown
+payload writes, not the already-fixed generic specialization case.
+
+## Strict unknown outer payload
+
+Strict project writes now reject whole Dynamic/DynFn values (including absent
+type evidence) when the Ref payload has a non-Dynamic contract. Ref<Dynamic>
+continues to accept unknown values intentionally; compatibility mode is unchanged.
+The new CLI regression assigns both init and reload to the hinted entry, so an
+unrelated missing-schema error cannot satisfy the negative test. It checks
+Ref<Number>, Ref<List<Dynamic>>, Ref<T> rejection and Ref<Dynamic> acceptance.
+All four cases pass. The first red test exposed that resolve_type_value returns
+None for some Dynamic locals; the checker now treats that as unknown rather than
+silently skipping the write check.
+
+This checks the outer payload contract; nested erased positions in otherwise
+known containers and empty-container/none exceptions still need an explicit
+audit before calling the full Ref boundary complete.
+
+严格模式未知值写入已补回归：具体外层契约不能被未知值覆盖，显式开放引用仍可用。
+嵌套容器的未知位置及空值构造例外尚待审计，不提前宣称全部边界完成。
+
+The strict-outer follow-up passes cargo fmt --check, git diff --check and the
+full cargo test run (712 library, 302 CLI, 23 integration tests). Final check-all
+must be rerun after completing the remaining nested-position audit; the prior
+check-all success covers the generic-write checkpoint, not this later patch.
+
+## Nested erased positions and constructor evidence
+
+Strict reset checks now compare nested type positions against the fixed target
+contract, including collection keys/values, nominal arguments, and function
+signatures. Explicit Dynamic positions remain open. Literal List/Set/Map and
+core Option constructors provide value-level evidence, allowing empty and nested
+empty literals without pretending their inferred element types are concrete.
+Literal elements are checked individually, so wrapping an unknown value in a
+List does not bypass the boundary.
+
+The new ten-case strict regression passes: reject List<Dynamic>, Map<Tag,Dynamic>
+and Option<Dynamic> into concrete payloads; preserve open List<Dynamic>; accept
+empty List/Set/Map, nested empty List and %none; reject a literal List containing
+an unknown element. Full Rust tests (712/303/23), formatting and all-target clippy
+pass. Full check-all is running on this nested-position checkpoint.
+
+嵌套未知位置已增加定向检查和十组正反回归；空构造器使用实际表达式证据，
+不通过扩大目标类型或关闭门禁放行。当前仍未公开发布、合并或发版。
+
+The nested-position full check-all run completed successfully. Calcium's full
+23-test selection with the new compiler is **not green**: 22 pass, while the
+dispatch regression is blocked during preprocessing by the three timer warnings
+and an additional ws-edn global-client write (Option<WsClient> versus Option<T>).
+That fourth diagnostic needs source-level validation before changing its provider
+or calling it a confirmed provider defect. No warning was suppressed.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -152,6 +152,97 @@ fn result_generic_declaration_order_preserves_ok_and_err_payload_types() {
 }
 
 #[test]
+fn reset_rejects_incompatible_inferred_reference_payloads() {
+  run_with_large_stack(|| {
+    for snippet in [
+      "let ((state $ atom 1)) (reset! state |wrong)",
+      "let ((state $ atom $ {} $ :states $ {} $ :cursor $ [])) (reset! state $ {} $ :states $ {} $ :login $ {} (:data 1))",
+      "reset! 1 2",
+      "fn (state value)\n  hint-fn $ {} (:args $ [] (:: 'Ref 'T) 'T) (:generics $ [] 'T) (:return 'Unit)\n  reset! state |wrong\n  , &unit",
+      "fn (state value)\n  hint-fn $ {} (:args $ [] (:: 'Ref 'Number) 'T) (:generics $ [] 'T) (:return 'Unit)\n  reset! state value\n  , &unit",
+      "fn (state value)\n  hint-fn $ {} (:args $ [] (:: 'Ref $ :: 'List 'T) (:: 'List 'U)) (:generics $ [] 'T 'U) (:return 'Unit)\n  reset! state value\n  , &unit",
+      "fn (state)\n  hint-fn $ {} (:args $ [] $ :: 'Ref 'Number) (:return 'Unit)\n  reset! state |wrong\n  , &unit",
+    ] {
+      let entries = load_snippet_entries(snippet);
+      run_check_only(&entries).expect_err("incompatible reset! must fail before typed reads can use stale evidence");
+    }
+    for snippet in [
+      "let ((state $ atom 1)) (reset! state 2) (+ @state 1)",
+      "fn (state value)\n  hint-fn $ {} (:args $ [] (:: 'Ref 'T) 'T) (:generics $ [] 'T) (:return 'Unit)\n  reset! state value\n  , &unit",
+      "fn (state value)\n  hint-fn $ {} (:args $ [] (:: 'Ref $ :: 'List 'T) (:: 'List 'T)) (:generics $ [] 'T) (:return 'Unit)\n  reset! state value\n  , &unit",
+      "let ((state $ atom $ {} (:count 1))) (reset! state $ {} (:count 2)) (get-in @state $ [] :count)",
+      "fn (state)\n  hint-fn $ {} (:args $ [] $ :: 'Ref 'Number) (:return 'Unit)\n  reset! state 2\n  , &unit",
+      "fn (state)\n  hint-fn $ {} (:args $ [] $ :: 'Ref 'Dynamic) (:return 'Unit)\n  reset! state |open-boundary\n  , &unit",
+    ] {
+      let entries = load_snippet_entries(snippet);
+      run_check_only(&entries).expect("compatible reference writes should retain their payload types");
+    }
+  });
+}
+
+#[test]
+fn strict_reset_requires_known_outer_payload_or_explicit_open_reference() {
+  run_with_large_stack(|| {
+    for (payload, passes) in [
+      ("'Number", false),
+      ("(:: 'List 'Dynamic)", false),
+      ("'T", false),
+      ("'Dynamic", true),
+    ] {
+      let snippet = format!(
+        "hint-fn $ {{}} (:args $ []) (:return 'Unit)\nlet\n    write $ fn (state value)\n      hint-fn $ {{}} (:args $ [] (:: 'Ref {payload}) 'Dynamic) (:generics $ [] 'T) (:return 'Unit)\n      reset! state value\n      , &unit\n  , &unit"
+      );
+      let mut entries = load_snippet_entries(&snippet);
+      // Both entries use the explicitly hinted function, so a missing schema
+      // on the synthetic reload stub cannot masquerade as write rejection.
+      entries.reload_fn = entries.init_fn.clone();
+      entries.reload_ns = entries.init_ns.clone();
+      entries.reload_def = entries.init_def.clone();
+      let _strict = StrictTypesReset::enabled();
+      let result = run_check_only(&entries);
+      if passes {
+        result.expect("Ref<Dynamic> intentionally accepts an unknown payload");
+      } else {
+        result.expect_err("strict reset! must not write whole Dynamic into a constrained reference");
+      }
+    }
+  });
+}
+
+#[test]
+fn strict_reset_checks_nested_unknowns_and_literal_empty_values() {
+  run_with_large_stack(|| {
+    for (payload, input, value, passes) in [
+      ("(:: 'List 'Number)", "(:: 'List 'Dynamic)", "value", false),
+      ("(:: 'Map 'Tag 'Number)", "(:: 'Map 'Tag 'Dynamic)", "value", false),
+      ("(:: 'Option 'Number)", "(:: 'Option 'Dynamic)", "value", false),
+      ("(:: 'List 'Dynamic)", "(:: 'List 'Dynamic)", "value", true),
+      ("(:: 'List 'Number)", "'Number", "([])", true),
+      ("(:: 'Set 'Number)", "'Number", "(#{})", true),
+      ("(:: 'Map 'Tag 'Number)", "'Number", "({})", true),
+      ("(:: 'List $ :: 'List 'Number)", "'Number", "([] $ [])", true),
+      ("(:: 'Option 'Number)", "'Number", "(%none)", true),
+      ("(:: 'List 'Number)", "'Dynamic", "([] value)", false),
+    ] {
+      let snippet = format!(
+        "hint-fn $ {{}} (:args $ []) (:return 'Unit)\nlet\n    write $ fn (state value)\n      hint-fn $ {{}} (:args $ [] (:: 'Ref {payload}) {input}) (:return 'Unit)\n      reset! state {value}\n      , &unit\n  , &unit"
+      );
+      let mut entries = load_snippet_entries(&snippet);
+      entries.reload_fn = entries.init_fn.clone();
+      entries.reload_ns = entries.init_ns.clone();
+      entries.reload_def = entries.init_def.clone();
+      let _strict = StrictTypesReset::enabled();
+      let result = run_check_only(&entries);
+      assert_eq!(
+        result.is_ok(),
+        passes,
+        "payload={payload}, input={input}, value={value}: {result:?}"
+      );
+    }
+  });
+}
+
+#[test]
 fn type_fail_schema_mismatch_fixtures_report_error_code() {
   run_with_large_stack(|| {
     let fixtures = [

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use type_checking::{
   CallTypeCheckInfo, check_core_fn_arg_types, check_function_return_type, check_local_fn_call_arg_types, check_proc_arg_types,
-  check_user_fn_arg_types, detect_return_type_hint_from_processed_body,
+  check_reset_arg_types, check_user_fn_arg_types, detect_return_type_hint_from_processed_body,
 };
 pub use type_inference::infer_static_type_from_expr;
 use type_inference::{
@@ -2560,10 +2560,17 @@ fn preprocess_list_call(
         | CalcitSyntax::Macroexpand
         | CalcitSyntax::MacroexpandAll
         | CalcitSyntax::Macroexpand1
-        | CalcitSyntax::Gensym
-        | CalcitSyntax::Reset => {
+        | CalcitSyntax::Gensym => {
           let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
           Ok(preprocess_each_items(name, name_ns, &args, &mut ctx)?)
+        }
+        CalcitSyntax::Reset => {
+          let mut ctx = PreprocessContext::new(scope_defs, scope_types, file_ns, check_warnings, call_stack);
+          let form = preprocess_each_items(name, name_ns, &args, &mut ctx)?;
+          if let Calcit::List(items) = &form {
+            check_reset_arg_types(&head_form, &items.drop_left(), scope_types, file_ns, check_warnings);
+          }
+          Ok(form)
         }
         CalcitSyntax::Quote | CalcitSyntax::Eval => Ok(preprocess_quote(name, name_ns, &args, scope_defs, file_ns)?),
         CalcitSyntax::HintFn => {

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -778,6 +778,131 @@ pub(crate) fn check_core_fn_arg_types(
   }
 }
 
+/// Find erased positions relative to a fixed write contract, not merely any
+/// Dynamic nested somewhere in a type (which may be intentionally open).
+fn reset_type_erases_contract(actual: &CalcitTypeAnnotation, expected: &CalcitTypeAnnotation) -> bool {
+  use CalcitTypeAnnotation as T;
+  match (actual, expected) {
+    (_, T::Dynamic) => false,
+    (T::Dynamic | T::DynFn, _) => true,
+    (T::List(a), T::List(e))
+    | (T::Set(a), T::Set(e))
+    | (T::Ref(a), T::Ref(e))
+    | (T::Optional(a), T::Optional(e))
+    | (T::JsNullish(a), T::JsNullish(e))
+    | (T::Variadic(a), T::Variadic(e)) => reset_type_erases_contract(a, e),
+    (T::Map(ak, av), T::Map(ek, ev)) => reset_type_erases_contract(ak, ek) || reset_type_erases_contract(av, ev),
+    (T::TypeRef(_, a), T::TypeRef(_, e)) | (T::Struct(_, a), T::Struct(_, e)) | (T::Enum(_, a), T::Enum(_, e)) => {
+      a.iter().zip(e.iter()).any(|(a, e)| reset_type_erases_contract(a, e))
+    }
+    (T::Fn(a), T::Fn(e)) => {
+      a.arg_types
+        .iter()
+        .zip(e.arg_types.iter())
+        .any(|(a, e)| reset_type_erases_contract(a, e))
+        || reset_type_erases_contract(&a.return_type, &e.return_type)
+        || a
+          .rest_type
+          .as_ref()
+          .zip(e.rest_type.as_ref())
+          .is_some_and(|(a, e)| reset_type_erases_contract(a, e))
+    }
+    _ => false,
+  }
+}
+
+/// Literal constructors provide stronger evidence than their homogeneous
+/// inferred types, especially for empty collections and nested empty values.
+fn reset_value_erases_contract(value: &Calcit, expected: &CalcitTypeAnnotation, scope: &ScopeTypes) -> bool {
+  use CalcitTypeAnnotation as T;
+  if matches!(expected, T::Dynamic) {
+    return false;
+  }
+  if let Calcit::List(items) = value {
+    match (items.first(), expected) {
+      (Some(Calcit::Proc(CalcitProc::List)), T::List(inner)) | (Some(Calcit::Proc(CalcitProc::Set)), T::Set(inner)) => {
+        return items.iter().skip(1).any(|item| reset_value_erases_contract(item, inner, scope));
+      }
+      (Some(Calcit::Proc(CalcitProc::NativeMap)), T::Map(key, val)) if items.len() % 2 == 1 => {
+        return items
+          .iter()
+          .skip(1)
+          .enumerate()
+          .any(|(index, item)| reset_value_erases_contract(item, if index % 2 == 0 { key } else { val }, scope));
+      }
+      (Some(Calcit::Import(import)), _) if import.ns.as_ref() == calcit::CORE_NS && expected.is_option_type() => {
+        if import.def.as_ref() == "%none" && items.len() == 1 {
+          return false;
+        }
+        if import.def.as_ref() == "%some"
+          && items.len() == 2
+          && let T::TypeRef(_, args) = expected
+          && let Some(inner) = args.first()
+        {
+          return reset_value_erases_contract(&items[1], inner, scope);
+        }
+      }
+      _ => {}
+    }
+  }
+  let actual = resolve_type_value(value, scope).unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
+  reset_type_erases_contract(actual.as_ref(), expected) || !actual.matches_annotation(expected)
+}
+
+/// A mutable reference's payload type is fixed by its declaration/initializer,
+/// not widened by an incompatible write before a later typed read.
+pub(super) fn check_reset_arg_types(
+  head_form: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) {
+  let payload = args.first().and_then(|target| resolve_type_value(target, scope_types));
+  let payload = match payload.as_deref() {
+    Some(CalcitTypeAnnotation::Ref(inner)) => inner.clone(),
+    _ => calcit::DYNAMIC_TYPE.clone(),
+  };
+  let expected_types = [Arc::new(CalcitTypeAnnotation::Ref(payload.clone())), payload];
+  let ctx = CheckContext {
+    head_form,
+    args,
+    expected_types: &expected_types,
+    where_bounds: &[],
+    scope_types,
+    file_ns,
+    call_location: head_form.get_location(),
+    warning_code: "W_RESET_ARG_TYPE_MISMATCH",
+    check_warnings,
+  };
+  let message = |index, expected: &str, actual: &str, expr: String| {
+    format!("[Warn] `reset!` arg {index} expects type `{expected}`, but got `{actual}`\n  Expression: (reset! {expr})")
+  };
+  if let Some(value) = args.get(1) {
+    let actual = resolve_type_value(value, scope_types).unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
+    let expected = expected_types[1].as_ref();
+    // Unknown positions cannot establish a concrete payload contract. Literal
+    // constructors can prove empty/nested values without inventing element types.
+    // Explicit Dynamic positions stay open; compatibility mode is unchanged.
+    if super::strict_types_enabled()
+      && super::should_emit_project_source_lint(file_ns)
+      && reset_value_erases_contract(value, expected, scope_types)
+    {
+      ctx.emit_warning(2, expected, actual.as_ref(), message);
+      return;
+    }
+    // Unlike a fresh polymorphic function call, a write cannot specialize an
+    // existing reference's type variables, nor assume an unrelated input T is
+    // the reference's concrete payload type. Identical variables need no binding.
+    let mut bindings = HashMap::new();
+    if actual.matches_with_bindings(expected, &mut bindings) && !bindings.is_empty() {
+      ctx.emit_warning(2, expected, actual.as_ref(), message);
+      return;
+    }
+  }
+  check_arg_types_loop(ctx, message);
+}
+
 /// Check argument types when calling a local variable with a known Fn type.
 pub(crate) fn check_local_fn_call_arg_types(
   head_form: &Calcit,


### PR DESCRIPTION
## Scope / 范围

Fixes #879. Preserve a Ref's declared or initializer-inferred payload contract
when preprocessing reset!, so later typed reads cannot trust evidence invalidated
by an incompatible write.

- Reuse the existing argument diagnostic infrastructure with W_RESET_ARG_TYPE_MISMATCH.
- Reject concrete mismatches and writes that freshly specialize existing generic variables.
- In strict project code, reject erased outer/nested positions relative to the fixed contract.
- Preserve explicit Dynamic positions and constructor evidence for empty collections/Option none.
- Add positive and negative regressions; do not widen types or disable path lowering.

修复引用写入破坏类型依据的问题，覆盖声明/推断引用、泛型、严格未知位置和空构造器。
不修改 Reel、不升级版本、不放宽现有门禁。

## Verification / 验证

- cargo fmt --check; cargo clippy --all-targets -- -D warnings.
- cargo test: 712 library, 303 CLI, 23 integration tests.
- Node 24 yarn check-all (includes compile, Agent interface, native/JS, WASM and literal paths).
- Local Calcium integration with this unreleased binary and separate unreleased
  ws-edn/cumulo-util fixes: client/server preprocessing, 23 native tests, generated-JS
  Session/User/config and serialized snapshot/patch regressions, production build,
  connected browser and actual static stylesheet application.

The new checker exposes existing timer and nominal-client boundary issues in
published providers. Local provider fixes were used only as integration evidence;
they are NOT published dependency acceptance. Global Calcit remains unchanged.
Calcium whole strict still stops at its cursor Map / parsed-database boundaries.

检查器揭示了 provider 既有 timer/nominal client 契约问题；本地联调修复不是正式
依赖验收。等待最新 head 的 bot/user review、处理意见、threads=0 和 Actions 全绿，
再考虑合并；合并后还需精确 main Actions 验证。
