### PR TITLE
Separate compatibility from static type proof

### DIFF
--- a/RFCs/06-01-generic-binding-unification-rfc.md
+++ b/RFCs/06-01-generic-binding-unification-rfc.md
@@ -11,7 +11,7 @@
 - 函数级泛型变量 `TypeVar`
 - `:where` trait 约束
 - `Struct` / `Enum` / `TypeRef` 三类命名类型表示
-- 在 `matches_with_bindings` 中边匹配边收集泛型绑定
+- 在 `compatible_with_bindings` 中边匹配边收集泛型绑定
 
 但是这条链路还不够统一。
 
@@ -356,7 +356,7 @@ defn demo-result ()
 
 或者至少在仅一侧 applied 的情况下，把已有那一侧参数回填到 enum 声明的泛型名上。
 
-新版里这块底层元数据已经补齐：`CalcitEnum` 本身就保存 `generics`。因此这里的剩余工作不再是“先改数据结构”，而是把 `matches_with_bindings` 里的 enum 分支改成与 struct 一样的单边绑定策略。
+新版里这块底层元数据已经补齐：`CalcitEnum` 本身就保存 `generics`。因此这里的剩余工作不再是“先改数据结构”，而是把 `compatible_with_bindings` 里的 enum 分支改成与 struct 一样的单边绑定策略。
 
 ## 为什么这些 Calcit 片段今天还“不够显眼”
 
@@ -551,7 +551,7 @@ enum 侧的结构升级在当前版本里已经完成，真正还更深的一步
 
 落点：
 
-- `matches_with_bindings`
+- `compatible_with_bindings`
 - 抽出复用 helper，避免同类分支各写一遍绑定逻辑
 
 ### 阶段 2：补齐 `Enum <-> TypeRef` 的单边绑定

--- a/RFCs/07-19-type-introspection-consistency-rfc.md
+++ b/RFCs/07-19-type-introspection-consistency-rfc.md
@@ -23,7 +23,7 @@
 
 `to-pairs`/`keys`/`&record:to-map` 在运行时(`to_pairs` in [maps.rs](../src/builtins/maps.rs))原生支持 `Calcit::Record`，能拿到字段名（tag）。
 
-但 `ToPairs` 的类型签名声明 `arg_types: vec![some_tag("map")]`，而 `matches_with_bindings`([type_annotation.rs](../src/calcit/type_annotation.rs))里 `(TypeRef("map"), Record(base))` 这一分支是拿 `"map"` 去匹配 `base.name`（即结构体自己的名字，比如 `"Person"`），显然不相等 → **对 record 调用 `to-pairs`/`keys` 会在类型检查阶段被判定为类型不匹配并产生告警**，即便运行时完全正确。这是文档/类型签名与实际能力脱节的具体例子。
+但 `ToPairs` 的类型签名声明 `arg_types: vec![some_tag("map")]`，而 `compatible_with_bindings`([type_annotation.rs](../src/calcit/type_annotation.rs))里 `(TypeRef("map"), Record(base))` 这一分支是拿 `"map"` 去匹配 `base.name`（即结构体自己的名字，比如 `"Person"`），显然不相等 → **对 record 调用 `to-pairs`/`keys` 会在类型检查阶段被判定为类型不匹配并产生告警**，即便运行时完全正确。这是文档/类型签名与实际能力脱节的具体例子。
 
 没有实例、只有裸类型定义时（刚 `defstruct Person ...` 还没构造实例），**没有**可编程 API 能拿到字段名列表当数据用；唯一能看到字段的方式是 `println`/`str` 对 struct 值做格式化输出人肉读。
 
@@ -54,9 +54,9 @@
    - JS 同步：[ts-src/calcit.procs.mts](../ts-src/calcit.procs.mts) 的 `lookup_impls`/`_$n_methods_of`/`_$n_inspect_methods` 同步补齐 `CalcitStruct`/`CalcitEnum`/`CalcitTrait` 分支。
    - 测试：[calcit/test-traits.cirru](../calcit/test-traits.cirru) 的 `test-method-introspection` 新增对 `impl-traits Person0 MyFooImpl`（裸 struct）、`DemoBar`（裸 enum）、`MyFoo`（裸 trait）调用 `&methods-of` 的断言，`yarn check-all`（rs/js/ir/wasm 四目标）全部通过。
 3. ✅ **修正 `to-pairs`/`keys` 的类型签名**，让 record 也能匹配，消除虚假类型告警。
-   - 实现：[src/calcit/type_annotation.rs](../src/calcit/type_annotation.rs) `matches_with_bindings` 里 `(TypeRef, Record)` 分支新增：当 `TypeRef` 名字就是泛化的 `"map"` 时，结构性地匹配任意 record（不要求 record 名字等于 `"map"`）。
+   - 实现：[src/calcit/type_annotation.rs](../src/calcit/type_annotation.rs) `compatible_with_bindings` 里 `(TypeRef, Record)` 分支新增：当 `TypeRef` 名字就是泛化的 `"map"` 时，结构性地匹配任意 record（不要求 record 名字等于 `"map"`）。
    - 测试：新增单元测试 `generic_map_type_ref_accepts_records_structurally`，直接验证 `TypeRef("map")` 与 `Record(Person)` 现在双向匹配，同时确认无关的 `TypeRef` 名字仍然不会误匹配。
-   - 备注：实测 `calcit --check-only` 在当前仓库测试集里并未因这个 gap 产生可观察的告警（`test-record.cirru` 里 `keys p2` 这行本来就没有触发过告警，猜测是这条路径上的静态类型推断没有把 `p2` 识别为具体的 `Record` 类型，所以没有触发 `check_proc_arg_types` 这条检查分支）。但 `matches_with_bindings` 的错误比较逻辑本身是真实存在的 bug，属于防御性修复：一旦未来静态推断能力增强（例如给变量加显式类型标注后传入 `to-pairs`/`keys`），就不会再误报。
+   - 备注：实测 `calcit --check-only` 在当前仓库测试集里并未因这个 gap 产生可观察的告警（`test-record.cirru` 里 `keys p2` 这行本来就没有触发过告警，猜测是这条路径上的静态类型推断没有把 `p2` 识别为具体的 `Record` 类型，所以没有触发 `check_proc_arg_types` 这条检查分支）。但 `compatible_with_bindings` 的错误比较逻辑本身是真实存在的 bug，属于防御性修复：一旦未来静态推断能力增强（例如给变量加显式类型标注后传入 `to-pairs`/`keys`），就不会再误报。
 4. ⏸️ **（可选，视时间，本轮未实现）** 新增 `&struct:fields`/`&enum:variants` 之类的编程接口，让“裸类型定义”的字段/variant 列表也能被程序消费，而不仅仅是打印文本。
    - 未实现原因：新增一个 proc 需要贯穿 `proc_name.rs`(注册+类型签名)、`builtins.rs`(分发)、`builtins/records.rs`或`meta.rs`(实现)、以及 JS/IR/WASM 三个 codegen 目标的同步实现，工作量与收益相比前三项更低（前三项已经解决了运行时能力不对齐的核心问题；字段/variant 名字目前仍可通过 `Display`/`println` 人肉获取，只是没有编程接口）。留作后续独立迭代。
 

--- a/RFCs/08-08-cross-backend-host-ffi-contracts-rfc.md
+++ b/RFCs/08-08-cross-backend-host-ffi-contracts-rfc.md
@@ -453,7 +453,7 @@ Native codegen 不应尝试解释 JS external trait。反过来，JS codegen 也
 - 异常、trap、panic 与异步机制；
 - 所有权和生命周期。
 
-这些后端事实不进入普通 `CalcitTypeAnnotation::matches_with_bindings`。
+这些后端事实不进入普通 `CalcitTypeAnnotation::compatible_with_bindings`。
 
 ## 10. 诊断
 

--- a/RFCs/08-18-calcit-typed-js-ffi-boundary-rfc.md
+++ b/RFCs/08-18-calcit-typed-js-ffi-boundary-rfc.md
@@ -160,7 +160,7 @@ read-only 与 writable。DOM、Node 和 npm API 中大量属性只读；仅检�
 
 - 不新增 `JsPromise<T>`、`JsArray<T>`、`JsEvent<T>`、`JsIterator<T>` 等核心 type
   variant；
-- 不修改 `CalcitTypeAnnotation::matches_with_bindings` 来解释 `:ffi` 或 `:features`；
+- 不修改 `CalcitTypeAnnotation::compatible_with_bindings` 来解释 `:ffi` 或 `:features`；
 - 不为 FFI 增加普通 trait 的 structural satisfaction、自动 impl 或特殊 where-bound；
 - 不改变普通 trait 的 method candidate、requires、impl-traits 与 generic unification；
 - external-object 分支只在 trait definition 显式具有
@@ -807,7 +807,7 @@ operation。它读取已经完成的类型结果，但不得回写 type binding�
 
 所有从 schema、函数实现体、import 或 callback hint 建立 capability context 的路径都应
 保留 features，query/analyze 也应能报告它们。但 MVP 不把 feature set 加入
-`CalcitTypeAnnotation::matches_with_bindings`、`matches_signature`、trait method selection
+`CalcitTypeAnnotation::compatible_with_bindings`、`matches_signature`、trait method selection
 或 generic unification；也不要求因 FFI 修改核心类型的 `Eq`、`Ord` 和 `Hash` 语义。
 
 编译器在普通类型检查完成后运行独立的 capability validation：遍历已经归属到 lexical
@@ -938,7 +938,7 @@ trait satisfaction 规则。
 - 先 warning，再在 `js-ffi` 自身切到 error。
 
 HostOperation 分类与 `:js-ffi` 检查是独立 validation，不进入
-`matches_with_bindings`、trait candidate 或 generic unification。
+`compatible_with_bindings`、trait candidate 或 generic unification。
 
 ### Phase 2：capability metadata 与 target 检查
 

--- a/RFCs/08-21-js-ffi-runtime-contract-validation-rfc.md
+++ b/RFCs/08-21-js-ffi-runtime-contract-validation-rfc.md
@@ -129,7 +129,7 @@ evidence 时，测试/调试模式至少可以验证：
 - assertion kind：checked/decoded/unsafe；
 - definition/path。
 
-它是类型检查后的 contract analysis，不参与普通 `matches_with_bindings`、泛型统一或 trait
+它是类型检查后的 contract analysis，不参与普通 `compatible_with_bindings`、泛型统一或 trait
 candidate selection。
 
 ### 诊断

