### PR TITLE
fix: scope generated function provenance / 收紧生成函数来源判断

### DIFF
--- a/editing-history/202609072106-fix-generated-function-provenance.md
+++ b/editing-history/202609072106-fix-generated-function-provenance.md
@@ -1,0 +1,13 @@
+# Fix generated-function macro provenance / 修复生成函数宏来源判断
+
+## English
+
+- Followed up the post-merge review on #903 by defining macro provenance from the newest call-stack frame only.
+- Reused one helper in both generated-function schema synthesis and strict public-schema rejection so the two decisions cannot drift.
+- Added a strict regression where a macro expansion reaches an independently authored definition without a schema. The definition must still fail with `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA`, while the existing generated-closure regression remains accepted.
+
+## 中文
+
+- 跟进 #903 合并后的审查意见，仅使用调用栈最新 frame 判断宏生成来源。
+- 生成函数 schema 合成和严格公开 schema 拒绝共用同一 helper，避免两处判断漂移。
+- 新增严格模式回归：宏展开间接访问一个没有 schema 的独立源码定义时，该定义仍必须以 `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA` 失败；已有的真实宏生成闭包仍保持通过。

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -444,6 +444,31 @@ fn strict_mode_accepts_macro_generated_closures_without_public_schemas() {
 }
 
 #[test]
+fn strict_mode_rejects_source_definition_reached_from_macro_expansion_without_public_schema() {
+  run_with_large_stack(|| {
+    let main_schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: Arc::new(CalcitTypeAnnotation::Number),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    let entries = load_snippet_entries_with_main_schema(
+      "defn independent-source () 1\n\ndefmacro call-independent ()\n  quasiquote $ independent-source\n\ndefn main! ()\n  call-independent",
+      Some(main_schema),
+    );
+    let _strict = StrictTypesReset::enabled();
+
+    let err =
+      run_check_only(&entries).expect_err("a source definition reached through a macro expansion must still declare a public schema");
+    assert!(err.contains("E_WHOLE_DYNAMIC_PUBLIC_SCHEMA"), "unexpected strict error: {err}");
+    assert!(err.contains("independent-source"), "error should name the source definition: {err}");
+  });
+}
+
+#[test]
 fn strict_mode_runs_definition_tests_with_generated_function_schemas() {
   run_with_large_stack(|| {
     let namespace = format!("app.strict-definition-test-{}", std::process::id());

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -7846,7 +7846,7 @@ pub fn preprocess_defn(
         }
       })?;
       let def_schema = program::lookup_def_schema(ctx.file_ns, def_name.as_ref());
-      let generated_by_macro = ctx.call_stack.0.iter().any(|frame| matches!(frame.kind, StackKind::Macro));
+      let generated_by_macro = newest_call_stack_frame_is_macro(ctx.call_stack);
       let strict_generated_by_macro = strict_types_enabled() && generated_by_macro;
       if matches!(head, CalcitSyntax::DefWasmImport) && !has_valid_wasm_import_body(args) {
         return Err(CalcitErr::use_msg_stack_location(
@@ -9366,6 +9366,10 @@ fn effective_user_call_schema(info: &CalcitFn) -> Arc<CalcitFnTypeAnnotation> {
   signature
 }
 
+fn newest_call_stack_frame_is_macro(call_stack: &CallStackList) -> bool {
+  call_stack.0.first().is_some_and(|frame| matches!(frame.kind, StackKind::Macro))
+}
+
 fn reject_strict_whole_dynamic_public_schema(
   head: &CalcitSyntax,
   ns: &str,
@@ -9375,7 +9379,7 @@ fn reject_strict_whole_dynamic_public_schema(
   call_stack: &CallStackList,
   definition_location: Option<NodeLocation>,
 ) -> Result<(), CalcitErr> {
-  let generated_by_macro = call_stack.0.iter().any(|frame| matches!(frame.kind, StackKind::Macro));
+  let generated_by_macro = newest_call_stack_frame_is_macro(call_stack);
   if !strict_types_enabled()
     || !should_emit_project_source_lint(ns)
     || generated_by_macro


### PR DESCRIPTION
## English

Follow-up for #902 and the valid post-merge finding on #903.

- Determine macro-generated provenance from only the newest call-stack frame at both schema-synthesis and public-schema-rejection sites.
- Keep real macro-generated closures accepted in strict mode.
- Add a regression proving that an independently authored definition reached through a macro expansion still fails without a public schema.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUST_MIN_STACK=16777216 cargo test` (765 library + 311 CLI + 23 WASM)
- `yarn check-all`
- Respo 0.16.96 exact tag: compatibility check, 40/40 tests, strict DomPatch positive/negative gate, JS generation, typed DOM host, and SSR ref contract all passed
- Respo strict check advances past generated `f%` and reports only its existing genuine `Option<dynamic>` generic migration diagnostic

## 中文

跟进 #902 以及 #903 合并后的有效审查意见。

- 在 schema 合成与公开 schema 拒绝两个位置，仅使用调用栈最新 frame 判断宏生成来源。
- 真实宏生成闭包在严格模式下继续通过。
- 新增回归，证明宏展开间接触达的独立源码定义没有公开 schema 时仍会失败。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUST_MIN_STACK=16777216 cargo test`（765 library + 311 CLI + 23 WASM）
- `yarn check-all`
- Respo 0.16.96 精确 tag：兼容检查、40/40 测试、严格 DomPatch 正负门禁、JS 生成、typed DOM host 与 SSR ref contract 全部通过
- Respo 严格检查已越过生成的 `f%`，只报告项目现有真实 `Option<dynamic>` 泛型迁移诊断

Closes #902.