### PR TITLE
Preserve explicit Dynamic container arguments in schema edits

### DIFF
--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -2840,15 +2840,18 @@ fn print_import_usage_tips(rule: &Cirru, source_ns: &str) {
 mod tests {
   use super::{
     TransactionOperationReport, bump_semver_value, collect_format_advisories, count_legacy_any_schema_fields,
-    count_legacy_inherent_impls, handle_add_import, handle_add_test, handle_imports, handle_rm_test, load_snapshot,
+    count_legacy_inherent_impls, handle_add_import, handle_add_test, handle_imports, handle_rm_test, handle_schema, load_snapshot,
     parse_examples_input, parse_import_rules_input, parse_input_to_cirru, parse_schema_input, parse_transaction_operations,
     rename_definition_declaration, run_staged_transaction_with, save_schema_preserving_snapshot, save_snapshot,
   };
-  use crate::cli_args::{EditAddImportCommand, EditAddTestCommand, EditImportsCommand, EditRmTestCommand};
+  use crate::cli_args::{EditAddImportCommand, EditAddTestCommand, EditImportsCommand, EditRmTestCommand, EditSchemaCommand};
   use crate::cli_handlers::test_support::TestProject;
+  use calcit::calcit::CalcitTypeAnnotation;
+  use cirru_edn::Edn;
   use cirru_parser::Cirru;
   use std::fs;
   use std::path::Path;
+  use std::sync::Arc;
 
   type TestSnapshot = TestProject;
 
@@ -3230,6 +3233,28 @@ mod tests {
     );
     let error = parse_schema_input(":: :ref :bool").expect_err("bare schema should fail");
     assert!(error.contains("Schema examples: `quote :string`"), "error: {error}");
+  }
+
+  #[test]
+  fn schema_edit_preserves_explicit_dynamic_container_arguments() {
+    let fixture = TestSnapshot::from_fixture();
+    let path = fixture.snapshot_string();
+    let opts = EditSchemaCommand {
+      target: "app.main/test-fn".to_owned(),
+      file: None,
+      code: Some("quote $ :: 'Fn $ {} (:args ([] (:: 'List 'Dynamic))) (:return (:: 'List 'Dynamic))".to_owned()),
+      clear: false,
+    };
+
+    handle_schema(&opts, &path).expect("explicit List<Dynamic> schema should be written");
+    let snapshot = load_snapshot(&path).expect("edited snapshot should load");
+    let schema = &snapshot.files["app.main"].defs["test-fn"].schema;
+    let CalcitTypeAnnotation::Fn(signature) = schema.as_ref() else {
+      panic!("expected Fn schema, got {schema:?}")
+    };
+    let explicit_list = Edn::enum_value("List", vec![Edn::Symbol(Arc::from("Dynamic"))]);
+    assert_eq!(signature.arg_types[0].to_type_edn(), explicit_list);
+    assert_eq!(signature.return_type.to_type_edn(), explicit_list);
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -2975,18 +2975,14 @@ impl CalcitTypeAnnotation {
           if let Some(inner_form) = enum_value.extra.first() {
             return Arc::new(CalcitTypeAnnotation::List(parse_nested(inner_form)));
           }
-          return Arc::new(CalcitTypeAnnotation::List(Arc::new(Self::Dynamic)));
+          return Arc::new(CalcitTypeAnnotation::List(DYNAMIC_TYPE.clone()));
         }
         if is_map_tag(tag) {
           if enum_value.extra.len() > 2 {
             eprintln!("[Warn] :map expects at most 2 arguments, got {}", enum_value.extra.len());
           }
-          let key_type = enum_value
-            .extra
-            .first()
-            .map(parse_nested)
-            .unwrap_or_else(|| Arc::new(Self::Dynamic));
-          let val_type = enum_value.extra.get(1).map(parse_nested).unwrap_or_else(|| Arc::new(Self::Dynamic));
+          let key_type = enum_value.extra.first().map(parse_nested).unwrap_or_else(|| DYNAMIC_TYPE.clone());
+          let val_type = enum_value.extra.get(1).map(parse_nested).unwrap_or_else(|| DYNAMIC_TYPE.clone());
           return Arc::new(CalcitTypeAnnotation::Map(key_type, val_type));
         }
         if is_set_tag(tag) {
@@ -2996,7 +2992,7 @@ impl CalcitTypeAnnotation {
           if let Some(inner_form) = enum_value.extra.first() {
             return Arc::new(CalcitTypeAnnotation::Set(parse_nested(inner_form)));
           }
-          return Arc::new(CalcitTypeAnnotation::Set(Arc::new(Self::Dynamic)));
+          return Arc::new(CalcitTypeAnnotation::Set(DYNAMIC_TYPE.clone()));
         }
         if is_ref_tag(tag) {
           if enum_value.extra.len() > 1 {
@@ -3005,7 +3001,7 @@ impl CalcitTypeAnnotation {
           if let Some(inner_form) = enum_value.extra.first() {
             return Arc::new(CalcitTypeAnnotation::Ref(parse_nested(inner_form)));
           }
-          return Arc::new(CalcitTypeAnnotation::Ref(Arc::new(Self::Dynamic)));
+          return Arc::new(CalcitTypeAnnotation::Ref(DYNAMIC_TYPE.clone()));
         }
         if tag.ref_str().trim_start_matches(':') == "fn" {
           if let Some(schema_form) = enum_value.extra.first()
@@ -3123,14 +3119,14 @@ impl CalcitTypeAnnotation {
           if let Some(inner_form) = xs.get(1) {
             return Arc::new(CalcitTypeAnnotation::List(parse_nested(inner_form)));
           }
-          return Arc::new(CalcitTypeAnnotation::List(Arc::new(Self::Dynamic)));
+          return Arc::new(CalcitTypeAnnotation::List(DYNAMIC_TYPE.clone()));
         }
         if is_map_tag(tag) {
           if xs.len() > 3 {
             eprintln!("[Warn] :map expects at most 2 arguments, got {}", xs.len() as i64 - 1);
           }
-          let key_type = xs.get(1).map(parse_nested).unwrap_or_else(|| Arc::new(Self::Dynamic));
-          let val_type = xs.get(2).map(parse_nested).unwrap_or_else(|| Arc::new(Self::Dynamic));
+          let key_type = xs.get(1).map(parse_nested).unwrap_or_else(|| DYNAMIC_TYPE.clone());
+          let val_type = xs.get(2).map(parse_nested).unwrap_or_else(|| DYNAMIC_TYPE.clone());
           return Arc::new(CalcitTypeAnnotation::Map(key_type, val_type));
         }
         if is_set_tag(tag) {
@@ -3140,7 +3136,7 @@ impl CalcitTypeAnnotation {
           if let Some(inner_form) = xs.get(1) {
             return Arc::new(CalcitTypeAnnotation::Set(parse_nested(inner_form)));
           }
-          return Arc::new(CalcitTypeAnnotation::Set(Arc::new(Self::Dynamic)));
+          return Arc::new(CalcitTypeAnnotation::Set(DYNAMIC_TYPE.clone()));
         }
         if is_ref_tag(tag) {
           if xs.len() > 2 {
@@ -3149,7 +3145,7 @@ impl CalcitTypeAnnotation {
           if let Some(inner_form) = xs.get(1) {
             return Arc::new(CalcitTypeAnnotation::Ref(parse_nested(inner_form)));
           }
-          return Arc::new(CalcitTypeAnnotation::Ref(Arc::new(Self::Dynamic)));
+          return Arc::new(CalcitTypeAnnotation::Ref(DYNAMIC_TYPE.clone()));
         }
         if tag_name == "fn" {
           if let Some(schema_form) = xs.get(1)
@@ -3210,24 +3206,24 @@ impl CalcitTypeAnnotation {
             if let Some(inner_form) = xs.get(2) {
               return Arc::new(CalcitTypeAnnotation::List(parse_nested(inner_form)));
             }
-            return Arc::new(CalcitTypeAnnotation::List(Arc::new(Self::Dynamic)));
+            return Arc::new(CalcitTypeAnnotation::List(DYNAMIC_TYPE.clone()));
           }
           if tag_name == "map" {
-            let key_type = xs.get(2).map(parse_nested).unwrap_or_else(|| Arc::new(Self::Dynamic));
-            let val_type = xs.get(3).map(parse_nested).unwrap_or_else(|| Arc::new(Self::Dynamic));
+            let key_type = xs.get(2).map(parse_nested).unwrap_or_else(|| DYNAMIC_TYPE.clone());
+            let val_type = xs.get(3).map(parse_nested).unwrap_or_else(|| DYNAMIC_TYPE.clone());
             return Arc::new(CalcitTypeAnnotation::Map(key_type, val_type));
           }
           if tag_name == "set" {
             if let Some(inner_form) = xs.get(2) {
               return Arc::new(CalcitTypeAnnotation::Set(parse_nested(inner_form)));
             }
-            return Arc::new(CalcitTypeAnnotation::Set(Arc::new(Self::Dynamic)));
+            return Arc::new(CalcitTypeAnnotation::Set(DYNAMIC_TYPE.clone()));
           }
           if tag_name == "ref" {
             if let Some(inner_form) = xs.get(2) {
               return Arc::new(CalcitTypeAnnotation::Ref(parse_nested(inner_form)));
             }
-            return Arc::new(CalcitTypeAnnotation::Ref(Arc::new(Self::Dynamic)));
+            return Arc::new(CalcitTypeAnnotation::Ref(DYNAMIC_TYPE.clone()));
           }
           if tag_name == "fn" {
             if let Some(schema_form) = xs.get(2)
@@ -4933,30 +4929,31 @@ impl CalcitTypeAnnotation {
           Edn::enum_value(name.trim_start_matches('\''), args.iter().map(|arg| arg.to_type_edn()).collect())
         }
       }
-      // Parameterized builtins – keep inner type if non-dynamic
+      // Bare containers share DYNAMIC_TYPE for their omitted arguments. An
+      // explicitly written Dynamic is a distinct Arc and must round-trip.
       Self::List(inner) => {
-        if matches!(inner.as_ref(), Self::Dynamic) {
+        if Arc::ptr_eq(inner, &DYNAMIC_TYPE) {
           Edn::Symbol(Arc::from("List"))
         } else {
           Edn::enum_value("List", vec![inner.to_type_edn()])
         }
       }
       Self::Map(k, v) => {
-        if matches!(k.as_ref(), Self::Dynamic) && matches!(v.as_ref(), Self::Dynamic) {
+        if Arc::ptr_eq(k, &DYNAMIC_TYPE) && Arc::ptr_eq(v, &DYNAMIC_TYPE) {
           Edn::Symbol(Arc::from("Map"))
         } else {
           Edn::enum_value("Map", vec![k.to_type_edn(), v.to_type_edn()])
         }
       }
       Self::Set(inner) => {
-        if matches!(inner.as_ref(), Self::Dynamic) {
+        if Arc::ptr_eq(inner, &DYNAMIC_TYPE) {
           Edn::Symbol(Arc::from("Set"))
         } else {
           Edn::enum_value("Set", vec![inner.to_type_edn()])
         }
       }
       Self::Ref(inner) => {
-        if matches!(inner.as_ref(), Self::Dynamic) {
+        if Arc::ptr_eq(inner, &DYNAMIC_TYPE) {
           Edn::Symbol(Arc::from("Ref"))
         } else {
           Edn::enum_value("Ref", vec![inner.to_type_edn()])
@@ -7211,6 +7208,37 @@ mod tests {
       CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from("Dynamic"))).as_ref(),
       CalcitTypeAnnotation::Dynamic
     ));
+  }
+
+  #[test]
+  fn explicit_dynamic_container_arguments_round_trip_without_becoming_bare() {
+    for name in ["List", "Set", "Ref"] {
+      let explicit =
+        CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::enum_value(name, vec![Edn::Symbol(Arc::from("Dynamic"))]));
+      assert_eq!(
+        explicit.to_type_edn(),
+        Edn::enum_value(name, vec![Edn::Symbol(Arc::from("Dynamic"))]),
+        "explicit {name}<Dynamic> must remain auditable"
+      );
+
+      let bare = CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from(name)));
+      assert_eq!(
+        bare.to_type_edn(),
+        Edn::Symbol(Arc::from(name)),
+        "bare {name} must remain distinguishable"
+      );
+    }
+
+    let explicit_map = CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::enum_value(
+      "Map",
+      vec![Edn::Symbol(Arc::from("Dynamic")), Edn::Symbol(Arc::from("Dynamic"))],
+    ));
+    assert_eq!(
+      explicit_map.to_type_edn(),
+      Edn::enum_value("Map", vec![Edn::Symbol(Arc::from("Dynamic")), Edn::Symbol(Arc::from("Dynamic"))])
+    );
+    let bare_map = CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from("Map")));
+    assert_eq!(bare_map.to_type_edn(), Edn::Symbol(Arc::from("Map")));
   }
 
   #[test]

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -4684,9 +4684,9 @@ impl CalcitTypeAnnotation {
           Self::Tag
         }
       }
-      Calcit::List(_) => Self::List(Arc::new(Self::Dynamic)),
-      Calcit::Map(_) => Self::Map(Arc::new(Self::Dynamic), Arc::new(Self::Dynamic)),
-      Calcit::Set(_) => Self::Set(Arc::new(Self::Dynamic)),
+      Calcit::List(_) => Self::List(DYNAMIC_TYPE.clone()),
+      Calcit::Map(_) => Self::Map(DYNAMIC_TYPE.clone(), DYNAMIC_TYPE.clone()),
+      Calcit::Set(_) => Self::Set(DYNAMIC_TYPE.clone()),
       Calcit::Struct(struct_value) => Self::StructValue(struct_value.struct_ref.clone()),
       Calcit::EnumDef(enum_def) => Self::EnumDef(Arc::new(enum_def.to_owned())),
       Calcit::StructDef(struct_def) => Self::StructDef(Arc::new(struct_def.to_owned())),
@@ -4718,7 +4718,7 @@ impl CalcitTypeAnnotation {
           Self::Dynamic
         }
       }
-      Calcit::Ref(_, _) => Self::Ref(Arc::new(Self::Dynamic)),
+      Calcit::Ref(_, _) => Self::Ref(DYNAMIC_TYPE.clone()),
       Calcit::Symbol { .. } => Self::Symbol,
       Calcit::Buffer(_) => Self::Buffer,
       Calcit::F64Buffer(_) => Self::F64Buffer,
@@ -7239,6 +7239,15 @@ mod tests {
     );
     let bare_map = CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::Symbol(Arc::from("Map")));
     assert_eq!(bare_map.to_type_edn(), Edn::Symbol(Arc::from("Map")));
+
+    let nested = CalcitTypeAnnotation::parse_type_annotation_from_edn(&Edn::enum_value(
+      "List",
+      vec![Edn::enum_value("List", vec![Edn::Symbol(Arc::from("Dynamic"))])],
+    ));
+    assert_eq!(
+      nested.to_type_edn(),
+      Edn::enum_value("List", vec![Edn::enum_value("List", vec![Edn::Symbol(Arc::from("Dynamic"))])])
+    );
   }
 
   #[test]

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -14428,6 +14428,8 @@ mod tests {
     use cirru_edn::EdnTag;
     use cirru_parser::Cirru;
 
+    let _guard = lock_preprocess_test_state();
+
     let internal_target = Calcit::Import(CalcitImport {
       ns: Arc::from(calcit::CORE_NS),
       def: Arc::from("&demo:rename"),


### PR DESCRIPTION
## Summary

Fix #912 by preserving the distinction between omitted container type arguments
and explicitly written `Dynamic` arguments across schema edit/save/load cycles.

- bare List/Map/Set/Ref arguments use the shared missing-Dynamic marker
- explicitly parsed Dynamic arguments keep distinct provenance and serialize as
  `List<Dynamic>`, `Map<Dynamic,Dynamic>`, `Set<Dynamic>`, or `Ref<Dynamic>`
- bare containers continue serializing as bare containers, so strict diagnostics
  are not weakened or silently bypassed

## Regression coverage

- direct round trips for all four parameterized container kinds
- CLI `edit schema` round trip for Fn(List<Dynamic>) -> List<Dynamic>
- existing strict preprocessing test confirms explicit List<Dynamic> is accepted
- full cargo test: 779 library, 313 CLI, 23 WASM tests pass
- real Respo snapshot smoke confirms `query schema` retains `:: 'List 'Dynamic`

The change is intentionally limited to schema provenance/serialization; it does
not change runtime container types or the E_BARE_CONTAINER_SCHEMA policy.