--- a/editing-history/202609062310-static-type-proof.md
+++ b/editing-history/202609062310-static-type-proof.md
@@ -1,0 +1,30 @@
+# Separate compatibility from static proof / 分离兼容与静态证明
+
+Issue: #842. Milestone: 0.14.0 — Strict by default.
+
+The annotation relation now exposes compatibility and static proof as distinct
+operations. Compatibility retains the legacy acceptance rules used by runtime
+validation and diagnostics, while proof reports `Proven`, `NeedsBoundary`, or
+`Mismatch` and commits generic bindings transactionally. Dynamic values,
+legacy `any`, unknown callables, callable tags, unresolved type slots, legacy
+nullish widening, recursive type variables, and erased applied arguments no
+longer count as concrete proof.
+
+Generic return inference, `apply`, method argument projection, enum/struct
+payload inference, strict generic binding, homogeneous collection inference,
+callback inference, and Ref proof now select the appropriate relation
+explicitly. Projection inference may retain concrete bindings that are
+independent of an open boundary, such as `Result<Number, Dynamic> -> Number`,
+but a mismatch rolls back the whole candidate and Dynamic itself never binds a
+concrete type variable. Compatibility-based branch joins retain the weaker
+type instead of sharpening Dynamic evidence.
+
+类型注解关系现在明确区分旧兼容判断与可授权静态推断的证明。兼容路径继续服务运行时
+校验和诊断；证明路径返回 `Proven`、`NeedsBoundary` 或 `Mismatch`，并以事务方式提交
+泛型绑定。Dynamic、旧 `any`、未知函数、Tag 函数、未绑定 type slot、旧 nullish
+扩宽、循环类型变量及擦除的类型参数都不再被当作具体证明。
+
+泛型返回值、`apply`、方法参数投影、enum/struct payload、strict generic binding、
+同质集合、callback 与 Ref 不变量均显式选择关系。与开放边界无关的具体投影仍可保留，
+例如 `Result<Number, Dynamic> -> Number`；但 mismatch 会整体回滚，Dynamic 本身不会
+绑定成具体类型。基于兼容性的分支合并始终保留较弱类型，避免把开放证据反向收紧。

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -863,8 +863,8 @@ mod type_query_tests {
       "'Dynamic"
     );
     assert!(matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic));
-    assert!(CalcitTypeAnnotation::String.matches_annotation(annotation.as_ref()));
-    assert!(annotation.matches_annotation(&CalcitTypeAnnotation::String));
+    assert!(CalcitTypeAnnotation::String.is_compatible_with(annotation.as_ref()));
+    assert!(annotation.is_compatible_with(&CalcitTypeAnnotation::String));
   }
 
   #[test]
