### PR TITLE
feat(calx): check whole-program eligibility / 检查整程序可编译性

### DIFF
--- a/docs/run/calx-program-target.md
+++ b/docs/run/calx-program-target.md
@@ -46,7 +46,9 @@ The compilation unit is derived from one explicitly selected Snapshot entry and 
 
 Both roles remain present when they name the same definition, while later reachability analysis may deduplicate the shared definition body. A malformed root or missing selected entry produces `CALX_PROGRAM_DEFINITION_REF` or `CALX_PROGRAM_ENTRY_SELECTION`; it never falls back to another entry.
 
-This edition defines compilation input only. calx-vm 0.5.0 still executes the compatibility function named `main`, so program-level multi-root eligibility remains follow-up work and [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) tracks strict named-root execution. Existing `:mode :native` and `:mode :js` behavior is unchanged; this contract does not prematurely expose a `:calx` runtime mode.
+Whole-program eligibility checks `init` and `reload` as one atomic unit. It deduplicates shared reachable function bodies, preserves both lifecycle roles, and publishes no partial eligible program when either root fails. Explicit typed imports are shared across the roots; undeclared host behavior remains ineligible. Invalid editions and root sets fail before definition analysis with `CALX_PROGRAM_ELIGIBILITY_ABI_EDITION` or `CALX_PROGRAM_ELIGIBILITY_ROOT_SET`.
+
+This edition now defines compilation input and a checked reachable program, but not program lowering or execution. calx-vm 0.5.0 still executes the compatibility function named `main`; [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) tracks strict named-root execution required before lifecycle roots can be lowered without a dispatcher. Existing `:mode :native` and `:mode :js` behavior is unchanged; this contract does not prematurely expose a `:calx` runtime mode.
 
 ### Hard boundaries
 
@@ -105,7 +107,9 @@ Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次�
 
 两个角色指向同一 definition 时仍分别保留；后续 reachability analysis 可以去重共享 definition body。root 格式错误或 selected entry 缺失时分别产生 `CALX_PROGRAM_DEFINITION_REF` 或 `CALX_PROGRAM_ENTRY_SELECTION`，绝不回退到其他 entry。
 
