### PR TITLE
feat: make strict trait dispatch origin-based / 严格 trait 分发按来源消歧

### DIFF
--- a/docs/features/traits.md
+++ b/docs/features/traits.md
@@ -140,7 +140,7 @@ Implementation notes:
 
 ## Attach impls to struct/enum definitions
 
-`impl-traits` attaches impl records to a **struct/enum type**. For user values, later impls override earlier impls for the same method name ("last-wins").
+`impl-traits` attaches impl records to a **struct/enum type**. In compatibility mode, user values retain the historical rule that later impls override earlier impls for the same method name ("last-wins"). Strict mode rejects that call as ambiguous when the candidates have different nominal trait origins. It also rejects attaching multiple implementations of the same nominal trait when the duplicated method is called; remove the duplicate rather than relying on attachment order.
 
 Constraints:
 
@@ -223,8 +223,10 @@ evidence; live branches with different attachments remain conservative.
 
 When running `warn-dyn-method`, preprocess emits extra diagnostics for:
 
-- `.method` call sites that have multiple trait candidates with the same method name.
+- `.method` call sites that have multiple origin candidates with the same method name. Diagnostics print namespace-qualified source origins (or a runtime identity), so `app.a/Show` and `app.b/Show` are never collapsed to the short name `Show`.
 - `impl-traits` used inside function/macro bodies (non-top-level attachment).
+
+Method checking, callback signature inference, static lowering, and these diagnostics consume the same candidate resolution. Trait requirements are de-duplicated by nominal origin and normalized independently of declaration order. A requires cycle or a reachable method/default without callable signature metadata is invalid static evidence; it cannot satisfy a generic `:where` bound.
 
 ## Docs as tests
 
@@ -236,7 +238,9 @@ Key trait docs examples are mirrored by executable smoke cases in `calcit/test-d
 
 ## Method call vs explicit trait call
 
-Normal method invocation uses `.method` dispatch. If multiple traits provide the same method name, `.method` resolves by impl precedence.
+Normal method invocation uses `.method` dispatch. In strict mode, one method name must resolve to exactly one nominal trait origin and one attached impl. If multiple traits provide it, `.method` reports `E_AMBIGUOUS_TRAIT_METHOD`; duplicate implementations of one origin report `E_DUPLICATE_TRAIT_IMPL`. Use `&trait-call` for the former and remove duplicate attachments for the latter.
+
+Compatibility mode continues to resolve by the historical built-in/user precedence rules. `--warn-dyn-method` reports the selected origin and every competing full origin so migrations can be made before enabling strict types.
 
 When you want to **disambiguate** (or bypass `.method` resolution), use `&trait-call`.
 
@@ -269,7 +273,7 @@ let
     Person0 $ defstruct Person (:name 'String)
     Person $ impl-traits Person0 MyZapAImpl MyZapBImpl
     p $ %{} Person (:name |Alice)
-  ; .zap follows normal dispatch $ last-wins for user impls
+  ; compatibility mode keeps last-wins; strict mode rejects this ambiguous call
   p .zap
   ; explicitly pick a "trait’s" implementation
   &trait-call MyZapA :zap p

--- a/editing-history/202609071511-make-trait-dispatch-origin-based.md
+++ b/editing-history/202609071511-make-trait-dispatch-origin-based.md
@@ -24,7 +24,7 @@ Issue: calcit-lang/calcit#844
 
 ## Verification / 验证
 
-- `cargo test --workspace --all-features` (747 library, 308 native CLI, 23 WASM, and 0 doc tests passed)
+- `cargo test --workspace --all-features` (748 library, 308 native CLI, 23 WASM, and 0 doc tests passed after review fix)
 - focused exact-origin, duplicate-impl, originless, requires-cycle, invalid/default-schema, compatibility-order, cache-dependency, and explicit `&trait-call` tests
 - `cargo fmt --check`
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`

--- a/editing-history/202609071511-make-trait-dispatch-origin-based.md
+++ b/editing-history/202609071511-make-trait-dispatch-origin-based.md
@@ -1,0 +1,34 @@
+# Make strict trait dispatch origin-based / 严格 trait 分发改用 nominal origin
+
+Issue: calcit-lang/calcit#844
+
+## 中文
+
+- 抽出统一 method candidate resolution，供参数/签名检查、返回类型推断、静态内联和冲突诊断共同使用；候选按 `definition_ref` 或 runtime identity 区分，不再用 trait 短名合并。
+- strict mode 对不同 trait origin 的同名方法报告 `E_AMBIGUOUS_TRAIT_METHOD`，对同一 origin 的重复 impl 报告 `E_DUPLICATE_TRAIT_IMPL`，对 originless legacy method bag 报告 `E_ORIGINLESS_METHOD_DISPATCH`。compat mode 保留 builtin first-wins / user last-wins，并用完整 origin 报警。
+- `&trait-call` 继续按精确 trait origin 选择；strict runtime 同样拒绝同一 trait 的重复 impl。
+- requires closure 按 nominal origin 去重并稳定排序，检测并报告 origin 路径循环；可达 method/default schema 不完整或不满足声明时不再作为 `:where` 的 Proven 证据。
+- compiler-generated nominal callable 新增 trait definition dependency，使 impl、default 或 method schema 变化能在增量编译/hot reload 时失效旧静态分发结果。
+- 更新 trait 文档，明确 strict/compat 规则、错误码、迁移方式和 origin-qualified 诊断。
+- 用当前工作树 binary 对本地 Respo 与 Recollect 执行 `--compat-types --warn-dyn-method --check-only`：两者实际 multiple-origin conflict inventory 均为 0，因此未虚构或迁移消费者调用；Respo 仅有 3 个既有 unresolved `.to-list` finding，Recollect（含依赖）同样只有这 3 个 unresolved finding。
+
+## English
+
+- Added one shared method-candidate resolution path for argument/signature checking, return inference, static lowering, and conflict diagnostics. Candidates use `definition_ref` or runtime identity instead of the printed trait short name.
+- Strict mode reports `E_AMBIGUOUS_TRAIT_METHOD` for competing trait origins, `E_DUPLICATE_TRAIT_IMPL` for duplicate implementations of one origin, and `E_ORIGINLESS_METHOD_DISPATCH` for legacy originless method bags. Compatibility mode retains built-in first-wins and user last-wins behavior while warning with fully qualified origins.
+- Kept `&trait-call` as the exact-origin selector and made strict runtime calls reject duplicate implementations of the selected trait.
+- Normalized and de-duplicated requires closures by nominal origin, reported cycle paths, and prevented incomplete reachable method/default schemas from becoming Proven `:where` evidence.
+- Added the trait definition as a dependency of compiler-generated nominal callables so impl/default/schema edits invalidate stale static dispatch across incremental compilation and hot reload.
+- Documented the strict/compat rules, stable diagnostics, and migration path.
+- Audited local Respo and Recollect with the current binary using `--compat-types --warn-dyn-method --check-only`. Both real multiple-origin inventories are zero, so no consumer conflict was invented or migrated. The only method findings were the same three unresolved `.to-list` sites from Respo (also visible through Recollect dependencies).
+
+## Verification / 验证
+
+- `cargo test --workspace --all-features` (747 library, 308 native CLI, 23 WASM, and 0 doc tests passed)
+- focused exact-origin, duplicate-impl, originless, requires-cycle, invalid/default-schema, compatibility-order, cache-dependency, and explicit `&trait-call` tests
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `yarn compile`
+- `yarn check-all` (native, JS, IR, WASM, and benchmark smoke checks passed)
+- `yarn check-agent-interface` (18/18 passed as part of the full gate)
+- Respo/Recollect compatibility inventory commands above; consumer worktrees unchanged

