### PR TITLE
Bound recursive type analysis / 有界递归类型分析

### DIFF
--- a/editing-history/202609071609-bounded-type-analysis.md
+++ b/editing-history/202609071609-bounded-type-analysis.md
@@ -1,0 +1,27 @@
+# Bound high-risk type analysis paths / 有界化高风险类型分析路径
+
+## Summary / 概要
+
+- Replaced recursive generic substitution and type-variable scans with explicit worklists. Substitution caches results by source-node identity so shared subtype DAGs keep `Arc` sharing instead of being rebuilt repeatedly.
+- 将递归的泛型替换和类型变量扫描改为显式 worklist；替换过程按源节点身份缓存结果，确保共享子类型 DAG 继续复用 `Arc`，而不是重复重建。
+- Added an iterative compatibility fast path for List, Map, Option/Optional, Ref, Set, nominal TypeRef, Struct, and Enum layers, with a 16,384-node budget that rejects oversized relations rather than widening them to Dynamic.
+- 为 List、Map、Option/Optional、Ref、Set、具名 TypeRef、Struct 和 Enum 层增加迭代兼容检查快速路径；16,384 节点预算超限时稳定拒绝，不回退 Dynamic。
+- Guarded schema-alias and type-slot expansion against recursive symbolic cycles. Diagnostic rendering now truncates nested types after 32 levels with an explicit ellipsis marker.
+- 为 schema alias 与 type-slot 展开增加符号环保护；类型诊断在 32 层后使用明确省略号截断。
+- Corrected the misleading `CalcitStructDef::index_of` binary-search comment. Release measurements for 10,000 worst-position lookups were 3.3/12.7/31.8 ms at 32/256/1,024 fields, so this batch keeps the declaration-order scan instead of changing the public struct layout for a cache.
+- 修正 `CalcitStructDef::index_of` 误导性的二分查找注释。Release 模式下 10,000 次最坏位置查询在 32/256/1,024 字段时约为 3.3/12.7/31.8 ms，因此本批保留声明顺序扫描，不为缓存改变公共 struct 布局。
+
+## Evidence / 证据
+
+- Rust unit coverage includes 32/256/2,048-deep Map, Option, and nominal relations; 2,048-deep substitution/scan/rendering; shared-DAG identity; oversized relation rejection; recursive type-slot cleanup; and a real program registry alias cycle.
+- Rust 单测覆盖 32/256/2,048 层 Map、Option 与具名关系，2,048 层替换/扫描/渲染，共享 DAG 身份，超预算拒绝，递归 type-slot 清理，以及真实 program registry alias 环。
+- `cargo test`, `cargo clippy --all-targets -- -D warnings`, and `yarn check-all` pass across native, JavaScript, IR, WASM, static lowering, agent interface, and quality gates.
+- `cargo test`、`cargo clippy --all-targets -- -D warnings` 与 `yarn check-all` 全部通过，覆盖 native、JavaScript、IR、WASM、静态 lowering、Agent interface 与质量门禁。
+- Latest Calcium `main` at `5b63382` passes the deterministic diff/patch workload with the branch compiler. The real server listens on 5021, reads persisted EDN, and completes a browser WebSocket connect/disconnect; Vite 8.0.5 renders the login page without browser errors.
+- 最新 Calcium `main`（`5b63382`）使用本分支编译器通过确定性 diff/patch workload；真实服务端监听 5021、读取持久化 EDN，并完成浏览器 WebSocket 连接/断开；Vite 8.0.5 登录页正常渲染且无浏览器 error。
+
+## Follow-up boundary / 后续边界
+
+This is the first implementation slice of #845. A dedicated structured complexity diagnostic and broader relation-context caching remain in the issue; this commit does not claim to close it.
+
+这是 #845 的第一批实现。专用的结构化复杂度诊断与更广泛的关系上下文缓存仍留在该 Issue；本提交不宣称关闭 #845。

--- a/editing-history/202609071612-bounded-recursive-type-analysis.md
+++ b/editing-history/202609071612-bounded-recursive-type-analysis.md
@@ -1,0 +1,49 @@
+# Bound recursive type analysis / 有界递归类型分析
+
+Issue: calcit-lang/calcit#845
+
+## English
+
+- Added an iterative, pair-memoized relation path for deeply nested lists,
+  maps, options, references, nominal arguments, and shared type DAGs. A fixed
+  8,192-node budget returns an explicit complexity boundary instead of
+  authorizing a Dynamic fallback.
+- Made nominal data-schema identity traversal iterative and bounded. Protected
+  schema-alias expansion with relation-local cycle state so mutually recursive
+  named types remain valid while pure alias cycles are rejected explicitly.
+- Bounded diagnostic type rendering, and cached generic substitutions only
+  within one substitution call so shared subgraphs stay shared without leaking
+  bindings across entries or reloads.
+- Added a read-only field-index cache for structs with at least 32 fields. It
+  keys live immutable field allocations with `Weak` validation, preserves
+  declaration and first-match order, and does not reuse stale reload entries.
+- Added fixed depth 32/256/2048, shared-DAG, recursive Tree/Node, alias-cycle,
+  complexity-limit, diagnostic-bound, and width 32/256/1024 regressions. The
+  measurement tests report visits, worklist size, tracked payload memory,
+  allocator availability, and cold/warm time.
+- Validation: `cargo fmt`, 757 library tests, and clippy with all targets and
+  features passed. Calcium's generated-JavaScript smoke oracle passed all
+  no-op sharing, patch convergence, corruption, revision, and recovery checks.
+  Recompiling current Calcium with the new strict frontend independently finds
+  its existing `Option<dynamic>` generic boundary; this is recorded separately
+  from the #845 relation regression.
+
+## 中文
+
+- 为深层 List、Map、Option、Ref、名义类型参数及共享类型 DAG 增加显式 worklist
+  与成对访问记忆。固定 8,192 节点预算，超限时返回明确的 complexity boundary，
+  不允许借 Dynamic 静默放宽。
+- 将名义数据 schema identity 比较改为迭代且有界；schema alias 展开使用关系局部
+  的环状态，使合法具名互递归继续成立，同时明确拒绝纯 alias cycle。
+- 限制诊断类型渲染长度；泛型替换结果只在单次替换调用内缓存，保持共享子图，且不
+  将绑定泄漏到其他 entry 或 reload。
+- 为至少 32 个字段的宽 Struct 增加只读 field-index cache。缓存通过 `Weak` 校验
+  不可变 fields allocation，保留声明顺序与首个匹配语义，也不会复用失效的 reload
+  entry。
+- 增加固定深度 32/256/2048、共享 DAG、递归 Tree/Node、alias cycle、复杂度超限、
+  诊断截断以及宽度 32/256/1024 回归。度量测试记录访问数、worklist 大小、已跟踪
+  payload 内存、allocator 可用性与 cold/warm 时间。
+- 验证：`cargo fmt`、757 项库测试及 all-target/all-feature clippy 已通过。Calcium
+  生成 JavaScript 的 smoke oracle 通过 no-op 共享、patch 收敛、损坏检测、revision
+  与恢复全部断言。用新严格前端重新编译当前 Calcium 会独立暴露其既有
+  `Option<dynamic>` 泛型边界；该结果与 #845 类型关系回归分开记录。

--- a/editing-history/202609071612-bounded-recursive-type-analysis.md
+++ b/editing-history/202609071612-bounded-recursive-type-analysis.md
@@ -6,7 +6,7 @@ Issue: calcit-lang/calcit#845
 
 - Added an iterative, pair-memoized relation path for deeply nested lists,
   maps, options, references, nominal arguments, and shared type DAGs. A fixed
-  8,192-node budget returns an explicit complexity boundary instead of
+  16,384-node budget returns an explicit complexity boundary instead of
   authorizing a Dynamic fallback.
 - Made nominal data-schema identity traversal iterative and bounded. Protected
   schema-alias expansion with relation-local cycle state so mutually recursive
@@ -31,7 +31,7 @@ Issue: calcit-lang/calcit#845
 ## 中文
 
 - 为深层 List、Map、Option、Ref、名义类型参数及共享类型 DAG 增加显式 worklist
-  与成对访问记忆。固定 8,192 节点预算，超限时返回明确的 complexity boundary，
+  与成对访问记忆。固定 16,384 节点预算，超限时返回明确的 complexity boundary，
   不允许借 Dynamic 静默放宽。
 - 将名义数据 schema identity 比较改为迭代且有界；schema alias 展开使用关系局部
   的环状态，使合法具名互递归继续成立，同时明确拒绝纯 alias cycle。

--- a/editing-history/202609071631-guard-type-slot-proof-cycles.md
+++ b/editing-history/202609071631-guard-type-slot-proof-cycles.md
@@ -1,0 +1,15 @@
+# Guard type-slot proof cycles / 保护 type-slot proof 环
+
+## English
+
+- Apply the existing relation-local type-slot guard to static proof in both
+  directions, not only compatibility checks.
+- Return the explicit `RecursiveTypeSlot` boundary when a slot graph re-enters
+  itself, and add a regression for a two-slot cycle.
+
+## 中文
+
+- 将现有的关系局部 type-slot 环保护同时用于双向静态 proof，而不只用于
+  compatibility 检查。
+- slot 图重新进入自身时返回明确的 `RecursiveTypeSlot` boundary，并增加双 slot
+  环回归。

--- a/editing-history/202609071642-share-relation-and-render-budgets.md
+++ b/editing-history/202609071642-share-relation-and-render-budgets.md
@@ -1,0 +1,17 @@
+# Share relation and render budgets / 共享关系与渲染预算
+
+## English
+
+- Address review findings by sharing one compatibility visit budget across
+  nested signatures, aliases, slots, and recursive relation calls.
+- Thread the same diagnostic depth/node budget through function arguments,
+  rest arguments, return types, and wide nominal argument lists.
+- Add regressions for an oversized nested function relation and a deep,
+  1,024-argument function diagnostic.
+
+## 中文
+
+- 根据审查意见，让嵌套函数签名、alias、slot 及递归关系调用共享同一个
+  compatibility 访问预算。
+- 函数参数、rest 参数、返回值与宽名义参数列表共同使用诊断深度/节点预算。
+- 增加超宽嵌套函数关系，以及深返回值加 1,024 参数函数诊断的回归。

--- a/editing-history/202609071645-bound-wide-struct-cache.md
+++ b/editing-history/202609071645-bound-wide-struct-cache.md
@@ -1,0 +1,17 @@
+# Bound the wide Struct cache / 限制宽 Struct 缓存
+
+## English
+
+- Keep all live indexes when the 256-entry cache is full and send additional
+  definitions through the declaration-order linear fallback.
+- Bound cache admission by both 65,536 aggregate fields and 8 MiB of copied
+  field-name bytes per thread, in addition to the entry limit.
+- Add regressions proving an over-budget definition is not cached, earlier live
+  indexes remain present, and both aggregate resource limits reject overflow.
+
+## 中文
+
+- 256 项缓存已满时保留全部已有 live index，新增定义退回按声明顺序的线性查询。
+- 除 entry 数外，每线程缓存准入同时限制为累计 65,536 个字段与 8 MiB 复制字段名。
+- 增加回归，验证超预算定义不会进入缓存、已有 live index 不被清空，且两个累计资源
+  上限都会拒绝溢出。

--- a/src/calcit/calcit_struct.rs
+++ b/src/calcit/calcit_struct.rs
@@ -1,9 +1,23 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use cirru_edn::EdnTag;
 
 use super::{CalcitGenericBound, CalcitImpl, CalcitTypeAnnotation, type_annotation::same_data_schema_annotation};
+
+const STRUCT_FIELD_INDEX_CACHE_THRESHOLD: usize = 32;
+const STRUCT_FIELD_INDEX_CACHE_LIMIT: usize = 256;
+
+type FieldIndexCacheEntry = (Weak<Vec<EdnTag>>, Arc<HashMap<String, usize>>);
+
+thread_local! {
+  /// Wide struct definitions are immutable. Cache by the live `fields` Arc
+  /// allocation, not by name or declaration contents, so entry changes and hot
+  /// reloads cannot reuse an index from a stale nominal definition.
+  static STRUCT_FIELD_INDEX_CACHE: RefCell<HashMap<usize, FieldIndexCacheEntry>> = RefCell::new(HashMap::new());
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CalcitStructDef {
@@ -61,9 +75,50 @@ impl CalcitStructDef {
     }
   }
 
-  /// Binary search for the position of a field name (fields must be sorted)
+  /// Return the declaration-order field position. Small structs stay on the
+  /// allocation-free linear path; wide structs use a read-only pointer/Weak
+  /// cache without sorting or changing field layout.
   pub fn index_of(&self, y: &str) -> Option<usize> {
-    self.fields.iter().position(|f| f.ref_str() == y)
+    if self.fields.len() < STRUCT_FIELD_INDEX_CACHE_THRESHOLD {
+      return self.fields.iter().position(|field| field.ref_str() == y);
+    }
+
+    let cache_key = Arc::as_ptr(&self.fields) as usize;
+    STRUCT_FIELD_INDEX_CACHE.with(|cache| {
+      let mut cache = cache.borrow_mut();
+      if let Some((fields, index)) = cache.get(&cache_key)
+        && fields.upgrade().is_some_and(|fields| Arc::ptr_eq(&fields, &self.fields))
+      {
+        return index.get(y).copied();
+      }
+
+      if cache.len() >= STRUCT_FIELD_INDEX_CACHE_LIMIT {
+        cache.retain(|_, (fields, _)| fields.strong_count() > 0);
+        if cache.len() >= STRUCT_FIELD_INDEX_CACHE_LIMIT {
+          cache.clear();
+        }
+      }
+      let index = Arc::new(self.fields.iter().enumerate().fold(HashMap::new(), |mut index, (position, field)| {
+        // Preserve the historical `position` behavior for malformed
+        // duplicate declarations too: the first field wins.
+        index.entry(field.ref_str().to_owned()).or_insert(position);
+        index
+      }));
+      let result = index.get(y).copied();
+      cache.insert(cache_key, (Arc::downgrade(&self.fields), index));
+      result
+    })
+  }
+
+  #[cfg(test)]
+  fn has_cached_field_index(&self) -> bool {
+    let cache_key = Arc::as_ptr(&self.fields) as usize;
+    STRUCT_FIELD_INDEX_CACHE.with(|cache| {
+      cache
+        .borrow()
+        .get(&cache_key)
+        .is_some_and(|(fields, _)| fields.upgrade().is_some_and(|fields| Arc::ptr_eq(&fields, &self.fields)))
+    })
   }
 }
 
@@ -119,5 +174,44 @@ mod tests {
     let right = wrapper(nested_struct("beta.models"));
 
     assert!(!left.same_nominal_definition(&right));
+  }
+
+  #[test]
+  fn wide_struct_field_index_is_cached_without_changing_declaration_order() {
+    for width in [32, 256, 1_024] {
+      let fields = (0..width)
+        .map(|index| EdnTag::new(format!("field-{index:04}")))
+        .rev()
+        .collect::<Vec<_>>();
+      let definition = CalcitStructDef::from_fields(EdnTag::new("Wide"), fields.clone());
+      assert!(!definition.has_cached_field_index());
+      let cold_started = std::time::Instant::now();
+      assert_eq!(definition.index_of("field-0000"), Some(width - 1));
+      let cold_elapsed = cold_started.elapsed();
+      assert!(definition.has_cached_field_index());
+      let warm_started = std::time::Instant::now();
+      assert_eq!(definition.index_of(&format!("field-{:04}", width - 1)), Some(0));
+      let warm_elapsed = warm_started.elapsed();
+      assert_eq!(definition.fields.as_ref(), &fields, "cache must preserve declaration layout");
+      let reloaded = CalcitStructDef::from_fields(EdnTag::new("Wide"), fields.clone());
+      assert!(
+        !reloaded.has_cached_field_index(),
+        "a new entry allocation must not inherit the old cache"
+      );
+      eprintln!(
+        "struct-index width={width} cold-us={} warm-us={} cache=yes",
+        cold_elapsed.as_micros(),
+        warm_elapsed.as_micros()
+      );
+    }
+
+    let mut duplicate_fields = (0..32).map(|index| EdnTag::new(format!("field-{index:04}"))).collect::<Vec<_>>();
+    duplicate_fields[31] = duplicate_fields[0].clone();
+    let malformed = CalcitStructDef::from_fields(EdnTag::new("DuplicateWide"), duplicate_fields);
+    assert_eq!(
+      malformed.index_of("field-0000"),
+      Some(0),
+      "wide cache must preserve first-match semantics"
+    );
   }
 }

