### PR TITLE
feat(calx): define program compilation unit / 定义程序编译单元

### DIFF
--- a/docs/run/calx-program-target.md
+++ b/docs/run/calx-program-target.md
@@ -33,6 +33,21 @@ The initial stages are:
 
 The inventory is authoritative. A stage may be narrowed or reordered before implementation when validation or conformance evidence requires it.
 
+### Program contract edition 1
+
+`calcit-calx-program/1` identifies the first program-level compilation-unit contract. It is separate from the executable kernel ABI editions and does not change their meaning.
+
+The compilation unit is derived from one explicitly selected Snapshot entry and preserves:
+
+- the selected entry name;
+- the optional host target, which scopes externally injected capabilities but does not move them into Calx;
+- an `init` root from `:init-fn`;
+- a `reload` root from `:reload-fn`.
+
+Both roles remain present when they name the same definition, while later reachability analysis may deduplicate the shared definition body. A malformed root or missing selected entry produces `CALX_PROGRAM_DEFINITION_REF` or `CALX_PROGRAM_ENTRY_SELECTION`; it never falls back to another entry.
+
+This edition defines compilation input only. calx-vm 0.5.0 still executes the compatibility function named `main`, so program-level multi-root eligibility remains follow-up work and [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) tracks strict named-root execution. Existing `:mode :native` and `:mode :js` behavior is unchanged; this contract does not prematurely expose a `:calx` runtime mode.
+
 ### Hard boundaries
 
 - Unsupported reachable code fails compilation; one compiled program does not silently mix Calx and Calcit execution.
@@ -76,6 +91,21 @@ Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次�
 6. 显式选定的 reference、error 和其他 stateful semantics。
 
 清单是权威依据。若 validation 或 conformance 证据要求，具体阶段可以在实现前收窄或调整顺序。