--- a/editing-history/202609071529-preserve-runtime-trait-origin-identity.md
+++ b/editing-history/202609071529-preserve-runtime-trait-origin-identity.md
@@ -1,0 +1,24 @@
+# Preserve runtime trait origin identity / 保留 runtime trait 来源身份
+
+Issue: calcit-lang/calcit#844
+Review: calcit-lang/calcit#900
+
+## 中文
+
+- 根据 CodeRabbit 对最新 head 的有效审查，修正 requires 稳定排序：machine key 同时包含 source-facing origin label 与 `runtime_id`，避免热重载前后的 trait 共享 `definition_ref` 时回退到输入顺序。
+- strict 重复 impl 判定改为 `has_same_origin`，不再比较可能相同的展示标签；诊断仍保持面向源码的完整 origin。
+- 新增两个 runtime trait 共享同一 `definition_ref`、但 `runtime_id` 不同的回归，验证两者不会被去重且 requires 重排不改变稳定顺序。
+
+## English
+
+- Addressed the valid CodeRabbit finding on the latest head by including `runtime_id` alongside the source-facing label in the stable requires ordering key, so reload generations sharing one `definition_ref` do not fall back to input order.
+- Changed strict duplicate-impl classification to use `has_same_origin` instead of comparing rendered labels; diagnostics remain source-facing.
+- Added a regression with two runtime traits sharing one `definition_ref` but carrying different `runtime_id` values, proving they remain distinct and reorder deterministically.
+
+## Verification / 验证
+
+- focused runtime-origin and strict duplicate-impl tests
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- `cargo test --workspace --all-features`
+- `git diff --check`

--- a/src/builtins/meta.rs
+++ b/src/builtins/meta.rs
@@ -1579,19 +1579,32 @@ pub fn trait_call(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, C
   let receiver = &xs[2];
   let impls = collect_impls_for_value(receiver, call_stack)?;
 
-  let mut selected_impl: Option<&Arc<CalcitImpl>> = None;
+  let mut matching_impls: Vec<&Arc<CalcitImpl>> = vec![];
   for imp in iter_impls_in_precedence_order(receiver, &impls) {
     if imp.implements_trait(&trait_def) {
-      selected_impl = Some(imp);
-      break;
+      matching_impls.push(imp);
     }
+  }
+
+  if runner::preprocess::is_strict_types_enabled() && matching_impls.len() > 1 {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      format!(
+        "&trait-call: trait {} has {} implementations attached to the same receiver; strict dispatch cannot choose between duplicate impls",
+        trait_def.origin_label(),
+        matching_impls.len()
+      ),
+      "E_DUPLICATE_TRAIT_IMPL",
+      call_stack,
+      receiver.get_location(),
+    ));
   }
 
   let mut method_args: Vec<Calcit> = Vec::with_capacity(xs.len().saturating_sub(2));
   method_args.push(receiver.to_owned());
   method_args.extend_from_slice(&xs[3..]);
 
-  if let Some(impl_value) = selected_impl {
+  if let Some(impl_value) = matching_impls.first() {
     return invoke_impl_method(impl_value.as_ref(), receiver, &method_name, &method_args, call_stack);
   }
 
@@ -1603,7 +1616,7 @@ pub fn trait_call(xs: &[Calcit], call_stack: &CallStackList) -> Result<Calcit, C
     CalcitErrKind::Type,
     format!(
       "&trait-call: cannot find impl for trait {} on {receiver}. Hint: use `defimpl` to create impls tagged by trait.",
-      trait_def.name
+      trait_def.origin_label()
     ),
     call_stack,
     receiver.get_location(),
@@ -2156,7 +2169,9 @@ pub fn with_type_slot_runtime(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitGenericBound, CalcitSymbolInfo};
+  use crate::calcit::{
+    CalcitFn, CalcitFnArgs, CalcitFnCallShape, CalcitFnUsageMeta, CalcitGenericBound, CalcitLocal, CalcitScope, CalcitSymbolInfo,
+  };
 
   fn symbol(name: &str) -> Calcit {
     Calcit::Symbol {
@@ -2203,6 +2218,79 @@ mod tests {
       struct_ref: Arc::new(struct_def),
       values: Arc::new(vec![]),
     })
+  }
+
+  fn constant_method(value: &str) -> Calcit {
+    Calcit::Fn {
+      id: crate::calcit::gen_core_id(),
+      info: Arc::new(CalcitFn {
+        name: Arc::from("render"),
+        def_ns: Arc::from("test.meta"),
+        def_ref: None,
+        usage: CalcitFnUsageMeta::default(),
+        scope: Arc::new(CalcitScope::default()),
+        args: Arc::new(CalcitFnArgs::Args(vec![CalcitLocal::track_sym(&Arc::from("self"))])),
+        call_shape: CalcitFnCallShape::fixed(1),
+        body: vec![Calcit::Str(Arc::from(value))],
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: vec![crate::calcit::DYNAMIC_TYPE.clone()],
+        return_type: Arc::new(CalcitTypeAnnotation::String),
+        rest_type: None,
+      }),
+    }
+  }
+
+  #[test]
+  fn explicit_trait_call_selects_exact_nominal_origin() {
+    let left = Arc::new(
+      CalcitTrait::new_runtime(
+        EdnTag::new("Show"),
+        vec![EdnTag::new("render")],
+        vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+      )
+      .with_definition_ref("app.a", "Show"),
+    );
+    let right = Arc::new(
+      CalcitTrait::new_runtime(
+        EdnTag::new("Show"),
+        vec![EdnTag::new("render")],
+        vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+      )
+      .with_definition_ref("app.b", "Show"),
+    );
+    let mut receiver_def = CalcitStructDef::from_fields(EdnTag::new("Card"), vec![]);
+    receiver_def.impls = vec![
+      Arc::new(CalcitImpl {
+        name: EdnTag::new("LeftShow"),
+        origin: Some(left.clone()),
+        fields: Arc::new(vec![EdnTag::new("render")]),
+        values: Arc::new(vec![constant_method("A")]),
+      }),
+      Arc::new(CalcitImpl {
+        name: EdnTag::new("RightShow"),
+        origin: Some(right.clone()),
+        fields: Arc::new(vec![EdnTag::new("render")]),
+        values: Arc::new(vec![constant_method("B")]),
+      }),
+    ];
+    let receiver = Calcit::Struct(CalcitStructValue {
+      struct_ref: Arc::new(receiver_def),
+      values: Arc::new(vec![]),
+    });
+
+    let left_result = trait_call(
+      &[Calcit::Trait(left.as_ref().clone()), Calcit::tag("render"), receiver.clone()],
+      &CallStackList::default(),
+    )
+    .expect("left origin call");
+    let right_result = trait_call(
+      &[Calcit::Trait(right.as_ref().clone()), Calcit::tag("render"), receiver],
+      &CallStackList::default(),
+    )
+    .expect("right origin call");
+    assert_eq!(left_result, Calcit::Str(Arc::from("A")));
+    assert_eq!(right_result, Calcit::Str(Arc::from("B")));
   }
 
   #[test]

--- a/src/calcit/calcit_trait.rs
+++ b/src/calcit/calcit_trait.rs
@@ -122,6 +122,13 @@ impl CalcitTrait {
     }
   }
 