--- a/src/calcit/calcit_struct.rs
+++ b/src/calcit/calcit_struct.rs
@@ -9,8 +9,25 @@ use super::{CalcitGenericBound, CalcitImpl, CalcitTypeAnnotation, type_annotatio
 
 const STRUCT_FIELD_INDEX_CACHE_THRESHOLD: usize = 32;
 const STRUCT_FIELD_INDEX_CACHE_LIMIT: usize = 256;
+const STRUCT_FIELD_INDEX_CACHE_MAX_FIELDS: usize = 65_536;
+const STRUCT_FIELD_INDEX_CACHE_MAX_NAME_BYTES: usize = 8 * 1_024 * 1_024;
 
-type FieldIndexCacheEntry = (Weak<Vec<EdnTag>>, Arc<HashMap<String, usize>>);
+type FieldIndexCacheEntry = (Weak<Vec<EdnTag>>, Arc<HashMap<String, usize>>, usize);
+
+/// Decide whether one more immutable field index fits every thread-local cache
+/// budget. Field count bounds map overhead while copied-name bytes bound owned
+/// string payloads.
+fn field_index_cache_admissible(
+  entries: usize,
+  fields: usize,
+  name_bytes: usize,
+  added_fields: usize,
+  added_name_bytes: usize,
+) -> bool {
+  entries < STRUCT_FIELD_INDEX_CACHE_LIMIT
+    && fields.saturating_add(added_fields) <= STRUCT_FIELD_INDEX_CACHE_MAX_FIELDS
+    && name_bytes.saturating_add(added_name_bytes) <= STRUCT_FIELD_INDEX_CACHE_MAX_NAME_BYTES
+}
 
 thread_local! {
   /// Wide struct definitions are immutable. Cache by the live `fields` Arc
@@ -86,17 +103,25 @@ impl CalcitStructDef {
     let cache_key = Arc::as_ptr(&self.fields) as usize;
     STRUCT_FIELD_INDEX_CACHE.with(|cache| {
       let mut cache = cache.borrow_mut();
-      if let Some((fields, index)) = cache.get(&cache_key)
+      if let Some((fields, index, _)) = cache.get(&cache_key)
         && fields.upgrade().is_some_and(|fields| Arc::ptr_eq(&fields, &self.fields))
       {
         return index.get(y).copied();
       }
 
-      if cache.len() >= STRUCT_FIELD_INDEX_CACHE_LIMIT {
-        cache.retain(|_, (fields, _)| fields.strong_count() > 0);
-        if cache.len() >= STRUCT_FIELD_INDEX_CACHE_LIMIT {
-          cache.clear();
-        }
+      cache.retain(|_, (fields, _, _)| fields.strong_count() > 0);
+      let added_name_bytes = self
+        .fields
+        .iter()
+        .fold(0usize, |total, field| total.saturating_add(field.ref_str().len()));
+      let (cached_fields, cached_name_bytes) = cache.values().fold((0usize, 0usize), |(field_total, byte_total), entry| {
+        (
+          field_total.saturating_add(entry.0.upgrade().map_or(0, |fields| fields.len())),
+          byte_total.saturating_add(entry.2),
+        )
+      });
+      if !field_index_cache_admissible(cache.len(), cached_fields, cached_name_bytes, self.fields.len(), added_name_bytes) {
+        return self.fields.iter().position(|field| field.ref_str() == y);
       }
       let index = Arc::new(self.fields.iter().enumerate().fold(HashMap::new(), |mut index, (position, field)| {
         // Preserve the historical `position` behavior for malformed
@@ -105,7 +130,7 @@ impl CalcitStructDef {
         index
       }));
       let result = index.get(y).copied();
-      cache.insert(cache_key, (Arc::downgrade(&self.fields), index));
+      cache.insert(cache_key, (Arc::downgrade(&self.fields), index, added_name_bytes));
       result
     })
   }
@@ -117,7 +142,7 @@ impl CalcitStructDef {
       cache
         .borrow()
         .get(&cache_key)
-        .is_some_and(|(fields, _)| fields.upgrade().is_some_and(|fields| Arc::ptr_eq(&fields, &self.fields)))
+        .is_some_and(|(fields, _, _)| fields.upgrade().is_some_and(|fields| Arc::ptr_eq(&fields, &self.fields)))
     })
   }
 }
@@ -213,5 +238,37 @@ mod tests {
       Some(0),
       "wide cache must preserve first-match semantics"
     );
+  }
+
+  #[test]
+  fn wide_struct_cache_keeps_live_entries_and_rejects_over_budget_admission() {
+    STRUCT_FIELD_INDEX_CACHE.with(|cache| cache.borrow_mut().clear());
+    let definitions = (0..STRUCT_FIELD_INDEX_CACHE_LIMIT)
+      .map(|definition_index| {
+        let definition = CalcitStructDef::from_fields(
+          EdnTag::new(format!("Wide{definition_index}")),
+          (0..STRUCT_FIELD_INDEX_CACHE_THRESHOLD)
+            .map(|field_index| EdnTag::new(format!("field-{field_index:04}")))
+            .collect(),
+        );
+        assert_eq!(definition.index_of("field-0031"), Some(31));
+        definition
+      })
+      .collect::<Vec<_>>();
+    assert!(definitions[0].has_cached_field_index());
+
+    let overflow = CalcitStructDef::from_fields(
+      EdnTag::new("Overflow"),
+      (0..STRUCT_FIELD_INDEX_CACHE_THRESHOLD)
+        .map(|field_index| EdnTag::new(format!("field-{field_index:04}")))
+        .collect(),
+    );
+    assert_eq!(overflow.index_of("field-0031"), Some(31));
+    assert!(!overflow.has_cached_field_index(), "over-budget definitions must use linear lookup");
+    assert!(definitions[0].has_cached_field_index(), "existing live indexes must not be evicted");
+
+    assert!(!field_index_cache_admissible(0, STRUCT_FIELD_INDEX_CACHE_MAX_FIELDS, 0, 1, 0));
+    assert!(!field_index_cache_admissible(0, 0, STRUCT_FIELD_INDEX_CACHE_MAX_NAME_BYTES, 0, 1));
+    STRUCT_FIELD_INDEX_CACHE.with(|cache| cache.borrow_mut().clear());
   }
 }

--- a/src/calcit/calcit_struct.rs
+++ b/src/calcit/calcit_struct.rs
@@ -61,7 +61,8 @@ impl CalcitStructDef {
     }
   }
 
-  /// Binary search for the position of a field name (fields must be sorted)
+  /// Find a field without changing declaration order. Some embedders create
+  /// unsorted definitions directly, so this cannot assume parser sorting.
   pub fn index_of(&self, y: &str) -> Option<usize> {
     self.fields.iter().position(|f| f.ref_str() == y)
   }
@@ -119,5 +120,25 @@ mod tests {
     let right = wrapper(nested_struct("beta.models"));
 
     assert!(!left.same_nominal_definition(&right));
+  }
+
+  #[test]
+  fn wide_struct_lookup_preserves_unsorted_declaration_order() {
+    for width in [32usize, 256, 1_024] {
+      let fields = (0..width)
+        .rev()
+        .map(|idx| EdnTag::new(format!("field-{idx:04}")))
+        .collect::<Vec<_>>();
+      let target = fields.last().expect("wide struct field").clone();
+      let definition = CalcitStructDef::from_fields(EdnTag::new("Wide"), fields);
+      let started = std::time::Instant::now();
+      for _ in 0..10_000 {
+        assert_eq!(definition.index_of(target.ref_str()), Some(width - 1));
+      }
+      eprintln!(
+        "struct-index width={width} lookups=10000 elapsed_us={}",
+        started.elapsed().as_micros()
+      );
+    }
   }
 }

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -226,96 +226,176 @@ fn type_ref_arity_resolution_key(name: &str) -> Arc<str> {
   }
 }
 
-fn annotation_slices_share_data_schema(actual: &[Arc<CalcitTypeAnnotation>], expected: &[Arc<CalcitTypeAnnotation>]) -> bool {
-  actual.len() == expected.len()
-    && actual
-      .iter()
-      .zip(expected.iter())
-      .all(|(actual, expected)| same_data_schema_annotation(actual, expected))
-}
-
-fn same_macro_syntax_data_schema(actual: &MacroSyntaxType, expected: &MacroSyntaxType) -> bool {
-  match (actual, expected) {
-    (MacroSyntaxType::Expr(actual), MacroSyntaxType::Expr(expected)) => same_data_schema_annotation(actual, expected),
-    _ => actual == expected,
-  }
-}
-
-fn macro_syntax_slices_share_data_schema(actual: &[MacroSyntaxType], expected: &[MacroSyntaxType]) -> bool {
-  actual.len() == expected.len()
-    && actual
-      .iter()
-      .zip(expected.iter())
-      .all(|(actual, expected)| same_macro_syntax_data_schema(actual, expected))
-}
-
-fn same_macro_expansion_data_schema(actual: &MacroExpansionType, expected: &MacroExpansionType) -> bool {
-  match (actual, expected) {
-    (MacroExpansionType::Expr(actual), MacroExpansionType::Expr(expected))
-    | (MacroExpansionType::Definition(actual), MacroExpansionType::Definition(expected)) => {
-      same_data_schema_annotation(actual, expected)
-    }
-    _ => actual == expected,
-  }
-}
-
 /// Compare the static data-schema identity of annotations without allowing
 /// attached struct/enum impls to change nominal identity. Unlike the display
-/// EDN form, this preserves qualified nested nominal definitions.
-pub(crate) fn same_data_schema_annotation(actual: &CalcitTypeAnnotation, expected: &CalcitTypeAnnotation) -> bool {
+/// EDN form, this preserves qualified nested nominal definitions. Traversal is
+/// iterative and pair-memoized so deep schemas and shared subgraphs are finite.
+pub(crate) fn same_data_schema_annotation<'a>(actual: &'a CalcitTypeAnnotation, expected: &'a CalcitTypeAnnotation) -> bool {
   use CalcitTypeAnnotation as Type;
 
-  match (actual, expected) {
-    (Type::List(a), Type::List(b))
-    | (Type::Set(a), Type::Set(b))
-    | (Type::Ref(a), Type::Ref(b))
-    | (Type::Variadic(a), Type::Variadic(b))
-    | (Type::Optional(a), Type::Optional(b))
-    | (Type::JsNullish(a), Type::JsNullish(b)) => same_data_schema_annotation(a, b),
-    (Type::Map(ak, av), Type::Map(bk, bv)) => same_data_schema_annotation(ak, bk) && same_data_schema_annotation(av, bv),
-    (Type::Struct(a, a_args), Type::Struct(b, b_args)) => {
-      a.same_nominal_definition(b) && annotation_slices_share_data_schema(a_args, b_args)
+  fn push_slices<'a>(worklist: &mut Vec<(&'a Type, &'a Type)>, actual: &'a [Arc<Type>], expected: &'a [Arc<Type>]) -> bool {
+    if actual.len() != expected.len() {
+      return false;
     }
-    (Type::Enum(a, a_args), Type::Enum(b, b_args)) => {
-      a.same_nominal_definition(b) && annotation_slices_share_data_schema(a_args, b_args)
-    }
-    (Type::StructValue(a), Type::StructValue(b)) | (Type::StructDef(a), Type::StructDef(b)) => a.same_nominal_definition(b),
-    (Type::EnumValue(a), Type::EnumValue(b)) | (Type::EnumDef(a), Type::EnumDef(b)) => a.same_nominal_definition(b),
-    (Type::TypeRef(a_name, a_args), Type::TypeRef(b_name, b_args)) => {
-      a_name == b_name && annotation_slices_share_data_schema(a_args, b_args)
-    }
-    (Type::Fn(a), Type::Fn(b)) => {
-      a.generics == b.generics
-        && a.where_bounds == b.where_bounds
-        && a.fn_kind == b.fn_kind
-        && a.features == b.features
-        && annotation_slices_share_data_schema(&a.arg_types, &b.arg_types)
-        && same_data_schema_annotation(&a.return_type, &b.return_type)
-        && match (&a.rest_type, &b.rest_type) {
-          (Some(a), Some(b)) => same_data_schema_annotation(a, b),
-          (None, None) => true,
-          _ => false,
-        }
-    }
-    (Type::Macro(a), Type::Macro(b)) => {
-      a.generics == b.generics
-        && a.where_bounds == b.where_bounds
-        && a.capabilities == b.capabilities
-        && a.features == b.features
-        && macro_syntax_slices_share_data_schema(&a.required_inputs, &b.required_inputs)
-        && macro_syntax_slices_share_data_schema(&a.optional_inputs, &b.optional_inputs)
-        && match (&a.rest_input, &b.rest_input) {
-          (Some(a), Some(b)) => same_macro_syntax_data_schema(a, b),
-          (None, None) => true,
-          _ => false,
-        }
-        && same_macro_expansion_data_schema(&a.expansion, &b.expansion)
-    }
-    (Type::Syntax(a), Type::Syntax(b)) => same_macro_syntax_data_schema(a, b),
-    // The remaining variants contain no nested struct/enum data annotations,
-    // or have their own nominal identity rules (traits and opaque custom data).
-    _ => actual == expected,
+    worklist.extend(
+      actual
+        .iter()
+        .zip(expected.iter())
+        .map(|(actual, expected)| (actual.as_ref(), expected.as_ref())),
+    );
+    true
   }
+
+  fn push_struct<'a>(worklist: &mut Vec<(&'a Type, &'a Type)>, actual: &'a CalcitStructDef, expected: &'a CalcitStructDef) -> bool {
+    if actual.definition_ref.is_none()
+      || actual.definition_ref != expected.definition_ref
+      || actual.name != expected.name
+      || actual.fields != expected.fields
+      || actual.generics != expected.generics
+      || actual.where_bounds != expected.where_bounds
+    {
+      return false;
+    }
+    push_slices(worklist, actual.field_types.as_ref(), expected.field_types.as_ref())
+  }
+
+  fn push_enum<'a>(worklist: &mut Vec<(&'a Type, &'a Type)>, actual: &'a CalcitEnumDef, expected: &'a CalcitEnumDef) -> bool {
+    if actual.definition_ref().is_none()
+      || actual.definition_ref() != expected.definition_ref()
+      || actual.name() != expected.name()
+      || actual.generics() != expected.generics()
+      || actual.where_bounds() != expected.where_bounds()
+      || actual.variants().len() != expected.variants().len()
+    {
+      return false;
+    }
+    for (actual, expected) in actual.variants().iter().zip(expected.variants().iter()) {
+      if actual.tag != expected.tag || !push_slices(worklist, actual.payload_types(), expected.payload_types()) {
+        return false;
+      }
+    }
+    true
+  }
+
+  fn push_macro_syntax<'a>(
+    worklist: &mut Vec<(&'a Type, &'a Type)>,
+    actual: &'a MacroSyntaxType,
+    expected: &'a MacroSyntaxType,
+  ) -> bool {
+    match (actual, expected) {
+      (MacroSyntaxType::Expr(actual), MacroSyntaxType::Expr(expected)) => {
+        worklist.push((actual.as_ref(), expected.as_ref()));
+        true
+      }
+      _ => actual == expected,
+    }
+  }
+
+  let mut worklist = vec![(actual, expected)];
+  let mut visited = HashSet::new();
+  let mut visits = 0usize;
+  while let Some((actual, expected)) = worklist.pop() {
+    if !visited.insert((actual as *const Type as usize, expected as *const Type as usize)) {
+      continue;
+    }
+    visits += 1;
+    if visits > TYPE_RELATION_NODE_LIMIT {
+      return false;
+    }
+
+    let matches = match (actual, expected) {
+      (Type::List(actual), Type::List(expected))
+      | (Type::Set(actual), Type::Set(expected))
+      | (Type::Ref(actual), Type::Ref(expected))
+      | (Type::Variadic(actual), Type::Variadic(expected))
+      | (Type::Optional(actual), Type::Optional(expected))
+      | (Type::JsNullish(actual), Type::JsNullish(expected)) => {
+        worklist.push((actual.as_ref(), expected.as_ref()));
+        true
+      }
+      (Type::Map(actual_key, actual_value), Type::Map(expected_key, expected_value)) => {
+        worklist.push((actual_key.as_ref(), expected_key.as_ref()));
+        worklist.push((actual_value.as_ref(), expected_value.as_ref()));
+        true
+      }
+      (Type::Struct(actual, actual_args), Type::Struct(expected, expected_args)) => {
+        push_struct(&mut worklist, actual, expected) && push_slices(&mut worklist, actual_args, expected_args)
+      }
+      (Type::Enum(actual, actual_args), Type::Enum(expected, expected_args)) => {
+        push_enum(&mut worklist, actual, expected) && push_slices(&mut worklist, actual_args, expected_args)
+      }
+      (Type::StructValue(actual), Type::StructValue(expected)) | (Type::StructDef(actual), Type::StructDef(expected)) => {
+        push_struct(&mut worklist, actual, expected)
+      }
+      (Type::EnumValue(actual), Type::EnumValue(expected)) | (Type::EnumDef(actual), Type::EnumDef(expected)) => {
+        push_enum(&mut worklist, actual, expected)
+      }
+      (Type::TypeRef(actual_name, actual_args), Type::TypeRef(expected_name, expected_args)) => {
+        actual_name == expected_name && push_slices(&mut worklist, actual_args, expected_args)
+      }
+      (Type::Fn(actual), Type::Fn(expected)) => {
+        actual.generics == expected.generics
+          && actual.where_bounds == expected.where_bounds
+          && actual.fn_kind == expected.fn_kind
+          && actual.features == expected.features
+          && push_slices(&mut worklist, &actual.arg_types, &expected.arg_types)
+          && match (&actual.rest_type, &expected.rest_type) {
+            (Some(actual), Some(expected)) => {
+              worklist.push((actual.as_ref(), expected.as_ref()));
+              true
+            }
+            (None, None) => true,
+            _ => false,
+          }
+          && {
+            worklist.push((actual.return_type.as_ref(), expected.return_type.as_ref()));
+            true
+          }
+      }
+      (Type::Macro(actual), Type::Macro(expected)) => {
+        if actual.generics != expected.generics
+          || actual.where_bounds != expected.where_bounds
+          || actual.capabilities != expected.capabilities
+          || actual.features != expected.features
+          || actual.required_inputs.len() != expected.required_inputs.len()
+          || actual.optional_inputs.len() != expected.optional_inputs.len()
+        {
+          false
+        } else {
+          let required_match = actual
+            .required_inputs
+            .iter()
+            .zip(expected.required_inputs.iter())
+            .all(|(actual, expected)| push_macro_syntax(&mut worklist, actual, expected));
+          let optional_match = actual
+            .optional_inputs
+            .iter()
+            .zip(expected.optional_inputs.iter())
+            .all(|(actual, expected)| push_macro_syntax(&mut worklist, actual, expected));
+          let rest_match = match (&actual.rest_input, &expected.rest_input) {
+            (Some(actual), Some(expected)) => push_macro_syntax(&mut worklist, actual, expected),
+            (None, None) => true,
+            _ => false,
+          };
+          let expansion_match = match (&actual.expansion, &expected.expansion) {
+            (MacroExpansionType::Expr(actual), MacroExpansionType::Expr(expected))
+            | (MacroExpansionType::Definition(actual), MacroExpansionType::Definition(expected)) => {
+              worklist.push((actual.as_ref(), expected.as_ref()));
+              true
+            }
+            (actual, expected) => actual == expected,
+          };
+          required_match && optional_match && rest_match && expansion_match
+        }
+      }
+      (Type::Syntax(actual), Type::Syntax(expected)) => push_macro_syntax(&mut worklist, actual, expected),
+      _ => actual == expected,
+    };
+    if !matches {
+      return false;
+    }
+  }
+  true
 }
 
 /// Result of asking whether an annotation is strong enough to authorize
