### PR TITLE
fix(types): reject nominal stringification in strict mode

### DIFF
--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -397,6 +397,8 @@ Dynamic 应限制在 JS FFI、宏和框架开放数据边界。普通多态使�
 
 `get-in` 返回 `Option<T>`，适合开放 Map/List 路径；不要用它绕过 Struct 字段检查，Struct 应使用 `(:field value)`。`update-in` 的 updater 接收 `Option<T>`，必须显式处理缺失值。
 
+默认 strict mode 不允许把核心 `Option<T>` 或 `Result<T,E>` 直接传给 `str` / `turn-string`，并报告 `E_NOMINAL_ENUM_STRINGIFICATION`。应先用 `match`、`.unwrap-or` 或对应的 Option/Result helper 明确处理分支和 payload；只有确实需要诊断表示时才使用 `to-lispy-string`。`--compat-types` 仍保留旧的 enum 渲染行为，便于渐进迁移。
+
 ### Complex Types
 
 #### Legacy Optional Types

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -417,6 +417,11 @@ Struct 字段是定义的一部分，因此已知 struct 上的 `get`、`:field`
 | `get-in` | `Option<T>`（开放动态路径常为 `Option<Dynamic>`） | 任一路径缺失都是 `%none` |
 | `get-env` | `Option<String>` | 未设置的环境变量是 `%none` |
 
+不要用 `str` 或 `turn-string` 掩盖尚未处理的 `Option<T>` / `Result<T,E>`。默认 strict mode 会以
+`E_NOMINAL_ENUM_STRINGIFICATION` 拒绝这种隐式转换；先用 `match`、`.unwrap-or` 或对应 helper 取出 payload。
+如果目的就是打印 enum 的诊断表示，显式使用 `to-lispy-string`。迁移期间可用
+`--compat-types` 暂时保留旧渲染路径。
+
 默认严格诊断还会检查这些访问 API 的接收者能力。`first`、`last`、`nth` 只接受可静态确认的
 `List<T>`、`String` 或 `Enum`，`get` 另外接受 `Map<K,V>`；把 Number、Set、Struct、函数或未收窄的
 optional/FFI host value 传入时会报告 `E_UNSUPPORTED_INDEXED_RECEIVER`，而不是把 core schema 中保留的

--- a/editing-history/202609091150-strict-nominal-stringification.md
+++ b/editing-history/202609091150-strict-nominal-stringification.md
@@ -1,0 +1,6 @@
+# Reject implicit Option/Result stringification in strict mode
+
+- Added the stable `E_NOMINAL_ENUM_STRINGIFICATION` preprocessing error when project code passes a statically known core `Option<T>` or `Result<T,E>` directly to `str` or `turn-string`.
+- Kept ordinary values, unrelated application enums, explicit `to-lispy-string` representation, core implementation code, and `--compat-types` behavior unchanged.
+- Covered public `str`, direct `turn-string`, variadic argument positions, Option and Result guidance, application-defined enum names, and an end-to-end strict preprocessing regression.
+- Documented the explicit payload-handling and diagnostic-representation migration paths.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -1019,6 +1019,58 @@ fn option_migration_source_calls_fail_during_preprocessing() {
 }
 
 #[test]
