### PR TITLE
fix(calx): 限定 checked index 的 I64 边界 / confine checked-index I64 values

### DIFF
--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -89,8 +89,8 @@ name；direct tail call 与 `recur` 降为 `return-call`。
 - fixed arity top-level function；
 - Number/Bool literal、typed local、单 binding `&let`、有 else 的 `if`；
 - `&+`、一元/二元 `&-`、`&*`、`&/`、`&=`、`&<`、`&>`；
-- internal typed-buffer intrinsics：`&f64:to-i64-index`、`&f64-buffer:get`；conversion/bounds failure
-  在 VM 中 trap，绝不返回 `Nil`；
+- internal typed-buffer read：`&f64-buffer:get buffer (&f64:to-i64-index index)`；转换仅支持直接位于
+  读取的 index 位置，产生的 I64 只供紧随其后的读取指令使用；conversion/bounds failure 在 VM 中 trap，绝不返回 `Nil`；
 - fixed-arity direct call 与 tail-position `recur`；
 - 显式 allowlist 的 zero-result / single-result typed host import；
 - 条件必须静态为 Bool，不复用 Calcit 或 Calx 的 numeric truthiness。
@@ -101,6 +101,11 @@ name；direct tail call 与 `recur` 降为 `return-call`。
 - closure、function value、local/dynamic operator、HOF、rest/optional arity；
 - 无 else 的 `if`、非 tail `recur`、global/ref/atom、collection/nominal value；
 - 未加入 allowlist 的 host/native capability。
+
+`&f64:to-i64-index` 不能独立返回、绑定到 Number local、参与算术或作为普通函数参数；
+这些位置在 Calcit 中仍是 Number/F64，而 VM 转换结果是 I64。省略显式转换的 buffer 读取也会在
+eligibility 阶段拒绝，而不是拖到 VM validation 才报告栈类型错误。嵌套 buffer 读取仍支持：
+转换的 F64 operand 可以是另一次合法的 buffer 读取结果。这里不引入公开 I64 类型或隐式转换。
 
 `&f64-buffer:len` 暂不属于 producer 子集：Calcit 的公开返回类型是 `Number`/F64，而 Calx VM 的
 严格指令结果是 I64。eligibility 会在 lowering 前拒绝它，直到 Calcit 拥有显式、语义无损的 I64

--- a/editing-history/202609080834-rust-198-clippy.md
+++ b/editing-history/202609080834-rust-198-clippy.md
@@ -1,0 +1,7 @@
+# Rust 1.98 Clippy compatibility
+
+- While validating Calx issue #908 against main f714edc6, `cargo clippy -- -D warnings` found four existing warnings in untouched code.
+- Use `as_chunks::<N>().0` for three fixed-size slice iterations. Existing arity/divisibility guards and ignored-remainder behavior are unchanged.
+- Initialize the cursor-maintenance detail with an if expression; preserve both branches, mutation order and message strings.
+- No type-system, cursor, API or dependency behavior changes. This mechanical prerequisite is recorded separately from the Calx fix.
+- Validation: `cargo fmt`; `cargo clippy -- -D warnings` passes on Rust 1.98.1. Full regression results are recorded with the subsequent Calx change.

--- a/editing-history/202609080837-calx-index-boundary.md
+++ b/editing-history/202609080837-calx-index-boundary.md
@@ -1,0 +1,9 @@
+# Calx checked-index boundary (#908)
+
+- Source `&f64:to-i64-index` returns a validated Calcit Number, while its VM opcode produces I64. Treating the opcode result as a planned F64 lets invalid locals, returns and arithmetic reach VM validation.
+- Eligibility now accepts the conversion only as the direct index of a buffer read. Its one operand must remain F64; malformed read shapes and operand types always produce a fallback issue.
+- Plan the buffer and original F64 operand, then emit conversion plus read together. There is no standalone conversion plan or I64 source slot; no new Nil, Dynamic, public type, opcode or implicit conversion.
+- Source-backed tests cover return, local, arithmetic, branch, recur argument, unchecked read and nested conversion. Existing dot-product/gather golden programs, native parity and runtime trap origins remain unchanged.
+- Native-only source forms continue to work; unsupported Calx forms fail during eligibility, before lowering/VM validation. Document this deliberate producer boundary.
+- Validation: cargo fmt; cargo clippy -- -D warnings; cargo test; yarn compile and yarn check-agent-interface via yarn check-all. Agent interface: 18/18; observed expression-type query 239.01 ms / 2,957 stdout bytes, source-backed data type 232.94 ms / 938 bytes (local debug smoke, not performance evidence).
+- No benchmark report or profiler asset is added. This does not complete the real application-owned consumer work in #887.

