### PR TITLE
build: 精确消费 Calx VM 0.5.0 / pin published Calx VM 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "73ebd0fd554c1e6778850f26743d7a06dca3f387e945d03f202abd424c4b1743"
 
 [[package]]
 name = "calx_vm"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6c7b1ce24e4e724da7d7831b87daac55213b900493a4f081cc97a48d56ca83"
+checksum = "fbe17d233477ea19af07355bae3920d17ea6c4f9606b2cc636da15f46117fd5c"
 dependencies = [
  "argh",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1.0.151"
 cirru_edn = "0.8.0"
 cirru_parser = "=0.2.15"
 bisection_key = "0.0.1"
-calx_vm = "0.4.0"
+calx_vm = "=0.5.0"
 calcit_native_ffi = { version = "0.1.3", default-features = false }
 rmp-serde = "1.3.0"
 semver = "1.0.28"

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -3,6 +3,17 @@
 Calcit 正在验证一个很窄的 typed kernel 子集能否编译到 Calx。这个实验不改变默认 native
 runner、JS codegen 或仓库内部 WASM backend，也不会把任意 Calcit 函数静默发送给另一个运行时。
 
+当前依赖精确锁定 crates.io 发布的 `calx_vm = "=0.5.0"`。该版本收紧 strict value domain，
+并复用尾调用的 locals 容量；Calcit 的 typed lowering 边界、ABI edition 和 benchmark session
+edition 不变，不新增动态值回退或运行模式。性能采样与消费者版本组合仍由
+[独立 harness](https://github.com/calcit-lang/calcit-calx-bench) 的 `pins.json` 和报告记录。
+
+The dependency is pinned to the published crates.io release `calx_vm = "=0.5.0"`, which tightens
+the strict value domain and reuses tail-call locals capacity. Calcit's typed lowering boundary,
+ABI edition, and benchmark session edition remain unchanged; this adds no dynamic-value fallback
+or execution mode. Performance sampling and consumer version combinations remain owned by the
+[standalone harness](https://github.com/calcit-lang/calcit-calx-bench), its `pins.json`, and reports.
+
 当前阶段建立 eligibility boundary，并把通过证明的 closed kernel 降为可执行的 strict Calx program：
 
 ```text

--- a/editing-history/202609061023-calx-0.5.0-consumer.md
+++ b/editing-history/202609061023-calx-0.5.0-consumer.md
@@ -1,0 +1,19 @@
+# Calx 0.5.0 published consumer / 正式版本消费者
+
+## 中文
+
+- 将 Calcit 的 VM 依赖精确锁定到 crates.io 已发布的 `calx_vm = "=0.5.0"`，不使用 path 或 git override。
+- 保持现有 typed lowering、ABI 与 benchmark session edition；strict admission 和尾调用 locals 容量复用由 VM 提供。
+- 更新 target 文档的版本边界；机器相关的性能采样和 pin 组合仍由独立 harness 维护。
+- 关联 calx-vm #60、#61；harness 必须在本改动合并且精确 main SHA 验证成功后再更新 Calcit revision。
+- 验证：`cargo fmt`、`cargo clippy --offline -- -D warnings`、`cargo test --offline`、18 项 Calx 专项测试、`yarn compile` 与 `yarn check-all` 通过。隔离 checkout 先通过 `yarn procs-link` 配置 CI 同款本地 JS 包链接。
+- Agent interface 18/18 通过；本机 arm64、Rust 1.97.1、Node 20.10.0，debug semantic context 查询 373.58 ms / 3940 bytes、表达式类型查询 218.71 ms / 2729 bytes、summary-only coverage 117.03 ms / 1273 bytes。仅记录 smoke 测量，不作为性能比较。
+
+## English
+
+- Pin Calcit to the published crates.io release `calx_vm = "=0.5.0"`, without path or git overrides.
+- Preserve typed lowering, the ABI, and the benchmark session edition; strict admission and tail-call locals reuse belong to the VM.
+- Document the consumer version boundary while leaving machine-specific sampling and pin combinations in the standalone harness.
+- Track calx-vm #60 and #61; update the harness Calcit revision only after this change merges and its exact main SHA passes verification.
+- Validation passed: `cargo fmt`, `cargo clippy --offline -- -D warnings`, `cargo test --offline`, 18 Calx tests, `yarn compile`, and `yarn check-all`. The isolated checkout uses `yarn procs-link` for the same local JS package link as CI.
+- Agent interface: 18/18 passed on arm64, Rust 1.97.1, Node 20.10.0. Debug semantic context: 373.58 ms / 3940 bytes; expression type: 218.71 ms / 2729 bytes; summary-only coverage: 117.03 ms / 1273 bytes. These are smoke observations, not comparative performance evidence.


### PR DESCRIPTION
## 中文

关联 https://github.com/calcit-lang/calx-vm/issues/60 和 https://github.com/calcit-lang/calx-vm/issues/61。

### 范围

- 精确消费 crates.io 已发布的 `calx_vm = "=0.5.0"`；lockfile 仅更新该包的版本与 checksum，没有 path/git override 或其他依赖升级。
- 保留现有 typed lowering、ABI 与 benchmark session edition；不新增动态值回退、运行模式或 VM 复用 API。
- 记录正式消费者边界。性能报告与机器相关采样仍留在 standalone harness；本 PR 不声称端到端加速。

### 验证

- `cargo fmt`、`cargo clippy --offline -- -D warnings`、`cargo test --offline` 通过（712 library + 304 CLI + 23 WASM tests）。
- `cargo test --offline calx`：18/18 通过。
- `yarn compile`、`yarn check-all` 通过，包含 native/JS/IR/WASM 与 Agent interface 18/18。首次 JS 检查缺少隔离 checkout 的本地包链接，通过 `yarn procs-link` 按 CI 配置后完整重跑通过。
- Agent CLI debug smoke：context 373.58 ms / 3940 bytes；expression type 218.71 ms / 2729 bytes；summary-only coverage 117.03 ms / 1273 bytes。arm64、Rust 1.97.1、Node 20.10.0；不是性能前后对比。
- Cargo metadata 确认只有一个 VM 0.5.0，来源为 crates.io；scalar/F64Buffer fixture SHA-256 与 harness 当前 pins 一致。

### 后续

合并且精确 main SHA 的 Actions 成功后，再通过独立 PR 更新 `calcit-calx-bench` 的 Calcit revision、VM 版本和 lockfile，执行完整 debug/release matrix。保留历史报告及其原始复现 revision，不在 core 加入 raw profiler JSON。

## English

Tracks https://github.com/calcit-lang/calx-vm/issues/60 and https://github.com/calcit-lang/calx-vm/issues/61.

### Scope

- Consume the exact published crates.io release `calx_vm = "=0.5.0"`; only that package's version/checksum change in the lockfile, with no path/git override or unrelated dependency update.
- Preserve typed lowering, the ABI, and benchmark session edition; add no dynamic-value fallback, execution mode, or VM reuse API.
- Document the published consumer boundary. Performance reports and machine-specific sampling stay in the standalone harness; this PR makes no end-to-end speedup claim.

### Validation

- Passed `cargo fmt`, `cargo clippy --offline -- -D warnings`, and `cargo test --offline` (712 library + 304 CLI + 23 WASM tests).
- `cargo test --offline calx`: 18/18 passed.
- Passed `yarn compile` and `yarn check-all`, including native/JS/IR/WASM and all 18 Agent interface scenarios. The first JS run lacked the isolated checkout's local package link; after `yarn procs-link` reproduced CI setup, the complete rerun passed.
- Agent CLI debug smoke: context 373.58 ms / 3940 bytes; expression type 218.71 ms / 2729 bytes; summary-only coverage 117.03 ms / 1273 bytes. arm64, Rust 1.97.1, Node 20.10.0; not a before/after performance comparison.
- Cargo metadata resolves exactly one VM 0.5.0 from crates.io; scalar/F64Buffer fixture SHA-256 values match the current harness pins.

### Next step

After merge and successful Actions on the exact main SHA, update the standalone harness's Calcit revision, VM version, and lockfile in a separate PR, then run its complete debug/release matrix. Preserve historical reports and their original reproduction revisions; do not add raw profiler JSON to core.