@@ -1187,7 +1187,7 @@ mod type_query_tests {
     let result_type = CalcitTypeAnnotation::TypeRef(Arc::from("test-enum.main/Result0"), Arc::new(vec![]));
     assert!(result_type.resolve_to_enum().is_some(), "source-backed Result0 should resolve");
     assert!(
-      result_type.matches_annotation(&CalcitTypeAnnotation::AnonymousEnum),
+      result_type.is_compatible_with(&CalcitTypeAnnotation::AnonymousEnum),
       "a source-backed enum reference should satisfy enum operations"
     );
     let person_symbol =
@@ -1950,7 +1950,7 @@ fn type_at_expected_mismatch_diagnostic(
   source: &str,
   path: &str,
 ) -> Option<ContextDiagnostic> {
-  if actual.matches_annotation(required) {
+  if actual.is_compatible_with(required) {
     return None;
   }
   Some(ContextDiagnostic {

--- a/src/bin/cli_handlers/scaffold.rs
+++ b/src/bin/cli_handlers/scaffold.rs
@@ -621,7 +621,7 @@ fn scaffold_schema_compatible(existing: &CalcitTypeAnnotation, planned: &CalcitT
   existing == planned
     || (matches!(existing, CalcitTypeAnnotation::StructDef(_) | CalcitTypeAnnotation::EnumDef(_))
       && matches!(planned, CalcitTypeAnnotation::Custom(_))
-      && existing.matches_annotation(planned))
+      && existing.is_compatible_with(planned))
 }
 
 fn report_to_edn(report: &ScaffoldPlanReport, dry_run: bool, apply_result: &ScaffoldApplyResult) -> Edn {

--- a/src/builtins/structs.rs
+++ b/src/builtins/structs.rs
@@ -90,7 +90,7 @@ fn validate_trait_impl_entries(trait_def: &crate::calcit::CalcitTrait, entries: 
     if matches!(value, Calcit::Proc(proc) if proc.get_type_signature().is_none()) {
       continue;
     }
-    if !actual.matches_annotation(expected.as_ref()) {
+    if !actual.is_compatible_with(expected.as_ref()) {
       return Err(CalcitErr::use_str(
         CalcitErrKind::Type,
         format!(

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -211,6 +211,46 @@ pub static DYNAMIC_TYPE: LazyLock<Arc<CalcitTypeAnnotation>> = LazyLock::new(|| 
 
 pub(crate) type TypeBindings = HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>;
 
+/// Result of asking whether an annotation is strong enough to authorize
+/// static inference or unchecked lowering. Compatibility may still accept a
+/// boundary that proof deliberately refuses to cross.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TypeProof {
+  Proven,
+  NeedsBoundary(TypeBoundaryReason),
+  Mismatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TypeBoundaryReason {
+  Dynamic,
+  LegacyAny,
+  UnknownCallable,
+  TagCallable,
+  UnresolvedTypeSlot,
+  LegacyNullish,
+  ErasedTypeArguments,
+  RecursiveTypeVariable,
+}
+
+impl TypeProof {
+  pub(crate) fn is_proven(self) -> bool {
+    matches!(self, Self::Proven)
+  }
+
+  pub(crate) fn is_mismatch(self) -> bool {
+    matches!(self, Self::Mismatch)
+  }
+
+  fn and(self, other: Self) -> Self {
+    match (self, other) {
+      (Self::Mismatch, _) | (_, Self::Mismatch) => Self::Mismatch,
+      (Self::NeedsBoundary(reason), _) | (_, Self::NeedsBoundary(reason)) => Self::NeedsBoundary(reason),
+      (Self::Proven, Self::Proven) => Self::Proven,
+    }
+  }
+}
+
 #[derive(Default)]
 struct FnSchemaFields<'a> {
   has_any: bool,
@@ -631,7 +671,7 @@ impl CalcitTypeAnnotation {
         return false;
       };
       let var = Arc::new(CalcitTypeAnnotation::TypeVar(var_name.to_owned()));
-      if !arg.matches_with_bindings(var.as_ref(), bindings) {
+      if !arg.compatible_with_bindings(var.as_ref(), bindings) {
         return false;
       }
     }
@@ -3068,12 +3108,17 @@ impl CalcitTypeAnnotation {
       .all(|trait_def| self.satisfies_trait_bound(trait_def.as_ref()))
   }
 
-  pub fn matches_annotation(&self, expected: &CalcitTypeAnnotation) -> bool {
+  pub fn is_compatible_with(&self, expected: &CalcitTypeAnnotation) -> bool {
     let mut bindings = TypeBindings::new();
-    self.matches_with_bindings(expected, &mut bindings)
+    self.compatible_with_bindings(expected, &mut bindings)
   }
 
-  pub(crate) fn matches_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
+  pub(crate) fn is_proven_for(&self, expected: &CalcitTypeAnnotation) -> bool {
+    let mut bindings = TypeBindings::new();
+    self.prove_with_bindings(expected, &mut bindings).is_proven()
+  }
+
+  pub(crate) fn compatible_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
     match (self, expected) {
       (_, Self::Dynamic) | (Self::Dynamic, _) => true,
       (Self::Macro(actual), Self::Macro(expected)) => actual == expected,
@@ -3102,7 +3147,7 @@ impl CalcitTypeAnnotation {
         }
         Some(bound) => {
           let bound = bound.clone();
-          actual.matches_with_bindings(bound.as_ref(), bindings)
+          actual.compatible_with_bindings(bound.as_ref(), bindings)
         }
         None if actual.contains_type_var_named_with_bindings(var, bindings) => true,
         None => {
@@ -3111,17 +3156,17 @@ impl CalcitTypeAnnotation {
         }
       },
       (_, Self::Optional(expected_inner)) => match self {
-        Self::Optional(actual_inner) => actual_inner.matches_with_bindings(expected_inner, bindings),
+        Self::Optional(actual_inner) => actual_inner.compatible_with_bindings(expected_inner, bindings),
         Self::JsNullish(_) => false,
         Self::Nil => true,
-        _ => self.matches_with_bindings(expected_inner, bindings),
+        _ => self.compatible_with_bindings(expected_inner, bindings),
       },
       (Self::Optional(_), _) => false,
       (_, Self::JsNullish(expected_inner)) => match self {
-        Self::JsNullish(actual_inner) => actual_inner.matches_with_bindings(expected_inner, bindings),
+        Self::JsNullish(actual_inner) => actual_inner.compatible_with_bindings(expected_inner, bindings),
         Self::Optional(_) => false,
         Self::Nil => true,
-        _ => self.matches_with_bindings(expected_inner, bindings),
+        _ => self.compatible_with_bindings(expected_inner, bindings),
       },
       (Self::JsNullish(_), _) => false,
       (Self::Bool, Self::Bool)
@@ -3155,7 +3200,7 @@ impl CalcitTypeAnnotation {
         }
         Some(bound) => {
           let bound = bound.clone();
-          bound.as_ref().matches_with_bindings(expected_type, bindings)
+          bound.as_ref().compatible_with_bindings(expected_type, bindings)
         }
         None if expected_type.contains_type_var_named_with_bindings(var, bindings) => true,
         None => {
@@ -3170,12 +3215,16 @@ impl CalcitTypeAnnotation {
         if a_args.is_empty() || b_args.is_empty() {
           return true;
         }
-        a_args.len() == b_args.len() && a_args.iter().zip(b_args.iter()).all(|(x, y)| x.matches_with_bindings(y, bindings))
+        a_args.len() == b_args.len()
+          && a_args
+            .iter()
+            .zip(b_args.iter())
+            .all(|(x, y)| x.compatible_with_bindings(y, bindings))
       }
-      (Self::List(a), Self::List(b)) => a.matches_with_bindings(b, bindings),
-      (Self::Map(ak, av), Self::Map(bk, bv)) => ak.matches_with_bindings(bk, bindings) && av.matches_with_bindings(bv, bindings),
-      (Self::Set(a), Self::Set(b)) => a.matches_with_bindings(b, bindings),
-      (Self::Ref(a), Self::Ref(b)) => a.matches_with_bindings(b, bindings),
+      (Self::List(a), Self::List(b)) => a.compatible_with_bindings(b, bindings),
+      (Self::Map(ak, av), Self::Map(bk, bv)) => ak.compatible_with_bindings(bk, bindings) && av.compatible_with_bindings(bv, bindings),
+      (Self::Set(a), Self::Set(b)) => a.compatible_with_bindings(b, bindings),
+      (Self::Ref(a), Self::Ref(b)) => a.compatible_with_bindings(b, bindings),
       (Self::TypeRef(name, args), Self::Struct(base, other_args)) | (Self::Struct(base, other_args), Self::TypeRef(name, args)) => {
         if !Self::type_ref_name_matches(name, base.name.ref_str()) && !Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
         {
@@ -3188,7 +3237,7 @@ impl CalcitTypeAnnotation {
               && args
                 .iter()
                 .zip(other_args.iter())
-                .all(|(x, y)| x.matches_with_bindings(y, bindings))
+                .all(|(x, y)| x.compatible_with_bindings(y, bindings))
           }
           (true, false) => Self::bind_declared_generics_from_applied_args(base.generics.as_ref(), other_args.as_ref(), bindings),
           (false, true) => Self::bind_declared_generics_from_applied_args(base.generics.as_ref(), args.as_ref(), bindings),
@@ -3207,7 +3256,7 @@ impl CalcitTypeAnnotation {
               && args
                 .iter()
                 .zip(other_args.iter())
-                .all(|(x, y)| x.matches_with_bindings(y, bindings))
+                .all(|(x, y)| x.compatible_with_bindings(y, bindings))
           }
           (true, false) => Self::bind_declared_generics_from_applied_args(base.generics(), other_args.as_ref(), bindings),
           (false, true) => Self::bind_declared_generics_from_applied_args(base.generics(), args.as_ref(), bindings),
@@ -3231,7 +3280,11 @@ impl CalcitTypeAnnotation {
         match (a_args.is_empty(), b_args.is_empty()) {
           (true, true) => true,
           (false, false) => {
-            a_args.len() == b_args.len() && a_args.iter().zip(b_args.iter()).all(|(x, y)| x.matches_with_bindings(y, bindings))
+            a_args.len() == b_args.len()
+              && a_args
+                .iter()
+                .zip(b_args.iter())
+                .all(|(x, y)| x.compatible_with_bindings(y, bindings))
           }
           _ => {
             // one applied, one bare — bind generics from the applied side
@@ -3247,7 +3300,11 @@ impl CalcitTypeAnnotation {
         if a_args.is_empty() || b_args.is_empty() {
           return true;
         }
-        a_args.len() == b_args.len() && a_args.iter().zip(b_args.iter()).all(|(x, y)| x.matches_with_bindings(y, bindings))
+        a_args.len() == b_args.len()
+          && a_args
+            .iter()
+            .zip(b_args.iter())
+            .all(|(x, y)| x.compatible_with_bindings(y, bindings))
       }
       (Self::TypeRef(name, args), Self::Trait(trait_def)) | (Self::Trait(trait_def), Self::TypeRef(name, args)) => {
         args.is_empty() && Self::type_ref_matches_trait(name, trait_def.as_ref())
@@ -3299,8 +3356,8 @@ impl CalcitTypeAnnotation {
       (Self::Fn(_), Self::DynFn) | (Self::DynFn, Self::Fn(_)) => true,
       // Tags are callable in Calcit (as map key accessors), so they satisfy :fn requirements
       (Self::Tag, Self::DynFn) | (Self::Tag, Self::Fn(_)) => true,
-      (Self::Fn(a), Self::Fn(b)) => a.matches_signature_with_bindings(b.as_ref(), bindings),
-      (Self::Variadic(a), Self::Variadic(b)) => a.matches_with_bindings(b, bindings),
+      (Self::Fn(a), Self::Fn(b)) => a.compatible_signature_with_bindings(b.as_ref(), bindings),
+      (Self::Variadic(a), Self::Variadic(b)) => a.compatible_with_bindings(b, bindings),
       (Self::Custom(a), Self::Custom(b)) => a.as_ref() == b.as_ref(),
       (Self::StructValue(a), Self::StructValue(b)) => a.name == b.name,
       (Self::StructValue(a), Self::Struct(b, _)) => a.name == b.name,
@@ -3336,20 +3393,186 @@ impl CalcitTypeAnnotation {
       // try to resolve it as a type alias by looking up the definition's schema.
       (Self::TypeRef(name, _), other) | (other, Self::TypeRef(name, _)) => {
         if let Some(resolved) = resolve_type_ref_as_schema(name) {
-          return resolved.matches_with_bindings(other, bindings);
+          return resolved.compatible_with_bindings(other, bindings);
         }
         false
       }
       // TypeSlot: resolve the bound type from the global registry and delegate
       (Self::TypeSlot(name), other) | (other, Self::TypeSlot(name)) => {
         if let Some(resolved) = resolve_type_slot(name) {
-          return resolved.matches_with_bindings(other, bindings);
+          return resolved.compatible_with_bindings(other, bindings);
         }
         // Slot not yet bound — treat as Dynamic (no checking)
         true
       }
       _ => false,
     }
+  }
+
+  /// Prove that `self` satisfies `expected` using only concrete static
+  /// evidence. Bindings are committed atomically only for a complete proof.
+  /// Legacy compatibility boundaries remain observable as `NeedsBoundary`.
+  pub(crate) fn prove_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> TypeProof {
+    let mut staged = bindings.clone();
+    let result = self.prove_with_staged_bindings(expected, &mut staged);
+    if result.is_proven() {
+      *bindings = staged;
+    }
+    result
+  }
+
+  /// Collect concrete bindings that were proven before an unrelated boundary
+  /// was encountered. A mismatch still rolls the whole relation back. This is
+  /// intended for output projections such as `Result<T, Dynamic> -> T`.
+  pub(crate) fn prove_available_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> TypeProof {
+    let mut staged = bindings.clone();
+    let result = self.prove_with_staged_bindings(expected, &mut staged);
+    if !result.is_mismatch() {
+      *bindings = staged;
+    }
+    result
+  }
+
+  fn prove_with_staged_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> TypeProof {
+    use TypeBoundaryReason as Boundary;
+    use TypeProof::{Mismatch, NeedsBoundary, Proven};
+
+    match (self, expected) {
+      (_, Self::Dynamic) | (Self::Dynamic, _) => NeedsBoundary(Boundary::Dynamic),
+      (_, Self::Custom(value)) if Self::custom_keyword_matches(value, "any") => NeedsBoundary(Boundary::LegacyAny),
+      (Self::Custom(value), _) if Self::custom_keyword_matches(value, "any") => NeedsBoundary(Boundary::LegacyAny),
+      (Self::TypeVar(actual), Self::TypeVar(expected)) if actual == expected => Proven,
+      (actual, Self::TypeVar(var)) => match bindings.get(var).cloned() {
+        Some(bound) => actual.prove_with_staged_bindings(bound.as_ref(), bindings),
+        None if actual.contains_type_var_named_with_bindings(var, bindings) => NeedsBoundary(Boundary::RecursiveTypeVariable),
+        None => {
+          bindings.insert(var.clone(), Arc::new(actual.clone()));
+          Proven
+        }
+      },
+      (Self::TypeVar(var), expected_type) => match bindings.get(var).cloned() {
+        Some(bound) => bound.prove_with_staged_bindings(expected_type, bindings),
+        None if expected_type.contains_type_var_named_with_bindings(var, bindings) => NeedsBoundary(Boundary::RecursiveTypeVariable),
+        None => {
+          bindings.insert(var.clone(), Arc::new(expected_type.clone()));
+          Proven
+        }
+      },
+      (Self::Optional(actual), Self::Optional(expected)) | (Self::JsNullish(actual), Self::JsNullish(expected)) => {
+        actual.prove_with_staged_bindings(expected, bindings)
+      }
+      (_, Self::Optional(_)) | (Self::Optional(_), _) | (_, Self::JsNullish(_)) | (Self::JsNullish(_), _) => {
+        if self.compatible_with_bindings(expected, &mut bindings.clone()) {
+          NeedsBoundary(Boundary::LegacyNullish)
+        } else {
+          Mismatch
+        }
+      }
+      (Self::TypeRef(a_name, a_args), Self::TypeRef(b_name, b_args)) => {
+        if !Self::type_ref_name_matches(a_name, b_name) && !Self::type_ref_name_matches(b_name, a_name) {
+          return Mismatch;
+        }
+        if a_args.is_empty() != b_args.is_empty() {
+          return NeedsBoundary(Boundary::ErasedTypeArguments);
+        }
+        Self::prove_slices(a_args, b_args, bindings)
+      }
+      (Self::TypeRef(name, args), Self::Struct(base, other_args)) | (Self::Struct(base, other_args), Self::TypeRef(name, args)) => {
+        if !Self::type_ref_name_matches(name, base.name.ref_str()) && !Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
+        {
+          return Mismatch;
+        }
+        match (args.is_empty(), other_args.is_empty()) {
+          (true, true) => Proven,
+          (false, false) => Self::prove_slices(args, other_args, bindings),
+          (true, false) => Self::prove_declared_generics(base.generics.as_ref(), other_args, bindings),
+          (false, true) => Self::prove_declared_generics(base.generics.as_ref(), args, bindings),
+        }
+      }
+      (Self::TypeRef(name, args), Self::Enum(base, other_args)) | (Self::Enum(base, other_args), Self::TypeRef(name, args)) => {
+        if !Self::type_ref_name_matches(name, base.name().ref_str())
+          && !Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
+        {
+          return Mismatch;
+        }
+        match (args.is_empty(), other_args.is_empty()) {
+          (true, true) => Proven,
+          (false, false) => Self::prove_slices(args, other_args, bindings),
+          (true, false) => Self::prove_declared_generics(base.generics(), other_args, bindings),
+          (false, true) => Self::prove_declared_generics(base.generics(), args, bindings),
+        }
+      }
+      (Self::List(actual), Self::List(expected))
+      | (Self::Set(actual), Self::Set(expected))
+      | (Self::Variadic(actual), Self::Variadic(expected)) => actual.prove_with_staged_bindings(expected, bindings),
+      (Self::Ref(actual), Self::Ref(expected)) => {
+        let mut invariant_bindings = bindings.clone();
+        let result = actual
+          .prove_with_staged_bindings(expected, &mut invariant_bindings)
+          .and(expected.prove_with_staged_bindings(actual, &mut invariant_bindings));
+        if result.is_proven() {
+          *bindings = invariant_bindings;
+        }
+        result
+      }
+      (Self::Map(actual_key, actual_value), Self::Map(expected_key, expected_value)) => actual_key
+        .prove_with_staged_bindings(expected_key, bindings)
+        .and(actual_value.prove_with_staged_bindings(expected_value, bindings)),
+      (Self::Struct(actual, actual_args), Self::Struct(expected, expected_args)) if actual.name == expected.name => {
+        if actual_args.is_empty() != expected_args.is_empty() {
+          NeedsBoundary(Boundary::ErasedTypeArguments)
+        } else {
+          Self::prove_slices(actual_args, expected_args, bindings)
+        }
+      }
+      (Self::Enum(actual, actual_args), Self::Enum(expected, expected_args)) if actual.name() == expected.name() => {
+        if actual_args.is_empty() != expected_args.is_empty() {
+          NeedsBoundary(Boundary::ErasedTypeArguments)
+        } else {
+          Self::prove_slices(actual_args, expected_args, bindings)
+        }
+      }
+      (Self::Fn(actual), Self::Fn(expected)) => actual.prove_signature_with_bindings(expected, bindings),
+      (Self::Fn(_), Self::DynFn) | (Self::DynFn, Self::Fn(_)) => NeedsBoundary(Boundary::UnknownCallable),
+      (Self::Tag, Self::DynFn) | (Self::Tag, Self::Fn(_)) => NeedsBoundary(Boundary::TagCallable),
+      (Self::TypeSlot(name), other) | (other, Self::TypeSlot(name)) => match resolve_type_slot(name) {
+        Some(resolved) => resolved.prove_with_staged_bindings(other, bindings),
+        None => NeedsBoundary(Boundary::UnresolvedTypeSlot),
+      },
+      (Self::TypeRef(name, _), other) | (other, Self::TypeRef(name, _)) => match resolve_type_ref_as_schema(name) {
+        Some(resolved) => resolved.prove_with_staged_bindings(other, bindings),
+        None => Mismatch,
+      },
+      _ => {
+        if self.compatible_with_bindings(expected, &mut bindings.clone()) {
+          Proven
+        } else {
+          Mismatch
+        }
+      }
+    }
+  }
+
+  fn prove_slices(
+    actual: &[Arc<CalcitTypeAnnotation>],
+    expected: &[Arc<CalcitTypeAnnotation>],
+    bindings: &mut TypeBindings,
+  ) -> TypeProof {
+    if actual.len() != expected.len() {
+      return TypeProof::Mismatch;
+    }
+    actual.iter().zip(expected).fold(TypeProof::Proven, |result, (actual, expected)| {
+      result.and(actual.prove_with_staged_bindings(expected, bindings))
+    })
+  }
+
+  fn prove_declared_generics(declared: &[Arc<str>], applied: &[Arc<CalcitTypeAnnotation>], bindings: &mut TypeBindings) -> TypeProof {
+    if declared.len() != applied.len() {
+      return TypeProof::Mismatch;
+    }
+    declared.iter().zip(applied).fold(TypeProof::Proven, |result, (name, actual)| {
+      result.and(actual.prove_with_staged_bindings(&Self::TypeVar(name.clone()), bindings))
+    })
   }
 
   pub fn from_calcit(value: &Calcit) -> Self {
@@ -4379,10 +4602,10 @@ mod tests {
     let user_debug = Arc::new(CalcitTrait::new_reference("app.main/Debug"));
     let runtime_user_debug = Arc::new(CalcitTrait::new_runtime(EdnTag::new("Debug"), vec![], vec![]));
 
-    assert!(number.matches_annotation(&CalcitTypeAnnotation::Trait(core_debug)));
-    assert!(!number.matches_annotation(&CalcitTypeAnnotation::Trait(core_show)));
-    assert!(!number.matches_annotation(&CalcitTypeAnnotation::Trait(user_debug)));
-    assert!(!number.matches_annotation(&CalcitTypeAnnotation::Trait(runtime_user_debug)));
+    assert!(number.is_compatible_with(&CalcitTypeAnnotation::Trait(core_debug)));
+    assert!(!number.is_compatible_with(&CalcitTypeAnnotation::Trait(core_show)));
+    assert!(!number.is_compatible_with(&CalcitTypeAnnotation::Trait(user_debug)));
+    assert!(!number.is_compatible_with(&CalcitTypeAnnotation::Trait(runtime_user_debug)));
   }
 
   #[test]
@@ -4393,8 +4616,8 @@ mod tests {
     evaluated_dom_element.runtime_id = Some(7);
     let annotation = CalcitTypeAnnotation::Trait(Arc::new(evaluated_dom_element));
 
-    assert!(annotation.matches_annotation(&CalcitTypeAnnotation::TypeRef(Arc::from("respo.dom/DomElement"), Arc::new(vec![]),)));
-    assert!(!annotation.matches_annotation(&CalcitTypeAnnotation::TypeRef(Arc::from("other.dom/DomElement"), Arc::new(vec![]),)));
+    assert!(annotation.is_compatible_with(&CalcitTypeAnnotation::TypeRef(Arc::from("respo.dom/DomElement"), Arc::new(vec![]),)));
+    assert!(!annotation.is_compatible_with(&CalcitTypeAnnotation::TypeRef(Arc::from("other.dom/DomElement"), Arc::new(vec![]),)));
     assert!(annotation.satisfies_trait_bound(dom_element.as_ref()));
     assert!(!annotation.satisfies_trait_bound(other_dom_element.as_ref()));
     let CalcitTypeAnnotation::Trait(evaluated_dom_element) = &annotation else {
@@ -4583,15 +4806,15 @@ mod tests {
     let result_def = CalcitTypeAnnotation::EnumDef(result.clone());
     let result_value = CalcitTypeAnnotation::EnumValue(result.clone());
 
-    assert!(!person_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Struct")));
-    assert!(person_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("StructDef")));
-    assert!(person_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Struct")));
-    assert!(!person_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("StructDef")));
+    assert!(!person_def.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("Struct")));
+    assert!(person_def.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("StructDef")));
+    assert!(person_value.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("Struct")));
+    assert!(!person_value.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("StructDef")));
 
-    assert!(!result_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Enum")));
-    assert!(result_def.matches_annotation(&CalcitTypeAnnotation::from_tag_name("EnumDef")));
-    assert!(result_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("Enum")));
-    assert!(!result_value.matches_annotation(&CalcitTypeAnnotation::from_tag_name("EnumDef")));
+    assert!(!result_def.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("Enum")));
+    assert!(result_def.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("EnumDef")));
+    assert!(result_value.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("Enum")));
+    assert!(!result_value.is_compatible_with(&CalcitTypeAnnotation::from_tag_name("EnumDef")));
 
     assert_eq!(person_def.to_brief_string(), "struct-def Person");
     assert_eq!(result_def.to_brief_string(), "enum-def Result");
@@ -4650,13 +4873,13 @@ mod tests {
     let map_type = CalcitTypeAnnotation::TypeRef(Arc::from("map"), Arc::new(vec![]));
 
     let mut bindings = TypeBindings::new();
-    assert!(struct_type.matches_with_bindings(&map_type, &mut bindings));
-    assert!(map_type.matches_with_bindings(&struct_type, &mut bindings));
+    assert!(struct_type.compatible_with_bindings(&map_type, &mut bindings));
+    assert!(map_type.compatible_with_bindings(&struct_type, &mut bindings));
 
     // unrelated type-ref names still must not match a struct structurally
     let person_type = CalcitTypeAnnotation::TypeRef(Arc::from("SomeOtherName"), Arc::new(vec![]));
     let mut bindings2 = TypeBindings::new();
-    assert!(!struct_type.matches_with_bindings(&person_type, &mut bindings2));
+    assert!(!struct_type.compatible_with_bindings(&person_type, &mut bindings2));
   }
 
   #[test]
@@ -4664,8 +4887,8 @@ mod tests {
     let type_var = CalcitTypeAnnotation::TypeVar(Arc::from("T"));
     let mut bindings = TypeBindings::new();
 
-    assert!(type_var.matches_with_bindings(&type_var, &mut bindings));
-    assert!(type_var.matches_with_bindings(&type_var, &mut bindings));
+    assert!(type_var.compatible_with_bindings(&type_var, &mut bindings));
+    assert!(type_var.compatible_with_bindings(&type_var, &mut bindings));
     assert!(bindings.is_empty(), "an identical type variable needs no self-binding");
   }
 
@@ -4676,21 +4899,21 @@ mod tests {
     let expected_type_var = CalcitTypeAnnotation::TypeVar(Arc::from("T"));
     let mut bindings = TypeBindings::new();
 
-    assert!(optional_type_var.matches_with_bindings(&expected_type_var, &mut bindings));
+    assert!(optional_type_var.compatible_with_bindings(&expected_type_var, &mut bindings));
     assert!(bindings.is_empty(), "T must not be bound to Optional<T>");
 
-    assert!(CalcitTypeAnnotation::Tag.matches_with_bindings(&expected_type_var, &mut bindings));
+    assert!(CalcitTypeAnnotation::Tag.compatible_with_bindings(&expected_type_var, &mut bindings));
     assert_eq!(bindings.get("T").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::Tag));
 
     let reverse_type_var = CalcitTypeAnnotation::TypeVar(Arc::from("T"));
     let reverse_optional = CalcitTypeAnnotation::Optional(Arc::new(reverse_type_var.clone()));
     let mut reverse_bindings = TypeBindings::new();
-    assert!(reverse_type_var.matches_with_bindings(&reverse_optional, &mut reverse_bindings));
+    assert!(reverse_type_var.compatible_with_bindings(&reverse_optional, &mut reverse_bindings));
     assert!(
       reverse_bindings.is_empty(),
       "T must not be bound to Optional<T> in the reverse direction"
     );
-    assert!(reverse_type_var.matches_with_bindings(&CalcitTypeAnnotation::String, &mut reverse_bindings));
+    assert!(reverse_type_var.compatible_with_bindings(&CalcitTypeAnnotation::String, &mut reverse_bindings));
     assert_eq!(reverse_bindings.get("T").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::String));
   }
 
@@ -4701,16 +4924,16 @@ mod tests {
     let optional_t = CalcitTypeAnnotation::Optional(Arc::new(generic_t.clone()));
     let mut bindings = TypeBindings::new();
 
-    assert!(generic_u.matches_with_bindings(&generic_t, &mut bindings));
+    assert!(generic_u.compatible_with_bindings(&generic_t, &mut bindings));
     assert_eq!(bindings.get("T").map(AsRef::as_ref), Some(&generic_u));
 
-    assert!(optional_t.matches_with_bindings(&generic_t, &mut bindings));
+    assert!(optional_t.compatible_with_bindings(&generic_t, &mut bindings));
     assert!(
       !bindings.contains_key("U"),
       "U must not be bound to Optional<T> through the T -> U alias"
     );
 
-    assert!(CalcitTypeAnnotation::Tag.matches_with_bindings(&generic_t, &mut bindings));
+    assert!(CalcitTypeAnnotation::Tag.compatible_with_bindings(&generic_t, &mut bindings));
     assert_eq!(bindings.get("U").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::Tag));
   }
 
@@ -4725,9 +4948,9 @@ mod tests {
       CalcitTypeAnnotation::from_function_parts(vec![Arc::new(CalcitTypeAnnotation::Number)], Arc::new(CalcitTypeAnnotation::Number));
     let mut bindings = TypeBindings::new();
 
-    assert!(actual_none.matches_with_bindings(&expected_none, &mut bindings));
+    assert!(actual_none.compatible_with_bindings(&expected_none, &mut bindings));
     assert!(
-      !actual_some.matches_with_bindings(&expected_some, &mut bindings),
+      !actual_some.compatible_with_bindings(&expected_some, &mut bindings),
       "a sibling callback must return the U bound by the first callback"
     );
   }
@@ -4742,7 +4965,7 @@ mod tests {
     );
     let mut bindings = TypeBindings::new();
 
-    assert!(!actual.matches_with_bindings(&expected, &mut bindings));
+    assert!(!actual.compatible_with_bindings(&expected, &mut bindings));
     assert!(bindings.is_empty(), "a failed callback match must not constrain later arguments");
   }
 
@@ -5305,14 +5528,14 @@ mod tests {
       CalcitTypeAnnotation::from_calcit(&Calcit::Tag(EdnTag::from("any"))),
       CalcitTypeAnnotation::Dynamic
     ));
-    assert!(CalcitTypeAnnotation::Number.matches_annotation(&any));
-    assert!(any.matches_annotation(&CalcitTypeAnnotation::Number));
+    assert!(CalcitTypeAnnotation::Number.is_compatible_with(&any));
+    assert!(any.is_compatible_with(&CalcitTypeAnnotation::Number));
     assert_eq!(any.to_type_edn(), Edn::Symbol(Arc::from("Dynamic")));
 
     let list_of_numbers = CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Number));
     let list_of_any = CalcitTypeAnnotation::List(Arc::new(any));
-    assert!(list_of_numbers.matches_annotation(&list_of_any));
-    assert!(list_of_any.matches_annotation(&list_of_numbers));
+    assert!(list_of_numbers.is_compatible_with(&list_of_any));
+    assert!(list_of_any.is_compatible_with(&list_of_numbers));
   }
 
   #[test]
@@ -5390,7 +5613,7 @@ mod tests {
     let expected = CalcitTypeAnnotation::TypeRef(Arc::from("Pair"), Arc::new(vec![]));
     let mut bindings = TypeBindings::new();
 
-    assert!(actual.matches_with_bindings(&expected, &mut bindings));
+    assert!(actual.compatible_with_bindings(&expected, &mut bindings));
     assert!(matches!(bindings.get("A"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::Number)));
     assert!(matches!(bindings.get("B"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::String)));
   }
@@ -5412,7 +5635,7 @@ mod tests {
     let expected = CalcitTypeAnnotation::Struct(pair, Arc::new(vec![]));
     let mut bindings = TypeBindings::new();
 
-    assert!(actual.matches_with_bindings(&expected, &mut bindings));
+    assert!(actual.compatible_with_bindings(&expected, &mut bindings));
     assert!(matches!(bindings.get("A"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::Number)));
     assert!(matches!(bindings.get("B"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::String)));
   }
@@ -5427,7 +5650,7 @@ mod tests {
     let expected = CalcitTypeAnnotation::TypeRef(Arc::from("Result"), Arc::new(vec![]));
     let mut bindings = TypeBindings::new();
 
-    assert!(actual.matches_with_bindings(&expected, &mut bindings));
+    assert!(actual.compatible_with_bindings(&expected, &mut bindings));
     assert!(matches!(bindings.get("T"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::Number)));
     assert!(matches!(bindings.get("E"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::String)));
   }
@@ -5442,9 +5665,128 @@ mod tests {
     let expected = CalcitTypeAnnotation::Enum(result, Arc::new(vec![]));
     let mut bindings = TypeBindings::new();
 
-    assert!(actual.matches_with_bindings(&expected, &mut bindings));
+    assert!(actual.compatible_with_bindings(&expected, &mut bindings));
     assert!(matches!(bindings.get("T"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::Number)));
     assert!(matches!(bindings.get("E"), Some(bound) if matches!(bound.as_ref(), CalcitTypeAnnotation::String)));
+  }
+
+  #[test]
+  fn proof_distinguishes_legacy_compatibility_boundaries() {
+    let mut bindings = TypeBindings::new();
+    assert_eq!(
+      CalcitTypeAnnotation::Dynamic.prove_with_bindings(&CalcitTypeAnnotation::Number, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::Dynamic)
+    );
+    assert_eq!(
+      CalcitTypeAnnotation::Tag.prove_with_bindings(&CalcitTypeAnnotation::DynFn, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::TagCallable)
+    );
+    assert_eq!(
+      CalcitTypeAnnotation::TypeSlot(Arc::from("unbound")).prove_with_bindings(&CalcitTypeAnnotation::String, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::UnresolvedTypeSlot)
+    );
+    assert!(bindings.is_empty());
+  }
+
+  #[test]
+  fn proof_is_transactional_and_does_not_synthesize_optional_bindings() {
+    let var: Arc<str> = Arc::from("T");
+    let expected = CalcitTypeAnnotation::TypeVar(var.clone());
+    let mut bindings = TypeBindings::new();
+
+    assert_eq!(
+      CalcitTypeAnnotation::Nil.prove_with_bindings(&expected, &mut bindings),
+      TypeProof::Proven
+    );
+    assert!(matches!(bindings.get(&var).map(AsRef::as_ref), Some(CalcitTypeAnnotation::Nil)));
+
+    let before = bindings.clone();
+    assert_eq!(
+      CalcitTypeAnnotation::Number.prove_with_bindings(&expected, &mut bindings),
+      TypeProof::Mismatch
+    );
+    assert_eq!(bindings, before, "a failed sibling proof must not widen or leak bindings");
+  }
+
+  #[test]
+  fn proof_rejects_dynamic_inside_ref_and_erased_applied_arguments() {
+    let mut bindings = TypeBindings::new();
+    let dynamic_ref = CalcitTypeAnnotation::Ref(Arc::new(CalcitTypeAnnotation::Dynamic));
+    let number_ref = CalcitTypeAnnotation::Ref(Arc::new(CalcitTypeAnnotation::Number));
+    assert_eq!(
+      dynamic_ref.prove_with_bindings(&number_ref, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::Dynamic)
+    );
+    assert_eq!(
+      number_ref.prove_with_bindings(&dynamic_ref, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::Dynamic)
+    );
+
+    let optional_number_ref =
+      CalcitTypeAnnotation::Ref(Arc::new(CalcitTypeAnnotation::Optional(Arc::new(CalcitTypeAnnotation::Number))));
+    assert!(!number_ref.prove_with_bindings(&optional_number_ref, &mut bindings).is_proven());
+
+    let bare = CalcitTypeAnnotation::TypeRef(Arc::from("app/Box"), Arc::new(vec![]));
+    let applied = CalcitTypeAnnotation::TypeRef(Arc::from("app/Box"), Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]));
+    assert!(bare.is_compatible_with(&applied));
+    assert_eq!(
+      bare.prove_with_bindings(&applied, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::ErasedTypeArguments)
+    );
+  }
+
+  #[test]
+  fn projection_proof_keeps_only_concrete_bindings_across_an_unrelated_boundary() {
+    let actual = CalcitTypeAnnotation::TypeRef(
+      Arc::from("app/Result"),
+      Arc::new(vec![
+        Arc::new(CalcitTypeAnnotation::Number),
+        Arc::new(CalcitTypeAnnotation::Dynamic),
+      ]),
+    );
+    let expected = CalcitTypeAnnotation::TypeRef(
+      Arc::from("app/Result"),
+      Arc::new(vec![
+        Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))),
+        Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("E"))),
+      ]),
+    );
+    let mut bindings = TypeBindings::new();
+    assert_eq!(
+      actual.prove_available_bindings(&expected, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::Dynamic)
+    );
+    assert!(matches!(bindings.get("T").map(AsRef::as_ref), Some(CalcitTypeAnnotation::Number)));
+    assert!(!bindings.contains_key("E"), "Dynamic must not become a concrete generic binding");
+  }
+
+  #[test]
+  fn proof_requires_a_declared_callable_signature() {
+    let signature =
+      CalcitTypeAnnotation::from_function_parts(vec![Arc::new(CalcitTypeAnnotation::Number)], Arc::new(CalcitTypeAnnotation::String));
+    let mut bindings = TypeBindings::new();
+    assert_eq!(
+      CalcitTypeAnnotation::DynFn.prove_with_bindings(&signature, &mut bindings),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::UnknownCallable)
+    );
+    assert_eq!(signature.prove_with_bindings(&signature, &mut bindings), TypeProof::Proven);
+  }
+
+  #[test]
+  fn conflicting_generic_siblings_roll_back_the_whole_projection() {
+    let var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let actual = CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Number));
+    let expected = CalcitTypeAnnotation::List(var.clone());
+    let mut bindings = TypeBindings::new();
+    assert_eq!(actual.prove_available_bindings(&expected, &mut bindings), TypeProof::Proven);
+    let committed = bindings.clone();
+
+    let conflicting = CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::String));
+    assert_eq!(
+      conflicting.prove_available_bindings(&CalcitTypeAnnotation::List(var), &mut bindings),
+      TypeProof::Mismatch
+    );
+    assert_eq!(bindings, committed);
   }
 
   #[test]
