### PR TITLE
Fix async invocation review gaps / 修复异步调用审阅缺口

### DIFF
--- a/calcit/test-js.cirru
+++ b/calcit/test-js.cirru
@@ -20,7 +20,18 @@
               :required $ [] (:: 'Expr 'String)
         'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn main! () (log-title "|Testing js") (test-js) (test-let-example) (test-collection) (test-async) (test-async-in-data) (test-data-gen) (test-regexp) (test-property) (test-tag-keys)
+            defn main! ()
+              hint-fn $ {} (:async true)
+              log-title "|Testing js"
+              test-js
+              test-let-example
+              test-collection
+              test-async
+              js-await $ test-async-in-data
+              test-data-gen
+              test-regexp
+              test-property
+              test-tag-keys
               when (> 1 2)
                 raise $ str "|error of math" 2 1
                 raise "|base error"
@@ -65,19 +76,21 @@
               :features $ #{} :js-ffi
         'test-async-in-data $ %{} 'CodeEntry (:doc "|async fn inside data. if wrong, it will be a syntax error from await outside async")
           :code $ quote
-            fn () $ let
-                timeout $ fn (ms)
-                  new js/Promise $ fn (resolve reject) (js/setTimeout resolve ms)
-                f 0
-                f $ let
-                    b $ fn ()
-                      hint-fn $ {} (:async true)
-                      let
-                          a 1
-                          a $ js-await (timeout 200)
-                        assert= &unit a
-                  b
-              js/console.log "|a promise from nested let" f
+            fn ()
+              hint-fn $ {} (:async true)
+              let
+                  timeout $ fn (ms)
+                    new js/Promise $ fn (resolve reject) (js/setTimeout resolve ms)
+                  f 0
+                  f $ let
+                      b $ fn ()
+                        hint-fn $ {} (:async true)
+                        let
+                            a 1
+                            a $ js-await (timeout 200)
+                          assert= &unit a
+                    b
+                js/console.log "|a promise from nested let" $ js-await f
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)

--- a/editing-history/202609081940-async-review-followups.md
+++ b/editing-history/202609081940-async-review-followups.md
@@ -1,0 +1,41 @@
+# Async invocation review follow-ups
+
+## English
+
+- Address the post-merge review findings from calcit#923.
+- Preserve pending async results through `apply` and reject pending receivers.
+- Keep the internal async marker out of public feature sets and normalize string-keyed `:async` schemas.
+- Tighten definition-level hint detection and add focused regression coverage.
+- Migrate `test-async-in-data` to await the nested async result before synchronous consumption.
+
+## Validation
+
+- `RUST_MIN_STACK=16777216 cargo test` — 1113 tests passed.
+- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
+- `yarn try-js` — emitted JavaScript and completed the real Node runtime suite.
+- Static lowering, IR, WASM, literal-path, typed-method and documentation gates passed.
+
+## Remaining after the draft checkpoint
+
+- Wait for latest-head CI and automated review, then address any valid comments.
+- Merge this follow-up before validating the js-ffi consumer tracked by calcit#910.
+
+## 中文
+
+- 处理 calcit#923 合并后审阅发现的问题。
+- 在 `apply` 路径保留待 await 的异步结果，并拒绝未 await 的 receiver。
+- 防止内部异步标记进入公开 feature 集合，并归一化字符串键形式的 `:async` schema。
+- 收紧定义级 hint 检测并补充聚焦回归测试。
+- 迁移 `test-async-in-data`，在同步消费嵌套 async 调用结果前显式 `js-await`。
+
+## 验证
+
+- `RUST_MIN_STACK=16777216 cargo test`：1113 项测试通过。
+- `cargo clippy --all-targets --all-features -- -D warnings`：通过。
+- `yarn try-js`：成功生成 JavaScript，并完成真实 Node 运行时测试。
+- 静态 lowering、IR、WASM、literal-path、typed-method 和文档门禁均通过。
+
+## Draft 检查点后的待办
+
+- 等待最新 head 的 CI 与自动审阅，处理全部有效意见。
+- 合并本 follow-up 后，再验证 calcit#910 跟踪的 js-ffi 消费端。

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -1847,8 +1847,11 @@ impl CalcitTypeAnnotation {
             fields.features = Some(value);
           }
         }
-        "async" if fields.async_invocation.is_none() => {
-          fields.async_invocation = Some(value);
+        "async" => {
+          fields.has_any = true;
+          if fields.async_invocation.is_none() {
+            fields.async_invocation = Some(value);
+          }
         }
         _ => {}
       }
