### PR TITLE
fix: render reset diagnostic once / 清理重复诊断调用头

### DIFF
--- a/editing-history/202609061020-reset-diagnostic.md
+++ b/editing-history/202609061020-reset-diagnostic.md
@@ -1,0 +1,15 @@
+# Reset diagnostic follow-up / 引用写入诊断跟进
+
+Issue: #881.
+
+Follow up the CodeRabbit finding on #880, related to #879. The shared
+CheckContext already includes the call head when supplying the expression to
+the formatter. Remove the additional reset! prefix without changing the warning
+code, argument index, expected/actual types, or rejection semantics.
+
+The regression first failed on `(reset! (&syntax reset!) 'state |wrong)` with
+two occurrences. It checks exactly one W_RESET_ARG_TYPE_MISMATCH, preserves the
+Number/String details, and requires a single call head in the expression.
+
+复现并修复合并后到达的 review 意见：共享诊断上下文已经包含调用头，不再重复
+拼接 reset!。新增先红后绿回归，保留错误代码、参数和类型信息，不改变类型检查规则。

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -152,6 +152,26 @@ fn result_generic_declaration_order_preserves_ok_and_err_payload_types() {
 }
 
 #[test]
+fn reset_diagnostic_renders_the_call_head_once() {
+  run_with_large_stack(|| {
+    let entries = load_snippet_entries("let ((state $ atom 1)) (reset! state |wrong)");
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("mismatched reset should produce a warning");
+    let warnings = warnings.borrow();
+    let matched: Vec<_> = warnings
+      .iter()
+      .filter(|warning| warning.code() == Some("W_RESET_ARG_TYPE_MISMATCH"))
+      .collect();
+    assert_eq!(matched.len(), 1, "{warnings:?}");
+    let message = matched[0].message();
+    assert!(message.contains("arg 2 expects type `:number`, but got `:string`"), "{message}");
+    let expression = message.split("Expression: ").nth(1).expect("diagnostic includes expression");
+    assert_eq!(expression.matches("reset!").count(), 1, "{expression}");
+  });
+}
+
+#[test]
 fn reset_rejects_incompatible_inferred_reference_payloads() {
   run_with_large_stack(|| {
     for snippet in [

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -876,7 +876,7 @@ pub(super) fn check_reset_arg_types(
     check_warnings,
   };
   let message = |index, expected: &str, actual: &str, expr: String| {
-    format!("[Warn] `reset!` arg {index} expects type `{expected}`, but got `{actual}`\n  Expression: (reset! {expr})")
+    format!("[Warn] `reset!` arg {index} expects type `{expected}`, but got `{actual}`\n  Expression: ({expr})")
   };
   if let Some(value) = args.get(1) {
     let actual = resolve_type_value(value, scope_types).unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());


### PR DESCRIPTION
Fixes #881. Follow-up to https://github.com/calcit-lang/calcit/pull/880#discussion_r3942688470.

## Change / 修改

CheckContext already includes the call head. Remove the reset formatter's duplicate
prefix, preserving the warning code, argument index, expected/actual types and
type-checking behavior. Add a regression that first failed on two occurrences of
reset! and now requires exactly one in the rendered expression.

复现并处理 #880 合并后到达的 review 意见；只修正诊断文本并补回归，不改变校验语义。

## Verification / 验证

- cargo fmt; cargo clippy --all-targets -- -D warnings.
- cargo test: 712 library, 304 CLI, 23 integration tests pass.
- Node 24 yarn check-all, including compile, Agent CLI, native/JS and WASM checks.

Wait for latest-head bot/user review, all valid findings handled, zero unresolved
threads and successful Actions before merging. 等待 review 和 Actions 完成后再合并。
