### PR TITLE
fix: prevent WASI preprocess stack trap / 避免 WASI 预处理栈 trap

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,23 @@ on:
 name: Test
 
 jobs:
+  wasi_preprocess:
+    name: WASI preprocess regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+          targets: wasm32-wasip1
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Wasmtime 18.0.3
+        uses: bytecodealliance/actions/wasmtime/setup@v1.1.3
+        with:
+          version: "18.0.3"
+      - name: Verify native and WASI preprocessing parity
+        run: bash scripts/test-wasi-preprocess.sh
+
   macos_main_thread:
     name: macOS main-thread CLI
     runs-on: macos-14

--- a/build.rs
+++ b/build.rs
@@ -575,6 +575,13 @@ fn main() {
     // AppKit event loops can own it. Match the worker stack used elsewhere.
     println!("cargo:rustc-link-arg-bin=calcit=-Wl,-stack_size,0x2000000");
   }
+  if target.starts_with("wasm32-wasi") {
+    // The standalone compiler recursively preprocesses the bundled core before
+    // user code. wasm-ld's 1 MiB default stack is too small for that valid
+    // workload in an unoptimized WASI build, where it otherwise underflows the
+    // shadow stack and traps as an out-of-bounds linear-memory access.
+    println!("cargo:rustc-link-arg-bin=cr-wasm=-zstack-size=4194304");
+  }
 
   let out_dir = env::var_os("OUT_DIR").unwrap();
   let dest_path = Path::new(&out_dir).join("calcit-core.rmp");

