### PR TITLE
feat(config): support entry targets

### DIFF
--- a/docs/run/entries.md
+++ b/docs/run/entries.md
@@ -51,13 +51,23 @@ Bare `calcit calcit.cirru` selects `entries.default` and emits JavaScript becaus
 
 Use `:description` for a concise, human- and agent-readable explanation of the entry's purpose. It has no runtime effect and may be omitted in existing snapshots. Update it with `calcit config set description "Interactive browser client"` (or add `--entry server` for a named entry).
 
+Use the structured config command to declare the host target rather than editing the Snapshot as plain text. Accepted values are `browser`, `node`, `native`, and `wasm`; add `--entry <name>` to update a named entry. `calcit config show` displays the parsed target and prints `(none)` for an entry that has not declared one.
+
+```bash
+calcit config set target browser
+calcit config set --entry server target native
+calcit config show
+```
+
 `:init-fn` and `:reload-fn` are Calcit definition symbols, written as `'app.main/main!` rather than strings. Existing string-valued entries remain compatible on read and are converted on the next canonical snapshot write.
 
 A named entry is a complete configuration, not a partial override. In particular, it does not inherit the default entry's modules or type slots. Bind a slot for each entry that needs it:
 
 ```bash
 calcit config set mode js
+calcit config set target browser
 calcit config set-type-slot :dispatch-op app.schema/ClientOp
+calcit config set --entry server target native
 calcit config set-type-slot --entry server :dispatch-op app.schema/ServerOp
 calcit config type-slots
 calcit config type-slots --entry server

--- a/docs/run/project-structure.md
+++ b/docs/run/project-structure.md
@@ -81,7 +81,9 @@ Type slot 优先用配置命令维护，避免直接改 snapshot：
 ```bash
 calcit config set-type-slot :dispatch-op app.schema/Op
 calcit config set mode js
+calcit config set target browser
 calcit config set description "Browser client"
