### PR TITLE
feat(config): add structured JSON query output

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -113,6 +113,9 @@ caps tree
 caps why '<owner/repo>'
 calcit calcit.cirru config modules
 calcit calcit.cirru config modules --entry '<entry-name>'
+calcit calcit.cirru config show --format json
+calcit calcit.cirru config modules --entry '<entry-name>' --format json
+calcit calcit.cirru config type-slots --entry '<entry-name>' --format json
 calcit calcit.cirru --check-only
 calcit calcit.cirru --entry '<entry-name>' --check-only
 # Here --entry is the snapshot filename, not a named entry:
@@ -127,6 +130,10 @@ entry 都是独立配置，不能假设其模块继承 default。`--check-only` 
 
 注意：`config modules --entry` 与顶层 `--entry` 选择 named entry；`docs check-md --entry` 则选择用于
 检查的 snapshot 文件（`calcit.cirru`），两者不是同一种参数。
+
+Agent 和 CI 读取 entry 配置时使用 config 查询的 `--format json`，不要解析彩色 human 输出。三个命令
+都返回带 `schema_version`、`command`、`data`、`diagnostics` 与 Snapshot `revision` 的单一 envelope；
+entry 不存在或 Snapshot 配置无效时仍输出结构化诊断并以非零状态退出。
 
 读取源码优先使用 human/Cirru 输出；只有需要稳定字段、自动分支或静态证据时才使用 `--format json`。`--format json` 承诺 stdout 为单个 JSON envelope；某些命令的 `--json` 只是在人类输出后附加 JSON，具体以子命令 `--help` 为准。
 

--- a/docs/run/entries.md
+++ b/docs/run/entries.md
@@ -57,7 +57,14 @@ Use the structured config command to declare the host target rather than editing
 calcit config set target browser
 calcit config set --entry server target native
 calcit config show
+calcit config show --format json
 ```
+
+`config show`, `config modules`, and `config type-slots` accept `--format human|json`. JSON mode writes one
+schema-versioned envelope to stdout and keeps command explanations and incidental log output on stderr. Each selected entry
+includes its name, mode, optional target, init/reload definitions, description, modules, type slots, and feature
+policy. The all-entry `config show` form sorts entries by name; missing entries return a non-zero status with a
+structured diagnostic instead of partial success output.
 
 `:init-fn` and `:reload-fn` are Calcit definition symbols, written as `'app.main/main!` rather than strings. Existing string-valued entries remain compatible on read and are converted on the next canonical snapshot write.
 
@@ -71,6 +78,7 @@ calcit config set --entry server target native
 calcit config set-type-slot --entry server :dispatch-op app.schema/ServerOp
 calcit config type-slots
 calcit config type-slots --entry server
+calcit config type-slots --entry server --format json
 ```
 
 The type-slot environment is selected before preprocessing starts, so the binding applies to the whole reachable call graph. Entry functions do not need a `with-type-slot` wrapper.

--- a/docs/run/load-deps.md
+++ b/docs/run/load-deps.md
@@ -95,6 +95,7 @@ caps why calcit-lang/memof
 # Inspect the module list for each relevant executable entry.
 calcit calcit.cirru config modules
 calcit calcit.cirru config modules --entry test
+calcit calcit.cirru config modules --entry test --format json
 
 # Validate the reachable paths for those entries.
 calcit calcit.cirru --check-only
@@ -107,6 +108,9 @@ metadata, or Markdown snippets. They also currently merge root `:dependencies` a
 `:dev-dependencies` in their display, so use `deps.cirru` as the authority for a root module's declared
 group. An installed module is therefore not automatically a runtime dependency: it can be a development
 module, a module configured only for another entry, or a module retained for a documentation check.
+
+Automation should add `--format json`: the single versioned envelope includes the complete selected entry and a
+deterministic module list whose rows distinguish `loaded` paths and unresolved `failed` paths.
 
 Named entries do not inherit the default entry's modules. Audit each entry that CI or a release supports.
 For Markdown code, `calcit docs check-md` defaults to modules from the default entry; use an explicit

--- a/docs/run/project-structure.md
+++ b/docs/run/project-structure.md
@@ -74,7 +74,15 @@ calcit query config
 calcit query ns <target-ns>
 calcit query defs <target-ns>
 calcit config type-slots
+calcit config show --format json
+calcit config modules --format json
+calcit config type-slots --format json
 ```