--- a/src/bin/cli_handlers/cursor.rs
+++ b/src/bin/cli_handlers/cursor.rs
@@ -1414,15 +1414,14 @@ pub(crate) fn maintain_cursor_after_split_definition(
   if document.active.target != source {
     return Ok(());
   }
-  let detail;
-  if document.active.path.starts_with(split_path) {
+  let detail = if document.active.path.starts_with(split_path) {
     document.active.target = target.to_string();
     document.active.path = document.active.path[split_path.len()..].to_vec();
-    detail = format!("followed extracted subtree: {source} → {target}");
+    format!("followed extracted subtree: {source} → {target}")
   } else {
     document.active.path = transform_cursor_path(&document.active.path, &TreeCursorMutation::Replace { path: split_path.to_vec() }).0;
-    detail = "split expression replaced by new definition reference".to_string();
-  }
+    "split expression replaced by new definition reference".to_string()
+  };
   refresh_cursor_state(&mut document.active, snapshot_file)?;
   save_cursor_document(snapshot_file, &document)?;
   emit_cursor_after(snapshot_file, &document.active, &detail)

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -924,11 +924,48 @@ fn analyze_proc(proc: CalcitProc, args: &[Calcit], tail: bool, context: &mut Exp
       None
     }
     CalcitProc::NativeF64ToI64Index => {
-      analyze_typed_args(proc, args, &[CalxScalarType::F64], context)?;
-      Some(Some(CalxScalarType::F64))
+      issue(
+        context,
+        CalxFallbackCode::UnsupportedForm,
+        args.first().and_then(source_path),
+        "`&f64:to-i64-index` produces an internal Calx I64, not Number/F64; it is only supported directly in the index position of `&f64-buffer:get`".to_owned(),
+      );
+      None
     }
     CalcitProc::NativeF64BufferGet => {
-      analyze_typed_args(proc, args, &[CalxScalarType::F64Buffer, CalxScalarType::F64], context)?;
+      let [buffer, index] = args else {
+        issue(
+          context,
+          CalxFallbackCode::Arity,
+          args.first().and_then(source_path),
+          format!("`{proc}` expects 2 arguments, found {}", args.len()),
+        );
+        return None;
+      };
+      let Some(operand) = checked_buffer_index_operand(index) else {
+        issue(
+          context,
+          CalxFallbackCode::UnsupportedForm,
+          source_path(index),
+          "`&f64-buffer:get` requires a direct `&f64:to-i64-index` call with one Number/F64 operand".to_owned(),
+        );
+        return None;
+      };
+      let mut valid = true;
+      for (argument, expected) in [(buffer, CalxScalarType::F64Buffer), (operand, CalxScalarType::F64)] {
+        if analyze_expression(argument, false, context) != Some(Some(expected)) {
+          issue(
+            context,
+            CalxFallbackCode::UnsupportedType,
+            source_path(argument),
+            format!("`{proc}` checked read requires {expected:?} at this position"),
+          );
+          valid = false;
+        }
+      }
+      if !valid {
+        return None;
+      }
       Some(Some(CalxScalarType::F64))
     }
     CalcitProc::Recur => {
@@ -953,6 +990,16 @@ fn analyze_proc(proc: CalcitProc, args: &[Calcit], tail: bool, context: &mut Exp
       );
       None
     }
+  }
+}
+
+// I64 is an instruction-local index, never a Calcit Number local or result.
+fn checked_buffer_index_operand(expression: &Calcit) -> Option<&Calcit> {
+  let Calcit::List(items) = expression else { return None };
+  if items.len() == 2 && matches!(items.first(), Some(Calcit::Proc(CalcitProc::NativeF64ToI64Index))) {
+    items.get(1)
+  } else {
+    None
   }
 }
 