@@ -338,7 +418,303 @@ pub(crate) enum TypeBoundaryReason {
   LegacyNullish,
   ErasedTypeArguments,
   RecursiveTypeVariable,
+  RecursiveTypeAlias,
   UnresolvedNominalIdentity,
+  TypeComplexityLimit,
+}
+
+const TYPE_RELATION_NODE_LIMIT: usize = 8_192;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct TypeRelationStats {
+  node_visits: usize,
+  memo_hits: usize,
+  max_worklist: usize,
+  max_depth: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PlainRelationMode {
+  Compatibility,
+  Proof,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AliasRelationKey {
+  alias: Arc<str>,
+  other: usize,
+  alias_on_actual_side: bool,
+  proof: bool,
+}
+
+thread_local! {
+  static TYPE_ALIAS_RELATION_STACK: RefCell<Vec<AliasRelationKey>> = const { RefCell::new(vec![]) };
+}
+
+struct AliasRelationGuard;
+
+impl Drop for AliasRelationGuard {
+  fn drop(&mut self) {
+    TYPE_ALIAS_RELATION_STACK.with(|stack| {
+      stack.borrow_mut().pop();
+    });
+  }
+}
+
+/// Guard schema-alias expansion within one relation. The key includes relation
+/// direction and the other type node, so legitimate repeated aliases in
+/// sibling branches remain independent while pure expansion cycles terminate.
+fn enter_alias_relation(
+  alias: &Arc<str>,
+  other: &CalcitTypeAnnotation,
+  alias_on_actual_side: bool,
+  proof: bool,
+) -> Result<AliasRelationGuard, TypeBoundaryReason> {
+  let key = AliasRelationKey {
+    alias: alias.clone(),
+    other: other as *const CalcitTypeAnnotation as usize,
+    alias_on_actual_side,
+    proof,
+  };
+  TYPE_ALIAS_RELATION_STACK.with(|stack| {
+    let mut stack = stack.borrow_mut();
+    if stack.contains(&key) {
+      return Err(TypeBoundaryReason::RecursiveTypeAlias);
+    }
+    if stack.len() >= 256 {
+      return Err(TypeBoundaryReason::TypeComplexityLimit);
+    }
+    stack.push(key);
+    Ok(AliasRelationGuard)
+  })
+}
+
+/// Iterative fast path for the high-volume structural part of type relations.
+///
+/// Returning `None` hands uncommon semantic cases (traits, callable variance,
+/// aliases, and generic binding) to the existing matcher. Supported shapes use
+/// a per-relation pair memo and a hard node budget, so deep container/nominal
+/// arguments and shared DAGs do not consume the Rust call stack.
+fn bounded_plain_type_relation<'a>(
+  actual: &'a CalcitTypeAnnotation,
+  expected: &'a CalcitTypeAnnotation,
+  mode: PlainRelationMode,
+) -> Result<Option<(TypeProof, TypeRelationStats)>, TypeRelationStats> {
+  use CalcitTypeAnnotation as Type;
+  use TypeBoundaryReason as Boundary;
+  use TypeProof::{Mismatch, NeedsBoundary, Proven};
+
+  fn push_pair<'a>(
+    worklist: &mut Vec<(&'a CalcitTypeAnnotation, &'a CalcitTypeAnnotation, usize)>,
+    left: &'a Arc<CalcitTypeAnnotation>,
+    right: &'a Arc<CalcitTypeAnnotation>,
+    depth: usize,
+  ) {
+    worklist.push((left.as_ref(), right.as_ref(), depth + 1));
+  }
+
+  fn is_plain_mismatch_node(value: &CalcitTypeAnnotation) -> bool {
+    matches!(
+      value,
+      CalcitTypeAnnotation::Bool
+        | CalcitTypeAnnotation::Number
+        | CalcitTypeAnnotation::String
+        | CalcitTypeAnnotation::Symbol
+        | CalcitTypeAnnotation::Buffer
+        | CalcitTypeAnnotation::F64Buffer
+        | CalcitTypeAnnotation::CirruQuote
+        | CalcitTypeAnnotation::JsObject
+        | CalcitTypeAnnotation::Nil
+        | CalcitTypeAnnotation::Unit
+        | CalcitTypeAnnotation::List(_)
+        | CalcitTypeAnnotation::Map(_, _)
+        | CalcitTypeAnnotation::Set(_)
+        | CalcitTypeAnnotation::Ref(_)
+        | CalcitTypeAnnotation::Variadic(_)
+    )
+  }
+
+  let mut worklist = vec![(actual, expected, 0usize)];
+  let mut visited: HashSet<(usize, usize)> = HashSet::new();
+  let mut result = Proven;
+  let mut stats = TypeRelationStats {
+    max_worklist: 1,
+    ..TypeRelationStats::default()
+  };
+
+  while let Some((actual, expected, depth)) = worklist.pop() {
+    stats.max_depth = stats.max_depth.max(depth);
+    let key = (actual as *const Type as usize, expected as *const Type as usize);
+    if !visited.insert(key) {
+      stats.memo_hits += 1;
+      continue;
+    }
+    stats.node_visits += 1;
+    if stats.node_visits > TYPE_RELATION_NODE_LIMIT {
+      return Err(stats);
+    }
+
+    match (actual, expected) {
+      (_, Type::Dynamic) | (Type::Dynamic, _) => {
+        if matches!(mode, PlainRelationMode::Proof) {
+          result = result.and(NeedsBoundary(Boundary::Dynamic));
+        }
+      }
+      (Type::TypeVar(left), Type::TypeVar(right)) if left == right => {}
+      (Type::List(left), Type::List(right))
+      | (Type::Set(left), Type::Set(right))
+      | (Type::Variadic(left), Type::Variadic(right))
+      | (Type::Optional(left), Type::Optional(right))
+      | (Type::JsNullish(left), Type::JsNullish(right)) => push_pair(&mut worklist, left, right, depth),
+      (Type::Ref(left), Type::Ref(right)) => {
+        push_pair(&mut worklist, left, right, depth);
+        if matches!(mode, PlainRelationMode::Proof) {
+          worklist.push((right.as_ref(), left.as_ref(), depth + 1));
+        }
+      }
+      (Type::Map(actual_key, actual_value), Type::Map(expected_key, expected_value)) => {
+        push_pair(&mut worklist, actual_key, expected_key, depth);
+        push_pair(&mut worklist, actual_value, expected_value, depth);
+      }
+      (Type::TypeRef(actual_name, actual_args), Type::TypeRef(expected_name, expected_args)) => {
+        match Type::type_ref_nominal_match(actual_name, expected_name) {
+          Some(true) => {}
+          Some(false) => return Ok(Some((Mismatch, stats))),
+          None => return Ok(None),
+        }
+        if actual_args.is_empty() != expected_args.is_empty() {
+          match mode {
+            PlainRelationMode::Compatibility => continue,
+            PlainRelationMode::Proof => {
+              result = result.and(NeedsBoundary(Boundary::ErasedTypeArguments));
+              continue;
+            }
+          }
+        }
+        if actual_args.len() != expected_args.len() {
+          return Ok(Some((Mismatch, stats)));
+        }
+        for (left, right) in actual_args.iter().zip(expected_args.iter()) {
+          push_pair(&mut worklist, left, right, depth);
+        }
+      }
+      (Type::Struct(actual_def, actual_args), Type::Struct(expected_def, expected_args)) => {
+        let nominal_match = if Arc::ptr_eq(actual_def, expected_def) {
+          Some(true)
+        } else {
+          Type::struct_nominal_match(actual_def, expected_def)
+        };
+        match nominal_match {
+          Some(true) => {}
+          Some(false) => return Ok(Some((Mismatch, stats))),
+          None => return Ok(None),
+        }
+        if actual_args.is_empty() != expected_args.is_empty() {
+          match mode {
+            PlainRelationMode::Compatibility => return Ok(None),
+            PlainRelationMode::Proof => {
+              result = result.and(NeedsBoundary(Boundary::ErasedTypeArguments));
+              continue;
+            }
+          }
+        }
+        if actual_args.len() != expected_args.len() {
+          return Ok(Some((Mismatch, stats)));
+        }
+        for (left, right) in actual_args.iter().zip(expected_args.iter()) {
+          push_pair(&mut worklist, left, right, depth);
+        }
+      }
+      (Type::Enum(actual_def, actual_args), Type::Enum(expected_def, expected_args)) => {
+        let nominal_match = if Arc::ptr_eq(actual_def, expected_def) {
+          Some(true)
+        } else {
+          Type::enum_nominal_match(actual_def, expected_def)
+        };
+        match nominal_match {
+          Some(true) => {}
+          Some(false) => return Ok(Some((Mismatch, stats))),
+          None => return Ok(None),
+        }
+        if actual_args.is_empty() != expected_args.is_empty() {
+          match mode {
+            PlainRelationMode::Compatibility => continue,
+            PlainRelationMode::Proof => {
+              result = result.and(NeedsBoundary(Boundary::ErasedTypeArguments));
+              continue;
+            }
+          }
+        }
+        if actual_args.len() != expected_args.len() {
+          return Ok(Some((Mismatch, stats)));
+        }
+        for (left, right) in actual_args.iter().zip(expected_args.iter()) {
+          push_pair(&mut worklist, left, right, depth);
+        }
+      }
+      (Type::Bool, Type::Bool)
+      | (Type::Number, Type::Number)
+      | (Type::String, Type::String)
+      | (Type::Symbol, Type::Symbol)
+      | (Type::Tag, Type::Tag)
+      | (Type::DynFn, Type::DynFn)
+      | (Type::Buffer, Type::Buffer)
+      | (Type::F64Buffer, Type::F64Buffer)
+      | (Type::CirruQuote, Type::CirruQuote)
+      | (Type::JsObject, Type::JsObject)
+      | (Type::AnonymousEnum, Type::AnonymousEnum)
+      | (Type::Nil, Type::Nil)
+      | (Type::Unit, Type::Unit) => {}
+      (Type::Nil, Type::Optional(_)) | (Type::Nil, Type::JsNullish(_)) => {
+        if matches!(mode, PlainRelationMode::Proof) {
+          result = result.and(NeedsBoundary(Boundary::LegacyNullish));
+        }
+      }
+      (plain, Type::Optional(inner)) if !matches!(plain, Type::Optional(_) | Type::JsNullish(_)) => {
+        if matches!(mode, PlainRelationMode::Proof) {
+          result = result.and(NeedsBoundary(Boundary::LegacyNullish));
+        }
+        worklist.push((plain, inner.as_ref(), depth + 1));
+      }
+      (plain, Type::JsNullish(inner)) if !matches!(plain, Type::Optional(_) | Type::JsNullish(_)) => {
+        if matches!(mode, PlainRelationMode::Proof) {
+          result = result.and(NeedsBoundary(Boundary::LegacyNullish));
+        }
+        worklist.push((plain, inner.as_ref(), depth + 1));
+      }
+      (Type::Fn(_), _)
+      | (_, Type::Fn(_))
+      | (Type::Macro(_), _)
+      | (_, Type::Macro(_))
+      | (Type::Syntax(_), _)
+      | (_, Type::Syntax(_))
+      | (Type::Custom(_), _)
+      | (_, Type::Custom(_))
+      | (Type::Trait(_), _)
+      | (_, Type::Trait(_))
+      | (Type::TraitSet(_), _)
+      | (_, Type::TraitSet(_))
+      | (Type::TypeSlot(_), _)
+      | (_, Type::TypeSlot(_))
+      | (Type::StructDef(_), _)
+      | (_, Type::StructDef(_))
+      | (Type::EnumDef(_), _)
+      | (_, Type::EnumDef(_))
+      | (Type::StructValue(_), _)
+      | (_, Type::StructValue(_))
+      | (Type::EnumValue(_), _)
+      | (_, Type::EnumValue(_))
+      | (Type::TypeVar(_), _)
+      | (_, Type::TypeVar(_))
+      | (Type::TypeRef(_, _), _)
+      | (_, Type::TypeRef(_, _)) => return Ok(None),
+      _ if is_plain_mismatch_node(actual) && is_plain_mismatch_node(expected) => return Ok(Some((Mismatch, stats))),
+      _ => return Ok(None),
+    }
+    stats.max_worklist = stats.max_worklist.max(worklist.len());
+  }
+
+  Ok(Some((result, stats)))
 }
 
 impl TypeProof {
@@ -2864,25 +3240,42 @@ impl CalcitTypeAnnotation {
 
   /// Render a concise representation used in warnings or logs
   pub fn to_brief_string(&self) -> String {
+    let mut remaining = 128;
+    self.to_brief_string_bounded(0, &mut remaining)
+  }
+
+  fn to_brief_string_bounded(&self, depth: usize, remaining: &mut usize) -> String {
+    if depth >= 32 || *remaining == 0 {
+      return "…".to_owned();
+    }
+    *remaining -= 1;
     if let Some(tag) = self.builtin_tag_name() {
       return format!(":{tag}");
     }
 
     match self {
       Self::Fn(signature) => signature.render_signature_brief(),
-      Self::Variadic(inner) => format!("&{}", inner.to_brief_string()),
-      Self::List(inner) => format!("list<{}>", inner.to_brief_string()),
-      Self::Map(k, v) => format!("map<{},{}>", k.to_brief_string(), v.to_brief_string()),
-      Self::Set(inner) => format!("set<{}>", inner.to_brief_string()),
-      Self::Ref(inner) => format!("ref<{}>", inner.to_brief_string()),
+      Self::Variadic(inner) => format!("&{}", inner.to_brief_string_bounded(depth + 1, remaining)),
+      Self::List(inner) => format!("list<{}>", inner.to_brief_string_bounded(depth + 1, remaining)),
+      Self::Map(k, v) => format!(
+        "map<{},{}>",
+        k.to_brief_string_bounded(depth + 1, remaining),
+        v.to_brief_string_bounded(depth + 1, remaining)
+      ),
+      Self::Set(inner) => format!("set<{}>", inner.to_brief_string_bounded(depth + 1, remaining)),
+      Self::Ref(inner) => format!("ref<{}>", inner.to_brief_string_bounded(depth + 1, remaining)),
       Self::Custom(inner) => format!("{inner}"),
-      Self::Optional(inner) => format!("{}?", inner.to_brief_string()),
-      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.to_brief_string()),
+      Self::Optional(inner) => format!("{}?", inner.to_brief_string_bounded(depth + 1, remaining)),
+      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.to_brief_string_bounded(depth + 1, remaining)),
       Self::Struct(base, args) => {
         if args.is_empty() {
           format!("struct {}", base.name)
         } else {
-          let rendered = args.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.to_brief_string_bounded(depth + 1, remaining))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("struct {}<{}>", base.name, rendered)
         }
       }
@@ -2896,7 +3289,11 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("'{name}")
         } else {
-          let rendered = args.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.to_brief_string_bounded(depth + 1, remaining))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("'{name}<{rendered}>")
         }
       }