--- a/calcit/test-wasi-preprocess.cirru
+++ b/calcit/test-wasi-preprocess.cirru
@@ -1,0 +1,23 @@
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |app)
+  :entries $ {}
+    :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :native) (:reload-fn 'app.main/reload!)
+      :feature-policy $ {}
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'app.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn main! () $ + 1 2
+          :examples $ []
+          :schema $ :: 'Dynamic
+        'reload! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn reload! () 0
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns app.main $ :require

--- a/editing-history/202609070948-wasi-preprocess-stack.md
+++ b/editing-history/202609070948-wasi-preprocess-stack.md
@@ -1,0 +1,30 @@
+# Reserve WASI preprocessing stack / 为 WASI 预处理预留栈空间
+
+- Reproduced calcit#763 with the archived 0.13.77-era Snapshot and Wasmtime
+  18.0.3: native preprocessing completed, while the default 1 MiB wasm-ld
+  shadow stack underflowed and trapped as an out-of-bounds memory access.
+- Splitting the largest `preprocess_list_call` frame only moved the trap into
+  another recursive evaluator path. The failure belongs to the standalone
+  compiler's aggregate recursive workload, not one malformed source function.
+- Set the `cr-wasm` WASI link stack to 4 MiB in `build.rs`. The resulting
+  `__stack_pointer` starts at 4194304 and the unchanged recursive preprocessing
+  path completes under Wasmtime.
+- Added a minimized, canonically formatted legacy Snapshot plus a native/WASI
+  parity script and a pinned CI job using Wasmtime 18.0.3.
+
+- 使用归档的 0.13.77-era Snapshot 和 Wasmtime 18.0.3 复现 calcit#763：native
+  预处理成功，而 wasm-ld 默认 1 MiB shadow stack 下溢并触发越界内存 trap。
+- 拆分最大的 `preprocess_list_call` 栈帧只会把 trap 移到另一个递归求值路径，
+  因此根因是独立编译器整体递归工作负载，而不是单个异常源码函数。
+- 在 `build.rs` 中把 `cr-wasm` 的 WASI 链接栈设为 4 MiB；生成模块的
+  `__stack_pointer` 初值为 4194304，原递归预处理路径可在 Wasmtime 完成。
+- 添加最小化并规范格式化的旧 Snapshot、native/WASI parity 脚本，以及固定
+  Wasmtime 18.0.3 的 CI job。
+
+## Validation / 验证
+
+- `bash scripts/test-wasi-preprocess.sh`
+- `cargo fmt --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test` (730 + 308 + 23 passed)
+- `yarn check-all`

--- a/editing-history/202609071006-harden-wasi-regression-sandbox.md
+++ b/editing-history/202609071006-harden-wasi-regression-sandbox.md
@@ -1,0 +1,18 @@
+# Harden the WASI regression sandbox / 收窄 WASI 回归沙箱
+
+- Disable persisted checkout credentials in the pull-request WASI regression
+  job because no later step performs an authenticated Git operation.
+- Preopen only the repository's `calcit/` fixture directory for Wasmtime. This
+  preserves Snapshot-relative module lookup without exposing the checkout root
+  or `.git` to the guest binary.
+
+- WASI PR 回归 job 不再持久化 checkout credentials；后续步骤不需要执行认证的
+  Git 操作。
+- Wasmtime 只预打开仓库的 `calcit/` fixture 目录，在保留 Snapshot 相对模块
+  查找能力的同时，不向 guest binary 暴露 checkout 根目录或 `.git`。
+
+## Validation / 验证
+
+- `bash scripts/test-wasi-preprocess.sh`
+- `cargo fmt --check`
+- `git diff --check`

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -13,6 +13,6 @@ cargo run --bin calcit -- --compat-types --check-only "$FIXTURE"
 cargo build --bin cr-wasm --target "$TARGET"
 
 WASMTIME_NEW_CLI=0 wasmtime run \
-  --dir "$PWD::/workspace" \
+  --dir "$PWD/calcit::/workspace" \
   "$WASM_BIN" \
-  -- --check-only "/workspace/$FIXTURE"
+  -- --check-only "/workspace/$(basename "$FIXTURE")"

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Reproduce the legacy snapshot preprocessing path in both native and WASI CLIs.
+set -euo pipefail
+
+readonly TARGET="wasm32-wasip1"
+readonly FIXTURE="calcit/test-wasi-preprocess.cirru"
+readonly WASM_BIN="${CARGO_TARGET_DIR:-target}/${TARGET}/debug/cr-wasm.wasm"
+
+command -v wasmtime >/dev/null
+
+# The captured 0.13.77-era snapshot intentionally retains whole-Dynamic schemas.
+cargo run --bin calcit -- --compat-types --check-only "$FIXTURE"
+cargo build --bin cr-wasm --target "$TARGET"
+
+WASMTIME_NEW_CLI=0 wasmtime run \
+  --dir "$PWD::/workspace" \
+  "$WASM_BIN" \
+  -- --check-only "/workspace/$FIXTURE"


### PR DESCRIPTION
## Summary / 概要

- reserve a 4 MiB wasm-ld stack for the `cr-wasm` WASI binary, matching its recursive bundled-core preprocessing workload
- add a minimized, canonically formatted 0.13.77-era Snapshot regression that previously trapped under Wasmtime 18.0.3
- verify native compatibility preprocessing and WASI `--check-only` parity in a dedicated CI job with pinned Wasmtime tooling

- 为 `cr-wasm` WASI 二进制预留 4 MiB wasm-ld 栈，以承载 bundled core 的递归预处理工作负载
- 添加最小化、规范格式化的 0.13.77-era Snapshot 回归；该路径此前在 Wasmtime 18.0.3 下触发 trap
- 在独立 CI job 中固定 Wasmtime 工具，验证 native compatibility preprocessing 与 WASI `--check-only` 一致通过

## Root cause / 根因

The default 1 MiB WASI shadow stack underflows during aggregate recursive preprocessing/evaluation and surfaces as an out-of-bounds linear-memory trap. Reducing the largest individual `preprocess_list_call` frame only moved the failure to another recursive path. Linking `cr-wasm` with a 4 MiB stack makes the resulting `__stack_pointer` start at 4194304 and lets the unchanged recursive path complete.

WASI 默认 1 MiB shadow stack 在整体递归预处理/求值期间下溢，最终表现为线性内存越界 trap。缩小最大的单个 `preprocess_list_call` 栈帧只会把失败移动到另一条递归路径。把 `cr-wasm` 链接栈设为 4 MiB 后，生成模块的 `__stack_pointer` 初值为 4194304，原递归路径可正常完成。

## Validation / 验证

- `bash scripts/test-wasi-preprocess.sh`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (730 + 308 + 23 passed)
- `yarn check-all`

Closes #763