+
+自动化应使用三个 config 查询的 `--format json`，不要解析带颜色的人类输出。成功与失败都会使用
+`schema_version`、`command`、`data`、`diagnostics`、`revision` 组成的单一 JSON envelope；失败仍以非零
+状态退出。`config show` 的全 entry 结果按名称排序，`config modules` 会为每个声明路径报告
+`loaded`/`failed` 和解析出的 package。
 
 Type slot 优先用配置命令维护，避免直接改 snapshot：
 

--- a/editing-history/202609091635-config-query-json.md
+++ b/editing-history/202609091635-config-query-json.md
@@ -1,0 +1,5 @@
+# Add structured JSON config queries
+
+- Added schema-versioned single-envelope JSON output to `config show`, `config modules`, and `config type-slots` while preserving their human output.
+- Included complete selected-entry metadata, deterministic all-entry ordering, resolved module status, Snapshot revisions, and structured non-zero diagnostics.
+- Covered all four entry targets, empty and populated maps/lists, missing and malformed configurations, CLI help, embedded Agent guidance, and automated inventory of the real `calcit-core` library.

--- a/editing-history/202609091635-config-query-json.md
+++ b/editing-history/202609091635-config-query-json.md
@@ -3,3 +3,4 @@
 - Added schema-versioned single-envelope JSON output to `config show`, `config modules`, and `config type-slots` while preserving their human output.
 - Included complete selected-entry metadata, deterministic all-entry ordering, resolved module status, Snapshot revisions, and structured non-zero diagnostics.
 - Covered all four entry targets, empty and populated maps/lists, missing and malformed configurations, CLI help, embedded Agent guidance, and automated inventory of the real `calcit-core` library.
