### PR TITLE
Check public definitions by entry target

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -200,6 +200,7 @@ calcit cursor show
 calcit cursor apply replace --code 'quote <replacement-leaf>'
 calcit tree show @cursor --path @cursor
 calcit query type-at @cursor --path @cursor --format json
+calcit --entry '<target-entry>' calcit.cirru analyze check-public --ns '<public-namespace>' --format json
 calcit analyze check-examples --ns '<namespace>' --def '<definition>'
 calcit test '<namespace>/<definition>'
 ```
@@ -469,7 +470,7 @@ calcit cirru show-guide
 按从便宜到昂贵的顺序形成闭环：
 
 1. 结构：`cursor show` 或 `tree show`，确认实际 subtree。
-2. 语义：`query type-at ... --format json`，运行 `analyze check-types --summary-only`；发布审计加 `--deps --format json`，以 Snapshot loader 成功解析作为 strict macro schema 的门槛。已结构化 `CodeEntry` 中的旧 runtime `Fn` / `Dynamic` macro schema 必须用最终兼容版本 0.13.51 迁移为显式 Macro contract。更早的 direct-quote macro 则使用当前 `edit format`，它只按参数形状生成 `Syntax` / `Expr<Dynamic>` / 空 capabilities 的保守 contract；必须人工审阅和收窄，不能把该桥接结果当成推断出的业务语义。看到 `W_TYPE_COVERAGE_GAPS` 后继续执行 `analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved --summary-only`，再对命中范围去掉 `--summary-only` 查看 path、impact 与 suggestion。项目门禁使用 `analyze quality`（零容忍）；存量债务先执行一次 `analyze quality --write-baseline config/calcit-quality.cirru`，人工审阅后把同一文件提交到仓库，CI 改执行 `analyze quality --baseline config/calcit-quality.cirru`。仓库内 baseline 默认使用 Cirru EDN；只有外部工具明确消费时才用 `.json`。不要再拼接多个 JSON 后交给 JavaScript 比较。门禁失败时保留 `--format json` 的单一 envelope，并按其中的 definition/path 回到 `weak-types` 或 `query type-at` 定位。
+2. 语义：`query type-at ... --format json`，运行 `analyze check-types --summary-only`；类库发布还要针对每个 entry target 运行 `analyze check-public --ns <shared> --ns <target-specific> --format json`，以 `checked_definition_ids` 与 `complete: true` 证明未引用的公开函数、data/trait definitions 也已预处理。不要注入临时引用函数或维护手写 export 清单。发布审计加 `--deps --format json`，以 Snapshot loader 成功解析作为 strict macro schema 的门槛。已结构化 `CodeEntry` 中的旧 runtime `Fn` / `Dynamic` macro schema 必须用最终兼容版本 0.13.51 迁移为显式 Macro contract。更早的 direct-quote macro 则使用当前 `edit format`，它只按参数形状生成 `Syntax` / `Expr<Dynamic>` / 空 capabilities 的保守 contract；必须人工审阅和收窄，不能把该桥接结果当成推断出的业务语义。看到 `W_TYPE_COVERAGE_GAPS` 后继续执行 `analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved --summary-only`，再对命中范围去掉 `--summary-only` 查看 path、impact 与 suggestion。项目门禁使用 `analyze quality`（零容忍）；存量债务先执行一次 `analyze quality --write-baseline config/calcit-quality.cirru`，人工审阅后把同一文件提交到仓库，CI 改执行 `analyze quality --baseline config/calcit-quality.cirru`。仓库内 baseline 默认使用 Cirru EDN；只有外部工具明确消费时才用 `.json`。不要再拼接多个 JSON 后交给 JavaScript 比较。门禁失败时保留 `--format json` 的单一 envelope，并按其中的 definition/path 回到 `weak-types` 或 `query type-at` 定位。
 3. definition：`analyze check-examples --ns <ns> --def <def>`；存在 definition-attached tests 时运行 `calcit test <ns>/<def>`。
 4. 项目：运行 `calcit test` 及仓库规定的 entry 和测试；默认 `calcit test` 只发现当前输入 snapshot 定义的命名空间，不触发 `calcit-core.cirru` 或外部模块中的测试。变更范围明确时可先用 `calcit test --affected <ns>/<def>` 做静态依赖筛选，但提交前仍按仓库要求执行全量门禁。CI/Agent 按 tag 或 affected 筛选时加 `--require-match`，避免空选择误报成功；大套件可加 `--summary-only --format json` 保持 stdout 紧凑可解析。只有项目目标是 JavaScript 时才运行对应的 `calcit js` codegen。
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -14,6 +14,7 @@ aliases:
 entry_for:
   - "assert-type"
   - "calcit analyze check-types"
+  - "calcit analyze check-public"
   - "calcit analyze weak-types"
   - "calcit analyze deprecated"
   - "calcit analyze quality"
@@ -56,6 +57,10 @@ Use the CLI reports when you need to understand type quality without running the
 ```bash
 # Coverage by definition; unknown code is reported as none, never as full
 calcit analyze check-types --ns app.main
+
+# Preprocess every definition in shared and Node-specific public namespaces
+calcit --entry node calcit.cirru analyze check-public \
+  --ns package.shared --ns package.node --format json
 
 # All weak type locations
 calcit analyze weak-types --ns app.main