+
+### Program contract edition 1
+
+`calcit-calx-program/1` 标识第一版程序级 compilation-unit contract。它与可执行 kernel ABI editions 分离，不改变后者语义。
+
+编译单元来自一个显式选中的 Snapshot entry，并保留：
+
+- 选中的 entry 名称；
+- 可选 host target：它约束外部注入 capability，但不把 capability 实现迁入 Calx；
+- 来自 `:init-fn` 的 `init` root；
+- 来自 `:reload-fn` 的 `reload` root。
+
+两个角色指向同一 definition 时仍分别保留；后续 reachability analysis 可以去重共享 definition body。root 格式错误或 selected entry 缺失时分别产生 `CALX_PROGRAM_DEFINITION_REF` 或 `CALX_PROGRAM_ENTRY_SELECTION`，绝不回退到其他 entry。
+
+本 edition 只定义编译输入。calx-vm 0.5.0 仍只执行名为 `main` 的兼容函数，所以 program-level multi-root eligibility 仍是后续任务，严格 named-root execution 由 [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 追踪。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。
 
 ### 硬边界
 

--- a/editing-history/202609100100-calx-program-contract-v1.md
+++ b/editing-history/202609100100-calx-program-contract-v1.md
@@ -1,0 +1,7 @@
+# Define the first Calx program compilation unit
+
+- Added the separate `calcit-calx-program/1` edition without changing the existing kernel `/1` and `/2` contracts.
+- Derived one deterministic compilation unit from the explicitly selected Snapshot entry, preserving entry name, optional host target, and distinct init/reload roles.
+- Kept duplicate lifecycle roles even when they reference one definition so later reachability can deduplicate code without losing lifecycle meaning.
+- Added stable errors for missing entry selection and malformed qualified roots, with no fallback to another entry.
+- Recorded that calx-vm 0.5.0 still requires `main`; named strict execution is tracked separately before multi-root program lowering.

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -10,6 +10,7 @@ pub mod benchmark_session;
 mod cache;
 pub mod coverage;
 mod lowering;
+mod program_contract;
 
 pub use cache::{CalxCacheMissReason, CalxCachePreparation, CalxCachePrepareReport, CalxCompileCache, CalxCompileCacheStats};
 pub use calx_vm::{Calx as CalxValue, CalxBuildError, CalxError, CalxProgramError};
@@ -21,6 +22,10 @@ pub use lowering::{
   CalxCompiledArtifact, CalxCompiledKernel, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind, CalxKernelCompileError,
   CalxKernelCompileTimings, CalxKernelRunError, CalxLoweringError, CalxPreparedKernel, compile_calx_kernel,
   compile_calx_kernel_measured, compile_calx_kernel_with_imports, compile_calx_kernel_with_imports_measured,
+};
+pub use program_contract::{
+  CALX_PROGRAM_ABI_EDITION, CalxProgramCompilationUnit, CalxProgramContractCode, CalxProgramContractError, CalxProgramRoot,
+  CalxProgramRootRole,
 };
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/codegen/calx/program_contract.rs
+++ b/src/codegen/calx/program_contract.rs
@@ -1,0 +1,207 @@
+//! Versioned compilation-unit contract for the Calx program backend.
+//!
+//! This module selects lifecycle roots from one configured Snapshot entry. It
+//! does not lower or execute them: the current VM still exposes the kernel
+//! compatibility entry named `main` only.
+
+use std::fmt;
+use std::sync::Arc;
+
+use crate::snapshot::{Snapshot, SnapshotTarget};
+
+use super::CalxDefinitionRef;
+
+/// First program-level contract. Kernel editions `/1` and `/2` remain separate.
+pub const CALX_PROGRAM_ABI_EDITION: &str = "calcit-calx-program/1";
+
+/// Lifecycle role preserved when multiple configured roots share one definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalxProgramRootRole {
+  Init,
+  Reload,
+}
+
+impl CalxProgramRootRole {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::Init => "init",
+      Self::Reload => "reload",
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxProgramRoot {
+  pub role: CalxProgramRootRole,
+  pub definition: CalxDefinitionRef,
+}
+
+/// Deterministic program input selected before eligibility and lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxProgramCompilationUnit {
+  pub abi_edition: Arc<str>,
+  pub entry_name: Arc<str>,
+  pub host_target: Option<SnapshotTarget>,
+  pub roots: Vec<CalxProgramRoot>,
+}
+
+impl CalxProgramCompilationUnit {
+  /// Select the active Snapshot entry without changing the configured native/JS mode.
+  pub fn from_snapshot(snapshot: &Snapshot) -> Result<Self, CalxProgramContractError> {
+    let entry_name: Arc<str> = Arc::from(snapshot.active_entry_name());
+    let entry = snapshot.active_entry().map_err(|message| CalxProgramContractError {
+      code: CalxProgramContractCode::EntrySelection,
+      entry_name: entry_name.clone(),
+      role: None,
+      message,
+    })?;
+    let init = parse_root(&entry_name, CalxProgramRootRole::Init, &entry.init_fn)?;
+    let reload = parse_root(&entry_name, CalxProgramRootRole::Reload, &entry.reload_fn)?;
+    Ok(Self {
+      abi_edition: Arc::from(CALX_PROGRAM_ABI_EDITION),
+      entry_name,
+      host_target: entry.target,
+      roots: vec![init, reload],
+    })
+  }
+
+  /// Deterministic diagnostic/golden text; not a serialized compiler ABI.
+  pub fn stable_summary(&self) -> String {
+    let target = self.host_target.map(SnapshotTarget::as_str).unwrap_or("unspecified");
+    let mut output = format!("abi {}\nentry {}\nhost-target {target}\n", self.abi_edition, self.entry_name);
+    for root in &self.roots {
+      output.push_str(&format!("root {} {}\n", root.role.as_str(), root.definition.qualified()));
+    }
+    output
+  }
+}
+
+fn parse_root(entry_name: &Arc<str>, role: CalxProgramRootRole, configured: &str) -> Result<CalxProgramRoot, CalxProgramContractError> {
+  let parsed = configured.split_once('/').and_then(|(namespace, definition)| {
+    if configured.trim() == configured && !namespace.is_empty() && !definition.is_empty() {
+      Some(CalxDefinitionRef::new(namespace, definition))
+    } else {
+      None
+    }
+  });
+  let Some(definition) = parsed else {
+    return Err(CalxProgramContractError {
+      code: CalxProgramContractCode::DefinitionRef,
+      entry_name: entry_name.clone(),
+      role: Some(role),
+      message: format!(
+        "entry `{entry_name}` {} root must be a non-empty `namespace/definition`, got `{configured}`",
+        role.as_str()
+      ),
+    });
+  };
+  Ok(CalxProgramRoot { role, definition })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CalxProgramContractCode {
+  EntrySelection,
+  DefinitionRef,
+}
+
+impl CalxProgramContractCode {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::EntrySelection => "CALX_PROGRAM_ENTRY_SELECTION",
+      Self::DefinitionRef => "CALX_PROGRAM_DEFINITION_REF",
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxProgramContractError {
+  pub code: CalxProgramContractCode,
+  pub entry_name: Arc<str>,
+  pub role: Option<CalxProgramRootRole>,
+  pub message: String,
+}
+
+impl fmt::Display for CalxProgramContractError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "[{}] {}", self.code.as_str(), self.message)
+  }
+}
+
+impl std::error::Error for CalxProgramContractError {}
+
+#[cfg(test)]
+mod tests {
+  use std::collections::HashMap;
+
+  use crate::snapshot::{SnapshotEntry, SnapshotRunMode};
+
+  use super::*;
+
+  fn snapshot_with(entry_name: &str, entry: SnapshotEntry) -> Snapshot {
+    Snapshot {
+      package: "demo".to_owned(),
+      about: None,
+      version: "0.0.1".to_owned(),
+      entries: HashMap::from([(entry_name.to_owned(), entry)]),
+      files: HashMap::new(),
+      active_entry: entry_name.to_owned(),
+    }
+  }
+
+  fn entry(init_fn: &str, reload_fn: &str, target: Option<SnapshotTarget>) -> SnapshotEntry {
+    SnapshotEntry {
+      mode: SnapshotRunMode::Native,
+      init_fn: init_fn.to_owned(),
+      reload_fn: reload_fn.to_owned(),
+      description: String::new(),
+      modules: vec![],
+      type_slots: HashMap::new(),
+      feature_policy: HashMap::new(),
+      target,
+    }
+  }
+
+  #[test]
+  fn preserves_lifecycle_roles_even_when_they_share_a_definition() {
+    let snapshot = snapshot_with(
+      "server",
+      entry("app.server/main!", "app.server/main!", Some(SnapshotTarget::Native)),
+    );
+    let unit = CalxProgramCompilationUnit::from_snapshot(&snapshot).expect("program unit");
+    assert_eq!(unit.abi_edition.as_ref(), CALX_PROGRAM_ABI_EDITION);
+    assert_eq!(unit.roots.len(), 2);
+    assert_eq!(unit.roots[0].role, CalxProgramRootRole::Init);
+    assert_eq!(unit.roots[1].role, CalxProgramRootRole::Reload);
+    assert_eq!(unit.roots[0].definition, unit.roots[1].definition);
+    assert_eq!(
+      unit.stable_summary(),
+      "abi calcit-calx-program/1\nentry server\nhost-target native\nroot init app.server/main!\nroot reload app.server/main!\n"
+    );
+  }
+
+  #[test]
+  fn preserves_operator_definition_names_after_the_first_separator() {
+    let snapshot = snapshot_with("default", entry("calcit.core//", "app.main/reload!", None));
+    let unit = CalxProgramCompilationUnit::from_snapshot(&snapshot).expect("program unit");
+    assert_eq!(unit.roots[0].definition.namespace.as_ref(), "calcit.core");
+    assert_eq!(unit.roots[0].definition.definition.as_ref(), "/");
+  }
+
+  #[test]
+  fn rejects_malformed_roots_with_a_stable_code_and_role() {
+    let snapshot = snapshot_with("default", entry("app.main", "app.main/reload!", None));
+    let error = CalxProgramCompilationUnit::from_snapshot(&snapshot).expect_err("invalid root");
+    assert_eq!(error.code, CalxProgramContractCode::DefinitionRef);
+    assert_eq!(error.role, Some(CalxProgramRootRole::Init));
+    assert_eq!(error.code.as_str(), "CALX_PROGRAM_DEFINITION_REF");
+  }
+
+  #[test]
+  fn reports_missing_selected_entry_without_falling_back_to_default() {
+    let mut snapshot = snapshot_with("default", entry("app.main/main!", "app.main/reload!", None));
+    snapshot.active_entry = "missing".to_owned();
+    let error = CalxProgramCompilationUnit::from_snapshot(&snapshot).expect_err("missing entry");
+    assert_eq!(error.code, CalxProgramContractCode::EntrySelection);
+    assert_eq!(error.entry_name.as_ref(), "missing");
+  }
+}


