### PR TITLE
Fix wrapped generic enum JS lowering / 修复包装泛型枚举的 JS 降级

### DIFF
--- a/calcit/test-map.cirru
+++ b/calcit/test-map.cirru
@@ -23,13 +23,16 @@
                 filter-map-kv
                   {} (:a 1) (:b 2) (:c 3)
                   fn (k v)
+                    hint-fn $ {}
+                      :args $ [] 'Tag 'Number
+                      :return $ :: 'MapEntryDecision 'Tag 'Number
                     if (> v 1)
-                      %:: MapEntryDecision :keep k $ * v 10
-                      %:: MapEntryDecision :drop
+                      MapEntryDecision :keep k $ * v 10
+                      MapEntryDecision :drop
               assert= ({})
                 .filter-map-kv
                   {} $ :a 1
-                  fn (k v) (%:: MapEntryDecision :drop)
+                  fn (k v) (MapEntryDecision :drop)
               do
                 let
                     calls $ atom 0
@@ -37,7 +40,7 @@
                       {} (:a 1) (:b 2) (:c 3)
                       fn (_k v)
                         reset! calls $ + 1 @calls
-                        %:: MapEntryDecision :keep :same v
+                        MapEntryDecision :keep :same v
                   assert= 3 @calls
                   assert= 1 $ count result
                   assert= true $ contains? result :same

--- a/editing-history/202609072126-fix-wrapped-enum-constructor-lowering.md
+++ b/editing-history/202609072126-fix-wrapped-enum-constructor-lowering.md
@@ -1,0 +1,13 @@
+# Fix wrapped enum constructor lowering / 修复包装枚举构造降级
+
+## English
+
+- Reuse nominal type-definition source resolution when identifying direct Struct and Enum constructor calls.
+- Recognize generic `defenum` values wrapped by `impl-traits`, so direct `MapEntryDecision :keep ...` lowers to the named enum constructor in JavaScript.
+- Add focused source-resolution coverage and a native/JS Snapshot regression with an explicit generic `hint-fn` return contract.
+
+## 中文
+
+- 识别直接 Struct 和 Enum 构造调用时，复用具名类型定义的源码解析逻辑。
+- 支持由 `impl-traits` 包装的泛型 `defenum`，确保直接 `MapEntryDecision :keep ...` 在 JavaScript 中降级为具名枚举构造。
+- 增加源码解析覆盖，以及带显式泛型 `hint-fn` 返回约束的 native/JS Snapshot 回归测试。

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3457,12 +3457,22 @@ fn constructor_definition_path(head_form: &Calcit) -> Option<(Arc<str>, Arc<str>
 }
 
 fn data_definition_kind(ns: &str, def: &str) -> Option<&'static str> {
-  let Calcit::List(code) = program::lookup_def_code(ns, def)? else {
-    return None;
-  };
-  match code.first() {
-    Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "defstruct" => Some("defstruct"),
-    Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "defenum" => Some("defenum"),
+  data_definition_kind_from_code(&program::lookup_def_code(ns, def)?)
+}
+
+fn data_definition_kind_from_code(code: &Calcit) -> Option<&'static str> {
+  // Keep accepting the minimal source markers used while definitions are still
+  // bootstrapping; wrapped definitions need the complete nominal resolver.
+  if let Calcit::List(items) = code {
+    match items.first() {
+      Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "defstruct" => return Some("defstruct"),
+      Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "defenum" => return Some("defenum"),
+      _ => {}
+    }
+  }
+  match calcit::type_annotation::resolve_type_def_from_code(code)? {
+    Calcit::StructDef(_) => Some("defstruct"),
+    Calcit::EnumDef(_) => Some("defenum"),
     _ => None,
   }
 }
@@ -14036,6 +14046,23 @@ mod tests {
       constructor_definition_path(&head),
       Some((Arc::from("tests.schema"), Arc::from("Op")))
     );
+  }
+
+  #[test]
+  fn recognizes_generic_enum_constructor_behind_impl_traits() {
+    let generic_params = Calcit::from(vec![test_symbol("[]"), test_symbol("K"), test_symbol("V")]);
+    let keep_variant = Calcit::from(vec![Calcit::Tag(EdnTag::from("keep")), test_symbol("K"), test_symbol("V")]);
+    let drop_variant = Calcit::from(vec![Calcit::Tag(EdnTag::from("drop"))]);
+    let enum_form = Calcit::from(vec![
+      test_symbol("defenum"),
+      test_symbol("MapEntryDecision"),
+      generic_params,
+      keep_variant,
+      drop_variant,
+    ]);
+    let wrapped = Calcit::from(vec![test_symbol("impl-traits"), enum_form, test_symbol("MapEntryDecisionOps")]);
+
+    assert_eq!(data_definition_kind_from_code(&wrapped), Some("defenum"));
   }
 
   #[test]


### PR DESCRIPTION
## English

### What changed

- identify direct Struct/Enum constructor heads through the shared nominal source resolver, including `impl-traits` wrappers;
- preserve the existing fast path for minimal bootstrapping `defstruct`/`defenum` markers;
- exercise direct `MapEntryDecision` construction in the map Snapshot, including an explicit generic `hint-fn` return contract.

### Why

Calcit 0.14.0 emitted an `impl-traits`-wrapped generic enum definition such as `MapEntryDecision` as a normal JavaScript function call. The generated `$clt.MapEntryDecision(...)` then failed at runtime. The direct nominal constructor now lowers to the same named-enum runtime primitive as `%::`.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (766 library, 311 CLI, 23 WASM tests)
- `yarn check-all`
- focused native and generated-JS execution of `test-map.main/test-filter-map-kv`
- real `calcium-workflow-map-kv` reproduction changed from invalid `$clt.MapEntryDecision(...)` emission to typed nominal checking; its current `Component`/`Element` mismatch is correctly rejected instead of reaching the browser

## 中文

### 变更

- 通过共享的具名类型源码解析器识别直接 Struct/Enum 构造头，包括 `impl-traits` 包装形式；
- 保留最小化 bootstrapping `defstruct`/`defenum` 标记的既有快速路径；
- 在 map Snapshot 中覆盖直接 `MapEntryDecision` 构造，并加入显式泛型 `hint-fn` 返回约束。

### 原因

Calcit 0.14.0 会把 `impl-traits` 包装的泛型枚举（如 `MapEntryDecision`）生成为普通 JavaScript 函数调用，生成的 `$clt.MapEntryDecision(...)` 会在运行时崩溃。现在直接具名构造会降级为与 `%::` 相同的具名枚举运行时原语。

### 验证

- Rust 格式、Clippy、完整测试通过；
- `yarn check-all` 通过；
- `test-map.main/test-filter-map-kv` 的 native 与生成 JS 聚焦执行通过；
- 真实 `calcium-workflow-map-kv` 从错误 JS 调用变为具名类型检查；其当前 `Component`/`Element` 不匹配被正确阻断，不再流入浏览器。

Closes #899
