### PR TITLE
chore(calx): consume calx-vm 0.5.1 / 使用 calx-vm 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "73ebd0fd554c1e6778850f26743d7a06dca3f387e945d03f202abd424c4b1743"
 
 [[package]]
 name = "calx_vm"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe17d233477ea19af07355bae3920d17ea6c4f9606b2cc636da15f46117fd5c"
+checksum = "866cf6e0bd446fd28a393e927768e6a7fbbbdf3d78fdce32e561d6e18f68e37d"
 dependencies = [
  "argh",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1.0.151"
 cirru_edn = "0.8.0"
 cirru_parser = "=0.2.15"
 bisection_key = "0.0.1"
-calx_vm = "=0.5.0"
+calx_vm = "=0.5.1"
 calcit_native_ffi = { version = "0.1.3", default-features = false }
 rmp-serde = "1.3.0"
 semver = "1.0.28"

--- a/docs/run/calx-program-target.md
+++ b/docs/run/calx-program-target.md
@@ -48,7 +48,7 @@ Both roles remain present when they name the same definition, while later reacha
 
 Whole-program eligibility checks `init` and `reload` as one atomic unit. It deduplicates shared reachable function bodies, preserves both lifecycle roles, and publishes no partial eligible program when either root fails. Explicit typed imports are shared across the roots; undeclared host behavior remains ineligible. Invalid editions and root sets fail before definition analysis with `CALX_PROGRAM_ELIGIBILITY_ABI_EDITION` or `CALX_PROGRAM_ELIGIBILITY_ROOT_SET`.
 
-This edition now defines compilation input and a checked reachable program, but not program lowering or execution. calx-vm 0.5.0 still executes the compatibility function named `main`; [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) tracks strict named-root execution required before lifecycle roots can be lowered without a dispatcher. Existing `:mode :native` and `:mode :js` behavior is unchanged; this contract does not prematurely expose a `:calx` runtime mode.
+This edition now defines compilation input and a checked reachable program, but not program lowering or execution. calx-vm 0.5.1 provides strict named-entry execution, so the next compiler slice can lower lifecycle roots without synthesizing a dispatcher; [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) records that completed VM prerequisite and its Calcit consumer validation. Existing `:mode :native` and `:mode :js` behavior is unchanged; this contract does not prematurely expose a `:calx` runtime mode.
 
 ### Hard boundaries
 
@@ -109,7 +109,7 @@ Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次�
 
 整程序 eligibility 将 `init` 和 `reload` 作为一个原子单元检查：共享的可达函数体会去重，两个生命周期角色仍被保留；任一 root 失败时都不发布部分 eligible program。两个 roots 共享同一组显式 typed imports，未声明的 host 行为仍然不合格。无效 edition 或 root 集合会在 definition analysis 前分别以 `CALX_PROGRAM_ELIGIBILITY_ABI_EDITION`、`CALX_PROGRAM_ELIGIBILITY_ROOT_SET` 失败。
 
-本 edition 现在定义编译输入和经过检查的可达 program，但还不包含 program lowering 或执行。calx-vm 0.5.0 仍只执行名为 `main` 的兼容函数；在不引入 dispatcher 的前提下 lowering 生命周期 roots 所需的严格 named-root execution 由 [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 追踪。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。
+本 edition 现在定义编译输入和经过检查的可达 program，但还不包含 program lowering 或执行。calx-vm 0.5.1 已提供严格 named-entry execution，下一阶段可以在不合成 dispatcher 的前提下 lowering 生命周期 roots；[calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 记录该 VM 前置能力及其 Calcit consumer 验证。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。
 
 ### 硬边界
 

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -6,15 +6,15 @@
 Calcit 正在验证一个很窄的 typed kernel 子集能否编译到 Calx。这个实验不改变默认 native
 runner、JS codegen 或仓库内部 WASM backend，也不会把任意 Calcit 函数静默发送给另一个运行时。
 
-当前依赖精确锁定 crates.io 发布的 `calx_vm = "=0.5.0"`。该版本收紧 strict value domain，
-并复用尾调用的 locals 容量；Calcit 的 typed lowering 边界、ABI edition 和 benchmark session
+当前依赖精确锁定 crates.io 发布的 `calx_vm = "=0.5.1"`。该版本在 0.5 strict value domain
+与尾调用 locals 复用基础上增加显式 named-entry execution；Calcit 的 kernel ABI edition 和 benchmark session
 edition 不变，不新增动态值回退或运行模式。性能采样与消费者版本组合仍由
 [独立 harness](https://github.com/calcit-lang/calcit-calx-bench) 的 `pins.json` 和报告记录。
 
-The dependency is pinned to the published crates.io release `calx_vm = "=0.5.0"`, which tightens
-the strict value domain and reuses tail-call locals capacity. Calcit's typed lowering boundary,
-ABI edition, and benchmark session edition remain unchanged; this adds no dynamic-value fallback
-or execution mode. Performance sampling and consumer version combinations remain owned by the
+The dependency is pinned to the published crates.io release `calx_vm = "=0.5.1"`, which adds
+explicit named-entry execution on top of the 0.5 strict value domain and tail-call local reuse.
+Calcit's kernel ABI edition and benchmark session edition remain unchanged; this adds no
+dynamic-value fallback or execution mode. Performance sampling and consumer version combinations remain owned by the
 [standalone harness](https://github.com/calcit-lang/calcit-calx-bench), its `pins.json`, and reports.
 
 当前阶段建立 eligibility boundary，并把通过证明的 closed kernel 降为可执行的 strict Calx program：

--- a/editing-history/202609100912-calx-vm-0.5.1-consumer.md
+++ b/editing-history/202609100912-calx-vm-0.5.1-consumer.md
@@ -1,0 +1,15 @@
+# Consume calx-vm 0.5.1 named entries / 使用 calx-vm 0.5.1 具名入口
+
+## English
+
+- Pin Calcit to the published crates.io release `calx_vm = "=0.5.1"` rather than a revision or movable version.
+- Add consumer conformance evidence that two strict roots can run by exact name without a synthetic `main` function.
+- Verify that a missing compatibility `main` remains an error and never falls back to another entry.
+- Keep program lowering, runtime-mode exposure, Dynamic/Nil fallback, scheduling, and platform FFI out of this dependency slice.
+
+## 中文
+
+- 将 Calcit 精确锁定到 crates.io 已发布的 `calx_vm = "=0.5.1"`，不使用 revision 或可移动版本。
+- 增加 consumer conformance 证据：两个 strict roots 无需合成 `main`，即可按准确名称分别执行。
+- 验证缺少兼容入口 `main` 时仍然报错，绝不回退到其他 entry。
+- 本依赖升级不夹带 program lowering、runtime mode、Dynamic/Nil fallback、调度或平台 FFI。

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -12,6 +12,7 @@ use crate::codegen::calx::{
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
 use crate::snapshot::SnapshotTarget;
+use calx_vm::{CalxHostBindings, CalxRunResult, CalxVM, parse_program};
 use cirru_edn::EdnTag;
 use std::collections::{BTreeSet, HashSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -611,6 +612,34 @@ fn calx_program_eligibility_rejects_unversioned_or_incomplete_units_before_analy
     vec![CalxProgramEligibilityCode::AbiEdition, CalxProgramEligibilityCode::RootSet]
   );
   assert!(report.root_issues.is_empty());
+}
+
+#[test]
+fn calx_vm_named_entry_release_executes_distinct_program_roots_without_main() {
+  let parsed = parse_program(
+    "calcit-consumer-named-entry.cirru",
+    r#"fn init (-> f64)
+  const 1.0
+  return
+
+fn reload (-> f64)
+  const 2.0
+  return"#,
+  )
+  .expect("parse strict named-entry consumer fixture");
+  let program = parsed.into_program().expect("build strict named-entry consumer fixture");
+  let mut vm = CalxVM::from_program(program, CalxHostBindings::new()).expect("validate named-entry consumer fixture");
+
+  assert_eq!(
+    vm.run_typed_entry("init", vec![]).expect("run init by exact name"),
+    CalxRunResult::Value(CalxValue::F64(1.0))
+  );
+  assert_eq!(
+    vm.run_typed_entry("reload", vec![]).expect("run reload by exact name"),
+    CalxRunResult::Value(CalxValue::F64(2.0))
+  );
+  let missing = vm.run_typed_entry("main", vec![]).expect_err("named entry must not fall back");
+  assert_eq!(missing.message, "main function is required");
 }
 
 #[test]


### PR DESCRIPTION
## English

### Summary

- pin Calcit to the published crates.io release `calx_vm = "=0.5.1"`
- add consumer conformance coverage for executing distinct init/reload entries without a synthetic `main`
- prove that missing `main` remains an error and never falls back to another entry
- update the kernel and program backend documentation to record that named-entry execution is available

### Boundaries

- no program lowering or runtime-mode exposure in this dependency slice
- no Dynamic/Nil fallback, dispatcher, scheduler, or platform FFI changes
- kernel ABI and benchmark session editions remain unchanged

### Validation

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`
- calx-vm 0.5.1 publish workflow completed successfully
- crates.io exposes calx_vm 0.5.1

Relates to #943, #887, and calcit-lang/calx-vm#70.

## 中文

### 概要

- 将 Calcit 精确锁定到 crates.io 已发布的 `calx_vm = "=0.5.1"`
- 增加 consumer conformance 覆盖：无需合成 `main` 即可分别执行 init/reload entries
- 证明缺少 `main` 时仍明确报错，绝不回退到其他 entry
- 更新 kernel 与 program backend 文档，记录 named-entry execution 已可用

### 边界

- 本依赖切片不实现 program lowering，也不暴露 runtime mode
- 不加入 Dynamic/Nil fallback、dispatcher、scheduler 或平台 FFI 改动
- kernel ABI 与 benchmark session editions 保持不变

### 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`
- calx-vm 0.5.1 publish workflow 已成功
- crates.io 已可读取 calx_vm 0.5.1

关联 #943、#887 和 calcit-lang/calx-vm#70。