@@ -1231,6 +1278,58 @@ fn source_path(expression: &Calcit) -> Option<Vec<u16>> {
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn checked_buffer_index_requires_exact_conversion_shape() {
+    let list = |items: Vec<Calcit>| Calcit::from(crate::calcit::CalcitList::from(items.as_slice()));
+    let proc = Calcit::Proc(CalcitProc::NativeF64ToI64Index);
+    let valid = list(vec![proc.clone(), Calcit::Number(1.0)]);
+    assert_eq!(checked_buffer_index_operand(&valid), Some(&Calcit::Number(1.0)));
+    for invalid in [
+      Calcit::Number(1.0),
+      list(vec![proc.clone()]),
+      list(vec![proc, Calcit::Number(1.0), Calcit::Number(2.0)]),
+      list(vec![Calcit::Proc(CalcitProc::NativeMinus), Calcit::Number(1.0)]),
+    ] {
+      assert!(checked_buffer_index_operand(&invalid).is_none(), "{invalid}");
+    }
+  }
+
+  #[test]
+  fn malformed_checked_reads_always_record_fallback_issues() {
+    let checked = |value| {
+      Calcit::from(crate::calcit::CalcitList::from(&[
+        Calcit::Proc(CalcitProc::NativeF64ToI64Index),
+        value,
+      ]))
+    };
+    for (args, expected) in [
+      (vec![], CalxFallbackCode::Arity),
+      (
+        vec![Calcit::Bool(true), checked(Calcit::Number(0.0))],
+        CalxFallbackCode::UnsupportedType,
+      ),
+      (
+        vec![Calcit::Bool(true), checked(Calcit::Bool(false))],
+        CalxFallbackCode::UnsupportedType,
+      ),
+      (vec![Calcit::Bool(true), Calcit::Number(0.0)], CalxFallbackCode::UnsupportedForm),
+    ] {
+      let mut issues = vec![];
+      let mut context = ExpressionContext {
+        program: &CompiledProgram::new(),
+        function: &CalxDefinitionRef::new("test", "checked-read"),
+        signature: None,
+        call_path: &[],
+        direct_calls: &mut BTreeSet::new(),
+        host_imports: &mut BTreeSet::new(),
+        imports: &CalxHostImports::new(),
+        issues: &mut issues,
+      };
+      assert_eq!(analyze_proc(CalcitProc::NativeF64BufferGet, &args, false, &mut context), None);
+      assert!(issues.iter().any(|issue| issue.code == expected), "{args:?}: {issues:?}");
+    }
+  }
 
   #[test]
   fn fallback_codes_keep_the_v1_abi_names() {

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -691,7 +691,6 @@ enum PlannedOperation {
   Equal,
   LessThan,
   GreaterThan,
-  F64ToI64Index,
   F64BufferGet,
 }
 
@@ -968,8 +967,31 @@ fn plan_proc(
     CalcitProc::NativeEquals => (Some(PlannedOperation::Equal), Some(CalxScalarType::Bool)),
     CalcitProc::NativeLessThan => (Some(PlannedOperation::LessThan), Some(CalxScalarType::Bool)),
     CalcitProc::NativeGreaterThan => (Some(PlannedOperation::GreaterThan), Some(CalxScalarType::Bool)),
-    CalcitProc::NativeF64ToI64Index => (Some(PlannedOperation::F64ToI64Index), Some(CalxScalarType::F64)),
-    CalcitProc::NativeF64BufferGet => (Some(PlannedOperation::F64BufferGet), Some(CalxScalarType::F64)),
+    CalcitProc::NativeF64BufferGet => {
+      let [buffer, index] = args else {
+        return Err(lower_error(
+          context.function,
+          None,
+          "eligible buffer read changed arity before lowering",
+        ));
+      };
+      let operand = super::checked_buffer_index_operand(index).ok_or_else(|| {
+        lower_error(
+          context.function,
+          source_path(index),
+          "eligible buffer index changed shape before lowering",
+        )
+      })?;
+      let args = vec![plan_expression(buffer, false, context)?, plan_expression(operand, false, context)?];
+      return Ok(planned(
+        Some(CalxScalarType::F64),
+        source_path(buffer),
+        PlannedExpressionKind::Operation {
+          operation: PlannedOperation::F64BufferGet,
+          args,
+        },
+      ));
+    }
     CalcitProc::Recur => {
       let name = context
         .names
@@ -1189,8 +1211,8 @@ fn emit_expression(
         PlannedOperation::Equal => body.emit(VmSyntax::F64Eq)?,
         PlannedOperation::LessThan => body.emit(VmSyntax::F64Lt)?,
         PlannedOperation::GreaterThan => body.emit(VmSyntax::F64Gt)?,
-        PlannedOperation::F64ToI64Index => body.f64_to_i64_index()?,
-        PlannedOperation::F64BufferGet => body.f64_buffer_get()?,
+        // Keep the temporary I64 on the stack only for the immediately following read.
+        PlannedOperation::F64BufferGet => body.f64_to_i64_index()?.f64_buffer_get()?,
       };
     }
     PlannedExpressionKind::Call {

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -623,6 +623,57 @@ fn calx_f64_buffer_len_falls_back_before_lowering() {
 }
 
 #[test]
+fn calx_buffer_index_cannot_escape_as_number_or_skip_conversion() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-index-boundary";
+  let mut defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/f64-buffer-index-boundary.cirru"));
+  let cases = [
+    ("index-result", false, 1.0),
+    ("index-local", false, 2.0),
+    ("index-arithmetic", false, 2.0),
+    ("index-branch", false, 1.0),
+    ("index-recur", false, 0.0),
+    ("unchecked-read", true, 20.0),
+    ("nested-conversion", true, 20.0),
+  ];
+  for (name, has_buffer, expected) in cases {
+    let mut arg_types = vec![];
+    let mut args = vec![];
+    if has_buffer {
+      arg_types.push(CalcitTypeAnnotation::F64Buffer);
+      args.push(Calcit::F64Buffer(Arc::from([10.0, 20.0])));
+    }
+    arg_types.push(CalcitTypeAnnotation::Number);
+    args.push(Calcit::Number(1.0));
+    install_calx_test_defs(
+      namespace,
+      vec![(
+        name,
+        defs.remove(name).expect("index boundary source"),
+        calx_test_fn_schema(arg_types, CalcitTypeAnnotation::Number),
+      )],
+    );
+    compile_calx_test_entry(namespace, name);
+    let snapshot = clone_compiled_program_snapshot().expect("index boundary snapshot");
+    assert_eq!(
+      run_program_with_docs(Arc::from(namespace), Arc::from(name), &args).expect("native index semantics"),
+      Calcit::Number(expected)
+    );
+    let Err(CalxKernelCompileError::Eligibility(report)) = compile_calx_kernel(&snapshot, namespace, name) else {
+      panic!("{name} must be rejected during eligibility, not VM validation");
+    };
+    assert!(
+      report
+        .issues
+        .iter()
+        .any(|issue| issue.code == CalxFallbackCode::UnsupportedForm && issue.message.contains("&f64:to-i64-index")),
+      "{name}: {report:?}"
+    );
+  }
+}
+
+#[test]
 fn calx_f64_buffer_dot_product_is_source_backed_strict_and_differential() {
   let _guard = lock_program_test_state();
   reset_program_test_state();

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -4176,7 +4176,7 @@ fn raw_struct_constructor_matches_known_layout(args: &CalcitList, scope_types: &
 
   let mut provided_fields = HashSet::with_capacity(struct_def.fields.len());
   let items = args.to_vec();
-  for pair in items[1..].chunks_exact(2) {
+  for pair in items[1..].as_chunks::<2>().0 {
     let Calcit::Tag(field) = &pair[0] else {
       return false;
     };
@@ -4348,11 +4348,11 @@ fn check_struct_update_fields(
     },
     Calcit::Proc(CalcitProc::NativeStructWith) if args.len() >= 3 && (args.len() - 1).is_multiple_of(2) => {
       let items = args.iter().skip(1).collect::<Vec<_>>();
-      items.chunks_exact(2).map(|pair| (pair[0], pair[1])).collect()
+      items.as_chunks::<2>().0.iter().map(|pair| (pair[0], pair[1])).collect()
     }
     Calcit::Proc(CalcitProc::NativeStructWithAt) if args.len() >= 4 && (args.len() - 1).is_multiple_of(3) => {
       let items = args.iter().skip(1).collect::<Vec<_>>();
-      items.chunks_exact(3).map(|triple| (triple[1], triple[2])).collect()
+      items.as_chunks::<3>().0.iter().map(|triple| (triple[1], triple[2])).collect()
     }
     _ => return,
   };

--- a/tests/fixtures/calx/f64-buffer-index-boundary.cirru
+++ b/tests/fixtures/calx/f64-buffer-index-boundary.cirru
@@ -1,0 +1,27 @@
+defn index-result (index)
+  &f64:to-i64-index index
+
+defn index-local (index)
+  &let
+    checked $ &f64:to-i64-index index
+    &+ checked 1
+
+defn index-arithmetic (index)
+  &+ 1 $ &f64:to-i64-index index
+
+defn index-branch (index)
+  if true
+    &f64:to-i64-index index
+    , index
+
+defn index-recur (index)
+  if (&< index 1)
+    , index
+    recur $ &f64:to-i64-index $ &- index 1
+
+defn unchecked-read (buffer index)
+  &f64-buffer:get buffer index
+
+defn nested-conversion (buffer index)
+  &f64-buffer:get buffer $ &f64:to-i64-index
+    &f64:to-i64-index index


### PR DESCRIPTION
Closes #908
Related: #887, #889

## 中文

### 改动

- 修正 checked-index 的 Number/F64 与 VM I64 表示错配，只接受直接用于 `&f64-buffer:get` index 位置的转换。
- 将转换与读取作为一个操作规划；不再将 I64 转换结果伪装为 F64。没有新公开类型、Nil/Dynamic、VM 指令或隐式转换。
- 返回、local、算术、分支、recur 参数、裸 index、嵌套转换均补充 source-backed 回归；已有 dot-product/gather golden、native parity 和 trap origin 保持通过。
- 更新 producer 子集文档。真实应用接入仍由 #887 追踪，不把此修复当成应用采用或性能收益证据。
- 单独的前置提交修复 main 中四处 Rust 1.98.1 Clippy 告警：三处固定 chunk 遍历与一处局部变量初始化，均不改变语义。

### 验证

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test -q`
- `yarn check-all`（包含 `yarn compile`、`yarn check-agent-interface`、native/JS/WASM 回归）
- Agent 接口 18/18；expression-type 查询观测 239.01 ms / 2,957 bytes，source-backed data-type 232.94 ms / 938 bytes，仅是本地 debug smoke。

## English

### Changes

- Correct the Number/F64 versus VM I64 representation mismatch. Accept checked conversion only directly in the index position of `&f64-buffer:get`.
- Plan conversion and read as one operation, without a fake F64 conversion result. No new public type, Nil/Dynamic, VM opcode or implicit conversion.
- Source-backed regressions cover returns, locals, arithmetic, branches, recur arguments, unchecked indices and nested conversions. Existing dot-product/gather goldens, native parity and trap origins remain valid.
- Document the producer boundary. Real application integration remains tracked by #887; this is not application adoption or performance evidence.
- A separate prerequisite commit resolves four pre-existing Rust 1.98.1 Clippy warnings: three fixed-size chunk iterations and one local initialization, without semantic changes.

### Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test -q`
- `yarn check-all`, including compilation, Agent interface and native/JS/WASM regressions.
- Agent interface 18/18; observed expression-type query 239.01 ms / 2,957 bytes and source-backed data-type query 232.94 ms / 938 bytes. Local debug smoke only.
