### PR TITLE
test: 增加严格 F64Buffer gather workload / add strict F64Buffer gather workload

### DIFF
--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -160,6 +160,19 @@ generated-program golden 固定 import declaration、guest syntax 与 Calcit tre
 Calcit preprocessing 后，生成程序 golden 固定 `F64ToI64Index`/`F64BufferGet`。测试同时对照 native
 Calcit 执行，并拒绝 Nil、List、byte Buffer 和越界访问；VM trap 后不会自动重跑 native Calcit。
 
+[`tests/fixtures/calx/f64-buffer-gather-kernel.cirru`](../../tests/fixtures/calx/f64-buffer-gather-kernel.cirru)
+增加第二种访存模式：顺序读取 concrete `F64Buffer` index stream，经 checked conversion 后对另一个
+`F64Buffer` 做间接 gather，并以尾递归求和。它复用 ABI `/2` 与现有三个 typed-buffer intrinsic，
+不新增 opcode 或动态兜底。golden 固定两级读取及 source origin；differential 测试覆盖乱序/重复索引、
+zero remaining，以及 index stream 越界、非整数/负数/非 finite index 和 value buffer 越界 trap。
+
+The independent `f64-buffer-gather-kernel.cirru` fixture adds a second access pattern:
+sequentially read a concrete `F64Buffer` index stream, apply checked conversion, and gather
+indirectly from another `F64Buffer` while accumulating through tail recursion. It reuses ABI `/2`
+and the three existing typed-buffer intrinsics, with no new opcode or dynamic fallback. Its golden
+fixes both reads and source origins; differential tests cover permuted/repeated indices, zero
+remaining, index-stream bounds, fractional/negative/non-finite indices, and value-buffer bounds.
+
 ## 错误与回退边界
 
 - `Eligibility` 是唯一允许 embedding 选择整体回退到 Calcit 的编译结果；

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -162,14 +162,14 @@ Calcit 执行，并拒绝 Nil、List、byte Buffer 和越界访问；VM trap 后
 
 [`tests/fixtures/calx/f64-buffer-gather-kernel.cirru`](../../tests/fixtures/calx/f64-buffer-gather-kernel.cirru)
 增加第二种访存模式：顺序读取 concrete `F64Buffer` index stream，经 checked conversion 后对另一个
-`F64Buffer` 做间接 gather，并以尾递归求和。它复用 ABI `/2` 与现有三个 typed-buffer intrinsic，
-不新增 opcode 或动态兜底。golden 固定两级读取及 source origin；differential 测试覆盖乱序/重复索引、
+`F64Buffer` 做间接 gather，并以尾递归求和。它复用 ABI `/2` 与现有的 `F64BufferGet`、
+`F64ToI64Index` 两个 intrinsic，不新增 opcode 或动态兜底。golden 固定两级读取及 source origin；differential 测试覆盖乱序/重复索引、
 zero remaining，以及 index stream 越界、非整数/负数/非 finite index 和 value buffer 越界 trap。
 
 The independent `f64-buffer-gather-kernel.cirru` fixture adds a second access pattern:
 sequentially read a concrete `F64Buffer` index stream, apply checked conversion, and gather
 indirectly from another `F64Buffer` while accumulating through tail recursion. It reuses ABI `/2`
-and the three existing typed-buffer intrinsics, with no new opcode or dynamic fallback. Its golden
+and the existing `F64BufferGet` and `F64ToI64Index` intrinsics, with no new opcode or dynamic fallback. Its golden
 fixes both reads and source origins; differential tests cover permuted/repeated indices, zero
 remaining, index-stream bounds, fractional/negative/non-finite indices, and value-buffer bounds.
 

