### PR TITLE
Resolve checked-call receiver type slots / 解引用 checked-call receiver 类型槽

### DIFF
--- a/editing-history/202609071110-resolve-checked-call-type-slots.md
+++ b/editing-history/202609071110-resolve-checked-call-type-slots.md
@@ -1,0 +1,16 @@
+# Resolve checked-call type slots / 解引用 checked-call 类型槽
+
+- Resolve bound `TypeSlot` receivers before selecting a shared collection
+  contract, with cycle detection that leaves open or cyclic slots on the
+  compatibility path.
+- 将已绑定的 `TypeSlot` receiver 解引用后再选择共享集合 contract，并通过循环
+  检测让未绑定或循环类型槽继续走兼容路径。
+- Exercise strict `get` lowering through a bound generic list receiver so the
+  contract and optional-access lowering stay aligned.
+- 通过绑定为泛型列表 receiver 的严格 `get` 覆盖 lowering，确保 contract 与
+  optional-access lowering 保持一致。
+
+## Validation / 验证
+
+- `cargo test checked_call_contract`
+- `cargo test strict_types_reject_concrete_unsupported_optional_access_receivers`

--- a/editing-history/202609071120-share-type-slot-chain-resolution.md
+++ b/editing-history/202609071120-share-type-slot-chain-resolution.md
@@ -1,0 +1,15 @@
+# Share type-slot chain resolution / 共享类型槽链解引用
+
+- Extract the cycle-safe bound `TypeSlot` traversal into the checked-call
+  contract module and reuse it from typed optional-access lowering.
+- 将循环安全的已绑定 `TypeSlot` 遍历提取到 checked-call contract 模块，并在
+  typed optional-access lowering 中复用。
+- Keep contract selection and lowering on one resolution policy so future
+  changes cannot silently diverge.
+- 让 contract 选择与 lowering 使用同一解引用策略，避免后续修改静默漂移。
+
+## Validation / 验证
+
+- `cargo fmt --check`
+- `cargo test checked_call_contract`
+- `cargo test strict_types_reject_concrete_unsupported_optional_access_receivers`

--- a/src/runner/preprocess/checked_call_contract.rs
+++ b/src/runner/preprocess/checked_call_contract.rs
@@ -1,7 +1,7 @@
 //! Receiver-specialized contracts shared by checking, inference, rewriting,
 //! and lowering for polymorphic collection calls.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use crate::calcit::{self, Calcit, CalcitList, CalcitTypeAnnotation};
 
@@ -66,7 +66,17 @@ pub(crate) fn resolve_checked_call_contract(
     return None;
   }
 
