### PR TITLE
Enforce checked async invocation / 强制检查异步调用契约

### DIFF
--- a/docs/features/js-interop.md
+++ b/docs/features/js-interop.md
@@ -365,6 +365,23 @@ Use `hint-fn $ {} (:async true)` in function body when using `js-await`:
 
 `js-await` should stay inside async-marked function bodies.
 
+When a function also declares a checked function schema, `:async true` is part
+of its invocation contract. The schema's `:return T` describes the value after
+awaiting, not the Promise-like value returned by the JavaScript call:
+
+```cirru.no-check
+hint-fn $ {}
+  :args $ []
+  :return String
+  :async true
+```
+
+Calling this function produces a pending async value in static checking. Pass
+the call through `js-await` before using it as `T`; otherwise checking fails
+with `E_ASYNC_INVOCATION_REQUIRES_AWAIT`. Function aliases and callback schemas
+retain this contract, so async and synchronous callbacks are not interchangeable.
+The checker does not insert `await`, retry calls, or model effects automatically.
+
 ```cirru.no-check
 let
     fetch-data $ fn () nil

--- a/editing-history/202609081908-checked-async-invocation.md
+++ b/editing-history/202609081908-checked-async-invocation.md
@@ -1,0 +1,25 @@
+# Check async invocation contracts / 检查异步调用契约
+
+- Treat `:async true` as part of a function's checked invocation contract. The
+  declared return type remains the logical value after `js-await`; an invocation
+  carries an internal pending boundary until `js-await` unwraps it.
+- Preserve the marker through definition references, aliases, callbacks, schema
+  serialization, and JS lowering. Async and synchronous callback signatures are
+  intentionally incompatible; no automatic await, retry, or general effect model
+  is introduced.
+- Reject a pending result consumed by an ordinary call with the source-located
+  `E_ASYNC_INVOCATION_REQUIRES_AWAIT` diagnostic. Perform this check only after
+  argument preprocessing so core bootstrap is not forced to resolve definitions
+  early.
+- Verified with `cargo test async_ -- --nocapture`, `cargo clippy -- -D warnings`,
+  `yarn check-all`, and `bash scripts/check-docs-md.sh`. A current js-ffi fixture
+  rejects the missing-await form and emits `await async_value()` for the accepted
+  form.
+
+- 将 `:async true` 纳入函数调用契约；`:return` 仍描述 `js-await` 后的逻辑值，
+  调用结果在静态检查中先保留为待 await 的内部边界。
+- 契约会穿过定义引用、别名、callback、schema 序列化与 JS lowering；
+  async/sync callback 不可互换，且不自动插入 await、retry 或扩展通用 effect 模型。
+- 普通调用消费未 await 的结果时给出带源码位置的
+  `E_ASYNC_INVOCATION_REQUIRES_AWAIT`。检查放在参数预处理之后，避免 core bootstrap
+  提前解析尚未就绪的定义。

--- a/editing-history/202609081915-isolate-async-schema-marker.md
+++ b/editing-history/202609081915-isolate-async-schema-marker.md
@@ -1,0 +1,9 @@
+# Isolate the internal async marker / 隔离内部异步标记
+
+- Store the checked async-invocation bit under a private reserved feature tag,
+  while continuing to parse and serialize only the public `:async true` schema
+  field. This prevents a user-defined `:features #{:async}` flag from silently
+  changing invocation or callback semantics.
+- 内部调用标记改用不可见的保留 feature tag；公开协议仍只使用 `:async true`。
+  这样用户已有的 `:features #{:async}` 不会被误解为异步调用契约。
+- Verified with the focused async/schema tests and `cargo clippy -- -D warnings`.

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -832,6 +832,7 @@ struct FnSchemaFields<'a> {
   rest: Option<&'a Calcit>,
   kind: Option<&'a Calcit>,
   features: Option<&'a Calcit>,
+  async_invocation: Option<&'a Calcit>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1844,6 +1845,9 @@ impl CalcitTypeAnnotation {
             fields.features = Some(value);
           }
         }
+        "async" if fields.async_invocation.is_none() => {
+          fields.async_invocation = Some(value);
+        }
         _ => {}
       }
     };
@@ -2212,6 +2216,26 @@ impl CalcitTypeAnnotation {
     }
   }
 