@@ -2904,7 +3301,11 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("enum {}", enum_def.name())
         } else {
-          let rendered = args.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.to_brief_string_bounded(depth + 1, remaining))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
@@ -2921,23 +3322,45 @@ impl CalcitTypeAnnotation {
   /// Substitute all `TypeVar` occurrences with their bound types from `bindings`.
   /// Returns a new annotation with variables resolved; unbound variables remain as-is.
   pub fn substitute_type_vars(&self, bindings: &TypeBindings) -> Arc<CalcitTypeAnnotation> {
-    match self {
+    self.substitute_type_vars_with_memo(bindings, &mut HashMap::new())
+  }
+
+  /// Keep substitution results local to one inference/preprocessing context. The
+  /// pointer key is only used while the source annotations remain borrowed, so a
+  /// later entry, scope, or hot reload cannot observe stale substitutions.
+  fn substitute_type_vars_with_memo(
+    &self,
+    bindings: &TypeBindings,
+    memo: &mut HashMap<usize, Arc<CalcitTypeAnnotation>>,
+  ) -> Arc<CalcitTypeAnnotation> {
+    let key = self as *const CalcitTypeAnnotation as usize;
+    if let Some(found) = memo.get(&key) {
+      return found.clone();
+    }
+    let substituted = match self {
       Self::TypeVar(name) => bindings.get(name).cloned().unwrap_or_else(|| Arc::new(self.clone())),
       Self::TypeRef(name, args) => {
-        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars(bindings)).collect();
+        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars_with_memo(bindings, memo)).collect();
         Arc::new(Self::TypeRef(name.clone(), Arc::new(new_args)))
       }
-      Self::List(inner) => Arc::new(Self::List(inner.substitute_type_vars(bindings))),
-      Self::Map(k, v) => Arc::new(Self::Map(k.substitute_type_vars(bindings), v.substitute_type_vars(bindings))),
-      Self::Set(inner) => Arc::new(Self::Set(inner.substitute_type_vars(bindings))),
-      Self::Ref(inner) => Arc::new(Self::Ref(inner.substitute_type_vars(bindings))),
-      Self::Optional(inner) => Arc::new(Self::Optional(inner.substitute_type_vars(bindings))),
-      Self::JsNullish(inner) => Arc::new(Self::JsNullish(inner.substitute_type_vars(bindings))),
-      Self::Variadic(inner) => Arc::new(Self::Variadic(inner.substitute_type_vars(bindings))),
+      Self::List(inner) => Arc::new(Self::List(inner.substitute_type_vars_with_memo(bindings, memo))),
+      Self::Map(k, v) => Arc::new(Self::Map(
+        k.substitute_type_vars_with_memo(bindings, memo),
+        v.substitute_type_vars_with_memo(bindings, memo),
+      )),
+      Self::Set(inner) => Arc::new(Self::Set(inner.substitute_type_vars_with_memo(bindings, memo))),
+      Self::Ref(inner) => Arc::new(Self::Ref(inner.substitute_type_vars_with_memo(bindings, memo))),
+      Self::Optional(inner) => Arc::new(Self::Optional(inner.substitute_type_vars_with_memo(bindings, memo))),
+      Self::JsNullish(inner) => Arc::new(Self::JsNullish(inner.substitute_type_vars_with_memo(bindings, memo))),
+      Self::Variadic(inner) => Arc::new(Self::Variadic(inner.substitute_type_vars_with_memo(bindings, memo))),
       Self::Fn(sig) => {
-        let new_args = sig.arg_types.iter().map(|a| a.substitute_type_vars(bindings)).collect();
-        let new_ret = sig.return_type.substitute_type_vars(bindings);
-        let new_rest = sig.rest_type.as_ref().map(|r| r.substitute_type_vars(bindings));
+        let new_args = sig
+          .arg_types
+          .iter()
+          .map(|a| a.substitute_type_vars_with_memo(bindings, memo))
+          .collect();
+        let new_ret = sig.return_type.substitute_type_vars_with_memo(bindings, memo);
+        let new_rest = sig.rest_type.as_ref().map(|r| r.substitute_type_vars_with_memo(bindings, memo));
         Arc::new(Self::Fn(Arc::new(CalcitFnTypeAnnotation {
           generics: sig.generics.clone(),
           where_bounds: sig.where_bounds.clone(),
@@ -2949,16 +3372,18 @@ impl CalcitTypeAnnotation {
         })))
       }
       Self::Struct(base, args) => {
-        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars(bindings)).collect();
+        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars_with_memo(bindings, memo)).collect();
         Arc::new(Self::Struct(base.clone(), Arc::new(new_args)))
       }
       Self::Enum(base, args) => {
-        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars(bindings)).collect();
+        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars_with_memo(bindings, memo)).collect();
         Arc::new(Self::Enum(base.clone(), Arc::new(new_args)))
       }
       // Leaf types: no TypeVars inside
       _ => Arc::new(self.clone()),
-    }
+    };
+    memo.insert(key, substituted.clone());
+    substituted
   }
 
   /// Check whether this annotation contains any `TypeVar`.
@@ -3354,6 +3779,11 @@ impl CalcitTypeAnnotation {
   }
 
   pub(crate) fn compatible_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