@@ -5455,14 +5797,14 @@ mod tests {
     );
     let dynamic_enum = CalcitTypeAnnotation::AnonymousEnum;
 
-    assert!(named.matches_annotation(&dynamic_enum));
-    assert!(!dynamic_enum.matches_annotation(&named));
+    assert!(named.is_compatible_with(&dynamic_enum));
+    assert!(!dynamic_enum.is_compatible_with(&named));
 
     // A named reference must never be accepted in the reverse direction. The
     // forward, resolvable TypeRef path is covered by the same matcher arm as
     // the concrete enum assertion above.
     let named_ref = CalcitTypeAnnotation::TypeRef(Arc::from("tests/Result"), Arc::new(vec![]));
-    assert!(!dynamic_enum.matches_annotation(&named_ref));
+    assert!(!dynamic_enum.is_compatible_with(&named_ref));
   }
 
   #[test]
@@ -5501,7 +5843,7 @@ mod tests {
       features: Arc::new(HashSet::new()),
     }));
 
-    assert!(actual.matches_annotation(&expected));
+    assert!(actual.is_compatible_with(&expected));
     assert_eq!(actual.to_brief_string(), "fn(:number, & :number) -> :number");
   }
 
@@ -5520,8 +5862,8 @@ mod tests {
       features: Arc::new(HashSet::new()),
     }));
 