+fn strict_mode_rejects_implicit_option_and_result_stringification() {
+  run_with_large_stack(|| {
+    let _strict = StrictTypesReset::enabled();
+    let main_schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: Arc::new(CalcitTypeAnnotation::String),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    for (source, operation, nominal) in [
+      ("defn main! ()\n  str $ %some :remove", "str", "Option"),
+      ("defn main! ()\n  turn-string $ %err |failed", "turn-string", "Result"),
+    ] {
+      let entries = load_snippet_entries_with_main_schema(source, Some(main_schema.clone()));
+      let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+      let error = runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+        .expect_err("strict stringification should fail during preprocessing");
+      assert_eq!(error.code.as_deref(), Some("E_NOMINAL_ENUM_STRINGIFICATION"));
+      assert!(error.msg.contains(&format!("`{operation}`")), "unexpected error: {error:?}");
+      assert!(error.msg.contains(nominal), "unexpected error: {error:?}");
+      assert!(error.msg.contains("to-lispy-string"), "unexpected error: {error:?}");
+    }
+  });
+}
+
+#[test]
+fn strict_mode_keeps_explicit_enum_representation_and_plain_stringification() {
+  run_with_large_stack(|| {
+    let _strict = StrictTypesReset::enabled();
+    let main_schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: Arc::new(CalcitTypeAnnotation::String),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    let entries = load_snippet_entries_with_main_schema(
+      "defn main! ()\n  str |prefix 1 $ to-lispy-string $ %some :remove",
+      Some(main_schema),
+    );
+    let warnings: RefCell<Vec<LocatedWarning>> = RefCell::new(vec![]);
+    runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, &warnings, &CallStackList::default())
+      .expect("strict code should accept ordinary values and an explicit Option representation");
+  });
+}
+
+#[test]
 fn dynamic_option_method_receiver_fails_during_preprocessing() {
   run_with_large_stack(|| {
     let entries =

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -2462,6 +2462,7 @@ fn preprocess_list_call(
         // their statically known struct fields in this branch as well.
         check_struct_field_access(&head_form, &current_args, scope_types, file_ns, call_stack, check_warnings);
         reject_strict_bare_enum_constructor_comparison(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), call_stack)?;
+        reject_strict_nominal_enum_stringification(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), call_stack)?;
         warn_on_nominal_enum_legacy_absence_use(&head_form, &current_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
         reject_or_warn_on_legacy_js_nullish_predicate(
           &head_form,
@@ -2990,6 +2991,7 @@ fn preprocess_list_call(
             def_name.as_ref(),
             call_stack,
           )?;
+          reject_strict_nominal_enum_stringification(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), call_stack)?;
           warn_on_nominal_enum_legacy_absence_use(call_head, &processed_args, scope_types, file_ns, def_name.as_ref(), check_warnings);
           reject_or_warn_on_legacy_js_nullish_predicate(
             call_head,
@@ -5371,6 +5373,56 @@ fn nominal_enum_expression_name(value: &Calcit, scope_types: &ScopeTypes) -> Opt
     Some("%ok" | "%err" | "parse-float") => Some("Result".to_owned()),
     _ => None,
   }
+}
+
+fn core_stringification_operation(head: &Calcit) -> Option<&str> {
+  match head {
+    Calcit::Import(CalcitImport { ns, def, .. }) if ns.as_ref() == calcit::CORE_NS && matches!(def.as_ref(), "str" | "turn-string") => {
+      Some(def.as_ref())
+    }
+    Calcit::Fn { info, .. } if info.def_ns.as_ref() == calcit::CORE_NS && matches!(info.name.as_ref(), "str" | "turn-string") => {
+      Some(info.name.as_ref())
+    }
+    Calcit::Proc(CalcitProc::TurnString) => Some("turn-string"),
+    _ => None,
+  }
+}
+
+fn reject_strict_nominal_enum_stringification(
+  head: &Calcit,
+  args: &CalcitList,
+  scope_types: &ScopeTypes,
+  file_ns: &str,
+  def_name: &str,
+  call_stack: &CallStackList,
+) -> Result<(), CalcitErr> {
+  if !strict_types_enabled() || !should_emit_project_source_lint(file_ns) {
+    return Ok(());
+  }
+  let Some(operation) = core_stringification_operation(head) else {
+    return Ok(());
+  };
+  let Some((value, enum_name)) = args.iter().find_map(|value| {
+    let enum_name = nominal_enum_expression_name(value, scope_types)?;
+    Some((value, enum_name))
+  }) else {
+    return Ok(());
+  };
+
+  let handling = if enum_name == "Option" {
+    "pattern-match the Option or use an explicit Option helper such as `.unwrap-or` before converting its payload"
+  } else {
+    "pattern-match the Result and convert the success or error payload deliberately"
+  };
+  Err(CalcitErr::use_msg_stack_location_with_code(
+    CalcitErrKind::Type,
+    format!(
+      "implicit `{operation}` stringification of `{enum_name}` is not allowed in strict code at {file_ns}/{def_name}; {handling}; use `to-lispy-string` only when the enum representation itself is intended"
+    ),
+    "E_NOMINAL_ENUM_STRINGIFICATION",
+    call_stack,
+    value.get_location().or_else(|| head.get_location()),
+  ))
 }
 
 /// Return the nominal element type used by a membership operation, when the
@@ -11322,6 +11374,83 @@ mod tests {
     warn_on_nominal_enum_truthiness(&option_value, &ScopeTypes::new(), "tests.option-migration", &truthiness_warnings);
     assert_eq!(truthiness_warnings.borrow().len(), 1, "Option truthiness should warn");
     assert_eq!(truthiness_warnings.borrow()[0].code(), Some("W_NOMINAL_ENUM_LEGACY_USE"));
+  }
+
+  #[test]
+  fn strict_types_reject_implicit_option_and_result_stringification() {
+    let _lock = lock_preprocess_test_state();
+    let typed_local = |name: &str, type_ref: &str, type_args: Vec<Arc<CalcitTypeAnnotation>>| {
+      let sym: Arc<str> = Arc::from(name);
+      Calcit::Local(CalcitLocal {
+        idx: CalcitLocal::track_sym(&sym),
+        sym,
+        info: Arc::new(CalcitSymbolInfo {
+          at_ns: Arc::from("tests.nominal-stringification"),
+          at_def: Arc::from("demo"),
+        }),
+        location: None,
+        type_info: Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from(type_ref), Arc::new(type_args))),
+      })
+    };
+    let option = typed_local("option-value", "calcit.core/Option", vec![Arc::new(CalcitTypeAnnotation::Tag)]);
+    let result = typed_local(
+      "result-value",
+      "calcit.core/Result",
+      vec![Arc::new(CalcitTypeAnnotation::Number), Arc::new(CalcitTypeAnnotation::String)],
+    );
+    let core_str = core_import("str", "tests.nominal-stringification");
+    let stack = CallStackList::default();
+
+    {
+      let _compat = StrictTypesGuard::new(false);
+      reject_strict_nominal_enum_stringification(
+        &core_str,
+        &CalcitList::from(&[Calcit::Str(Arc::from("prefix")), option.to_owned()][..]),
+        &ScopeTypes::new(),
+        "tests.nominal-stringification",
+        "demo",
+        &stack,
+      )
+      .expect("compatibility mode should preserve enum rendering");
+    }
+
+    let _strict = StrictTypesGuard::new(true);
+    let option_error = reject_strict_nominal_enum_stringification(
+      &core_str,
+      &CalcitList::from(&[Calcit::Str(Arc::from("prefix")), option][..]),
+      &ScopeTypes::new(),
+      "tests.nominal-stringification",
+      "demo",
+      &stack,
+    )
+    .expect_err("strict str should reject an Option in any variadic position");
+    assert_eq!(option_error.code.as_deref(), Some("E_NOMINAL_ENUM_STRINGIFICATION"));
+    assert!(option_error.msg.contains("pattern-match the Option"));
+    assert!(option_error.msg.contains(".unwrap-or"));
+    assert!(option_error.msg.contains("to-lispy-string"));
+
+    let result_error = reject_strict_nominal_enum_stringification(
+      &Calcit::Proc(CalcitProc::TurnString),
+      &CalcitList::from(std::slice::from_ref(&result)),
+      &ScopeTypes::new(),
+      "tests.nominal-stringification",
+      "demo",
+      &stack,
+    )
+    .expect_err("strict turn-string should reject a Result");
+    assert_eq!(result_error.code.as_deref(), Some("E_NOMINAL_ENUM_STRINGIFICATION"));
+    assert!(result_error.msg.contains("pattern-match the Result"));
+
+    let application_option = typed_local("application-option", "app.model/Option", vec![Arc::new(CalcitTypeAnnotation::Tag)]);
+    reject_strict_nominal_enum_stringification(
+      &core_str,
+      &CalcitList::from(std::slice::from_ref(&application_option)),
+      &ScopeTypes::new(),
+      "tests.nominal-stringification",
+      "demo",
+      &stack,
+    )
+    .expect("an unrelated application enum named Option must not be treated as calcit.core/Option");
   }
 
   struct WarnDynMethodGuard {


### PR DESCRIPTION
Closes #932

## Summary
- reject implicit Option/Result arguments to str and turn-string in default strict mode
- retain compatibility mode, ordinary values, application-defined enums, and explicit to-lispy-string representation
- add stable diagnostic guidance, integration/unit coverage, docs, and editing history

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test (781 lib + 321 CLI + 23 WASM tests)
- yarn compile
- yarn check-all
- yarn check-agent-interface
- focused strict stringification tests rerun after final wording change