@@ -111,6 +116,29 @@ calcit query type-at app.main/calculate-total --path code@3.2 --format json
 ```
 
 `check-types` treats nested dynamic slots such as bare `:ref`, `:list`, or `:map` as partial coverage and includes actionable `[W_SCHEMA_DYNAMIC]` entries in `schema_issues`. An unbound `*type-slot` is also partial and emits `[W_UNRESOLVED_TYPE_SLOT]`; bind it in the selected entry or explicitly choose `:dynamic` for a documented boundary. When partial/none definitions exist, human output adds an `agent-note` and JSON emits `W_TYPE_COVERAGE_GAPS`. Strict preprocessing reports `E_WHOLE_DYNAMIC_PUBLIC_SCHEMA` when a reachable project function has neither a structured root schema nor an embedded structured `Fn` hint, or when a programmatically supplied macro that reaches preprocessing has no structured root schema; a nested function hint is not macro-contract evidence. Replace a missing or whole-`Dynamic` root with a structured contract and keep any reviewed `Dynamic` at an exact nested position. Existing embedded `Fn` hints remain valid function-contract evidence during Snapshot migration. Normal Snapshot-loaded macros follow an earlier, stricter path: a legacy runtime `Fn` or whole-`Dynamic` macro schema is rejected with its definition path during Snapshot loading, before static analysis starts. For an already structured `CodeEntry`, migrate it with the final compatible Calcit 0.13.51 release, then declare phase-aware `Macro` fields explicitly. An earlier direct-quote definition instead uses current `edit format`, which derives only parameter arity as `Syntax`, emits `Expr<Dynamic>`, and grants no capabilities; it does not rewrite existing Dynamic schemas or guess semantic contracts. Use `--deps`: release audits must inspect resolved module artifacts, not only each dependency's current source branch. `weak-types --format json` reports the exact Snapshot/schema path plus an `impact` and `suggestion` for every occurrence; unresolved dynamic debt emits `W_DYNAMIC_TYPE_DEBT`, unbound slots emit `W_UNRESOLVED_TYPE_SLOT`, while unresolved or compatibility-Optional nil debt emits `W_NIL_TYPE_DEBT`. Definitions marked with the explicit `:js-ffi` feature remain classified as intentional boundaries rather than ordinary unresolved dynamic debt. The bundled-core classification is position-specific: a receiver may remain queued for a future capability while its key, callback, or return position is retained as `compiler-specialized-contracts` only when preprocessing has focused receiver-driven checking or inference regressions. This records recovered type flow without treating the whole fallback contract as fully typed.
+
+### Target-aware public definition checks
+
+`analyze check-public` preprocesses every top-level definition in each exact
+`--ns` scope without running the entry or host effects. Calcit has no separate
+private-export marker, so every definition stored in a selected namespace is
+public for this command; functions, values, macros, structs, enums, traits, and
+implementations are all enumerated. Repeat `--ns` to combine a shared namespace
+with the namespace for one runtime.
+
+The selected entry must declare `:target :browser`, `:node`, `:native`, or
+`:wasm`. A definition without `:ffi :target` is shared. A definition whose
+target differs from the entry fails with `E_JS_FFI_TARGET_MISMATCH` before its
+body is preprocessed. Missing, empty, dependency-owned, or malformed scopes
+also fail closed; pass `--deps` only when checking an explicitly selected
+loaded dependency namespace. Ordinary `--check-only` keeps its entry-reachable
+semantics.
+
+JSON output uses the `analyze.check-public` schema-version 1 envelope. It always
+includes `checked_definition_ids`, completeness/pass counts, diagnostics,
+target, duration, and a deterministic scope revision. `--summary-only` omits
+the per-definition rows but retains checked IDs so CI can prove what was
+actually covered. Any preprocessing warning or error produces a non-zero exit.
 
 Strict call preprocessing also reports `E_ERASED_GENERIC_RELATION` when an
 argument still contains `Dynamic` at a position tied to another occurrence of

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -290,6 +290,22 @@ calcit analyze dynamic-methods --deps
 
 The default scope contains project namespaces only. `--deps` includes reachable dependency namespaces, and `--max` returns a non-zero status when the finding count exceeds the reviewed limit.
 
+To preprocess every definition in explicitly selected public namespaces under
+the active entry target, use:
+
+```bash
+calcit --entry node calcit.cirru analyze check-public \
+  --ns package.shared --ns package.node --format json
+```
+
+`check-public` requires one or more exact `--ns` values and an entry with an
+explicit target. Definitions without `:ffi :target` are shared; mismatched
+definition targets fail before preprocessing. Project namespaces are admitted
+by default, while `--deps` explicitly admits selected loaded dependency/core
+namespaces. Zero matches and partial checks fail. JSON schema version 1 reports
+the checked definition IDs, per-definition status, diagnostics, completeness,
+duration, and scope revision; `--summary-only` omits only the detailed rows.
+
 ### Macro Expansion Metrics (--macro-metrics)
 
 Use opt-in macro metrics to profile compile, check, and hot-reload work without

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -163,6 +163,21 @@ calcit calcit.cirru analyze call-graph --show-unused --ns-prefix package
 
 这是 entry-relative 报告。公开 API、外部回调、替代入口和由消费者调用的定义都可能显示为 unreachable；不得仅凭该报告自动删除。发布前应把每个命中分类为：真正 dead code、公开 API、替代入口、动态/FFI 调用，或缺失测试覆盖。
 
+类库应另外显式检查每个承诺的运行目标。每条命令选择 shared namespace
+和对应 target namespace，且 entry 必须配置同名 `:target`：
+
+```bash
+calcit --entry node calcit.cirru analyze check-public \
+  --ns package.shared --ns package.node --format json
+calcit --entry browser calcit.cirru analyze check-public \
+  --ns package.shared --ns package.browser --format json
+```
+
+该检查枚举 namespace 中全部 definitions，因此未被测试入口引用的公开函数、
+data declaration 和 external trait 也会预处理。空 scope、缺少 target、错误
+runtime target 或任何诊断都会返回非零；不要用生成的引用函数或手写 export
+清单替代它。普通 `--check-only` 仍只验证 entry 可达路径。
+
 ## 6. 真实消费者回归
 
 CLI 查询、编辑、类型分析或公共 API 改动后，使用全局安装的新 `calcit` 在 Respo 等真实项目验证：
@@ -180,6 +195,8 @@ caps --ci
 calcit calcit.cirru edit format
 git diff --exit-code -- calcit.cirru
 calcit calcit.cirru --check-only
+calcit --entry node calcit.cirru analyze check-public \
+  --ns package.shared --ns package.node --summary-only --format json
 calcit calcit.cirru analyze check-types --summary-only --format json
 calcit calcit.cirru analyze weak-types \
   --only schema-dynamic,unresolved-type-slot,code-dynamic \

--- a/editing-history/202609082335-target-aware-public-check.md
+++ b/editing-history/202609082335-target-aware-public-check.md
@@ -1,0 +1,57 @@
+# Target-aware public definition checks / 按目标检查公开定义
+
+Issue: calcit-lang/calcit#874
+
+## English
+
+- Added `calcit analyze check-public` to preprocess every definition in one or
+  more exact public namespaces without running the application entry or host
+  effects. Calcit has no private-export marker, so functions, values, macros,
+  data declarations, traits, and implementations in the selected namespaces
+  are all included.
+- Required an explicit target on the selected entry and validated definition
+  `:ffi :target` metadata before preprocessing. Wrong runtime targets, malformed
+  metadata, missing or empty scopes, and unapproved dependency namespaces fail
+  closed.
+- Added a versioned JSON report with deterministic scope revision, checked
+  definition IDs, per-definition status, diagnostics, completeness, duration,
+  and summary-only support. Any preprocessing warning or error returns a
+  non-zero status.
+- Preserved ordinary `--check-only` reachability semantics and added a
+  regression proving an unused invalid public function is missed there but is
+  caught by `check-public`.
+
+## 中文
+
+- 新增 `calcit analyze check-public`，在不运行应用入口和 host effects 的
+  前提下，预处理一个或多个明确公开 namespace 中的全部 definitions。Calcit
+  没有独立 private export 标记，因此函数、值、macro、data declaration、trait
+  和 implementation 都纳入检查。
+- 要求所选 entry 显式声明 target，并在预处理前验证 definition 的
+  `:ffi :target`。错误运行目标、畸形 metadata、缺失或空 scope，以及未显式
+  允许的 dependency namespace 均 fail closed。
+- 新增版本化 JSON 报告，包含确定性 scope revision、实际 checked definition
+  IDs、逐 definition 状态、diagnostics、完整性、耗时和 summary-only 支持；
+  任一预处理 warning/error 都返回非零。
+- 保留普通 `--check-only` 的可达性语义，并用回归测试证明未引用错误公开函数
+  会被普通入口检查漏过、但会被 `check-public` 捕获。
+
+## Validation / 验证
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test` after rebasing onto main at `00ea1c27` (779 library + 315 CLI
+  + 23 wasm passed)
+- `yarn compile`
+- `yarn check-agent-interface` (21/21 scenarios passed)
+- Calcit 0.14.4 reproduction: ordinary js-ffi Node `--check-only` returned 0
+  with an injected unused bad function; the historical temporary-reference
+  checker failed with `W_FN_ARG_TYPE_MISMATCH`.
+- Candidate js-ffi checks: Node 85/85 definitions and browser 114/114 passed;
+  the inventories included 18 and 34 data/trait rows respectively. A Node entry
+  checking the browser namespace failed before preprocessing with
+  `E_JS_FFI_TARGET_MISMATCH`.
+- Release-build preprocessing duration across three warm process runs was
+  10.47–11.38 ms for Node and 18.00–18.34 ms for browser. Full JSON output was
+  15,206 and 21,557 bytes; summary-only output retaining checked IDs was 2,868
+  and 4,120 bytes.

