### PR TITLE
fix: complete FFI query metadata / 完整 FFI 查询元数据

### DIFF
--- a/docs/run/query.md
+++ b/docs/run/query.md
@@ -64,6 +64,23 @@ calcit query def calcit.core/to-js-data
 
 For source-backed definitions, `query def` prints the stored Cirru body. For special builtin helpers such as `calcit.core/to-js-data`, it falls back to builtin metadata (doc, schema, examples count) even when no snapshot source exists.
 
+Since 0.14.3, automation should use `calcit query def namespace/name --format json`.
+Stdout is one JSON envelope (`schema_version: 1`, `command: "query.def"`, `revision`,
+`data`, `diagnostics`); command echoes and warnings remain on stderr. Failures exit
+nonzero with diagnostics on stderr, not a partial success object. `data` contains
+`id`, `doc`, `tags`, `examples`, `tests`, `code`, `schema`, `ffi`, and `ffi_edn`.
+`ffi` is complete EDN-encoded JSON, using the same representation as `cirru parse-edn`:
+tag map keys retain `:`, tag values use `{"__edn_tag":"js"}`, and sets use
+`{"__edn_set":[...]}`. `ffi_edn` is complete, parseable Cirru EDN text. Both are
+`null` when absent; neither is a preview. Source-backed definitions have a content
+revision; source-less builtins have `revision: null`, `code: null`, and `builtin: true`.
+The schema field remains a Cirru syntax tree, not raw persisted schema data.
+
+兼容性：`--json` 仍在 human 输出末尾附加 `JSON:` 与旧字段对象，其中 `ffi` 保持
+字符串类型，但不再截断。`--format json` 优先于 `--json`，不需要 `--raw` 就会返回
+完整元数据。human 模式默认标明 FFI preview；`--raw` 同时输出完整代码与 FFI。
+本接口只查询声明，不改变 Interface IR v2、目标可用性检查或 async 调用语义。
+
 Local metadata queries (`ns <name>`, `defs`, `def`, `peek`, `examples`, `schema`, `pkg`, and `config`) first read only the main Snapshot. Modules/core are loaded only when the requested namespace is not local. This keeps repeated Agent navigation fast and avoids unrelated dependency warnings; semantic queries such as `type`, `type-at`, and `context` still load the metadata needed for static resolution.
 
 ### Peek Signature (`peek`)

--- a/editing-history/202609080846-complete-ffi-query.md
+++ b/editing-history/202609080846-complete-ffi-query.md
@@ -1,0 +1,8 @@
+# Complete definition metadata / 完整定义元数据
+
+- Fix #875: add `query def --format json` schema-version 1 envelope, structured EDN FFI and lossless `ffi_edn`; keep legacy `--json` mixed output and its string field compatible. Raw human output no longer truncates FFI; bounded human output is explicitly a preview.
+- Regression coverage: 300 member mappings, escaping/Unicode/newlines, absent FFI, source-less builtins, legacy/raw parity, parse failures and single-JSON stdout. Interface IR v2 is unchanged.
+- Consumer candidate: js-ffi's 149-definition catalog uses the new query; persisted schemaData still uses Snapshot decoding. Node tests and 71 browser assertions pass with this unreleased candidate CLI (no formal version pin before publication).
+- Validation: cargo fmt; cargo test (766 library / 312 CLI plus WASM tests); yarn check-all; 20 agent protocol scenarios plus full definition round trips. Complete local definition: 13.14 ms / 1385 bytes; builtin: 62.71 ms / 580 bytes. DomElementHost debug candidate warm 28.47–29.43 ms / 2597 bytes vs installed 0.14.2 release 11.22–11.50 ms / 3282 bytes (different build profiles, not a speed comparison).
+- Release-gate hygiene: #918 adds the missing shared-policy lock to an existing field-access test; Rust 1.98.1 Clippy's three constant chunks_exact warnings are mechanically updated to as_chunks without changing remainder behavior.
+- 兼容旧输出，机器输出明确区分结构化数据与完整 EDN；不扩展 async/public checker 范围。真实消费者验证后再发布，后续正式版本 pin 和 release 由 #909/#914 跟踪。

