### PR TITLE
Preserve nominal identity and applied ADT arguments

### DIFF
--- a/editing-history/202609062354-nominal-definition-identity.md
+++ b/editing-history/202609062354-nominal-definition-identity.md
@@ -1,0 +1,46 @@
+# Preserve nominal definition identity and applied arguments
+
+## Context
+
+Milestone issue #843 requires the type checker to distinguish declarations by
+qualified identity, retain applied ADT arguments, and invalidate stale schema
+evidence without treating `impl-traits` decoration as a new data type. This
+change also carries the valid directionality finding that arrived on merged PR
+#891 after its merge.
+
+## Changes
+
+- Added an optional qualified `definition_ref` to struct and enum definitions.
+  Program storage and source-code resolution attach the owning
+  `namespace/definition` while the legacy serialized struct-prototype shape is
+  unchanged.
+- Added a shared nominal comparison rule based on declaration path and data
+  schema. Attached impls are deliberately excluded, so decoration retains the
+  base data identity; changed fields, payloads, generics, or bounds invalidate
+  old evidence.
+- Routed Struct, Enum, TypeRef, definition-value, and instance-value proof
+  cases through nominal identity. Strict proof rejects cross-namespace
+  short-name matches and treats missing identity or erased generic arguments as
+  explicit boundaries.
+- Made applied nominal arguments participate in ordering, and updated runtime
+  definition comparison/hash ordering to include qualified definition identity.
+- Propagated qualified paths through struct/enum resolution and data-shape
+  derivation. Data-shape validation accepts clones of the same qualified schema
+  but rejects a stale incompatible reload.
+- Split the directional TypeSlot/TypeRef proof fallbacks and TypeRef-to-ADT
+  argument relations reported by CodeRabbit on PR #891. Added the concrete
+  AnonymousEnum-against-expected-TypeSlot regression.
+- Added coverage for same-name declarations in different namespaces, changed
+  schema at the same path, impl decoration, bare/applied generic mismatch,
+  nested List arguments, and runtime program identity attachment.
+
+## Verification
+
+- `cargo test --workspace --all-features` (727 library + 304 native binary +
+  23 WASM binary tests)
+- `cargo test -q type_inference --lib`
+- focused nominal identity, data-shape reload, ordering/hash, program storage,
+  and PR #891 directionality regressions
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `fnm exec --using=24.4.1 yarn check-all` (complete native, generated JS, IR,
+  WASM, agent-interface, literal-path, and quality gates)

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -350,6 +350,7 @@ fn strict_type_fail_dynamic_nominal_argument_reports_decoder_migration() {
     ))
     .expect("dynamic nominal boundary snippet should parse");
     let person = Arc::new(calcit::calcit::CalcitStructDef {
+      definition_ref: None,
       name: cirru_edn::EdnTag::new("Person"),
       fields: Arc::new(vec![cirru_edn::EdnTag::new("name")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -2172,6 +2172,7 @@ mod tests {
   fn shown_maybe_enum(show_trait: Arc<CalcitTrait>) -> CalcitEnumDef {
     CalcitEnumDef::from_struct(CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::new("ShownMaybe"),
         fields: Arc::new(vec![EdnTag::new("none"), EdnTag::new("some")]),
         field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),

--- a/src/builtins/structs.rs
+++ b/src/builtins/structs.rs
@@ -383,6 +383,7 @@ pub fn new_struct(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   let field_types: Vec<Arc<CalcitTypeAnnotation>> = fields.iter().map(|(_, t)| t.to_owned()).collect();
 
   Ok(Calcit::StructDef(CalcitStructDef {
+    definition_ref: None,
     name: name_id,
     fields: Arc::new(field_names),
     field_types: Arc::new(field_types),
@@ -1544,6 +1545,7 @@ mod tests {
   #[test]
   fn required_recursive_field_returns_a_type_error_without_recursing() {
     let struct_def = CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("RequiredNode"),
       fields: Arc::new(vec![EdnTag::new("next")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeRef(
@@ -1673,6 +1675,7 @@ mod tests {
 
   fn shown_box_struct(show_trait: Arc<CalcitTrait>) -> CalcitStructDef {
     CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("ShownBox"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -532,6 +532,7 @@ impl Hash for Calcit {
         values.hash(_state);
       }
       StructDef(CalcitStructDef {
+        definition_ref,
         name,
         fields,
         field_types,
@@ -541,6 +542,7 @@ impl Hash for Calcit {
         ..
       }) => {
         "struct:".hash(_state);
+        definition_ref.hash(_state);
         name.hash(_state);
         fields.hash(_state);
         field_types.hash(_state);
@@ -555,6 +557,7 @@ impl Hash for Calcit {
       }
       EnumDef(enum_def) => {
         "enum:".hash(_state);
+        enum_def.definition_ref().hash(_state);
         enum_def.name().hash(_state);
         enum_def.generics().hash(_state);
         enum_def.where_bounds().hash(_state);
@@ -822,7 +825,7 @@ impl PartialEq for Calcit {
       (Map(a), Map(b)) => a == b,
       (Struct(a), Struct(b)) => a == b,
       (StructDef(a), StructDef(b)) => a == b,
-      (EnumDef(a), EnumDef(b)) => a.name() == b.name() && a.variants() == b.variants(),
+      (EnumDef(a), EnumDef(b)) => a == b,
       (Trait(a), Trait(b)) => a == b,
       (Impl(a), Impl(b)) => a == b,
       (Proc(a), Proc(b)) => a == b,
@@ -1616,6 +1619,7 @@ mod tests {
     assert_ne!(impl_left.cmp(&impl_right), Equal);
 
     let struct_left = Calcit::StructDef(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("age")]),
       field_types: Arc::new(vec![DYNAMIC_TYPE.clone()]),
@@ -1624,6 +1628,7 @@ mod tests {
       impls: vec![],
     });
     let struct_right = Calcit::StructDef(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("age")]),
       field_types: Arc::new(vec![DYNAMIC_TYPE.clone()]),
@@ -1714,6 +1719,7 @@ mod tests {
       }]),
     });
     let struct_value = Calcit::StructDef(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("S"),
       fields: Arc::new(vec![EdnTag::new("v")]),
       field_types: Arc::new(vec![DYNAMIC_TYPE.clone()]),

--- a/src/calcit/calcit_struct.rs
+++ b/src/calcit/calcit_struct.rs
@@ -7,6 +7,10 @@ use super::{CalcitGenericBound, CalcitImpl, CalcitTypeAnnotation};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CalcitStructDef {
+  /// Qualified source declaration (`namespace/definition`) when known.
+  /// Runtime values and static annotations retain this identity across
+  /// `impl-traits` decoration.
+  pub definition_ref: Option<Arc<str>>,
   pub name: EdnTag,
   pub fields: Arc<Vec<EdnTag>>,
   pub field_types: Arc<Vec<Arc<CalcitTypeAnnotation>>>,
@@ -21,12 +25,39 @@ impl CalcitStructDef {
     let field_types = vec![super::DYNAMIC_TYPE.clone(); fields.len()];
     let generics = Arc::new(vec![]);
     CalcitStructDef {
+      definition_ref: None,
       name,
       fields: Arc::new(fields),
       field_types: Arc::new(field_types),
       generics,
       where_bounds: Arc::new(vec![]),
       impls: vec![],
+    }
+  }
+
+  pub fn with_definition_ref(mut self, ns: &str, def: &str) -> Self {
+    self.definition_ref = Some(Arc::from(format!("{ns}/{def}")));
+    self
+  }
+
+  /// Data-schema identity deliberately excludes attached impls: decorating a
+  /// declaration changes method evidence, not the nominal data type.
+  pub fn same_nominal_definition(&self, other: &Self) -> bool {
+    match (&self.definition_ref, &other.definition_ref) {
+      (Some(actual), Some(expected)) => {
+        actual == expected
+          && self.name == other.name
+          && self.fields == other.fields
+          && self.field_types.len() == other.field_types.len()
+          && self
+            .field_types
+            .iter()
+            .zip(other.field_types.iter())
+            .all(|(actual, expected)| actual.to_type_edn() == expected.to_type_edn())
+          && self.generics == other.generics
+          && self.where_bounds == other.where_bounds
+      }
+      _ => false,
     }
   }
 
@@ -38,6 +69,7 @@ impl CalcitStructDef {
 
 impl Hash for CalcitStructDef {
   fn hash<H: Hasher>(&self, state: &mut H) {
+    self.definition_ref.hash(state);
     self.name.hash(state);
     self.fields.hash(state);
     self.field_types.hash(state);

--- a/src/calcit/compare.rs
+++ b/src/calcit/compare.rs
@@ -105,6 +105,10 @@ fn compare_impl_origin(a: Option<&Arc<CalcitTrait>>, b: Option<&Arc<CalcitTrait>
 }
 
 pub(super) fn compare_calcit_struct_values(a: &CalcitStructDef, b: &CalcitStructDef) -> Ordering {
+  match a.definition_ref.cmp(&b.definition_ref) {
+    Equal => {}
+    ord => return ord,
+  }
   match a.name.cmp(&b.name) {
     Equal => match a.fields.cmp(&b.fields) {
       Equal => match a.field_types.cmp(&b.field_types) {
@@ -139,6 +143,10 @@ fn compare_struct_impls(a: &[Arc<CalcitImpl>], b: &[Arc<CalcitImpl>]) -> Orderin
 }
 
 pub(super) fn compare_calcit_enum_values(a: &CalcitEnumDef, b: &CalcitEnumDef) -> Ordering {
+  match a.definition_ref().cmp(&b.definition_ref()) {
+    Equal => {}
+    ord => return ord,
+  }
   match a.name().cmp(b.name()) {
     Equal => a
       .generics()
@@ -168,7 +176,8 @@ pub(super) fn compare_calcit_enum_values(a: &CalcitEnumDef, b: &CalcitEnumDef) -
           }
           Equal
         })
-      }),
+      })
+      .then_with(|| compare_struct_impls(&a.impls, &b.impls)),
     ord => ord,
   }
 }

--- a/src/calcit/data_shape.rs
+++ b/src/calcit/data_shape.rs
@@ -242,7 +242,7 @@ impl DataShapeGraph {
           if enum_value
             .sum_type
             .as_ref()
-            .is_some_and(|actual| Arc::ptr_eq(actual, nominal) || actual.name() == nominal.name()) =>
+            .is_some_and(|actual| Arc::ptr_eq(actual, nominal) || actual.same_nominal_definition(nominal)) =>
         {
           match (enum_value.tag.as_ref(), enum_value.extra.as_slice()) {
             (Calcit::Tag(tag), []) if tag.ref_str() == "none" => Ok(()),
@@ -295,7 +295,7 @@ impl DataShapeGraph {
         let Calcit::Struct(struct_value) = value else {
           return Err(shape_kind_mismatch(path, &format!("struct :{}", nominal.name), value));
         };
-        if !Arc::ptr_eq(&struct_value.struct_ref, nominal) {
+        if !Arc::ptr_eq(&struct_value.struct_ref, nominal) && !struct_value.struct_ref.same_nominal_definition(nominal) {
           return Err(DataShapeValueError::at(
             path,
             format!("expected nominal struct :{}, got :{}", nominal.name, struct_value.struct_ref.name),
@@ -333,7 +333,7 @@ impl DataShapeGraph {
             format!("expected nominal enum :{}, got anonymous enum", nominal.name()),
           ));
         };
-        if !Arc::ptr_eq(actual_enum, nominal) {
+        if !Arc::ptr_eq(actual_enum, nominal) && !actual_enum.same_nominal_definition(nominal) {
           return Err(DataShapeValueError::at(
             path,
             format!("expected nominal enum :{}, got :{}", nominal.name(), actual_enum.name()),
@@ -456,19 +456,35 @@ impl GraphBuilder {
         Ok(self.push(DataShapeNode::Ref(inner)))
       }
       CalcitTypeAnnotation::Struct(nominal, args) => {
-        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
+        let path = nominal
+          .definition_ref
+          .as_deref()
+          .and_then(split_nominal_path)
+          .or_else(|| infer_nominal_path(default_ns, nominal.name.ref_str()));
         self.build_struct(nominal.clone(), args, path, default_ns)
       }
       CalcitTypeAnnotation::StructValue(nominal) => {
-        let path = infer_nominal_path(default_ns, nominal.name.ref_str());
+        let path = nominal
+          .definition_ref
+          .as_deref()
+          .and_then(split_nominal_path)
+          .or_else(|| infer_nominal_path(default_ns, nominal.name.ref_str()));
         self.build_struct(nominal.clone(), &Arc::new(vec![]), path, default_ns)
       }
       CalcitTypeAnnotation::Enum(nominal, args) => {
-        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
+        let path = nominal
+          .definition_ref()
+          .map(AsRef::as_ref)
+          .and_then(split_nominal_path)
+          .or_else(|| infer_nominal_path(default_ns, nominal.name().ref_str()));
         self.build_enum(nominal.clone(), args, path, default_ns)
       }
       CalcitTypeAnnotation::EnumValue(nominal) => {
-        let path = infer_nominal_path(default_ns, nominal.name().ref_str());
+        let path = nominal
+          .definition_ref()
+          .map(AsRef::as_ref)
+          .and_then(split_nominal_path)
+          .or_else(|| infer_nominal_path(default_ns, nominal.name().ref_str()));
         self.build_enum(nominal.clone(), &Arc::new(vec![]), path, default_ns)
       }
       CalcitTypeAnnotation::StructDef(_) | CalcitTypeAnnotation::EnumDef(_) => Err(unsupported_type(
@@ -686,6 +702,12 @@ fn infer_nominal_path(default_ns: &str, name: &str) -> Option<(Arc<str>, Arc<str
   }
 }
 
+fn split_nominal_path(path: &str) -> Option<(Arc<str>, Arc<str>)> {
+  path
+    .rsplit_once('/')
+    .map(|(namespace, definition)| (Arc::from(namespace), Arc::from(definition)))
+}
+
 fn nominal_key(
   kind: &str,
   name: &EdnTag,
@@ -789,6 +811,7 @@ mod tests {
 
   fn phantom_box() -> Arc<CalcitStructDef> {
     Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("PhantomBox"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -827,6 +850,7 @@ mod tests {
     assert!(dynamic.to_string().contains("Dynamic is forbidden"));
 
     let generic = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Box"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
@@ -884,9 +908,36 @@ mod tests {
   }
 
   #[test]
+  fn qualified_nominal_shapes_accept_clones_but_reject_stale_schema_reloads() {
+    let nominal = Arc::new(CalcitStructDef::from_fields(EdnTag::new("User"), vec![]).with_definition_ref("app.models", "User"));
+    let shape = DataShapeGraph::build(&CalcitTypeAnnotation::Struct(nominal.clone(), Arc::new(vec![])), "tests.shape")
+      .expect("qualified user shape");
+    let cloned_value = Calcit::Struct(CalcitStructValue {
+      struct_ref: Arc::new(nominal.as_ref().clone()),
+      values: Arc::new(vec![]),
+    });
+    shape
+      .validate_value(&cloned_value)
+      .expect("a clone of the same qualified declaration and schema remains the same data type");
+
+    let mut reloaded = CalcitStructDef::from_fields(EdnTag::new("User"), vec![EdnTag::new("name")]);
+    reloaded.definition_ref = Some(Arc::from("app.models/User"));
+    reloaded.field_types = Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]);
+    let stale_value = Calcit::Struct(CalcitStructValue {
+      struct_ref: Arc::new(reloaded),
+      values: Arc::new(vec![Calcit::Str(Arc::from("Ada"))]),
+    });
+    let error = shape
+      .validate_value(&stale_value)
+      .expect_err("a changed schema must invalidate the old shape proof");
+    assert!(error.message.contains("expected nominal struct"), "unexpected error: {error}");
+  }
+
+  #[test]
   fn enforces_generic_where_bounds_while_deriving() {
     let marker = Arc::new(CalcitTrait::new(EdnTag::new("DataMarker"), vec![], vec![]));
     let bounded = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("MarkedBox"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),

--- a/src/calcit/sum_type.rs
+++ b/src/calcit/sum_type.rs
@@ -23,6 +23,7 @@ impl EnumVariant {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CalcitEnumDef {
+  definition_ref: Option<Arc<str>>,
   name: EdnTag,
   generics: Arc<Vec<Arc<str>>>,
   where_bounds: Arc<Vec<CalcitGenericBound>>,
@@ -47,6 +48,7 @@ impl CalcitEnumDef {
     let where_bounds = struct_value.struct_ref.where_bounds.clone();
     let impls = struct_value.struct_ref.impls.clone();
     Ok(Self {
+      definition_ref: struct_value.struct_ref.definition_ref.clone(),
       name,
       generics,
       where_bounds,
@@ -58,6 +60,38 @@ impl CalcitEnumDef {
 
   pub fn name(&self) -> &EdnTag {
     &self.name
+  }
+
+  pub fn definition_ref(&self) -> Option<&Arc<str>> {
+    self.definition_ref.as_ref()
+  }
+
+  pub fn with_definition_ref(mut self, ns: &str, def: &str) -> Self {
+    self.definition_ref = Some(Arc::from(format!("{ns}/{def}")));
+    self
+  }
+
+  /// Compare nominal data identity without attached method implementations.
+  pub fn same_nominal_definition(&self, other: &Self) -> bool {
+    match (&self.definition_ref, &other.definition_ref) {
+      (Some(actual), Some(expected)) => {
+        actual == expected
+          && self.name == other.name
+          && self.generics == other.generics
+          && self.where_bounds == other.where_bounds
+          && self.variants.len() == other.variants.len()
+          && self.variants.iter().zip(other.variants.iter()).all(|(actual, expected)| {
+            actual.tag == expected.tag
+              && actual.payload_types.len() == expected.payload_types.len()
+              && actual
+                .payload_types
+                .iter()
+                .zip(expected.payload_types.iter())
+                .all(|(actual, expected)| actual.to_type_edn() == expected.to_type_edn())
+          })
+      }
+      _ => false,
+    }
   }
 
   pub fn generics(&self) -> &[Arc<str>] {
@@ -85,6 +119,7 @@ impl CalcitEnumDef {
       })
       .collect();
     let struct_def = CalcitStructDef {
+      definition_ref: self.definition_ref.clone(),
       name: self.name.clone(),
       fields: Arc::new(fields),
       field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); values.len()]),
@@ -234,6 +269,7 @@ mod tests {
   fn parses_generic_enum_prototype() {
     let struct_value = CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::new("Result"),
         fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
         field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -231,6 +231,7 @@ pub(crate) enum TypeBoundaryReason {
   LegacyNullish,
   ErasedTypeArguments,
   RecursiveTypeVariable,
+  UnresolvedNominalIdentity,
 }
 
 impl TypeProof {
@@ -756,9 +757,26 @@ impl CalcitTypeAnnotation {
 
         Ok(())
       }
-      Self::TypeRef(_, args) => {
+      Self::TypeRef(name, args) => {
         for arg in args.iter() {
           arg.validate_applied_type_args()?;
+        }
+        let declared_arity = self
+          .resolve_to_struct()
+          .map(|definition| ("struct", definition.name.to_string(), definition.generics.len()))
+          .or_else(|| {
+            self
+              .resolve_to_enum()
+              .map(|definition| ("enum", definition.name().to_string(), definition.generics().len()))
+          });
+        if let Some((kind, definition, expected)) = declared_arity
+          && args.len() != expected
+        {
+          return Err(format!(
+            "{kind} `{definition}` referenced by `{}` expects {expected} type argument(s), but received {}; apply every declared argument or use a context that can infer them",
+            name.trim_start_matches('\''),
+            args.len()
+          ));
         }
         Ok(())
       }
@@ -1010,6 +1028,84 @@ impl CalcitTypeAnnotation {
     Self::TypeRef(Arc::from(name), Arc::new(vec![]))
       .resolve_to_enum()
       .is_some_and(|resolved| resolved.name().ref_str() == target)
+  }
+
+  fn struct_nominal_match(actual: &Arc<CalcitStructDef>, expected: &Arc<CalcitStructDef>) -> Option<bool> {
+    if Arc::ptr_eq(actual, expected) {
+      return Some(true);
+    }
+    if actual.definition_ref.is_some() && expected.definition_ref.is_some() {
+      Some(actual.same_nominal_definition(expected))
+    } else {
+      None
+    }
+  }
+
+  fn enum_nominal_match(actual: &Arc<CalcitEnumDef>, expected: &Arc<CalcitEnumDef>) -> Option<bool> {
+    if Arc::ptr_eq(actual, expected) {
+      return Some(true);
+    }
+    if actual.definition_ref().is_some() && expected.definition_ref().is_some() {
+      Some(actual.same_nominal_definition(expected))
+    } else {
+      None
+    }
+  }
+
+  fn type_ref_matches_struct_definition(name: &str, expected: &Arc<CalcitStructDef>) -> Option<bool> {
+    let normalized = name.trim_start_matches('\'').trim_start_matches(':');
+    let resolved = Self::TypeRef(Arc::from(normalized), Arc::new(vec![])).resolve_to_struct();
+    if let Some(actual) = resolved.map(Arc::new)
+      && let Some(matches) = Self::struct_nominal_match(&actual, expected)
+    {
+      return Some(matches);
+    }
+    expected
+      .definition_ref
+      .as_deref()
+      .filter(|_| normalized.contains('/'))
+      .map(|definition_ref| definition_ref == normalized)
+  }
+
+  fn type_ref_matches_enum_definition(name: &str, expected: &Arc<CalcitEnumDef>) -> Option<bool> {
+    let normalized = name.trim_start_matches('\'').trim_start_matches(':');
+    let resolved = Self::TypeRef(Arc::from(normalized), Arc::new(vec![])).resolve_to_enum();
+    if let Some(actual) = resolved.map(Arc::new)
+      && let Some(matches) = Self::enum_nominal_match(&actual, expected)
+    {
+      return Some(matches);
+    }
+    expected
+      .definition_ref()
+      .map(AsRef::as_ref)
+      .filter(|_| normalized.contains('/'))
+      .map(|definition_ref| definition_ref == normalized)
+  }
+
+  fn type_ref_nominal_match(actual: &str, expected: &str) -> Option<bool> {
+    let actual = actual.trim_start_matches('\'').trim_start_matches(':');
+    let expected = expected.trim_start_matches('\'').trim_start_matches(':');
+    let actual_ref = Self::TypeRef(Arc::from(actual), Arc::new(vec![]));
+    let expected_ref = Self::TypeRef(Arc::from(expected), Arc::new(vec![]));
+
+    if let (Some(actual_def), Some(expected_def)) = (
+      actual_ref.resolve_to_struct().map(Arc::new),
+      expected_ref.resolve_to_struct().map(Arc::new),
+    ) && let Some(matches) = Self::struct_nominal_match(&actual_def, &expected_def)
+    {
+      return Some(matches);
+    }
+    if let (Some(actual_def), Some(expected_def)) = (
+      actual_ref.resolve_to_enum().map(Arc::new),
+      expected_ref.resolve_to_enum().map(Arc::new),
+    ) && let Some(matches) = Self::enum_nominal_match(&actual_def, &expected_def)
+    {
+      return Some(matches);
+    }
+    if actual.contains('/') && expected.contains('/') {
+      return Some(actual == expected);
+    }
+    None
   }
 
   fn type_ref_matches_trait(name: &str, target: &CalcitTrait) -> bool {
@@ -2855,8 +2951,8 @@ impl CalcitTypeAnnotation {
   #[allow(clippy::type_complexity)]
   pub fn resolve_to_struct_with_ref(&self) -> Option<(CalcitStructDef, Option<(Arc<str>, Arc<str>)>)> {
     match self {
-      Self::Struct(base, _) => Some((base.as_ref().clone(), None)),
-      Self::StructValue(base) => Some((base.as_ref().clone(), None)),
+      Self::Struct(base, _) => Some((base.as_ref().clone(), split_nominal_definition_ref(base.definition_ref.as_deref()))),
+      Self::StructValue(base) => Some((base.as_ref().clone(), split_nominal_definition_ref(base.definition_ref.as_deref()))),
       Self::TypeRef(name, _) => {
         // TypeRef name may be "ns/def" or just "def" — try to split on '/'
         let stripped = name.trim_start_matches('\'').trim_start_matches(':');
@@ -2885,8 +2981,14 @@ impl CalcitTypeAnnotation {
   #[allow(clippy::type_complexity)]
   pub fn resolve_to_enum_with_ref(&self) -> Option<(CalcitEnumDef, Option<(Arc<str>, Arc<str>)>)> {
     match self {
-      Self::Enum(base, _) => Some((base.as_ref().clone(), None)),
-      Self::EnumValue(base) => Some((base.as_ref().clone(), None)),
+      Self::Enum(base, _) => Some((
+        base.as_ref().clone(),
+        split_nominal_definition_ref(base.definition_ref().map(AsRef::as_ref)),
+      )),
+      Self::EnumValue(base) => Some((
+        base.as_ref().clone(),
+        split_nominal_definition_ref(base.definition_ref().map(AsRef::as_ref)),
+      )),
       Self::TypeRef(name, _) => {
         let stripped = name.trim_start_matches('\'').trim_start_matches(':');
         if let Some((ns, def)) = stripped.rsplit_once('/') {
@@ -3209,7 +3311,9 @@ impl CalcitTypeAnnotation {
         }
       },
       (Self::TypeRef(a_name, a_args), Self::TypeRef(b_name, b_args)) => {
-        if !Self::type_ref_name_matches(a_name, b_name) && !Self::type_ref_name_matches(b_name, a_name) {
+        let nominal_matches = Self::type_ref_nominal_match(a_name, b_name)
+          .unwrap_or_else(|| Self::type_ref_name_matches(a_name, b_name) || Self::type_ref_name_matches(b_name, a_name));
+        if !nominal_matches {
           return false;
         }
         if a_args.is_empty() || b_args.is_empty() {
@@ -3226,8 +3330,10 @@ impl CalcitTypeAnnotation {
       (Self::Set(a), Self::Set(b)) => a.compatible_with_bindings(b, bindings),
       (Self::Ref(a), Self::Ref(b)) => a.compatible_with_bindings(b, bindings),
       (Self::TypeRef(name, args), Self::Struct(base, other_args)) | (Self::Struct(base, other_args), Self::TypeRef(name, args)) => {
-        if !Self::type_ref_name_matches(name, base.name.ref_str()) && !Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
-        {
+        let nominal_matches = Self::type_ref_matches_struct_definition(name, base).unwrap_or_else(|| {
+          Self::type_ref_name_matches(name, base.name.ref_str()) || Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
+        });
+        if !nominal_matches {
           return false;
         }
         match (args.is_empty(), other_args.is_empty()) {
@@ -3244,9 +3350,10 @@ impl CalcitTypeAnnotation {
         }
       }
       (Self::TypeRef(name, args), Self::Enum(base, other_args)) | (Self::Enum(base, other_args), Self::TypeRef(name, args)) => {
-        if !Self::type_ref_name_matches(name, base.name().ref_str())
-          && !Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
-        {
+        let nominal_matches = Self::type_ref_matches_enum_definition(name, base).unwrap_or_else(|| {
+          Self::type_ref_name_matches(name, base.name().ref_str()) || Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
+        });
+        if !nominal_matches {
           return false;
         }
         match (args.is_empty(), other_args.is_empty()) {
@@ -3266,15 +3373,18 @@ impl CalcitTypeAnnotation {
         // Structs are structurally map-like (field name -> value), so procs typed as
         // accepting a generic "map" (e.g. `to-pairs`/`keys`) should also accept structs,
         // in addition to matching the struct's own type name.
-        Self::type_ref_name_matches(name, base.name.ref_str())
-          || Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
-          || Self::type_ref_name_matches(name, "map")
+        Self::type_ref_name_matches(name, "map")
+          || Self::type_ref_matches_struct_definition(name, base).unwrap_or_else(|| {
+            Self::type_ref_name_matches(name, base.name.ref_str()) || Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
+          })
       }
       (Self::TypeRef(name, _), Self::EnumValue(base)) | (Self::EnumValue(base), Self::TypeRef(name, _)) => {
-        Self::type_ref_name_matches(name, base.name().ref_str()) || Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
+        Self::type_ref_matches_enum_definition(name, base).unwrap_or_else(|| {
+          Self::type_ref_name_matches(name, base.name().ref_str()) || Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
+        })
       }
       (Self::Struct(a, a_args), Self::Struct(b, b_args)) => {
-        if a.name != b.name {
+        if !Self::struct_nominal_match(a, b).unwrap_or_else(|| a.name == b.name) {
           return false;
         }
         match (a_args.is_empty(), b_args.is_empty()) {
@@ -3294,7 +3404,7 @@ impl CalcitTypeAnnotation {
         }
       }
       (Self::Enum(a, a_args), Self::Enum(b, b_args)) => {
-        if a.name() != b.name() {
+        if !Self::enum_nominal_match(a, b).unwrap_or_else(|| a.name() == b.name()) {
           return false;
         }
         if a_args.is_empty() || b_args.is_empty() {
@@ -3339,8 +3449,12 @@ impl CalcitTypeAnnotation {
       (Self::TypeRef(_, _), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "enum-def") => {
         self.resolve_to_enum().is_some()
       }
-      (Self::StructDef(actual), Self::StructDef(expected)) => actual.name == expected.name,
-      (Self::EnumDef(actual), Self::EnumDef(expected)) => actual.name() == expected.name(),
+      (Self::StructDef(actual), Self::StructDef(expected)) => {
+        Self::struct_nominal_match(actual, expected).unwrap_or_else(|| actual.name == expected.name)
+      }
+      (Self::EnumDef(actual), Self::EnumDef(expected)) => {
+        Self::enum_nominal_match(actual, expected).unwrap_or_else(|| actual.name() == expected.name())
+      }
       (Self::StructDef(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "struct-def") => true,
       (Self::EnumDef(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "enum-def") => true,
       (Self::Trait(_), Self::Custom(expected)) if Self::custom_keyword_matches(expected, "trait") => true,
@@ -3359,15 +3473,17 @@ impl CalcitTypeAnnotation {
       (Self::Fn(a), Self::Fn(b)) => a.compatible_signature_with_bindings(b.as_ref(), bindings),
       (Self::Variadic(a), Self::Variadic(b)) => a.compatible_with_bindings(b, bindings),
       (Self::Custom(a), Self::Custom(b)) => a.as_ref() == b.as_ref(),
-      (Self::StructValue(a), Self::StructValue(b)) => a.name == b.name,
-      (Self::StructValue(a), Self::Struct(b, _)) => a.name == b.name,
+      (Self::StructValue(a), Self::StructValue(b)) => Self::struct_nominal_match(a, b).unwrap_or_else(|| a.name == b.name),
+      (Self::StructValue(a), Self::Struct(b, _)) => Self::struct_nominal_match(a, b).unwrap_or_else(|| a.name == b.name),
       (Self::StructValue(_), Self::Custom(expected))
         if Self::custom_keyword_matches(expected, "record") || Self::custom_keyword_matches(expected, "struct") =>
       {
         true
       }
-      (Self::EnumValue(a), Self::EnumValue(b)) => a.name() == b.name(),
-      (Self::EnumValue(a), Self::Enum(b, _)) | (Self::Enum(b, _), Self::EnumValue(a)) => a.name() == b.name(),
+      (Self::EnumValue(a), Self::EnumValue(b)) => Self::enum_nominal_match(a, b).unwrap_or_else(|| a.name() == b.name()),
+      (Self::EnumValue(a), Self::Enum(b, _)) | (Self::Enum(b, _), Self::EnumValue(a)) => {
+        Self::enum_nominal_match(a, b).unwrap_or_else(|| a.name() == b.name())
+      }
       (Self::EnumValue(_), Self::Custom(expected))
         if Self::custom_keyword_matches(expected, "tuple") || Self::custom_keyword_matches(expected, "enum") =>
       {
@@ -3469,37 +3585,78 @@ impl CalcitTypeAnnotation {
         }
       }
       (Self::TypeRef(a_name, a_args), Self::TypeRef(b_name, b_args)) => {
-        if !Self::type_ref_name_matches(a_name, b_name) && !Self::type_ref_name_matches(b_name, a_name) {
-          return Mismatch;
+        match Self::type_ref_nominal_match(a_name, b_name) {
+          Some(true) => {}
+          Some(false) => return Mismatch,
+          None => return NeedsBoundary(Boundary::UnresolvedNominalIdentity),
         }
         if a_args.is_empty() != b_args.is_empty() {
           return NeedsBoundary(Boundary::ErasedTypeArguments);
         }
         Self::prove_slices(a_args, b_args, bindings)
       }
-      (Self::TypeRef(name, args), Self::Struct(base, other_args)) | (Self::Struct(base, other_args), Self::TypeRef(name, args)) => {
-        if !Self::type_ref_name_matches(name, base.name.ref_str()) && !Self::type_ref_resolves_to_struct_name(name, base.name.ref_str())
-        {
-          return Mismatch;
+      (Self::TypeRef(name, actual_args), Self::Struct(base, expected_args)) => {
+        match Self::type_ref_matches_struct_definition(name, base) {
+          Some(true) => {}
+          Some(false) => return Mismatch,
+          None => return NeedsBoundary(Boundary::UnresolvedNominalIdentity),
         }
-        match (args.is_empty(), other_args.is_empty()) {
+        match (actual_args.is_empty(), expected_args.is_empty()) {
           (true, true) => Proven,
-          (false, false) => Self::prove_slices(args, other_args, bindings),
-          (true, false) => Self::prove_declared_generics(base.generics.as_ref(), other_args, bindings),
-          (false, true) => Self::prove_declared_generics(base.generics.as_ref(), args, bindings),
+          (false, false) => Self::prove_slices(actual_args, expected_args, bindings),
+          _ => NeedsBoundary(Boundary::ErasedTypeArguments),
         }
       }
-      (Self::TypeRef(name, args), Self::Enum(base, other_args)) | (Self::Enum(base, other_args), Self::TypeRef(name, args)) => {
-        if !Self::type_ref_name_matches(name, base.name().ref_str())
-          && !Self::type_ref_resolves_to_enum_name(name, base.name().ref_str())
-        {
-          return Mismatch;
+      (Self::Struct(base, actual_args), Self::TypeRef(name, expected_args)) => {
+        match Self::type_ref_matches_struct_definition(name, base) {
+          Some(true) => {}
+          Some(false) => return Mismatch,
+          None => return NeedsBoundary(Boundary::UnresolvedNominalIdentity),
         }
-        match (args.is_empty(), other_args.is_empty()) {
+        match (actual_args.is_empty(), expected_args.is_empty()) {
           (true, true) => Proven,
-          (false, false) => Self::prove_slices(args, other_args, bindings),
-          (true, false) => Self::prove_declared_generics(base.generics(), other_args, bindings),
-          (false, true) => Self::prove_declared_generics(base.generics(), args, bindings),
+          (false, false) => Self::prove_slices(actual_args, expected_args, bindings),
+          _ => NeedsBoundary(Boundary::ErasedTypeArguments),
+        }
+      }
+      (Self::TypeRef(name, actual_args), Self::Enum(base, expected_args)) => {
+        match Self::type_ref_matches_enum_definition(name, base) {
+          Some(true) => {}
+          Some(false) => return Mismatch,
+          None => return NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+        }
+        match (actual_args.is_empty(), expected_args.is_empty()) {
+          (true, true) => Proven,
+          (false, false) => Self::prove_slices(actual_args, expected_args, bindings),
+          _ => NeedsBoundary(Boundary::ErasedTypeArguments),
+        }
+      }
+      (Self::Enum(base, actual_args), Self::TypeRef(name, expected_args)) => {
+        match Self::type_ref_matches_enum_definition(name, base) {
+          Some(true) => {}
+          Some(false) => return Mismatch,
+          None => return NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+        }
+        match (actual_args.is_empty(), expected_args.is_empty()) {
+          (true, true) => Proven,
+          (false, false) => Self::prove_slices(actual_args, expected_args, bindings),
+          _ => NeedsBoundary(Boundary::ErasedTypeArguments),
+        }
+      }
+      (Self::TypeRef(name, args), Self::StructValue(base)) | (Self::StructValue(base), Self::TypeRef(name, args)) => {
+        match Self::type_ref_matches_struct_definition(name, base) {
+          Some(false) => Mismatch,
+          Some(true) if args.is_empty() && base.generics.is_empty() => Proven,
+          Some(true) => NeedsBoundary(Boundary::ErasedTypeArguments),
+          None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+        }
+      }
+      (Self::TypeRef(name, args), Self::EnumValue(base)) | (Self::EnumValue(base), Self::TypeRef(name, args)) => {
+        match Self::type_ref_matches_enum_definition(name, base) {
+          Some(false) => Mismatch,
+          Some(true) if args.is_empty() && base.generics().is_empty() => Proven,
+          Some(true) => NeedsBoundary(Boundary::ErasedTypeArguments),
+          None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
         }
       }
       (Self::List(actual), Self::List(expected))
@@ -3518,29 +3675,86 @@ impl CalcitTypeAnnotation {
       (Self::Map(actual_key, actual_value), Self::Map(expected_key, expected_value)) => actual_key
         .prove_with_staged_bindings(expected_key, bindings)
         .and(actual_value.prove_with_staged_bindings(expected_value, bindings)),
-      (Self::Struct(actual, actual_args), Self::Struct(expected, expected_args)) if actual.name == expected.name => {
+      (Self::Struct(actual, actual_args), Self::Struct(expected, expected_args)) => {
+        match Self::struct_nominal_match(actual, expected) {
+          Some(true) => {}
+          Some(false) => return Mismatch,
+          None => return NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+        }
         if actual_args.is_empty() != expected_args.is_empty() {
           NeedsBoundary(Boundary::ErasedTypeArguments)
         } else {
           Self::prove_slices(actual_args, expected_args, bindings)
         }
       }
-      (Self::Enum(actual, actual_args), Self::Enum(expected, expected_args)) if actual.name() == expected.name() => {
+      (Self::Enum(actual, actual_args), Self::Enum(expected, expected_args)) => {
+        match Self::enum_nominal_match(actual, expected) {
+          Some(true) => {}
+          Some(false) => return Mismatch,
+          None => return NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+        }
         if actual_args.is_empty() != expected_args.is_empty() {
           NeedsBoundary(Boundary::ErasedTypeArguments)
         } else {
           Self::prove_slices(actual_args, expected_args, bindings)
         }
       }
+      (Self::StructValue(actual), Self::StructValue(expected)) => match Self::struct_nominal_match(actual, expected) {
+        Some(true) => Proven,
+        Some(false) => Mismatch,
+        None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+      },
+      (Self::StructValue(actual), Self::Struct(expected, expected_args)) => match Self::struct_nominal_match(actual, expected) {
+        Some(false) => Mismatch,
+        Some(true) if expected_args.is_empty() && actual.generics.is_empty() => Proven,
+        Some(true) => NeedsBoundary(Boundary::ErasedTypeArguments),
+        None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+      },
+      (Self::Struct(actual, actual_args), Self::StructValue(expected)) => match Self::struct_nominal_match(actual, expected) {
+        Some(false) => Mismatch,
+        Some(true) if actual_args.is_empty() && expected.generics.is_empty() => Proven,
+        Some(true) => NeedsBoundary(Boundary::ErasedTypeArguments),
+        None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+      },
+      (Self::EnumValue(actual), Self::EnumValue(expected)) => match Self::enum_nominal_match(actual, expected) {
+        Some(true) => Proven,
+        Some(false) => Mismatch,
+        None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+      },
+      (Self::EnumValue(actual), Self::Enum(expected, expected_args))
+      | (Self::Enum(expected, expected_args), Self::EnumValue(actual)) => match Self::enum_nominal_match(actual, expected) {
+        Some(false) => Mismatch,
+        Some(true) if expected_args.is_empty() && actual.generics().is_empty() => Proven,
+        Some(true) => NeedsBoundary(Boundary::ErasedTypeArguments),
+        None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+      },
+      (Self::StructDef(actual), Self::StructDef(expected)) => match Self::struct_nominal_match(actual, expected) {
+        Some(true) => Proven,
+        Some(false) => Mismatch,
+        None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+      },
+      (Self::EnumDef(actual), Self::EnumDef(expected)) => match Self::enum_nominal_match(actual, expected) {
+        Some(true) => Proven,
+        Some(false) => Mismatch,
+        None => NeedsBoundary(Boundary::UnresolvedNominalIdentity),
+      },
       (Self::Fn(actual), Self::Fn(expected)) => actual.prove_signature_with_bindings(expected, bindings),
       (Self::Fn(_), Self::DynFn) | (Self::DynFn, Self::Fn(_)) => NeedsBoundary(Boundary::UnknownCallable),
       (Self::Tag, Self::DynFn) | (Self::Tag, Self::Fn(_)) => NeedsBoundary(Boundary::TagCallable),
-      (Self::TypeSlot(name), other) | (other, Self::TypeSlot(name)) => match resolve_type_slot(name) {
+      (Self::TypeSlot(name), other) => match resolve_type_slot(name) {
         Some(resolved) => resolved.prove_with_staged_bindings(other, bindings),
         None => NeedsBoundary(Boundary::UnresolvedTypeSlot),
       },
-      (Self::TypeRef(name, _), other) | (other, Self::TypeRef(name, _)) => match resolve_type_ref_as_schema(name) {
+      (other, Self::TypeSlot(name)) => match resolve_type_slot(name) {
+        Some(resolved) => other.prove_with_staged_bindings(resolved.as_ref(), bindings),
+        None => NeedsBoundary(Boundary::UnresolvedTypeSlot),
+      },
+      (Self::TypeRef(name, _), other) => match resolve_type_ref_as_schema(name) {
         Some(resolved) => resolved.prove_with_staged_bindings(other, bindings),
+        None => Mismatch,
+      },
+      (other, Self::TypeRef(name, _)) => match resolve_type_ref_as_schema(name) {
+        Some(resolved) => other.prove_with_staged_bindings(resolved.as_ref(), bindings),
         None => Mismatch,
       },
       _ => {
@@ -3563,15 +3777,6 @@ impl CalcitTypeAnnotation {
     }
     actual.iter().zip(expected).fold(TypeProof::Proven, |result, (actual, expected)| {
       result.and(actual.prove_with_staged_bindings(expected, bindings))
-    })
-  }
-
-  fn prove_declared_generics(declared: &[Arc<str>], applied: &[Arc<CalcitTypeAnnotation>], bindings: &mut TypeBindings) -> TypeProof {
-    if declared.len() != applied.len() {
-      return TypeProof::Mismatch;
-    }
-    declared.iter().zip(applied).fold(TypeProof::Proven, |result, (name, actual)| {
-      result.and(actual.prove_with_staged_bindings(&Self::TypeVar(name.clone()), bindings))
     })
   }
 
@@ -4075,6 +4280,12 @@ fn resolve_struct_annotation(struct_form: &Calcit, class_form: Option<&Calcit>) 
   Some(struct_def)
 }
 
+fn split_nominal_definition_ref(definition_ref: Option<&str>) -> Option<(Arc<str>, Arc<str>)> {
+  definition_ref
+    .and_then(|path| path.rsplit_once('/'))
+    .map(|(namespace, definition)| (Arc::from(namespace), Arc::from(definition)))
+}
+
 fn resolve_enum_annotation(enum_form: &Calcit, class_form: Option<&Calcit>) -> Option<CalcitEnumDef> {
   let mut enum_def = resolve_enum_def(enum_form)?;
   if let Some(class_struct) = class_form.and_then(resolve_struct_value) {
@@ -4114,6 +4325,13 @@ fn resolve_struct_from_program(ns: &str, def: &str) -> Option<CalcitStructDef> {
         })
       })
     })
+    .map(|struct_def| {
+      if struct_def.definition_ref.is_some() {
+        struct_def
+      } else {
+        struct_def.with_definition_ref(ns, def)
+      }
+    })
 }
 
 /// Resolve an enum definition by namespace and definition name from the program registry.
@@ -4137,6 +4355,13 @@ fn resolve_enum_from_program(ns: &str, def: &str) -> Option<CalcitEnumDef> {
           _ => None,
         })
       })
+    })
+    .map(|enum_def| {
+      if enum_def.definition_ref().is_some() {
+        enum_def
+      } else {
+        enum_def.with_definition_ref(ns, def)
+      }
     })
 }
 
@@ -4288,6 +4513,10 @@ fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStructDef> {
   let forms = normalized_data_definition_forms(items);
   let name_form = forms.get(1)?;
   let name = parse_type_name(name_form)?;
+  let definition_ref = match name_form {
+    Calcit::Symbol { info, .. } => Some(Arc::from(format!("{}/{}", info.at_ns, name.ref_str()))),
+    _ => None,
+  };
   let mut generics: Vec<Arc<str>> = vec![];
   let mut where_bounds = vec![];
   let mut start_idx = 2;
@@ -4337,6 +4566,7 @@ fn parse_defstruct_code(items: &CalcitList) -> Option<CalcitStructDef> {
   let field_types: Vec<Arc<CalcitTypeAnnotation>> = fields.iter().map(|(_, t)| t.to_owned()).collect();
 
   Some(CalcitStructDef {
+    definition_ref,
     name,
     fields: Arc::new(field_names),
     field_types: Arc::new(field_types),
@@ -4350,6 +4580,10 @@ fn parse_defenum_code(items: &CalcitList) -> Option<CalcitEnumDef> {
   let forms = normalized_data_definition_forms(items);
   let name_form = forms.get(1)?;
   let name = parse_type_name(name_form)?;
+  let definition_ref = match name_form {
+    Calcit::Symbol { info, .. } => Some(Arc::from(format!("{}/{}", info.at_ns, name.ref_str()))),
+    _ => None,
+  };
   let mut generics: Vec<Arc<str>> = vec![];
   let mut where_bounds = vec![];
   let mut start_idx = 2;
@@ -4398,6 +4632,7 @@ fn parse_defenum_code(items: &CalcitList) -> Option<CalcitEnumDef> {
   let values: Vec<Calcit> = variants.iter().map(|(_, value)| value.to_owned()).collect();
   dedup_generic_names(&mut generics);
   let mut struct_ref = CalcitStructDef::from_fields(name, fields);
+  struct_ref.definition_ref = definition_ref;
   struct_ref.generics = Arc::new(generics);
   struct_ref.where_bounds = Arc::new(where_bounds);
   let struct_value = CalcitStructValue {
@@ -4704,6 +4939,7 @@ mod tests {
       Calcit::from(vec![symbol("{}"), Calcit::from(vec![Calcit::tag("text"), symbol("'String")])]),
     ] as &[Calcit]);
     let struct_def = parse_defstruct_code(&struct_code).expect("map-wrapped struct definition");
+    assert_eq!(struct_def.definition_ref.as_deref(), Some("tests/Store"));
     assert_eq!(struct_def.fields.as_ref(), &[EdnTag::new("text")]);
     assert_eq!(struct_def.field_types.len(), 1);
 
@@ -4717,6 +4953,7 @@ mod tests {
       ]),
     ] as &[Calcit]);
     let enum_def = parse_defenum_code(&enum_code).expect("map-wrapped enum definition");
+    assert_eq!(enum_def.definition_ref().map(AsRef::as_ref), Some("tests/Choice"));
     assert!(enum_def.find_variant_by_name("some").is_some());
     assert!(enum_def.find_variant_by_name("none").is_some());
   }
@@ -4754,6 +4991,7 @@ mod tests {
     Arc::new(
       CalcitEnumDef::from_struct(CalcitStructValue {
         struct_ref: Arc::new(CalcitStructDef {
+          definition_ref: None,
           name: EdnTag::new("Result"),
           fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
           field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
@@ -4782,6 +5020,7 @@ mod tests {
 
     let user_option = CalcitEnumDef::from_struct(CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::new("Option"),
         fields: Arc::new(vec![EdnTag::new("some"), EdnTag::new("none")]),
         field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
@@ -5557,6 +5796,7 @@ mod tests {
   #[test]
   fn rejects_type_args_on_non_generic_struct_annotation() {
     let pair = CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -5578,6 +5818,7 @@ mod tests {
   #[test]
   fn rejects_wrong_arity_on_generic_struct_annotation() {
     let pair = CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -5599,6 +5840,7 @@ mod tests {
   #[test]
   fn matching_named_struct_ref_binds_generic_args_from_struct_annotation() {
     let pair = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -5621,6 +5863,7 @@ mod tests {
   #[test]
   fn matching_bare_struct_annotation_binds_generic_args_from_named_struct_ref() {
     let pair = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Pair"),
       fields: Arc::new(vec![]),
       field_types: Arc::new(vec![]),
@@ -5689,6 +5932,26 @@ mod tests {
   }
 
   #[test]
+  fn proof_preserves_direction_when_the_expected_type_slot_resolves() {
+    clear_type_slots();
+    let slot_name: Arc<str> = Arc::from("dispatch");
+    let concrete_enum = Arc::new(CalcitTypeAnnotation::Enum(generic_result_enum(), Arc::new(vec![])));
+    push_type_slot_override(slot_name.clone(), concrete_enum.clone());
+
+    let mut bindings = TypeBindings::new();
+    let anonymous = CalcitTypeAnnotation::AnonymousEnum;
+    let slot = CalcitTypeAnnotation::TypeSlot(slot_name.clone());
+    assert_eq!(anonymous.prove_with_bindings(&slot, &mut bindings), TypeProof::Mismatch);
+    assert_eq!(
+      concrete_enum.prove_with_bindings(&CalcitTypeAnnotation::AnonymousEnum, &mut bindings),
+      TypeProof::Proven
+    );
+
+    pop_type_slot_override(&slot_name);
+    clear_type_slots();
+  }
+
+  #[test]
   fn proof_is_transactional_and_does_not_synthesize_optional_bindings() {
     let var: Arc<str> = Arc::from("T");
     let expected = CalcitTypeAnnotation::TypeVar(var.clone());
@@ -5732,6 +5995,107 @@ mod tests {
     assert_eq!(
       bare.prove_with_bindings(&applied, &mut bindings),
       TypeProof::NeedsBoundary(TypeBoundaryReason::ErasedTypeArguments)
+    );
+  }
+
+  #[test]
+  fn nominal_proof_uses_qualified_definition_and_schema_identity() {
+    let user = |namespace: &str, field_type: Arc<CalcitTypeAnnotation>| {
+      Arc::new(CalcitStructDef {
+        definition_ref: Some(Arc::from(format!("{namespace}/User"))),
+        name: EdnTag::new("User"),
+        fields: Arc::new(vec![EdnTag::new("id")]),
+        field_types: Arc::new(vec![field_type]),
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        impls: vec![],
+      })
+    };
+    let app_user = user("app.models", Arc::new(CalcitTypeAnnotation::Number));
+    let admin_user = user("admin.models", Arc::new(CalcitTypeAnnotation::Number));
+    let reloaded_user = user("app.models", Arc::new(CalcitTypeAnnotation::String));
+
+    let app_type = CalcitTypeAnnotation::Struct(app_user.clone(), Arc::new(vec![]));
+    let admin_type = CalcitTypeAnnotation::Struct(admin_user, Arc::new(vec![]));
+    let reloaded_type = CalcitTypeAnnotation::Struct(reloaded_user, Arc::new(vec![]));
+    assert!(!app_type.is_compatible_with(&admin_type));
+    assert_eq!(
+      app_type.prove_with_bindings(&admin_type, &mut TypeBindings::new()),
+      TypeProof::Mismatch
+    );
+    assert_eq!(
+      app_type.prove_with_bindings(&reloaded_type, &mut TypeBindings::new()),
+      TypeProof::Mismatch,
+      "a schema change at the same declaration path must invalidate an old proof"
+    );
+
+    let mut decorated = app_user.as_ref().clone();
+    decorated.impls.push(Arc::new(CalcitImpl {
+      name: EdnTag::new("UserDebug"),
+      origin: None,
+      fields: Arc::new(vec![]),
+      values: Arc::new(vec![]),
+    }));
+    let decorated_type = CalcitTypeAnnotation::Struct(Arc::new(decorated), Arc::new(vec![]));
+    assert_eq!(
+      app_type.prove_with_bindings(&decorated_type, &mut TypeBindings::new()),
+      TypeProof::Proven,
+      "impl decoration must preserve the base data identity"
+    );
+
+    let app_ref = CalcitTypeAnnotation::TypeRef(Arc::from("app.models/User"), Arc::new(vec![]));
+    let admin_ref = CalcitTypeAnnotation::TypeRef(Arc::from("admin.models/User"), Arc::new(vec![]));
+    assert_eq!(app_ref.prove_with_bindings(&app_type, &mut TypeBindings::new()), TypeProof::Proven);
+    assert_eq!(
+      admin_ref.prove_with_bindings(&app_type, &mut TypeBindings::new()),
+      TypeProof::Mismatch
+    );
+  }
+
+  #[test]
+  fn nominal_proof_preserves_applied_arguments_and_rejects_bare_wildcards() {
+    let box_def = Arc::new(CalcitStructDef {
+      definition_ref: Some(Arc::from("app.models/Box")),
+      name: EdnTag::new("Box"),
+      fields: Arc::new(vec![EdnTag::new("value")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    });
+    let number = CalcitTypeAnnotation::Struct(box_def.clone(), Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]));
+    let string = CalcitTypeAnnotation::Struct(box_def.clone(), Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]));
+    let bare = CalcitTypeAnnotation::Struct(box_def, Arc::new(vec![]));
+
+    assert_eq!(number.prove_with_bindings(&string, &mut TypeBindings::new()), TypeProof::Mismatch);
+    assert_ne!(
+      number.cmp(&string),
+      Ordering::Equal,
+      "applied nominal arguments participate in ordering"
+    );
+    assert_eq!(
+      bare.prove_with_bindings(&number, &mut TypeBindings::new()),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::ErasedTypeArguments)
+    );
+  }
+
+  #[test]
+  fn nominal_enum_proof_rejects_same_short_name_from_another_namespace() {
+    let app_result = Arc::new(generic_result_enum().as_ref().clone().with_definition_ref("app.models", "Result"));
+    let admin_result = Arc::new(generic_result_enum().as_ref().clone().with_definition_ref("admin.models", "Result"));
+    let app_type = CalcitTypeAnnotation::Enum(
+      app_result,
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
+    );
+    let admin_type = CalcitTypeAnnotation::Enum(
+      admin_result,
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
+    );
+
+    assert!(!app_type.is_compatible_with(&admin_type));
+    assert_eq!(
+      app_type.prove_with_bindings(&admin_type, &mut TypeBindings::new()),
+      TypeProof::Mismatch
     );
   }
 
@@ -6104,8 +6468,8 @@ impl Ord for CalcitTypeAnnotation {
       | (Self::CirruQuote, Self::CirruQuote) => Ordering::Equal,
       (Self::List(a), Self::List(b)) => a.cmp(b),
       (Self::Map(ak, av), Self::Map(bk, bv)) => ak.cmp(bk).then_with(|| av.cmp(bv)),
-      (Self::StructValue(a), Self::StructValue(b)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
-      (Self::EnumValue(a), Self::EnumValue(b)) => a.name().cmp(b.name()),
+      (Self::StructValue(a), Self::StructValue(b)) => super::compare::compare_calcit_struct_values(a, b),
+      (Self::EnumValue(a), Self::EnumValue(b)) => super::compare::compare_calcit_enum_values(a, b),
       (Self::Fn(a), Self::Fn(b)) => a
         .generics
         .cmp(&b.generics)
@@ -6122,10 +6486,14 @@ impl Ord for CalcitTypeAnnotation {
       (Self::Dynamic, Self::Dynamic) => Ordering::Equal,
       (Self::TypeVar(a), Self::TypeVar(b)) => a.cmp(b),
       (Self::TypeRef(a_name, a_args), Self::TypeRef(b_name, b_args)) => a_name.cmp(b_name).then_with(|| a_args.cmp(b_args)),
-      (Self::Struct(a, _), Self::Struct(b, _)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
-      (Self::Enum(a, _), Self::Enum(b, _)) => a.name().cmp(b.name()),
-      (Self::StructDef(a), Self::StructDef(b)) => a.name.cmp(&b.name).then_with(|| a.fields.cmp(&b.fields)),
-      (Self::EnumDef(a), Self::EnumDef(b)) => a.name().cmp(b.name()),
+      (Self::Struct(a, a_args), Self::Struct(b, b_args)) => {
+        super::compare::compare_calcit_struct_values(a, b).then_with(|| a_args.cmp(b_args))
+      }
+      (Self::Enum(a, a_args), Self::Enum(b, b_args)) => {
+        super::compare::compare_calcit_enum_values(a, b).then_with(|| a_args.cmp(b_args))
+      }
+      (Self::StructDef(a), Self::StructDef(b)) => super::compare::compare_calcit_struct_values(a, b),
+      (Self::EnumDef(a), Self::EnumDef(b)) => super::compare::compare_calcit_enum_values(a, b),
       (Self::Trait(a), Self::Trait(b)) => a.name.cmp(&b.name),
       (Self::TraitSet(a), Self::TraitSet(b)) => a.iter().map(|t| &t.name).cmp(b.iter().map(|t| &t.name)),
       _ => Ordering::Equal, // other variants already separated by kind order

--- a/src/codegen/emit_wasm/structs.rs
+++ b/src/codegen/emit_wasm/structs.rs
@@ -131,6 +131,7 @@ pub(super) fn try_parse_defrecord_form(code: &Calcit) -> Option<CalcitStructDef>
   }
   fields.sort();
   Some(CalcitStructDef {
+    definition_ref: None,
     name,
     fields: std::sync::Arc::new(fields),
     field_types: std::sync::Arc::new(vec![]),

--- a/src/data/edn_decode.rs
+++ b/src/data/edn_decode.rs
@@ -587,6 +587,7 @@ mod tests {
 
   fn person_struct() -> Arc<CalcitStructDef> {
     Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("age"), EdnTag::new("name")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)]),
@@ -599,6 +600,7 @@ mod tests {
   fn option_enum() -> Arc<CalcitEnumDef> {
     let prototype = CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::new("Option"),
         fields: Arc::new(vec![EdnTag::new("none"), EdnTag::new("some")]),
         field_types: Arc::new(vec![
@@ -620,6 +622,7 @@ mod tests {
   #[test]
   fn runtime_map_decode_requires_fields_lifts_option_and_rejects_unknown_keys() {
     let response = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Response"),
       fields: Arc::new(vec![EdnTag::new("code"), EdnTag::new("message"), EdnTag::new("body")]),
       field_types: Arc::new(vec![
@@ -803,6 +806,7 @@ mod tests {
   fn decodes_enum_and_checks_payload_arity() {
     let prototype = CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::new("ResultText"),
         fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
         field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),

--- a/src/program.rs
+++ b/src/program.rs
@@ -1102,6 +1102,12 @@ pub fn write_runtime_ready(ns: &str, def: &str, value: Calcit) -> Result<(), Str
     Calcit::Trait(trait_def) if trait_def.definition_ref.is_none() => {
       write_runtime_value(def_id, Calcit::Trait(trait_def.with_definition_ref(ns, def)))
     }
+    Calcit::StructDef(struct_def) if struct_def.definition_ref.is_none() => {
+      write_runtime_value(def_id, Calcit::StructDef(struct_def.with_definition_ref(ns, def)))
+    }
+    Calcit::EnumDef(enum_def) if enum_def.definition_ref().is_none() => {
+      write_runtime_value(def_id, Calcit::EnumDef(enum_def.with_definition_ref(ns, def)))
+    }
     other => write_runtime_value(def_id, other),
   }
 

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -1336,6 +1336,33 @@ fn write_runtime_ready_attaches_trait_definition_identity() {
 }
 
 #[test]
+fn write_runtime_ready_attaches_struct_and_enum_definition_identity() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+
+  let struct_value = crate::calcit::CalcitStructDef::from_fields(cirru_edn::EdnTag::new("User"), vec![]);
+  write_runtime_ready("app.models", "User", Calcit::StructDef(struct_value)).expect("store runtime struct");
+  let Calcit::StructDef(stored_struct) = lookup_runtime_ready("app.models", "User").expect("stored struct") else {
+    panic!("expected stored struct");
+  };
+  assert_eq!(stored_struct.definition_ref.as_deref(), Some("app.models/User"));
+
+  let enum_struct = crate::calcit::CalcitStructValue {
+    struct_ref: Arc::new(crate::calcit::CalcitStructDef::from_fields(
+      cirru_edn::EdnTag::new("Status"),
+      vec![cirru_edn::EdnTag::new("ready")],
+    )),
+    values: Arc::new(vec![Calcit::Nil]),
+  };
+  let enum_value = crate::calcit::CalcitEnumDef::from_struct(enum_struct).expect("build runtime enum");
+  write_runtime_ready("app.models", "Status", Calcit::EnumDef(enum_value)).expect("store runtime enum");
+  let Calcit::EnumDef(stored_enum) = lookup_runtime_ready("app.models", "Status").expect("stored enum") else {
+    panic!("expected stored enum");
+  };
+  assert_eq!(stored_enum.definition_ref().map(AsRef::as_ref), Some("app.models/Status"));
+}
+
+#[test]
 fn clear_runtime_caches_for_changes_clears_transitive_dependents() {
   let _guard = lock_program_test_state();
   reset_program_test_state();

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -10030,6 +10030,7 @@ mod tests {
     }
 
     let struct_def = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Task"),
       fields: Arc::new(vec![EdnTag::new("done?")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::Bool)]),
@@ -11137,6 +11138,7 @@ mod tests {
     });
     let type_value = CalcitTypeAnnotation::Struct(
       Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::new("Demo"),
         fields: Arc::new(vec![]),
         field_types: Arc::new(vec![]),
@@ -13059,6 +13061,7 @@ mod tests {
 
     let generic: Arc<str> = Arc::from("T");
     let enum_struct = CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::from("Wrapped"),
       fields: Arc::new(vec![EdnTag::from("empty"), EdnTag::from("some")]),
       field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(), crate::calcit::DYNAMIC_TYPE.clone()]),
@@ -14537,6 +14540,7 @@ mod tests {
 
     let class_struct = CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::from("Greeter"),
         fields: Arc::new(vec![EdnTag::from("greet")]),
         field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone()]),
@@ -15635,6 +15639,7 @@ mod tests {
 
     let class_struct = CalcitStructValue {
       struct_ref: Arc::new(CalcitStructDef {
+        definition_ref: None,
         name: EdnTag::from("Person"),
         fields: Arc::new(vec![EdnTag::from("greet")]),
         field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone()]),
@@ -16491,6 +16496,7 @@ mod tests {
     let _state = lock_preprocess_test_state();
     let _slots = TypeSlotsGuard::cleared();
     let person_def = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Person"),
       fields: Arc::new(vec![EdnTag::new("name")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),
@@ -16587,6 +16593,7 @@ mod tests {
     assert!(related_error.msg.contains("struct Person"));
 
     let box_def = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Box"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
@@ -16669,6 +16676,7 @@ mod tests {
   fn type_slot_struct_annotations_preserve_generic_arguments_for_erasure_checks() {
     let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
     let box_def = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Box"),
       fields: Arc::new(vec![EdnTag::new("value")]),
       field_types: Arc::new(vec![type_var.clone()]),

--- a/src/runner/preprocess/type_checking.rs
+++ b/src/runner/preprocess/type_checking.rs
@@ -1263,6 +1263,7 @@ mod tests {
   #[test]
   fn specialize_update_uses_struct_field_type_for_callback() {
     let task_struct = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Task"),
       fields: Arc::new(vec![EdnTag::new("done?")]),
       field_types: Arc::new(vec![tag_annotation("bool")]),
@@ -1761,6 +1762,7 @@ mod tests {
     assert_eq!(map_specialized[2], number);
 
     let task_struct = Arc::new(CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::new("Task"),
       fields: Arc::new(vec![EdnTag::new("done?")]),
       field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::Bool)]),

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -2836,6 +2836,7 @@ mod tests {
   fn enum_constructor_keeps_nominal_type_without_payload_evidence() {
     let generic: Arc<str> = Arc::from("T");
     let struct_def = CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::from("MaybeX"),
       fields: Arc::new(vec![EdnTag::from("none"), EdnTag::from("some")]),
       field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),
@@ -2876,6 +2877,22 @@ mod tests {
         if inferred.name() == enum_def.name()
           && matches!(args.first().map(AsRef::as_ref), Some(CalcitTypeAnnotation::Number))
     ));
+
+    let some_list_call = CalcitList::from(&[
+      Calcit::Proc(CalcitProc::NativeNamedEnumNew),
+      Calcit::EnumDef(enum_def.clone()),
+      Calcit::Tag(EdnTag::from("some")),
+      Calcit::from(vec![Calcit::Proc(CalcitProc::List), Calcit::Number(1.0), Calcit::Number(2.0)]),
+    ] as &[Calcit]);
+    assert!(matches!(
+      infer_enum_annotation(&some_list_call, &ScopeTypes::new()).as_deref(),
+      Some(CalcitTypeAnnotation::Enum(inferred, args))
+        if inferred.name() == enum_def.name()
+          && matches!(
+            args.first().map(AsRef::as_ref),
+            Some(CalcitTypeAnnotation::List(item)) if matches!(item.as_ref(), CalcitTypeAnnotation::Number)
+          )
+    ));
   }
 
   #[test]
@@ -2887,6 +2904,7 @@ mod tests {
     let box_def = Arc::new(box_def);
 
     let enum_struct = CalcitStructDef {
+      definition_ref: None,
       name: EdnTag::from("MaybeBox"),
       fields: Arc::new(vec![EdnTag::from("empty"), EdnTag::from("box")]),
       field_types: Arc::new(vec![calcit::DYNAMIC_TYPE.clone(), calcit::DYNAMIC_TYPE.clone()]),


### PR DESCRIPTION
## 中文说明

此 PR 完成 #843 的 nominal ADT 身份与泛型实参保留工作：

- 为 struct/enum 定义附加 `namespace/definition` 身份，并在比较时同时校验数据 schema；同名但不同命名空间的类型不再被视为相同。
- `impl-traits` 装饰不会改变基础数据类型身份，但字段、variant payload、泛型或约束变化会使旧 schema 证据失效。
- 在 Struct、Enum、TypeRef、定义值和实例值之间统一 proof 规则，保留 applied ADT arguments；裸泛型不再作为 wildcard 参与严格 proof。
- TypeRef 在可解析时校验泛型参数数量，并给出可执行的迁移提示。
- DataShape 使用 qualified nominal path；同一声明与 schema 的 clone 可通过，热更新后 schema 改变会被拒绝。
- 保持旧 serialized struct prototype 的 wire shape 不变，兼容旧数据边界。
- 一并修复已合并 #891 后 CodeRabbit 指出的 proof 方向错误：拆分 TypeSlot/TypeRef 的 actual/expected fallback，并加入 AnonymousEnum 回归测试。

验证：

- `cargo test --workspace --all-features`（727 library + 304 native binary + 23 WASM binary tests）
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `fnm exec --using=24.4.1 yarn check-all`（native、generated JS、IR、WASM、agent-interface、quality 与 literal-path gates）

关闭 #843。

## English Description

This PR completes the nominal ADT identity and applied-argument work tracked by #843:

- Attaches `namespace/definition` identity to struct and enum definitions and compares both declaration identity and data schema, so equal short names in different namespaces no longer match.
- Keeps the base data identity stable across `impl-traits` decoration while invalidating stale evidence when fields, variant payloads, generics, or bounds change.
- Unifies proof rules across Struct, Enum, TypeRef, definition values, and instance values while preserving applied ADT arguments; bare generics no longer act as strict-proof wildcards.
- Validates TypeRef arity when the declaration is resolvable and reports an actionable migration hint.
- Uses qualified nominal paths in DataShape; clones of the same declaration/schema remain valid, while incompatible hot-reloaded schemas are rejected.
- Preserves the legacy serialized struct-prototype wire shape for boundary compatibility.
- Also carries the valid post-merge CodeRabbit finding from #891 by splitting directional TypeSlot/TypeRef actual-vs-expected fallbacks and adding the AnonymousEnum regression.

Verification:

- `cargo test --workspace --all-features` (727 library + 304 native binary + 23 WASM binary tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `fnm exec --using=24.4.1 yarn check-all` (native, generated JS, IR, WASM, agent-interface, quality, and literal-path gates)

Closes #843.