-    assert!(!actual.matches_annotation(&binary_expected));
-    assert!(!actual.matches_annotation(&variadic_expected));
+    assert!(!actual.is_compatible_with(&binary_expected));
+    assert!(!actual.is_compatible_with(&variadic_expected));
   }
 
   #[test]
@@ -5533,7 +5875,7 @@ mod tests {
     );
     let expected = CalcitTypeAnnotation::from_function_parts(vec![number.clone()], Arc::new(CalcitTypeAnnotation::Optional(number)));
 
-    assert!(actual.matches_annotation(&expected));
+    assert!(actual.is_compatible_with(&expected));
   }
 
   #[test]
@@ -5542,11 +5884,11 @@ mod tests {
     let optional = CalcitTypeAnnotation::Optional(number.clone());
     let js_nullish = CalcitTypeAnnotation::JsNullish(number.clone());
 
-    assert!(!js_nullish.matches_annotation(&optional));
-    assert!(!optional.matches_annotation(&js_nullish));
-    assert!(CalcitTypeAnnotation::Number.matches_annotation(&js_nullish));
-    assert!(CalcitTypeAnnotation::Nil.matches_annotation(&js_nullish));
-    assert!(!CalcitTypeAnnotation::Unit.matches_annotation(&js_nullish));
+    assert!(!js_nullish.is_compatible_with(&optional));
+    assert!(!optional.is_compatible_with(&js_nullish));
+    assert!(CalcitTypeAnnotation::Number.is_compatible_with(&js_nullish));
+    assert!(CalcitTypeAnnotation::Nil.is_compatible_with(&js_nullish));
+    assert!(!CalcitTypeAnnotation::Unit.is_compatible_with(&js_nullish));
     assert_eq!(js_nullish.to_type_edn(), Edn::enum_value("JsNullish", vec![number.to_type_edn()]));
   }
 
@@ -5560,8 +5902,8 @@ mod tests {
       CalcitTypeAnnotation::builtin_type_from_tag_name("unit"),
       Some(CalcitTypeAnnotation::Unit)
     );