+    match bounded_plain_type_relation(self, expected, PlainRelationMode::Compatibility) {
+      Ok(Some((result, _))) => return !result.is_mismatch(),
+      Err(_) => return false,
+      Ok(None) => {}
+    }
     match (self, expected) {
       (_, Self::Dynamic) | (Self::Dynamic, _) => true,
       (Self::Macro(actual), Self::Macro(expected)) => actual == expected,
@@ -3640,9 +4070,21 @@ impl CalcitTypeAnnotation {
       }
       // TypeRef schema resolution: when a TypeRef doesn't match any concrete type above,
       // try to resolve it as a type alias by looking up the definition's schema.
-      (Self::TypeRef(name, _), other) | (other, Self::TypeRef(name, _)) => {
+      (Self::TypeRef(name, _), other) => {
         if let Some(resolved) = resolve_type_ref_as_schema(name) {
+          let Ok(_guard) = enter_alias_relation(name, other, true, false) else {
+            return false;
+          };
           return resolved.compatible_with_bindings(other, bindings);
+        }
+        false
+      }
+      (other, Self::TypeRef(name, _)) => {
+        if let Some(resolved) = resolve_type_ref_as_schema(name) {
+          let Ok(_guard) = enter_alias_relation(name, other, false, false) else {
+            return false;
+          };
+          return other.compatible_with_bindings(resolved.as_ref(), bindings);
         }
         false
       }
@@ -3685,6 +4127,12 @@ impl CalcitTypeAnnotation {
   fn prove_with_staged_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> TypeProof {
     use TypeBoundaryReason as Boundary;
     use TypeProof::{Mismatch, NeedsBoundary, Proven};
+
+    match bounded_plain_type_relation(self, expected, PlainRelationMode::Proof) {
+      Ok(Some((result, _))) => return result,
+      Err(_) => return NeedsBoundary(Boundary::TypeComplexityLimit),
+      Ok(None) => {}
+    }
 
     match (self, expected) {
       (_, Self::Dynamic) | (Self::Dynamic, _) => NeedsBoundary(Boundary::Dynamic),
@@ -3883,11 +4331,17 @@ impl CalcitTypeAnnotation {
         None => NeedsBoundary(Boundary::UnresolvedTypeSlot),
       },
       (Self::TypeRef(name, _), other) => match resolve_type_ref_as_schema(name) {
-        Some(resolved) => resolved.prove_with_staged_bindings(other, bindings),
+        Some(resolved) => match enter_alias_relation(name, other, true, true) {
+          Ok(_guard) => resolved.prove_with_staged_bindings(other, bindings),
+          Err(reason) => NeedsBoundary(reason),
+        },
         None => Mismatch,
       },
       (other, Self::TypeRef(name, _)) => match resolve_type_ref_as_schema(name) {
-        Some(resolved) => other.prove_with_staged_bindings(resolved.as_ref(), bindings),
+        Some(resolved) => match enter_alias_relation(name, other, false, true) {
+          Ok(_guard) => other.prove_with_staged_bindings(resolved.as_ref(), bindings),
+          Err(reason) => NeedsBoundary(reason),
+        },
         None => Mismatch,
       },
       _ => {
@@ -4285,30 +4739,43 @@ impl CalcitTypeAnnotation {
   }
 
   pub fn describe(&self) -> String {
+    let mut remaining = 128;
+    self.describe_bounded(0, &mut remaining)
+  }
+
+  fn describe_bounded(&self, depth: usize, remaining: &mut usize) -> String {
+    if depth >= 32 || *remaining == 0 {
+      return "…".to_owned();
+    }
+    *remaining -= 1;
     match self {
       Self::List(inner) => {
         if matches!(inner.as_ref(), Self::Dynamic) {
           return "list".to_string();
         }
-        return format!("list<{}>", inner.describe());
+        return format!("list<{}>", inner.describe_bounded(depth + 1, remaining));
       }
       Self::Map(k, v) => {
         if matches!(k.as_ref(), Self::Dynamic) && matches!(v.as_ref(), Self::Dynamic) {
           return "map".to_string();
         }
-        return format!("map<{}, {}>", k.describe(), v.describe());
+        return format!(
+          "map<{}, {}>",
+          k.describe_bounded(depth + 1, remaining),
+          v.describe_bounded(depth + 1, remaining)
+        );
       }
       Self::Set(inner) => {
         if matches!(inner.as_ref(), Self::Dynamic) {
           return "set".to_string();
         }
-        return format!("set<{}>", inner.describe());
+        return format!("set<{}>", inner.describe_bounded(depth + 1, remaining));
       }
       Self::Ref(inner) => {
         if matches!(inner.as_ref(), Self::Dynamic) {
           return "ref".to_string();
         }
-        return format!("ref<{}>", inner.describe());
+        return format!("ref<{}>", inner.describe_bounded(depth + 1, remaining));
       }
       _ => {}
     }
@@ -4324,17 +4791,21 @@ impl CalcitTypeAnnotation {
         MacroSyntaxType::Syntax => "syntax".to_owned(),
         MacroSyntaxType::SyntaxSymbol => "syntax-symbol".to_owned(),
         MacroSyntaxType::SyntaxList => "syntax-list".to_owned(),
-        MacroSyntaxType::Expr(semantic) => format!("syntax-expr<{}>", semantic.describe()),
+        MacroSyntaxType::Expr(semantic) => format!("syntax-expr<{}>", semantic.describe_bounded(depth + 1, remaining)),
       },
-      Self::Variadic(inner) => format!("variadic {}", inner.describe()),
+      Self::Variadic(inner) => format!("variadic {}", inner.describe_bounded(depth + 1, remaining)),
       Self::Custom(_) => "custom".to_string(),
-      Self::Optional(inner) => format!("optional<{}>", inner.describe()),
-      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.describe()),
+      Self::Optional(inner) => format!("optional<{}>", inner.describe_bounded(depth + 1, remaining)),
+      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.describe_bounded(depth + 1, remaining)),
       Self::Struct(base, args) => {
         if args.is_empty() {
           format!("struct {}", base.name)
         } else {
-          let rendered = args.iter().map(|t| t.describe()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.describe_bounded(depth + 1, remaining))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("struct {}<{}>", base.name, rendered)
         }
       }
@@ -4343,7 +4814,11 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("type {name}")
         } else {
-          let rendered = args.iter().map(|t| t.describe()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.describe_bounded(depth + 1, remaining))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("type {name}<{rendered}>")
         }
       }
@@ -4351,7 +4826,11 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("enum {}", enum_def.name())
         } else {
-          let rendered = args.iter().map(|t| t.describe()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.describe_bounded(depth + 1, remaining))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
@@ -4844,6 +5323,245 @@ mod tests {
   use super::*;
   use crate::calcit::CalcitSymbolInfo;
   use std::collections::BTreeSet;
+
+  fn nested_relation_fixture(depth: usize, leaf: CalcitTypeAnnotation) -> Arc<CalcitTypeAnnotation> {
+    let mut current = Arc::new(leaf);
+    for level in 0..depth {
+      current = Arc::new(match level % 4 {
+        0 => CalcitTypeAnnotation::List(current),
+        1 => CalcitTypeAnnotation::Optional(current),
+        2 => CalcitTypeAnnotation::Map(Arc::new(CalcitTypeAnnotation::String), current),
+        _ => CalcitTypeAnnotation::TypeRef(Arc::from("tests.types/Layer"), Arc::new(vec![current])),
+      });
+    }
+    current
+  }
+
+  #[test]
+  fn bounded_plain_relations_keep_deep_types_precise_without_recursion() {
+    for depth in [32, 256, 2_048] {
+      let actual = nested_relation_fixture(depth, CalcitTypeAnnotation::Number);
+      let expected = nested_relation_fixture(depth, CalcitTypeAnnotation::Number);
+      let mismatch = nested_relation_fixture(depth, CalcitTypeAnnotation::String);
+
+      let cold_started = std::time::Instant::now();
+      let (proof, stats) = bounded_plain_type_relation(actual.as_ref(), expected.as_ref(), PlainRelationMode::Proof)
+        .expect("fixture is inside the relation budget")
+        .expect("fixture uses the iterative relation subset");
+      let cold_elapsed = cold_started.elapsed();
+      let warm_started = std::time::Instant::now();
+      let (_, warm_stats) = bounded_plain_type_relation(actual.as_ref(), expected.as_ref(), PlainRelationMode::Proof)
+        .expect("repeated relation is inside the relation budget")
+        .expect("repeated fixture uses the iterative relation subset");
+      let warm_elapsed = warm_started.elapsed();
+      assert_eq!(proof, TypeProof::Proven);
+      assert!(stats.node_visits > depth, "depth {depth}: {stats:?}");
+      assert!(stats.max_depth >= depth, "depth {depth}: {stats:?}");
+      assert_eq!(stats.node_visits, warm_stats.node_visits, "relation memo must remain context-local");
+      let tracked_payload_bytes = stats.node_visits * std::mem::size_of::<(usize, usize)>()
+        + stats.max_worklist * std::mem::size_of::<(&CalcitTypeAnnotation, &CalcitTypeAnnotation, usize)>();
+      eprintln!(
+        "type-relation depth={depth} visits={} memo-hits={} max-worklist={} tracked-payload-bytes={} allocator-peak=unavailable cold-us={} warm-us={}",
+        stats.node_visits,
+        stats.memo_hits,
+        stats.max_worklist,
+        tracked_payload_bytes,
+        cold_elapsed.as_micros(),
+        warm_elapsed.as_micros()
+      );
+      assert!(actual.is_proven_for(expected.as_ref()));
+      assert!(!actual.is_proven_for(mismatch.as_ref()));
+    }
+  }
+
+  #[test]
+  fn bounded_plain_relations_memoize_shared_type_dags() {
+    let actual_shared = nested_relation_fixture(64, CalcitTypeAnnotation::Number);
+    let expected_shared = nested_relation_fixture(64, CalcitTypeAnnotation::Number);
+    let actual = CalcitTypeAnnotation::Map(actual_shared.clone(), actual_shared);
+    let expected = CalcitTypeAnnotation::Map(expected_shared.clone(), expected_shared);
+
+    let (proof, stats) = bounded_plain_type_relation(&actual, &expected, PlainRelationMode::Proof)
+      .expect("DAG is inside the relation budget")
+      .expect("DAG uses the iterative relation subset");
+    assert_eq!(proof, TypeProof::Proven);
+    assert!(stats.memo_hits >= 1, "shared pair should be visited once: {stats:?}");
+    assert!(
+      stats.node_visits < 100,
+      "shared subtree should not be copied or revisited: {stats:?}"
+    );
+  }
+
+  #[test]
+  fn type_variable_substitution_reuses_shared_dag_results_per_call() {
+    let shared = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("tests.shared/Box"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+    ));
+    let annotation = CalcitTypeAnnotation::Map(shared.clone(), shared);
+    let substituted = annotation.substitute_type_vars(&HashMap::from([(Arc::from("T"), Arc::new(CalcitTypeAnnotation::Number))]));
+    let CalcitTypeAnnotation::Map(key, value) = substituted.as_ref() else {
+      panic!("map substitution must preserve the container")
+    };
+    assert!(Arc::ptr_eq(key, value), "one substitution context must preserve DAG sharing");
+
+    let next = annotation.substitute_type_vars(&HashMap::from([(Arc::from("T"), Arc::new(CalcitTypeAnnotation::String))]));
+    assert!(!Arc::ptr_eq(&substituted, &next), "a later context must not reuse stale results");
+    let CalcitTypeAnnotation::Map(key, _) = next.as_ref() else {
+      panic!("map substitution must preserve the container")
+    };
+    let CalcitTypeAnnotation::TypeRef(_, args) = key.as_ref() else {
+      panic!("map key must preserve its nominal reference")
+    };
+    assert_eq!(args.as_slice(), &[Arc::new(CalcitTypeAnnotation::String)]);
+  }
+
+  #[test]
+  fn data_schema_identity_uses_the_same_bounded_deep_traversal() {
+    let actual = nested_relation_fixture(2_048, CalcitTypeAnnotation::Number);
+    let expected = nested_relation_fixture(2_048, CalcitTypeAnnotation::Number);
+    let mismatch = nested_relation_fixture(2_048, CalcitTypeAnnotation::String);
+    assert!(same_data_schema_annotation(actual.as_ref(), expected.as_ref()));
+    assert!(!same_data_schema_annotation(actual.as_ref(), mismatch.as_ref()));
+  }
+
+  #[test]
+  fn mutually_recursive_nominal_refs_remain_finite_and_preserve_payloads() {
+    let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let tree_ref = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("tests.recursive/Tree"),
+      Arc::new(vec![type_var.clone()]),
+    ));
+    let node_ref = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("tests.recursive/Node"),
+      Arc::new(vec![type_var.clone()]),
+    ));
+    let tree = CalcitStructDef {
+      definition_ref: Some(Arc::from("tests.recursive/Tree")),
+      name: EdnTag::new("Tree"),
+      fields: Arc::new(vec![EdnTag::new("children")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::List(node_ref))]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    };
+    let node = CalcitStructDef {
+      definition_ref: Some(Arc::from("tests.recursive/Node")),
+      name: EdnTag::new("Node"),
+      fields: Arc::new(vec![EdnTag::new("value"), EdnTag::new("tree")]),
+      field_types: Arc::new(vec![type_var.clone(), tree_ref.clone()]),
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    };
+    assert!(same_data_schema_annotation(
+      &CalcitTypeAnnotation::Struct(Arc::new(tree.clone()), Arc::new(vec![type_var.clone()])),
+      &CalcitTypeAnnotation::Struct(Arc::new(tree), Arc::new(vec![type_var.clone()]))
+    ));
+    assert!(same_data_schema_annotation(
+      &CalcitTypeAnnotation::Struct(Arc::new(node.clone()), Arc::new(vec![type_var.clone()])),
+      &CalcitTypeAnnotation::Struct(Arc::new(node), Arc::new(vec![type_var.clone()]))
+    ));
+
+    let substituted = tree_ref.substitute_type_vars(&HashMap::from([(Arc::from("T"), Arc::new(CalcitTypeAnnotation::Number))]));
+    let expected = CalcitTypeAnnotation::TypeRef(
+      Arc::from("tests.recursive/Tree"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    );
+    assert!(substituted.is_proven_for(&expected), "recursive payload T must remain Number");
+  }
+
+  #[test]
+  fn bounded_plain_relations_report_complexity_instead_of_dynamic_fallback() {
+    let actual = nested_relation_fixture(TYPE_RELATION_NODE_LIMIT + 32, CalcitTypeAnnotation::Number);
+    let expected = nested_relation_fixture(TYPE_RELATION_NODE_LIMIT + 32, CalcitTypeAnnotation::Number);
+    assert_eq!(
+      actual.prove_with_bindings(expected.as_ref(), &mut TypeBindings::new()),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::TypeComplexityLimit)
+    );
+    assert!(!actual.is_compatible_with(expected.as_ref()));
+
+    // Avoid recursively dropping a deliberately over-budget test fixture.
+    std::mem::forget(actual);
+    std::mem::forget(expected);
+  }
+
+  #[test]
+  fn deep_type_diagnostics_are_truncated_before_recursive_rendering_grows() {
+    let mut annotation = Arc::new(CalcitTypeAnnotation::Number);
+    for _ in 0..2_048 {
+      annotation = Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from("tests.types/Layer"),
+        Arc::new(vec![annotation]),
+      ));
+    }
+    let brief = annotation.to_brief_string();
+    let described = annotation.describe();
+    assert!(brief.contains('…'), "brief diagnostic should expose truncation: {brief}");
+    assert!(
+      described.contains('…'),
+      "described diagnostic should expose truncation: {described}"
+    );
+    assert!(brief.len() < 1_024, "brief diagnostic is unexpectedly large: {} bytes", brief.len());
+    assert!(
+      described.len() < 1_024,
+      "described diagnostic is unexpectedly large: {} bytes",
+      described.len()
+    );
+  }
+
+  #[test]
+  fn pure_schema_alias_cycles_are_not_compatible_or_proven() {
+    use crate::program::{PROGRAM_CODE_DATA, ProgramDefEntry, ProgramFileData, lock_program_test_state};
+
+    let _guard = lock_program_test_state();
+    register_program_lookups(
+      crate::program::lookup_runtime_ready,
+      crate::program::lookup_def_code,
+      crate::program::lookup_def_schema,
+    );
+    let alias_ref = |name: &'static str| {
+      Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from(format!("tests.alias-cycle/{name}")),
+        Arc::new(vec![]),
+      ))
+    };
+    PROGRAM_CODE_DATA.write().expect("seed alias cycle").insert(
+      Arc::from("tests.alias-cycle"),
+      ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([
+          (
+            Arc::from("A"),
+            ProgramDefEntry {
+              code: Calcit::Nil,
+              schema: alias_ref("B"),
+              doc: Arc::from(""),
+              examples: vec![],
+              ffi: None,
+            },
+          ),
+          (
+            Arc::from("B"),
+            ProgramDefEntry {
+              code: Calcit::Nil,
+              schema: alias_ref("A"),
+              doc: Arc::from(""),
+              examples: vec![],
+              ffi: None,
+            },
+          ),
+        ]),
+      },
+    );
+
+    let alias = alias_ref("A");
+    assert!(!alias.is_compatible_with(&CalcitTypeAnnotation::Number));
+    assert_eq!(
+      alias.prove_with_bindings(&CalcitTypeAnnotation::Number, &mut TypeBindings::new()),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::RecursiveTypeAlias)
+    );
+  }
 
   #[test]
   fn phase_aware_macro_signature_round_trips_without_fn_conflation() {

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -209,11 +209,46 @@ thread_local! {
   /// currently being built (for example, an enum containing itself). Keep the
   /// recursive edge symbolic while still validating the outer application.
   static TYPE_REF_ARITY_RESOLUTION_STACK: RefCell<HashSet<Arc<str>>> = RefCell::new(HashSet::new());
+  /// Alias and slot expansion are relation-local. These stacks prevent a
+  /// malformed alias graph from recursively re-entering the same symbolic
+  /// edge while keeping independent compatibility checks isolated.
+  static TYPE_RELATION_ALIAS_STACK: RefCell<HashSet<Arc<str>>> = RefCell::new(HashSet::new());
+  static TYPE_RELATION_SLOT_STACK: RefCell<HashSet<Arc<str>>> = RefCell::new(HashSet::new());
 }
 
 pub static DYNAMIC_TYPE: LazyLock<Arc<CalcitTypeAnnotation>> = LazyLock::new(|| Arc::new(CalcitTypeAnnotation::Dynamic));
 
 pub(crate) type TypeBindings = HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>;
+
+const TYPE_RELATION_VISIT_LIMIT: usize = 16_384;
+const TYPE_DIAGNOSTIC_DEPTH_LIMIT: usize = 32;
+
+fn with_type_relation_symbol<T>(
+  stack: &'static std::thread::LocalKey<RefCell<HashSet<Arc<str>>>>,
+  name: &str,
+  f: impl FnOnce() -> T,
+) -> Option<T> {
+  struct SymbolGuard {
+    stack: &'static std::thread::LocalKey<RefCell<HashSet<Arc<str>>>>,
+    key: Arc<str>,
+  }
+
+  impl Drop for SymbolGuard {
+    fn drop(&mut self) {
+      self.stack.with(|active| {
+        active.borrow_mut().remove(&self.key);
+      });
+    }
+  }
+
+  let key: Arc<str> = Arc::from(name.trim_start_matches('\'').trim_start_matches(':'));
+  let entered = stack.with(|active| active.borrow_mut().insert(key.clone()));
+  if !entered {
+    return None;
+  }
+  let _guard = SymbolGuard { stack, key };
+  Some(f())
+}
 
 fn type_ref_arity_resolution_key(name: &str) -> Arc<str> {
   let stripped = name.trim_start_matches('\'').trim_start_matches(':');
@@ -2864,25 +2899,41 @@ impl CalcitTypeAnnotation {
 
   /// Render a concise representation used in warnings or logs
   pub fn to_brief_string(&self) -> String {
+    self.to_brief_string_at_depth(0)
+  }
+
+  fn to_brief_string_at_depth(&self, depth: usize) -> String {
+    if depth >= TYPE_DIAGNOSTIC_DEPTH_LIMIT {
+      return "…".to_string();
+    }
+    let next_depth = depth + 1;
     if let Some(tag) = self.builtin_tag_name() {
       return format!(":{tag}");
     }
 
     match self {
       Self::Fn(signature) => signature.render_signature_brief(),
-      Self::Variadic(inner) => format!("&{}", inner.to_brief_string()),
-      Self::List(inner) => format!("list<{}>", inner.to_brief_string()),
-      Self::Map(k, v) => format!("map<{},{}>", k.to_brief_string(), v.to_brief_string()),
-      Self::Set(inner) => format!("set<{}>", inner.to_brief_string()),
-      Self::Ref(inner) => format!("ref<{}>", inner.to_brief_string()),
+      Self::Variadic(inner) => format!("&{}", inner.to_brief_string_at_depth(next_depth)),
+      Self::List(inner) => format!("list<{}>", inner.to_brief_string_at_depth(next_depth)),
+      Self::Map(k, v) => format!(
+        "map<{},{}>",
+        k.to_brief_string_at_depth(next_depth),
+        v.to_brief_string_at_depth(next_depth)
+      ),
+      Self::Set(inner) => format!("set<{}>", inner.to_brief_string_at_depth(next_depth)),
+      Self::Ref(inner) => format!("ref<{}>", inner.to_brief_string_at_depth(next_depth)),
       Self::Custom(inner) => format!("{inner}"),
-      Self::Optional(inner) => format!("{}?", inner.to_brief_string()),
-      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.to_brief_string()),
+      Self::Optional(inner) => format!("{}?", inner.to_brief_string_at_depth(next_depth)),
+      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.to_brief_string_at_depth(next_depth)),
       Self::Struct(base, args) => {
         if args.is_empty() {
           format!("struct {}", base.name)
         } else {
-          let rendered = args.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.to_brief_string_at_depth(next_depth))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("struct {}<{}>", base.name, rendered)
         }
       }
@@ -2896,7 +2947,11 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("'{name}")
         } else {
-          let rendered = args.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.to_brief_string_at_depth(next_depth))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("'{name}<{rendered}>")
         }
       }