@@ -2208,7 +2211,9 @@ impl CalcitTypeAnnotation {
       Calcit::Set(xs) => {
         let mut features = HashSet::with_capacity(xs.size());
         for item in xs.iter() {
-          if let Calcit::Tag(tag) = item {
+          if let Calcit::Tag(tag) = item
+            && tag.ref_str() != ASYNC_INVOCATION_FEATURE
+          {
             features.insert(tag.clone());
           }
         }
@@ -2224,10 +2229,10 @@ impl CalcitTypeAnnotation {
     let Some(items) = Self::get_hint_fn_items(form) else {
       return false;
     };
-    items.iter().skip(1).any(|item| {
-      Self::extract_schema_value_single(item, "async")
-        .is_some_and(|value| !matches!(value, Calcit::Nil | Calcit::Unit | Calcit::Bool(false)))
-    })
+    items
+      .get(1)
+      .and_then(|item| Self::extract_schema_value_single(item, "async"))
+      .is_some_and(|value| !matches!(value, Calcit::Nil | Calcit::Unit | Calcit::Bool(false)))
   }
 
   /// Return whether a source or preprocessed function definition carries an async hint.
@@ -2559,6 +2564,7 @@ impl CalcitTypeAnnotation {
       .unwrap_or_default()
       .as_ref()
       .clone();
+    features.retain(|feature| feature.ref_str() != ASYNC_INVOCATION_FEATURE);
     if matches!(map.tag_get("async"), Some(Edn::Bool(true))) {
       features.insert(EdnTag::from(ASYNC_INVOCATION_FEATURE));
     }
@@ -6602,6 +6608,56 @@ mod tests {
       CalcitTypeAnnotation::Fn(async_signature.clone()).cmp(&CalcitTypeAnnotation::Fn(Arc::new(sync_signature))),
       Ordering::Equal
     );
+  }
+
+  #[test]
+  fn async_only_schema_is_valid_but_target_hint_does_not_mark_definition() {
+    let async_schema = Calcit::from(vec![
+      symbol("{}"),
+      Calcit::from(vec![Calcit::Tag(EdnTag::from("async")), Calcit::Bool(true)]),
+    ]);
+    let definition_hint = Calcit::from(vec![Calcit::Syntax(CalcitSyntax::HintFn, Arc::from("tests")), async_schema.clone()]);
+
+    let annotation = CalcitTypeAnnotation::extract_fn_annotation_from_hint_form(&definition_hint).expect("async-only fn schema");
+    assert!(matches!(annotation.as_ref(), CalcitTypeAnnotation::Fn(signature) if signature.is_async_invocation()));
+    assert!(CalcitTypeAnnotation::hint_form_marks_async(&definition_hint));
+
+    let target_hint = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::HintFn, Arc::from("tests")),
+      symbol("target"),
+      async_schema,
+    ]);
+    assert!(!CalcitTypeAnnotation::hint_form_marks_async(&target_hint));
+  }
+
+  #[test]
+  fn reserved_async_feature_cannot_override_explicit_false() {
+    let reserved = EdnTag::from(ASYNC_INVOCATION_FEATURE);
+    let source_schema = Calcit::from(vec![
+      symbol("{}"),
+      Calcit::from(vec![
+        Calcit::Tag(EdnTag::from("features")),
+        Calcit::Set([Calcit::Tag(reserved.clone())].into_iter().collect()),
+      ]),
+      Calcit::from(vec![Calcit::Tag(EdnTag::from("async")), Calcit::Bool(false)]),
+    ]);
+    let source_hint = Calcit::from(vec![Calcit::Syntax(CalcitSyntax::HintFn, Arc::from("tests")), source_schema]);
+    let source = CalcitTypeAnnotation::extract_fn_annotation_from_hint_form(&source_hint).expect("source fn schema");
+    let CalcitTypeAnnotation::Fn(source) = source.as_ref() else {
+      panic!("expected source fn annotation")
+    };
+    assert!(!source.is_async_invocation());
+    assert!(!source.features.contains(&reserved));
+
+    let mut features = EdnSetView::default();
+    features.insert(Edn::Tag(reserved.clone()));
+    let edn_schema = Edn::Map(EdnMapView::from(HashMap::from([
+      (Edn::tag("features"), Edn::Set(features)),
+      (Edn::tag("async"), Edn::Bool(false)),
+    ])));
+    let edn = CalcitTypeAnnotation::parse_fn_schema_from_edn(&edn_schema).expect("EDN fn schema");
+    assert!(!edn.is_async_invocation());
+    assert!(!edn.features.contains(&reserved));
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -1806,6 +1806,15 @@ fn reject_pending_async_arguments(
   if is_js_await {
     return Ok(());
   }
+  if resolve_type_value(head, scope_types).as_deref().is_some_and(is_pending_async_value) {
+    return Err(CalcitErr::use_msg_stack_location_with_code(
+      CalcitErrKind::Type,
+      format!("async invocation result is used without `js-await` as the receiver of `{head}`; await it first"),
+      "E_ASYNC_INVOCATION_REQUIRES_AWAIT",
+      call_stack,
+      head.get_location(),
+    ));
+  }
   for (index, arg) in args.iter().enumerate() {
     if resolve_type_value(arg, scope_types).as_deref().is_some_and(is_pending_async_value) {
       return Err(CalcitErr::use_msg_stack_location_with_code(
@@ -17450,5 +17459,44 @@ mod tests {
     .expect_err("pending async values must not flow into synchronous calls");
     assert_eq!(error.code.as_deref(), Some("E_ASYNC_INVOCATION_REQUIRES_AWAIT"));
     assert!(error.msg.contains("argument 1"));
+  }
+
+  #[test]
+  fn preprocess_rejects_pending_async_value_as_call_receiver() {
+    let signature = CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: Arc::new(CalcitTypeAnnotation::String),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    };
+    let fn_type = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature.with_async_invocation())));
+    let async_name: Arc<str> = Arc::from("load-text");
+    let async_local = Calcit::Local(CalcitLocal {
+      idx: CalcitLocal::track_sym(&async_name),
+      sym: async_name,
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.async"),
+        at_def: Arc::from("main!"),
+      }),
+      location: Some(Arc::from(vec![4, 2])),
+      type_info: fn_type,
+    });
+    let pending_receiver = Calcit::from(vec![async_local]);
+    let call = CalcitList::from(&[pending_receiver, Calcit::Tag(EdnTag::from("name"))] as &[Calcit]);
+
+    let error = preprocess_list_call(
+      &call,
+      &HashSet::new(),
+      &mut ScopeTypes::new(),
+      "tests.async",
+      &RefCell::new(vec![]),
+      &CallStackList::default(),
+    )
+    .expect_err("pending async receivers must be awaited before postfix calls");
+    assert_eq!(error.code.as_deref(), Some("E_ASYNC_INVOCATION_REQUIRES_AWAIT"));
+    assert!(error.msg.contains("receiver"));
   }
 }

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -619,7 +619,7 @@ fn infer_core_apply_return_type(call_expr: &CalcitList, scope_types: &ScopeTypes
     bindings.entry(generic.clone()).or_insert_with(|| calcit::DYNAMIC_TYPE.clone());
   }
   let resolved = signature.return_type.substitute_type_vars(&bindings);