--- a/editing-history/202609061107-f64-buffer-gather.md
+++ b/editing-history/202609061107-f64-buffer-gather.md
@@ -1,0 +1,23 @@
+# Strict F64Buffer gather lowering / 严格 F64Buffer gather 编译
+
+## 中文
+
+- 为 #884 增加独立 source-backed `gather-sum`：顺序读取 index buffer，再以 checked index 间接读取 values buffer；与已有顺序 dot-product 互补。
+- 复用 `calcit-calx-kernel/2`、`F64BufferGet`、`F64ToI64Index` 和尾调用，不新增 opcode、VM API、Nil/Dynamic/List 或隐式 conversion。
+- generated-program golden 固定两级 get/conversion、tail call 和 Calcit source origin。
+- 同源码 native/Calx 正常路径覆盖乱序与重复索引；zero remaining 不访问空 buffer。
+- 异常覆盖 index buffer/value buffer 越界，以及非整数、负数、非 finite gathered index；均保持带 source origin 的 Calx runtime trap，不自动重跑 native。两个 buffer boundary 都拒绝 Nil、List 与 byte Buffer。
+- standalone harness 只在本 PR 合并且精确 main 验证后更新 pin、复制 fixture provenance 和扩展 matrix；普通 JSON 保留在 ignored target。
+- 验证：`cargo fmt --check`、`cargo clippy --offline -- -D warnings`、`cargo test --offline`（713 library + 304 CLI + 23 WASM）、19 项 Calx 专项、`yarn compile`、`yarn check-all` 与 68 份 markdown 检查通过。
+- Agent interface 18/18 通过；本机 debug smoke：project context 369.52 ms / 3940 bytes、expression type 222.28 ms / 2729 bytes、summary-only coverage 113.63 ms / 1273 bytes，仅记录协议检查，不作为性能比较。
+
+## English
+
+- Add an independent source-backed `gather-sum` for #884: read an index buffer sequentially, then perform checked indirect reads from a values buffer, complementing sequential dot product.
+- Reuse `calcit-calx-kernel/2`, `F64BufferGet`, `F64ToI64Index`, and tail calls, adding no opcode, VM API, Nil/Dynamic/List path, or implicit conversion.
+- The generated-program golden fixes both get/conversion levels, the tail call, and Calcit source origins.
+- Same-source native/Calx success covers permuted and repeated indices; zero remaining performs no access on empty buffers.
+- Failures cover index/value buffer bounds plus fractional, negative, and non-finite gathered indices. Each remains a source-origin-bearing Calx runtime trap with no native retry. Both buffer boundaries reject Nil, List, and byte Buffer.
+- Update standalone pins, copy fixture provenance, and extend the matrix only after this PR merges and exact-main checks pass; routine JSON remains in ignored target storage.
+- Validation passed: `cargo fmt --check`, `cargo clippy --offline -- -D warnings`, `cargo test --offline` (713 library + 304 CLI + 23 WASM), 19 Calx-focused tests, `yarn compile`, `yarn check-all`, and all 68 Markdown checks.
+- Agent interface passed 18/18. Local debug smoke: project context 369.52 ms / 3940 bytes, expression type 222.28 ms / 2729 bytes, summary-only coverage 113.63 ms / 1273 bytes. These record protocol checks, not comparative performance evidence.

--- a/editing-history/202609061119-unsafe-coerce-test-isolation.md
+++ b/editing-history/202609061119-unsafe-coerce-test-isolation.md
@@ -1,0 +1,15 @@
+# 隔离 `unsafe-coerce` 预处理测试 / Isolate the `unsafe-coerce` preprocess test
+
+## 中文
+
+- PR #885 的 Linux 测试暴露出两个 `unsafe_coerce` 单元测试之间的共享状态竞争。
+- 严格模式测试会临时启用全局 `STRICT_TYPES`，但兼容模式测试未获取 program/preprocess 测试状态锁，因此并行执行时可能错误地产生 `E_UNSCOPED_UNSAFE_COERCE`。
+- 让兼容模式测试也持有现有的 `lock_preprocess_test_state`，把全局模式切换与读取纳入同一串行边界；不改变生产代码语义。
+- 回归验证应显式以两个线程反复并行运行 `unsafe_coerce` 测试，并执行仓库完整门禁。
+
+## English
+
+- The Linux run for PR #885 exposed a shared-state race between the two `unsafe_coerce` unit tests.
+- The strict-mode test temporarily enables the global `STRICT_TYPES` flag, while the compatibility-mode test did not acquire the program/preprocess test-state lock. Parallel execution could therefore produce a spurious `E_UNSCOPED_UNSAFE_COERCE` error.
+- The compatibility-mode test now holds the existing `lock_preprocess_test_state`, placing the global mode write and read under the same serialization boundary without changing production semantics.
+- Regression validation should repeatedly run both `unsafe_coerce` tests with two test threads and then run the complete repository gates.