-  let receiver_type = resolve_type_value(args.first()?, scope_types)?;
+  let mut receiver_type = resolve_type_value(args.first()?, scope_types)?;
+  let mut resolving_slots = HashSet::new();
+  while let T::TypeSlot(name) = receiver_type.as_ref() {
+    if !resolving_slots.insert(name.clone()) {
+      break;
+    }
+    let Some(bound) = calcit::resolve_type_slot(name) else {
+      break;
+    };
+    receiver_type = bound;
+  }
   match (fn_def, receiver_type.as_ref()) {
     ("get", T::Map(key_type, value_type)) => Some(CheckedCallContract {
       expected_types: Some(vec![receiver_type.clone(), key_type.clone()]),

--- a/src/runner/preprocess/checked_call_contract.rs
+++ b/src/runner/preprocess/checked_call_contract.rs
@@ -43,6 +43,22 @@ fn callback_return_type(callback: &Calcit, scope_types: &ScopeTypes) -> Option<A
   }
 }
 
+/// Follow concrete type-slot bindings while leaving unresolved or cyclic slots
+/// open for compatibility handling by the caller.
+pub(crate) fn resolve_bound_type_slot_chain(mut type_value: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
+  let mut resolving_slots = HashSet::new();
+  while let CalcitTypeAnnotation::TypeSlot(name) = type_value.as_ref() {
+    if !resolving_slots.insert(name.clone()) {
+      break;
+    }
+    let Some(bound) = calcit::resolve_type_slot(name) else {
+      break;
+    };
+    type_value = bound;
+  }
+  type_value
+}
+
 /// Resolve one concrete collection contract from the receiver and current call
 /// scope. Returning `None` keeps Dynamic/open receivers on the compatibility
 /// path and never authorizes static lowering.
@@ -66,17 +82,7 @@ pub(crate) fn resolve_checked_call_contract(
     return None;
   }
 
-  let mut receiver_type = resolve_type_value(args.first()?, scope_types)?;
-  let mut resolving_slots = HashSet::new();
-  while let T::TypeSlot(name) = receiver_type.as_ref() {
-    if !resolving_slots.insert(name.clone()) {
-      break;
-    }
-    let Some(bound) = calcit::resolve_type_slot(name) else {
-      break;
-    };
-    receiver_type = bound;
-  }
+  let receiver_type = resolve_bound_type_slot_chain(resolve_type_value(args.first()?, scope_types)?);
   match (fn_def, receiver_type.as_ref()) {
     ("get", T::Map(key_type, value_type)) => Some(CheckedCallContract {
       expected_types: Some(vec![receiver_type.clone(), key_type.clone()]),

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -16,7 +16,7 @@ use crate::{
   codegen, program, runner,
 };
 
-use checked_call_contract::{CheckedCallLowering, resolve_checked_call_contract};
+use checked_call_contract::{CheckedCallLowering, resolve_bound_type_slot_chain, resolve_checked_call_contract};
 use type_checking::{
   CallTypeCheckInfo, check_core_fn_arg_types, check_function_return_type, check_local_fn_call_arg_types, check_proc_arg_types,
   check_reset_arg_types, check_user_fn_arg_types, detect_return_type_hint_from_processed_body,
@@ -1395,19 +1395,10 @@ fn try_expand_typed_optional_access_call(
   let Some(receiver_expr) = args.first() else {
     return Ok(None);
   };
-  let Some(mut receiver_type) = resolve_type_value(receiver_expr, scope_types) else {
+  let Some(receiver_type) = resolve_type_value(receiver_expr, scope_types) else {
     return Ok(None);
   };
-  let mut resolving_slots = HashSet::new();
-  while let T::TypeSlot(name) = receiver_type.as_ref() {
-    if !resolving_slots.insert(name.clone()) {
-      break;
-    }
-    let Some(bound) = calcit::resolve_type_slot(name) else {
-      break;
-    };
-    receiver_type = bound;
-  }
+  let receiver_type = resolve_bound_type_slot_chain(receiver_type);
 
   let indexed_procs = match receiver_type.as_ref() {
     T::List(_) => Some((CalcitProc::NativeListCount, CalcitProc::NativeListNth)),

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -10148,14 +10148,14 @@ mod tests {
     let bound_list_args = CalcitList::from(&[bound_list, Calcit::Number(0.0)] as &[Calcit]);
     let bound_list_expansion = try_expand_typed_optional_access_call(
       calcit::CORE_NS,
-      "nth",
+      "get",
       &bound_list_args,
       &ScopeTypes::new(),
       "tests.typed-access",
       &stack,
     )
     .expect("a bound List slot should be accepted")
-    .expect("a bound List slot should specialize indexed access");
+    .expect("a bound List slot should specialize checked optional access");
     assert!(bound_list_expansion.lisp_str().contains("&list:nth"));
     calcit::pop_type_slot_override("indexed-receiver");
 


### PR DESCRIPTION
## English

### Summary

- resolve bound `TypeSlot` receivers before selecting the shared checked collection-call contract
- keep unresolved and cyclic slots on the existing compatibility path through cycle detection
- make the strict optional-access regression test exercise public `get`, ensuring contract evidence and typed lowering stay aligned

### Context

PR #897 was merged before its latest-head CodeRabbit finding could be applied. This follow-up contains only that verified fix.

### Validation

- `cargo fmt --check`
- `cargo test` — 735 library, 308 CLI, and 23 WASM tests passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn check-all` — native, JavaScript, IR, WASM, strict-default, quality, and agent-interface gates passed

Closes #797

## 中文

### 摘要

- 在选择共享 checked collection-call contract 前，先解引用已绑定的 `TypeSlot` receiver
- 通过循环检测，让未绑定和循环类型槽继续走现有兼容路径
- 将严格 optional-access 回归测试改为覆盖公开 `get`，确保 contract 证据与 typed lowering 保持一致

### 背景

PR #897 在 latest-head CodeRabbit 意见应用前已经合并。本 follow-up 仅包含已核实的对应修复。

### 验证

- `cargo fmt --check`
- `cargo test` — 735 个 library、308 个 CLI、23 个 WASM 测试通过
- `cargo clippy --all-targets --all-features -- -D warnings`
- `yarn check-all` — native、JavaScript、IR、WASM、strict-default、quality 与 agent-interface 门禁通过

Closes #797
