### PR TITLE
fix(calx): reject mismatched F64Buffer length lowering / 拒绝类型不匹配的 F64Buffer 长度 lowering

### DIFF
--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -89,8 +89,8 @@ name；direct tail call 与 `recur` 降为 `return-call`。
 - fixed arity top-level function；
 - Number/Bool literal、typed local、单 binding `&let`、有 else 的 `if`；
 - `&+`、一元/二元 `&-`、`&*`、`&/`、`&=`、`&<`、`&>`；
-- internal typed-buffer intrinsics：`&f64-buffer:len`、`&f64:to-i64-index`、`&f64-buffer:get`；后两者的
-  conversion/bounds failure 在 VM 中 trap，绝不返回 `Nil`；
+- internal typed-buffer intrinsics：`&f64:to-i64-index`、`&f64-buffer:get`；conversion/bounds failure
+  在 VM 中 trap，绝不返回 `Nil`；
 - fixed-arity direct call 与 tail-position `recur`；
 - 显式 allowlist 的 zero-result / single-result typed host import；
 - 条件必须静态为 Bool，不复用 Calcit 或 Calx 的 numeric truthiness。
@@ -101,6 +101,17 @@ name；direct tail call 与 `recur` 降为 `return-call`。
 - closure、function value、local/dynamic operator、HOF、rest/optional arity；
 - 无 else 的 `if`、非 tail `recur`、global/ref/atom、collection/nominal value；
 - 未加入 allowlist 的 host/native capability。
+
+`&f64-buffer:len` 暂不属于 producer 子集：Calcit 的公开返回类型是 `Number`/F64，而 Calx VM 的
+严格指令结果是 I64。eligibility 会在 lowering 前拒绝它，直到 Calcit 拥有显式、语义无损的 I64
+结果表示或转换；不得把 I64 暗中解释为 F64，也不得用 Nil/Dynamic 兜底。Calx VM 自身的
+`f64-buffer.len` 支持不受影响。
+
+`&f64-buffer:len` is not currently part of the producer subset: its public Calcit result is
+`Number`/F64, while the strict Calx VM instruction produces I64. Eligibility rejects it before
+lowering until Calcit has an explicit, semantics-preserving I64 result representation or conversion.
+The producer must not reinterpret I64 as F64 or fall back through Nil/Dynamic. The VM-level
+`f64-buffer.len` instruction remains supported.
 
 ## Typed host import contract
 

