### PR TITLE
ci: skip unchanged documentation deploys / 跳过未变化的文档部署

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -108,7 +110,22 @@ jobs:
           && cp -v scripts/main.mjs js-out/
           && node js-out/main.mjs
 
+      - name: Detect documentation changes
+        id: docs_changes
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- docs/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy CalcitAgent.md to server
+        if: steps.docs_changes.outputs.changed == 'true'
         id: deploy
         uses: Pendect/action-rsyncer@v2.0.0
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --bin calcit
@@ -52,6 +54,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -118,10 +121,16 @@ jobs:
         run: |
           if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- docs/; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            set +e
+            git diff --quiet "$BEFORE_SHA" "$GITHUB_SHA" -- docs/
+            status=$?
+            set -e
+            case "$status" in
+              0) echo "changed=false" >> "$GITHUB_OUTPUT" ;;
+              1) echo "changed=true" >> "$GITHUB_OUTPUT" ;;
+              *) echo "::error::Unable to compare pushed range"; exit "$status" ;;
+            esac
           fi
 
       - name: Deploy CalcitAgent.md to server

--- a/editing-history/202609080101-skip-unchanged-doc-deploy.md
+++ b/editing-history/202609080101-skip-unchanged-doc-deploy.md
@@ -1,0 +1,11 @@
+# Skip unchanged documentation deploys / 跳过未变化的文档部署
+
+## Summary / 概要
+
+- The main test workflow now fetches enough Git history to compare the pushed range.
+- The rsync documentation deployment runs only when a main push actually changes `docs/`.
+- Pull requests and source/version-only main pushes still run all build and test gates, but no longer consume remote documentation storage or fail because an unrelated deploy target is full.
+
+## Behavior / 行为
+
+Documentation changes continue to exercise the existing deployment step, so remote authentication, capacity, and rsync failures remain visible when deployment is relevant. An initial push with an all-zero `before` SHA conservatively deploys.

--- a/editing-history/202609080101-skip-unchanged-doc-deploy.md
+++ b/editing-history/202609080101-skip-unchanged-doc-deploy.md
@@ -5,7 +5,8 @@
 - The main test workflow now fetches enough Git history to compare the pushed range.
 - The rsync documentation deployment runs only when a main push actually changes `docs/`.
 - Pull requests and source/version-only main pushes still run all build and test gates, but no longer consume remote documentation storage or fail because an unrelated deploy target is full.
+- Checkout credentials are not persisted in jobs that execute repository code from pull requests.
 
 ## Behavior / 行为
 
-Documentation changes continue to exercise the existing deployment step, so remote authentication, capacity, and rsync failures remain visible when deployment is relevant. An initial push with an all-zero `before` SHA conservatively deploys.
+Documentation changes continue to exercise the existing deployment step, so remote authentication, capacity, and rsync failures remain visible when deployment is relevant. An initial push with an all-zero `before` SHA conservatively deploys. The pushed-range comparison distinguishes changed, unchanged, and command-error statuses so a comparison failure cannot masquerade as a documentation change.


### PR DESCRIPTION
## Summary / 概要

- detect whether a `main` push actually changes `docs/`
- run the rsync documentation deployment only for relevant pushes
- keep all build, test, WASI, macOS, documentation-validation, and generated-JS gates unchanged

## Motivation / 原因

The `0.14.2` version-only main commit passed every code and documentation validation step, then failed while redundantly uploading unchanged documentation because the remote server was full (`rsync: No space left on device`). The previous main commit had already deployed the current docs successfully.

This keeps deployment failures visible when documentation changes, while preventing source/version-only pushes and pull requests from depending on unrelated remote storage capacity.

Failed run: https://github.com/calcit-lang/calcit/actions/runs/34145551525

## Validation / 验证

- workflow YAML parses successfully
- `git diff --check`
- reviewed event conditions: PR skips deploy; main push compares the complete pushed range; an all-zero initial `before` SHA deploys conservatively
