### PR TITLE
Reject bare enum constructor values / 拒绝裸枚举构造器值

### DIFF
--- a/editing-history/202609091737-bare-enum-constructor-values.md
+++ b/editing-history/202609091737-bare-enum-constructor-values.md
@@ -1,0 +1,45 @@
+# Bare enum constructor value diagnostics / 裸枚举构造器值诊断
+
+Issue: calcit-lang/calcit#928
+
+## English
+
+- Strict preprocessing now rejects a bare zero-argument `%name` enum
+  constructor when an enum value is required by a definition return, an `if`
+  branch, or a callable parameter. The stable
+  `E_BARE_ENUM_CONSTRUCTOR_VALUE` diagnostic shows both types and suggests an
+  explicit invocation such as `(%none)`.
+- Equality between bare constructors of the same enum is rejected because
+  comparing the same function object can hide a missing invocation.
+- Explicit constructor calls and constructor symbols in an intentional `Fn`
+  context remain valid.
+- `query type-at` propagates a definition return expectation into `if`
+  branches and recovers implicit core symbol schemas even when strict
+  preprocessing stops before a source-correlated processed node is available.
+
+## 中文
+
+- 严格预处理现在会在 definition return、`if` 分支或 callable 参数要求枚举值
+  时拒绝裸的零参数 `%name` enum constructor。稳定诊断
+  `E_BARE_ENUM_CONSTRUCTOR_VALUE` 会展示实际/预期类型，并建议使用
+  `(%none)` 这样的显式调用。
+- 同一枚举的裸 constructor 之间不再允许直接相等比较，避免同一个函数对象的
+  比较掩盖缺失调用。
+- 显式 constructor 调用，以及明确 `Fn` 上下文中的 constructor symbol 保持有效。
+- `query type-at` 会把 definition return 预期传播到 `if` 分支；即使严格预处理
+  提前停止、无法生成对应 processed node，也能恢复隐式 core symbol 的函数签名。
+
+## Validation / 验证
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test` (780 library, 318 CLI, and 23 WASM tests)
+- `yarn compile`
+- `yarn check-agent-interface` (22/22 plus definition protocol round trips)
+- `yarn procs-link && yarn check-all`
+- Candidate CLI against current `calcit.std`: strict check-only, zero-debt
+  quality, 53/53 full type coverage, five focused examples, and native runtime
+  all passed.
+- Candidate CLI against `calcit.std` before its `rand-nth` fix: `query type-at`
+  reports the constructor `Fn` type, inherited `Option<T>` expectation,
+  `E_BARE_ENUM_CONSTRUCTOR_VALUE`, and `W_TYPE_AT_EXPECTED_MISMATCH`.

--- a/editing-history/202609091748-bare-enum-review-fixes.md
+++ b/editing-history/202609091748-bare-enum-review-fixes.md
@@ -1,0 +1,25 @@
+# Bare enum review fixes / 裸枚举评审修复
+
+## English
+
+- Updated expected-value descent for the indexed match representation emitted
+  by preprocessing nominal enums; empty table slots are ignored and actual
+  branch bodies are checked.
+- Added a strict regression with a bare `%none` in an indexed `match` branch.
+- Reused `resolve_to_fn` instead of cloning a full annotation, documented the
+  new helpers, and clarified the top-level Cirru invocation fixture.
+
+## 中文
+
+- 适配名义枚举预处理产生的 indexed match 表示；忽略空 slot，并继续检查实际
+  branch body 的预期值。
+- 新增 indexed `match` 分支中裸 `%none` 的严格模式回归。
+- 改用 `resolve_to_fn`，避免复制完整类型 annotation；同时补充新 helper 文档，
+  并解释顶层 Cirru 调用测试的语义。
+
+## Validation / 验证
+
+- `cargo test --bin calcit enum_constructor -- --nocapture`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `git diff --check`

--- a/editing-history/202609091755-enum-constructor-doc-coverage.md
+++ b/editing-history/202609091755-enum-constructor-doc-coverage.md
@@ -1,0 +1,14 @@
+# Enum constructor diagnostic doc coverage
+
+## English
+
+- Documented the `type-at` expected-context helper after review reported that
+  touched-function doc coverage remained below the repository threshold.
+- This is documentation-only and does not change query or preprocessing
+  behavior.
+
+## 中文
+
+- 针对 review 提示的 touched-function 文档覆盖率不足，为 `type-at` 的预期
+  上下文 helper 补充文档注释。
+- 此变更仅涉及文档，不改变 query 或 preprocess 行为。

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -1329,6 +1329,46 @@ mod type_query_tests {
   }
 
   #[test]
+  fn definition_return_schema_propagates_into_if_branches() {
+    let mut nodes = cirru_parser::parse("fn ()\n  if true %none (%none)").expect("test function should parse");
+    let mut entry = snapshot::CodeEntry::from_code(nodes.remove(0));
+    let option_number = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("calcit.core/Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    entry.schema = Arc::new(CalcitTypeAnnotation::from_function_parts(vec![], option_number.clone()));
+
+    for path in [&[2, 2][..], &[2, 3][..]] {
+      let (expected, source) = expected_type_at_path(&entry, None, "tests.type-at", "demo", path)
+        .expect("each if result branch should inherit the definition return schema");
+      assert_eq!(expected, option_number);
+      assert_eq!(source, "if branch inherited from definition return schema");
+    }
+  }
+
+  #[test]
+  fn type_at_recovers_implicit_core_constructor_schema_after_preprocess_failure() {
+    let _guard = crate::GLOBAL_TEST_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+    let snapshot = load_core_snapshot().expect("core snapshot should load");
+    prepare_program_for_type_query_on_cli_stack(snapshot);
+    let source = Calcit::Symbol {
+      sym: Arc::from("%none"),
+      info: Arc::new(calcit::calcit::CalcitSymbolInfo {
+        at_ns: Arc::from("tests.type-at"),
+        at_def: Arc::from("demo"),
+      }),
+      location: None,
+    };
+
+    let inferred = infer_type_at_target(&source, None, "tests.type-at").expect("implicit core constructor should retain its schema");
+    let CalcitTypeAnnotation::Fn(signature) = inferred.as_ref() else {
+      panic!("expected constructor function schema, got {inferred:?}");
+    };
+    assert!(signature.arg_types.is_empty());
+    assert!(signature.return_type.to_brief_string().contains("Option"));
+  }
+
+  #[test]
   fn type_at_reports_expected_type_mismatches_without_rejecting_optional_values() {
     let mismatch = type_at_expected_mismatch_diagnostic(
       &CalcitTypeAnnotation::Number,
@@ -1671,6 +1711,10 @@ fn expected_type_at_path(
   if matches!(head_name, Some("if" | "&if")) && target_index == 1 {
     return Some((Arc::new(CalcitTypeAnnotation::Bool), "if condition".to_owned()));
   }
+  if matches!(head_name, Some("if" | "&if")) && matches!(target_index, 2 | 3) {
+    return expected_type_at_path(entry, processed_root, namespace, definition, parent_path)
+      .map(|(expected, source)| (expected, format!("if branch inherited from {source}")));
+  }
 
   let processed_parent = processed_root.and_then(|root| {
     find_preprocessed_node_at_path(root, namespace, definition, parent_path, true).and_then(|node| match node {
@@ -1694,6 +1738,24 @@ fn expected_type_at_path(
   signature
     .expected_arg(arg_index)
     .map(|expected| (expected, "callable parameter".to_owned()))
+}
+
+fn infer_type_at_target(source: &Calcit, processed: Option<&Calcit>, namespace: &str) -> Option<Arc<CalcitTypeAnnotation>> {
+  processed
+    .and_then(runner::preprocess::infer_static_type_from_expr)
+    .or_else(|| runner::preprocess::infer_static_type_from_expr(source))
+    .or_else(|| match source {
+      Calcit::Symbol { sym, .. } => {
+        let local = program::lookup_def_schema(namespace, sym);
+        if !matches!(local.as_ref(), CalcitTypeAnnotation::Dynamic) {
+          Some(local)
+        } else {
+          let core = program::lookup_def_schema(calcit::calcit::CORE_NS, sym);
+          (!matches!(core.as_ref(), CalcitTypeAnnotation::Dynamic)).then_some(core)
+        }
+      }
+      _ => None,
+    })
 }
 
 fn type_at_evidence(node: &Calcit, path: &str, used_preprocessed: bool) -> TypeAtEvidence {
@@ -2108,7 +2170,7 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
       .collect::<Result<Vec<_>, _>>()?,
   )?;
   let inference_target = processed_target.unwrap_or(&source_target);
-  let inferred = runner::preprocess::infer_static_type_from_expr(inference_target);
+  let inferred = infer_type_at_target(&source_target, processed_target, namespace);
   let expected = expected_type_at_path(entry, processed_root, namespace, &definition, &target_path);
   let inferred_rendered = inferred
     .as_ref()

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -1740,6 +1740,8 @@ fn expected_type_at_path(
     .map(|expected| (expected, "callable parameter".to_owned()))
 }
 
+/// Prefer processed static evidence, then recover source and implicit-core
+/// definition schemas when preprocessing stopped before node correlation.
 fn infer_type_at_target(source: &Calcit, processed: Option<&Calcit>, namespace: &str) -> Option<Arc<CalcitTypeAnnotation>> {
   processed
     .and_then(runner::preprocess::infer_static_type_from_expr)

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -1684,6 +1684,8 @@ fn callable_signature_from_head(head: &Calcit) -> Option<StaticCallableSignature
   }
 }
 
+/// Infer the type required by the target's parent context and describe the
+/// source of that expectation for diagnostics.
 fn expected_type_at_path(
   entry: &snapshot::CodeEntry,
   processed_root: Option<&Calcit>,

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -239,7 +239,11 @@ fn strict_rejects_bare_zero_argument_enum_constructor_value_positions() {
     };
     let _strict = StrictTypesReset::enabled();
 
-    for snippet in ["let\n    _ &unit\n  , %none", "if true %none (%none)"] {
+    for snippet in [
+      "let\n    _ &unit\n  , %none",
+      "if true %none (%none)",
+      "match (%some 1)\n  (:some _) %none\n  (:none) (%none)",
+    ] {
       let entries = load_snippet_entries_with_main_schema(snippet, Some(main_schema(option_number.clone())));
       let error = run_check_only(&entries).expect_err("bare %none must not satisfy an Option return or branch type");
       assert!(error.contains("E_BARE_ENUM_CONSTRUCTOR_VALUE"), "unexpected error: {error}");
@@ -283,6 +287,7 @@ fn strict_accepts_invoked_enum_constructor_and_intentional_constructor_function(
     };
     let _strict = StrictTypesReset::enabled();
 
+    // A single top-level Cirru line is a call, so this snippet body is `(%none)`.
     let invoked = load_snippet_entries_with_main_schema("%none", Some(main_schema(option_number.clone())));
     run_check_only(&invoked).expect("(%none) must remain a valid Option value");
 

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -220,6 +220,87 @@ fn self_referential_enum_type_ref_validation_is_finite() {
 }
 
 #[test]
+fn strict_rejects_bare_zero_argument_enum_constructor_value_positions() {
+  run_with_large_stack(|| {
+    let option_number = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("calcit.core/Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    let main_schema = |return_type| {
+      Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: vec![],
+        return_type,
+        fn_kind: SchemaKind::Fn,
+        rest_type: None,
+        features: Arc::new(HashSet::new()),
+      })))
+    };
+    let _strict = StrictTypesReset::enabled();
+
+    for snippet in ["let\n    _ &unit\n  , %none", "if true %none (%none)"] {
+      let entries = load_snippet_entries_with_main_schema(snippet, Some(main_schema(option_number.clone())));
+      let error = run_check_only(&entries).expect_err("bare %none must not satisfy an Option return or branch type");
+      assert!(error.contains("E_BARE_ENUM_CONSTRUCTOR_VALUE"), "unexpected error: {error}");
+      assert!(
+        error.contains("(%none)"),
+        "diagnostic must suggest invoking the constructor: {error}"
+      );
+    }
+
+    let entries = load_snippet_entries_with_main_schema("= %none %none", Some(main_schema(Arc::new(CalcitTypeAnnotation::Bool))));
+    let error = run_check_only(&entries).expect_err("comparing the same bare constructor must not mask the missing invocation");
+    assert!(error.contains("E_BARE_ENUM_CONSTRUCTOR_VALUE"), "unexpected error: {error}");
+    assert!(
+      error.contains("mask the missing invocation"),
+      "comparison diagnostic must explain the trap: {error}"
+    );
+
+    let entries = load_snippet_entries_with_main_schema("option:none? %none", Some(main_schema(Arc::new(CalcitTypeAnnotation::Bool))));
+    let error = run_check_only(&entries).expect_err("bare %none must not satisfy an Option-valued call argument");
+    assert!(error.contains("E_BARE_ENUM_CONSTRUCTOR_VALUE"), "unexpected error: {error}");
+  });
+}
+
+#[test]
+fn strict_accepts_invoked_enum_constructor_and_intentional_constructor_function() {
+  run_with_large_stack(|| {
+    let option_number = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("calcit.core/Option"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::Number)]),
+    ));
+    let main_schema = |return_type| {
+      Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+        generics: Arc::new(vec![]),
+        where_bounds: Arc::new(vec![]),
+        arg_types: vec![],
+        return_type,
+        fn_kind: SchemaKind::Fn,
+        rest_type: None,
+        features: Arc::new(HashSet::new()),
+      })))
+    };
+    let _strict = StrictTypesReset::enabled();
+
+    let invoked = load_snippet_entries_with_main_schema("%none", Some(main_schema(option_number.clone())));
+    run_check_only(&invoked).expect("(%none) must remain a valid Option value");
+
+    let constructor_type = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![Arc::from("T")]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: option_number,
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    let constructor = load_snippet_entries_with_main_schema("let\n    _ &unit\n  , %none", Some(main_schema(constructor_type)));
+    run_check_only(&constructor).expect("bare %none must remain valid when a constructor function is expected");
+  });
+}
+
+#[test]
 fn postfix_map_kv_gate_ignores_concrete_non_map_receivers() {
   run_with_large_stack(|| {
     let entries = load_snippet_entries("|text .map-kv $ fn (value) value");

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -7787,6 +7787,8 @@ fn reject_strict_nil_for_unit_return(
   ))
 }
 
+/// Return constructor name and produced enum type for a bare zero-argument
+/// `%name` function value. A list call is intentionally excluded.
 fn bare_zero_argument_enum_producer(value: &Calcit, scope_types: &ScopeTypes) -> Option<(Arc<str>, Arc<CalcitTypeAnnotation>)> {
   let name = match value {
     Calcit::Fn { info, .. } => info.name.clone(),
@@ -7801,15 +7803,15 @@ fn bare_zero_argument_enum_producer(value: &Calcit, scope_types: &ScopeTypes) ->
   if !name.starts_with('%') {
     return None;
   }
-  let CalcitTypeAnnotation::Fn(signature) = resolve_type_value(value, scope_types)?.as_ref().clone() else {
-    return None;
-  };
+  let signature = resolve_type_value(value, scope_types)?.resolve_to_fn()?;
   if !signature.arg_types.is_empty() || signature.rest_type.is_some() || signature.return_type.resolve_to_enum().is_none() {
     return None;
   }
   Some((name, signature.return_type.clone()))
 }
 
+/// Reject a bare enum constructor where the surrounding strict context
+/// requires an enum value, descending through value-producing control flow.
 fn reject_strict_bare_enum_constructor_value(
   value: &Calcit,
   expected_type: &Arc<CalcitTypeAnnotation>,
@@ -7840,7 +7842,13 @@ fn reject_strict_bare_enum_constructor_value(
         return Ok(());
       }
       Some(Calcit::Syntax(CalcitSyntax::Match, _)) => {
-        for branch in items.iter().skip(2) {
+        let branches: Vec<&Calcit> = match (items.get(2), items.get(3)) {
+          (Some(Calcit::EnumDef(_)), Some(Calcit::List(table))) => {
+            table.iter().filter(|branch| !matches!(branch, Calcit::Nil)).collect()
+          }
+          _ => items.iter().skip(2).collect(),
+        };
+        for branch in branches {
           if let Calcit::List(pair) = branch
             && let Some(branch_value) = pair.get(1)
           {
@@ -7900,6 +7908,8 @@ fn reject_strict_bare_enum_constructor_value(
   ))
 }
 
+/// Reject equality that compares enum constructor functions and can therefore
+/// make the same missing invocation appear to pass.
 fn reject_strict_bare_enum_constructor_comparison(
   head: &Calcit,
   args: &CalcitList,

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2426,6 +2426,18 @@ fn preprocess_list_call(
 
         let form = result?;
 
+        if let Some(expected) = expected_type.as_ref() {
+          reject_strict_bare_enum_constructor_value(
+            &form,
+            expected,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
+            call_stack,
+            call_location.clone(),
+          )?;
+        }
+
         if strict_types_enabled()
           && checked_contract.is_some()
           && let Some(expected) = preprocessing_expected_types.get(arg_idx)
@@ -2449,6 +2461,7 @@ fn preprocess_list_call(
         // Core helpers such as `get` resolve to ordinary functions, so validate
         // their statically known struct fields in this branch as well.
         check_struct_field_access(&head_form, &current_args, scope_types, file_ns, call_stack, check_warnings);
+        reject_strict_bare_enum_constructor_comparison(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), call_stack)?;
         warn_on_nominal_enum_legacy_absence_use(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         reject_or_warn_on_legacy_js_nullish_predicate(
           &head_form,
@@ -2967,6 +2980,14 @@ fn preprocess_list_call(
             file_ns,
             def_name.as_ref(),
             check_warnings,
+            call_stack,
+          )?;
+          reject_strict_bare_enum_constructor_comparison(
+            call_head,
+            &processed_args,
+            scope_types,
+            file_ns,
+            def_name.as_ref(),
             call_stack,
           )?;
           warn_on_nominal_enum_legacy_absence_use(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
@@ -7766,6 +7787,165 @@ fn reject_strict_nil_for_unit_return(
   ))
 }
 
+fn bare_zero_argument_enum_producer(value: &Calcit, scope_types: &ScopeTypes) -> Option<(Arc<str>, Arc<CalcitTypeAnnotation>)> {
+  let name = match value {
+    Calcit::Fn { info, .. } => info.name.clone(),
+    Calcit::Import(CalcitImport { def, .. }) => def.clone(),
+    Calcit::Symbol { sym, .. } => sym.clone(),
+    Calcit::Local(local) => local.sym.clone(),
+    _ => return None,
+  };
+  // `%name` is the source convention for enum-variant constructor functions.
+  // Ordinary zero-argument functions that happen to return an enum stay
+  // first-class values and continue through the normal Fn type checks.
+  if !name.starts_with('%') {
+    return None;
+  }
+  let CalcitTypeAnnotation::Fn(signature) = resolve_type_value(value, scope_types)?.as_ref().clone() else {
+    return None;
+  };
+  if !signature.arg_types.is_empty() || signature.rest_type.is_some() || signature.return_type.resolve_to_enum().is_none() {
+    return None;
+  }
+  Some((name, signature.return_type.clone()))
+}
+
+fn reject_strict_bare_enum_constructor_value(
+  value: &Calcit,
+  expected_type: &Arc<CalcitTypeAnnotation>,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  def_name: &str,
+  call_stack: &CallStackList,
+  fallback_location: Option<NodeLocation>,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled() || !should_emit_project_source_lint(file_ns) || expected_type.resolve_to_enum().is_none() {
+    return Ok(());
+  }
+
+  if let Calcit::List(items) = value {
+    match items.first() {
+      Some(Calcit::Syntax(CalcitSyntax::If, _)) => {
+        for branch in items.iter().skip(2).take(2) {
+          reject_strict_bare_enum_constructor_value(
+            branch,
+            expected_type,
+            scope_types,
+            file_ns,
+            def_name,
+            call_stack,
+            fallback_location.clone(),
+          )?;
+        }
+        return Ok(());
+      }
+      Some(Calcit::Syntax(CalcitSyntax::Match, _)) => {
+        for branch in items.iter().skip(2) {
+          if let Calcit::List(pair) = branch
+            && let Some(branch_value) = pair.get(1)
+          {
+            reject_strict_bare_enum_constructor_value(
+              branch_value,
+              expected_type,
+              scope_types,
+              file_ns,
+              def_name,
+              call_stack,
+              fallback_location.clone(),
+            )?;
+          }
+        }
+        return Ok(());
+      }
+      Some(Calcit::Syntax(CalcitSyntax::CoreLet, _)) => {
+        if let Some(returned) = items.get(items.len().saturating_sub(1)) {
+          return reject_strict_bare_enum_constructor_value(
+            returned,
+            expected_type,
+            scope_types,
+            file_ns,
+            def_name,
+            call_stack,
+            fallback_location,
+          );
+        }
+      }
+      _ => {}
+    }
+  }
+
+  let Some((constructor, produced_type)) = bare_zero_argument_enum_producer(value, scope_types) else {
+    return Ok(());
+  };
+  let mut bindings = HashMap::new();
+  if !produced_type
+    .as_ref()
+    .compatible_with_bindings(expected_type.as_ref(), &mut bindings)
+  {
+    return Ok(());
+  }
+
+  Err(CalcitErr::use_msg_stack_location_with_code(
+    CalcitErrKind::Type,
+    format!(
+      "bare zero-argument enum constructor `{}` is used as a value in `{file_ns}/{def_name}`; expected `{}`, but the bare symbol is a function returning `{}`; invoke it as `({})`",
+      constructor,
+      expected_type.to_brief_string(),
+      produced_type.to_brief_string(),
+      constructor,
+    ),
+    "E_BARE_ENUM_CONSTRUCTOR_VALUE",
+    call_stack,
+    value.get_location().or(fallback_location),
+  ))
+}
+
+fn reject_strict_bare_enum_constructor_comparison(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  def_name: &str,
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled()
+    || !should_emit_project_source_lint(file_ns)
+    || !matches!(canonical_absence_operation_name(head), Some("=" | "&="))
+  {
+    return Ok(());
+  }
+
+  let producers = args
+    .iter()
+    .filter_map(|value| {
+      bare_zero_argument_enum_producer(value, scope_types).map(|(constructor, produced)| (value, constructor, produced))
+    })
+    .collect::<Vec<_>>();
+  if producers.len() < 2 {
+    return Ok(());
+  }
+  if !producers.iter().all(|(_, _, produced)| {
+    let mut bindings = HashMap::new();
+    produced.as_ref().compatible_with_bindings(producers[0].2.as_ref(), &mut bindings)
+  }) {
+    return Ok(());
+  }
+
+  let (value, constructor, produced_type) = &producers[0];
+  Err(CalcitErr::use_msg_stack_location_with_code(
+    CalcitErrKind::Type,
+    format!(
+      "comparison in `{file_ns}/{def_name}` uses bare zero-argument enum constructor `{}` as a value; both operands can compare as functions and mask the missing invocation; compare constructed `{}` values by writing `({})`",
+      constructor,
+      produced_type.to_brief_string(),
+      constructor,
+    ),
+    "E_BARE_ENUM_CONSTRUCTOR_VALUE",
+    call_stack,
+    value.get_location().or_else(|| head.get_location()),
+  ))
+}
+
 pub fn preprocess_defn(
   head: &CalcitSyntax,
   head_ns: &str,
@@ -8093,6 +8273,17 @@ pub fn preprocess_defn(
       } else {
         detected_return_type
       };
+      if let Some(returned_expr) = processed_body.last() {
+        reject_strict_bare_enum_constructor_value(
+          returned_expr,
+          &return_type_hint,
+          &body_types,
+          ctx.file_ns,
+          def_name.as_ref(),
+          ctx.call_stack,
+          ctx.call_location.clone().or(Some(definition_location.clone())),
+        )?;
+      }
       reject_strict_nil_for_unit_return(
         &processed_body,
         &return_type_hint,


### PR DESCRIPTION
## English

### Summary

- Reject bare zero-argument `%name` enum constructors in strict enum-value contexts with stable `E_BARE_ENUM_CONSTRUCTOR_VALUE` diagnostics and an explicit invocation suggestion such as `(%none)`.
- Cover definition returns, inherited `if` branch expectations, typed callable arguments, and equality that could otherwise compare the same constructor function on both sides.
- Preserve explicit constructor calls and bare constructor symbols when a `Fn` value is intentionally expected.
- Improve `query type-at` so an `if` branch inherits its definition return expectation and an implicit core constructor retains its function schema even when strict preprocessing stops early.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 780 library, 319 CLI, and 23 WASM tests passed
- `yarn compile`
- `yarn check-agent-interface` — 22/22 scenarios plus definition protocol round trips
- `yarn check-all` — native, JavaScript, IR, WASM, quality, and performance smoke checks passed
- Candidate CLI against current `calcit.std`: strict check-only passed; all nine quality metrics remained zero; check-types reported 53/53 full definitions; five FFI-backed examples and the native application entry ran successfully.
- Candidate CLI against the pre-fix `calcit.std/rand-nth`: `query type-at code@3.2` reports `Fn<'T>() -> Option<T>` as inferred, `Option<T>` as expected from the inherited `if` branch, `E_BARE_ENUM_CONSTRUCTOR_VALUE`, and `W_TYPE_AT_EXPECTED_MISMATCH`.