--- a/editing-history/202609061345-calx-f64-buffer-len-boundary.md
+++ b/editing-history/202609061345-calx-f64-buffer-len-boundary.md
@@ -1,0 +1,31 @@
+# Calx F64Buffer length boundary / Calx F64Buffer 长度边界
+
+## English
+
+Calcit exposes `&f64-buffer:len` as `F64Buffer -> Number`, and every Calcit `Number` in the current
+Calx producer maps to VM `F64`. The Calx VM deliberately exposes `f64-buffer.len` as
+`F64Buffer -> I64`, so emitting that instruction directly makes an apparently eligible kernel fail
+later during strict validation with `expected F64, found I64`.
+
+Eligibility must not promise a program that lowering cannot construct. Until Calcit has an explicit,
+semantics-preserving representation or conversion for the VM I64 result, the producer rejects this
+intrinsic as `CALX_SUBSET_UNSUPPORTED_FORM`. The VM instruction stays available, and the already
+working checked-index/get path stays unchanged. This avoids an implicit numeric coercion and does not
+introduce Nil or Dynamic.
+
+The regression fixture runs the same source natively to preserve the Calcit result contract, then
+asserts that Calx rejects it at eligibility rather than at lowering, construction, or validation.
+
+## 中文
+
+Calcit 将 `&f64-buffer:len` 公开为 `F64Buffer -> Number`，而当前 Calx producer 会把所有 Calcit
+`Number` 映射成 VM `F64`。Calx VM 则有意把 `f64-buffer.len` 定义为 `F64Buffer -> I64`，直接生成
+这条指令会让一个表面上 eligible 的 kernel 随后在严格 validation 阶段以
+`expected F64, found I64` 失败。
+
+eligibility 不能承诺 lowering 无法构造的程序。在 Calcit 拥有可保持语义的显式 I64 结果表示或转换
+之前，producer 用 `CALX_SUBSET_UNSUPPORTED_FORM` 拒绝该 intrinsic。VM 指令本身继续可用，已经工作的
+checked-index/get 路径不变。这样既不引入隐式数值 coercion，也不使用 Nil 或 Dynamic。
+
+回归 fixture 先用 native Calcit 执行同一份源码以固定 Calcit 返回值契约，再断言 Calx 在 eligibility
+阶段拒绝，而不是拖到 lowering、construction 或 validation 才失败。

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -914,8 +914,14 @@ fn analyze_proc(proc: CalcitProc, args: &[Calcit], tail: bool, context: &mut Exp
       Some(Some(CalxScalarType::Bool))
     }
     CalcitProc::NativeF64BufferLen => {
-      analyze_typed_args(proc, args, &[CalxScalarType::F64Buffer], context)?;
-      Some(Some(CalxScalarType::F64))
+      issue(
+        context,
+        CalxFallbackCode::UnsupportedForm,
+        args.first().and_then(source_path),
+        "`&f64-buffer:len` returns Calcit Number/F64, but strict Calx `f64-buffer.len` returns I64; an explicit result conversion is required"
+          .to_owned(),
+      );
+      None
     }
     CalcitProc::NativeF64ToI64Index => {
       analyze_typed_args(proc, args, &[CalxScalarType::F64], context)?;

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -691,7 +691,6 @@ enum PlannedOperation {
   Equal,
   LessThan,
   GreaterThan,
-  F64BufferLen,
   F64ToI64Index,
   F64BufferGet,
 }
@@ -969,7 +968,6 @@ fn plan_proc(
     CalcitProc::NativeEquals => (Some(PlannedOperation::Equal), Some(CalxScalarType::Bool)),
     CalcitProc::NativeLessThan => (Some(PlannedOperation::LessThan), Some(CalxScalarType::Bool)),
     CalcitProc::NativeGreaterThan => (Some(PlannedOperation::GreaterThan), Some(CalxScalarType::Bool)),
-    CalcitProc::NativeF64BufferLen => (Some(PlannedOperation::F64BufferLen), Some(CalxScalarType::F64)),
     CalcitProc::NativeF64ToI64Index => (Some(PlannedOperation::F64ToI64Index), Some(CalxScalarType::F64)),
     CalcitProc::NativeF64BufferGet => (Some(PlannedOperation::F64BufferGet), Some(CalxScalarType::F64)),
     CalcitProc::Recur => {
@@ -1191,7 +1189,6 @@ fn emit_expression(
         PlannedOperation::Equal => body.emit(VmSyntax::F64Eq)?,
         PlannedOperation::LessThan => body.emit(VmSyntax::F64Lt)?,
         PlannedOperation::GreaterThan => body.emit(VmSyntax::F64Gt)?,
-        PlannedOperation::F64BufferLen => body.f64_buffer_len()?,
         PlannedOperation::F64ToI64Index => body.f64_to_i64_index()?,
         PlannedOperation::F64BufferGet => body.f64_buffer_get()?,
       };

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -555,6 +555,44 @@ fn install_calx_f64_buffer_kernel_fixture(namespace: &str) {
   compile_calx_test_entry(namespace, "dot-product");
 }
 
+fn install_calx_f64_buffer_len_fixture(namespace: &str) {
+  let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/f64-buffer-len-kernel.cirru"));
+  install_calx_test_defs(
+    namespace,
+    vec![(
+      "buffer-length",
+      source_defs.remove("buffer-length").expect("buffer-length source"),
+      calx_test_fn_schema(vec![CalcitTypeAnnotation::F64Buffer], CalcitTypeAnnotation::Number),
+    )],
+  );
+  compile_calx_test_entry(namespace, "buffer-length");
+}
+
+#[test]
+fn calx_f64_buffer_len_falls_back_before_lowering() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-f64-buffer-len";
+  install_calx_f64_buffer_len_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed F64Buffer length fixture");
+
+  let args = [Calcit::F64Buffer(Arc::from([1.0, 2.0, 3.0]))];
+  let native_result =
+    run_program_with_docs(Arc::from(namespace), Arc::from("buffer-length"), &args).expect("run native F64Buffer length kernel");
+  assert_eq!(native_result, Calcit::Number(3.0));
+
+  let report = analyze_calx_eligibility(&snapshot, namespace, "buffer-length")
+    .expect_err("F64Buffer length must fall back until Calcit can represent the Calx I64 result");
+  assert_eq!(report.issues.len(), 1);
+  assert_eq!(report.issues[0].code, CalxFallbackCode::UnsupportedForm);
+  assert!(report.issues[0].message.contains("Calcit Number/F64"));
+  assert!(report.issues[0].message.contains("Calx `f64-buffer.len` returns I64"));
+  assert!(matches!(
+    compile_calx_kernel(&snapshot, namespace, "buffer-length"),
+    Err(CalxKernelCompileError::Eligibility(_))
+  ));
+}
+
 #[test]
 fn calx_f64_buffer_dot_product_is_source_backed_strict_and_differential() {
   let _guard = lock_program_test_state();

--- a/tests/fixtures/calx/f64-buffer-len-kernel.cirru
+++ b/tests/fixtures/calx/f64-buffer-len-kernel.cirru
@@ -1,0 +1,2 @@
+defn buffer-length (values)
+  &f64-buffer:len values


### PR DESCRIPTION
## English

### Summary

- reject `&f64-buffer:len` during Calx whole-kernel eligibility instead of admitting a program that fails later in strict validation
- remove the unreachable producer lowering operation while preserving the VM's frozen `F64Buffer -> I64` contract
- add a source-backed fixture proving native Calcit still returns `Number(3.0)` and Calx reports `CALX_SUBSET_UNSUPPORTED_FORM` before lowering
- document the narrower current producer boundary and the requirement for a future explicit, semantics-preserving I64 result representation/conversion

This change does not add an opcode, reinterpret I64 as F64, or introduce Nil/Dynamic fallback.

### Validation

- `cargo fmt`
- `cargo clippy --offline --all-targets --all-features -- -D warnings`
- `cargo test --offline` (714 library, 304 CLI, 23 Wasm tests)
- `yarn compile`
- `yarn check-all` (including 18/18 Agent interface scenarios, 237 Calcit core tests, JS/IR/Wasm checks)
- `git diff --check`

Closes #889.

## 中文

### 概要

- 在 Calx whole-kernel eligibility 阶段拒绝 `&f64-buffer:len`，避免先承诺可编译、随后才在 strict validation 失败
- 删除不可达的 producer lowering operation，同时保持 VM 已固定的 `F64Buffer -> I64` 契约
- 新增 source-backed fixture，证明 native Calcit 仍返回 `Number(3.0)`，而 Calx 会在 lowering 前报告 `CALX_SUBSET_UNSUPPORTED_FORM`
- 文档明确当前更窄的 producer 边界，并记录未来必须提供显式、可保持语义的 I64 结果表示/转换

本改动不新增 opcode，不把 I64 暗中解释为 F64，也不引入 Nil/Dynamic 兜底。

### 验证

- `cargo fmt`
- `cargo clippy --offline --all-targets --all-features -- -D warnings`
- `cargo test --offline`（714 个库测试、304 个 CLI 测试、23 个 Wasm 测试）
- `yarn compile`
- `yarn check-all`（包括 18/18 Agent interface 场景、237 个 Calcit core tests、JS/IR/Wasm 检查）
- `git diff --check`

关闭 #889。