+  /// Stable machine-facing ordering key for nominal origins. A source label
+  /// alone is insufficient after hot reload because two evaluated traits may
+  /// retain one definition path while carrying distinct runtime identities.
+  fn nominal_origin_sort_key(&self) -> (String, Option<u64>) {
+    (self.origin_label(), self.runtime_id)
+  }
+
   /// Nominal-origin equality for candidate de-duplication. This deliberately
   /// does not compare the short printed name.
   pub fn has_same_origin(&self, other: &Self) -> bool {
@@ -162,7 +169,7 @@ impl CalcitTrait {
 
     let mut output = vec![];
     visit(self, &mut vec![], &mut output)?;
-    output.sort_by_key(|item| item.origin_label());
+    output.sort_by_key(|item| item.nominal_origin_sort_key());
     Ok(output)
   }
 
@@ -524,6 +531,43 @@ mod tests {
       .collect::<Vec<_>>();
     assert_eq!(forward_labels, reversed_labels);
     assert_eq!(forward_labels, vec!["app.left/Left", "app.right/Right", "app.root/Root"]);
+  }
+
+  #[test]
+  fn reachable_runtime_traits_with_one_definition_ref_keep_distinct_stable_origins() {
+    let left = Arc::new(
+      CalcitTrait::new_runtime(
+        EdnTag::new("Reloaded"),
+        vec![EdnTag::new("run")],
+        vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+      )
+      .with_definition_ref("app.shared", "Reloaded"),
+    );
+    let right = Arc::new(
+      CalcitTrait::new_runtime(
+        EdnTag::new("Reloaded"),
+        vec![EdnTag::new("run")],
+        vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+      )
+      .with_definition_ref("app.shared", "Reloaded"),
+    );
+    assert!(!left.has_same_origin(right.as_ref()));
+
+    let mut forward = callable_source_trait("app.root", "Root");
+    forward.requires = Arc::new(vec![left.clone(), right.clone()]);
+    let mut reversed = callable_source_trait("app.root", "Root");
+    reversed.requires = Arc::new(vec![right.clone(), left.clone()]);
+
+    let runtime_ids = |trait_def: &CalcitTrait| {
+      trait_def
+        .normalized_reachable_traits()
+        .expect("distinct reload origins are valid")
+        .iter()
+        .filter_map(|item| item.runtime_id)
+        .collect::<Vec<_>>()
+    };
+    assert_eq!(runtime_ids(&forward), runtime_ids(&reversed));
+    assert_eq!(runtime_ids(&forward), vec![left.runtime_id.unwrap(), right.runtime_id.unwrap()]);
   }
 
   #[test]

--- a/src/calcit/calcit_trait.rs
+++ b/src/calcit/calcit_trait.rs
@@ -109,6 +109,116 @@ impl PartialEq for CalcitTrait {
 impl Eq for CalcitTrait {}
 
 impl CalcitTrait {
+  /// Human-readable nominal origin used by diagnostics. Source-backed traits
+  /// keep their qualified definition path; runtime-only traits retain their
+  /// allocation identity so two equally named values are never conflated.
+  pub fn origin_label(&self) -> String {
+    if let Some(definition_ref) = self.definition_ref.as_deref() {
+      definition_ref.to_owned()
+    } else if let Some(runtime_id) = self.runtime_id {
+      format!("{}#runtime:{runtime_id}", self.name)
+    } else {
+      format!("<legacy>/{}", self.name)
+    }
+  }
+
+  /// Nominal-origin equality for candidate de-duplication. This deliberately
+  /// does not compare the short printed name.
+  pub fn has_same_origin(&self, other: &Self) -> bool {
+    match (self.runtime_id, other.runtime_id) {
+      (Some(left), Some(right)) => left == right,
+      (Some(_), None) | (None, Some(_)) => false,
+      (None, None) => match (&self.definition_ref, &other.definition_ref) {
+        (Some(left), Some(right)) => left == right,
+        (Some(_), None) | (None, Some(_)) => false,
+        (None, None) => self.structural_eq(other),
+      },
+    }
+  }
+
+  /// Return this trait and all transitive requirements in a stable nominal
+  /// order. Re-visiting an origin on the active path is an invalid requires
+  /// cycle; visiting it from another branch is ordinary de-duplication.
+  pub fn normalized_reachable_traits(&self) -> Result<Vec<Arc<CalcitTrait>>, String> {
+    fn visit(current: &CalcitTrait, active: &mut Vec<Arc<CalcitTrait>>, output: &mut Vec<Arc<CalcitTrait>>) -> Result<(), String> {
+      if let Some(cycle_start) = active.iter().position(|item| item.has_same_origin(current)) {
+        let mut path = active[cycle_start..].iter().map(|item| item.origin_label()).collect::<Vec<_>>();
+        path.push(current.origin_label());
+        return Err(format!("trait requires cycle: {}", path.join(" -> ")));
+      }
+      if output.iter().any(|item| item.has_same_origin(current)) {
+        return Ok(());
+      }
+
+      let current = Arc::new(current.clone());
+      active.push(current.clone());
+      for required in current.requires.iter() {
+        visit(required.as_ref(), active, output)?;
+      }
+      active.pop();
+      output.push(current);
+      Ok(())
+    }
+
+    let mut output = vec![];
+    visit(self, &mut vec![], &mut output)?;
+    output.sort_by_key(|item| item.origin_label());
+    Ok(output)
+  }
+
+  /// Validate every reachable method/default schema before it is used as
+  /// static proof. A missing or non-callable signature is never Proven.
+  pub fn validate_reachable_method_schemas(&self) -> Result<(), String> {
+    for trait_def in self.normalized_reachable_traits()? {
+      if trait_def.methods.len() != trait_def.method_types.len()
+        || trait_def.methods.len() != trait_def.member_kinds.len()
+        || trait_def.methods.len() != trait_def.defaults.len()
+      {
+        return Err(format!(
+          "trait {} has incomplete member signature metadata",
+          trait_def.origin_label()
+        ));
+      }
+      for (index, ((method, kind), method_type)) in trait_def
+        .methods
+        .iter()
+        .zip(trait_def.member_kinds.iter())
+        .zip(trait_def.method_types.iter())
+        .enumerate()
+      {
+        if *kind == CalcitTraitMemberKind::Method
+          && !matches!(method_type.as_ref(), CalcitTypeAnnotation::Fn(_) | CalcitTypeAnnotation::DynFn)
+        {
+          return Err(format!(
+            "trait {} method .{} is missing a callable signature",
+            trait_def.origin_label(),
+            method
+          ));
+        }
+        if trait_def.defaults[index].is_some() && *kind != CalcitTraitMemberKind::Method {
+          return Err(format!(
+            "trait {} field :{} cannot have a default method implementation",
+            trait_def.origin_label(),
+            method
+          ));
+        }
+        if let Some(default_impl) = trait_def.defaults[index].as_ref() {
+          let default_schema = CalcitTypeAnnotation::from_calcit_fn(default_impl.as_ref());
+          if !default_schema.is_proven_for(method_type.as_ref()) {
+            return Err(format!(
+              "trait {} default .{} has schema {}, which does not satisfy declared method schema {}",
+              trait_def.origin_label(),
+              method,
+              default_schema.to_brief_string(),
+              method_type.to_brief_string()
+            ));
+          }
+        }
+      }
+    }
+    Ok(())
+  }
+
   fn structural_eq(&self, other: &Self) -> bool {
     self.definition_ref == other.definition_ref
       && self.name == other.name
@@ -380,5 +490,93 @@ mod tests {
 
     assert_eq!(left, right);
     assert_eq!(hash_trait(&left), hash_trait(&right));
+  }
+
+  fn callable_source_trait(ns: &str, name: &str) -> CalcitTrait {
+    CalcitTrait::new(
+      EdnTag::new(name),
+      vec![EdnTag::new("run")],
+      vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+    )
+    .with_definition_ref(ns, name)
+  }
+
+  #[test]
+  fn reachable_requirements_are_origin_deduplicated_and_order_independent() {
+    let left = Arc::new(callable_source_trait("app.left", "Left"));
+    let right = Arc::new(callable_source_trait("app.right", "Right"));
+    let mut forward = callable_source_trait("app.root", "Root");
+    forward.requires = Arc::new(vec![left.clone(), right.clone(), left.clone()]);
+    let mut reversed = callable_source_trait("app.root", "Root");
+    reversed.requires = Arc::new(vec![right, left]);
+
+    let forward_labels = forward
+      .normalized_reachable_traits()
+      .expect("valid requirements")
+      .iter()
+      .map(|item| item.origin_label())
+      .collect::<Vec<_>>();
+    let reversed_labels = reversed
+      .normalized_reachable_traits()
+      .expect("valid requirements")
+      .iter()
+      .map(|item| item.origin_label())
+      .collect::<Vec<_>>();
+    assert_eq!(forward_labels, reversed_labels);
+    assert_eq!(forward_labels, vec!["app.left/Left", "app.right/Right", "app.root/Root"]);
+  }
+
+  #[test]
+  fn reachable_requirements_report_nominal_cycle_path() {
+    let back_to_a = Arc::new(callable_source_trait("app.a", "A"));
+    let mut b = callable_source_trait("app.b", "B");
+    b.requires = Arc::new(vec![back_to_a]);
+    let mut a = callable_source_trait("app.a", "A");
+    a.requires = Arc::new(vec![Arc::new(b)]);
+
+    let error = a.normalized_reachable_traits().expect_err("A -> B -> A must be rejected");
+    assert_eq!(error, "trait requires cycle: app.a/A -> app.b/B -> app.a/A");
+  }
+
+  #[test]
+  fn reachable_method_without_signature_is_invalid_static_evidence() {
+    let invalid = CalcitTrait {
+      runtime_id: None,
+      definition_ref: Some(Arc::from("app.invalid/Render")),
+      name: EdnTag::new("Render"),
+      methods: Arc::new(vec![EdnTag::new("render")]),
+      defaults: Arc::new(vec![None]),
+      method_types: Arc::new(vec![]),
+      member_kinds: Arc::new(vec![CalcitTraitMemberKind::Method]),
+      requires: Arc::new(vec![]),
+    };
+
+    let error = invalid
+      .validate_reachable_method_schemas()
+      .expect_err("missing method schema must not become static proof");
+    assert!(error.contains("app.invalid/Render"), "error: {error}");
+    assert!(error.contains("incomplete member signature metadata"), "error: {error}");
+  }
+
+  #[test]
+  fn default_method_schema_must_prove_the_declared_contract() {
+    let method_schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(crate::calcit::CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![Arc::new(CalcitTypeAnnotation::Number)],
+      return_type: Arc::new(CalcitTypeAnnotation::String),
+      fn_kind: crate::calcit::SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(std::collections::HashSet::new()),
+    })));
+    let mut trait_def = CalcitTrait::new(EdnTag::new("Render"), vec![EdnTag::new("render")], vec![method_schema])
+      .with_definition_ref("app.render", "Render");
+    trait_def.defaults = Arc::new(vec![Some(build_default_fn("render-default", None, 1))]);
+
+    let error = trait_def
+      .validate_reachable_method_schemas()
+      .expect_err("a Dynamic default cannot prove a Number -> String method contract");
+    assert!(error.contains("app.render/Render"), "error: {error}");
+    assert!(error.contains("does not satisfy declared method schema"), "error: {error}");
   }
 }

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -3242,7 +3242,24 @@ impl CalcitTypeAnnotation {
   }
 
   fn impl_matches_trait(imp: &CalcitImpl, expected_trait: &CalcitTrait) -> bool {
-    imp.matches_trait_reference(expected_trait)
+    let Some(origin) = imp.origin() else {
+      return false;
+    };
+    if expected_trait.validate_reachable_method_schemas().is_err() || origin.validate_reachable_method_schemas().is_err() {
+      return false;
+    }
+    origin
+      .normalized_reachable_traits()
+      .is_ok_and(|traits| traits.iter().any(|actual| Self::trait_references_match(actual, expected_trait)))
+  }
+
+  fn trait_annotation_proves(actual: &CalcitTrait, expected: &CalcitTrait) -> bool {
+    if expected.validate_reachable_method_schemas().is_err() || actual.validate_reachable_method_schemas().is_err() {
+      return false;
+    }
+    actual
+      .normalized_reachable_traits()
+      .is_ok_and(|traits| traits.iter().any(|reachable| Self::trait_references_match(reachable, expected)))
   }
 
   /// Bootstrap metadata used only before a core impl list has been evaluated.