-    assert!(!CalcitTypeAnnotation::Nil.matches_annotation(&CalcitTypeAnnotation::Unit));
-    assert!(!CalcitTypeAnnotation::Unit.matches_annotation(&CalcitTypeAnnotation::Nil));
+    assert!(!CalcitTypeAnnotation::Nil.is_compatible_with(&CalcitTypeAnnotation::Unit));
+    assert!(!CalcitTypeAnnotation::Unit.is_compatible_with(&CalcitTypeAnnotation::Nil));
     assert!(value_matches_type_annotation(&Calcit::Nil, &CalcitTypeAnnotation::Nil));
     assert!(!value_matches_type_annotation(&Calcit::Nil, &CalcitTypeAnnotation::Unit));
     assert!(value_matches_type_annotation(&Calcit::Unit, &CalcitTypeAnnotation::Unit));
@@ -5574,22 +5916,22 @@ mod tests {
   fn generic_bindings_lift_nil_and_values_into_optional() {
     let var = Arc::<str>::from("T");
     let mut nil_first = TypeBindings::new();
-    assert!(CalcitTypeAnnotation::Nil.matches_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut nil_first));
-    assert!(CalcitTypeAnnotation::Bool.matches_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut nil_first));
+    assert!(CalcitTypeAnnotation::Nil.compatible_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut nil_first));
+    assert!(CalcitTypeAnnotation::Bool.compatible_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut nil_first));
     assert!(matches!(
       nil_first.get(&var).map(Arc::as_ref),
       Some(CalcitTypeAnnotation::Optional(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Bool)
     ));
 
     let mut value_first = TypeBindings::new();
-    assert!(CalcitTypeAnnotation::Bool.matches_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut value_first));
-    assert!(CalcitTypeAnnotation::Nil.matches_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut value_first));
+    assert!(CalcitTypeAnnotation::Bool.compatible_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut value_first));
+    assert!(CalcitTypeAnnotation::Nil.compatible_with_bindings(&CalcitTypeAnnotation::TypeVar(var.clone()), &mut value_first));
     assert!(matches!(
       value_first.get(&var).map(Arc::as_ref),
       Some(CalcitTypeAnnotation::Optional(inner)) if matches!(inner.as_ref(), CalcitTypeAnnotation::Bool)
     ));
 
-    assert!(!CalcitTypeAnnotation::Unit.matches_with_bindings(
+    assert!(!CalcitTypeAnnotation::Unit.compatible_with_bindings(
       &CalcitTypeAnnotation::Optional(Arc::new(CalcitTypeAnnotation::Bool)),
       &mut TypeBindings::new()
     ));
@@ -5603,7 +5945,7 @@ mod tests {
     );
     let expected = CalcitTypeAnnotation::from_tag_name("struct");
 
-    assert!(actual.matches_annotation(&expected));
+    assert!(actual.is_compatible_with(&expected));
   }
 }
 