+- Bound each revision to the exact Snapshot bytes used for parsing and sorted available-entry diagnostics after review.

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -194,6 +194,82 @@ const scenarios = [
     },
   },
   {
+    name: "machine-readable config entries",
+    args: ["calcit/type-fail/type-slot-entry-scope.cirru", "config", "show", "--format", "json"],
+    check(result) {
+      if (result.schema_version !== 1 || result.command !== "config.show" || result.diagnostics.length !== 0) {
+        throw new Error("unexpected config.show envelope");
+      }
+      if (result.data.entries.map((entry) => entry.name).join(",") !== "default,server") {
+        throw new Error("config.show entries are not deterministically ordered");
+      }
+      const server = result.data.entries[1];
+      if (server.mode !== "native" || server.type_slots["dispatch-op"] !== "type-fail-type-slot-entry-scope.main/ServerOp") {
+        throw new Error("config.show lost entry mode or type slots");
+      }
+      if (!result.revision.startsWith("md5:")) {
+        throw new Error("config.show lost its Snapshot revision");
+      }
+    },
+  },
+  {
+    name: "core library config inventory",
+    args: ["src/cirru/calcit-core.cirru", "config", "show", "--format", "json"],
+    check(result) {
+      const entry = result.data?.entries?.[0];
+      if (result.command !== "config.show" || result.data?.package !== "calcit" || entry?.name !== "default") {
+        throw new Error("calcit-core automation could not read its config inventory");
+      }
+      if (entry.target !== null || entry.modules.length !== 0 || Object.keys(entry.type_slots).length !== 0) {
+        throw new Error("calcit-core empty config fields did not round-trip");
+      }
+    },
+  },
+  {
+    name: "machine-readable config modules",
+    args: ["calcit/test.cirru", "config", "modules", "--format", "json"],
+    check(result) {
+      if (result.command !== "config.modules" || result.data.entry.name !== "default") {
+        throw new Error("unexpected config.modules envelope");
+      }
+      if (result.data.modules.length !== result.data.entry.modules.length || result.data.modules.some((module) => module.status !== "loaded")) {
+        throw new Error("config.modules lost resolved module status");
+      }
+    },
+  },
+  {
+    name: "machine-readable config type slots",
+    args: ["calcit/type-fail/type-slot-entry-scope.cirru", "config", "type-slots", "--entry", "server", "--format", "json"],
+    check(result) {
+      if (result.command !== "config.type-slots" || result.data.entry.name !== "server") {
+        throw new Error("unexpected config.type-slots envelope");
+      }
+      if (result.data.type_slots["dispatch-op"] !== "type-fail-type-slot-entry-scope.main/ServerOp") {
+        throw new Error("config.type-slots lost the selected binding");
+      }
+    },
+  },
+  {
+    name: "missing config entry stays structured",
+    args: ["calcit/test.cirru", "config", "show", "--entry", "missing", "--format", "json"],
+    expectedStatus: 1,
+    check(result) {
+      if (result.command !== "config.show" || result.data !== null || result.diagnostics[0]?.code !== "E_CONFIG_ENTRY_NOT_FOUND") {
+        throw new Error("missing config entry lost its structured diagnostic");
+      }
+    },
+  },
+  {
+    name: "malformed config stays structured",
+    args: ["package.json", "config", "show", "--format", "json"],
+    expectedStatus: 1,
+    check(result) {
+      if (result.command !== "config.show" || result.data !== null || result.diagnostics[0]?.code !== "E_CONFIG_SNAPSHOT_INVALID") {
+        throw new Error("malformed config lost its structured diagnostic");
+      }
+    },
+  },
+  {
     name: "staged edit transaction",
     args: [
       "calcit/test.cirru",

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -1432,9 +1432,15 @@ fn push_ffi(tokens: &mut Vec<String>, cmd: &FfiCommand) {
 
 fn push_config(tokens: &mut Vec<String>, cmd: &ConfigCommand) {
   match &cmd.subcommand {
-    ConfigSubcommand::Show(opts) => echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none"),
-    ConfigSubcommand::Modules(opts) => echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none"),
-    ConfigSubcommand::TypeSlots(opts) => echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none"),
+    ConfigSubcommand::Show(opts) => {
+      echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none", opt "format" => Some(opts.format.as_str()); default "human")
+    }
+    ConfigSubcommand::Modules(opts) => {
+      echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none", opt "format" => Some(opts.format.as_str()); default "human")
+    }
+    ConfigSubcommand::TypeSlots(opts) => {
+      echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none", opt "format" => Some(opts.format.as_str()); default "human")
+    }
     ConfigSubcommand::Version(opts) => echo_items!(tokens, opt "value" => opts.value.as_deref(); default "none"),
     ConfigSubcommand::Set(opts) => {
       echo_items!(tokens, opt "entry" => opts.entry.as_deref(); default "none");

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -10,12 +10,189 @@ use calcit::snapshot;
 use calcit::util::string::strip_shebang;
 use cirru_edn::{Edn, EdnMapView};
 use colored::Colorize;
-use std::collections::HashMap;
+use md5::{Digest, Md5};
+use serde::Serialize;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 
-use super::common::{deps_path_for_snapshot, guard_snapshot_mutation_toolchain};
+use super::common::{deps_path_for_snapshot, guard_snapshot_mutation_toolchain, package_version_for_snapshot};
 use super::edit::{load_snapshot, save_snapshot};
+
+const CONFIG_JSON_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize)]
+struct ConfigDiagnostic {
+  code: &'static str,
+  message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigJsonEnvelope<T> {
+  schema_version: u32,
+  command: &'static str,
+  data: Option<T>,
+  diagnostics: Vec<ConfigDiagnostic>,
+  revision: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EntryConfigJson {
+  name: String,
+  mode: &'static str,
+  target: Option<&'static str>,
+  init_fn: String,
+  reload_fn: String,
+  description: String,
+  modules: Vec<String>,
+  type_slots: BTreeMap<String, String>,
+  feature_policy: BTreeMap<String, &'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigShowJson {
+  package: String,
+  version: Option<String>,
+  selected_entry: Option<String>,
+  entries: Vec<EntryConfigJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct ModuleConfigJson {
+  path: String,
+  package: Option<String>,
+  status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigModulesJson {
+  package: String,
+  entry: EntryConfigJson,
+  modules: Vec<ModuleConfigJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigTypeSlotsJson {
+  package: String,
+  entry: EntryConfigJson,
+  type_slots: BTreeMap<String, String>,
+}
+
+fn entry_config_json(name: &str, entry: &snapshot::SnapshotEntry) -> EntryConfigJson {
+  EntryConfigJson {
+    name: name.to_owned(),
+    mode: entry.mode.as_str(),
+    target: entry.target.map(snapshot::SnapshotTarget::as_str),
+    init_fn: entry.init_fn.clone(),
+    reload_fn: entry.reload_fn.clone(),
+    description: entry.description.clone(),
+    modules: entry.modules.clone(),
+    type_slots: entry.type_slots.iter().map(|(key, value)| (key.clone(), value.clone())).collect(),
+    feature_policy: entry
+      .feature_policy
+      .iter()
+      .map(|(feature, policy)| (feature.clone(), policy.as_str()))
+      .collect(),
+  }
+}
+
+fn config_show_json(
+  snapshot: &snapshot::Snapshot,
+  selected_entry: Option<&str>,
+  version: Option<String>,
+) -> Result<ConfigShowJson, String> {
+  let mut names = match selected_entry {
+    Some(name) => {
+      if !snapshot.entries.contains_key(name) {
+        return Err(format!(
+          "Entry '{name}' not found. Available: {}",
+          snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
+        ));
+      }
+      vec![name.to_owned()]
+    }
+    None => snapshot.entries.keys().cloned().collect::<Vec<_>>(),
+  };
+  names.sort();
+  let entries = names
+    .iter()
+    .map(|name| {
+      let entry = snapshot
+        .entries
+        .get(name)
+        .ok_or_else(|| format!("Missing entry config for '{name}'"))?;
+      Ok(entry_config_json(name, entry))
+    })
+    .collect::<Result<Vec<_>, String>>()?;
+  Ok(ConfigShowJson {
+    package: snapshot.package.clone(),
+    version,
+    selected_entry: selected_entry.map(str::to_owned),
+    entries,
+  })
+}
+
+fn snapshot_content_revision(input_path: &str) -> Result<String, String> {
+  let content = fs::read(input_path).map_err(|error| format!("Failed to read {input_path}: {error}"))?;
+  let mut hasher = Md5::new();
+  hasher.update(content);
+  Ok(format!("md5:{}", hex::encode(hasher.finalize())))
+}
+
+fn config_error_code(error: &str) -> &'static str {
+  if error.starts_with("Entry '") && error.contains(" not found") {
+    "E_CONFIG_ENTRY_NOT_FOUND"
+  } else if error.ends_with(" does not exist") {
+    "E_CONFIG_SNAPSHOT_NOT_FOUND"
+  } else {
+    "E_CONFIG_SNAPSHOT_INVALID"
+  }
+}
+
+fn emit_config_json<T: Serialize>(command: &'static str, input_path: &str, result: Result<T, String>) -> Result<(), String> {
+  let revision = snapshot_content_revision(input_path).ok();
+  match result {
+    Ok(data) => {
+      let envelope = ConfigJsonEnvelope {
+        schema_version: CONFIG_JSON_SCHEMA_VERSION,
+        command,
+        data: Some(data),
+        diagnostics: vec![],
+        revision,
+      };
+      println!(
+        "{}",
+        serde_json::to_string_pretty(&envelope).map_err(|error| format!("Failed to serialize config JSON: {error}"))?
+      );
+      Ok(())
+    }
+    Err(error) => {
+      let envelope = ConfigJsonEnvelope::<serde_json::Value> {
+        schema_version: CONFIG_JSON_SCHEMA_VERSION,
+        command,
+        data: None,
+        diagnostics: vec![ConfigDiagnostic {
+          code: config_error_code(&error),
+          message: error.clone(),
+        }],
+        revision,
+      };
+      println!(
+        "{}",
+        serde_json::to_string_pretty(&envelope).map_err(|json_error| format!("Failed to serialize config JSON: {json_error}"))?
+      );
+      Err(error)
+    }
+  }
+}
+
+fn json_output_requested(format: &str) -> Result<bool, String> {
+  match format {
+    "human" | "text" => Ok(false),
+    "json" => Ok(true),
+    other => Err(format!("Unknown config output format `{other}`. Expected `human` or `json`.")),
+  }
+}
 
 fn load_snapshot_for_display(input_path: &str) -> Result<snapshot::Snapshot, String> {
   if !Path::new(input_path).exists() {
@@ -76,6 +253,13 @@ fn format_target(target: Option<snapshot::SnapshotTarget>) -> &'static str {
 }
 
 fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String> {
+  if json_output_requested(&opts.format)? {
+    let result = (|| {
+      let snapshot = load_snapshot_for_display(input_path)?;
+      config_show_json(&snapshot, opts.entry.as_deref(), package_version_for_snapshot(input_path)?)
+    })();
+    return emit_config_json("config.show", input_path, result);
+  }
   let snapshot = load_snapshot_for_display(input_path)?;
 
   if let Some(name) = &opts.entry {
@@ -126,6 +310,25 @@ fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String>
 }
 
 fn handle_type_slots(opts: &ConfigTypeSlotsCommand, input_path: &str) -> Result<(), String> {
+  if json_output_requested(&opts.format)? {
+    let result = (|| {
+      let snapshot = load_snapshot_for_display(input_path)?;
+      let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
+      let entry = snapshot.entries.get(name).ok_or_else(|| {
+        format!(
+          "Entry '{name}' not found. Available: {}",
+          snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
+        )
+      })?;
+      let entry = entry_config_json(name, entry);
+      Ok(ConfigTypeSlotsJson {
+        package: snapshot.package,
+        type_slots: entry.type_slots.clone(),
+        entry,
+      })
+    })();
+    return emit_config_json("config.type-slots", input_path, result);
+  }
   let snapshot = load_snapshot_for_display(input_path)?;
   let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
   let (label, type_slots) = {
@@ -152,6 +355,42 @@ fn handle_type_slots(opts: &ConfigTypeSlotsCommand, input_path: &str) -> Result<
 }
 
 fn handle_modules(opts: &ConfigModulesCommand, input_path: &str) -> Result<(), String> {
+  if json_output_requested(&opts.format)? {
+    let result = (|| {
+      let snapshot = load_snapshot_for_display(input_path)?;
+      let base_dir = Path::new(input_path).parent().unwrap_or(Path::new("."));
+      let module_folder = calcit::project_module_folder(base_dir);
+      let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
+      let entry = snapshot.entries.get(name).ok_or_else(|| {
+        format!(
+          "Entry '{name}' not found. Available: {}",
+          snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
+        )
+      })?;
+      let modules = entry
+        .modules
+        .iter()
+        .map(|module_path| match load_module_silent(module_path, base_dir, &module_folder) {
+          Ok(module_snapshot) => ModuleConfigJson {
+            path: module_path.clone(),
+            package: Some(module_snapshot.package),
+            status: "loaded",
+          },
+          Err(_) => ModuleConfigJson {
+            path: module_path.clone(),
+            package: None,
+            status: "failed",
+          },
+        })
+        .collect();
+      Ok(ConfigModulesJson {
+        package: snapshot.package,
+        entry: entry_config_json(name, entry),
+        modules,
+      })
+    })();
+    return emit_config_json("config.modules", input_path, result);
+  }
   let snapshot = load_snapshot_for_display(input_path)?;
 
   let base_dir = Path::new(input_path).parent().unwrap_or(Path::new("."));
@@ -628,6 +867,79 @@ mod tests {
   fn entry_target_display_marks_unset_values() {
     assert_eq!(format_target(Some(snapshot::SnapshotTarget::Node)), "node");
     assert_eq!(format_target(None), "(none)");
+  }
+
+  #[test]
+  fn config_json_round_trips_targets_and_orders_entries_and_maps() {
+    let make_entry = |target| snapshot::SnapshotEntry {
+      mode: snapshot::SnapshotRunMode::Js,
+      init_fn: "app.main/main!".to_owned(),
+      reload_fn: "app.main/reload!".to_owned(),
+      description: "demo".to_owned(),
+      modules: vec!["z/".to_owned(), "a/".to_owned()],
+      type_slots: HashMap::from([
+        ("z-slot".to_owned(), "app.schema/Z".to_owned()),
+        ("a-slot".to_owned(), "app.schema/A".to_owned()),
+      ]),
+      feature_policy: HashMap::from([
+        ("z-feature".to_owned(), snapshot::FeaturePolicy::Warn),
+        ("js-ffi".to_owned(), snapshot::FeaturePolicy::Error),
+      ]),
+      target,
+    };
+    for (target, expected) in [
+      (Some(snapshot::SnapshotTarget::Browser), Some("browser")),
+      (Some(snapshot::SnapshotTarget::Node), Some("node")),
+      (Some(snapshot::SnapshotTarget::Native), Some("native")),
+      (Some(snapshot::SnapshotTarget::Wasm), Some("wasm")),
+      (None, None),
+    ] {
+      let entry = entry_config_json("default", &make_entry(target));
+      assert_eq!(entry.target, expected);
+      assert_eq!(entry.type_slots.keys().cloned().collect::<Vec<_>>(), ["a-slot", "z-slot"]);
+      assert_eq!(entry.feature_policy.keys().cloned().collect::<Vec<_>>(), ["js-ffi", "z-feature"]);
+      assert_eq!(
+        entry.modules,
+        ["z/", "a/"],
+        "module declaration order is semantic and must be preserved"
+      );
+    }
+
+    let snapshot = snapshot::Snapshot {
+      package: "demo".to_owned(),
+      about: None,
+      version: "0.0.1".to_owned(),
+      entries: HashMap::from([
+        ("zeta".to_owned(), make_entry(Some(snapshot::SnapshotTarget::Wasm))),
+        ("default".to_owned(), make_entry(Some(snapshot::SnapshotTarget::Native))),
+        ("alpha".to_owned(), make_entry(Some(snapshot::SnapshotTarget::Browser))),
+      ]),
+      files: HashMap::new(),
+      active_entry: snapshot::DEFAULT_ENTRY_NAME.to_owned(),
+    };
+    let all = config_show_json(&snapshot, None, Some("1.2.3".to_owned())).expect("all entries");
+    assert_eq!(
+      all.entries.iter().map(|entry| entry.name.as_str()).collect::<Vec<_>>(),
+      ["alpha", "default", "zeta"]
+    );
+    assert_eq!(all.version.as_deref(), Some("1.2.3"));
+    let selected = config_show_json(&snapshot, Some("zeta"), None).expect("selected entry");
+    assert_eq!(selected.entries.len(), 1);
+    assert_eq!(selected.entries[0].target, Some("wasm"));
+    assert_eq!(selected.selected_entry.as_deref(), Some("zeta"));
+  }
+
+  #[test]
+  fn config_json_error_codes_are_stable() {
+    assert_eq!(
+      config_error_code("Entry 'missing' not found. Available: default"),
+      "E_CONFIG_ENTRY_NOT_FOUND"
+    );
+    assert_eq!(config_error_code("missing.cirru does not exist"), "E_CONFIG_SNAPSHOT_NOT_FOUND");
+    assert_eq!(
+      config_error_code("Failed to parse file 'calcit.cirru'"),
+      "E_CONFIG_SNAPSHOT_INVALID"
+    );
   }
 
   #[test]

--- a/src/bin/cli_handlers/config.rs
+++ b/src/bin/cli_handlers/config.rs
@@ -96,6 +96,16 @@ fn entry_config_json(name: &str, entry: &snapshot::SnapshotEntry) -> EntryConfig
   }
 }
 
+fn available_entry_names(snapshot: &snapshot::Snapshot) -> String {
+  let mut names = snapshot.entries.keys().cloned().collect::<Vec<_>>();
+  names.sort();
+  names.join(", ")
+}
+
+fn missing_entry_error(snapshot: &snapshot::Snapshot, name: &str) -> String {
+  format!("Entry '{name}' not found. Available: {}", available_entry_names(snapshot))
+}
+
 fn config_show_json(
   snapshot: &snapshot::Snapshot,
   selected_entry: Option<&str>,
@@ -104,10 +114,7 @@ fn config_show_json(
   let mut names = match selected_entry {
     Some(name) => {
       if !snapshot.entries.contains_key(name) {
-        return Err(format!(
-          "Entry '{name}' not found. Available: {}",
-          snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
-        ));
+        return Err(missing_entry_error(snapshot, name));
       }
       vec![name.to_owned()]
     }
@@ -132,11 +139,10 @@ fn config_show_json(
   })
 }
 
-fn snapshot_content_revision(input_path: &str) -> Result<String, String> {
-  let content = fs::read(input_path).map_err(|error| format!("Failed to read {input_path}: {error}"))?;
+fn snapshot_content_revision(content: &[u8]) -> String {
   let mut hasher = Md5::new();
   hasher.update(content);
-  Ok(format!("md5:{}", hex::encode(hasher.finalize())))
+  format!("md5:{}", hex::encode(hasher.finalize()))
 }
 
 fn config_error_code(error: &str) -> &'static str {
@@ -149,8 +155,7 @@ fn config_error_code(error: &str) -> &'static str {
   }
 }
 
-fn emit_config_json<T: Serialize>(command: &'static str, input_path: &str, result: Result<T, String>) -> Result<(), String> {
-  let revision = snapshot_content_revision(input_path).ok();
+fn emit_config_json<T: Serialize>(command: &'static str, revision: Option<String>, result: Result<T, String>) -> Result<(), String> {
   match result {
     Ok(data) => {
       let envelope = ConfigJsonEnvelope {
@@ -194,11 +199,15 @@ fn json_output_requested(format: &str) -> Result<bool, String> {
   }
 }
 
-fn load_snapshot_for_display(input_path: &str) -> Result<snapshot::Snapshot, String> {
+fn read_snapshot_content(input_path: &str) -> Result<Vec<u8>, String> {
   if !Path::new(input_path).exists() {
     return Err(format!("{input_path} does not exist"));
   }
-  let mut content = fs::read_to_string(input_path).map_err(|e| format!("Failed to read file: {e}"))?;
+  fs::read(input_path).map_err(|e| format!("Failed to read file: {e}"))
+}
+
+fn parse_snapshot_content(content: Vec<u8>, input_path: &str) -> Result<snapshot::Snapshot, String> {
+  let mut content = String::from_utf8(content).map_err(|e| format!("Failed to read file: {e}"))?;
   strip_shebang(&mut content);
   let data = cirru_edn::parse(&content).map_err(|e| {
     eprintln!("\nFailed to parse file '{input_path}':");
@@ -206,6 +215,24 @@ fn load_snapshot_for_display(input_path: &str) -> Result<snapshot::Snapshot, Str
     format!("Failed to parse file '{input_path}'")
   })?;
   snapshot::load_snapshot_data(&data, input_path)
+}
+
+fn load_snapshot_for_display(input_path: &str) -> Result<snapshot::Snapshot, String> {
+  parse_snapshot_content(read_snapshot_content(input_path)?, input_path)
+}
+
+fn config_json_query<T>(
+  input_path: &str,
+  query: impl FnOnce(snapshot::Snapshot) -> Result<T, String>,
+) -> (Option<String>, Result<T, String>) {
+  match read_snapshot_content(input_path) {
+    Ok(content) => {
+      let revision = Some(snapshot_content_revision(&content));
+      let result = parse_snapshot_content(content, input_path).and_then(query);
+      (revision, result)
+    }
+    Err(error) => (None, Err(error)),
+  }
 }
 
 pub fn handle_config_command(cmd: &ConfigCommand, snapshot_file: &str) -> Result<(), String> {
@@ -254,21 +281,15 @@ fn format_target(target: Option<snapshot::SnapshotTarget>) -> &'static str {
 
 fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String> {
   if json_output_requested(&opts.format)? {
-    let result = (|| {
-      let snapshot = load_snapshot_for_display(input_path)?;
+    let (revision, result) = config_json_query(input_path, |snapshot| {
       config_show_json(&snapshot, opts.entry.as_deref(), package_version_for_snapshot(input_path)?)
-    })();
-    return emit_config_json("config.show", input_path, result);
+    });
+    return emit_config_json("config.show", revision, result);
   }
   let snapshot = load_snapshot_for_display(input_path)?;
 
   if let Some(name) = &opts.entry {
-    let entry = snapshot.entries.get(name).ok_or_else(|| {
-      format!(
-        "Entry '{name}' not found. Available: {}",
-        snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
-      )
-    })?;
+    let entry = snapshot.entries.get(name).ok_or_else(|| missing_entry_error(&snapshot, name))?;
     println!("{}", format!("Entry '{name}':").bold());
     println!("  {}: {}", "mode".cyan(), entry.mode);
     println!("  {}: {}", "target".cyan(), format_target(entry.target));
@@ -311,33 +332,22 @@ fn handle_show(opts: &ConfigShowCommand, input_path: &str) -> Result<(), String>
 
 fn handle_type_slots(opts: &ConfigTypeSlotsCommand, input_path: &str) -> Result<(), String> {
   if json_output_requested(&opts.format)? {
-    let result = (|| {
-      let snapshot = load_snapshot_for_display(input_path)?;
+    let (revision, result) = config_json_query(input_path, |snapshot| {
       let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
-      let entry = snapshot.entries.get(name).ok_or_else(|| {
-        format!(
-          "Entry '{name}' not found. Available: {}",
-          snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
-        )
-      })?;
+      let entry = snapshot.entries.get(name).ok_or_else(|| missing_entry_error(&snapshot, name))?;
       let entry = entry_config_json(name, entry);
       Ok(ConfigTypeSlotsJson {
         package: snapshot.package,
         type_slots: entry.type_slots.clone(),
         entry,
       })
-    })();
-    return emit_config_json("config.type-slots", input_path, result);
+    });
+    return emit_config_json("config.type-slots", revision, result);
   }
   let snapshot = load_snapshot_for_display(input_path)?;
   let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
   let (label, type_slots) = {
-    let entry = snapshot.entries.get(name).ok_or_else(|| {
-      format!(
-        "Entry '{name}' not found. Available: {}",
-        snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
-      )
-    })?;
+    let entry = snapshot.entries.get(name).ok_or_else(|| missing_entry_error(&snapshot, name))?;
     (format!("Type slots in entry '{name}':"), &entry.type_slots)
   };
 
@@ -356,17 +366,11 @@ fn handle_type_slots(opts: &ConfigTypeSlotsCommand, input_path: &str) -> Result<
 
 fn handle_modules(opts: &ConfigModulesCommand, input_path: &str) -> Result<(), String> {
   if json_output_requested(&opts.format)? {
-    let result = (|| {
-      let snapshot = load_snapshot_for_display(input_path)?;
+    let (revision, result) = config_json_query(input_path, |snapshot| {
       let base_dir = Path::new(input_path).parent().unwrap_or(Path::new("."));
       let module_folder = calcit::project_module_folder(base_dir);
       let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
-      let entry = snapshot.entries.get(name).ok_or_else(|| {
-        format!(
-          "Entry '{name}' not found. Available: {}",
-          snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
-        )
-      })?;
+      let entry = snapshot.entries.get(name).ok_or_else(|| missing_entry_error(&snapshot, name))?;
       let modules = entry
         .modules
         .iter()
@@ -388,8 +392,8 @@ fn handle_modules(opts: &ConfigModulesCommand, input_path: &str) -> Result<(), S
         entry: entry_config_json(name, entry),
         modules,
       })
-    })();
-    return emit_config_json("config.modules", input_path, result);
+    });
+    return emit_config_json("config.modules", revision, result);
   }
   let snapshot = load_snapshot_for_display(input_path)?;
 
@@ -398,12 +402,7 @@ fn handle_modules(opts: &ConfigModulesCommand, input_path: &str) -> Result<(), S
 
   let name = opts.entry.as_deref().unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
   let (label, modules) = {
-    let entry = snapshot.entries.get(name).ok_or_else(|| {
-      format!(
-        "Entry '{name}' not found. Available: {}",
-        snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ")
-      )
-    })?;
+    let entry = snapshot.entries.get(name).ok_or_else(|| missing_entry_error(&snapshot, name))?;
     (format!("Modules in entry '{name}':"), entry.modules.clone())
   };
 
@@ -567,8 +566,7 @@ fn handle_add_module(opts: &ConfigAddModuleCommand, snapshot_file: &str) -> Resu
   if let Some(name) = &opts.entry
     && !snapshot.entries.contains_key(name)
   {
-    let available: Vec<_> = snapshot.entries.keys().cloned().collect();
-    return Err(format!("Entry '{name}' not found. Available: {}", available.join(", ")));
+    return Err(missing_entry_error(&snapshot, name));
   }
 
   let configs = select_entry_mut(&mut snapshot, opts.entry.as_deref())?;
@@ -591,8 +589,7 @@ fn handle_rm_module(opts: &ConfigRmModuleCommand, snapshot_file: &str) -> Result
   if let Some(name) = &opts.entry
     && !snapshot.entries.contains_key(name)
   {
-    let available: Vec<_> = snapshot.entries.keys().cloned().collect();
-    return Err(format!("Entry '{name}' not found. Available: {}", available.join(", ")));
+    return Err(missing_entry_error(&snapshot, name));
   }
 
   let configs = select_entry_mut(&mut snapshot, opts.entry.as_deref())?;
@@ -621,7 +618,7 @@ fn normalize_type_slot_name(raw: &str) -> Result<String, String> {
 
 fn select_entry_mut<'a>(snapshot: &'a mut snapshot::Snapshot, entry: Option<&str>) -> Result<&'a mut snapshot::SnapshotEntry, String> {
   let name = entry.unwrap_or(snapshot::DEFAULT_ENTRY_NAME);
-  let available = snapshot.entries.keys().cloned().collect::<Vec<_>>().join(", ");
+  let available = available_entry_names(snapshot);
   snapshot
     .entries
     .get_mut(name)
@@ -927,6 +924,10 @@ mod tests {
     assert_eq!(selected.entries.len(), 1);
     assert_eq!(selected.entries[0].target, Some("wasm"));
     assert_eq!(selected.selected_entry.as_deref(), Some("zeta"));
+    assert_eq!(
+      config_show_json(&snapshot, Some("missing"), None).expect_err("missing entry"),
+      "Entry 'missing' not found. Available: alpha, default, zeta"
+    );
   }
 
   #[test]

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -2519,6 +2519,9 @@ pub struct ConfigShowCommand {
   /// show a named entry (e.g. "test"); defaults to showing all entries
   #[argh(option)]
   pub entry: Option<String>,
+  /// output format: human (default) or json
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
 }
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
@@ -2528,6 +2531,9 @@ pub struct ConfigModulesCommand {
   /// list modules for a named entry (e.g. "test"); defaults to "default"
   #[argh(option)]
   pub entry: Option<String>,
+  /// output format: human (default) or json
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
 }
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
@@ -2537,6 +2543,9 @@ pub struct ConfigTypeSlotsCommand {
   /// list bindings for a named entry; defaults to "default"
   #[argh(option)]
   pub entry: Option<String>,
+  /// output format: human (default) or json
+  #[argh(option, default = "String::from(\"human\")")]
+  pub format: String,
 }
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]


### PR DESCRIPTION
Closes #929

## Summary
- add `--format human|json` to config show/modules/type-slots
- emit deterministic schema-versioned envelopes with complete entry metadata and stable failure diagnostics
- document the contract and extend agent-interface coverage, including automated inventory of the real calcit-core library

## Validation
- `cargo check --bin calcit`
- `cargo test config_json`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface` (28/28)
- `yarn check-all`
- `cargo fmt --check`
- `git diff --check`