-  (!resolved.contains_type_var()).then_some(resolved)
+  (!resolved.contains_type_var()).then(|| invocation_return_type(signature.as_ref(), resolved, false))
 }
 
 fn core_type_ref(name: &str, args: Vec<Arc<CalcitTypeAnnotation>>) -> Arc<CalcitTypeAnnotation> {
@@ -2479,6 +2479,26 @@ mod tests {
       infer_core_apply_return_type(&call, &ScopeTypes::new()).as_deref(),
       Some(CalcitTypeAnnotation::String)
     ));
+  }
+
+  #[test]
+  fn apply_preserves_an_async_callable_pending_result() {
+    let signature = CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![Arc::new(CalcitTypeAnnotation::String)],
+      return_type: Arc::new(CalcitTypeAnnotation::String),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    }
+    .with_async_invocation();
+    let callable = local("load-text", Arc::new(CalcitTypeAnnotation::Fn(Arc::new(signature))));
+    let arguments = proc_call(CalcitProc::List, vec![Calcit::Str(Arc::from("notes.txt"))]);
+    let call = CalcitList::from(&[symbol("apply"), callable, arguments][..]);
+
+    let inferred = infer_core_apply_return_type(&call, &ScopeTypes::new()).expect("async apply result");
+    assert!(is_pending_async_value(inferred.as_ref()));
   }
 
   #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -79,6 +79,7 @@ fn canonical_schema_field_name(text: &str) -> Option<&'static str> {
     "generics" => Some("generics"),
     "where" => Some("where"),
     "features" => Some("features"),
+    "async" => Some("async"),
     "capabilities" => Some("capabilities"),
     _ => None,
   }
@@ -3901,13 +3902,14 @@ mod tests {
   }
 
   #[test]