--- a/editing-history/202609061132-f64-buffer-gather-review.md
+++ b/editing-history/202609061132-f64-buffer-gather-review.md
@@ -1,0 +1,15 @@
+# 收口 F64Buffer gather review / Close F64Buffer gather review findings
+
+## 中文
+
+- CodeRabbit 指出 gather 文档把实际使用的两个 intrinsic 误写成三个；文档现明确列出 `F64BufferGet` 与 `F64ToI64Index`，不再暗示使用 `F64BufferLen`。
+- zero-remaining 用例此前只检查 Calx 返回 `7`。现在同参数也通过 native Calcit 执行，并显式断言 native/Calx 相等，使文档中的 differential coverage 与测试一致。
+- 新增 fixture helper 和综合回归测试补充简短职责说明，满足 touched-function docstring 检查而不增加公共 API 文档噪声。
+- CI 暴露的 `unsafe-coerce` 测试隔离修复由 #886 单独记录并继续由本 PR 携带，避免当前 gather PR 在独立修复合并前重新暴露竞态。
+
+## English
+
+- CodeRabbit identified that the gather documentation described three intrinsics although the fixture uses two. It now names `F64BufferGet` and `F64ToI64Index` explicitly and no longer implies `F64BufferLen` usage.
+- The zero-remaining case previously checked only the Calx result of `7`. It now executes the same arguments through native Calcit and asserts native/Calx equality, aligning the differential-coverage claim with the test.
+- Brief responsibility comments now cover the new fixture helper and comprehensive regression test, satisfying the touched-function docstring check without adding public-API documentation noise.
+- Issue #886 separately records the `unsafe-coerce` test-isolation fix exposed by CI while this PR continues to carry it, avoiding renewed flakiness before a separate dependency could merge.

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -606,6 +606,137 @@ fn calx_f64_buffer_dot_product_is_source_backed_strict_and_differential() {
   assert!(matches!(trap, CalxKernelRunError::Runtime(_)));
 }
 