@@ -3270,13 +3287,13 @@ impl CalcitTypeAnnotation {
 
   fn satisfies_trait_bound(&self, expected_trait: &CalcitTrait) -> bool {
     match self {
-      Self::Trait(actual_trait) if Self::trait_references_match(actual_trait, expected_trait) => {
+      Self::Trait(actual_trait) if Self::trait_annotation_proves(actual_trait, expected_trait) => {
         return true;
       }
       Self::TraitSet(actual_traits)
         if actual_traits
           .iter()
-          .any(|actual_trait| Self::trait_references_match(actual_trait, expected_trait)) =>
+          .any(|actual_trait| Self::trait_annotation_proves(actual_trait, expected_trait)) =>
       {
         return true;
       }
@@ -4975,6 +4992,40 @@ mod tests {
       unreachable!();
     };
     assert!(CalcitTypeAnnotation::Trait(dom_element).satisfies_trait_bound(evaluated_dom_element));
+  }
+
+  #[test]
+  fn transitive_trait_requirements_prove_bounds_but_invalid_schemas_do_not() {
+    let required = Arc::new(
+      CalcitTrait::new(
+        EdnTag::new("Display"),
+        vec![EdnTag::new("display")],
+        vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+      )
+      .with_definition_ref("app.display", "Display"),
+    );
+    let mut composite = CalcitTrait::new(
+      EdnTag::new("Widget"),
+      vec![EdnTag::new("render")],
+      vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+    )
+    .with_definition_ref("app.widget", "Widget");
+    composite.requires = Arc::new(vec![required.clone()]);
+    let annotation = CalcitTypeAnnotation::Trait(Arc::new(composite));
+    assert!(annotation.satisfies_trait_bound(required.as_ref()));
+
+    let invalid = CalcitTrait {
+      runtime_id: None,
+      definition_ref: Some(Arc::from("app.invalid/Broken")),
+      name: EdnTag::new("Broken"),
+      methods: Arc::new(vec![EdnTag::new("missing")]),
+      defaults: Arc::new(vec![None]),
+      method_types: Arc::new(vec![]),
+      member_kinds: Arc::new(vec![crate::calcit::CalcitTraitMemberKind::Method]),
+      requires: Arc::new(vec![]),
+    };
+    let invalid_annotation = CalcitTypeAnnotation::Trait(Arc::new(invalid.clone()));
+    assert!(!invalid_annotation.satisfies_trait_bound(&invalid));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6276,7 +6276,17 @@ fn validate_method_call(
     ImplMethodResolution::Selected(_) => return Ok(()),
     ImplMethodResolution::Ambiguous(candidates) if strict_types_enabled() => {
       let origins = candidates.iter().map(impl_candidate_origin).collect::<Vec<_>>();
-      let duplicate_origin = origins.iter().skip(1).all(|origin| origin == &origins[0]);
+      let duplicate_origin = candidates
+        .first()
+        .and_then(|candidate| candidate.impl_value.origin())
+        .is_some_and(|first_origin| {
+          candidates.iter().skip(1).all(|candidate| {
+            candidate
+              .impl_value
+              .origin()
+              .is_some_and(|origin| origin.has_same_origin(first_origin))
+          })
+        });
       let (code, detail) = if duplicate_origin {
         (
           "E_DUPLICATE_TRAIT_IMPL",

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2093,8 +2093,8 @@ fn preprocess_list_call(
               processed_args = processed_args.push(processed?);
             }
             let processed_args = CalcitList::from(processed_args);
-            if is_display_contract {
-              validate_method_call(&typed_method, &processed_args, scope_types, call_stack)?;
+            if strict_types_enabled() || is_display_contract {
+              validate_method_call(&typed_method, &processed_args, scope_types, file_ns, call_stack)?;
             }
             check_struct_method_args(&typed_method, &processed_args, scope_types, file_ns, &def_name, check_warnings);
             require_js_ffi_feature_for_operation(&typed_method, file_ns, def_name.as_ref(), check_warnings, call_stack)?;
@@ -2766,7 +2766,7 @@ fn preprocess_list_call(
 
         // Check for struct field access after processing arguments
         let processed_args = CalcitList::from(ys.drop_left()); // Skip the head, convert to CalcitList
-        validate_method_call(&head_form, &processed_args, scope_types, call_stack)?;
+        validate_method_call(&head_form, &processed_args, scope_types, file_ns, call_stack)?;
         check_struct_field_access(&head_form, &processed_args, scope_types, file_ns, call_stack, check_warnings);
         check_struct_update_fields(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
         check_struct_method_args(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
@@ -4554,8 +4554,10 @@ fn check_struct_method_args(
   };
 
   if let Some(traits) = trait_list_from_type(type_value.as_ref())
-    && let Some((trait_def, method_type)) = find_trait_method_type(&traits, method_name.as_ref())
+    && let Some(candidate) = selected_trait_method(&traits, method_name.as_ref())
   {
+    let trait_def = candidate.trait_def;
+    let method_type = candidate.method_type;
     let Some(signature) = method_type.as_function() else {
       return;
     };
@@ -4818,7 +4820,7 @@ fn check_struct_method_args(
 /// return contracts are available while the callback body is checked.
 fn expected_method_argument_types(type_value: &CalcitTypeAnnotation, method_name: &str) -> Option<Vec<Arc<CalcitTypeAnnotation>>> {
   let signature = if let Some(traits) = trait_list_from_type(type_value) {
-    find_trait_method_type(&traits, method_name).map(|(_, method_type)| method_type.clone())?
+    selected_trait_method(&traits, method_name).map(|candidate| candidate.method_type)?
   } else {
     let impl_values = get_impls_from_type(type_value)?;
     let method_entry = find_method_entry_for_type(type_value, &impl_values, method_name)?;
@@ -5605,60 +5607,41 @@ fn warn_on_method_name_conflict(
     return;
   };
 
-  let Some(impl_values) = get_impls_from_type(type_value.as_ref()) else {
-    return;
-  };
-
-  if impl_values.len() < 2 {
-    return;
-  }
-
-  let last_wins = core_impl_list_symbol_from_type_annotation(type_value.as_ref()).is_none();
-  let matched_impls: Vec<&Arc<CalcitImpl>> = if last_wins {
-    impl_values
-      .iter()
-      .rev()
-      .filter(|imp| imp.get(method_name.as_ref()).is_some() && imp.origin().is_some())
-      .collect()
-  } else {
-    impl_values
-      .iter()
-      .filter(|imp| imp.get(method_name.as_ref()).is_some() && imp.origin().is_some())
-      .collect()
-  };
-
-  if matched_impls.len() < 2 {
-    return;
-  }
-
-  let mut trait_names: Vec<String> = vec![];
-  let mut seen = HashSet::new();
-  for imp in &matched_impls {
-    if let Some(origin) = imp.origin() {
-      let trait_name = origin.name.to_string();
-      if seen.insert(trait_name.clone()) {
-        trait_names.push(trait_name);
+  let candidates = if let Some(traits) = trait_list_from_type(type_value.as_ref()) {
+    match resolve_trait_method(&traits, method_name.as_ref()) {
+      TraitMethodResolution::Ambiguous(candidates) => candidates
+        .iter()
+        .map(|candidate| candidate.trait_def.origin_label())
+        .collect::<Vec<_>>(),
+      TraitMethodResolution::Invalid(error) => {
+        let message = format!("[Warn] method `.{method_name}` cannot use invalid trait metadata in {file_ns}/{def_name}: {error}");
+        if let Some(loc) = head.get_location().or_else(|| receiver.get_location()) {
+          gen_check_warning_with_location(message, loc, check_warnings);
+        } else {
+          gen_check_warning(message, file_ns, check_warnings);
+        }
+        return;
       }
+      _ => return,
     }
-  }
-
-  if trait_names.len() < 2 {
-    return;
-  }
-
-  let selected_trait = matched_impls
-    .first()
-    .and_then(|imp| imp.origin())
-    .map(|origin| origin.name.to_string())
-    .unwrap_or_else(|| "<unknown>".to_string());
+  } else {
+    let Some(impl_values) = get_impls_from_type(type_value.as_ref()) else {
+      return;
+    };
+    match resolve_impl_method(type_value.as_ref(), &impl_values, method_name.as_ref()) {
+      ImplMethodResolution::Ambiguous(candidates) => candidates.iter().map(impl_candidate_origin).collect::<Vec<_>>(),
+      _ => return,
+    }
+  };
+  let selected_origin = candidates.first().cloned().unwrap_or_else(|| "<unknown>".to_owned());
 
   let message = format!(
-    "[Warn] method `.{}` has multiple trait candidates ({}) in {}/{}; current dispatch picks `{}` by precedence, use `&trait-call` to disambiguate",
+    "[Warn] method `.{}` has multiple origin candidates ({}) in {}/{}; compatibility dispatch picks `{}` by precedence, use `&trait-call` to disambiguate",
     method_name,
-    trait_names.join(", "),
+    candidates.join(", "),
     file_ns,
     def_name,
-    selected_trait,
+    selected_origin,
   );
 
   if let Some(loc) = head.get_location().or_else(|| receiver.get_location()) {
@@ -5828,10 +5811,27 @@ fn try_inline_method_call(
       let Some(impl_values) = get_impls_from_type(type_ref) else {
         return Ok(None);
       };
-      let Some((_impl_index, impl_value, method_entry)) = find_method_entry_with_impl(type_ref, &impl_values, method_name.as_ref())
-      else {
-        return Ok(None);
+      let selected = match resolve_impl_method(type_ref, &impl_values, method_name.as_ref()) {
+        ImplMethodResolution::Missing => return Ok(None),
+        ImplMethodResolution::Selected(candidate) => candidate,
+        ImplMethodResolution::Ambiguous(mut candidates) => {
+          if strict_types_enabled() {
+            let origins = candidates.iter().map(impl_candidate_origin).collect::<Vec<_>>().join(", ");
+            return Err(CalcitErr::use_msg_stack_location_with_code(
+              CalcitErrKind::Type,
+              format!(
+                "ambiguous strict method `.{method_name}` has candidates from {origins}; use `&trait-call Trait :{method_name} receiver ...` to select a nominal trait origin"
+              ),
+              "E_AMBIGUOUS_TRAIT_METHOD",
+              call_stack,
+              head.get_location(),
+            ));
+          }
+          candidates.remove(0)
+        }
       };
+      let impl_value = selected.impl_value;
+      let method_entry = selected.entry;
 
       if let Some(callable_head) =
         pick_callable_from_method_entry(method_entry, impl_value, type_ref, method_name.as_ref(), file_ns, call_stack)?
@@ -5999,6 +5999,15 @@ fn nominal_callable_owner_deps(target_ns: &str, impl_value: &CalcitImpl, receive
   if let Some(owner_def) = program::find_source_def_for_runtime_value(target_ns, &Calcit::Impl(impl_value.clone())) {
     deps.push(program::ensure_def_id(target_ns, owner_def.as_ref()));
   }
+  if let Some(origin_ref) = impl_value.origin().and_then(|origin| origin.definition_ref.as_deref())
+    && let Some((trait_ns, trait_def)) = origin_ref.rsplit_once('/')
+    && program::has_def_code(trait_ns, trait_def)
+  {
+    // Defaults and method schemas belong to the nominal trait definition.
+    // Keeping this edge invalidates a synthesized direct callable when either
+    // changes during incremental compilation or hot reload.
+    deps.push(program::ensure_def_id(trait_ns, trait_def));
+  }
 
   let type_ref = match receiver_type {
     CalcitTypeAnnotation::TypeRef(path, _) => Some(path.as_ref()),
@@ -6135,28 +6144,6 @@ fn build_inlined_call(callable_head: Calcit, args: &CalcitList, scope_types: &Sc
   Calcit::from(CalcitList::executable(call_nodes, kind))
 }
 
-fn find_method_entry_with_impl<'a>(
-  type_ref: &CalcitTypeAnnotation,
-  impls: &'a [Arc<CalcitImpl>],
-  name: &str,
-) -> Option<(usize, &'a Arc<CalcitImpl>, &'a Calcit)> {
-  let last_wins = core_impl_list_symbol_from_type_annotation(type_ref).is_none();
-  if last_wins {
-    for (idx, imp) in impls.iter().enumerate().rev() {
-      if let Some(entry) = imp.get(name) {
-        return Some((idx, imp, entry));
-      }
-    }
-  } else {
-    for (idx, imp) in impls.iter().enumerate() {
-      if let Some(entry) = imp.get(name) {
-        return Some((idx, imp, entry));
-      }
-    }
-  }
-  None
-}
-
 fn append_string_method_receiver_hint(mut message: String, method_name: &str, type_desc: &str) -> String {
   let replacement = match method_name {
     "trim" => "trim",
@@ -6173,6 +6160,7 @@ fn validate_method_call(
   head: &Calcit,
   args: &CalcitList,
   scope_types: &ScopeTypes,
+  file_ns: &str,
   call_stack: &CallStackList,
 ) -> Result<(), CalcitErr> {
   // Only validate Method(Invoke) calls
@@ -6200,14 +6188,36 @@ fn validate_method_call(
 
   if let Some(traits) = trait_list_from_type(type_value.as_ref()) {
     let method_str = method_name.as_ref();
-    if traits.iter().rev().any(|trait_def| {
-      trait_def
-        .methods
-        .iter()
-        .zip(trait_def.member_kinds.iter())
-        .any(|(method, kind)| *kind == CalcitTraitMemberKind::Method && method.ref_str() == method_str)
-    }) {
-      return Ok(());
+    match resolve_trait_method(&traits, method_str) {
+      TraitMethodResolution::Selected(_) => return Ok(()),
+      TraitMethodResolution::Ambiguous(candidates) if strict_types_enabled() => {
+        let origins = candidates
+          .iter()
+          .map(|candidate| candidate.trait_def.origin_label())
+          .collect::<Vec<_>>()
+          .join(", ");
+        return Err(CalcitErr::use_msg_stack_location_with_code(
+          CalcitErrKind::Type,
+          format!(
+            "ambiguous strict method `.{method_name}` is declared by {origins}; use `&trait-call Trait :{method_name} receiver ...` to select a nominal trait origin"
+          ),
+          "E_AMBIGUOUS_TRAIT_METHOD",
+          call_stack,
+          head.get_location(),
+        ));
+      }
+      TraitMethodResolution::Ambiguous(_) => return Ok(()),
+      TraitMethodResolution::Invalid(error) if strict_types_enabled() => {
+        return Err(CalcitErr::use_msg_stack_location_with_code(
+          CalcitErrKind::Type,
+          error,
+          "E_INVALID_TRAIT_SCHEMA",
+          call_stack,
+          head.get_location(),
+        ));
+      }
+      TraitMethodResolution::Invalid(_) => return Ok(()),
+      TraitMethodResolution::Missing => {}
     }
 
     let methods_list = collect_trait_method_names(&traits).join(" ");
@@ -6248,11 +6258,46 @@ fn validate_method_call(
 
   // Check if method exists in the impls
   let method_str = method_name.as_ref();
-  if impl_values
-    .iter()
-    .any(|struct_def| struct_def.fields().iter().any(|field| field.ref_str() == method_str))
-  {
-    return Ok(()); // Method found, validation passed
+  match resolve_impl_method(type_value.as_ref(), &impl_values, method_str) {
+    ImplMethodResolution::Selected(candidate)
+      if strict_types_enabled() && should_emit_project_source_lint(file_ns) && candidate.impl_value.is_inherent() =>
+    {
+      return Err(CalcitErr::use_msg_stack_location_with_code(
+        CalcitErrKind::Type,
+        format!(
+          "strict method `.{method_name}` resolves only through originless legacy impl bag `{}`; define a nominal trait with `deftrait`/`defimpl`, or call a typed named function directly",
+          candidate.impl_value.name()
+        ),
+        "E_ORIGINLESS_METHOD_DISPATCH",
+        call_stack,
+        head.get_location(),
+      ));
+    }
+    ImplMethodResolution::Selected(_) => return Ok(()),
+    ImplMethodResolution::Ambiguous(candidates) if strict_types_enabled() => {
+      let origins = candidates.iter().map(impl_candidate_origin).collect::<Vec<_>>();
+      let duplicate_origin = origins.iter().skip(1).all(|origin| origin == &origins[0]);
+      let (code, detail) = if duplicate_origin {
+        (
+          "E_DUPLICATE_TRAIT_IMPL",
+          "multiple implementations of the same nominal trait origin",
+        )
+      } else {
+        ("E_AMBIGUOUS_TRAIT_METHOD", "multiple nominal trait origins")
+      };
+      return Err(CalcitErr::use_msg_stack_location_with_code(
+        CalcitErrKind::Type,
+        format!(
+          "ambiguous strict method `.{method_name}` has {detail}: {}; use `&trait-call Trait :{method_name} receiver ...` when the origins differ, and remove duplicate impl attachments when they are the same",
+          origins.join(", ")
+        ),
+        code,
+        call_stack,
+        head.get_location(),
+      ));
+    }
+    ImplMethodResolution::Ambiguous(_) => return Ok(()),
+    ImplMethodResolution::Missing => {}
   }
 
   // Method not found, generate error
@@ -6815,18 +6860,110 @@ fn annotation_dynamic_weight(type_value: &CalcitTypeAnnotation) -> usize {
   }
 }
 
-fn find_trait_method_type<'a>(
-  traits: &'a [Arc<CalcitTrait>],
-  method_name: &str,
-) -> Option<(&'a CalcitTrait, &'a Arc<CalcitTypeAnnotation>)> {
+#[derive(Debug)]
+struct TraitMethodCandidate {
+  trait_def: Arc<CalcitTrait>,
+  method_type: Arc<CalcitTypeAnnotation>,
+}
+
+#[derive(Debug)]
+enum TraitMethodResolution {
+  Missing,
+  Selected(TraitMethodCandidate),
+  Ambiguous(Vec<TraitMethodCandidate>),
+  Invalid(String),
+}
+
+/// Resolve a trait-set method once for checking, callback inference and
+/// diagnostics. Candidates are de-duplicated by nominal origin, never by the
+/// short trait name. The vector remains in compatibility precedence order.
+fn resolve_trait_method(traits: &[Arc<CalcitTrait>], method_name: &str) -> TraitMethodResolution {
+  let mut reachable: Vec<Arc<CalcitTrait>> = vec![];
   for trait_def in traits.iter().rev() {
-    if let Some(method_idx) = trait_def.method_index(method_name)
-      && let Some(method_type) = trait_def.method_types.get(method_idx)
+    if let Err(error) = trait_def.validate_reachable_method_schemas() {
+      return TraitMethodResolution::Invalid(error);
+    }
+    let Ok(required) = trait_def.normalized_reachable_traits() else {
+      unreachable!("schema validation already checked requires cycles")
+    };
+    for item in std::iter::once(trait_def.clone()).chain(required.into_iter().filter(|item| !item.has_same_origin(trait_def.as_ref())))
     {
-      return Some((trait_def.as_ref(), method_type));
+      if !reachable.iter().any(|existing| existing.has_same_origin(item.as_ref())) {
+        reachable.push(item);
+      }
     }
   }
-  None
+
+  let mut candidates: Vec<TraitMethodCandidate> = vec![];
+  for trait_def in reachable {
+    let Some(method_idx) = trait_def.method_index(method_name) else {
+      continue;
+    };
+    let Some(method_type) = trait_def.method_types.get(method_idx).cloned() else {
+      return TraitMethodResolution::Invalid(format!(
+        "trait {} method .{method_name} is missing signature metadata",
+        trait_def.origin_label()
+      ));
+    };
+    if candidates
+      .iter()
+      .any(|candidate| candidate.trait_def.has_same_origin(trait_def.as_ref()))
+    {
+      continue;
+    }
+    candidates.push(TraitMethodCandidate { trait_def, method_type });
+  }
+  match candidates.len() {
+    0 => TraitMethodResolution::Missing,
+    1 => TraitMethodResolution::Selected(candidates.remove(0)),
+    _ => TraitMethodResolution::Ambiguous(candidates),
+  }
+}
+
+fn selected_trait_method(traits: &[Arc<CalcitTrait>], method_name: &str) -> Option<TraitMethodCandidate> {
+  match resolve_trait_method(traits, method_name) {
+    TraitMethodResolution::Selected(candidate) => Some(candidate),
+    TraitMethodResolution::Ambiguous(mut candidates) => Some(candidates.remove(0)),
+    TraitMethodResolution::Missing | TraitMethodResolution::Invalid(_) => None,
+  }
+}
+
+#[derive(Debug)]
+struct ImplMethodCandidate<'a> {
+  impl_value: &'a Arc<CalcitImpl>,
+  entry: &'a Calcit,
+}
+
+#[derive(Debug)]
+enum ImplMethodResolution<'a> {
+  Missing,
+  Selected(ImplMethodCandidate<'a>),
+  Ambiguous(Vec<ImplMethodCandidate<'a>>),
+}
+
+fn resolve_impl_method<'a>(type_ref: &CalcitTypeAnnotation, impls: &'a [Arc<CalcitImpl>], name: &str) -> ImplMethodResolution<'a> {
+  let last_wins = core_impl_list_symbol_from_type_annotation(type_ref).is_none();
+  let ordered: Box<dyn Iterator<Item = &'a Arc<CalcitImpl>>> = if last_wins {
+    Box::new(impls.iter().rev())
+  } else {
+    Box::new(impls.iter())
+  };
+  let candidates: Vec<_> = ordered
+    .filter_map(|impl_value| impl_value.get(name).map(|entry| ImplMethodCandidate { impl_value, entry }))
+    .collect();
+  match candidates.len() {
+    0 => ImplMethodResolution::Missing,
+    1 => ImplMethodResolution::Selected(candidates.into_iter().next().expect("checked one candidate")),
+    _ => ImplMethodResolution::Ambiguous(candidates),
+  }
+}
+
+fn impl_candidate_origin(candidate: &ImplMethodCandidate<'_>) -> String {
+  candidate
+    .impl_value
+    .origin()
+    .map(|origin| origin.origin_label())
+    .unwrap_or_else(|| format!("<originless>/{}", candidate.impl_value.name()))
 }
 
 pub(crate) fn find_trait_field_type<'a>(
@@ -6898,7 +7035,7 @@ pub fn static_method_descriptors(type_value: &CalcitTypeAnnotation) -> Option<Ve
         if seen.insert(name.clone()) {
           methods.push(StaticMethodDescriptor {
             name,
-            origin: trait_def.name.ref_str().to_owned(),
+            origin: trait_def.origin_label(),
           });
         }
       }
@@ -6917,7 +7054,10 @@ pub fn static_method_descriptors(type_value: &CalcitTypeAnnotation) -> Option<Ve
     let mut methods = vec![];
 
     for imp in ordered_impls {
-      let origin = imp.trait_name().unwrap_or_else(|| imp.name()).ref_str().to_owned();
+      let origin = imp
+        .origin()
+        .map(|trait_def| trait_def.origin_label())
+        .unwrap_or_else(|| format!("<originless>/{}", imp.name()));
       for field in imp.fields().iter() {
         let name = format!(".{}", field.ref_str());
         if seen.insert(name.clone()) {
@@ -6942,28 +7082,12 @@ pub fn static_method_descriptors(type_value: &CalcitTypeAnnotation) -> Option<Ve
   }
 }
 
-fn find_method_entry<'a>(impls: &'a [Arc<CalcitImpl>], name: &str, last_wins: bool) -> Option<&'a Calcit> {
-  if last_wins {
-    for imp in impls.iter().rev() {
-      if let Some(entry) = imp.get(name) {
-        return Some(entry);
-      }
-    }
-  } else {
-    for imp in impls.iter() {
-      if let Some(entry) = imp.get(name) {
-        return Some(entry);
-      }
-    }
-  }
-  None
-}
-
 fn find_method_entry_for_type<'a>(type_ref: &CalcitTypeAnnotation, impls: &'a [Arc<CalcitImpl>], name: &str) -> Option<&'a Calcit> {
-  // builtin impl lists are ordered by priority in calcit-core
-  let last_wins = core_impl_list_symbol_from_type_annotation(type_ref).is_none();
-  // user-defined values: impl-traits appends, so later impls override earlier ones
-  find_method_entry(impls, name, last_wins)
+  match resolve_impl_method(type_ref, impls, name) {
+    ImplMethodResolution::Selected(candidate) => Some(candidate.entry),
+    ImplMethodResolution::Ambiguous(mut candidates) => Some(candidates.remove(0).entry),
+    ImplMethodResolution::Missing => None,
+  }
 }
 
 /// Describe the type for error messages
@@ -11206,18 +11330,167 @@ mod tests {
       vec![
         StaticMethodDescriptor {
           name: ".high".to_owned(),
-          origin: "HighImpl".to_owned(),
+          origin: "<originless>/HighImpl".to_owned(),
         },
         StaticMethodDescriptor {
           name: ".shared".to_owned(),
-          origin: "HighImpl".to_owned(),
+          origin: "<originless>/HighImpl".to_owned(),
         },
         StaticMethodDescriptor {
           name: ".low".to_owned(),
-          origin: "LowImpl".to_owned(),
+          origin: "<originless>/LowImpl".to_owned(),
         },
       ]
     );
+  }
+
+  fn source_trait(ns: &str, name: &str, method: &str) -> Arc<CalcitTrait> {
+    Arc::new(
+      CalcitTrait::new(
+        EdnTag::new(name),
+        vec![EdnTag::new(method)],
+        vec![Arc::new(CalcitTypeAnnotation::DynFn)],
+      )
+      .with_definition_ref(ns, name),
+    )
+  }
+
+  fn method_test_receiver(type_info: Arc<CalcitTypeAnnotation>) -> Calcit {
+    Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&Arc::from("value")),
+      sym: Arc::from("value"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.trait-origin"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+      type_info,
+    })
+  }
+
+  #[test]
+  fn strict_trait_set_rejects_same_short_name_from_distinct_origins() {
+    let _guard = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let left = source_trait("app.a", "Show", "render");
+    let right = source_trait("app.b", "Show", "render");
+    let receiver_type = Arc::new(CalcitTypeAnnotation::TraitSet(Arc::new(vec![left, right])));
+    let receiver = method_test_receiver(receiver_type.clone());
+    let head = Calcit::Method(Arc::from("render"), calcit::MethodKind::Invoke(receiver_type));
+    let args = CalcitList::from(&[receiver][..]);
+
+    let error = validate_method_call(&head, &args, &ScopeTypes::new(), "tests.trait-origin", &CallStackList::default())
+      .expect_err("strict dispatch must not pick between distinct Show origins");
+    assert_eq!(error.code(), Some("E_AMBIGUOUS_TRAIT_METHOD"));
+    assert!(error.msg.contains("app.a/Show"), "error: {error}");
+    assert!(error.msg.contains("app.b/Show"), "error: {error}");
+    assert!(error.msg.contains("&trait-call"), "error: {error}");
+  }
+
+  #[test]
+  fn compatibility_trait_set_keeps_historical_last_wins_order() {
+    let left = source_trait("app.a", "Show", "render");
+    let right = source_trait("app.b", "Show", "render");
+    let traits = vec![left, right];
+    let candidate = selected_trait_method(&traits, "render").expect("compatibility candidate");
+    assert_eq!(candidate.trait_def.origin_label(), "app.b/Show");
+  }
+
+  #[test]
+  fn strict_nominal_dispatch_rejects_duplicate_impls_of_one_trait() {
+    let _guard = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let show = source_trait("app.shared", "Show", "render");
+    let make_impl = |name: &str| {
+      Arc::new(CalcitImpl {
+        name: EdnTag::new(name),
+        origin: Some(show.clone()),
+        fields: Arc::new(vec![EdnTag::new("render")]),
+        values: Arc::new(vec![Calcit::Nil]),
+      })
+    };
+    let mut nominal = CalcitStructDef::from_fields(EdnTag::new("Card"), vec![]);
+    nominal.impls = vec![make_impl("FirstShow"), make_impl("SecondShow")];
+    let receiver_type = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(nominal)));
+    let receiver = method_test_receiver(receiver_type.clone());
+    let head = Calcit::Method(Arc::from("render"), calcit::MethodKind::Invoke(receiver_type));
+
+    let error = validate_method_call(
+      &head,
+      &CalcitList::from(&[receiver][..]),
+      &ScopeTypes::new(),
+      "tests.trait-origin",
+      &CallStackList::default(),
+    )
+    .expect_err("strict dispatch must reject duplicate impl attachments");
+    assert_eq!(error.code(), Some("E_DUPLICATE_TRAIT_IMPL"));
+    assert!(error.msg.contains("app.shared/Show"), "error: {error}");
+  }
+
+  #[test]
+  fn strict_nominal_dispatch_rejects_originless_legacy_method_bag() {
+    let _guard = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let mut nominal = CalcitStructDef::from_fields(EdnTag::new("Card"), vec![]);
+    nominal.impls = vec![Arc::new(CalcitImpl {
+      name: EdnTag::new("LegacyRenderMethods"),
+      origin: None,
+      fields: Arc::new(vec![EdnTag::new("render")]),
+      values: Arc::new(vec![Calcit::Nil]),
+    })];
+    let receiver_type = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(nominal)));
+    let receiver = method_test_receiver(receiver_type.clone());
+    let head = Calcit::Method(Arc::from("render"), calcit::MethodKind::Invoke(receiver_type));
+
+    let error = validate_method_call(
+      &head,
+      &CalcitList::from(&[receiver][..]),
+      &ScopeTypes::new(),
+      "tests.trait-origin",
+      &CallStackList::default(),
+    )
+    .expect_err("strict typed source must not dispatch through an originless method bag");
+    assert_eq!(error.code(), Some("E_ORIGINLESS_METHOD_DISPATCH"));
+    assert!(error.msg.contains("LegacyRenderMethods"), "error: {error}");
+    assert!(error.msg.contains("deftrait"), "error: {error}");
+  }
+
+  #[test]
+  fn compatibility_dispatch_keeps_precedence_and_warns_with_full_origins() {
+    let _guard = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(false);
+    let _warn = WarnDynMethodGuard::new(true);
+    let left = source_trait("app.a", "Show", "render");
+    let right = source_trait("app.b", "Show", "render");
+    let make_impl = |name: &str, origin: Arc<CalcitTrait>| {
+      Arc::new(CalcitImpl {
+        name: EdnTag::new(name),
+        origin: Some(origin),
+        fields: Arc::new(vec![EdnTag::new("render")]),
+        values: Arc::new(vec![Calcit::Str(Arc::from(name))]),
+      })
+    };
+    let mut nominal = CalcitStructDef::from_fields(EdnTag::new("Card"), vec![]);
+    nominal.impls = vec![make_impl("LeftShow", left), make_impl("RightShow", right)];
+    let receiver_type = Arc::new(CalcitTypeAnnotation::StructValue(Arc::new(nominal)));
+    let receiver = method_test_receiver(receiver_type.clone());
+    let head = Calcit::Method(Arc::from("render"), calcit::MethodKind::Invoke(receiver_type.clone()));
+    let args = CalcitList::from(&[receiver][..]);
+
+    validate_method_call(&head, &args, &ScopeTypes::new(), "tests.trait-origin", &CallStackList::default())
+      .expect("compatibility mode retains last-wins dispatch");
+    let impls = get_impls_from_type(receiver_type.as_ref()).expect("nominal impls");
+    let ImplMethodResolution::Ambiguous(candidates) = resolve_impl_method(receiver_type.as_ref(), &impls, "render") else {
+      panic!("two trait origins must remain visible")
+    };
+    assert_eq!(impl_candidate_origin(&candidates[0]), "app.b/Show");
+
+    let warnings = RefCell::new(vec![]);
+    warn_on_method_name_conflict(&head, &args, &ScopeTypes::new(), "tests.trait-origin", "demo", &warnings);
+    let message = warnings.borrow()[0].to_string();
+    assert!(message.contains("app.a/Show"), "warning: {message}");
+    assert!(message.contains("app.b/Show"), "warning: {message}");
+    assert!(message.contains("compatibility dispatch picks `app.b/Show`"), "warning: {message}");
   }
 
   #[test]
@@ -14190,6 +14463,61 @@ mod tests {
   }
 
   #[test]
+  fn nominal_callable_cache_tracks_trait_schema_owner() {
+    let _guard = lock_preprocess_test_state();
+    let owner_ns: Arc<str> = Arc::from("tests.trait-cache-owner");
+    program::install_internal_source_namespace(
+      owner_ns.clone(),
+      program::ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([
+          (
+            Arc::from("Render"),
+            program::ProgramDefEntry {
+              code: Calcit::Nil,
+              schema: calcit::DYNAMIC_TYPE.clone(),
+              doc: Arc::from(""),
+              examples: vec![],
+              ffi: None,
+            },
+          ),
+          (
+            Arc::from("CardRenderImpl"),
+            program::ProgramDefEntry {
+              code: Calcit::Nil,
+              schema: calcit::DYNAMIC_TYPE.clone(),
+              doc: Arc::from(""),
+              examples: vec![],
+              ffi: None,
+            },
+          ),
+        ]),
+      },
+    )
+    .expect("install cache owner fixture");
+    let origin = source_trait(owner_ns.as_ref(), "Render", "render");
+    let impl_value = CalcitImpl {
+      name: EdnTag::new("CardRenderImpl"),
+      origin: Some(origin),
+      fields: Arc::new(vec![EdnTag::new("render")]),
+      values: Arc::new(vec![Calcit::Nil]),
+    };
+    program::write_runtime_ready(&owner_ns, "CardRenderImpl", Calcit::Impl(impl_value.clone())).expect("install impl runtime fixture");
+
+    let deps = nominal_callable_owner_deps(
+      owner_ns.as_ref(),
+      &impl_value,
+      &CalcitTypeAnnotation::TypeRef(Arc::from("tests.trait-cache-owner/Card"), Arc::new(vec![])),
+    );
+    assert!(deps.contains(&program::ensure_def_id(&owner_ns, "CardRenderImpl")));
+    assert!(
+      deps.contains(&program::ensure_def_id(&owner_ns, "Render")),
+      "changing a trait method/default schema must invalidate its generated callable"
+    );
+    program::remove_internal_source_namespace(&owner_ns);
+  }
+
+  #[test]
   fn nominal_callable_tracks_inline_type_owner_or_falls_back_without_source() {
     let _guard = lock_preprocess_test_state();
     let owner_ns: Arc<str> = Arc::from("tests.inline-impl-owner");
@@ -14954,7 +15282,7 @@ mod tests {
     });
     let args = CalcitList::from(&[receiver][..]);
 
-    let error = validate_method_call(&head, &args, &ScopeTypes::new(), &CallStackList::default())
+    let error = validate_method_call(&head, &args, &ScopeTypes::new(), "tests.method", &CallStackList::default())
       .expect_err("trim should reject a non-String receiver through method validation");
     let message = error.to_string();
 
@@ -15209,7 +15537,7 @@ mod tests {
     let show_trait = Arc::new(crate::calcit::CalcitTrait::new(
       EdnTag::new("Renderable"),
       vec![EdnTag::new("show")],
-      vec![crate::calcit::DYNAMIC_TYPE.clone()],
+      vec![Arc::new(CalcitTypeAnnotation::DynFn)],
     ));
     let hint_generics = Calcit::List(Arc::new(CalcitList::from(&[
       Calcit::Symbol {
@@ -15359,7 +15687,7 @@ mod tests {
     let show_trait = Arc::new(crate::calcit::CalcitTrait::new(
       EdnTag::new("Renderable"),
       vec![EdnTag::new("show")],
-      vec![crate::calcit::DYNAMIC_TYPE.clone()],
+      vec![Arc::new(CalcitTypeAnnotation::DynFn)],
     ));
 
     let local_fn = CalcitLocal {

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -29,8 +29,8 @@ use cirru_edn::EdnTag;
 
 use super::{
   ScopeTypes, checked_call_contract::resolve_checked_call_contract, find_method_entry_for_type, find_trait_field_type,
-  find_trait_method_type, get_impls_from_type, resolve_local_type_refs_for_body, resolve_namespace_type_refs_for_body,
-  resolve_trait_def_from_source_code, tag_annotation, trait_is_external_object, trait_list_from_type,
+  get_impls_from_type, resolve_local_type_refs_for_body, resolve_namespace_type_refs_for_body, resolve_trait_def_from_source_code,
+  selected_trait_method, tag_annotation, trait_is_external_object, trait_list_from_type,
 };
 
 // ---------------------------------------------------------------------------
@@ -989,7 +989,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
             .and_then(|receiver| resolve_type_value(receiver, scope_types))
             .unwrap_or_else(|| receiver_hint.clone());
           let method_type = if let Some(traits) = trait_list_from_type(receiver_type.as_ref()) {
-            find_trait_method_type(&traits, method_name).map(|(_, method_type)| method_type.clone())?
+            selected_trait_method(&traits, method_name).map(|candidate| candidate.method_type)?
           } else {
             let impls = get_impls_from_type(receiver_type.as_ref())?;
             let method = find_method_entry_for_type(receiver_type.as_ref(), &impls, method_name)?;


### PR DESCRIPTION
Closes #844

## 中文

- 统一参数检查、返回类型推断、静态 lowering 与诊断所使用的 trait method candidate resolution，并以 nominal origin（`definition_ref` / runtime identity）区分候选。
- strict mode 对跨 trait 同名方法、同 origin 重复 impl、originless legacy method bag 分别给出稳定错误码；compat mode 保留既有 builtin/user 优先级并显示完整 origin。
- `&trait-call` 严格按完整 origin 选择，并在 strict runtime 拒绝同 trait 重复实现。
- requires closure 按 origin 去重、稳定排序并检测循环；不完整或不匹配的可达 schema/default 不再成为 `:where` 的 Proven 证据。
- 让生成的 nominal callable 依赖 trait definition，从而在 impl/default/schema 编辑与 hot reload 后失效旧静态分发缓存。
- 更新 trait 文档；审计 Respo/Recollect，真实 multiple-origin inventory 均为 0，无需消费者迁移。

## English

- Unifies trait method candidate resolution across argument checking, return inference, static lowering, and diagnostics, using nominal origin (`definition_ref` / runtime identity).
- Adds stable strict-mode errors for cross-trait ambiguity, duplicate same-origin impls, and originless legacy method bags; compatibility mode preserves existing builtin/user precedence and reports full origins.
- Keeps `&trait-call` exact-origin and rejects duplicate implementations of that origin at strict runtime.
- Normalizes requires closures by origin, detects cycles, and prevents incomplete or incompatible reachable schemas/defaults from proving `:where` bounds.
- Makes generated nominal callables depend on trait definitions so impl/default/schema edits and hot reload invalidate stale static dispatch.
- Updates trait documentation. Real Respo/Recollect multiple-origin inventories are both zero, so no consumer migration was needed.

## Verification / 验证

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (747 library, 308 native CLI, 23 WASM)
- `yarn compile`
- `yarn check-all` (native, JS, IR, WASM, benchmark smoke)
- `yarn check-agent-interface` (18/18)
- focused origin ambiguity, duplicate impl, originless bag, requires cycle/schema/default, compatibility order, cache invalidation, and explicit `&trait-call` tests
- Respo/Recollect `--compat-types --warn-dyn-method --check-only` inventories: 0 multiple-origin conflicts