-  fn test_normalize_schema_canonicalizes_string_keys_and_kind_values() {
+  fn test_normalize_schema_canonicalizes_string_keys_kind_and_async_values() {
     let wrapped = Edn::enum_value(
       "fn",
       vec![Edn::Map(EdnMapView::from(HashMap::from([
         (Edn::Str(Arc::from(":args")), Edn::List(EdnListView(vec![Edn::tag("set")]))),
         (Edn::Str(Arc::from(":return")), Edn::tag("bool")),
         (Edn::Str(Arc::from(":kind")), Edn::Str(Arc::from(":fn"))),
+        (Edn::Str(Arc::from(":async")), Edn::Bool(true)),
       ])))],
     );
 
@@ -3919,7 +3921,9 @@ mod tests {
     assert!(matches!(map.tag_get("args"), Some(Edn::List(_))));
     assert!(matches!(map.tag_get("return"), Some(Edn::Tag(tag)) if tag.ref_str() == "bool"));
     assert!(matches!(map.tag_get("kind"), Some(Edn::Tag(tag)) if tag.ref_str() == "fn"));
-    assert!(CalcitTypeAnnotation::parse_fn_schema_from_edn(&Edn::Map(map)).is_some());
+    assert!(matches!(map.tag_get("async"), Some(Edn::Bool(true))));
+    let parsed = CalcitTypeAnnotation::parse_fn_schema_from_edn(&Edn::Map(map)).expect("normalized async fn schema");
+    assert!(parsed.is_async_invocation());
   }
 
   #[test]


### PR DESCRIPTION
## English

### Summary

Follow up on the post-merge findings from the [#923 CodeRabbit review](https://github.com/calcit-lang/calcit/pull/923#pullrequestreview-5141186176). This draft keeps the fixes isolated before continuing the js-ffi consumer work in #910.

### Changes

- Treat an async-only source schema as a valid function schema.
- Restrict definition-level async detection so a `(hint-fn target schema)` annotation does not mark the enclosing function.
- Strip the reserved `$async-invocation` marker from public `:features`.
- Preserve pending async results through `apply`.
- Reject pending async values used as postfix/call receivers.
- Canonicalize string-keyed `:async` snapshot fields.
- Migrate the nested async JS runtime fixture to explicit checked awaits using `calcit tree/edit`.

### Validation completed

- `RUST_MIN_STACK=16777216 cargo test` — 1113 tests passed.
- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- Focused async tests — passed.
- Real JavaScript emission and Node runtime via `yarn try-js` — passed.
- Static lowering, IR, WASM, literal-path, typed-method, and documentation gates — passed.

### Remaining before ready for review

- Wait for latest-head GitHub CI and automated review.
- Address every valid new comment and resolve all review threads.
- Rebase if `main` advances and rerun affected gates.
- After merge, resume #910 in `calcit-lang/js-ffi`.

Refs #910.

## 中文

### 摘要

跟进 [#923 CodeRabbit review](https://github.com/calcit-lang/calcit/pull/923#pullrequestreview-5141186176) 在合并后给出的意见。本 Draft 将修复独立交付，之后再继续 #910 的 js-ffi 消费端工作。

### 修改

- 将仅包含 async 字段的源码 schema 识别为有效函数 schema。
- 限制定义级 async 检测，避免 `(hint-fn target schema)` 把目标注解误判为外层函数契约。
- 从公开 `:features` 中过滤保留的 `$async-invocation` 内部标记。
- 在 `apply` 路径保留 pending async 结果。
- 拒绝把未 await 的 async 值作为 postfix/调用 receiver。
- 归一化字符串键形式的 `:async` 快照字段。
- 使用 `calcit tree/edit` 将嵌套 async JavaScript 运行时 fixture 迁移到显式受检查的 await。

### 已完成验证

- `RUST_MIN_STACK=16777216 cargo test`：1113 项测试通过。
- `cargo clippy --all-targets --all-features -- -D warnings`：通过。
- 聚焦 async 测试：通过。
- `yarn try-js` 的真实 JavaScript 生成与 Node 运行：通过。
- 静态 lowering、IR、WASM、literal-path、typed-method 与文档门禁：通过。

### 转为 Ready 前仍需完成

- 等待最新 head 的 GitHub CI 与自动审阅。
- 处理所有有效新意见并清零 review thread。
- 若 `main` 前进则 rebase，并重跑受影响门禁。
- 合并后恢复 `calcit-lang/js-ffi` 中的 #910 工作。

关联 #910。