### PR DESCRIPTION
## English

### Summary

- Define the separate `calcit-calx-program/1` compilation-unit edition without changing kernel ABI `/1` or `/2`.
- Derive a deterministic Calx program unit from the explicitly selected Snapshot entry.
- Preserve entry name, optional host target, and distinct `init`/`reload` root roles.
- Add stable errors for missing entry selection and malformed qualified roots, with no fallback to another entry.
- Document that named-root execution is blocked on calx-vm #70; no `:calx` runtime mode is exposed yet.

### Boundaries

This PR defines program compilation input only. It does not lower multiple roots, change VM values, inject platform FFI, generate a dispatcher, or alter native/JS entry behavior. Generic Nil and Dynamic do not enter the contract.

### Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test` — 789 library tests, 325 CLI tests, 23 WASM tests
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` — 28/28 scenarios plus definition protocol round trips

Refs #887
Refs #943
Refs calcit-lang/calx-vm#61
Refs calcit-lang/calx-vm#70

## 中文

### 概要

- 定义独立的 `calcit-calx-program/1` compilation-unit edition，不改变 kernel ABI `/1` 或 `/2`。
- 从显式选中的 Snapshot entry 产生确定性的 Calx program unit。
- 保留 entry 名称、可选 host target，以及不同的 `init`/`reload` root 角色。
- 为 selected entry 缺失和 qualified root 格式错误增加稳定错误码，不回退到其他 entry。
- 记录 named-root execution 由 calx-vm #70 阻塞；当前不暴露 `:calx` runtime mode。

### 边界

本 PR 只定义程序编译输入。它不 lowering 多 roots、不改变 VM values、不注入平台 FFI、不生成 dispatcher，也不改变 native/JS entry 行为。通用 Nil 与 Dynamic 不进入本契约。

### 验证

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test` — 789 个 library tests、325 个 CLI tests、23 个 WASM tests
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` — 28/28 scenarios，并通过 definition protocol round trips

关联 #887
关联 #943
关联 calcit-lang/calx-vm#61
关联 calcit-lang/calx-vm#70