-本 edition 只定义编译输入。calx-vm 0.5.0 仍只执行名为 `main` 的兼容函数，所以 program-level multi-root eligibility 仍是后续任务，严格 named-root execution 由 [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 追踪。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。
+整程序 eligibility 将 `init` 和 `reload` 作为一个原子单元检查：共享的可达函数体会去重，两个生命周期角色仍被保留；任一 root 失败时都不发布部分 eligible program。两个 roots 共享同一组显式 typed imports，未声明的 host 行为仍然不合格。无效 edition 或 root 集合会在 definition analysis 前分别以 `CALX_PROGRAM_ELIGIBILITY_ABI_EDITION`、`CALX_PROGRAM_ELIGIBILITY_ROOT_SET` 失败。
+
+本 edition 现在定义编译输入和经过检查的可达 program，但还不包含 program lowering 或执行。calx-vm 0.5.0 仍只执行名为 `main` 的兼容函数；在不引入 dispatcher 的前提下 lowering 生命周期 roots 所需的严格 named-root execution 由 [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 追踪。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。
 
 ### 硬边界
 

--- a/editing-history/202609100125-calx-program-eligibility.md
+++ b/editing-history/202609100125-calx-program-eligibility.md
@@ -1,0 +1,7 @@
+# Check Calx lifecycle roots as one program
+
+- Added fail-closed eligibility for a `calcit-calx-program/1` compilation unit: exactly one init root and one reload root must pass together.
+- Merged reachable function closures deterministically while preserving lifecycle roles and deduplicating shared definitions.
+- Kept platform behavior outside the VM through explicit, signature-checked typed imports shared by all roots.
+- Added stable program-contract and root-scoped diagnostic summaries; no partial program, Dynamic/Nil fallback, lowering, dispatcher, or runtime mode was introduced.
+- Verified the change with `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`, `yarn compile`, `yarn check-agent-interface`, and `yarn check-all`.

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -11,6 +11,7 @@ mod cache;
 pub mod coverage;
 mod lowering;
 mod program_contract;
+mod program_eligibility;
 
 pub use cache::{CalxCacheMissReason, CalxCachePreparation, CalxCachePrepareReport, CalxCompileCache, CalxCompileCacheStats};
 pub use calx_vm::{Calx as CalxValue, CalxBuildError, CalxError, CalxProgramError};
@@ -26,6 +27,10 @@ pub use lowering::{
 pub use program_contract::{
   CALX_PROGRAM_ABI_EDITION, CalxProgramCompilationUnit, CalxProgramContractCode, CalxProgramContractError, CalxProgramRoot,
   CalxProgramRootRole,
+};
+pub use program_eligibility::{
+  CalxEligibleProgram, CalxProgramEligibilityCode, CalxProgramEligibilityIssue, CalxProgramEligibilityReport,
+  CalxProgramRootEligibilityIssue, analyze_calx_program_eligibility, analyze_calx_program_eligibility_with_imports,
 };
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -289,18 +294,22 @@ impl CalxEligibleCallGraph {
   /// experimental report format, not a serialized compiler ABI.
   pub fn stable_summary(&self) -> String {
     let mut output = format!("abi {}\nentry {}\n", self.abi_edition, self.entry.qualified());
-    for function in &self.functions {
-      let params = function.params.iter().map(|value| value.as_str()).collect::<Vec<_>>().join(",");
-      let result = function.result.map(CalxScalarType::as_str).unwrap_or("Void");
-      output.push_str(&format!("function {} ({params})->{result}\n", function.definition.qualified()));
-      for callee in &function.direct_calls {
-        output.push_str(&format!("  call {}\n", callee.qualified()));
-      }
-      for import in &function.host_imports {
-        output.push_str(&format!("  import {}\n", import.qualified()));
-      }
-    }
+    write_eligible_functions(&mut output, &self.functions);
     output
+  }
+}
+
+fn write_eligible_functions(output: &mut String, functions: &[CalxEligibleFunction]) {
+  for function in functions {
+    let params = function.params.iter().map(|value| value.as_str()).collect::<Vec<_>>().join(",");
+    let result = function.result.map(CalxScalarType::as_str).unwrap_or("Void");
+    output.push_str(&format!("function {} ({params})->{result}\n", function.definition.qualified()));
+    for callee in &function.direct_calls {
+      output.push_str(&format!("  call {}\n", callee.qualified()));
+    }
+    for import in &function.host_imports {
+      output.push_str(&format!("  import {}\n", import.qualified()));
+    }
   }
 }
 

--- a/src/codegen/calx/program_eligibility.rs
+++ b/src/codegen/calx/program_eligibility.rs
@@ -1,0 +1,206 @@
+//! Whole-program eligibility for the versioned Calx compilation unit.
+//!
+//! Lifecycle roots are checked together and their reachable functions are
+//! merged deterministically. No partial program is published when any root is
+//! ineligible, and host capabilities remain explicit typed imports.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::program::CompiledProgram;
+use crate::snapshot::SnapshotTarget;
+
+use super::{
+  CALX_PROGRAM_ABI_EDITION, CalxDefinitionRef, CalxEligibleFunction, CalxFallbackIssue, CalxHostImports, CalxProgramCompilationUnit,
+  CalxProgramRoot, CalxProgramRootRole, analyze_calx_eligibility_with_imports, calx_kernel_abi_edition, write_eligible_functions,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CalxProgramEligibilityCode {
+  AbiEdition,
+  RootSet,
+}
+
+impl CalxProgramEligibilityCode {
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::AbiEdition => "CALX_PROGRAM_ELIGIBILITY_ABI_EDITION",
+      Self::RootSet => "CALX_PROGRAM_ELIGIBILITY_ROOT_SET",
+    }
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CalxProgramEligibilityIssue {
+  pub code: CalxProgramEligibilityCode,
+  pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CalxProgramRootEligibilityIssue {
+  pub root_roles: Vec<CalxProgramRootRole>,
+  pub root: CalxDefinitionRef,
+  pub issue: CalxFallbackIssue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxProgramEligibilityReport {
+  pub abi_edition: Arc<str>,
+  pub entry_name: Arc<str>,
+  pub program_issues: Vec<CalxProgramEligibilityIssue>,
+  pub root_issues: Vec<CalxProgramRootEligibilityIssue>,
+}
+
+impl CalxProgramEligibilityReport {
+  /// Deterministic diagnostic/golden text; not a serialized compiler ABI.
+  pub fn stable_summary(&self) -> String {
+    let mut output = format!("abi {}\nentry {}\n", self.abi_edition, self.entry_name);
+    for issue in &self.program_issues {
+      output.push_str(&format!("program-issue {} message={}\n", issue.code.as_str(), issue.message));
+    }
+    for root_issue in &self.root_issues {
+      let roles = root_issue.root_roles.iter().map(|role| role.as_str()).collect::<Vec<_>>().join(",");
+      let source_path = root_issue
+        .issue
+        .source_path
+        .as_ref()
+        .map(|parts| parts.iter().map(u16::to_string).collect::<Vec<_>>().join("."))
+        .unwrap_or_else(|| "-".to_owned());
+      let call_path = root_issue
+        .issue
+        .call_path
+        .iter()
+        .map(CalxDefinitionRef::qualified)
+        .collect::<Vec<_>>()
+        .join(" -> ");
+      output.push_str(&format!(
+        "root-issue roles={roles} root={} {} {}/{} source={} call={} message={}\n",
+        root_issue.root.qualified(),
+        root_issue.issue.code.as_str(),
+        root_issue.issue.namespace,
+        root_issue.issue.definition,
+        source_path,
+        call_path,
+        root_issue.issue.message
+      ));
+    }
+    output
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxEligibleProgram {
+  pub abi_edition: Arc<str>,
+  pub kernel_abi_edition: Arc<str>,
+  pub entry_name: Arc<str>,
+  pub host_target: Option<SnapshotTarget>,
+  pub roots: Vec<CalxProgramRoot>,
+  pub functions: Vec<CalxEligibleFunction>,
+}
+
+impl CalxEligibleProgram {
+  /// Deterministic diagnostic/golden text; not a serialized compiler ABI.
+  pub fn stable_summary(&self) -> String {
+    let target = self.host_target.map(SnapshotTarget::as_str).unwrap_or("unspecified");
+    let mut output = format!(
+      "abi {}\nkernel-abi {}\nentry {}\nhost-target {target}\n",
+      self.abi_edition, self.kernel_abi_edition, self.entry_name
+    );
+    for root in &self.roots {
+      output.push_str(&format!("root {} {}\n", root.role.as_str(), root.definition.qualified()));
+    }
+    write_eligible_functions(&mut output, &self.functions);
+    output
+  }
+}
+
+pub fn analyze_calx_program_eligibility(
+  program: &CompiledProgram,
+  unit: &CalxProgramCompilationUnit,
+) -> Result<CalxEligibleProgram, CalxProgramEligibilityReport> {
+  analyze_calx_program_eligibility_with_imports(program, unit, &CalxHostImports::new())
+}
+
+pub fn analyze_calx_program_eligibility_with_imports(
+  program: &CompiledProgram,
+  unit: &CalxProgramCompilationUnit,
+  imports: &CalxHostImports,
+) -> Result<CalxEligibleProgram, CalxProgramEligibilityReport> {
+  let mut roots = unit.roots.clone();
+  roots.sort_by(|left, right| left.role.cmp(&right.role).then_with(|| left.definition.cmp(&right.definition)));
+
+  let mut program_issues = vec![];
+  if unit.abi_edition.as_ref() != CALX_PROGRAM_ABI_EDITION {
+    program_issues.push(CalxProgramEligibilityIssue {
+      code: CalxProgramEligibilityCode::AbiEdition,
+      message: format!(
+        "program unit edition `{}` does not match supported edition `{CALX_PROGRAM_ABI_EDITION}`",
+        unit.abi_edition
+      ),
+    });
+  }
+  let init_count = roots.iter().filter(|root| root.role == CalxProgramRootRole::Init).count();
+  let reload_count = roots.iter().filter(|root| root.role == CalxProgramRootRole::Reload).count();
+  if init_count != 1 || reload_count != 1 {
+    program_issues.push(CalxProgramEligibilityIssue {
+      code: CalxProgramEligibilityCode::RootSet,
+      message: format!("program unit requires exactly one init and one reload root, got init={init_count} reload={reload_count}"),
+    });
+  }
+  if !program_issues.is_empty() {
+    return Err(CalxProgramEligibilityReport {
+      abi_edition: unit.abi_edition.clone(),
+      entry_name: unit.entry_name.clone(),
+      program_issues,
+      root_issues: vec![],
+    });
+  }
+
+  let mut roots_by_definition = BTreeMap::<CalxDefinitionRef, Vec<CalxProgramRootRole>>::new();
+  for root in &roots {
+    roots_by_definition.entry(root.definition.clone()).or_default().push(root.role);
+  }
+  for roles in roots_by_definition.values_mut() {
+    roles.sort();
+    roles.dedup();
+  }
+
+  let mut functions = BTreeMap::<CalxDefinitionRef, CalxEligibleFunction>::new();
+  let mut root_issues = vec![];
+  for (root, roles) in roots_by_definition {
+    match analyze_calx_eligibility_with_imports(program, root.namespace.clone(), root.definition.clone(), imports) {
+      Ok(graph) => {
+        for function in graph.functions {
+          functions.entry(function.definition.clone()).or_insert(function);
+        }
+      }
+      Err(report) => {
+        root_issues.extend(report.issues.into_iter().map(|issue| CalxProgramRootEligibilityIssue {
+          root_roles: roles.clone(),
+          root: root.clone(),
+          issue,
+        }));
+      }
+    }
+  }
+  root_issues.sort();
+  root_issues.dedup();
+  if !root_issues.is_empty() {
+    return Err(CalxProgramEligibilityReport {
+      abi_edition: unit.abi_edition.clone(),
+      entry_name: unit.entry_name.clone(),
+      program_issues,
+      root_issues,
+    });
+  }
+
+  let functions = functions.into_values().collect::<Vec<_>>();
+  Ok(CalxEligibleProgram {
+    abi_edition: unit.abi_edition.clone(),
+    kernel_abi_edition: Arc::from(calx_kernel_abi_edition(functions.iter())),
+    entry_name: unit.entry_name.clone(),
+    host_target: unit.host_target,
+    roots,
+    functions,
+  })
+}

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -3,14 +3,17 @@ use crate::calcit::data_shape::{DataShapeGraph, DataShapeNode};
 use crate::calcit::{CalcitFnTypeAnnotation, CalcitImpl, CalcitImport, CalcitStructDef, CalcitSyntax, ImportInfo, SchemaKind};
 use crate::call_stack::CallStackList;
 use crate::codegen::calx::{
-  CalxCacheMissReason, CalxCompileCache, CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport, CalxHostImports,
-  CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError, CalxScalarType, CalxValue, analyze_calx_eligibility,
-  analyze_calx_eligibility_with_imports, compile_calx_kernel, compile_calx_kernel_measured, compile_calx_kernel_with_imports,
+  CALX_PROGRAM_ABI_EDITION, CalxCacheMissReason, CalxCompileCache, CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport,
+  CalxHostImports, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError, CalxProgramCompilationUnit,
+  CalxProgramEligibilityCode, CalxProgramRoot, CalxProgramRootRole, CalxScalarType, CalxValue, analyze_calx_eligibility,
+  analyze_calx_eligibility_with_imports, analyze_calx_program_eligibility, analyze_calx_program_eligibility_with_imports,
+  compile_calx_kernel, compile_calx_kernel_measured, compile_calx_kernel_with_imports,
 };
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
+use crate::snapshot::SnapshotTarget;
 use cirru_edn::EdnTag;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 static CALX_VOID_IMPORT_CALLS: AtomicUsize = AtomicUsize::new(0);
 
@@ -513,6 +516,101 @@ fn calx_eligibility_accepts_five_real_preprocessed_scalar_kernels() {
     bounded_simulation.stable_summary()
   );
   assert_eq!(summary, include_str!("../../tests/fixtures/calx/scalar-kernels.golden.txt"));
+}
+
+fn calx_program_unit(namespace: &str, init: &str, reload: &str) -> CalxProgramCompilationUnit {
+  CalxProgramCompilationUnit {
+    abi_edition: Arc::from(CALX_PROGRAM_ABI_EDITION),
+    entry_name: Arc::from("server"),
+    host_target: Some(SnapshotTarget::Native),
+    roots: vec![
+      CalxProgramRoot {
+        role: CalxProgramRootRole::Init,
+        definition: CalxDefinitionRef::new(namespace, init),
+      },
+      CalxProgramRoot {
+        role: CalxProgramRootRole::Reload,
+        definition: CalxDefinitionRef::new(namespace, reload),
+      },
+    ],
+  }
+}
+
+#[test]
+fn calx_program_eligibility_merges_lifecycle_call_closures() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed preprocessed Calx fixtures");
+  let unit = calx_program_unit(namespace, "range-sum", "affine");
+
+  let program = analyze_calx_program_eligibility(&snapshot, &unit).expect("program roots should be eligible together");
+  assert_eq!(program.abi_edition.as_ref(), CALX_PROGRAM_ABI_EDITION);
+  assert_eq!(program.kernel_abi_edition.as_ref(), "calcit-calx-kernel/1");
+  assert_eq!(program.roots, unit.roots);
+  assert_eq!(
+    program
+      .functions
+      .iter()
+      .map(|function| function.definition.definition.as_ref())
+      .collect::<Vec<_>>(),
+    vec!["affine", "affine-helper", "range-sum"]
+  );
+  assert_eq!(
+    program.stable_summary(),
+    include_str!("../../tests/fixtures/calx/program-eligibility.golden.txt")
+  );
+}
+
+#[test]
+fn calx_program_eligibility_preserves_shared_root_roles_without_duplicate_functions() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-shared";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed preprocessed Calx fixtures");
+  let unit = calx_program_unit(namespace, "affine", "affine");
+
+  let program = analyze_calx_program_eligibility(&snapshot, &unit).expect("shared lifecycle root should be eligible");
+  assert_eq!(program.roots.len(), 2);
+  assert_eq!(program.roots[0].definition, program.roots[1].definition);
+  assert_eq!(program.functions.len(), 2);
+}
+
+#[test]
+fn calx_program_eligibility_rejects_the_whole_unit_when_one_root_fails() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-failure";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed preprocessed Calx fixtures");
+  let unit = calx_program_unit(namespace, "range-sum", "missing");
+
+  let report = analyze_calx_program_eligibility(&snapshot, &unit).expect_err("one failed root must reject the whole program");
+  assert!(report.program_issues.is_empty());
+  assert_eq!(report.root_issues.len(), 1);
+  assert_eq!(report.root_issues[0].root_roles, vec![CalxProgramRootRole::Reload]);
+  assert_eq!(report.root_issues[0].issue.code, CalxFallbackCode::UnsupportedForm);
+  assert!(report.stable_summary().contains("roles=reload"));
+}
+
+#[test]
+fn calx_program_eligibility_rejects_unversioned_or_incomplete_units_before_analysis() {
+  let snapshot = CompiledProgram::default();
+  let unit = CalxProgramCompilationUnit {
+    abi_edition: Arc::from("calcit-calx-program/unknown"),
+    entry_name: Arc::from("server"),
+    host_target: None,
+    roots: vec![],
+  };
+
+  let report = analyze_calx_program_eligibility(&snapshot, &unit).expect_err("invalid program contract must fail closed");
+  assert_eq!(
+    report.program_issues.iter().map(|issue| issue.code).collect::<Vec<_>>(),
+    vec![CalxProgramEligibilityCode::AbiEdition, CalxProgramEligibilityCode::RootSet]
+  );
+  assert!(report.root_issues.is_empty());
 }
 
 #[test]
@@ -1229,6 +1327,34 @@ fn calx_typed_imports_cover_void_value_and_generated_program_golden() {
   assert_eq!(calx_result, native_result);
   assert_eq!(calx_result, Calcit::Number(7.0));
   assert_eq!(CALX_VOID_IMPORT_CALLS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn calx_program_eligibility_keeps_host_capabilities_explicit_across_roots() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-imports";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed import fixtures");
+  let imports = calx_test_host_imports(namespace);
+  let unit = calx_program_unit(namespace, "imported-pipeline", "imported-trap");
+
+  let program = analyze_calx_program_eligibility_with_imports(&snapshot, &unit, &imports)
+    .expect("both roots should use only declared typed capabilities");
+  assert_eq!(program.functions.len(), 2);
+  assert_eq!(
+    program
+      .functions
+      .iter()
+      .flat_map(|function| function.host_imports.iter())
+      .cloned()
+      .collect::<BTreeSet<_>>(),
+    BTreeSet::from([
+      CalxDefinitionRef::new(namespace, "host-observe"),
+      CalxDefinitionRef::new(namespace, "host-scale"),
+      CalxDefinitionRef::new(namespace, "host-trap"),
+    ])
+  );
 }
 
 #[test]

--- a/tests/fixtures/calx/program-eligibility.golden.txt
+++ b/tests/fixtures/calx/program-eligibility.golden.txt
@@ -1,0 +1,10 @@
+abi calcit-calx-program/1
+kernel-abi calcit-calx-kernel/1
+entry server
+host-target native
+root init tests.calx-program/range-sum
+root reload tests.calx-program/affine
+function tests.calx-program/affine (F64,F64,F64)->F64
+  call tests.calx-program/affine-helper
+function tests.calx-program/affine-helper (F64,F64,F64)->F64
+function tests.calx-program/range-sum (F64,F64)->F64


### PR DESCRIPTION
## English

### Summary

- check the init and reload roots from `calcit-calx-program/1` as one atomic program
- deterministically merge reachable function closures while preserving lifecycle roles
- reject invalid editions/root sets before analysis and return root-scoped structured eligibility issues
- keep platform behavior external through explicit signature-checked typed imports
- publish no partial eligible program when either root fails

### Boundaries

- no program lowering or execution yet
- no dispatcher, `:calx` runtime mode, Dynamic/Nil fallback, or runtime retry
- named VM entry execution remains tracked by calx-vm #70

### Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`

Relates to #943 and #887.

## 中文

### 概要

- 将 `calcit-calx-program/1` 的 init、reload roots 作为一个原子 program 检查
- 确定性合并可达函数闭包，同时保留生命周期角色
- 在 definition analysis 前拒绝无效 edition/root set，并返回带 root 上下文的结构化 eligibility issues
- 平台行为继续留在外部，只能通过签名精确匹配的显式 typed imports 注入
- 任一 root 失败时不发布部分 eligible program

### 边界

- 暂不实现 program lowering 或执行
- 不加入 dispatcher、`:calx` runtime mode、Dynamic/Nil fallback 或 runtime retry
- VM named entry 执行继续由 calx-vm #70 追踪

### 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`

关联 #943、#887。