@@ -2904,7 +2959,11 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("enum {}", enum_def.name())
         } else {
-          let rendered = args.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>().join(", ");
+          let rendered = args
+            .iter()
+            .map(|t| t.to_brief_string_at_depth(next_depth))
+            .collect::<Vec<_>>()
+            .join(", ");
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
@@ -2921,62 +2980,178 @@ impl CalcitTypeAnnotation {
   /// Substitute all `TypeVar` occurrences with their bound types from `bindings`.
   /// Returns a new annotation with variables resolved; unbound variables remain as-is.
   pub fn substitute_type_vars(&self, bindings: &TypeBindings) -> Arc<CalcitTypeAnnotation> {
-    match self {
-      Self::TypeVar(name) => bindings.get(name).cloned().unwrap_or_else(|| Arc::new(self.clone())),
-      Self::TypeRef(name, args) => {
-        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars(bindings)).collect();
-        Arc::new(Self::TypeRef(name.clone(), Arc::new(new_args)))
-      }
-      Self::List(inner) => Arc::new(Self::List(inner.substitute_type_vars(bindings))),
-      Self::Map(k, v) => Arc::new(Self::Map(k.substitute_type_vars(bindings), v.substitute_type_vars(bindings))),
-      Self::Set(inner) => Arc::new(Self::Set(inner.substitute_type_vars(bindings))),
-      Self::Ref(inner) => Arc::new(Self::Ref(inner.substitute_type_vars(bindings))),
-      Self::Optional(inner) => Arc::new(Self::Optional(inner.substitute_type_vars(bindings))),
-      Self::JsNullish(inner) => Arc::new(Self::JsNullish(inner.substitute_type_vars(bindings))),
-      Self::Variadic(inner) => Arc::new(Self::Variadic(inner.substitute_type_vars(bindings))),
-      Self::Fn(sig) => {
-        let new_args = sig.arg_types.iter().map(|a| a.substitute_type_vars(bindings)).collect();
-        let new_ret = sig.return_type.substitute_type_vars(bindings);
-        let new_rest = sig.rest_type.as_ref().map(|r| r.substitute_type_vars(bindings));
-        Arc::new(Self::Fn(Arc::new(CalcitFnTypeAnnotation {
-          generics: sig.generics.clone(),
-          where_bounds: sig.where_bounds.clone(),
-          arg_types: new_args,
-          return_type: new_ret,
-          fn_kind: sig.fn_kind,
-          rest_type: new_rest,
-          features: sig.features.clone(),
-        })))
-      }
-      Self::Struct(base, args) => {
-        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars(bindings)).collect();
-        Arc::new(Self::Struct(base.clone(), Arc::new(new_args)))
-      }
-      Self::Enum(base, args) => {
-        let new_args: Vec<_> = args.iter().map(|a| a.substitute_type_vars(bindings)).collect();
-        Arc::new(Self::Enum(base.clone(), Arc::new(new_args)))
-      }
-      // Leaf types: no TypeVars inside
-      _ => Arc::new(self.clone()),
+    enum Unary {
+      List,
+      Set,
+      Ref,
+      Optional,
+      JsNullish,
+      Variadic,
     }
+
+    enum Task<'a> {
+      Visit(&'a CalcitTypeAnnotation),
+      Cache(usize),
+      BuildUnary(Unary),
+      BuildMap,
+      BuildTypeRef(Arc<str>, usize),
+      BuildStruct(Arc<CalcitStructDef>, usize),
+      BuildEnum(Arc<CalcitEnumDef>, usize),
+      BuildFn(Arc<CalcitFnTypeAnnotation>, usize, bool),
+    }
+
+    let mut tasks = vec![Task::Visit(self)];
+    let mut values: Vec<Arc<CalcitTypeAnnotation>> = vec![];
+    let mut cache: HashMap<usize, Arc<CalcitTypeAnnotation>> = HashMap::new();
+    while let Some(task) = tasks.pop() {
+      match task {
+        Task::Visit(annotation) => {
+          let cache_key = std::ptr::from_ref(annotation) as usize;
+          if let Some(cached) = cache.get(&cache_key) {
+            values.push(cached.clone());
+            continue;
+          }
+          tasks.push(Task::Cache(cache_key));
+          match annotation {
+            Self::TypeVar(name) => values.push(bindings.get(name).cloned().unwrap_or_else(|| Arc::new(annotation.clone()))),
+            Self::TypeRef(name, args) => {
+              tasks.push(Task::BuildTypeRef(name.clone(), args.len()));
+              tasks.extend(args.iter().rev().map(|arg| Task::Visit(arg)));
+            }
+            Self::List(inner) => {
+              tasks.push(Task::BuildUnary(Unary::List));
+              tasks.push(Task::Visit(inner));
+            }
+            Self::Set(inner) => {
+              tasks.push(Task::BuildUnary(Unary::Set));
+              tasks.push(Task::Visit(inner));
+            }
+            Self::Ref(inner) => {
+              tasks.push(Task::BuildUnary(Unary::Ref));
+              tasks.push(Task::Visit(inner));
+            }
+            Self::Optional(inner) => {
+              tasks.push(Task::BuildUnary(Unary::Optional));
+              tasks.push(Task::Visit(inner));
+            }
+            Self::JsNullish(inner) => {
+              tasks.push(Task::BuildUnary(Unary::JsNullish));
+              tasks.push(Task::Visit(inner));
+            }
+            Self::Variadic(inner) => {
+              tasks.push(Task::BuildUnary(Unary::Variadic));
+              tasks.push(Task::Visit(inner));
+            }
+            Self::Map(key, value) => {
+              tasks.push(Task::BuildMap);
+              tasks.push(Task::Visit(value));
+              tasks.push(Task::Visit(key));
+            }
+            Self::Struct(base, args) => {
+              tasks.push(Task::BuildStruct(base.clone(), args.len()));
+              tasks.extend(args.iter().rev().map(|arg| Task::Visit(arg)));
+            }
+            Self::Enum(base, args) => {
+              tasks.push(Task::BuildEnum(base.clone(), args.len()));
+              tasks.extend(args.iter().rev().map(|arg| Task::Visit(arg)));
+            }
+            Self::Fn(signature) => {
+              tasks.push(Task::BuildFn(
+                signature.clone(),
+                signature.arg_types.len(),
+                signature.rest_type.is_some(),
+              ));
+              if let Some(rest) = &signature.rest_type {
+                tasks.push(Task::Visit(rest));
+              }
+              tasks.push(Task::Visit(&signature.return_type));
+              tasks.extend(signature.arg_types.iter().rev().map(|arg| Task::Visit(arg)));
+            }
+            _ => values.push(Arc::new(annotation.clone())),
+          }
+        }
+        Task::Cache(cache_key) => {
+          cache.insert(cache_key, values.last().expect("substitution cached result").clone());
+        }
+        Task::BuildUnary(kind) => {
+          let inner = values.pop().expect("substitution unary result");
+          values.push(Arc::new(match kind {
+            Unary::List => Self::List(inner),
+            Unary::Set => Self::Set(inner),
+            Unary::Ref => Self::Ref(inner),
+            Unary::Optional => Self::Optional(inner),
+            Unary::JsNullish => Self::JsNullish(inner),
+            Unary::Variadic => Self::Variadic(inner),
+          }));
+        }
+        Task::BuildMap => {
+          let value = values.pop().expect("substitution map value");
+          let key = values.pop().expect("substitution map key");
+          values.push(Arc::new(Self::Map(key, value)));
+        }
+        Task::BuildTypeRef(name, count) => {
+          let args = values.split_off(values.len() - count);
+          values.push(Arc::new(Self::TypeRef(name, Arc::new(args))));
+        }
+        Task::BuildStruct(base, count) => {
+          let args = values.split_off(values.len() - count);
+          values.push(Arc::new(Self::Struct(base, Arc::new(args))));
+        }
+        Task::BuildEnum(base, count) => {
+          let args = values.split_off(values.len() - count);
+          values.push(Arc::new(Self::Enum(base, Arc::new(args))));
+        }
+        Task::BuildFn(signature, arg_count, has_rest) => {
+          let child_count = arg_count + 1 + usize::from(has_rest);
+          let mut children = values.split_off(values.len() - child_count);
+          let args = children.drain(..arg_count).collect();
+          let return_type = children.remove(0);
+          let rest_type = has_rest.then(|| children.remove(0));
+          values.push(Arc::new(Self::Fn(Arc::new(CalcitFnTypeAnnotation {
+            generics: signature.generics.clone(),
+            where_bounds: signature.where_bounds.clone(),
+            arg_types: args,
+            return_type,
+            fn_kind: signature.fn_kind,
+            rest_type,
+            features: signature.features.clone(),
+          }))));
+        }
+      }
+    }
+    values.pop().expect("substitution root result")
   }
 
   /// Check whether this annotation contains any `TypeVar`.
   pub fn contains_type_var(&self) -> bool {
-    match self {
-      Self::TypeVar(_) => true,
-      Self::TypeRef(_, args) => args.iter().any(|a| a.contains_type_var()),
-      Self::List(inner)
-      | Self::Set(inner)
-      | Self::Ref(inner)
-      | Self::Optional(inner)
-      | Self::JsNullish(inner)
-      | Self::Variadic(inner) => inner.contains_type_var(),
-      Self::Map(k, v) => k.contains_type_var() || v.contains_type_var(),
-      Self::Fn(sig) => sig.arg_types.iter().any(|a| a.contains_type_var()) || sig.return_type.contains_type_var(),
-      Self::Struct(_, args) | Self::Enum(_, args) => args.iter().any(|a| a.contains_type_var()),
-      _ => false,
+    let mut pending = vec![self];
+    while let Some(annotation) = pending.pop() {
+      match annotation {
+        Self::TypeVar(_) => return true,
+        Self::TypeRef(_, args) | Self::Struct(_, args) | Self::Enum(_, args) => {
+          pending.extend(args.iter().map(Arc::as_ref));
+        }
+        Self::List(inner)
+        | Self::Set(inner)
+        | Self::Ref(inner)
+        | Self::Optional(inner)
+        | Self::JsNullish(inner)
+        | Self::Variadic(inner) => pending.push(inner),
+        Self::Map(key, value) => {
+          pending.push(value);
+          pending.push(key);
+        }
+        Self::Fn(signature) => {
+          pending.extend(signature.arg_types.iter().map(Arc::as_ref));
+          pending.push(&signature.return_type);
+          if let Some(rest) = &signature.rest_type {
+            pending.push(rest);
+          }
+        }
+        _ => {}
+      }
     }
+    false
   }
 
   /// Check whether this annotation recursively contains one named `TypeVar`.
@@ -2985,24 +3160,34 @@ impl CalcitTypeAnnotation {
   /// so a value such as `Optional<T>` cannot bind `T` to a type containing
   /// itself and make later comparisons recurse forever.
   fn contains_type_var_named(&self, name: &str) -> bool {
-    match self {
-      Self::TypeVar(current) => current.as_ref() == name,
-      Self::TypeRef(_, args) => args.iter().any(|arg| arg.contains_type_var_named(name)),
-      Self::List(inner)
-      | Self::Set(inner)
-      | Self::Ref(inner)
-      | Self::Optional(inner)
-      | Self::JsNullish(inner)
-      | Self::Variadic(inner) => inner.contains_type_var_named(name),
-      Self::Map(key, value) => key.contains_type_var_named(name) || value.contains_type_var_named(name),
-      Self::Fn(signature) => {
-        signature.arg_types.iter().any(|arg| arg.contains_type_var_named(name))
-          || signature.return_type.contains_type_var_named(name)
-          || signature.rest_type.as_ref().is_some_and(|rest| rest.contains_type_var_named(name))
+    let mut pending = vec![self];
+    while let Some(annotation) = pending.pop() {
+      match annotation {
+        Self::TypeVar(current) if current.as_ref() == name => return true,
+        Self::TypeRef(_, args) | Self::Struct(_, args) | Self::Enum(_, args) => {
+          pending.extend(args.iter().map(Arc::as_ref));
+        }
+        Self::List(inner)
+        | Self::Set(inner)
+        | Self::Ref(inner)
+        | Self::Optional(inner)
+        | Self::JsNullish(inner)
+        | Self::Variadic(inner) => pending.push(inner),
+        Self::Map(key, value) => {
+          pending.push(value);
+          pending.push(key);
+        }
+        Self::Fn(signature) => {
+          pending.extend(signature.arg_types.iter().map(Arc::as_ref));
+          pending.push(&signature.return_type);
+          if let Some(rest) = &signature.rest_type {
+            pending.push(rest);
+          }
+        }
+        _ => {}
       }
-      Self::Struct(_, args) | Self::Enum(_, args) => args.iter().any(|arg| arg.contains_type_var_named(name)),
-      _ => false,
     }
+    false
   }
 
   /// Binding-aware occurs-check used before inserting a generic binding.
@@ -3354,6 +3539,78 @@ impl CalcitTypeAnnotation {
   }
 
   pub(crate) fn compatible_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
+    let mut pending = vec![(self, expected)];
+    let mut visits = 0usize;
+
+    while let Some((actual, expected)) = pending.pop() {
+      visits += 1;
+      if visits > TYPE_RELATION_VISIT_LIMIT {
+        // A bounded rejection is safer than widening the unresolved relation
+        // to Dynamic. Callers will report the original actual/expected path.
+        return false;
+      }
+
+      match (actual, expected) {
+        (Self::List(a), Self::List(b))
+        | (Self::Set(a), Self::Set(b))
+        | (Self::Ref(a), Self::Ref(b))
+        | (Self::Variadic(a), Self::Variadic(b))
+        | (Self::Optional(a), Self::Optional(b))
+        | (Self::JsNullish(a), Self::JsNullish(b)) => pending.push((a, b)),
+        (Self::Map(actual_key, actual_value), Self::Map(expected_key, expected_value)) => {
+          // Preserve the recursive implementation's left-to-right binding order.
+          pending.push((actual_value, expected_value));
+          pending.push((actual_key, expected_key));
+        }
+        (Self::TypeRef(actual_name, actual_args), Self::TypeRef(expected_name, expected_args))
+          if actual_args.len() == expected_args.len()
+            && !actual_args.is_empty()
+            && Self::type_ref_nominal_match(actual_name, expected_name).unwrap_or_else(|| {
+              Self::type_ref_name_matches(actual_name, expected_name) || Self::type_ref_name_matches(expected_name, actual_name)
+            }) =>
+        {
+          pending.extend(
+            actual_args
+              .iter()
+              .zip(expected_args.iter())
+              .rev()
+              .map(|(actual, expected)| (actual.as_ref(), expected.as_ref())),
+          );
+        }
+        (Self::Struct(actual_base, actual_args), Self::Struct(expected_base, expected_args))
+          if actual_args.len() == expected_args.len()
+            && !actual_args.is_empty()
+            && Self::struct_nominal_match(actual_base, expected_base).unwrap_or_else(|| actual_base.name == expected_base.name) =>
+        {
+          pending.extend(
+            actual_args
+              .iter()
+              .zip(expected_args.iter())
+              .rev()
+              .map(|(actual, expected)| (actual.as_ref(), expected.as_ref())),
+          );
+        }
+        (Self::Enum(actual_base, actual_args), Self::Enum(expected_base, expected_args))
+          if actual_args.len() == expected_args.len()
+            && !actual_args.is_empty()
+            && Self::enum_nominal_match(actual_base, expected_base).unwrap_or_else(|| actual_base.name() == expected_base.name()) =>
+        {
+          pending.extend(
+            actual_args
+              .iter()
+              .zip(expected_args.iter())
+              .rev()
+              .map(|(actual, expected)| (actual.as_ref(), expected.as_ref())),
+          );
+        }
+        _ if actual.compatible_one_with_bindings(expected, bindings) => {}
+        _ => return false,
+      }
+    }
+    true
+  }
+
+  fn compatible_one_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
     match (self, expected) {
       (_, Self::Dynamic) | (Self::Dynamic, _) => true,
       (Self::Macro(actual), Self::Macro(expected)) => actual == expected,
@@ -3642,14 +3899,20 @@ impl CalcitTypeAnnotation {
       // try to resolve it as a type alias by looking up the definition's schema.
       (Self::TypeRef(name, _), other) | (other, Self::TypeRef(name, _)) => {
         if let Some(resolved) = resolve_type_ref_as_schema(name) {
-          return resolved.compatible_with_bindings(other, bindings);
+          return with_type_relation_symbol(&TYPE_RELATION_ALIAS_STACK, name, || {
+            resolved.compatible_with_bindings(other, bindings)
+          })
+          .unwrap_or(false);
         }
         false
       }
       // TypeSlot: resolve the bound type from the global registry and delegate
       (Self::TypeSlot(name), other) | (other, Self::TypeSlot(name)) => {
         if let Some(resolved) = resolve_type_slot(name) {
-          return resolved.compatible_with_bindings(other, bindings);
+          return with_type_relation_symbol(&TYPE_RELATION_SLOT_STACK, name, || {
+            resolved.compatible_with_bindings(other, bindings)
+          })
+          .unwrap_or(false);
         }
         // Slot not yet bound — treat as Dynamic (no checking)
         true
@@ -4285,30 +4548,38 @@ impl CalcitTypeAnnotation {
   }
 
   pub fn describe(&self) -> String {
+    self.describe_at_depth(0)
+  }
+
+  fn describe_at_depth(&self, depth: usize) -> String {
+    if depth >= TYPE_DIAGNOSTIC_DEPTH_LIMIT {
+      return "…".to_string();
+    }
+    let next_depth = depth + 1;
     match self {
       Self::List(inner) => {
         if matches!(inner.as_ref(), Self::Dynamic) {
           return "list".to_string();
         }
-        return format!("list<{}>", inner.describe());
+        return format!("list<{}>", inner.describe_at_depth(next_depth));
       }
       Self::Map(k, v) => {
         if matches!(k.as_ref(), Self::Dynamic) && matches!(v.as_ref(), Self::Dynamic) {
           return "map".to_string();
         }
-        return format!("map<{}, {}>", k.describe(), v.describe());
+        return format!("map<{}, {}>", k.describe_at_depth(next_depth), v.describe_at_depth(next_depth));
       }
       Self::Set(inner) => {
         if matches!(inner.as_ref(), Self::Dynamic) {
           return "set".to_string();
         }
-        return format!("set<{}>", inner.describe());
+        return format!("set<{}>", inner.describe_at_depth(next_depth));
       }
       Self::Ref(inner) => {
         if matches!(inner.as_ref(), Self::Dynamic) {
           return "ref".to_string();
         }
-        return format!("ref<{}>", inner.describe());
+        return format!("ref<{}>", inner.describe_at_depth(next_depth));
       }
       _ => {}
     }
@@ -4324,17 +4595,17 @@ impl CalcitTypeAnnotation {
         MacroSyntaxType::Syntax => "syntax".to_owned(),
         MacroSyntaxType::SyntaxSymbol => "syntax-symbol".to_owned(),
         MacroSyntaxType::SyntaxList => "syntax-list".to_owned(),
-        MacroSyntaxType::Expr(semantic) => format!("syntax-expr<{}>", semantic.describe()),
+        MacroSyntaxType::Expr(semantic) => format!("syntax-expr<{}>", semantic.describe_at_depth(next_depth)),
       },
-      Self::Variadic(inner) => format!("variadic {}", inner.describe()),
+      Self::Variadic(inner) => format!("variadic {}", inner.describe_at_depth(next_depth)),
       Self::Custom(_) => "custom".to_string(),
-      Self::Optional(inner) => format!("optional<{}>", inner.describe()),
-      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.describe()),
+      Self::Optional(inner) => format!("optional<{}>", inner.describe_at_depth(next_depth)),
+      Self::JsNullish(inner) => format!("js-nullish<{}>", inner.describe_at_depth(next_depth)),
       Self::Struct(base, args) => {
         if args.is_empty() {
           format!("struct {}", base.name)
         } else {
-          let rendered = args.iter().map(|t| t.describe()).collect::<Vec<_>>().join(", ");
+          let rendered = args.iter().map(|t| t.describe_at_depth(next_depth)).collect::<Vec<_>>().join(", ");
           format!("struct {}<{}>", base.name, rendered)
         }
       }
@@ -4343,7 +4614,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("type {name}")
         } else {
-          let rendered = args.iter().map(|t| t.describe()).collect::<Vec<_>>().join(", ");
+          let rendered = args.iter().map(|t| t.describe_at_depth(next_depth)).collect::<Vec<_>>().join(", ");
           format!("type {name}<{rendered}>")
         }
       }
@@ -4351,7 +4622,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("enum {}", enum_def.name())
         } else {
-          let rendered = args.iter().map(|t| t.describe()).collect::<Vec<_>>().join(", ");
+          let rendered = args.iter().map(|t| t.describe_at_depth(next_depth)).collect::<Vec<_>>().join(", ");
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
@@ -5321,6 +5592,121 @@ mod tests {
     );
     assert!(reverse_type_var.compatible_with_bindings(&CalcitTypeAnnotation::String, &mut reverse_bindings));
     assert_eq!(reverse_bindings.get("T").map(AsRef::as_ref), Some(&CalcitTypeAnnotation::String));
+  }
+
+  fn nested_list_type(depth: usize, leaf: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
+    (0..depth).fold(leaf, |inner, _| Arc::new(CalcitTypeAnnotation::List(inner)))
+  }
+
+  #[test]
+  fn deep_type_analysis_uses_bounded_iterative_paths() {
+    let depth = 2_048;
+    let actual = nested_list_type(depth, Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))));
+    let expected = nested_list_type(depth, Arc::new(CalcitTypeAnnotation::String));
+    let mut bindings = TypeBindings::new();
+    bindings.insert(Arc::from("T"), Arc::new(CalcitTypeAnnotation::String));
+
+    let started = std::time::Instant::now();
+    assert!(actual.contains_type_var());
+    let substituted = actual.substitute_type_vars(&bindings);
+    assert!(!substituted.contains_type_var());
+    assert!(substituted.is_compatible_with(&expected));
+    let diagnostic = substituted.describe();
+    let elapsed = started.elapsed();
+
+    assert!(diagnostic.contains('…'), "deep diagnostics must preserve a truncation marker");
+    assert!(
+      diagnostic.len() < 512,
+      "deep diagnostics must stay bounded, got {} bytes",
+      diagnostic.len()
+    );
+    eprintln!(
+      "type-analysis depth={depth} visits={} elapsed_us={}",
+      depth + 1,
+      elapsed.as_micros()
+    );
+  }
+
+  #[test]
+  fn deep_map_option_and_nominal_relations_remain_precise() {
+    for depth in [32usize, 256, 2_048] {
+      let map_actual = (0..depth).fold(Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))), |value, _| {
+        Arc::new(CalcitTypeAnnotation::Map(Arc::new(CalcitTypeAnnotation::String), value))
+      });
+      let map_expected = (0..depth).fold(Arc::new(CalcitTypeAnnotation::Number), |value, _| {
+        Arc::new(CalcitTypeAnnotation::Map(Arc::new(CalcitTypeAnnotation::String), value))
+      });
+      let option_actual = (0..depth).fold(Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))), |value, _| {
+        Arc::new(CalcitTypeAnnotation::TypeRef(
+          Arc::from("calcit.core/Option"),
+          Arc::new(vec![value]),
+        ))
+      });
+      let option_expected = (0..depth).fold(Arc::new(CalcitTypeAnnotation::Number), |value, _| {
+        Arc::new(CalcitTypeAnnotation::TypeRef(
+          Arc::from("calcit.core/Option"),
+          Arc::new(vec![value]),
+        ))
+      });
+      let nominal_actual = (0..depth).fold(Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T"))), |value, _| {
+        Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("tests/Node"), Arc::new(vec![value])))
+      });
+      let nominal_expected = (0..depth).fold(Arc::new(CalcitTypeAnnotation::Number), |value, _| {
+        Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("tests/Node"), Arc::new(vec![value])))
+      });
+
+      for (actual, expected) in [
+        (&map_actual, &map_expected),
+        (&option_actual, &option_expected),
+        (&nominal_actual, &nominal_expected),
+      ] {
+        let mut bindings = TypeBindings::new();
+        assert!(actual.compatible_with_bindings(expected, &mut bindings));
+        assert_eq!(bindings.get("T").map(Arc::as_ref), Some(&CalcitTypeAnnotation::Number));
+      }
+    }
+  }
+
+  #[test]
+  fn substituted_shared_subtypes_keep_arc_identity() {
+    let shared = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("tests/Shared"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")))]),
+    ));
+    let root = CalcitTypeAnnotation::TypeRef(Arc::from("tests/Pair"), Arc::new(vec![shared.clone(), shared]));
+    let bindings = TypeBindings::from([(Arc::from("T"), Arc::new(CalcitTypeAnnotation::String))]);
+
+    let substituted = root.substitute_type_vars(&bindings);
+    let CalcitTypeAnnotation::TypeRef(_, args) = substituted.as_ref() else {
+      panic!("expected substituted named pair");
+    };
+    assert!(Arc::ptr_eq(&args[0], &args[1]));
+    assert!(!substituted.contains_type_var());
+  }
+
+  #[test]
+  fn relation_budget_rejects_oversized_shapes_without_dynamic_fallback() {
+    let leaf = Arc::new(CalcitTypeAnnotation::String);
+    let oversized = TYPE_RELATION_VISIT_LIMIT + 1;
+    let actual = CalcitTypeAnnotation::TypeRef(Arc::from("app/Wide"), Arc::new(vec![leaf.clone(); oversized]));
+    let expected = CalcitTypeAnnotation::TypeRef(Arc::from("app/Wide"), Arc::new(vec![leaf; oversized]));
+
+    assert!(!actual.is_compatible_with(&expected));
+  }
+
+  #[test]
+  fn recursive_type_slot_relation_is_rejected_and_scope_is_cleaned_up() {
+    let left: Arc<str> = Arc::from("tests/Left");
+    let right: Arc<str> = Arc::from("tests/Right");
+    push_type_slot_override(left.clone(), Arc::new(CalcitTypeAnnotation::TypeSlot(right.clone())));
+    push_type_slot_override(right.clone(), Arc::new(CalcitTypeAnnotation::TypeSlot(left.clone())));
+
+    let recursive = CalcitTypeAnnotation::TypeSlot(left.clone());
+    assert!(!recursive.is_compatible_with(&CalcitTypeAnnotation::Number));
+
+    pop_type_slot_override(&right);
+    pop_type_slot_override(&left);
+    assert!(recursive.is_compatible_with(&CalcitTypeAnnotation::Number));
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -1,5 +1,5 @@
 use std::{
-  cell::RefCell,
+  cell::{Cell, RefCell},
   cmp::Ordering,
   collections::{HashMap, HashSet},
   fmt,
@@ -213,6 +213,7 @@ thread_local! {
   /// malformed alias graph from recursively re-entering the same symbolic
   /// edge while keeping independent compatibility checks isolated.
   static TYPE_RELATION_SLOT_STACK: RefCell<HashSet<Arc<str>>> = RefCell::new(HashSet::new());
+  static COMPATIBILITY_RELATION_VISITS: Cell<Option<usize>> = const { Cell::new(None) };
 }
 
 pub static DYNAMIC_TYPE: LazyLock<Arc<CalcitTypeAnnotation>> = LazyLock::new(|| Arc::new(CalcitTypeAnnotation::Dynamic));
@@ -220,6 +221,38 @@ pub static DYNAMIC_TYPE: LazyLock<Arc<CalcitTypeAnnotation>> = LazyLock::new(|| 
 pub(crate) type TypeBindings = HashMap<Arc<str>, Arc<CalcitTypeAnnotation>>;
 
 const TYPE_DIAGNOSTIC_DEPTH_LIMIT: usize = 32;
+
+struct CompatibilityRelationGuard {
+  owns_context: bool,
+}
+
+impl Drop for CompatibilityRelationGuard {
+  fn drop(&mut self) {
+    if self.owns_context {
+      COMPATIBILITY_RELATION_VISITS.with(|visits| visits.set(None));
+    }
+  }
+}
+
+fn enter_compatibility_relation() -> CompatibilityRelationGuard {
+  let owns_context = COMPATIBILITY_RELATION_VISITS.with(|visits| {
+    if visits.get().is_none() {
+      visits.set(Some(0));
+      true
+    } else {
+      false
+    }
+  });
+  CompatibilityRelationGuard { owns_context }
+}
+
+fn consume_compatibility_relation_visit() -> bool {
+  COMPATIBILITY_RELATION_VISITS.with(|visits| {
+    let next = visits.get().unwrap_or(0).saturating_add(1);
+    visits.set(Some(next));
+    next <= TYPE_RELATION_NODE_LIMIT
+  })
+}
 
 fn with_type_relation_symbol<T>(
   stack: &'static std::thread::LocalKey<RefCell<HashSet<Arc<str>>>>,
@@ -587,6 +620,9 @@ fn bounded_plain_type_relation<'a>(
     if stats.node_visits > TYPE_RELATION_NODE_LIMIT {
       return Err(stats);
     }
+    if matches!(mode, PlainRelationMode::Compatibility) && !consume_compatibility_relation_visit() {
+      return Err(stats);
+    }
 
     match (actual, expected) {
       (_, Type::Dynamic) | (Type::Dynamic, _) => {
@@ -749,6 +785,23 @@ fn bounded_plain_type_relation<'a>(
   }
 
   Ok(Some((result, stats)))
+}
+
+fn render_bounded_type_list(
+  types: &[Arc<CalcitTypeAnnotation>],
+  depth: usize,
+  remaining: &mut usize,
+  render: fn(&CalcitTypeAnnotation, usize, &mut usize) -> String,
+) -> String {
+  let mut parts = vec![];
+  for annotation in types {
+    if *remaining == 0 {
+      parts.push("…".to_owned());
+      break;
+    }
+    parts.push(render(annotation.as_ref(), depth, remaining));
+  }
+  parts.join(", ")
 }
 
 impl TypeProof {
@@ -3288,7 +3341,7 @@ impl CalcitTypeAnnotation {
     }
 
     match self {
-      Self::Fn(signature) => signature.render_signature_brief(),
+      Self::Fn(signature) => signature.render_signature_brief_bounded(depth + 1, remaining),
       Self::Variadic(inner) => format!("&{}", inner.to_brief_string_bounded(depth + 1, remaining)),
       Self::List(inner) => format!("list<{}>", inner.to_brief_string_bounded(depth + 1, remaining)),
       Self::Map(k, v) => format!(
@@ -3305,11 +3358,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("struct {}", base.name)
         } else {
-          let rendered = args
-            .iter()
-            .map(|t| t.to_brief_string_bounded(depth + 1, remaining))
-            .collect::<Vec<_>>()
-            .join(", ");
+          let rendered = render_bounded_type_list(args, depth + 1, remaining, CalcitTypeAnnotation::to_brief_string_bounded);
           format!("struct {}<{}>", base.name, rendered)
         }
       }
@@ -3323,11 +3372,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("'{name}")
         } else {
-          let rendered = args
-            .iter()
-            .map(|t| t.to_brief_string_bounded(depth + 1, remaining))
-            .collect::<Vec<_>>()
-            .join(", ");
+          let rendered = render_bounded_type_list(args, depth + 1, remaining, CalcitTypeAnnotation::to_brief_string_bounded);
           format!("'{name}<{rendered}>")
         }
       }
@@ -3335,11 +3380,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("enum {}", enum_def.name())
         } else {
-          let rendered = args
-            .iter()
-            .map(|t| t.to_brief_string_bounded(depth + 1, remaining))
-            .collect::<Vec<_>>()
-            .join(", ");
+          let rendered = render_bounded_type_list(args, depth + 1, remaining, CalcitTypeAnnotation::to_brief_string_bounded);
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
@@ -3915,6 +3956,7 @@ impl CalcitTypeAnnotation {
   }
 
   pub(crate) fn compatible_with_bindings(&self, expected: &CalcitTypeAnnotation, bindings: &mut TypeBindings) -> bool {
+    let _relation_guard = enter_compatibility_relation();
     match bounded_plain_type_relation(self, expected, PlainRelationMode::Compatibility) {
       Ok(Some((result, _))) => return !result.is_mismatch(),
       Err(_) => return false,
@@ -3926,7 +3968,7 @@ impl CalcitTypeAnnotation {
       if !visited.insert((actual as *const Self as usize, expected as *const Self as usize)) {
         continue;
       }
-      if visited.len() > TYPE_RELATION_NODE_LIMIT {
+      if !consume_compatibility_relation_visit() {
         return false;
       }
       match (actual, expected) {
@@ -5001,7 +5043,7 @@ impl CalcitTypeAnnotation {
     }
 
     match self {
-      Self::Fn(signature) => signature.describe(),
+      Self::Fn(signature) => signature.describe_bounded(depth + 1, remaining),
       Self::Macro(_) => "macro-signature".to_owned(),
       Self::Syntax(contract) => match contract.as_ref() {
         MacroSyntaxType::Syntax => "syntax".to_owned(),
@@ -5017,11 +5059,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("struct {}", base.name)
         } else {
-          let rendered = args
-            .iter()
-            .map(|t| t.describe_bounded(depth + 1, remaining))
-            .collect::<Vec<_>>()
-            .join(", ");
+          let rendered = render_bounded_type_list(args, depth + 1, remaining, CalcitTypeAnnotation::describe_bounded);
           format!("struct {}<{}>", base.name, rendered)
         }
       }
@@ -5030,11 +5068,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("type {name}")
         } else {
-          let rendered = args
-            .iter()
-            .map(|t| t.describe_bounded(depth + 1, remaining))
-            .collect::<Vec<_>>()
-            .join(", ");
+          let rendered = render_bounded_type_list(args, depth + 1, remaining, CalcitTypeAnnotation::describe_bounded);
           format!("type {name}<{rendered}>")
         }
       }
@@ -5042,11 +5076,7 @@ impl CalcitTypeAnnotation {
         if args.is_empty() {
           format!("enum {}", enum_def.name())
         } else {
-          let rendered = args
-            .iter()
-            .map(|t| t.describe_bounded(depth + 1, remaining))
-            .collect::<Vec<_>>()
-            .join(", ");
+          let rendered = render_bounded_type_list(args, depth + 1, remaining, CalcitTypeAnnotation::describe_bounded);
           format!("enum {}<{}>", enum_def.name(), rendered)
         }
       }
@@ -5724,6 +5754,45 @@ mod tests {
       "described diagnostic is unexpectedly large: {} bytes",
       described.len()
     );
+
+    let signature = CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![annotation.clone(); 1_024],
+      return_type: annotation,
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    }));
+    let fn_brief = signature.to_brief_string();
+    let fn_description = signature.describe();
+    assert!(
+      fn_brief.contains('…') && fn_brief.len() < 8_192,
+      "function brief must share the render budget"
+    );
+    assert!(
+      fn_description.contains('…') && fn_description.len() < 8_192,
+      "function description must share the render budget"
+    );
+  }
+
+  #[test]
+  fn compatibility_budget_spans_nested_function_signature_relations() {
+    let width = TYPE_RELATION_NODE_LIMIT + 1;
+    let signature = |arg_types| {
+      CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types,
+        return_type: Arc::new(CalcitTypeAnnotation::Unit),
+        fn_kind: SchemaKind::Fn,
+        rest_type: None,
+        features: Arc::new(HashSet::new()),
+      }))
+    };
+    let actual = signature((0..width).map(|_| Arc::new(CalcitTypeAnnotation::Number)).collect());
+    let expected = signature((0..width).map(|_| Arc::new(CalcitTypeAnnotation::Number)).collect());
+    assert!(!actual.is_compatible_with(&expected));
   }
 
   #[test]