+calcit config set --entry test target node
 calcit config set-type-slot --entry test :dispatch-op app.test-schema/TestOp
 calcit config rm-type-slot :dispatch-op
 ```

--- a/editing-history/202609091130-config-entry-target.md
+++ b/editing-history/202609091130-config-entry-target.md
@@ -1,0 +1,6 @@
+# Support entry target in config set/show
+
+- Added `calcit config set [--entry <name>] target <browser|node|native|wasm>` so projects can migrate entry targets through the supported structured Snapshot writer.
+- Made `calcit config show` report every parsed entry target and mark omitted targets as `(none)`.
+- Added default/named entry round-trip coverage for all four targets plus a regression assertion that invalid targets leave the Snapshot unchanged.
+- Updated CLI help and entry configuration documentation with the structured target workflow.

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -71,6 +71,10 @@ fn format_feature_policy(feature_policy: &HashMap<String, snapshot::FeaturePolic
   format!("{{{}}}", pairs.join(", "))
 }
 
+fn format_target(target: Option<snapshot::SnapshotTarget>) -> &'static str {
+  target.map(snapshot::SnapshotTarget::as_str).unwrap_or("(none)")
+}
+
 fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String> {
   let snapshot = load_snapshot_for_display(input_path)?;
 
@@ -83,6 +87,7 @@ fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String>
     })?;
     println!("{}", format!("Entry '{name}':").bold());
     println!("  {}: {}", "mode".cyan(), entry.mode);
+    println!("  {}: {}", "target".cyan(), format_target(entry.target));
     println!("  {}: {}", "init_fn".cyan(), entry.init_fn);
     println!("  {}: {}", "reload_fn".cyan(), entry.reload_fn);
     println!("  {}: {}", "description".cyan(), entry.description);
@@ -108,6 +113,7 @@ fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String>
 
     println!("  {}", name.cyan());
     println!("    {}: {}", "mode".cyan(), entry.mode);
+    println!("    {}: {}", "target".cyan(), format_target(entry.target));
     println!("    {}: {}", "init_fn".cyan(), entry.init_fn);
     println!("    {}: {}", "reload_fn".cyan(), entry.reload_fn);
     println!("    {}: {}", "description".cyan(), entry.description);
@@ -249,6 +255,20 @@ fn handle_set(opts: &ConfigSetCommand, snapshot_file: &str) -> Result<(), String
       };
       format!("{} Set [{entry_label}] mode = '{}'", "✓".green(), entry.mode)
     }
+    "target" => {
+      entry.target = Some(match opts.value.trim().trim_start_matches(':') {
+        "browser" => snapshot::SnapshotTarget::Browser,
+        "node" => snapshot::SnapshotTarget::Node,
+        "native" => snapshot::SnapshotTarget::Native,
+        "wasm" => snapshot::SnapshotTarget::Wasm,
+        value => {
+          return Err(format!(
+            "Unknown entry target '{value}'. Valid targets: browser, node, native, wasm"
+          ));
+        }
+      });
+      format!("{} Set [{entry_label}] target = '{}'", "✓".green(), format_target(entry.target))
+    }
     "init-fn" | "init_fn" => {
       entry.init_fn = opts.value.clone();
       format!("{} Set [{entry_label}] '{}' = '{}'", "✓".green(), opts.key.cyan(), opts.value)
@@ -282,7 +302,7 @@ fn handle_set(opts: &ConfigSetCommand, snapshot_file: &str) -> Result<(), String
     }
     _ => {
       return Err(format!(
-        "Unknown config key '{}'. Valid keys: mode, init-fn, reload-fn, description, feature-policy.<name>, version (accepts semver string or patch|minor|major)",
+        "Unknown config key '{}'. Valid keys: mode, target, init-fn, reload-fn, description, feature-policy.<name>, version (accepts semver string or patch|minor|major)",
         opts.key
       ));
     }
@@ -559,6 +579,55 @@ mod tests {
     assert_eq!(fs::read_to_string(&temp_path).expect("read unchanged fixture"), before_invalid);
 
     fs::remove_file(temp_path).expect("remove fixture");
+  }
+
+  #[test]
+  fn config_set_target_validates_and_persists_default_and_named_entries() {
+    let source = "{} (:package |demo)\n  :entries $ {}\n    :default $ {} (:mode :js) (:init-fn |app.main/main!) (:reload-fn |app.main/reload!)\n      :modules $ []\n    :server $ {} (:mode :native) (:init-fn |app.server/main!) (:reload-fn |app.server/reload!)\n      :modules $ []\n  :files $ {}\n";
+    let temp_path = std::env::temp_dir().join(format!("calcit-entry-target-{}.cirru", std::process::id()));
+    fs::write(&temp_path, source).expect("write fixture");
+    let path = temp_path.to_string_lossy();
+
+    for (entry_name, value, expected) in [
+      (None, ":browser", snapshot::SnapshotTarget::Browser),
+      (None, "node", snapshot::SnapshotTarget::Node),
+      (Some("server"), ":native", snapshot::SnapshotTarget::Native),
+      (Some("server"), "wasm", snapshot::SnapshotTarget::Wasm),
+    ] {
+      handle_set(
+        &ConfigSetCommand {
+          entry: entry_name.map(str::to_owned),
+          key: "target".to_owned(),
+          value: value.to_owned(),
+        },
+        &path,
+      )
+      .expect("set entry target");
+      let saved = load_snapshot_for_display(&path).expect("reload configured snapshot");
+      let name = entry_name.unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
+      assert_eq!(saved.entries[name].target, Some(expected));
+    }
+
+    let before_invalid = fs::read_to_string(&temp_path).expect("read configured fixture");
+    let error = handle_set(
+      &ConfigSetCommand {
+        entry: Some("server".to_owned()),
+        key: "target".to_owned(),
+        value: "desktop".to_owned(),
+      },
+      &path,
+    )
+    .expect_err("unknown target should fail before writing");
+    assert_eq!(error, "Unknown entry target 'desktop'. Valid targets: browser, node, native, wasm");
+    assert_eq!(fs::read_to_string(&temp_path).expect("read unchanged fixture"), before_invalid);
+
+    fs::remove_file(temp_path).expect("remove fixture");
+  }
+
+  #[test]
+  fn entry_target_display_marks_unset_values() {
+    assert_eq!(format_target(Some(snapshot::SnapshotTarget::Node)), "node");
+    assert_eq!(format_target(None), "(none)");
   }
 
   #[test]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -2500,7 +2500,7 @@ pub enum ConfigSubcommand {
   /// show or bump the project version (omit value to show; use patch|minor|major to bump; or pass a semver string)
   /// [Deprecated] prefer `caps version get/set/bump` which manages `deps.cirru :version`
   Version(ConfigVersionCommand),
-  /// set a configuration key to a value (mode, init-fn, reload-fn, description, feature-policy.<name>, version)
+  /// set a configuration key to a value (mode, target, init-fn, reload-fn, description, feature-policy.<name>, version)
   Set(ConfigSetCommand),
   /// add a module path to an entry's modules
   AddModule(ConfigAddModuleCommand),
@@ -2550,15 +2550,15 @@ pub struct ConfigVersionCommand {
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 #[argh(subcommand, name = "set")]
-/// set a configuration key (mode, init-fn, reload-fn, description, feature-policy.<name>, version)
+/// set a configuration key (mode, target, init-fn, reload-fn, description, feature-policy.<name>, version)
 pub struct ConfigSetCommand {
   /// apply to a named entry (e.g. "test"); defaults to "default" (version is always project-level)
   #[argh(option)]
   pub entry: Option<String>,
-  /// config key: mode, init-fn, reload-fn, description, feature-policy.<name>, version ([Deprecated] prefer `caps version`)
+  /// config key: mode, target, init-fn, reload-fn, description, feature-policy.<name>, version ([Deprecated] prefer `caps version`)
   #[argh(positional)]
   pub key: String,
-  /// config value; for "version" accepts semver string or patch|minor|major
+  /// config value; target accepts browser|node|native|wasm; version accepts semver string or patch|minor|major
   #[argh(positional)]
   pub value: String,
 }


### PR DESCRIPTION
## Summary

- support `calcit config set [--entry <name>] target <browser|node|native|wasm>`
- show parsed entry targets in both all-entry and named-entry config output, including `(none)` for legacy unset values
- document the structured migration path and cover default/named round trips plus no-write invalid input

Closes #927

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (1124 passed)
- `yarn compile`
- `yarn check-agent-interface` (22/22)
- real CLI smoke for `config show` and `config show --entry default`