@@ -6038,13 +6380,13 @@ impl CalcitFnTypeAnnotation {
 
   pub fn matches_signature(&self, other: &CalcitFnTypeAnnotation) -> bool {
     let mut bindings = TypeBindings::new();
-    self.matches_signature_with_bindings(other, &mut bindings)
+    self.compatible_signature_with_bindings(other, &mut bindings)
   }
 
   /// Match a callable signature while preserving bindings from its enclosing
   /// generic call. This lets sibling callbacks share a return type variable,
   /// such as the two branches accepted by `option:fold`.
-  pub(crate) fn matches_signature_with_bindings(&self, other: &CalcitFnTypeAnnotation, bindings: &mut TypeBindings) -> bool {
+  pub(crate) fn compatible_signature_with_bindings(&self, other: &CalcitFnTypeAnnotation, bindings: &mut TypeBindings) -> bool {
     // `self` is the actual callable and `other` is the expected callback shape. An actual
     // callable cannot require more fixed arguments than the expected contract guarantees.
     if self.arg_types.len() > other.arg_types.len() {
@@ -6064,7 +6406,7 @@ impl CalcitFnTypeAnnotation {
       // Callback parameters are contravariant: every value promised by the expected contract
       // must be accepted by the actual callable. This matters for a function accepting
       // `optional<T>` being used where a callback receives `T`.
-      if !expected.matches_with_bindings(actual, &mut staged_bindings) {
+      if !expected.compatible_with_bindings(actual, &mut staged_bindings) {
         return false;
       }
     }
@@ -6075,19 +6417,46 @@ impl CalcitFnTypeAnnotation {
       let Some(actual_rest) = &self.rest_type else {
         return false;
       };
-      if !expected_rest.matches_with_bindings(actual_rest, &mut staged_bindings) {
+      if !expected_rest.compatible_with_bindings(actual_rest, &mut staged_bindings) {
         return false;
       }
     }
 
     if !self
       .return_type
-      .matches_with_bindings(other.return_type.as_ref(), &mut staged_bindings)
+      .compatible_with_bindings(other.return_type.as_ref(), &mut staged_bindings)
     {
       return false;
     }
     *bindings = staged_bindings;
     true
+  }
+
+  fn prove_signature_with_bindings(&self, other: &CalcitFnTypeAnnotation, bindings: &mut TypeBindings) -> TypeProof {
+    if self.arg_types.len() > other.arg_types.len() {
+      return TypeProof::Mismatch;
+    }
+
+    let mut staged = bindings.clone();
+    let mut result = TypeProof::Proven;
+    for (idx, expected) in other.arg_types.iter().enumerate() {
+      let Some(actual) = self.arg_types.get(idx).or(self.rest_type.as_ref()) else {
+        return TypeProof::Mismatch;
+      };
+      result = result.and(expected.prove_with_staged_bindings(actual, &mut staged));
+    }
+    match (&self.rest_type, &other.rest_type) {
+      (Some(actual), Some(expected)) => {
+        result = result.and(expected.prove_with_staged_bindings(actual, &mut staged));
+      }
+      (None, Some(_)) => return TypeProof::Mismatch,
+      _ => {}
+    }
+    result = result.and(self.return_type.prove_with_staged_bindings(&other.return_type, &mut staged));
+    if result.is_proven() {
+      *bindings = staged;
+    }
+    result
   }
 }
 
@@ -6293,7 +6662,7 @@ pub fn infer_runtime_value_type(value: &Calcit) -> Arc<CalcitTypeAnnotation> {
 
 pub fn collect_runtime_type_bindings(value: &Calcit, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
   let actual = infer_runtime_value_type(value);
-  actual.as_ref().matches_with_bindings(expected, bindings)
+  actual.as_ref().compatible_with_bindings(expected, bindings)
 }
 
 pub fn validate_runtime_generic_where_bounds(bindings: &TypeBindings, where_bounds: &[CalcitGenericBound]) -> Result<(), String> {
@@ -6306,7 +6675,7 @@ pub fn validate_runtime_generic_where_bounds(bindings: &TypeBindings, where_boun
     }
 
     let required = bound.as_type_annotation();
-    if actual_type.as_ref().matches_annotation(required.as_ref()) {
+    if actual_type.as_ref().is_compatible_with(required.as_ref()) {
       continue;
     }
 

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -160,8 +160,8 @@ fn nominal_impl_wrapper_type_ref_matches_its_concrete_enum_value() {
     Arc::new(vec![]),
   );
 
-  assert!(wrapper_ref.matches_annotation(&concrete));
-  assert!(concrete.matches_annotation(&wrapper_ref));
+  assert!(wrapper_ref.is_compatible_with(&concrete));
+  assert!(concrete.is_compatible_with(&wrapper_ref));
 }
 
 #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3257,7 +3257,7 @@ fn try_rewrite_struct_enum_constructor_head_call(
         continue;
       }
       if let Some(actual_type) = resolve_type_value(value, scope_types)
-        && !actual_type.as_ref().matches_annotation(expected_type.as_ref())
+        && !actual_type.as_ref().is_compatible_with(expected_type.as_ref())
       {
         gen_check_warning(
           format!(
@@ -4292,7 +4292,7 @@ fn check_struct_update_fields(
       continue;
     }
     if let Some(actual_type) = resolve_type_value(value_arg, scope_types)
-      && !actual_type.as_ref().matches_annotation(expected_type.as_ref())
+      && !actual_type.as_ref().is_compatible_with(expected_type.as_ref())
     {
       gen_check_warning(
         format!(
@@ -4459,7 +4459,7 @@ pub(crate) fn check_enum_construction(
     }
 
     if let Some(actual_type) = resolve_type_value(payload_arg, scope_types)
-      && !actual_type.as_ref().matches_annotation(expected_type.as_ref())
+      && !actual_type.as_ref().is_compatible_with(expected_type.as_ref())
     {
       let expected_str = expected_type.as_ref().to_brief_string();
       let actual_str = actual_type.as_ref().to_brief_string();
@@ -4537,7 +4537,7 @@ fn check_struct_method_args(
     {
       receiver_type
         .as_ref()
-        .matches_with_bindings(expected_receiver.as_ref(), &mut bindings);
+        .compatible_with_bindings(expected_receiver.as_ref(), &mut bindings);
     }
     let arg_types_without_receiver = signature.arg_types.iter().skip(1);
     for (idx, (arg, expected_type)) in method_args.iter().zip(arg_types_without_receiver).enumerate() {
@@ -4546,7 +4546,7 @@ fn check_struct_method_args(
       }
 
       if let Some(actual_type) = resolve_type_value(arg, scope_types)
-        && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
+        && !actual_type.as_ref().compatible_with_bindings(expected_type.as_ref(), &mut bindings)
       {
         let expected_str = expected_type.substitute_type_vars(&bindings).to_brief_string();
         let actual_str = actual_type.as_ref().to_brief_string();
@@ -4618,14 +4618,16 @@ fn check_struct_method_args(
 
     let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
     if let Some(expected_receiver) = signature.arg_types.first() {
-      type_value.as_ref().matches_with_bindings(expected_receiver.as_ref(), &mut bindings);
+      type_value
+        .as_ref()
+        .compatible_with_bindings(expected_receiver.as_ref(), &mut bindings);
     }
     for (idx, (arg, expected_type)) in method_args.iter().zip(signature.arg_types.iter().skip(1)).enumerate() {
       if matches!(**expected_type, CalcitTypeAnnotation::Dynamic) {
         continue;
       }
       if let Some(actual_type) = resolve_type_value(arg, scope_types)
-        && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
+        && !actual_type.as_ref().compatible_with_bindings(expected_type.as_ref(), &mut bindings)
       {
         let expected_str = expected_type.substitute_type_vars(&bindings).to_brief_string();
         let actual_str = actual_type.as_ref().to_brief_string();
@@ -4700,7 +4702,9 @@ fn check_struct_method_args(
   let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
   let arg_types_without_receiver: Vec<Arc<CalcitTypeAnnotation>> = fn_info.arg_types.iter().skip(1).cloned().collect();
   if let Some(expected_receiver) = fn_info.arg_types.first() {
-    type_value.as_ref().matches_with_bindings(expected_receiver.as_ref(), &mut bindings);
+    type_value
+      .as_ref()
+      .compatible_with_bindings(expected_receiver.as_ref(), &mut bindings);
   }
 
   for (idx, (arg, expected_type)) in method_args.iter().zip(arg_types_without_receiver.iter()).enumerate() {
@@ -4715,7 +4719,7 @@ fn check_struct_method_args(
         if let Some(actual_type) = resolve_type_value(rest_arg, scope_types)
           && !actual_type
             .as_ref()
-            .matches_with_bindings(expected_rest_type.as_ref(), &mut bindings)
+            .compatible_with_bindings(expected_rest_type.as_ref(), &mut bindings)
         {
           let expected_str = expected_rest_type.describe();
           let actual_str = actual_type.as_ref().describe();
@@ -4735,7 +4739,7 @@ fn check_struct_method_args(
 
     if let Some(actual_type) = resolve_type_value(arg, scope_types) {
       // Compare types
-      if !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings) {
+      if !actual_type.as_ref().compatible_with_bindings(expected_type.as_ref(), &mut bindings) {
         let expected_str = expected_type.substitute_type_vars(&bindings).describe();
         let actual_str = actual_type.as_ref().describe();
         let migration = if method_name.as_ref() == "apply" && matches!(type_value.as_ref(), CalcitTypeAnnotation::List(_)) {
@@ -4784,7 +4788,10 @@ fn expected_method_argument_types(type_value: &CalcitTypeAnnotation, method_name
   let fn_annotation = signature.as_function()?;
   let expected_receiver = fn_annotation.arg_types.first()?;
   let mut bindings = HashMap::new();
-  if !type_value.matches_with_bindings(expected_receiver.as_ref(), &mut bindings) {
+  if !type_value
+    .prove_with_bindings(expected_receiver.as_ref(), &mut bindings)
+    .is_proven()
+  {
     return None;
   }
   Some(
@@ -5039,7 +5046,7 @@ fn check_typed_js_field_operation(
   if operation == "js-set"
     && let Some(value) = args.get(2)
     && let Some(value_type) = resolve_type_value(value, scope_types)
-    && !value_type.as_ref().matches_annotation(field_type.as_ref())
+    && !value_type.as_ref().is_compatible_with(field_type.as_ref())
   {
     let message = format!(
       "[Warn] `js-set` field `:{field_name}` expects {}, got {} in {file_ns}/{def_name}",
@@ -6374,7 +6381,7 @@ fn validate_macro_call_inputs(
     if let MacroSyntaxType::Expr(expected) = contract
       && let Some(actual) = infer_type_from_expr(arg, scope_types)
       && !matches!(actual.as_ref(), CalcitTypeAnnotation::Dynamic)
-      && !actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings)
+      && !actual.as_ref().compatible_with_bindings(expected.as_ref(), &mut bindings)
     {
       return Err(CalcitErr::use_msg_stack_location_with_code(
         CalcitErrKind::Type,
@@ -6450,7 +6457,7 @@ fn validate_macro_expansion_result(
       }
       if let Some(actual) = resolve_type_value(processed, scope_types)
         && !matches!(actual.as_ref(), CalcitTypeAnnotation::Dynamic)
-        && !actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings)
+        && !actual.as_ref().compatible_with_bindings(expected.as_ref(), &mut bindings)
       {
         return Err(CalcitErr::use_msg_stack_location_with_code(
           CalcitErrKind::Type,
@@ -6471,7 +6478,7 @@ fn validate_macro_expansion_result(
         return Ok(());
       };
       if matches!(actual.as_ref(), CalcitTypeAnnotation::Dynamic)
-        || actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings)
+        || actual.as_ref().compatible_with_bindings(expected.as_ref(), &mut bindings)
       {
         Ok(())
       } else {
@@ -8200,7 +8207,7 @@ pub fn preprocess_assert_type(
   if let Calcit::Local(local) = &asserted_target {
     let asserted_type = local_nominal_type.unwrap_or_else(|| CalcitTypeAnnotation::parse_type_annotation_form(&asserted_type_form));
     let current_type = resolve_type_value(&asserted_target, ctx.scope_types).unwrap_or_else(|| local.type_info.clone());
-    let type_entry = if current_type.as_ref().matches_annotation(asserted_type.as_ref())
+    let type_entry = if current_type.as_ref().is_compatible_with(asserted_type.as_ref())
       && annotation_dynamic_weight(current_type.as_ref()) < annotation_dynamic_weight(asserted_type.as_ref())
     {
       current_type
@@ -9079,7 +9086,7 @@ fn reject_strict_dynamic_nominal_argument(
       && expected.contains_type_var()
     {
       let mut candidate = bindings.clone();
-      if actual.as_ref().matches_with_bindings(expected.as_ref(), &mut candidate) {
+      if actual.as_ref().prove_with_bindings(expected.as_ref(), &mut candidate).is_proven() {
         bindings = candidate;
       }
     }
@@ -13036,11 +13043,11 @@ mod tests {
     let enum_ref = CalcitTypeAnnotation::TypeRef(Arc::from("Event"), Arc::new(vec![]));
     crate::calcit::with_type_annotation_warning_context(format!("{ns}/ClientStore"), || {
       assert!(
-        struct_ref.matches_annotation(&struct_marker),
+        struct_ref.is_compatible_with(&struct_marker),
         "unqualified struct TypeRef should resolve in its source namespace"
       );
       assert!(
-        enum_ref.matches_annotation(&enum_marker),
+        enum_ref.is_compatible_with(&enum_marker),
         "unqualified enum TypeRef should resolve in its source namespace"
       );
     });

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -99,7 +99,7 @@ fn check_generic_trait_bounds(ctx: &CheckContext<'_>, bindings: &HashMap<Arc<str
     }
 
     let required = bound.as_type_annotation();
-    if actual_type.as_ref().matches_annotation(required.as_ref()) {
+    if actual_type.as_ref().is_compatible_with(required.as_ref()) {
       continue;
     }
 
@@ -508,7 +508,7 @@ where
           let mut candidate = bindings.clone();
           let matches = actual_type
             .as_ref()
-            .matches_with_bindings(expected_rest_type.as_ref(), &mut candidate);
+            .compatible_with_bindings(expected_rest_type.as_ref(), &mut candidate);
           if matches {
             bindings = candidate;
           } else {
@@ -532,13 +532,15 @@ where
       };
       let matches = if expected_type.contains_type_var() || actual_type.contains_type_var() {
         let mut candidate = bindings.clone();
-        let matches = actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut candidate);
+        let matches = actual_type
+          .as_ref()
+          .compatible_with_bindings(expected_type.as_ref(), &mut candidate);
         if matches {
           bindings = candidate;
         }
         matches
       } else {
-        actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
+        actual_type.as_ref().compatible_with_bindings(expected_type.as_ref(), &mut bindings)
       };
       if !matches {
         let diagnostic_expected = expected_type.substitute_type_vars(&bindings);
@@ -668,7 +670,7 @@ pub(crate) fn check_proc_arg_types(
         if let Some(actual_type) = resolve_type_value(rest_arg, scope_types)
           && !actual_type
             .as_ref()
-            .matches_with_bindings(expected_rest_type.as_ref(), &mut bindings)
+            .compatible_with_bindings(expected_rest_type.as_ref(), &mut bindings)
         {
           let expected_str = diagnostic_type_string(expected_rest_type.as_ref());
           let actual_str = diagnostic_type_string(actual_type.as_ref());
@@ -699,7 +701,7 @@ pub(crate) fn check_proc_arg_types(
     }
 
     if let Some(actual_type) = resolve_type_value(arg, scope_types)
-      && !actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings)
+      && !actual_type.as_ref().compatible_with_bindings(expected_type.as_ref(), &mut bindings)
     {
       let expected_str = diagnostic_type_string(expected_type.as_ref());
       let actual_str = diagnostic_type_string(actual_type.as_ref());
@@ -755,7 +757,7 @@ pub(crate) fn check_core_fn_arg_types(
 
   for (idx, arg) in args.iter().enumerate() {
     if let Some(actual_type) = resolve_type_value(arg, scope_types)
-      && !actual_type.as_ref().matches_annotation(expected_type.as_ref())
+      && !actual_type.as_ref().is_compatible_with(expected_type.as_ref())
     {
       let actual_str = diagnostic_type_string(actual_type.as_ref());
       let warning_location = arg.get_location().or_else(|| call_location.clone());
@@ -846,7 +848,7 @@ fn reset_value_erases_contract(value: &Calcit, expected: &CalcitTypeAnnotation, 
     }
   }
   let actual = resolve_type_value(value, scope).unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
-  reset_type_erases_contract(actual.as_ref(), expected) || !actual.matches_annotation(expected)
+  reset_type_erases_contract(actual.as_ref(), expected) || !actual.is_compatible_with(expected)
 }
 
 /// A mutable reference's payload type is fixed by its declaration/initializer,
@@ -895,7 +897,7 @@ pub(super) fn check_reset_arg_types(
     // existing reference's type variables, nor assume an unrelated input T is
     // the reference's concrete payload type. Identical variables need no binding.
     let mut bindings = HashMap::new();
-    if actual.matches_with_bindings(expected, &mut bindings) && !bindings.is_empty() {
+    if actual.compatible_with_bindings(expected, &mut bindings) && !bindings.is_empty() {
       ctx.emit_warning(2, expected, actual.as_ref(), message);
       return;
     }
@@ -1078,7 +1080,7 @@ pub(crate) fn check_function_return_type(
   let mut bindings = HashMap::new();
   if !actual_type
     .as_ref()
-    .matches_with_bindings(declared_return_type.as_ref(), &mut bindings)
+    .compatible_with_bindings(declared_return_type.as_ref(), &mut bindings)
   {
     let expected_str = diagnostic_type_string(declared_return_type.as_ref());
     let actual_str = diagnostic_type_string(actual_type.as_ref());

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -103,9 +103,17 @@ fn merge_if_branch_types(
   true_type: Arc<CalcitTypeAnnotation>,
   false_type: Arc<CalcitTypeAnnotation>,
 ) -> Option<Arc<CalcitTypeAnnotation>> {
-  if true_type.as_ref().matches_annotation(false_type.as_ref()) {
+  let true_accepts_false = true_type.as_ref().is_compatible_with(false_type.as_ref());
+  let false_accepts_true = false_type.as_ref().is_compatible_with(true_type.as_ref());
+  let true_weight = super::annotation_dynamic_weight(true_type.as_ref());
+  let false_weight = super::annotation_dynamic_weight(false_type.as_ref());
+
+  // A compatibility join may retain the weaker branch shape, but must never
+  // turn Dynamic evidence into a more concrete result merely because the
+  // legacy matcher accepts Dynamic symmetrically.
+  if true_accepts_false && true_weight >= false_weight {
     Some(true_type)
-  } else if false_type.as_ref().matches_annotation(true_type.as_ref()) {
+  } else if false_accepts_true && false_weight >= true_weight {
     Some(false_type)
   } else {
     None
@@ -198,9 +206,13 @@ fn resolve_generic_return_type_parts<'a>(
     if matches!(**expected_type, CalcitTypeAnnotation::Dynamic) {
       continue;
     }
-    if let Some(actual_type) = resolve_type_value(arg, scope_types) {
-      // Use matches_with_bindings to populate TypeVar bindings
-      actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings);
+    let actual_type = resolve_type_value(arg, scope_types)?;
+    if actual_type
+      .as_ref()
+      .prove_available_bindings(expected_type.as_ref(), &mut bindings)
+      .is_mismatch()
+    {
+      return None;
     }
   }
 
@@ -338,8 +350,12 @@ pub(crate) fn infer_return_type_from_compiled_callable(
   for (arg, expected_type) in call_expr.iter().skip(1).zip(info.arg_types.iter()) {
     if !matches!(expected_type.as_ref(), CalcitTypeAnnotation::Dynamic)
       && let Some(actual_type) = resolve_type_value(arg, scope_types)
+      && !actual_type
+        .as_ref()
+        .prove_with_bindings(expected_type.as_ref(), &mut bindings)
+        .is_proven()
     {
-      actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings);
+      return None;
     }
   }
   // A constructor such as `%none` has no payload from which to infer one or
@@ -520,7 +536,11 @@ fn infer_core_apply_return_type(call_expr: &CalcitList, scope_types: &ScopeTypes
   let mut bindings = HashMap::new();
   for expected in signature.arg_types.iter().chain(signature.rest_type.iter()) {
     let mut candidate = bindings.clone();
-    if !item_type.as_ref().matches_with_bindings(expected.as_ref(), &mut candidate) {
+    if !item_type
+      .as_ref()
+      .prove_with_bindings(expected.as_ref(), &mut candidate)
+      .is_proven()
+    {
       return None;
     }
     bindings = candidate;
@@ -997,8 +1017,13 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           };
           let mut bindings = HashMap::new();
           for (argument, expected) in xs.iter().skip(1).zip(info.arg_types.iter()) {
-            if let Some(actual) = resolve_type_value(argument, scope_types) {
-              actual.as_ref().matches_with_bindings(expected.as_ref(), &mut bindings);
+            if let Some(actual) = resolve_type_value(argument, scope_types)
+              && actual
+                .as_ref()
+                .prove_available_bindings(expected.as_ref(), &mut bindings)
+                .is_mismatch()
+            {
+              return Some(calcit::DYNAMIC_TYPE.clone());
             }
           }
           Some(info.return_type.substitute_type_vars(&bindings))
@@ -1467,7 +1492,7 @@ fn infer_proc_call_return_type(proc: &CalcitProc, xs: &CalcitList, scope_types: 
     };
     if let Some(member_type) = member_type {
       let expected_reducer = CalcitTypeAnnotation::from_function_parts(vec![initial_type.clone(), member_type], initial_type.clone());
-      if matches!(reducer_type.as_ref(), CalcitTypeAnnotation::Fn(_)) && reducer_type.as_ref().matches_annotation(&expected_reducer) {
+      if matches!(reducer_type.as_ref(), CalcitTypeAnnotation::Fn(_)) && reducer_type.as_ref().is_proven_for(&expected_reducer) {
         return Some(initial_type);
       }
     }
@@ -1634,7 +1659,7 @@ fn infer_homogeneous_type<'a>(values: impl Iterator<Item = &'a Calcit>, scope_ty
       return calcit::DYNAMIC_TYPE.clone();
     }
     match &inferred {
-      Some(current) if !current.as_ref().matches_annotation(next.as_ref()) || !next.as_ref().matches_annotation(current.as_ref()) => {
+      Some(current) if !current.as_ref().is_proven_for(next.as_ref()) || !next.as_ref().is_proven_for(current.as_ref()) => {
         return calcit::DYNAMIC_TYPE.clone();
       }
       Some(_) => {}
@@ -1783,9 +1808,13 @@ fn infer_enum_applied_args<'a>(
   for (payload, expected_type) in payload_args.zip(variant.payload_types().iter()) {
     let actual_type = resolve_type_value(payload, scope_types).unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
     let resolved_expected = resolve_local_type_refs_for_body(expected_type.clone(), scope_types);
-    actual_type
+    if !actual_type
       .as_ref()
-      .matches_with_bindings(resolved_expected.as_ref(), &mut bindings);
+      .prove_with_bindings(resolved_expected.as_ref(), &mut bindings)
+      .is_proven()
+    {
+      return None;
+    }
   }
 
   Some(
@@ -1923,7 +1952,13 @@ fn infer_struct_applied_args<'a>(
   let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
   for (value, expected_type) in values.zip(struct_def.field_types.iter()) {
     let actual_type = resolve_type_value(value, scope_types).unwrap_or_else(|| calcit::DYNAMIC_TYPE.clone());
-    actual_type.as_ref().matches_with_bindings(expected_type.as_ref(), &mut bindings);
+    if !actual_type
+      .as_ref()
+      .prove_with_bindings(expected_type.as_ref(), &mut bindings)
+      .is_proven()
+    {
+      return struct_def.generics.iter().map(|_| calcit::DYNAMIC_TYPE.clone()).collect();
+    }
   }
 
   struct_def
@@ -2152,6 +2187,18 @@ mod tests {
   }
 
   #[test]
+  fn dynamic_if_branch_does_not_authorize_a_concrete_merge() {
+    assert!(matches!(
+      merge_if_branch_types(Arc::new(CalcitTypeAnnotation::Number), calcit::DYNAMIC_TYPE.clone()).as_deref(),
+      Some(CalcitTypeAnnotation::Dynamic)
+    ));
+    assert!(matches!(
+      merge_if_branch_types(calcit::DYNAMIC_TYPE.clone(), Arc::new(CalcitTypeAnnotation::Number)).as_deref(),
+      Some(CalcitTypeAnnotation::Dynamic)
+    ));
+  }
+
+  #[test]
   fn sort_preserves_the_concrete_list_type() {
     let string_list = Arc::new(CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::String)));
     for proc in [CalcitProc::Sort, CalcitProc::NativeListSort] {
@@ -2213,7 +2260,7 @@ mod tests {
   }
 
   #[test]
-  fn unresolved_generic_payload_keeps_nominal_return_wrapper() {
+  fn unresolved_generic_payload_does_not_authorize_a_static_return() {
     let type_var: Arc<CalcitTypeAnnotation> = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
     let fn_info = CalcitFn {
       name: Arc::from("find"),
@@ -2234,15 +2281,7 @@ mod tests {
       rest_type: None,
     };
     let unknown_list = local("xs", calcit::DYNAMIC_TYPE.clone());
-    let inferred = resolve_generic_return_type(&fn_info, std::iter::once(&unknown_list), &ScopeTypes::new())
-      .expect("outer nominal return type should remain visible");
-
-    assert!(matches!(
-      inferred.as_ref(),
-      CalcitTypeAnnotation::TypeRef(name, args)
-        if name.as_ref() == "calcit.core/Option"
-          && matches!(args.first().map(AsRef::as_ref), Some(CalcitTypeAnnotation::Dynamic))
-    ));
+    assert!(resolve_generic_return_type(&fn_info, std::iter::once(&unknown_list), &ScopeTypes::new()).is_none());
   }
 
   #[test]
@@ -2569,9 +2608,9 @@ mod tests {
     }
 
     let opaque = CalcitTypeAnnotation::JsObject;
-    assert!(opaque.matches_annotation(&CalcitTypeAnnotation::JsObject));
-    assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::String));
-    assert!(!opaque.matches_annotation(&CalcitTypeAnnotation::Number));
+    assert!(opaque.is_compatible_with(&CalcitTypeAnnotation::JsObject));
+    assert!(!opaque.is_compatible_with(&CalcitTypeAnnotation::String));
+    assert!(!opaque.is_compatible_with(&CalcitTypeAnnotation::Number));
   }
 
   #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -4840,8 +4840,8 @@ mod tests {
       // semantic type equality, while the assertions below separately protect
       // the serialized Fn/Macro markers.
       assert!(
-        saved_entry.schema.matches_annotation(source_entry.schema.as_ref())
-          && source_entry.schema.matches_annotation(saved_entry.schema.as_ref()),
+        saved_entry.schema.is_compatible_with(source_entry.schema.as_ref())
+          && source_entry.schema.is_compatible_with(saved_entry.schema.as_ref()),
         "schema should round-trip for {def_name}: source={:?}, saved={:?}",
         source_entry.schema,
         saved_entry.schema


### PR DESCRIPTION
Closes #842.

## 中文说明

### 变更内容

- 将原先语义含混的类型注解匹配器拆分为明确命名的兼容性 API，以及静态证明关系：`Proven`、`NeedsBoundary(reason)`、`Mismatch`。
- 诊断和运行时校验继续使用兼容性语义；静态证明不会穿透 Dynamic、旧式 any、未知/Tag callable、未解析类型槽、nullish 扩宽、递归类型变量或被擦除的类型参数。
- 类型证明中的泛型绑定采用事务语义：冲突的相邻约束不会泄漏绑定，严格证明也不会根据 Nil/值约束自动合成 Optional。
- `Ref` 的类型证明改为不变；函数参数继续逆变、返回值继续协变。
- 泛型返回值、`apply`、method projection、enum/struct payload、严格泛型绑定、fold 和同类集合的类型推断改为使用证明关系。
- 支持 `Result<Number, Dynamic> -> Number` 这类安全的局部投影，但不会从 Dynamic 本身建立绑定；兼容性分支合并会保留更弱的类型，避免 Dynamic 被错误收窄。
- 重命名其余源码调用点和 RFC 引用，使每个消费者明确选择“兼容性”或“证明”。

### 验证

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`（721 + 304 + 23）
- Node 24.4.1：`yarn check-all`
- Node 24.4.1：`yarn check-static-method-lowering`
- Node 24.4.1：`yarn try-js`

现有公开测试覆盖的严格 `E_ERASED_GENERIC_RELATION`、Ref 写入、类型槽、callable/method、原生后端、生成的 JavaScript、IR 和 WASM 均保持通过。本 PR 不实现 #843 的 nominal identity，也不包含 #701/#827 的契约迁移。

## English Description

### What changed

- Split the legacy annotation matcher into explicitly named compatibility APIs and a static proof relation: `Proven`, `NeedsBoundary(reason)`, or `Mismatch`.
- Keep compatibility behavior for diagnostics and runtime validation while refusing proof through Dynamic, legacy any, unknown/Tag callables, unresolved type slots, nullish widening, recursive variables, and erased type arguments.
- Make proof bindings transactional: mismatched siblings cannot leak bindings, and strict proof never synthesizes Optional from Nil/value constraints.
- Make `Ref` proof invariant while preserving callable input contravariance and output covariance.
- Route generic output inference, `apply` inference, method projections, enum/struct payload inference, strict generic binding, fold inference, and homogeneous collection inference through proof.
- Preserve safe partial projections such as `Result<Number, Dynamic> -> Number` without binding Dynamic itself, and keep compatibility branch joins on the weaker type.
- Rename remaining source call sites and RFC references so every consumer explicitly selects compatibility or proof.

### Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (721 + 304 + 23)
- Node 24.4.1: `yarn check-all`
- Node 24.4.1: `yarn check-static-method-lowering`
- Node 24.4.1: `yarn try-js`

The existing public strict `E_ERASED_GENERIC_RELATION`, Ref write, type-slot, callable/method, native, generated-JS, IR, and WASM coverage remains green. This PR does not implement #843 nominal identity or #701/#827 contract migrations.