@@ -7919,6 +7988,15 @@ impl CalcitFnTypeAnnotation {
   }
 
   pub fn describe(&self) -> String {
+    let mut remaining = 128;
+    self.describe_bounded(0, &mut remaining)
+  }
+
+  fn describe_bounded(&self, depth: usize, remaining: &mut usize) -> String {
+    if depth >= TYPE_DIAGNOSTIC_DEPTH_LIMIT || *remaining == 0 {
+      return "…".to_owned();
+    }
+    *remaining -= 1;
     let generics = if self.generics.is_empty() {
       "".to_string()
     } else {
@@ -7936,15 +8014,40 @@ impl CalcitFnTypeAnnotation {
         .join(", ");
       format!(" where {rendered}")
     };
-    let mut rendered_args = self.arg_types.iter().map(|t| t.describe()).collect::<Vec<_>>();
+    let mut rendered_args = vec![];
+    for annotation in &self.arg_types {
+      if *remaining == 0 {
+        rendered_args.push("…".to_owned());
+        break;
+      }
+      rendered_args.push(annotation.describe_bounded(depth + 1, remaining));
+    }
     if let Some(rest) = &self.rest_type {
-      rendered_args.push(format!("& {}", rest.describe()));
+      if *remaining == 0 {
+        if rendered_args.last().is_none_or(|part| part != "…") {
+          rendered_args.push("…".to_owned());
+        }
+      } else {
+        rendered_args.push(format!("& {}", rest.describe_bounded(depth + 1, remaining)));
+      }
     }
     let args = format!("({})", rendered_args.join(", "));
-    format!("fn{generics}{where_clause}{args} -> {}", self.return_type.describe())
+    format!(
+      "fn{generics}{where_clause}{args} -> {}",
+      self.return_type.describe_bounded(depth + 1, remaining)
+    )
   }
 
   pub fn render_signature_brief(&self) -> String {
+    let mut remaining = 128;
+    self.render_signature_brief_bounded(0, &mut remaining)
+  }
+
+  fn render_signature_brief_bounded(&self, depth: usize, remaining: &mut usize) -> String {
+    if depth >= TYPE_DIAGNOSTIC_DEPTH_LIMIT || *remaining == 0 {
+      return "…".to_owned();
+    }
+    *remaining -= 1;
     let generics = if self.generics.is_empty() {
       "".to_string()
     } else {
@@ -7962,13 +8065,29 @@ impl CalcitFnTypeAnnotation {
         .join(", ");
       format!(" where {rendered}")
     };
-    let mut parts = self.arg_types.iter().map(|t| t.to_brief_string()).collect::<Vec<_>>();
+    let mut parts = vec![];
+    for annotation in &self.arg_types {
+      if *remaining == 0 {
+        parts.push("…".to_owned());
+        break;
+      }
+      parts.push(annotation.to_brief_string_bounded(depth + 1, remaining));
+    }
     if let Some(rest) = &self.rest_type {
-      parts.push(format!("& {}", rest.to_brief_string()));
+      if *remaining == 0 {
+        if parts.last().is_none_or(|part| part != "…") {
+          parts.push("…".to_owned());
+        }
+      } else {
+        parts.push(format!("& {}", rest.to_brief_string_bounded(depth + 1, remaining)));
+      }
     }
     let args_repr = format!("({})", parts.join(", "));
 
-    format!("fn{generics}{where_clause}{args_repr} -> {}", self.return_type.to_brief_string())
+    format!(
+      "fn{generics}{where_clause}{args_repr} -> {}",
+      self.return_type.to_brief_string_bounded(depth + 1, remaining)
+    )
   }
 
   pub fn matches_signature(&self, other: &CalcitFnTypeAnnotation) -> bool {

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -452,6 +452,7 @@ pub(crate) enum TypeBoundaryReason {
   ErasedTypeArguments,
   RecursiveTypeVariable,
   RecursiveTypeAlias,
+  RecursiveTypeSlot,
   UnresolvedNominalIdentity,
   TypeComplexityLimit,
 }
@@ -4532,11 +4533,17 @@ impl CalcitTypeAnnotation {
       (Self::Fn(_), Self::DynFn) | (Self::DynFn, Self::Fn(_)) => NeedsBoundary(Boundary::UnknownCallable),
       (Self::Tag, Self::DynFn) | (Self::Tag, Self::Fn(_)) => NeedsBoundary(Boundary::TagCallable),
       (Self::TypeSlot(name), other) => match resolve_type_slot(name) {
-        Some(resolved) => resolved.prove_with_staged_bindings(other, bindings),
+        Some(resolved) => with_type_relation_symbol(&TYPE_RELATION_SLOT_STACK, name, || {
+          resolved.prove_with_staged_bindings(other, bindings)
+        })
+        .unwrap_or(NeedsBoundary(Boundary::RecursiveTypeSlot)),
         None => NeedsBoundary(Boundary::UnresolvedTypeSlot),
       },
       (other, Self::TypeSlot(name)) => match resolve_type_slot(name) {
-        Some(resolved) => other.prove_with_staged_bindings(resolved.as_ref(), bindings),
+        Some(resolved) => with_type_relation_symbol(&TYPE_RELATION_SLOT_STACK, name, || {
+          other.prove_with_staged_bindings(resolved.as_ref(), bindings)
+        })
+        .unwrap_or(NeedsBoundary(Boundary::RecursiveTypeSlot)),
         None => NeedsBoundary(Boundary::UnresolvedTypeSlot),
       },
       (Self::TypeRef(name, _), other) => match resolve_type_ref_as_schema(name) {
@@ -6364,6 +6371,10 @@ mod tests {
 
     let recursive = CalcitTypeAnnotation::TypeSlot(left.clone());
     assert!(!recursive.is_compatible_with(&CalcitTypeAnnotation::Number));
+    assert_eq!(
+      recursive.prove_with_bindings(&CalcitTypeAnnotation::Number, &mut TypeBindings::new()),
+      TypeProof::NeedsBoundary(TypeBoundaryReason::RecursiveTypeSlot)
+    );
 
     pop_type_slot_override(&right);
     pop_type_slot_override(&left);

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -165,6 +165,35 @@ fn nominal_impl_wrapper_type_ref_matches_its_concrete_enum_value() {
 }
 
 #[test]
+fn recursive_type_alias_relation_is_finite_and_incompatible() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  calcit::register_program_lookups(lookup_runtime_ready, lookup_def_code, lookup_def_schema);
+
+  let alias = |target: &str| ProgramDefEntry {
+    code: Calcit::Nil,
+    schema: Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from(target), Arc::new(vec![]))),
+    doc: Arc::from(""),
+    examples: vec![],
+    ffi: None,
+  };
+  PROGRAM_CODE_DATA.write().expect("seed recursive aliases").insert(
+    Arc::from("tests.alias-cycle"),
+    ProgramFileData {
+      import_map: HashMap::new(),
+      defs: HashMap::from([
+        (Arc::from("Left"), alias("tests.alias-cycle/Right")),
+        (Arc::from("Right"), alias("tests.alias-cycle/Left")),
+      ]),
+    },
+  );
+
+  let recursive = CalcitTypeAnnotation::TypeRef(Arc::from("tests.alias-cycle/Left"), Arc::new(vec![]));
+  assert!(!recursive.is_compatible_with(&CalcitTypeAnnotation::Number));
+  reset_program_test_state();
+}
+
+#[test]
 fn import_rule_validation_rejects_short_rules_without_panicking() {
   let error =
     validate_import_rules(&[cirru_list(vec![cirru_leaf("audit.invalid")])]).expect_err("short import rule should be rejected");


### PR DESCRIPTION
## 中文

完成 #845 的高风险类型分析与宽 Struct 路径：

- List/Map/Option/Ref/Set、具名类型参数及共享 DAG 使用显式 worklist 与成对访问记忆；合法 Tree/Node 递归保持有限，纯 alias/type-slot cycle 被明确拒绝。
- 类型变量扫描与泛型替换改为迭代式；替换缓存只存在于单次调用，保留共享 Arc，entry/scope/reload 不会复用旧绑定。
- 16,384 节点预算返回 TypeComplexityLimit boundary，不回退 Dynamic；递归 alias 返回 RecursiveTypeAlias boundary。
- 诊断渲染限制为 32 层和 128 节点并保留省略标记。
- 宽度 32/256/1024 的 Struct 使用只读字段索引缓存；Weak 校验实时 fields allocation，不排序、不改变声明布局或首个匹配语义。
- 固定覆盖深度 32/256/2048、共享 DAG、互递归 Tree/Node、alias/type-slot cycle、超限、缓存上下文隔离、诊断截断和宽字段 cold/warm。

验证：cargo fmt；all-target/all-feature clippy；cargo test（library 763、CLI 308、WASM 23）；yarn check-all（strict 正反例、native、JS、IR、WASM、Agent interface、quality baseline）全部通过。2048 层 debug 测量约 2.6ms、2561 visits、跟踪 payload 约 53KB；1024 字段索引 cold 建表约 0.8ms，warm 查询低于微秒分辨率。Calcium JS smoke 的 no-op identity、patch convergence、corrupt baseline、revision/recovery oracle 通过；已合并的 #794/#795 PR 与 exact-main Actions 提供业务消费者交接证据。

## English

Complete #845 across high-risk type analysis and wide Struct lookup paths:

- Use explicit worklists and pair visitation for nested List/Map/Option/Ref/Set, nominal arguments, and shared DAGs. Legal Tree/Node recursion stays finite; pure alias/type-slot cycles are rejected.
- Make type-variable scanning and generic substitution iterative. Substitution caching is call-local, preserves shared Arcs, and cannot leak across entries, scopes, or reloads.
- Return a TypeComplexityLimit boundary at 16,384 nodes instead of widening to Dynamic; recursive aliases return RecursiveTypeAlias.
- Bound diagnostic rendering to 32 levels and 128 nodes with an explicit truncation marker.
- Add a read-only field-index cache for 32/256/1024-wide Structs. Weak validation ties it to the live fields allocation without sorting or changing declaration/first-match order.
- Cover depths 32/256/2048, shared DAGs, mutually recursive Tree/Node, alias/type-slot cycles, budget rejection, context isolation, bounded diagnostics, and wide-field cold/warm behavior.

Validation passes: cargo fmt; all-target/all-feature clippy; cargo test (763 library, 308 CLI, 23 WASM); and yarn check-all (strict positive/negative fixtures, native, JS, IR, WASM, Agent interface, and quality baseline). A debug 2048-layer measurement is about 2.6ms for 2561 visits with about 53KB tracked payload; the 1024-field cache cold build is about 0.8ms and warm lookup is below microsecond resolution. Calcium's generated-JS smoke passes no-op identity, patch convergence, corrupt-baseline, revision, and recovery oracles; merged #794/#795 PRs plus exact-main Actions provide the application consumer handoff.

Closes #845