--- a/editing-history/202609090008-public-check-review-fixes.md
+++ b/editing-history/202609090008-public-check-review-fixes.md
@@ -1,0 +1,17 @@
+# Public check review fixes
+
+- Preserved `analyze check-public --format json` as one stdout JSON document under `--strict-types` by running its entry and quality preflight silently inside the public-check report.
+- Changed public checking to validate target metadata across the complete selected scope before preprocessing any selected definition; rejected or incomplete scopes now report zero checked definitions.
+- Tightened Snapshot loading so definition `:ffi` metadata must be a struct or a tag-keyed map, including valid target metadata when present.
+- Added loader unit coverage and an agent-interface regression for structured strict-preflight failures.
+
+Validation:
+
+- `cargo fmt --all -- --check`
+- `cargo test code_entry_rejects_malformed_ffi_metadata`
+- `cargo test --bin calcit public_check`
+- `cargo test` (780 library, 315 CLI, and 23 WASM tests)
+- `cargo clippy --all-targets -- -D warnings`
+- `yarn compile`
+- `yarn check-agent-interface` (22/22 scenarios plus definition protocol round trips)
+- `yarn check-all`

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -347,6 +347,31 @@ const scenarios = [
     },
   },
   {
+    name: "strict public check failure stays structured",
+    strictTypes: true,
+    args: [
+      "calcit/type-fail/js-nullish-dereference-strict.cirru",
+      "analyze",
+      "check-public",
+      "--ns",
+      "type-fail-js-nullish-dereference-strict.main",
+      "--format",
+      "json",
+    ],
+    expectedStatus: 1,
+    check(result) {
+      if (result.schema_version !== 1 || result.command !== "analyze.check-public") {
+        throw new Error("strict check-public lost its structured envelope");
+      }
+      if (result.data.summary.complete !== false || result.data.summary.definitions_checked !== 0) {
+        throw new Error("strict preflight failure reported partial public coverage");
+      }
+      if (result.diagnostics[0]?.code !== "E_PUBLIC_CHECK_STRICT_PREFLIGHT") {
+        throw new Error("strict preflight failure lost its structured diagnostic");
+      }
+    },
+  },
+  {
     name: "dynamic method summary",
     args: [
       "calcit/test-method-errors.cirru",
@@ -462,7 +487,9 @@ for (const scenario of scenarios) {
   const started = process.hrtime.bigint();
   // These scenarios exercise the historical all-features fixture and its
   // machine envelopes, not the 0.14 strict-default acceptance path.
-  const fixtureArgs = [scenario.args[0], "--compat-types", ...scenario.args.slice(1)];
+  const fixtureArgs = scenario.strictTypes
+    ? [scenario.args[0], "--strict-types", ...scenario.args.slice(1)]
+    : [scenario.args[0], "--compat-types", ...scenario.args.slice(1)];
   const child = spawnSync(binary, fixtureArgs, {
     cwd: process.cwd(),
     encoding: "utf8",

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -323,6 +323,30 @@ const scenarios = [
     },
   },
   {
+    name: "target-aware public check failure",
+    args: [
+      "calcit/type-fail/js-nullish-dereference-strict.cirru",
+      "analyze",
+      "check-public",
+      "--ns",
+      "type-fail-js-nullish-dereference-strict.main",
+      "--format",
+      "json",
+    ],
+    expectedStatus: 1,
+    check(result) {
+      if (result.schema_version !== 1 || result.command !== "analyze.check-public") {
+        throw new Error("unexpected analyze.check-public envelope");
+      }
+      if (result.data.target !== "node" || result.data.summary.complete !== true || result.data.summary.passed !== false) {
+        throw new Error("check-public lost target, completeness, or failure state");
+      }
+      if (result.data.checked_definition_ids.length !== 2 || result.diagnostics.length === 0) {
+        throw new Error("check-public omitted checked definition IDs or diagnostics");
+      }
+    },
+  },
+  {
     name: "dynamic method summary",
     args: [
       "calcit/test-method-errors.cirru",

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -560,6 +560,11 @@ fn render_analyze_explanation(cmd: &AnalyzeCommand) -> Option<String> {
       Some(definition) => format!("validates code examples for `{}/{definition}`", opts.ns),
       None => format!("validates all code examples in namespace `{}`", opts.ns),
     },
+    AnalyzeSubcommand::CheckPublic(opts) => format!(
+      "preprocesses every definition in {} selected public namespace(s) for the active entry target{}",
+      opts.ns.len(),
+      if opts.deps { ", including dependencies" } else { "" }
+    ),
     AnalyzeSubcommand::CheckTypes(opts) => {
       let mut desc = "checks type coverage and reports gaps that can erase polymorphic relationships".to_string();
       if let Some(ns) = &opts.ns {
@@ -869,6 +874,13 @@ fn push_analyze(tokens: &mut Vec<String>, cmd: &AnalyzeCommand) {
       tokens,
       value "ns" => &opts.ns,
       opt "def" => opts.definition.as_deref(); default "all"
+    ),
+    AnalyzeSubcommand::CheckPublic(opts) => echo_items!(
+      tokens,
+      list "ns" => &opts.ns,
+      value "format" => &opts.format; default "human",
+      switch "deps" => opts.deps,
+      switch "summary-only" => opts.summary_only
     ),
     AnalyzeSubcommand::CheckTypes(opts) => echo_items!(
       tokens,
@@ -1291,6 +1303,7 @@ fn analyze_name(subcommand: &AnalyzeSubcommand) -> &'static str {
     AnalyzeSubcommand::CountCalls(_) => "count-calls",
     AnalyzeSubcommand::ProgramDiff(_) => "program-diff",
     AnalyzeSubcommand::CheckExamples(_) => "check-examples",
+    AnalyzeSubcommand::CheckPublic(_) => "check-public",
     AnalyzeSubcommand::CheckTypes(_) => "check-types",
     AnalyzeSubcommand::WeakTypes(_) => "weak-types",
     AnalyzeSubcommand::DynamicMethods(_) => "dynamic-methods",

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -15,6 +15,8 @@ mod cli_handlers;
 
 #[path = "../deprecated_api.rs"]
 mod deprecated_api;
+#[path = "../public_api_check.rs"]
+mod public_api_check;
 #[path = "../quality_gate.rs"]
 mod quality_gate;
 #[path = "../type_coverage.rs"]
@@ -355,6 +357,7 @@ fn run_cli() -> Result<(), String> {
         let snapshot = cli_handlers::load_snapshot_for_static_analysis(&cli_args.input)?;
         return run_check_types(options, &snapshot);
       }
+      AnalyzeSubcommand::CheckPublic(_) => {}
       AnalyzeSubcommand::WeakTypes(options) => {
         let snapshot = cli_handlers::load_snapshot_for_static_analysis(&cli_args.input)?;
         return run_weak_types(options, &snapshot);
@@ -599,6 +602,7 @@ fn run_cli() -> Result<(), String> {
         &cli_args.emit_path,
         &snapshot,
       ),
+      AnalyzeSubcommand::CheckPublic(options) => public_api_check::run(options, &snapshot, &project_namespaces),
       AnalyzeSubcommand::CheckTypes(check_types_options) => run_check_types(check_types_options, &snapshot),
       AnalyzeSubcommand::WeakTypes(weak_type_options) => run_weak_types(weak_type_options, &snapshot),
       AnalyzeSubcommand::DynamicMethods(options) => run_dynamic_methods(options, &entries, &snapshot, &project_namespaces),

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -80,6 +80,10 @@ fn run_deprecated(options: &DeprecatedCommand, snapshot: &snapshot::Snapshot) ->
 }
 
 fn run_quality(options: &QualityCommand, snapshot: &snapshot::Snapshot) -> Result<(), String> {
+  run_quality_with_output(options, snapshot, true)
+}
+
+fn run_quality_with_output(options: &QualityCommand, snapshot: &snapshot::Snapshot, emit_output: bool) -> Result<(), String> {
   if !matches!(options.format.as_str(), "human" | "text" | "json") {
     return Err(format!(
       "Unknown quality output format `{}`. Expected `human` or `json`.",
@@ -87,10 +91,12 @@ fn run_quality(options: &QualityCommand, snapshot: &snapshot::Snapshot) -> Resul
     ));
   }
   let outcome = quality_gate::analyze_quality(options, snapshot)?;
-  match options.format.as_str() {
-    "human" | "text" => print!("{}", quality_gate::format_quality_report(&outcome)),
-    "json" => println!("{}", quality_gate::format_quality_json(&outcome)?),
-    _ => unreachable!("quality output format was validated before analysis"),
+  if emit_output {
+    match options.format.as_str() {
+      "human" | "text" => print!("{}", quality_gate::format_quality_report(&outcome)),
+      "json" => println!("{}", quality_gate::format_quality_json(&outcome)?),
+      _ => unreachable!("quality output format was validated before analysis"),
+    }
   }
   if outcome.passed {
     Ok(())
@@ -521,6 +527,10 @@ fn run_cli() -> Result<(), String> {
 
   // Check-only mode: just preprocess/validate without execution or codegen
   let check_only = cli_args.check_only || matches!(&cli_args.subcommand, Some(CalcitCommand::EmitJs(js_opts)) if js_opts.check_only);
+  let is_public_check = matches!(
+    &cli_args.subcommand,
+    Some(CalcitCommand::Analyze(analyze_cmd)) if matches!(&analyze_cmd.subcommand, AnalyzeSubcommand::CheckPublic(_))
+  );
 
   if check_only {
     eval_once = true;
@@ -547,7 +557,7 @@ fn run_cli() -> Result<(), String> {
   // `--strict-types` remains the explicit zero-debt preflight for every
   // execution/codegen mode. Default strict diagnostics do not claim that an
   // audited project has no reviewed open boundaries.
-  if strict_type_policy.zero_debt && !check_only {
+  if strict_type_policy.zero_debt && !check_only && !is_public_check {
     // Eval/exec already preprocess above so they can fail before evaluating.
     // Other run/codegen modes still need the explicit strict preflight here.
     if !is_eval_mode {
@@ -602,7 +612,32 @@ fn run_cli() -> Result<(), String> {
         &cli_args.emit_path,
         &snapshot,
       ),
-      AnalyzeSubcommand::CheckPublic(options) => public_api_check::run(options, &snapshot, &project_namespaces),
+      AnalyzeSubcommand::CheckPublic(options) => {
+        let emit_preflight_output = options.format != "json";
+        let strict_preflight = || {
+          run_check_only_with_output(&entries, emit_preflight_output)?;
+          run_quality_with_output(
+            &QualityCommand {
+              ns: None,
+              ns_prefix: None,
+              deps: false,
+              baseline: None,
+              write_baseline: None,
+              format: "human".to_owned(),
+            },
+            &snapshot,
+            emit_preflight_output,
+          )
+        };
+        public_api_check::run(
+          options,
+          &snapshot,
+          &project_namespaces,
+          strict_type_policy
+            .zero_debt
+            .then_some(&strict_preflight as &dyn Fn() -> Result<(), String>),
+        )
+      }
       AnalyzeSubcommand::CheckTypes(check_types_options) => run_check_types(check_types_options, &snapshot),
       AnalyzeSubcommand::WeakTypes(weak_type_options) => run_weak_types(weak_type_options, &snapshot),
       AnalyzeSubcommand::DynamicMethods(options) => run_dynamic_methods(options, &entries, &snapshot, &project_namespaces),
@@ -1376,6 +1411,10 @@ fn ensure_host_running(operation: &str) -> Result<(), String> {
 
 /// Check-only mode: preprocess init_fn and reload_fn to validate code without execution
 fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
+  run_check_only_with_output(entries, true)
+}
+
+fn run_check_only_with_output(entries: &ProgramEntries, emit_output: bool) -> Result<(), String> {
   let started_time = Instant::now();
   let check_warnings: &RefCell<Vec<LocatedWarning>> = &RefCell::new(vec![]);
 
@@ -1384,7 +1423,9 @@ fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
   // preprocess init_fn
   match runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, check_warnings, &CallStackList::default()) {
     Ok(_) => {
-      println!("  {} {}", "✓".green(), format!("{} preprocessed", entries.init_fn).dimmed());
+      if emit_output {
+        println!("  {} {}", "✓".green(), format!("{} preprocessed", entries.init_fn).dimmed());
+      }
     }
     Err(failure) => {
       eprintln!("\n{} preprocessing init_fn", "✗".red());
@@ -1397,7 +1438,9 @@ fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
   // preprocess reload_fn
   match runner::preprocess::ensure_ns_def_compiled(&entries.reload_ns, &entries.reload_def, check_warnings, &CallStackList::default()) {
     Ok(_) => {
-      println!("  {} {}", "✓".green(), format!("{} preprocessed", entries.reload_fn).dimmed());
+      if emit_output {
+        println!("  {} {}", "✓".green(), format!("{} preprocessed", entries.reload_fn).dimmed());
+      }
     }
     Err(failure) => {
       eprintln!("\n{} preprocessing reload_fn", "✗".red());
@@ -1416,11 +1459,13 @@ fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
   }
 
   let duration = Instant::now().duration_since(started_time);
-  println!(
-    "\n{} {}",
-    "✓ Check passed".green().bold(),
-    format!("({}ms)", duration.as_micros() as f64 / 1000.0).dimmed()
-  );
+  if emit_output {
+    println!(
+      "\n{} {}",
+      "✓ Check passed".green().bold(),
+      format!("({}ms)", duration.as_micros() as f64 / 1000.0).dimmed()
+    );
+  }
 
   Ok(())
 }

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -514,6 +514,7 @@ fn public_check_reaches_unused_definitions_without_changing_entry_check_semantic
       },
       &snapshot,
       &project_namespaces,
+      None,
     )
     .expect_err("public check must preprocess an unused invalid definition");
     assert!(error.contains("2 passed"), "unexpected public-check outcome: {error}");

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -469,6 +469,58 @@ fn strict_mode_rejects_source_definition_reached_from_macro_expansion_without_pu
 }
 
 #[test]
+fn public_check_reaches_unused_definitions_without_changing_entry_check_semantics() {
+  run_with_large_stack(|| {
+    builtins::effects::init_effects_states();
+    let mut snapshot = snapshot::Snapshot::default();
+    snapshot
+      .entries
+      .get_mut(snapshot::DEFAULT_ENTRY_NAME)
+      .expect("default entry")
+      .target = Some(snapshot::SnapshotTarget::Node);
+    let mut file = snapshot::create_file_from_snippet(concat!(
+      "defn main! () &unit\n\n",
+      "defn reload! () &unit\n\n",
+      "defn unused-bad ()\n  + 1 |bad",
+    ))
+    .expect("public-check snippet should parse");
+    let fn_schema = |return_type| {
+      Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: vec![],
+        return_type: Arc::new(return_type),
+        fn_kind: SchemaKind::Fn,
+        rest_type: None,
+        features: Arc::new(HashSet::new()),
+      })))
+    };
+    file.defs.get_mut("main!").expect("main entry").schema = fn_schema(CalcitTypeAnnotation::Unit);
+    file.defs.get_mut("reload!").expect("reload entry").schema = fn_schema(CalcitTypeAnnotation::Unit);
+    file.defs.get_mut("unused-bad").expect("unused entry").schema = fn_schema(CalcitTypeAnnotation::Number);
+    snapshot.files.insert("app.main".to_owned(), file);
+
+    let project_namespaces = HashSet::from(["app.main".to_owned()]);
+    let entries = prepare_snapshot_entries(snapshot.clone());
+    let _strict = StrictTypesReset::enabled();
+    run_check_only(&entries).expect("ordinary entry check must retain reachability semantics");
+
+    let error = public_api_check::run(
+      &calcit::cli_args::CheckPublicCommand {
+        ns: vec!["app.main".to_owned()],
+        format: "json".to_owned(),
+        deps: false,
+        summary_only: false,
+      },
+      &snapshot,
+      &project_namespaces,
+    )
+    .expect_err("public check must preprocess an unused invalid definition");
+    assert!(error.contains("2 passed"), "unexpected public-check outcome: {error}");
+  });
+}
+
+#[test]
 fn strict_mode_runs_definition_tests_with_generated_function_schemas() {
   run_with_large_stack(|| {
     let namespace = format!("app.strict-definition-test-{}", std::process::id());

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -224,7 +224,7 @@ pub struct ExecCommand {
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 #[argh(subcommand, name = "analyze")]
-/// analyze code structure and helpers (call-graph, call-graph-diff, count-calls, program-diff, check-examples, check-types, weak-types, dynamic-methods, deprecated, quality, js-escape)
+/// analyze code structure and helpers (call-graph, check-public, check-types, weak-types, dynamic-methods, deprecated, quality, js-escape)
 pub struct AnalyzeCommand {
   #[argh(subcommand)]
   pub subcommand: AnalyzeSubcommand,
@@ -243,6 +243,8 @@ pub enum AnalyzeSubcommand {
   ProgramDiff(ProgramDiffCommand),
   /// check examples in namespace
   CheckExamples(CheckExamplesCommand),
+  /// preprocess every definition in selected public namespaces for the active entry target
+  CheckPublic(CheckPublicCommand),
   /// check type-information coverage in namespace definitions
   CheckTypes(CheckTypesCommand),
   /// locate weakly-typed hotspots such as :dynamic schema usage and nil literals
@@ -259,6 +261,24 @@ pub enum AnalyzeSubcommand {
   JsEscape(JsEscapeCommand),
   /// decode escaped JavaScript identifier back to Calcit symbol (best-effort)
   JsUnescape(JsUnescapeCommand),
+}
+
+/// preprocess every definition in selected public namespaces for the active entry target
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand, name = "check-public")]
+pub struct CheckPublicCommand {
+  /// exact public namespace to check; repeat for shared and target-specific namespaces
+  #[argh(option)]
+  pub ns: Vec<String>,
+  /// output format: human (default) or json
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
+  /// allow selected namespaces loaded from dependencies or calcit.core
+  #[argh(switch)]
+  pub deps: bool,
+  /// emit aggregate counts without per-definition rows
+  #[argh(switch, long = "summary-only")]
+  pub summary_only: bool,
 }
 
 /// escape a Calcit symbol into JavaScript-safe identifier form

--- a/src/public_api_check.rs
+++ b/src/public_api_check.rs
@@ -21,6 +21,15 @@ struct DefinitionResult {
   status: &'static str,
 }
 
+struct PreparedDefinition {
+  id: String,
+  namespace: String,
+  definition: String,
+  kind: &'static str,
+  declared_target: Option<SnapshotTarget>,
+  rejected: bool,
+}
+
 fn definition_target(entry: &snapshot::CodeEntry) -> Result<Option<SnapshotTarget>, String> {
   let Some(ffi) = &entry.ffi else {
     return Ok(None);
@@ -65,7 +74,12 @@ fn result_json(row: &DefinitionResult) -> Value {
   })
 }
 
-pub fn run(options: &CheckPublicCommand, snapshot: &snapshot::Snapshot, project_namespaces: &HashSet<String>) -> Result<(), String> {
+pub fn run(
+  options: &CheckPublicCommand,
+  snapshot: &snapshot::Snapshot,
+  project_namespaces: &HashSet<String>,
+  strict_preflight: Option<&dyn Fn() -> Result<(), String>>,
+) -> Result<(), String> {
   if !matches!(options.format.as_str(), "human" | "text" | "json") {
     return Err(format!(
       "Unknown check-public output format `{}`. Expected `human` or `json`.",
@@ -146,6 +160,7 @@ pub fn run(options: &CheckPublicCommand, snapshot: &snapshot::Snapshot, project_
   let warnings = RefCell::new(Vec::<LocatedWarning>::new());
   let mut results = Vec::<DefinitionResult>::new();
   let mut checked_definition_ids = Vec::<String>::new();
+  let mut prepared = Vec::<PreparedDefinition>::new();
 
   if let Some(target) = active_target {
     for (namespace, definition, entry) in selected {
@@ -161,13 +176,13 @@ pub fn run(options: &CheckPublicCommand, snapshot: &snapshot::Snapshot, project_
             "definition": id,
             "message": message,
           }));
-          results.push(DefinitionResult {
+          prepared.push(PreparedDefinition {
             id,
             namespace,
             definition,
             kind,
             declared_target: None,
-            status: "rejected",
+            rejected: true,
           });
           continue;
         }
@@ -182,17 +197,55 @@ pub fn run(options: &CheckPublicCommand, snapshot: &snapshot::Snapshot, project_
           "definition": id,
           "message": format!("Definition `{id}` requires `{}` target, but entry `{}` targets `{}`.", expected.as_str(), snapshot.active_entry_name(), target.as_str()),
         }));
-        results.push(DefinitionResult {
+        prepared.push(PreparedDefinition {
           id,
           namespace,
           definition,
           kind,
           declared_target,
-          status: "rejected",
+          rejected: true,
         });
         continue;
       }
 
+      prepared.push(PreparedDefinition {
+        id,
+        namespace,
+        definition,
+        kind,
+        declared_target,
+        rejected: false,
+      });
+    }
+  }
+
+  // Validate the complete selected scope before any selected definition is
+  // preprocessed. A partial run could otherwise make a target-invalid report
+  // look as though some of its public surface had been checked successfully.
+  let mut preflight_ready = selection_complete && active_target.is_some() && prepared.iter().all(|row| !row.rejected);
+  if preflight_ready
+    && let Some(preflight) = strict_preflight
+    && let Err(message) = preflight()
+  {
+    diagnostics.push(json!({
+      "code": "E_PUBLIC_CHECK_STRICT_PREFLIGHT",
+      "phase": "preflight",
+      "severity": "error",
+      "message": message,
+    }));
+    preflight_ready = false;
+  }
+
+  for row in prepared {
+    if preflight_ready {
+      let PreparedDefinition {
+        id,
+        namespace,
+        definition,
+        kind,
+        declared_target,
+        ..
+      } = row;
       checked_definition_ids.push(id.clone());
       let warning_count = warnings.borrow().len();
       let result = runner::preprocess::ensure_ns_def_compiled(&namespace, &definition, &warnings, &CallStackList::default());
@@ -212,6 +265,15 @@ pub fn run(options: &CheckPublicCommand, snapshot: &snapshot::Snapshot, project_
         kind,
         declared_target,
         status,
+      });
+    } else {
+      results.push(DefinitionResult {
+        id: row.id,
+        namespace: row.namespace,
+        definition: row.definition,
+        kind: row.kind,
+        declared_target: row.declared_target,
+        status: if row.rejected { "rejected" } else { "not_checked" },
       });
     }
   }
@@ -324,6 +386,10 @@ mod tests {
 
     let ffi = Edn::map_from_iter([(Edn::tag("target"), Edn::tag("desktop"))]);
     assert!(definition_target(&entry_with_ffi(Some(ffi))).is_err());
+    assert!(definition_target(&entry_with_ffi(Some(Edn::str("browser")))).is_err());
+
+    let malformed_key = Edn::map_from_iter([(Edn::str("target"), Edn::tag("browser"))]);
+    assert!(definition_target(&entry_with_ffi(Some(malformed_key))).is_err());
     assert_eq!(definition_target(&entry_with_ffi(None)).unwrap(), None);
   }
 }

--- a/src/public_api_check.rs
+++ b/src/public_api_check.rs
@@ -1,0 +1,329 @@
+use std::cell::RefCell;
+use std::collections::{BTreeSet, HashSet};
+use std::time::Instant;
+
+use calcit::calcit::{CalcitErr, LocatedWarning};
+use calcit::call_stack::CallStackList;
+use calcit::cli_args::CheckPublicCommand;
+use calcit::runner;
+use calcit::snapshot::{self, SnapshotTarget};
+use serde_json::{Value, json};
+
+use crate::type_coverage;
+
+#[derive(Debug)]
+struct DefinitionResult {
+  id: String,
+  namespace: String,
+  definition: String,
+  kind: &'static str,
+  declared_target: Option<SnapshotTarget>,
+  status: &'static str,
+}
+
+fn definition_target(entry: &snapshot::CodeEntry) -> Result<Option<SnapshotTarget>, String> {
+  let Some(ffi) = &entry.ffi else {
+    return Ok(None);
+  };
+  snapshot::parse_ffi_target(ffi)
+}
+
+fn error_diagnostic(error: &CalcitErr, definition_id: &str) -> Value {
+  json!({
+    "code": error.code.as_deref().unwrap_or("E_PUBLIC_CHECK_PREPROCESS"),
+    "phase": "preprocess",
+    "severity": "error",
+    "definition": definition_id,
+    "kind": error.kind.to_string().to_lowercase(),
+    "message": error.headline(),
+    "location": error.location.as_ref().map(|location| json!({
+      "ns": location.ns.to_string(),
+      "def": location.def.to_string(),
+      "coord": location.coord.to_vec(),
+    })),
+    "hint": error.hint,
+  })
+}
+
+fn warning_diagnostic(warning: &LocatedWarning) -> Value {
+  let mut row = warning.as_json();
+  if let Value::Object(fields) = &mut row {
+    fields.insert("phase".to_owned(), json!("preprocess"));
+    fields.insert("severity".to_owned(), json!("warning"));
+  }
+  row
+}
+
+fn result_json(row: &DefinitionResult) -> Value {
+  json!({
+    "id": row.id,
+    "namespace": row.namespace,
+    "definition": row.definition,
+    "kind": row.kind,
+    "declared_target": row.declared_target.map(SnapshotTarget::as_str),
+    "status": row.status,
+  })
+}
+
+pub fn run(options: &CheckPublicCommand, snapshot: &snapshot::Snapshot, project_namespaces: &HashSet<String>) -> Result<(), String> {
+  if !matches!(options.format.as_str(), "human" | "text" | "json") {
+    return Err(format!(
+      "Unknown check-public output format `{}`. Expected `human` or `json`.",
+      options.format
+    ));
+  }
+
+  let started = Instant::now();
+  let requested_namespaces = options.ns.iter().cloned().collect::<BTreeSet<_>>();
+  let active_target = snapshot.active_entry()?.target;
+  let mut diagnostics = Vec::<Value>::new();
+  let mut selected = Vec::<(String, String, &snapshot::CodeEntry)>::new();
+
+  if requested_namespaces.is_empty() {
+    diagnostics.push(json!({
+      "code": "E_PUBLIC_CHECK_SCOPE_REQUIRED",
+      "phase": "selection",
+      "severity": "error",
+      "message": "check-public requires at least one --ns namespace.",
+    }));
+  }
+  if active_target.is_none() {
+    diagnostics.push(json!({
+      "code": "E_PUBLIC_CHECK_TARGET_REQUIRED",
+      "phase": "selection",
+      "severity": "error",
+      "message": format!("Entry `{}` has no :target; public checks require an explicit browser, node, native, or wasm target.", snapshot.active_entry_name()),
+    }));
+  }
+
+  for namespace in &requested_namespaces {
+    let Some(file) = snapshot.files.get(namespace) else {
+      diagnostics.push(json!({
+        "code": "E_PUBLIC_CHECK_NAMESPACE_NOT_FOUND",
+        "phase": "selection",
+        "severity": "error",
+        "namespace": namespace,
+        "message": format!("Selected namespace `{namespace}` is not loaded by entry `{}`.", snapshot.active_entry_name()),
+      }));
+      continue;
+    };
+    if !options.deps && !project_namespaces.contains(namespace) {
+      diagnostics.push(json!({
+        "code": "E_PUBLIC_CHECK_DEPENDENCY_SCOPE",
+        "phase": "selection",
+        "severity": "error",
+        "namespace": namespace,
+        "message": format!("Selected namespace `{namespace}` belongs to a dependency; pass --deps to admit it explicitly."),
+      }));
+      continue;
+    }
+    if file.defs.is_empty() {
+      diagnostics.push(json!({
+        "code": "E_PUBLIC_CHECK_EMPTY_NAMESPACE",
+        "phase": "selection",
+        "severity": "error",
+        "namespace": namespace,
+        "message": format!("Selected namespace `{namespace}` contains no definitions; zero coverage is not a successful check."),
+      }));
+      continue;
+    }
+    let mut definitions = file.defs.iter().collect::<Vec<_>>();
+    definitions.sort_by_key(|(definition, _)| *definition);
+    selected.extend(
+      definitions
+        .into_iter()
+        .map(|(definition, entry)| (namespace.clone(), definition.clone(), entry)),
+    );
+  }
+
+  let revision_ids = selected
+    .iter()
+    .map(|(namespace, definition, _)| (namespace.clone(), definition.clone()))
+    .collect::<Vec<_>>();
+  let selected_count = revision_ids.len();
+  let selection_complete = diagnostics.is_empty();
+  let revision = type_coverage::analysis_revision(snapshot, &revision_ids)?;
+  let warnings = RefCell::new(Vec::<LocatedWarning>::new());
+  let mut results = Vec::<DefinitionResult>::new();
+  let mut checked_definition_ids = Vec::<String>::new();
+
+  if let Some(target) = active_target {
+    for (namespace, definition, entry) in selected {
+      let id = format!("{namespace}/{definition}");
+      let kind = type_coverage::analyze_code_entry(&namespace, &definition, entry).kind.as_str();
+      let declared_target = match definition_target(entry) {
+        Ok(value) => value,
+        Err(message) => {
+          diagnostics.push(json!({
+            "code": "E_PUBLIC_CHECK_INVALID_TARGET",
+            "phase": "target",
+            "severity": "error",
+            "definition": id,
+            "message": message,
+          }));
+          results.push(DefinitionResult {
+            id,
+            namespace,
+            definition,
+            kind,
+            declared_target: None,
+            status: "rejected",
+          });
+          continue;
+        }
+      };
+      if let Some(expected) = declared_target
+        && expected != target
+      {
+        diagnostics.push(json!({
+          "code": "E_JS_FFI_TARGET_MISMATCH",
+          "phase": "target",
+          "severity": "error",
+          "definition": id,
+          "message": format!("Definition `{id}` requires `{}` target, but entry `{}` targets `{}`.", expected.as_str(), snapshot.active_entry_name(), target.as_str()),
+        }));
+        results.push(DefinitionResult {
+          id,
+          namespace,
+          definition,
+          kind,
+          declared_target,
+          status: "rejected",
+        });
+        continue;
+      }
+
+      checked_definition_ids.push(id.clone());
+      let warning_count = warnings.borrow().len();
+      let result = runner::preprocess::ensure_ns_def_compiled(&namespace, &definition, &warnings, &CallStackList::default());
+      let status = match result {
+        Ok(()) if warnings.borrow().len() == warning_count => "passed",
+        Ok(()) => "warning",
+        Err(error) => {
+          diagnostics.push(error_diagnostic(&error, &id));
+          diagnostics.extend(error.warnings.iter().map(warning_diagnostic));
+          "failed"
+        }
+      };
+      results.push(DefinitionResult {
+        id,
+        namespace,
+        definition,
+        kind,
+        declared_target,
+        status,
+      });
+    }
+  }
+
+  diagnostics.extend(warnings.borrow().iter().map(warning_diagnostic));
+  let checked_count = checked_definition_ids.len();
+  let passed_count = results.iter().filter(|row| row.status == "passed").count();
+  let complete = selection_complete && selected_count > 0 && checked_count == selected_count;
+  let passed = complete && passed_count == selected_count && diagnostics.is_empty();
+  if selected_count == 0 && diagnostics.is_empty() {
+    diagnostics.push(json!({
+      "code": "E_PUBLIC_CHECK_EMPTY_SCOPE",
+      "phase": "selection",
+      "severity": "error",
+      "message": "The selected public namespace scope contains no definitions; zero coverage is not a successful check.",
+    }));
+  }
+  let duration_ms = started.elapsed().as_secs_f64() * 1000.0;
+
+  match options.format.as_str() {
+    "json" => println!(
+      "{}",
+      json!({
+        "schema_version": 1,
+        "command": "analyze.check-public",
+        "revision": revision,
+        "data": {
+          "entry": snapshot.active_entry_name(),
+          "target": active_target.map(SnapshotTarget::as_str),
+          "filters": {
+            "namespaces": requested_namespaces,
+            "include_dependencies": options.deps,
+            "summary_only": options.summary_only,
+          },
+          "summary": {
+            "definitions_selected": selected_count,
+            "definitions_checked": checked_count,
+            "definitions_passed": passed_count,
+            "complete": complete,
+            "passed": passed,
+            "duration_ms": duration_ms,
+          },
+          "checked_definition_ids": checked_definition_ids,
+          "definitions": if options.summary_only { Vec::new() } else { results.iter().map(result_json).collect::<Vec<_>>() },
+        },
+        "diagnostics": diagnostics,
+      })
+    ),
+    "human" | "text" => {
+      println!("Public definition check");
+      println!("- entry: {}", snapshot.active_entry_name());
+      println!("- target: {}", active_target.map(SnapshotTarget::as_str).unwrap_or("missing"));
+      println!(
+        "- namespaces: {}",
+        requested_namespaces.iter().cloned().collect::<Vec<_>>().join(", ")
+      );
+      println!("- revision: {revision}");
+      println!("- coverage: {checked_count}/{selected_count} definitions checked");
+      println!("- result: {} ({duration_ms:.3}ms)", if passed { "PASS" } else { "FAIL" });
+      if !options.summary_only {
+        for row in &results {
+          println!("- [{}] {} ({})", row.status, row.id, row.kind);
+        }
+      }
+      for diagnostic in &diagnostics {
+        println!("- diagnostic: {}", diagnostic["message"].as_str().unwrap_or("unknown diagnostic"));
+      }
+    }
+    _ => unreachable!("check-public output format was validated before analysis"),
+  }
+
+  if passed {
+    Ok(())
+  } else {
+    Err(format!(
+      "Public definition check failed: {checked_count}/{selected_count} definitions checked, {passed_count} passed, {} diagnostic(s).",
+      diagnostics.len()
+    ))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::sync::Arc;
+
+  use calcit::calcit::DYNAMIC_TYPE;
+  use cirru_edn::Edn;
+  use cirru_parser::Cirru;
+
+  fn entry_with_ffi(ffi: Option<Edn>) -> snapshot::CodeEntry {
+    snapshot::CodeEntry {
+      doc: String::new(),
+      examples: vec![],
+      tests: vec![],
+      tags: HashSet::new(),
+      code: Cirru::Leaf(Arc::from("placeholder")),
+      schema: DYNAMIC_TYPE.clone(),
+      ffi,
+    }
+  }
+
+  #[test]
+  fn parses_definition_targets_and_rejects_unknown_values() {
+    let ffi = Edn::map_from_iter([(Edn::tag("target"), Edn::tag("browser"))]);
+    assert_eq!(
+      definition_target(&entry_with_ffi(Some(ffi))).unwrap(),
+      Some(SnapshotTarget::Browser)
+    );
+
+    let ffi = Edn::map_from_iter([(Edn::tag("target"), Edn::tag("desktop"))]);
+    assert!(definition_target(&entry_with_ffi(Some(ffi))).is_err());
+    assert_eq!(definition_target(&entry_with_ffi(None)).unwrap(), None);
+  }
+}

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -3701,28 +3701,12 @@ fn require_js_ffi_feature(
   Ok(())
 }
 
-fn ffi_metadata_value<'a>(ffi: &'a cirru_edn::Edn, key: &str) -> Option<&'a cirru_edn::Edn> {
-  match ffi {
-    cirru_edn::Edn::Struct(value) => value.pairs.iter().find(|(field, _)| field.ref_str() == key).map(|(_, value)| value),
-    cirru_edn::Edn::Map(value) => value.get(&cirru_edn::Edn::tag(key)),
-    _ => None,
-  }
+fn ffi_metadata_target(ffi: &cirru_edn::Edn) -> Option<crate::snapshot::SnapshotTarget> {
+  crate::snapshot::parse_ffi_target(ffi).ok().flatten()
 }
 
-fn ffi_metadata_target(ffi: &cirru_edn::Edn) -> Option<crate::snapshot::SnapshotTarget> {
-  let value = ffi_metadata_value(ffi, "target")?;
-  let name = match value {
-    cirru_edn::Edn::Tag(tag) => tag.ref_str(),
-    cirru_edn::Edn::Str(text) | cirru_edn::Edn::Symbol(text) => text.trim_start_matches(':'),
-    _ => return None,
-  };
-  match name {
-    "browser" => Some(crate::snapshot::SnapshotTarget::Browser),
-    "node" => Some(crate::snapshot::SnapshotTarget::Node),
-    "native" => Some(crate::snapshot::SnapshotTarget::Native),
-    "wasm" => Some(crate::snapshot::SnapshotTarget::Wasm),
-    _ => None,
-  }
+fn ffi_metadata_value<'a>(ffi: &'a cirru_edn::Edn, key: &str) -> Option<&'a cirru_edn::Edn> {
+  crate::snapshot::ffi_metadata_value(ffi, key)
 }
 
 fn validate_js_ffi_target(

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -184,6 +184,39 @@ impl SnapshotTarget {
   }
 }
 
+/// Read one field from definition-level `:ffi` metadata.
+pub fn ffi_metadata_value<'a>(ffi: &'a Edn, key: &str) -> Option<&'a Edn> {
+  match ffi {
+    Edn::Struct(value) => value.pairs.iter().find(|(field, _)| field.ref_str() == key).map(|(_, value)| value),
+    Edn::Map(value) => value.get(&Edn::tag(key)),
+    _ => None,
+  }
+}
+
+/// Read the optional host target from definition-level `:ffi` metadata.
+///
+/// Definitions without a target are shared across entry targets. Callers that
+/// implement fail-closed checks should surface the returned error instead of
+/// treating malformed target metadata as shared.
+pub fn parse_ffi_target(ffi: &Edn) -> Result<Option<SnapshotTarget>, String> {
+  let value = ffi_metadata_value(ffi, "target");
+  let Some(value) = value else {
+    return Ok(None);
+  };
+  let name = match value {
+    Edn::Tag(tag) => tag.ref_str(),
+    Edn::Str(text) | Edn::Symbol(text) => text.trim_start_matches(':'),
+    _ => return Err(format!("expected :ffi :target to be a tag, string, or symbol, got `{value}`")),
+  };
+  match name {
+    "browser" => Ok(Some(SnapshotTarget::Browser)),
+    "node" => Ok(Some(SnapshotTarget::Node)),
+    "native" => Ok(Some(SnapshotTarget::Native)),
+    "wasm" => Ok(Some(SnapshotTarget::Wasm)),
+    _ => Err(format!("unknown :ffi :target `{name}`; expected browser, node, native, or wasm")),
+  }
+}
+
 /// Per-entry capability policy. Features remain implementation metadata; this
 /// policy only controls the diagnostics emitted when a body uses a capability
 /// without declaring it.

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -199,6 +199,15 @@ pub fn ffi_metadata_value<'a>(ffi: &'a Edn, key: &str) -> Option<&'a Edn> {
 /// implement fail-closed checks should surface the returned error instead of
 /// treating malformed target metadata as shared.
 pub fn parse_ffi_target(ffi: &Edn) -> Result<Option<SnapshotTarget>, String> {
+  match ffi {
+    Edn::Struct(_) => {}
+    Edn::Map(value) => {
+      if let Some(key) = value.0.keys().find(|key| !matches!(key, Edn::Tag(_))) {
+        return Err(format!("expected definition :ffi map keys to be tags, got `{key}`"));
+      }
+    }
+    _ => return Err(format!("expected definition :ffi metadata to be a map or struct, got `{ffi}`")),
+  }
   let value = ffi_metadata_value(ffi, "target");
   let Some(value) = value else {
     return Ok(None);
@@ -926,6 +935,7 @@ impl TryFrom<Edn> for CodeEntry {
               schema = parse_loaded_schema_annotation(value, "CodeEntry.schema")?;
             }
             "ffi" if !matches!(value, Edn::Nil) => {
+              parse_ffi_target(value).map_err(|e| format!("failed to parse CodeEntry.ffi: {e}"))?;
               ffi = Some(value.to_owned());
             }
             _ => {}
@@ -964,6 +974,7 @@ impl TryFrom<Edn> for CodeEntry {
         if let Some(value) = map.get(&Edn::Tag(EdnTag::new("ffi")))
           && !matches!(value, Edn::Nil)
         {
+          parse_ffi_target(value).map_err(|e| format!("failed to parse CodeEntry.ffi: {e}"))?;
           ffi = Some(value.to_owned());
         }
       }
@@ -3277,6 +3288,28 @@ mod tests {
     );
     let error = CodeEntry::try_from(edn).expect_err("duplicate test names should be rejected");
     assert!(error.contains("duplicate test name `duplicate`"), "unexpected error: {error}");
+  }
+
+  #[test]
+  fn code_entry_rejects_malformed_ffi_metadata() {
+    let make_entry = |ffi| {
+      Edn::struct_from_pairs(
+        "CodeEntry",
+        &[
+          (EdnTag::new("doc"), Edn::Str(Arc::from(""))),
+          (EdnTag::new("examples"), Edn::List(EdnListView(vec![]))),
+          (EdnTag::new("code"), Cirru::leaf("nil").into()),
+          (EdnTag::new("ffi"), ffi),
+        ],
+      )
+    };
+
+    let error = CodeEntry::try_from(make_entry(Edn::str("browser"))).expect_err("scalar ffi metadata should be rejected");
+    assert!(error.contains("ffi metadata to be a map or struct"), "unexpected error: {error}");
+
+    let malformed_map = Edn::map_from_iter([(Edn::str("target"), Edn::tag("browser"))]);
+    let error = CodeEntry::try_from(make_entry(malformed_map)).expect_err("non-tag ffi keys should be rejected");
+    assert!(error.contains("ffi map keys to be tags"), "unexpected error: {error}");
   }
 
   #[test]


### PR DESCRIPTION
Closes #874

## Summary

- add `calcit analyze check-public` for effect-free preprocessing of every definition in exact public namespace scopes
- require an explicit selected-entry target and reject mismatched or malformed definition `:ffi :target` metadata before preprocessing
- emit schema-version 1 JSON with checked IDs, per-definition kinds/status, diagnostics, completeness, revision, duration, and fail-closed empty/dependency scope handling
- preserve ordinary entry-reachable `--check-only` behavior and document CI/Agent usage

## Current-release reproduction

Calcit 0.14.4 returned 0 for js-ffi Node `--check-only` after adding an unused typed function containing `(+ 1 |bad)`. The existing temporary-reference injection checker reached the same function and failed with `W_FN_ARG_TYPE_MISMATCH`. Main before this PR had the same code path.

## Candidate consumer evidence

Using the release build from this branch against calcit-lang/js-ffi main:

- Node: 85/85 definitions passed, including 18 data/trait rows; preprocessing 10.47–11.38 ms across three runs
- browser: 114/114 definitions passed, including 34 data/trait rows; preprocessing 18.00–18.34 ms
- full JSON: 15,206 / 21,557 bytes; summary-only with checked IDs: 2,868 / 4,120 bytes
- selecting `js-ffi.browser` under the Node entry fails with `E_JS_FFI_TARGET_MISMATCH` before those definitions are preprocessed

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (779 library + 315 CLI + 23 wasm)
- `yarn compile`
- `yarn check-agent-interface` (21/21)
- `yarn check-all`

Rebased onto latest main `00ea1c27` (#925) before the final full test and check-all runs.