### PR TITLE
ci: route npm prereleases to next / npm 预发布使用 next

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,5 +90,10 @@ jobs:
       - name: "generate procs.mjs"
         run: yarn && yarn tsc
 
-      # - run: npm publish --provenance --access public --tag next
-      - run: npm publish --provenance --access public
+      - name: Publish npm prerelease to next
+        if: github.event.release.prerelease
+        run: npm publish --provenance --access public --tag next
+
+      - name: Publish stable npm release to latest
+        if: github.event.release.prerelease == false
+        run: npm publish --provenance --access public

--- a/editing-history/202609061327-prerelease-npm-dist-tag.md
+++ b/editing-history/202609061327-prerelease-npm-dist-tag.md
@@ -1,0 +1,16 @@
+# Route npm prereleases to `next` / npm 预发布使用 `next`
+
+Issue: #680. Calcium consumer validation requires an immutable Calcit build
+containing the generic-order fix that landed after 0.13.77. The selected release
+sequence publishes `0.13.78-rc.1`, validates Calcium against that exact asset,
+and only then publishes the final stable release.
+
+The release workflow now branches on GitHub's immutable release `prerelease`
+flag. Prereleases publish `@calcit/procs` with npm dist-tag `next`; stable
+releases keep the existing default `latest` behavior. Cargo prerelease versions
+remain handled by the existing crates.io publish step. This prevents an rc from
+moving npm consumers on the default channel while preserving the stable path.
+
+为解决 0.13.77 不包含泛型声明顺序修复、Calcium 又必须基于正式产物验证的循环，
+本轮先发布 `0.13.78-rc.1`。GitHub prerelease 对应的 npm 包只更新 `next`，
+正式 release 仍按原流程更新 `latest`，避免预发布版本影响默认安装用户。


### PR DESCRIPTION
## 中文

关联 #680、#876。

Calcium 必须使用包含 #878 泛型声明顺序修复的不可变 Calcit 产物完成消费端验证，因此已选择先发布 `0.13.78-rc.1`。当前 publish workflow 对所有 release 都执行无 dist-tag 的 `npm publish`，会让 prerelease 错误更新 npm 默认 `latest`。

本 PR 只调整发布通道：

- GitHub prerelease 发布 `@calcit/procs` 时使用 npm `next`
- 正式 release 保持现有默认 `latest`
- crates.io 和 release assets 流程不变

合并并验证精确 main Actions 后，预发布版本元数据才会按 release 例外直接更新 main。

## English

Related to #680 and #876.

Calcium needs an immutable Calcit artifact containing the generic declaration-order fix from #878. The selected sequence therefore publishes `0.13.78-rc.1` before the final stable release. The current workflow runs an untagged `npm publish` for every GitHub release, which would incorrectly move npm `latest` to the prerelease.

This PR only routes publishing channels:

- GitHub prereleases publish `@calcit/procs` with npm dist-tag `next`
- stable releases retain the existing default `latest` behavior
- crates.io and release asset paths are unchanged

The prerelease metadata-only main commit will be made only after this PR is reviewed, merged, and its exact main Actions pass.

## Validation

- `git diff --check`
- Ruby YAML parser accepts `.github/workflows/publish.yaml`