Closes #928.

## 中文

### 摘要

- 在严格模式的 enum 值上下文中拒绝裸的零参数 `%name` enum constructor，提供稳定的 `E_BARE_ENUM_CONSTRUCTOR_VALUE` 诊断，并明确建议使用 `(%none)` 这样的调用形式。
- 覆盖 definition return、继承 return 预期的 `if` 分支、带类型的 callable 参数，以及原先可能在两侧比较同一个 constructor 函数的相等判断。
- 保留显式 constructor 调用；当上下文明确定义为 `Fn` 值时，也继续允许裸 constructor symbol。
- 改进 `query type-at`：`if` 分支会继承 definition return 预期；即使严格预处理提前终止，隐式 core constructor 仍能显示其函数签名。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 780 个 library、319 个 CLI、23 个 WASM 测试通过
- `yarn compile`
- `yarn check-agent-interface` — 22/22 场景及 definition protocol round trips 通过
- `yarn check-all` — native、JavaScript、IR、WASM、quality 与性能 smoke 全部通过
- 候选 CLI 回归当前 `calcit.std`：严格 check-only 通过；九项 quality 指标全部为零；check-types 为 53/53 full；5 个真实 FFI examples 与 native 应用入口运行成功。
- 候选 CLI 回归修复前的 `calcit.std/rand-nth`：`query type-at code@3.2` 同时报告推断类型 `Fn<'T>() -> Option<T>`、从 `if` 分支继承的预期类型 `Option<T>`、`E_BARE_ENUM_CONSTRUCTOR_VALUE` 与 `W_TYPE_AT_EXPECTED_MISMATCH`。

关闭 #928。