+fn install_calx_f64_buffer_gather_fixture(namespace: &str) {
+  let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/f64-buffer-gather-kernel.cirru"));
+  install_calx_test_defs(
+    namespace,
+    vec![(
+      "gather-sum",
+      source_defs.remove("gather-sum").expect("gather-sum source"),
+      calx_test_fn_schema(
+        vec![
+          CalcitTypeAnnotation::F64Buffer,
+          CalcitTypeAnnotation::F64Buffer,
+          CalcitTypeAnnotation::Number,
+          CalcitTypeAnnotation::Number,
+        ],
+        CalcitTypeAnnotation::Number,
+      ),
+    )],
+  );
+  compile_calx_test_entry(namespace, "gather-sum");
+}
+
+#[test]
+fn calx_f64_buffer_gather_is_source_backed_strict_and_differential() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-f64-gather";
+  install_calx_f64_buffer_gather_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed F64Buffer gather fixture");
+
+  let graph = analyze_calx_eligibility(&snapshot, namespace, "gather-sum").expect("F64Buffer gather should be eligible");
+  assert_eq!(graph.abi_edition.as_ref(), "calcit-calx-kernel/2");
+  assert_eq!(
+    graph.functions[0].params,
+    vec![
+      CalxScalarType::F64Buffer,
+      CalxScalarType::F64Buffer,
+      CalxScalarType::F64,
+      CalxScalarType::F64,
+    ]
+  );
+
+  let kernel = compile_calx_kernel(&snapshot, namespace, "gather-sum").expect("compile strict F64Buffer gather");
+  assert_eq!(
+    kernel.stable_program_summary(),
+    include_str!("../../tests/fixtures/calx/f64-buffer-gather-kernel.golden.txt")
+  );
+
+  let args = vec![
+    Calcit::F64Buffer(Arc::from([10.0, 20.0, 30.0])),
+    Calcit::F64Buffer(Arc::from([2.0, 0.0, 2.0])),
+    Calcit::Number(3.0),
+    Calcit::Number(0.0),
+  ];
+  let calx_result = kernel.run(&args).expect("run strict F64Buffer gather");
+  let native_result = run_program_with_docs(Arc::from(namespace), Arc::from("gather-sum"), &args).expect("run native F64Buffer gather");
+  assert_eq!(calx_result, Calcit::Number(70.0));
+  assert_eq!(calx_result, native_result);
+
+  let empty_args = vec![
+    Calcit::F64Buffer(Arc::from([])),
+    Calcit::F64Buffer(Arc::from([])),
+    Calcit::Number(0.0),
+    Calcit::Number(7.0),
+  ];
+  assert_eq!(
+    kernel.run(&empty_args).expect("zero remaining performs no buffer access"),
+    Calcit::Number(7.0)
+  );
+
+  for invalid in [Calcit::Nil, Calcit::from(vec![Calcit::Number(1.0)]), Calcit::Buffer(vec![0, 1])] {
+    for position in [0, 1] {
+      let mut invalid_args = args.clone();
+      invalid_args[position] = invalid.clone();
+      let error = kernel
+        .run(&invalid_args)
+        .expect_err("only concrete F64Buffer crosses the gather boundary");
+      assert!(
+        matches!(error, CalxKernelRunError::Boundary(ref boundary) if boundary.kind == CalxKernelBoundaryErrorKind::ArgumentType)
+      );
+    }
+  }
+
+  let trap_cases = [
+    (
+      Calcit::F64Buffer(Arc::from([10.0, 20.0, 30.0])),
+      Calcit::F64Buffer(Arc::from([0.0, 1.0])),
+      3.0,
+      "index buffer bounds",
+    ),
+    (
+      Calcit::F64Buffer(Arc::from([10.0, 20.0, 30.0])),
+      Calcit::F64Buffer(Arc::from([1.5])),
+      1.0,
+      "fractional gathered index",
+    ),
+    (
+      Calcit::F64Buffer(Arc::from([10.0, 20.0, 30.0])),
+      Calcit::F64Buffer(Arc::from([-1.0])),
+      1.0,
+      "negative gathered index",
+    ),
+    (
+      Calcit::F64Buffer(Arc::from([10.0, 20.0, 30.0])),
+      Calcit::F64Buffer(Arc::from([f64::INFINITY])),
+      1.0,
+      "non-finite gathered index",
+    ),
+    (
+      Calcit::F64Buffer(Arc::from([10.0, 20.0, 30.0])),
+      Calcit::F64Buffer(Arc::from([3.0])),
+      1.0,
+      "values buffer bounds",
+    ),
+  ];
+  for (values, indices, remaining, label) in trap_cases {
+    let error = kernel
+      .run(&[values, indices, Calcit::Number(remaining), Calcit::Number(0.0)])
+      .unwrap_err();
+    let CalxKernelRunError::Runtime(runtime) = error else {
+      panic!("{label} must remain a Calx runtime trap: {error}");
+    };
+    let span = runtime
+      .source_span()
+      .unwrap_or_else(|| panic!("{label} must retain a Calcit source origin"));
+    assert!(
+      span.source.starts_with("calcit:tests.calx-f64-gather/gather-sum@3."),
+      "{label} has unexpected source origin: {span}"
+    );
+  }
+}
+
 #[test]
 fn calx_measured_compile_reports_non_overlapping_stages() {
   let _guard = lock_program_test_state();

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -606,6 +606,7 @@ fn calx_f64_buffer_dot_product_is_source_backed_strict_and_differential() {
   assert!(matches!(trap, CalxKernelRunError::Runtime(_)));
 }
 
+/// Install and preprocess the source-backed gather fixture with its concrete schema.
 fn install_calx_f64_buffer_gather_fixture(namespace: &str) {
   let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/f64-buffer-gather-kernel.cirru"));
   install_calx_test_defs(
@@ -627,6 +628,7 @@ fn install_calx_f64_buffer_gather_fixture(namespace: &str) {
   compile_calx_test_entry(namespace, "gather-sum");
 }
 
+/// Verify strict lowering, native parity, boundary rejection, and gather trap origins.
 #[test]
 fn calx_f64_buffer_gather_is_source_backed_strict_and_differential() {
   let _guard = lock_program_test_state();
@@ -670,10 +672,11 @@ fn calx_f64_buffer_gather_is_source_backed_strict_and_differential() {
     Calcit::Number(0.0),
     Calcit::Number(7.0),
   ];
-  assert_eq!(
-    kernel.run(&empty_args).expect("zero remaining performs no buffer access"),
-    Calcit::Number(7.0)
-  );
+  let empty_calx_result = kernel.run(&empty_args).expect("zero remaining performs no buffer access");
+  let empty_native_result =
+    run_program_with_docs(Arc::from(namespace), Arc::from("gather-sum"), &empty_args).expect("run native zero-remaining gather");
+  assert_eq!(empty_calx_result, Calcit::Number(7.0));
+  assert_eq!(empty_calx_result, empty_native_result);
 
   for invalid in [Calcit::Nil, Calcit::from(vec![Calcit::Number(1.0)]), Calcit::Buffer(vec![0, 1])] {
     for position in [0, 1] {

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -11238,6 +11238,7 @@ mod tests {
 
   #[test]
   fn unsafe_coerce_preserves_boundary_node_and_declared_expression_type() {
+    let _state = lock_preprocess_test_state();
     let expr = Cirru::List(vec![Cirru::leaf("unsafe-coerce"), Cirru::leaf("x"), Cirru::leaf(":number")]);
     let code = code_to_calcit(&expr, "tests.unsafe-coerce", "main", vec![]).expect("parse cirru");
     let mut scope_defs: HashSet<Arc<str>> = HashSet::new();

--- a/tests/fixtures/calx/f64-buffer-gather-kernel.cirru
+++ b/tests/fixtures/calx/f64-buffer-gather-kernel.cirru
@@ -1,0 +1,13 @@
+defn gather-sum (values indices remaining acc)
+  if (&< remaining 1)
+    , acc
+    &let
+      offset $ &- remaining 1
+      recur
+        , values
+        , indices
+        , offset
+        &+
+          , acc
+          &f64-buffer:get values $ &f64:to-i64-index
+            &f64-buffer:get indices $ &f64:to-i64-index offset

--- a/tests/fixtures/calx/f64-buffer-gather-kernel.golden.txt
+++ b/tests/fixtures/calx/f64-buffer-gather-kernel.golden.txt
@@ -1,0 +1,28 @@
+abi calcit-calx-kernel/2
+entry tests.calx-f64-gather/gather-sum
+function main (F64Buffer,F64Buffer,F64,F64)->F64
+  000 LocalGet(2) @ calcit:tests.calx-f64-gather/gather-sum@3.1.1
+  001 Const(F64(1.0)) @ calcit:tests.calx-f64-gather/gather-sum@-
+  002 F64Lt @ calcit:tests.calx-f64-gather/gather-sum@-
+  003 If { ret_types: [F64], else_at: 23, to: 25 } @ calcit:tests.calx-f64-gather/gather-sum@-
+  004 LocalGet(2) @ calcit:tests.calx-f64-gather/gather-sum@3.3.1.1.1
+  005 Const(F64(1.0)) @ calcit:tests.calx-f64-gather/gather-sum@-
+  006 Neg @ calcit:tests.calx-f64-gather/gather-sum@-
+  007 Add @ calcit:tests.calx-f64-gather/gather-sum@-
+  008 LocalSet(4) @ calcit:tests.calx-f64-gather/gather-sum@-
+  009 LocalGet(0) @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.1
+  010 LocalGet(1) @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.2
+  011 LocalGet(4) @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.3
+  012 LocalGet(3) @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.1
+  013 LocalGet(0) @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.1
+  014 LocalGet(1) @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.1
+  015 LocalGet(4) @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.2.1
+  016 F64ToI64Index @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.2.1
+  017 F64BufferGet @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.2.1
+  018 F64ToI64Index @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.2.1
+  019 F64BufferGet @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.2.1
+  020 Add @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.2.1
+  021 ReturnCall("main") @ calcit:tests.calx-f64-gather/gather-sum@3.3.2.4.2.2.1.2.1
+  022 ElseEnd @ calcit:tests.calx-f64-gather/gather-sum@-
+  023 LocalGet(3) @ calcit:tests.calx-f64-gather/gather-sum@3.2
+  024 ThenEnd @ calcit:tests.calx-f64-gather/gather-sum@-


### PR DESCRIPTION
## 中文

关闭 #884 与 #886，关联 [calx-vm #61](https://github.com/calcit-lang/calx-vm/issues/61) 与 [harness #13](https://github.com/calcit-lang/calcit-calx-bench/issues/13)。

### 范围

- 新增独立 source-backed `gather-sum` fixture：顺序读取 concrete index `F64Buffer`，checked conversion 后间接读取 values `F64Buffer`，以尾递归累加。
- generated-program golden 固定 ABI `/2`、两级 `F64BufferGet` / `F64ToI64Index`、tail `ReturnCall` 和 Calcit source origin。
- 同源码 native/Calx differential 覆盖乱序/重复索引及 zero remaining。
- 分别覆盖 index buffer/value buffer 越界、非整数/负数/非 finite gathered index；均为带 Calcit source origin 的 Calx runtime trap，不自动重跑 native。
- 两个 buffer 参数都拒绝 Nil、List 与 byte Buffer。不新增 opcode、ABI edition、VM API、mutation、List lowering 或 Dynamic fallback。
- 文档明确第二种访问模式。dot-product fixture、历史 benchmark JSON 和现有 ABI 保持不变。
- #886 修复 Linux CI 暴露的 `unsafe-coerce` 测试状态竞争：兼容测试获取现有共享锁；只修复测试隔离，不改变生产语义。

### Review 修正

- 文档明确 gather 只使用 `F64BufferGet` 与 `F64ToI64Index` 两个 intrinsic。
- zero-remaining 现在用同一组空 buffer 参数执行 native Calcit 与 Calx，并断言结果相等。
- 新增 helper 与综合回归补充职责说明；#886 明确记录测试隔离修复的独立原因和范围。

### 验证

- `cargo fmt --check`
- `cargo clippy --offline -- -D warnings`
- `cargo test --offline`：713 library + 304 CLI + 23 WASM tests
- `cargo test --offline calx`：19/19
- 两个 `unsafe_coerce` 测试以双线程连续并行 100 次通过
- `yarn compile`、`yarn check-all`
- Markdown：68/68
- Agent interface：18/18；最新 debug smoke 为 context 375.18 ms / 3940 bytes、expression type 216.35 ms / 2729 bytes、summary-only coverage 116.57 ms / 1273 bytes，仅为协议观测。

### 后续

本 PR 合并且精确 main SHA 验证后，harness #13 再 pin 新 revision、复制新 fixture provenance、扩展 debug/release matrix。普通 JSON 留在 ignored target；本 PR 不声称应用端到端性能提升。

## English

Closes #884 and #886; tracks [calx-vm #61](https://github.com/calcit-lang/calx-vm/issues/61) and [harness #13](https://github.com/calcit-lang/calcit-calx-bench/issues/13).

### Scope

- Add an independent source-backed `gather-sum`: read a concrete index `F64Buffer` sequentially, apply checked conversion, perform indirect reads from a values `F64Buffer`, and accumulate through tail recursion.
- The generated-program golden fixes ABI `/2`, both `F64BufferGet` / `F64ToI64Index` levels, tail `ReturnCall`, and Calcit source origins.
- Same-source native/Calx differential execution covers permuted/repeated indices and zero remaining.
- Independently cover index/value buffer bounds and fractional/negative/non-finite gathered indices. Each remains a source-origin-bearing Calx runtime trap with no native retry.
- Both buffer arguments reject Nil, List, and byte Buffer. Add no opcode, ABI edition, VM API, mutation, List lowering, or Dynamic fallback.
- Document the second access pattern while preserving the dot-product fixture, historical benchmark JSON, and existing ABI.
- #886 fixes the `unsafe-coerce` test-state race exposed by Linux CI: the compatibility test acquires the existing shared lock. This changes test isolation only, not production semantics.

### Review fixes

- Documentation now identifies the two gather intrinsics, `F64BufferGet` and `F64ToI64Index`.
- Zero remaining now executes native Calcit and Calx with the same empty-buffer arguments and asserts equal results.
- The new helper and comprehensive regression have responsibility comments; #886 explicitly records the independent cause and scope of the test-isolation fix.

### Validation

- `cargo fmt --check`
- `cargo clippy --offline -- -D warnings`
- `cargo test --offline`: 713 library + 304 CLI + 23 WASM tests
- `cargo test --offline calx`: 19/19
- Both `unsafe_coerce` tests passed 100 consecutive two-thread parallel runs
- `yarn compile`, `yarn check-all`
- Markdown: 68/68
- Agent interface: 18/18. Latest debug smoke: context 375.18 ms / 3940 bytes, expression type 216.35 ms / 2729 bytes, summary-only coverage 116.57 ms / 1273 bytes; protocol observations only.

### Follow-up

After merge and exact-main verification, harness #13 will pin the new revision, copy the new fixture with provenance, and extend the debug/release matrix. Routine JSON stays in ignored target storage; this PR makes no application end-to-end performance claim.