+  /// Return whether a `hint-fn` schema marks the surrounding function as async.
+  /// This is the checked invocation contract shared with JavaScript lowering.
+  pub(crate) fn hint_form_marks_async(form: &Calcit) -> bool {
+    let Some(items) = Self::get_hint_fn_items(form) else {
+      return false;
+    };
+    items.iter().skip(1).any(|item| {
+      Self::extract_schema_value_single(item, "async")
+        .is_some_and(|value| !matches!(value, Calcit::Nil | Calcit::Unit | Calcit::Bool(false)))
+    })
+  }
+
+  /// Return whether a source or preprocessed function definition carries an async hint.
+  pub(crate) fn function_form_marks_async(form: &Calcit) -> bool {
+    let Calcit::List(items) = form else {
+      return false;
+    };
+    items.iter().skip(3).any(Self::hint_form_marks_async)
+  }
+
   fn parse_fn_annotation_from_schema_form(
     form: &Calcit,
     generics: &[Arc<str>],
@@ -2245,7 +2269,14 @@ impl CalcitTypeAnnotation {
       _ => SchemaKind::Fn,
     };
 
-    let features = Self::parse_fn_features_from_form(fields.features);
+    let mut features = Self::parse_fn_features_from_form(fields.features).as_ref().clone();
+    if fields
+      .async_invocation
+      .is_some_and(|value| !matches!(value, Calcit::Nil | Calcit::Unit | Calcit::Bool(false)))
+    {
+      features.insert(EdnTag::from("async"));
+    }
+    let features = Arc::new(features);
 
     Some(Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
       generics: Arc::new(local_generics),
@@ -2455,7 +2486,7 @@ impl CalcitTypeAnnotation {
       _ => return None,
     };
 
-    let has_schema_fields = ["kind", "args", "return", "generics", "where", "rest", "features"]
+    let has_schema_fields = ["kind", "args", "return", "generics", "where", "rest", "features", "async"]
       .iter()
       .any(|key| map.tag_get(key).is_some());
     if !has_schema_fields {
@@ -2508,7 +2539,7 @@ impl CalcitTypeAnnotation {
     let rest_type = map
       .tag_get("rest")
       .map(|v| Self::parse_type_annotation_form_with_generics(&Self::edn_type_to_calcit(v), generics.as_slice()));
-    let features = map
+    let mut features = map
       .tag_get("features")
       .and_then(|v| {
         if let Edn::Set(xs) = v {
@@ -2523,7 +2554,13 @@ impl CalcitTypeAnnotation {
           None
         }
       })
-      .unwrap_or_default();
+      .unwrap_or_default()
+      .as_ref()
+      .clone();
+    if matches!(map.tag_get("async"), Some(Edn::Bool(true))) {
+      features.insert(EdnTag::from("async"));
+    }
+    let features = Arc::new(features);
     Some(CalcitFnTypeAnnotation {
       generics: Arc::new(generics),
       where_bounds: Arc::new(where_bounds),
@@ -6535,6 +6572,37 @@ mod tests {
   }
 
   #[test]
+  fn async_fn_schema_roundtrips_and_changes_callback_contract() {
+    let schema_form = Calcit::from(vec![
+      symbol("{}"),
+      Calcit::from(vec![Calcit::Tag(EdnTag::from("args")), Calcit::from(vec![symbol("[]")])]),
+      Calcit::from(vec![Calcit::Tag(EdnTag::from("return")), symbol("String")]),
+      Calcit::from(vec![Calcit::Tag(EdnTag::from("async")), Calcit::Bool(true)]),
+    ]);
+    let hint = Calcit::from(vec![Calcit::Syntax(CalcitSyntax::HintFn, Arc::from("tests")), schema_form]);
+    let annotation = CalcitTypeAnnotation::extract_fn_annotation_from_hint_form(&hint).expect("async fn annotation");
+    let CalcitTypeAnnotation::Fn(async_signature) = annotation.as_ref() else {
+      panic!("expected fn annotation")
+    };
+    assert!(async_signature.is_async_invocation());
+
+    let serialized = async_signature.to_schema_edn();
+    let parsed = CalcitTypeAnnotation::parse_fn_schema_from_edn(&serialized).expect("roundtrip async schema");
+    assert!(parsed.is_async_invocation());
+
+    let sync_signature = CalcitFnTypeAnnotation {
+      features: Arc::new(HashSet::new()),
+      ..async_signature.as_ref().clone()
+    };
+    assert!(!async_signature.matches_signature(&sync_signature));
+    assert!(!sync_signature.matches_signature(async_signature));
+    assert_ne!(
+      CalcitTypeAnnotation::Fn(async_signature.clone()).cmp(&CalcitTypeAnnotation::Fn(Arc::new(sync_signature))),
+      Ordering::Equal
+    );
+  }
+
+  #[test]
   fn extracts_generics_from_schema_first_hint() {
     let ns: Arc<str> = Arc::from("tests");
     let hint_form = Calcit::List(Arc::new(CalcitList::from(&[
@@ -7768,7 +7836,8 @@ impl Ord for CalcitTypeAnnotation {
         .generics
         .cmp(&b.generics)
         .then_with(|| a.arg_types.cmp(&b.arg_types))
-        .then_with(|| a.return_type.cmp(&b.return_type)),
+        .then_with(|| a.return_type.cmp(&b.return_type))
+        .then_with(|| a.is_async_invocation().cmp(&b.is_async_invocation())),
       (Self::Macro(a), Self::Macro(b)) => a.cmp(b),
       (Self::Syntax(a), Self::Syntax(b)) => a.cmp(b),
       (Self::Set(a), Self::Set(b)) => a.cmp(b),
@@ -7833,6 +7902,7 @@ impl Ord for CalcitFnTypeAnnotation {
       .then_with(|| self.return_type.cmp(&other.return_type))
       .then_with(|| self.fn_kind.cmp(&other.fn_kind))
       .then_with(|| self.rest_type.cmp(&other.rest_type))
+      .then_with(|| self.is_async_invocation().cmp(&other.is_async_invocation()))
   }
 }
 
@@ -7844,10 +7914,23 @@ impl Hash for CalcitFnTypeAnnotation {
     self.return_type.hash(state);
     self.fn_kind.hash(state);
     self.rest_type.hash(state);
+    self.is_async_invocation().hash(state);
   }
 }
 
 impl CalcitFnTypeAnnotation {
+  pub(crate) fn is_async_invocation(&self) -> bool {
+    self.features.iter().any(|feature| feature.ref_str() == "async")
+  }
+
+  pub(crate) fn with_async_invocation(&self) -> Self {
+    let mut cloned = self.clone();
+    let mut features = cloned.features.as_ref().clone();
+    features.insert(EdnTag::from("async"));
+    cloned.features = Arc::new(features);
+    cloned
+  }
+
   fn where_bounds_to_edn(&self) -> Option<Edn> {
     if self.where_bounds.is_empty() {
       return None;
@@ -7883,12 +7966,18 @@ impl CalcitFnTypeAnnotation {
   }
 
   fn features_to_edn(&self) -> Option<Edn> {
-    if self.features.is_empty() {
+    let visible_features = self
+      .features
+      .iter()
+      .filter(|feature| feature.ref_str() != "async")
+      .cloned()
+      .collect::<Vec<_>>();
+    if visible_features.is_empty() {
       return None;
     }
     let mut set = EdnSetView::default();
-    for tag in self.features.iter() {
-      set.insert(Edn::Tag(tag.clone()));
+    for tag in visible_features {
+      set.insert(Edn::Tag(tag));
     }
     Some(Edn::Set(set))
   }
@@ -7916,6 +8005,9 @@ impl CalcitFnTypeAnnotation {
     }
     if let Some(rest) = &self.rest_type {
       map.insert_key("rest", rest.to_type_edn());
+    }
+    if self.is_async_invocation() {
+      map.insert_key("async", Edn::Bool(true));
     }
     if let Some(features) = self.features_to_edn() {
       map.insert_key("features", features);
@@ -7955,6 +8047,9 @@ impl CalcitFnTypeAnnotation {
     if let Some(rest) = &self.rest_type {
       map.insert_key("rest", rest.to_type_edn());
     }
+    if self.is_async_invocation() {
+      map.insert_key("async", Edn::Bool(true));
+    }
     if let Some(features) = self.features_to_edn() {
       map.insert_key("features", features);
     }
@@ -7979,6 +8074,9 @@ impl CalcitFnTypeAnnotation {
     }
     if let Some(rest) = &self.rest_type {
       map.insert_key("rest", rest.to_type_edn());
+    }
+    if self.is_async_invocation() {
+      map.insert_key("async", Edn::Bool(true));
     }
     if let Some(features) = self.features_to_edn() {
       map.insert_key("features", features);
@@ -8033,7 +8131,8 @@ impl CalcitFnTypeAnnotation {
     }
     let args = format!("({})", rendered_args.join(", "));
     format!(
-      "fn{generics}{where_clause}{args} -> {}",
+      "{}fn{generics}{where_clause}{args} -> {}",
+      if self.is_async_invocation() { "async " } else { "" },
       self.return_type.describe_bounded(depth + 1, remaining)
     )
   }
@@ -8085,7 +8184,8 @@ impl CalcitFnTypeAnnotation {
     let args_repr = format!("({})", parts.join(", "));
 
     format!(
-      "fn{generics}{where_clause}{args_repr} -> {}",
+      "{}fn{generics}{where_clause}{args_repr} -> {}",
+      if self.is_async_invocation() { "async " } else { "" },
       self.return_type.to_brief_string_bounded(depth + 1, remaining)
     )
   }
@@ -8099,6 +8199,9 @@ impl CalcitFnTypeAnnotation {
   /// generic call. This lets sibling callbacks share a return type variable,
   /// such as the two branches accepted by `option:fold`.
   pub(crate) fn compatible_signature_with_bindings(&self, other: &CalcitFnTypeAnnotation, bindings: &mut TypeBindings) -> bool {
+    if self.is_async_invocation() != other.is_async_invocation() {
+      return false;
+    }
     // `self` is the actual callable and `other` is the expected callback shape. An actual
     // callable cannot require more fixed arguments than the expected contract guarantees.
     if self.arg_types.len() > other.arg_types.len() {
@@ -8145,6 +8248,9 @@ impl CalcitFnTypeAnnotation {
   }
 
   fn prove_signature_with_bindings(&self, other: &CalcitFnTypeAnnotation, bindings: &mut TypeBindings) -> TypeProof {
+    if self.is_async_invocation() != other.is_async_invocation() {
+      return TypeProof::Mismatch;
+    }
     if self.arg_types.len() > other.arg_types.len() {
       return TypeProof::Mismatch;
     }

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -835,6 +835,8 @@ struct FnSchemaFields<'a> {
   async_invocation: Option<&'a Calcit>,
 }
 
+const ASYNC_INVOCATION_FEATURE: &str = "$async-invocation";
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CalcitGenericBound {
   pub name: Arc<str>,
@@ -2274,7 +2276,7 @@ impl CalcitTypeAnnotation {
       .async_invocation
       .is_some_and(|value| !matches!(value, Calcit::Nil | Calcit::Unit | Calcit::Bool(false)))
     {
-      features.insert(EdnTag::from("async"));
+      features.insert(EdnTag::from(ASYNC_INVOCATION_FEATURE));
     }
     let features = Arc::new(features);
 
@@ -2558,7 +2560,7 @@ impl CalcitTypeAnnotation {
       .as_ref()
       .clone();
     if matches!(map.tag_get("async"), Some(Edn::Bool(true))) {
-      features.insert(EdnTag::from("async"));
+      features.insert(EdnTag::from(ASYNC_INVOCATION_FEATURE));
     }
     let features = Arc::new(features);
     Some(CalcitFnTypeAnnotation {
@@ -7920,13 +7922,13 @@ impl Hash for CalcitFnTypeAnnotation {
 
 impl CalcitFnTypeAnnotation {
   pub(crate) fn is_async_invocation(&self) -> bool {
-    self.features.iter().any(|feature| feature.ref_str() == "async")
+    self.features.iter().any(|feature| feature.ref_str() == ASYNC_INVOCATION_FEATURE)
   }
 
   pub(crate) fn with_async_invocation(&self) -> Self {
     let mut cloned = self.clone();
     let mut features = cloned.features.as_ref().clone();
-    features.insert(EdnTag::from("async"));
+    features.insert(EdnTag::from(ASYNC_INVOCATION_FEATURE));
     cloned.features = Arc::new(features);
     cloned
   }
@@ -7969,7 +7971,7 @@ impl CalcitFnTypeAnnotation {
     let visible_features = self
       .features
       .iter()
-      .filter(|feature| feature.ref_str() != "async")
+      .filter(|feature| feature.ref_str() != ASYNC_INVOCATION_FEATURE)
       .cloned()
       .collect::<Vec<_>>();
     if visible_features.is_empty() {

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -25,7 +25,7 @@ use crate::builtins::syntax::get_raw_args_fn;
 use crate::builtins::{is_js_syntax_procs, is_proc_name};
 use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
 use crate::calcit::{self, CalcitArgLabel, CalcitFnArgs, CalcitImport, CalcitList, CalcitLocal, CalcitProc, MethodKind};
-use crate::calcit::{Calcit, CalcitSyntax, ImportInfo};
+use crate::calcit::{Calcit, CalcitSyntax, CalcitTypeAnnotation, ImportInfo};
 use crate::call_stack::StackKind;
 use crate::codegen::skip_arity_check;
 use crate::program;
@@ -500,6 +500,7 @@ fn gen_call_code(
               JsFnParams {
                 args: &raw_args,
                 arg_types: &arg_types,
+                async_invocation: false,
               },
               &func_body.to_vec(),
               &passed_defs,
@@ -1673,6 +1674,7 @@ fn uses_recur(xs: &Calcit) -> bool {
 struct JsFnParams<'a> {
   args: &'a CalcitFnArgs,
   arg_types: &'a [Arc<calcit::CalcitTypeAnnotation>],
+  async_invocation: bool,
 }
 
 fn gen_js_func(
@@ -1843,7 +1845,11 @@ fn gen_js_func(
   };
 
   let mut body: TernaryTreeList<Calcit> = TernaryTreeList::Empty;
-  let mut async_prefix: String = String::from("");
+  let mut async_prefix = if params.async_invocation {
+    String::from("async ")
+  } else {
+    String::new()
+  };
 
   for line in raw_body {
     if let Calcit::List(xs) = line {
@@ -1936,50 +1942,7 @@ fn gen_js_func(
 
 /// this is a very rough implementation for now
 fn hinted_async(xs: &CalcitList) -> bool {
-  fn is_async_key(form: &Calcit) -> bool {
-    match form {
-      Calcit::Tag(tag) => tag.ref_str().trim_start_matches(':') == "async",
-      Calcit::Symbol { sym, .. } => {
-        let raw = sym.as_ref();
-        raw == "async" || raw.trim_start_matches(':') == "async"
-      }
-      Calcit::Str(text) => text.as_ref() == "async",
-      _ => false,
-    }
-  }
-
-  fn is_truthy(form: &Calcit) -> bool {
-    !matches!(form, Calcit::Nil | Calcit::Unit | Calcit::Bool(false))
-  }
-
-  fn schema_marks_async(form: &Calcit) -> bool {
-    match form {
-      Calcit::Map(map) => map.iter().any(|(key, value)| is_async_key(key) && is_truthy(value)),
-      Calcit::List(list) => {
-        let is_map_literal = matches!(list.first(), Some(Calcit::Symbol { sym, .. }) if sym.as_ref() == "{}")
-          || matches!(list.first(), Some(Calcit::Proc(CalcitProc::NativeMap)));
-        if !is_map_literal {
-          return false;
-        }
-
-        list.iter().skip(1).any(|entry| {
-          let Calcit::List(pair) = entry else {
-            return false;
-          };
-          if pair.len() < 2 {
-            return false;
-          }
-          match (pair.get(0), pair.get(1)) {
-            (Some(key), Some(value)) => is_async_key(key) && is_truthy(value),
-            _ => false,
-          }
-        })
-      }
-      _ => false,
-    }
-  }
-
-  xs.iter().skip(1).any(schema_marks_async)
+  CalcitTypeAnnotation::hint_form_marks_async(&Calcit::List(Arc::new(xs.clone())))
 }
 
 /// Returns true when a value is in the schema map form recognised by hint-fn:
@@ -2137,6 +2100,10 @@ pub fn emit_js(entry_ns: &str, emit_path: &str) -> Result<(), String> {
             JsFnParams {
               args: &fn_parts.args,
               arg_types: &fn_parts.arg_types,
+              async_invocation: matches!(
+                program::lookup_def_schema(ns, &def).as_ref(),
+                CalcitTypeAnnotation::Fn(signature) if signature.is_async_invocation()
+              ),
             },
             &fn_parts.body,
             &passed_defs,
@@ -2458,6 +2425,35 @@ mod tests {
   }
 
   #[test]
+  fn declared_async_invocation_emits_async_function() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+    let passed_defs = PassedDefs {
+      ns: "tests.emit-js",
+      local_defs: &local_defs,
+      file_imports: &file_imports,
+    };
+    let args = CalcitFnArgs::Args(vec![]);
+    let code = gen_js_func(
+      "load-text",
+      JsFnParams {
+        args: &args,
+        arg_types: &[],
+        async_invocation: true,
+      },
+      &[Calcit::Str(Arc::from("ready"))],
+      &passed_defs,
+      true,
+      &tags,
+      "tests.emit-js",
+    )
+    .expect("declared async function should compile");
+
+    assert!(code.starts_with("export async function load_text()"), "{code}");
+  }
+
+  #[test]
   fn external_member_defaults_follow_calcit_naming_conventions() {
     assert_eq!(default_external_js_member_name("text-content"), "textContent");
     assert_eq!(default_external_js_member_name("matches?"), "matches");
@@ -2509,6 +2505,7 @@ mod tests {
       JsFnParams {
         args: &args,
         arg_types: &[],
+        async_invocation: false,
       },
       &raw_body,
       &passed_defs,
@@ -2538,6 +2535,7 @@ mod tests {
       JsFnParams {
         args: &args,
         arg_types: &[],
+        async_invocation: false,
       },
       &[Calcit::Nil],
       &passed_defs,
@@ -2579,6 +2577,7 @@ mod tests {
       JsFnParams {
         args: &args,
         arg_types: &[],
+        async_invocation: false,
       },
       &raw_body,
       &passed_defs,
@@ -2630,6 +2629,7 @@ mod tests {
       JsFnParams {
         args: &args,
         arg_types: &arg_types,
+        async_invocation: false,
       },
       &raw_body,
       &passed_defs,

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -24,7 +24,7 @@ use type_checking::{
 pub use type_inference::infer_static_type_from_expr;
 use type_inference::{
   extract_literal_list_items, find_struct_lookup_in_literal_path, fully_typed_literal_assoc_path, fully_typed_literal_lookup_path,
-  infer_struct_field_type, infer_struct_value_annotation, infer_type_from_expr, resolve_enum_value,
+  infer_struct_field_type, infer_struct_value_annotation, infer_type_from_expr, is_pending_async_value, resolve_enum_value,
   resolve_program_value_for_preprocess, resolve_type_value,
 };
 use type_rewriting::{
@@ -1795,6 +1795,34 @@ pub fn preprocess_expr(
   }
 }
 
+fn reject_pending_async_arguments(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
+  let is_js_await = matches!(head, Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "js-await")
+    || matches!(head, Calcit::Symbol { sym, .. } if sym.as_ref() == "js-await");
+  if is_js_await {
+    return Ok(());
+  }
+  for (index, arg) in args.iter().enumerate() {
+    if resolve_type_value(arg, scope_types).as_deref().is_some_and(is_pending_async_value) {
+      return Err(CalcitErr::use_msg_stack_location_with_code(
+        CalcitErrKind::Type,
+        format!(
+          "async invocation result is used without `js-await` at argument {}; await it before passing it to `{head}`",
+          index + 1
+        ),
+        "E_ASYNC_INVOCATION_REQUIRES_AWAIT",
+        call_stack,
+        arg.get_location().or_else(|| head.get_location()),
+      ));
+    }
+  }
+  Ok(())
+}
+
 fn preprocess_list_call(
   xs: &CalcitList,
   scope_defs: &HashSet<Arc<str>>,
@@ -2093,6 +2121,7 @@ fn preprocess_list_call(
               processed_args = processed_args.push(processed?);
             }
             let processed_args = CalcitList::from(processed_args);
+            reject_pending_async_arguments(&typed_method, &processed_args, scope_types, call_stack)?;
             if strict_types_enabled() || is_display_contract {
               validate_method_call(&typed_method, &processed_args, scope_types, file_ns, call_stack)?;
             }
@@ -2402,8 +2431,10 @@ fn preprocess_list_call(
 
         ys = ys.push(form);
       }
+      let processed_call_args = CalcitList::from(ys.drop_left());
+      reject_pending_async_arguments(&head_form, &processed_call_args, scope_types, call_stack)?;
       if !has_spread {
-        let mut current_args = CalcitList::from(ys.drop_left());
+        let mut current_args = processed_call_args;
         let checked_contract = resolve_checked_call_contract(&info.def_ns, &info.name, &current_args, scope_types);
         let checked_expected_types = checked_contract.as_ref().and_then(|contract| contract.expected_types.as_deref());
         // Core helpers such as `get` resolve to ordinary functions, so validate
@@ -2786,6 +2817,7 @@ fn preprocess_list_call(
 
         // Check for struct field access after processing arguments
         let processed_args = CalcitList::from(ys.drop_left()); // Skip the head, convert to CalcitList
+        reject_pending_async_arguments(&head_form, &processed_args, scope_types, call_stack)?;
         validate_method_call(&head_form, &processed_args, scope_types, file_ns, call_stack)?;
         check_struct_field_access(&head_form, &processed_args, scope_types, file_ns, call_stack, check_warnings);
         check_struct_update_fields(&head_form, &processed_args, scope_types, file_ns, &def_name, check_warnings);
@@ -7929,11 +7961,16 @@ pub fn preprocess_defn(
       // Inject declared argument types into the function body. Call-site checks alone are not
       // enough: without these bindings, local method dispatch and return inference inside a named
       // `defn` unnecessarily fall back to Dynamic. Anonymous callbacks still use EXPECTED_FN_TYPE.
-      let effective_fn_schema: Option<Arc<CalcitFnTypeAnnotation>> = body_fn_hint.or_else(|| match def_schema.as_ref() {
+      let mut effective_fn_schema: Option<Arc<CalcitFnTypeAnnotation>> = body_fn_hint.or_else(|| match def_schema.as_ref() {
         CalcitTypeAnnotation::Fn(fn_annot) => Some(fn_annot.clone()),
         CalcitTypeAnnotation::Dynamic => EXPECTED_FN_TYPE.with(|cell| cell.borrow().clone()),
         _ => None,
       });
+      if args.iter().skip(2).any(CalcitTypeAnnotation::hint_form_marks_async)
+        && let Some(signature) = effective_fn_schema.as_ref()
+      {
+        effective_fn_schema = Some(Arc::new(signature.with_async_invocation()));
+      }
       if let CalcitTypeAnnotation::Macro(signature) = def_schema.as_ref() {
         for (param_sym, type_info) in param_symbols.iter().zip(strict_macro_body_parameter_types(signature)) {
           body_types.insert(param_sym.clone(), type_info);
@@ -17374,5 +17411,45 @@ mod tests {
     assert_eq!(shape.optional, 1);
     assert!(!shape.has_rest);
     assert!(shape.errors.is_empty());
+  }
+
+  #[test]
+  fn preprocess_rejects_pending_async_value_as_call_argument() {
+    let mut features = HashSet::new();
+    features.insert(EdnTag::from("async"));
+    let fn_type = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: Arc::new(CalcitTypeAnnotation::String),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(features),
+    })));
+    let async_name: Arc<str> = Arc::from("load-text");
+    let async_local = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&async_name),
+      sym: async_name,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.async"),
+        at_def: Arc::from("main!"),
+      }),
+      location: Some(Arc::from(vec![4, 2])),
+      type_info: fn_type,
+    });
+    let invocation = Calcit::from(vec![async_local]);
+    let call = CalcitList::from(&[Calcit::Proc(CalcitProc::NativeStr), invocation] as &[Calcit]);
+
+    let error = preprocess_list_call(
+      &call,
+      &HashSet::new(),
+      &mut ScopeTypes::new(),
+      "tests.async",
+      &RefCell::new(vec![]),
+      &CallStackList::default(),
+    )
+    .expect_err("pending async values must not flow into synchronous calls");
+    assert_eq!(error.code.as_deref(), Some("E_ASYNC_INVOCATION_REQUIRES_AWAIT"));
+    assert!(error.msg.contains("argument 1"));
   }
 }

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -17415,17 +17415,16 @@ mod tests {
 
   #[test]
   fn preprocess_rejects_pending_async_value_as_call_argument() {
-    let mut features = HashSet::new();
-    features.insert(EdnTag::from("async"));
-    let fn_type = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+    let signature = CalcitFnTypeAnnotation {
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),
       arg_types: vec![],
       return_type: Arc::new(CalcitTypeAnnotation::String),
       fn_kind: SchemaKind::Fn,
       rest_type: None,
-      features: Arc::new(features),
-    })));
+      features: Arc::new(HashSet::new()),
+    };
+    let fn_type = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature.with_async_invocation())));
     let async_name: Arc<str> = Arc::from("load-text");
     let async_local = Calcit::Local(CalcitLocal {
       idx: CalcitLocal::track_sym(&async_name),

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -37,6 +37,62 @@ use super::{
 // Core resolution
 // ---------------------------------------------------------------------------
 
+const ASYNC_INVOCATION_VALUE_TYPE: &str = "calcit.core/$AsyncInvocation";
+
+fn pending_async_value(logical_return: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
+  Arc::new(CalcitTypeAnnotation::TypeRef(
+    Arc::from(ASYNC_INVOCATION_VALUE_TYPE),
+    Arc::new(vec![logical_return]),
+  ))
+}
+
+pub(crate) fn is_pending_async_value(value: &CalcitTypeAnnotation) -> bool {
+  matches!(value, CalcitTypeAnnotation::TypeRef(name, args) if name.as_ref() == ASYNC_INVOCATION_VALUE_TYPE && args.len() == 1)
+}
+
+fn awaited_async_value(value: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
+  match value.as_ref() {
+    CalcitTypeAnnotation::TypeRef(name, args) if name.as_ref() == ASYNC_INVOCATION_VALUE_TYPE && args.len() == 1 => args[0].clone(),
+    _ => calcit::DYNAMIC_TYPE.clone(),
+  }
+}
+
+fn definition_marks_async(ns: &str, def: &str) -> bool {
+  program::lookup_def_code(ns, def).is_some_and(|code| CalcitTypeAnnotation::function_form_marks_async(&code))
+}
+
+fn invocation_return_type(
+  signature: &CalcitFnTypeAnnotation,
+  logical_return: Arc<CalcitTypeAnnotation>,
+  definition_async: bool,
+) -> Arc<CalcitTypeAnnotation> {
+  if signature.is_async_invocation() || definition_async {
+    pending_async_value(logical_return)
+  } else {
+    logical_return
+  }
+}
+
+fn definition_value_schema(ns: &str, def: &str, schema: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
+  if !definition_marks_async(ns, def) {
+    return schema;
+  }
+  match schema.as_ref() {
+    CalcitTypeAnnotation::Fn(signature) => Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature.with_async_invocation()))),
+    _ => schema,
+  }
+}
+
+fn mark_async_callable(annotation: Arc<CalcitTypeAnnotation>, is_async: bool) -> Arc<CalcitTypeAnnotation> {
+  if !is_async {
+    return annotation;
+  }
+  match annotation.as_ref() {
+    CalcitTypeAnnotation::Fn(signature) => Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature.with_async_invocation()))),
+    _ => annotation,
+  }
+}
+
 pub(crate) fn resolve_type_value(target: &Calcit, scope_types: &ScopeTypes) -> Option<Arc<CalcitTypeAnnotation>> {
   match target {
     Calcit::Local(local) => {
@@ -304,9 +360,9 @@ pub(crate) fn infer_return_type_from_compiled_callable(
         && let Some(inferred_body_return) = infer_compiled_callable_body_return(ns, def, &compiled.preprocessed_code)
         && let Some(enriched) = enrich_declared_struct_return_with_impls(&declared_return, &inferred_body_return)
       {
-        return Some(enriched);
+        return Some(invocation_return_type(info, enriched, definition_marks_async(ns, def)));
       }
-      return Some(declared_return);
+      return Some(invocation_return_type(info, declared_return, definition_marks_async(ns, def)));
     }
   }
 
@@ -319,10 +375,18 @@ pub(crate) fn infer_return_type_from_compiled_callable(
     match compiled.preprocessed_code {
       Calcit::Fn { info, .. } => {
         if let Some(resolved) = resolve_generic_return_type(&info, call_expr.iter().skip(1), scope_types) {
-          return Some(resolved);
+          return Some(if definition_marks_async(ns, def) {
+            pending_async_value(resolved)
+          } else {
+            resolved
+          });
         }
         if !is_core_enum_constructor || !info.return_type.contains_type_var() {
-          return Some(info.return_type.clone());
+          return Some(if definition_marks_async(ns, def) {
+            pending_async_value(info.return_type.clone())
+          } else {
+            info.return_type.clone()
+          });
         }
       }
       Calcit::Proc(proc) => {
@@ -344,7 +408,11 @@ pub(crate) fn infer_return_type_from_compiled_callable(
     return None;
   };
   if info.generics.is_empty() || !info.return_type.contains_type_var() {
-    return Some(info.return_type.clone());
+    return Some(invocation_return_type(
+      info,
+      info.return_type.clone(),
+      definition_marks_async(ns, def),
+    ));
   }
 
   let mut bindings: HashMap<Arc<str>, Arc<CalcitTypeAnnotation>> = HashMap::new();
@@ -369,7 +437,8 @@ pub(crate) fn infer_return_type_from_compiled_callable(
   if resolved.contains_type_var() {
     return None;
   }
-  (resolved.resolve_to_struct().is_some() || resolved.resolve_to_enum().is_some()).then_some(resolved)
+  (resolved.resolve_to_struct().is_some() || resolved.resolve_to_enum().is_some())
+    .then(|| invocation_return_type(info, resolved, definition_marks_async(ns, def)))
 }
 
 thread_local! {
@@ -920,7 +989,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
         Calcit::Local(local) => {
           let type_ann = &local.type_info;
           match type_ann.as_ref() {
-            CalcitTypeAnnotation::Fn(fn_type) => Some(fn_type.return_type.clone()),
+            CalcitTypeAnnotation::Fn(fn_type) => Some(invocation_return_type(fn_type, fn_type.return_type.clone(), false)),
             CalcitTypeAnnotation::DynFn => Some(calcit::DYNAMIC_TYPE.clone()),
             _ => Some(type_ann.clone()),
           }
@@ -931,6 +1000,12 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
 
         // Import: could be a function, try to get its return type
         Calcit::Import(CalcitImport { ns, def, .. }) => {
+          if ns.as_ref() == calcit::CORE_NS && def.as_ref() == "js-await" {
+            return xs
+              .get(1)
+              .and_then(|value| resolve_type_value(value, scope_types))
+              .map(awaited_async_value);
+          }
           if &**ns == calcit::CORE_NS
             && (&**def == "record-get" || &**def == "&struct:get")
             && let Some(field_type) = infer_struct_get_type(xs, scope_types)
@@ -943,6 +1018,12 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
         // Symbol: might be a function reference before preprocessing
         // Try to resolve it and get the return type
         Calcit::Symbol { sym, info, .. } => {
+          if sym.as_ref() == "js-await" {
+            return xs
+              .get(1)
+              .and_then(|value| resolve_type_value(value, scope_types))
+              .map(awaited_async_value);
+          }
           if let Some(inferred) = infer_js_ffi_call_return_type(sym, xs, scope_types) {
             return Some(inferred);
           }
@@ -982,9 +1063,17 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
           if info.return_type.contains_type_var()
             && let Some(resolved) = resolve_generic_return_type(info, xs.iter().skip(1), scope_types)
           {
-            return Some(resolved);
+            return Some(if definition_marks_async(&info.def_ns, &info.name) {
+              pending_async_value(resolved)
+            } else {
+              resolved
+            });
           }
-          Some(info.return_type.clone())
+          Some(if definition_marks_async(&info.def_ns, &info.name) {
+            pending_async_value(info.return_type.clone())
+          } else {
+            info.return_type.clone()
+          })
         }
 
         // Typed method invocation: resolve the selected trait signature and
@@ -1015,7 +1104,11 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
               return Some(calcit::DYNAMIC_TYPE.clone());
             }
           }
-          Some(info.return_type.substitute_type_vars(&bindings))
+          Some(invocation_return_type(
+            info,
+            info.return_type.substitute_type_vars(&bindings),
+            false,
+          ))
         }
 
         // Method access: infer struct field type when available
@@ -1070,7 +1163,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
         Calcit::List(_) => {
           if let Some(head_type) = infer_type_from_expr(head, scope_types) {
             match head_type.as_ref() {
-              CalcitTypeAnnotation::Fn(fn_type) => Some(fn_type.return_type.clone()),
+              CalcitTypeAnnotation::Fn(fn_type) => Some(invocation_return_type(fn_type, fn_type.return_type.clone(), false)),
               CalcitTypeAnnotation::DynFn => Some(calcit::DYNAMIC_TYPE.clone()),
               // If head returns a non-function type, the call will fail at runtime
               // Return the non-callable type so caller can detect this issue
@@ -1090,6 +1183,7 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
 }
 
 fn infer_preprocessed_function_type(xs: &CalcitList) -> Arc<CalcitTypeAnnotation> {
+  let is_async = xs.iter().skip(3).any(CalcitTypeAnnotation::hint_form_marks_async);
   let hinted = xs
     .iter()
     .skip(3)
@@ -1108,10 +1202,13 @@ fn infer_preprocessed_function_type(xs: &CalcitList) -> Arc<CalcitTypeAnnotation
     if !signature.arg_types.is_empty() || signature.rest_type.is_some() {
       return Arc::new(CalcitTypeAnnotation::DynFn);
     }
-    return inferred;
+    return mark_async_callable(inferred, is_async);
   };
   let CalcitTypeAnnotation::Fn(fn_annotation) = hinted.as_ref() else {
-    return hinted;
+    if is_async && let Some(inferred) = infer_unhinted_callback_signature(xs, &ScopeTypes::new()) {
+      return mark_async_callable(inferred, true);
+    }
+    return mark_async_callable(hinted, is_async);
   };
 
   let (parameter_types, inferred_rest_type) = infer_preprocessed_function_parameters(xs.get(2));
@@ -1125,15 +1222,18 @@ fn infer_preprocessed_function_type(xs: &CalcitList) -> Arc<CalcitTypeAnnotation
     _ => fn_annotation.fn_kind,
   };
 
-  Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
-    generics: fn_annotation.generics.clone(),
-    where_bounds: fn_annotation.where_bounds.clone(),
-    arg_types,
-    return_type: fn_annotation.return_type.clone(),
-    fn_kind,
-    rest_type: fn_annotation.rest_type.clone().or(inferred_rest_type),
-    features: fn_annotation.features.clone(),
-  })))
+  mark_async_callable(
+    Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: fn_annotation.generics.clone(),
+      where_bounds: fn_annotation.where_bounds.clone(),
+      arg_types,
+      return_type: fn_annotation.return_type.clone(),
+      fn_kind,
+      rest_type: fn_annotation.rest_type.clone().or(inferred_rest_type),
+      features: fn_annotation.features.clone(),
+    }))),
+    is_async,
+  )
 }
 
 /// Recover a concrete signature from an already preprocessed anonymous
@@ -1147,10 +1247,12 @@ pub(crate) fn infer_unhinted_callback_signature(xs: &CalcitList, scope_types: &S
     _ => return None,
   };
   if xs.len() <= 3
-    || xs
-      .iter()
-      .skip(3)
-      .any(|form| CalcitTypeAnnotation::extract_fn_annotation_from_hint_form(form).is_some())
+    || xs.iter().skip(3).any(|form| {
+      matches!(
+        CalcitTypeAnnotation::extract_fn_annotation_from_hint_form(form).as_deref(),
+        Some(CalcitTypeAnnotation::Fn(_))
+      )
+    })
   {
     return None;
   }
@@ -1721,7 +1823,7 @@ fn infer_definition_value_type_inner(ns: &str, def: &str) -> Option<Arc<CalcitTy
   }
 
   if !matches!(schema.as_ref(), CalcitTypeAnnotation::Dynamic) {
-    return Some(schema);
+    return Some(definition_value_schema(ns, def, schema));
   }
 
   // Data definitions often keep `:dynamic` as their value schema because their concrete field
@@ -1734,7 +1836,11 @@ fn infer_definition_value_type_inner(ns: &str, def: &str) -> Option<Arc<CalcitTy
 
   let compiled = program::lookup_compiled_def(ns, def)?;
   match compiled.preprocessed_code {
-    Calcit::Fn { info, .. } => Some(Arc::new(CalcitTypeAnnotation::from_calcit_fn(&info))),
+    Calcit::Fn { info, .. } => Some(definition_value_schema(
+      ns,
+      def,
+      Arc::new(CalcitTypeAnnotation::from_calcit_fn(&info)),
+    )),
     Calcit::Proc(proc) => proc.get_type_signature().map(|signature| {
       Arc::new(CalcitTypeAnnotation::from_function_parts(
         signature.arg_types.clone(),
@@ -2104,6 +2210,60 @@ mod tests {
     items.push(Calcit::Proc(proc));
     items.extend(args);
     Calcit::from(items)
+  }
+
+  fn typed_local(name: &str, type_info: Arc<CalcitTypeAnnotation>) -> Calcit {
+    let sym: Arc<str> = Arc::from(name);
+    Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&sym),
+      sym,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.async"),
+        at_def: Arc::from("main!"),
+      }),
+      location: None,
+      type_info,
+    })
+  }
+
+  #[test]
+  fn async_callable_alias_requires_await_for_its_logical_value() {
+    let mut features = HashSet::new();
+    features.insert(EdnTag::from("async"));
+    let async_fn = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: Arc::new(CalcitTypeAnnotation::String),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(features),
+    })));
+    let invocation = Calcit::from(vec![typed_local("load-text", async_fn)]);
+
+    let pending = infer_type_from_expr(&invocation, &ScopeTypes::new()).expect("async invocation type");
+    assert!(is_pending_async_value(pending.as_ref()));
+    assert!(!pending.is_compatible_with(&CalcitTypeAnnotation::String));
+
+    let awaited = Calcit::from(vec![symbol("js-await"), invocation]);
+    assert!(matches!(
+      infer_type_from_expr(&awaited, &ScopeTypes::new()).as_deref(),
+      Some(CalcitTypeAnnotation::String)
+    ));
+  }
+
+  #[test]
+  fn sync_callable_control_keeps_its_logical_return() {
+    let sync_fn = Arc::new(CalcitTypeAnnotation::from_function_parts(
+      vec![],
+      Arc::new(CalcitTypeAnnotation::String),
+    ));
+    let invocation = Calcit::from(vec![typed_local("read-text", sync_fn)]);
+
+    assert!(matches!(
+      infer_type_from_expr(&invocation, &ScopeTypes::new()).as_deref(),
+      Some(CalcitTypeAnnotation::String)
+    ));
   }
 
   fn symbol(name: &str) -> Calcit {

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -2228,17 +2228,16 @@ mod tests {
 
   #[test]
   fn async_callable_alias_requires_await_for_its_logical_value() {
-    let mut features = HashSet::new();
-    features.insert(EdnTag::from("async"));
-    let async_fn = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+    let signature = CalcitFnTypeAnnotation {
       generics: Arc::new(vec![]),
       where_bounds: Arc::new(vec![]),
       arg_types: vec![],
       return_type: Arc::new(CalcitTypeAnnotation::String),
       fn_kind: SchemaKind::Fn,
       rest_type: None,
-      features: Arc::new(features),
-    })));
+      features: Arc::new(HashSet::new()),
+    };
+    let async_fn = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature.with_async_invocation())));
     let invocation = Calcit::from(vec![typed_local("load-text", async_fn)]);
 
     let pending = infer_type_from_expr(&invocation, &ScopeTypes::new()).expect("async invocation type");

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1263,6 +1263,7 @@ pub const VALID_SCHEMA_FIELDS: &[&str] = &[
   ":generics",
   ":where",
   ":features",
+  ":async",
   ":legacy-origin",
 ];
 
@@ -1615,6 +1616,7 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
   let mut legacy_origin_node: Option<&Cirru> = None;
   let mut where_node: Option<&Cirru> = None;
   let mut features_node: Option<&Cirru> = None;
+  let mut async_node: Option<&Cirru> = None;
 
   for pair in items.iter().skip(1) {
     if let Cirru::List(xs) = pair
@@ -1632,6 +1634,7 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
         ":rest" => rest_node = Some(val),
         ":where" => where_node = Some(val),
         ":features" => features_node = Some(val),
+        ":async" => async_node = Some(val),
         _ => {}
       }
     }
@@ -1724,6 +1727,12 @@ pub fn validate_schema_for_write(schema: &Cirru) -> Result<(), String> {
     && !matches!(legacy_origin, Cirru::Leaf(value) if matches!(value.as_ref(), ":fn" | ":dynamic"))
   {
     return Err("`:legacy-origin` must be `:fn` or `:dynamic`".to_owned());
+  }
+
+  if let Some(async_value) = async_node
+    && !matches!(async_value, Cirru::Leaf(value) if matches!(value.as_ref(), "true" | "false"))
+  {
+    return Err("`:async` must be `true` or `false`".to_owned());
   }
 
   // Validate :features value — must be a hashset of tags
@@ -3466,6 +3475,14 @@ mod tests {
   fn test_validate_schema_for_write() {
     let valid = parse_one(":: :fn $ {} (:args ([] :string)) (:return :bool)");
     assert!(validate_schema_for_write(&valid).is_ok(), "valid schema should pass");
+
+    let valid_async = parse_one(":: :fn $ {} (:args ([])) (:return :string) (:async true)");
+    assert!(validate_schema_for_write(&valid_async).is_ok(), "async schema should pass");
+    let invalid_async = parse_one(":: :fn $ {} (:args ([])) (:return :string) (:async :yes)");
+    assert_eq!(
+      validate_schema_for_write(&invalid_async).expect_err("invalid async marker should fail"),
+      "`:async` must be `true` or `false`"
+    );
 
     let valid_with_where = parse_one(":: :fn $ {} (:generics ([] 'T)) (:args ([] 'T)) (:where {} ('T Show)) (:return :string)");
     assert!(


### PR DESCRIPTION
## English

Closes #873.

### What changed

- Make `:async true` a checked function-invocation contract while keeping `:return T` as the logical value produced after `js-await`.
- Preserve async invocation metadata through direct definition references, local aliases, callback schemas, schema round trips, ordering/hashing, and JS lowering.
- Represent an unawaited invocation as an internal pending boundary and let only `js-await` unwrap it for static inference.
- Reject passing a pending async result to an ordinary call with the source-located `E_ASYNC_INVOCATION_REQUIRES_AWAIT` diagnostic.
- Keep checker and JS emission aligned for both body hints and declared schemas; no automatic await/retry or general effect model is added.
- Document the contract and validate `:async` snapshot fields as booleans.

### Verification

- `RUST_MIN_STACK=16777216 cargo test` — 1109 passed on latest `main` (`689e8b2f`).
- `cargo clippy -- -D warnings`
- `yarn compile`
- `yarn check-all` — native, JS, IR, WASM, quality, and Agent interface checks passed.
- `RUST_MIN_STACK=16777216 bash scripts/check-docs-md.sh` — 68 files and 330 blocks passed.
- Current js-ffi candidate fixture: missing await is rejected with `E_ASYNC_INVOCATION_REQUIRES_AWAIT`; the awaited form passes check-only and emits `await async_value()` inside an `async function`.

Consumer fetch/Response and Node async-filesystem runtime validation remains tracked by #910 after this core change merges. Release acceptance remains tracked by #915.

## 中文

关闭 #873。

### 修改内容

- 将 `:async true` 纳入可检查的函数调用契约，同时保持 `:return T` 表示经 `js-await` 后得到的逻辑值。
- 在直接定义引用、局部别名、callback schema、schema 往返、排序/哈希以及 JS lowering 中保留异步调用元数据。
- 用内部 pending 边界表示尚未 await 的调用结果，静态推断中只有 `js-await` 会解开该边界。
- 普通调用消费 pending 异步结果时，返回带源码位置的稳定诊断 `E_ASYNC_INVOCATION_REQUIRES_AWAIT`。
- 让检查器和 JS 生成同时识别函数体 hint 与声明 schema；不自动插入 await/retry，也不扩展为通用 effect 模型。
- 补充协议文档，并要求 Snapshot 的 `:async` 字段使用布尔值。

### 验证

- `RUST_MIN_STACK=16777216 cargo test` — 基于最新 `main`（`689e8b2f`）共 1109 项通过。
- `cargo clippy -- -D warnings`
- `yarn compile`
- `yarn check-all` — native、JS、IR、WASM、质量门禁和 Agent interface 均通过。
- `RUST_MIN_STACK=16777216 bash scripts/check-docs-md.sh` — 68 个文件、330 个代码块全部通过。
- 当前 js-ffi candidate fixture：漏 await 会以 `E_ASYNC_INVOCATION_REQUIRES_AWAIT` 拒绝；合法 await 通过 check-only，并在 `async function` 中生成 `await async_value()`。

真实 fetch/Response 与 Node async filesystem 的消费者运行时验证仍由 #910 在 core 合并后完成；发布验收继续由 #915 跟踪。