--- a/editing-history/202609080856-builtin-query-tags.md
+++ b/editing-history/202609080856-builtin-query-tags.md
@@ -1,0 +1,6 @@
+# Preserve builtin semantic tags / 保留 builtin 语义标签
+
+- PR #919 review correctly identified that the new source-less builtin JSON branch discarded SpecialBuiltinQueryMeta.semantic_tags. Serialize the authoritative tags and assert that to-js-data retains js-ffi classification. Legacy output remains unchanged.
+- 修复有效 bot comment，补充端到端协议测试；不改普通定义与消费者 API。
+- Additional release-profile evidence before this metadata-only follow-up: DomElementHost complete JSON 2597 bytes vs 0.14.2 legacy 3282 bytes; warm queries roughly 11–14 ms on both. Candidate binary 9,813,248 bytes vs installed 0.14.2 9,834,032 bytes. First invocation includes OS loader effects and is not used for warm comparison.
+- js-ffi catalog parity: all 149 records match the released baseline in every field except the intentionally updated inspect command.

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -26,6 +26,9 @@ const scenarios = [
       if (result.command !== "query.def" || !result.data.builtin || result.data.code !== null || result.data.ffi !== null) {
         throw new Error("query.def lost builtin metadata contract");
       }
+      if (!result.data.tags.includes("js-ffi")) {
+        throw new Error("query.def lost special-builtin semantic tags");
+      }
     },
   },
   {

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -1,8 +1,33 @@
 import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
 
 const binary = process.env.CALCIT_AGENT_BIN ?? process.env.CALCIT_AGENT_CR ?? "./target/debug/calcit";
 
 const scenarios = [
+  {
+    name: "complete definition metadata",
+    args: ["calcit/test.cirru", "query", "def", "app.main/main!", "--raw", "--format", "json"],
+    check(result) {
+      if (result.schema_version !== 1 || result.command !== "query.def" || result.data.id !== "app.main/main!") {
+        throw new Error("unexpected query.def envelope");
+      }
+      if (!Array.isArray(result.data.code) || result.data.ffi !== null || result.data.ffi_edn !== null || !result.revision.startsWith("md5:")) {
+        throw new Error("query.def lost code, absent metadata, or revision");
+      }
+    },
+  },
+  {
+    name: "builtin definition metadata",
+    args: ["calcit/test.cirru", "query", "def", "calcit.core/to-js-data", "--format", "json"],
+    check(result) {
+      if (result.command !== "query.def" || !result.data.builtin || result.data.code !== null || result.data.ffi !== null) {
+        throw new Error("query.def lost builtin metadata contract");
+      }
+    },
+  },
   {
     name: "typed FFI Interface IR",
     args: ["calcit/test.cirru", "ffi", "export", "--json"],
@@ -440,5 +465,46 @@ for (const scenario of scenarios) {
   });
 }
 
-console.log(`Agent interface smoke passed: ${rows.length}/${scenarios.length}`);
+// Real CLI round trips, including the legacy wire format and negative paths.
+const fixtureDir = mkdtempSync(join(tmpdir(), "calcit-query-def-"));
+try {
+  const fixture = join(fixtureDir, "calcit.cirru");
+  copyFileSync("calcit/test.cirru", fixture);
+  const run = (...args) => {
+    const child = spawnSync(binary, [fixture, ...args], { encoding: "utf8", maxBuffer: 4 * 1024 * 1024 });
+    assert.ifError(child.error);
+    return child;
+  };
+  const names = Array.from({ length: 300 }, (_, i) => `(:member-${i} ${JSON.stringify(`|宿主\\\"\n${i}`)})`).join(" ");
+  const ffi = `{} (:backend :js) (:names $ {} ${names})`;
+  const edit = run("edit", "ffi", "app.main/main!", "--code", ffi);
+  assert.equal(edit.status, 0, edit.stderr);
+  const query = (...flags) => run("query", "def", "app.main/main!", ...flags);
+  const machine = query("--format", "json", "--json", "--raw");
+  assert.equal(machine.status, 0, machine.stderr);
+  const data = JSON.parse(machine.stdout).data;
+  assert.equal(Object.keys(data.ffi[":names"]).length, 300);
+  assert.equal(data.ffi[":names"][":member-299"], "宿主\\\"\n299");
+  const roundTrip = run("cirru", "parse-edn", data.ffi_edn);
+  assert.equal(roundTrip.status, 0, roundTrip.stderr);
+  assert.deepEqual(JSON.parse(roundTrip.stdout), data.ffi);
+  const legacy = query("--raw", "--json");
+  assert.equal(legacy.status, 0, legacy.stderr);
+  assert.equal(JSON.parse(legacy.stdout.split("\nJSON:\n").at(-1)).ffi, data.ffi_edn);
+  assert.ok(legacy.stdout.includes(data.ffi_edn), "raw human FFI must also be complete");
+  assert.match(query().stdout, /FFI \(preview; use --raw/);
+  for (const args of [
+    ["query", "def", "app.main/nonexistent-875", "--format", "json"],
+    ["query", "def", "app.main/main!", "--format", "invalid"],
+  ]) {
+    const failed = run(...args);
+    assert.notEqual(failed.status, 0);
+    assert.equal(failed.stdout, "", "query failure must not emit partial success JSON");
+    assert.ok(failed.stderr.length > 0);
+  }
+} finally {
+  rmSync(fixtureDir, { recursive: true, force: true });
+}
+
+console.log(`Agent interface smoke passed: ${rows.length}/${scenarios.length}, plus definition protocol round trips`);
 console.table(rows);

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -670,6 +670,7 @@ fn push_query(tokens: &mut Vec<String>, cmd: &QueryCommand) {
       tokens,
       pos "target" => &opts.target,
       switch "json" => opts.json,
+      value "format" => &opts.format; default "human",
       value "chunk-target-nodes" => opts.chunk_target_nodes; default "56",
       value "chunk-max-nodes" => opts.chunk_max_nodes; default "68",
       value "chunk-trigger-nodes" => opts.chunk_trigger_nodes; default "88",

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -811,6 +811,34 @@ mod type_query_tests {
   use super::*;
   use crate::cli_handlers::test_support::TestProject;
 
+  #[test]
+  fn definition_ffi_json_is_complete_and_round_trips() {
+    use cirru_edn::{Edn, EdnMapView};
+    let mut names = EdnMapView::default();
+    for index in 0..300 {
+      names.insert(Edn::tag(format!("member-{index}")), Edn::str(format!("宿主\\\"\n{index}")));
+    }
+    let mut ffi = EdnMapView::default();
+    ffi.insert(Edn::tag("names"), names.into());
+    let ffi: Edn = ffi.into();
+    let mut entry = snapshot::CodeEntry::from_code(vec!["def", "example", "nil"].into());
+    entry.ffi = Some(ffi.clone());
+    let legacy = code_entry_to_json(&entry).unwrap();
+    let full = legacy["ffi"].as_str().unwrap();
+    assert!(full.len() > 5000);
+    assert_eq!(cirru_edn::parse(full).unwrap(), ffi);
+    assert_ne!(format_edn_display(&ffi), full);
+    let structured = serde_json::to_value(&ffi).unwrap();
+    assert_eq!(structured[":names"].as_object().unwrap().len(), 300);
+    assert_eq!(structured[":names"][":member-299"], "宿主\\\"\n299");
+    let encoded = format_def_query_json(structured.clone(), Some(snapshot::definition_revision(&entry).unwrap())).unwrap();
+    let decoded: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+    assert_eq!(decoded["data"], structured);
+    assert_eq!(decoded["command"], "query.def");
+    entry.ffi = None;
+    assert!(code_entry_to_json(&entry).unwrap()["ffi"].is_null());
+  }
+
   fn on_cli_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
     std::thread::Builder::new()
       .name("calcit-query-test".into())
@@ -3414,6 +3442,7 @@ fn render_chunked_display(display: &ChunkedDisplay) -> String {
 }
 
 fn handle_def(input_path: &str, namespace: &str, definition: &str, opts: &QueryDefCommand) -> Result<(), String> {
+  let json_only = matches!(parse_query_render_format(&opts.format)?, QueryRenderFormat::Json);
   let snapshot = load_snapshot_for_namespace(input_path, namespace)?;
 
   let file_data = snapshot
@@ -3424,6 +3453,28 @@ fn handle_def(input_path: &str, namespace: &str, definition: &str, opts: &QueryD
   if !file_data.defs.contains_key(definition)
     && let Some(meta) = lookup_special_builtin_query_meta(namespace, definition)?
   {
+    if json_only {
+      let schema = meta
+        .schema
+        .as_function()
+        .map(|annot| annot.to_schema_edn())
+        .unwrap_or(cirru_edn::Edn::Nil);
+      let data = serde_json::json!({
+        "id": format!("{namespace}/{definition}"),
+        "doc": meta.doc,
+        "tags": [],
+        "examples": meta.examples.iter().map(cirru_to_json).collect::<Vec<_>>(),
+        "tests": [],
+        "code": null,
+        "schema": cirru_to_json(&snapshot::schema_edn_to_cirru(&schema)?),
+        "ffi": null,
+        "ffi_edn": null,
+        "builtin": true,
+        "kind": "special-proc"
+      });
+      println!("{}", format_def_query_json(data, None)?);
+      return Ok(());
+    }
     let mut out = String::new();
     let _ = writeln!(&mut out, "{} {}", "Type:".bold(), meta.expr_preview);
     let _ = writeln!(&mut out, "{} {}", "Doc:".bold(), meta.doc);
@@ -3471,6 +3522,15 @@ fn handle_def(input_path: &str, namespace: &str, definition: &str, opts: &QueryD
     .get(resolved_definition.as_str())
     .expect("resolved definition exists");
 
+  if json_only {
+    let mut data = code_entry_to_json(code_entry)?;
+    data["id"] = serde_json::json!(format!("{namespace}/{resolved_definition}"));
+    data["ffi_edn"] = data["ffi"].take();
+    data["ffi"] = serde_json::to_value(&code_entry.ffi).map_err(|e| format!("Failed to serialize FFI metadata: {e}"))?;
+    println!("{}", format_def_query_json(data, Some(snapshot::definition_revision(code_entry)?))?);
+    return Ok(());
+  }
+
   let mut out = String::new();
 
   if let Ok(code_data) = calcit::data::cirru::code_to_calcit(&code_entry.code, namespace, &resolved_definition, vec![])
@@ -3491,7 +3551,21 @@ fn handle_def(input_path: &str, namespace: &str, definition: &str, opts: &QueryD
   }
 
   if let Some(ffi) = &code_entry.ffi {
-    let _ = writeln!(&mut out, "{} {}", "FFI:".bold(), format_edn_display(ffi));
+    let full = format_ffi_edn(ffi)?;
+    let (label, text) = if opts.raw {
+      ("FFI:", full)
+    } else {
+      let preview = format_edn_display(ffi);
+      (
+        if preview == full {
+          "FFI:"
+        } else {
+          "FFI (preview; use --raw for full metadata):"
+        },
+        preview,
+      )
+    };
+    let _ = writeln!(&mut out, "{} {}", label.bold(), text);
   }
 
   if !code_entry.examples.is_empty() {
@@ -3530,7 +3604,7 @@ fn handle_def(input_path: &str, namespace: &str, definition: &str, opts: &QueryD
 
   if opts.json {
     let _ = writeln!(&mut out, "\n{}", "JSON:".bold());
-    let json = code_entry_to_json(code_entry);
+    let json = code_entry_to_json(code_entry)?;
     let _ = writeln!(&mut out, "{}", serde_json::to_string(&json).unwrap());
   }
 
@@ -3545,14 +3619,28 @@ fn cirru_to_json(cirru: &Cirru) -> serde_json::Value {
   }
 }
 
-fn code_entry_to_json(entry: &snapshot::CodeEntry) -> serde_json::Value {
-  let schema_json = query_schema_cirru(entry.schema.as_ref(), false)
-    .ok()
-    .flatten()
-    .map(|cirru| cirru_to_json(&cirru));
+fn format_ffi_edn(ffi: &cirru_edn::Edn) -> Result<String, String> {
+  cirru_edn::format(ffi, true)
+    .map(|text| text.trim().to_owned())
+    .map_err(|e| format!("Failed to format FFI metadata: {e}"))
+}
+
+fn format_def_query_json(data: serde_json::Value, revision: Option<String>) -> Result<String, String> {
+  serde_json::to_string(&serde_json::json!({
+    "schema_version": 1,
+    "command": "query.def",
+    "revision": revision,
+    "data": data,
+    "diagnostics": [],
+  }))
+  .map_err(|e| format!("Failed to encode definition query JSON: {e}"))
+}
+
+fn code_entry_to_json(entry: &snapshot::CodeEntry) -> Result<serde_json::Value, String> {
+  let schema_json = query_schema_cirru(entry.schema.as_ref(), false)?.map(|cirru| cirru_to_json(&cirru));
   let mut tags: Vec<String> = entry.tags.iter().map(|tag| tag.ref_str().to_string()).collect();
   tags.sort();
-  serde_json::json!({
+  Ok(serde_json::json!({
     "doc": entry.doc,
     "tags": tags,
     "examples": entry.examples.iter().map(cirru_to_json).collect::<Vec<_>>(),
@@ -3563,8 +3651,8 @@ fn code_entry_to_json(entry: &snapshot::CodeEntry) -> serde_json::Value {
     }).collect::<Vec<_>>(),
     "code": cirru_to_json(&entry.code),
     "schema": schema_json,
-    "ffi": entry.ffi.as_ref().map(format_edn_display),
-  })
+    "ffi": entry.ffi.as_ref().map(format_ffi_edn).transpose()?,
+  }))
 }
 
 fn format_example_node(example: &Cirru) -> String {

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -3462,7 +3462,7 @@ fn handle_def(input_path: &str, namespace: &str, definition: &str, opts: &QueryD
       let data = serde_json::json!({
         "id": format!("{namespace}/{definition}"),
         "doc": meta.doc,
-        "tags": [],
+        "tags": meta.semantic_tags,
         "examples": meta.examples.iter().map(cirru_to_json).collect::<Vec<_>>(),
         "tests": [],
         "code": null,

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -712,9 +712,12 @@ pub struct QueryDefCommand {
   /// target in format "namespace/definition"
   #[argh(positional)]
   pub target: String,
-  /// also output JSON format for programmatic consumption
+  /// append legacy JSON to human output; prefer --format json for automation
   #[argh(switch)]
   pub json: bool,
+  /// output format: human (default) or a single versioned json envelope
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
   /// preferred nodes per display fragment when large expressions are chunked
   #[argh(option, default = "56")]
   pub chunk_target_nodes: usize,

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -15056,6 +15056,7 @@ mod tests {
 
   #[test]
   fn validates_method_field_access() {
+    let _state = lock_preprocess_test_state();
     use cirru_edn::EdnTag;
 
     // Create a test struct type with fields: name, age


### PR DESCRIPTION
## Scope / 范围
Closes #875. Closes #918. Release acceptance remains #909 / #914.

Add query def --format json (schema_version 1, structured ffi + lossless ffi_edn), preserve legacy --json mixed output/string field, and make --raw FFI complete. Explicitly label human previews. No Interface IR v2, async or target-checker changes. / 新增完整机器元数据，保留旧输出兼容，不扩展版本范围。

## Validation / 验证
- cargo fmt; cargo test: 766 library + 312 CLI + 23 WASM tests passed (missing shared test-policy lock fixed under #918).
- yarn check-all passed; agent interface 20 scenarios plus 300-member round trips, Unicode/escaping/newlines, absent metadata, builtins, legacy/raw compatibility, negative exit/stdout checks.
- js-ffi candidate: 149 public records, 3 recipes, Node/quality/type/tooling tests and 71 browser assertions passed using this unreleased candidate CLI. Consumer migration/pin follows #909 after publication.
- DomElementHost debug candidate: 2597 stdout bytes, warm 28.47–29.43 ms; installed release 0.14.2 legacy output 3282 bytes, 11.22–11.50 ms. Build profiles differ; this is protocol evidence, not a speedup claim.
- Rebased onto latest main 6bee4d37; final-head gates running. Clippy surfaced pre-existing Rust 1.98.1 lints; resolving before merge.

正式发布与消费者 pin 必须等待最新 head review、所有 comments 处理、CI/main 验证，见 #914.