### PR TITLE
feat(calx): lower checked lifecycle programs / Lowering 已检查的生命周期程序

### DIFF
--- a/docs/run/calx-program-target.md
+++ b/docs/run/calx-program-target.md
@@ -48,7 +48,9 @@ Both roles remain present when they name the same definition, while later reacha
 
 Whole-program eligibility checks `init` and `reload` as one atomic unit. It deduplicates shared reachable function bodies, preserves both lifecycle roles, and publishes no partial eligible program when either root fails. Explicit typed imports are shared across the roots; undeclared host behavior remains ineligible. Invalid editions and root sets fail before definition analysis with `CALX_PROGRAM_ELIGIBILITY_ABI_EDITION` or `CALX_PROGRAM_ELIGIBILITY_ROOT_SET`.
 
-This edition now defines compilation input and a checked reachable program, but not program lowering or execution. calx-vm 0.5.1 provides strict named-entry execution, so the next compiler slice can lower lifecycle roots without synthesizing a dispatcher; [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) records that completed VM prerequisite and its Calcit consumer validation. Existing `:mode :native` and `:mode :js` behavior is unchanged; this contract does not prematurely expose a `:calx` runtime mode.
+This edition now has a library-level lowering and execution foundation. `compile_calx_program` atomically proves the unit, lowers its merged reachable definitions into one validated program, and records each lifecycle role with its exact fully qualified VM function name and strict signature. A `CalxProgramInstance` can then invoke either role through calx-vm 0.5.1 named-entry execution. Shared roots keep both roles while reusing one emitted function body; no synthetic `main` dispatcher is generated.
+
+This API does not yet select a runtime backend, own lifecycle scheduling, or add program caching/watch invalidation. Existing `:mode :native` and `:mode :js` behavior is unchanged; the contract does not prematurely expose a `:calx` runtime mode. [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) records the completed VM prerequisite and downstream release validation.
 
 ### Hard boundaries
 
@@ -109,7 +111,9 @@ Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次�
 
 整程序 eligibility 将 `init` 和 `reload` 作为一个原子单元检查：共享的可达函数体会去重，两个生命周期角色仍被保留；任一 root 失败时都不发布部分 eligible program。两个 roots 共享同一组显式 typed imports，未声明的 host 行为仍然不合格。无效 edition 或 root 集合会在 definition analysis 前分别以 `CALX_PROGRAM_ELIGIBILITY_ABI_EDITION`、`CALX_PROGRAM_ELIGIBILITY_ROOT_SET` 失败。
 
-本 edition 现在定义编译输入和经过检查的可达 program，但还不包含 program lowering 或执行。calx-vm 0.5.1 已提供严格 named-entry execution，下一阶段可以在不合成 dispatcher 的前提下 lowering 生命周期 roots；[calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 记录该 VM 前置能力及其 Calcit consumer 验证。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。
+本 edition 现在具备库级 lowering 与执行基础。`compile_calx_program` 会原子证明整个 unit，把合并后的可达 definitions lowering 为一份 validated program，并为每个生命周期角色记录准确的完整限定 VM 函数名与 strict signature。随后 `CalxProgramInstance` 通过 calx-vm 0.5.1 的 named-entry execution 调用任一角色。两个 roots 指向同一 definition 时仍保留两个角色，但只复用一份已生成函数体；不会合成 `main` dispatcher。
+
+该 API 尚不选择 runtime backend，不负责生命周期调度，也不增加 program cache/watch invalidation。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。[calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 记录已完成的 VM 前置能力与下游发布验证。
 
 ### 硬边界
 

--- a/editing-history/202609101000-calx-program-lowering.md
+++ b/editing-history/202609101000-calx-program-lowering.md
@@ -1,0 +1,19 @@
+# Lower checked Calx programs / Lowering 已检查的 Calx program
+
+## English
+
+- Add a program-level compile API that atomically reuses the existing eligibility, planning, emission, build, and strict validation path for both lifecycle roots.
+- Emit one validated Calx program with fully qualified function names and no compatibility `main` dispatcher.
+- Preserve init/reload roles and exact strict signatures, including when both roles share one deduplicated function body.
+- Execute either root by explicit named entry on one reusable VM instance, with the existing strict Number/Bool/F64Buffer/Unit boundary conversions.
+- Attach one explicit typed host-capability set to the whole program; eligibility rejection and runtime traps remain distinct and never trigger mixed fallback.
+- Keep runtime-mode selection, lifecycle scheduling, program caching/watch invalidation, Dynamic/Nil escape hatches, and platform FFI implementations out of this slice.
+
+## 中文
+
+- 增加 program-level compile API，对两个生命周期 roots 原子复用现有 eligibility、planning、emission、build 与 strict validation 主干。
+- 生成一份使用完整限定函数名的 validated Calx program，不生成兼容 `main` dispatcher。
+- 保留 init/reload 角色与准确 strict signatures；两种角色共享同一 definition 时只生成一份函数体。
+- 在同一个可复用 VM instance 上通过显式 named entry 执行任一 root，并复用现有严格 Number/Bool/F64Buffer/Unit 边界转换。
+- 整个 program 只挂载一组显式 typed host capabilities；eligibility rejection 与 runtime trap 继续分离，绝不触发 mixed fallback。
+- 本切片不包含 runtime mode 选择、生命周期调度、program cache/watch invalidation、Dynamic/Nil 逃生口或平台 FFI 实现。

--- a/editing-history/202609101000-calx-program-lowering.md
+++ b/editing-history/202609101000-calx-program-lowering.md
@@ -6,6 +6,7 @@
 - Emit one validated Calx program with fully qualified function names and no compatibility `main` dispatcher.
 - Preserve init/reload roles and exact strict signatures, including when both roles share one deduplicated function body.
 - Execute either root by explicit named entry on one reusable VM instance, with the existing strict Number/Bool/F64Buffer/Unit boundary conversions.
+- Return a typed entry-boundary error if a requested lifecycle role is absent; public execution never relies on a panic.
 - Attach one explicit typed host-capability set to the whole program; eligibility rejection and runtime traps remain distinct and never trigger mixed fallback.
 - Keep runtime-mode selection, lifecycle scheduling, program caching/watch invalidation, Dynamic/Nil escape hatches, and platform FFI implementations out of this slice.
 
@@ -15,5 +16,6 @@
 - 生成一份使用完整限定函数名的 validated Calx program，不生成兼容 `main` dispatcher。
 - 保留 init/reload 角色与准确 strict signatures；两种角色共享同一 definition 时只生成一份函数体。
 - 在同一个可复用 VM instance 上通过显式 named entry 执行任一 root，并复用现有严格 Number/Bool/F64Buffer/Unit 边界转换。
+- 请求的生命周期角色不存在时返回 typed entry-boundary error；公开执行路径不依赖 panic。
 - 整个 program 只挂载一组显式 typed host capabilities；eligibility rejection 与 runtime trap 继续分离，绝不触发 mixed fallback。
 - 本切片不包含 runtime mode 选择、生命周期调度、program cache/watch invalidation、Dynamic/Nil 逃生口或平台 FFI 实现。

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -20,9 +20,10 @@ pub use coverage::{
   classify_calx_syntax_surface, classify_calx_type_surface,
 };
 pub use lowering::{
-  CalxCompiledArtifact, CalxCompiledKernel, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind, CalxKernelCompileError,
-  CalxKernelCompileTimings, CalxKernelRunError, CalxLoweringError, CalxPreparedKernel, compile_calx_kernel,
-  compile_calx_kernel_measured, compile_calx_kernel_with_imports, compile_calx_kernel_with_imports_measured,
+  CalxCompiledArtifact, CalxCompiledKernel, CalxCompiledProgramArtifact, CalxKernelBoundaryError, CalxKernelBoundaryErrorKind,
+  CalxKernelCompileError, CalxKernelCompileTimings, CalxKernelRunError, CalxLoweringError, CalxPreparedKernel, CalxPreparedProgram,
+  CalxProgramCompileError, CalxProgramEntry, CalxProgramInstance, compile_calx_kernel, compile_calx_kernel_measured,
+  compile_calx_kernel_with_imports, compile_calx_kernel_with_imports_measured, compile_calx_program, compile_calx_program_with_imports,
 };
 pub use program_contract::{
   CALX_PROGRAM_ABI_EDITION, CalxProgramCompilationUnit, CalxProgramContractCode, CalxProgramContractError, CalxProgramRoot,

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -177,6 +177,7 @@ impl From<CalxProgramError> for CalxKernelCompileError {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CalxKernelBoundaryErrorKind {
+  Entry,
   Arity,
   ArgumentType,
   ResultType,
@@ -516,12 +517,7 @@ pub struct CalxProgramInstance {
 
 impl CalxProgramInstance {
   pub fn run_root(&mut self, role: CalxProgramRootRole, args: &[Calcit]) -> Result<Calcit, CalxKernelRunError> {
-    let entry = self
-      .artifact
-      .entries
-      .iter()
-      .find(|entry| entry.role == role)
-      .expect("validated Calx program contract must contain each lifecycle role");
+    let entry = program_entry_for_role(&self.artifact.entries, role)?;
     let vm_args = convert_calx_arguments(args, &entry.params)?;
     let output = self
       .vm
@@ -529,6 +525,15 @@ impl CalxProgramInstance {
       .map_err(CalxKernelRunError::Runtime)?;
     convert_calx_result(entry.result, output)
   }
+}
+
+fn program_entry_for_role(entries: &[CalxProgramEntry], role: CalxProgramRootRole) -> Result<&CalxProgramEntry, CalxKernelRunError> {
+  entries.iter().find(|entry| entry.role == role).ok_or_else(|| {
+    CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+      kind: CalxKernelBoundaryErrorKind::Entry,
+      message: format!("compiled Calx program has no entry for lifecycle role `{}`", role.as_str()),
+    })
+  })
 }
 
 /// Prove, lower, build, and validate all lifecycle roots as one strict Calx
@@ -1595,5 +1600,17 @@ mod tests {
     assert_eq!(error.function, definition);
     assert_eq!(error.source_path, Some(vec![3, 1]));
     assert!(error.message.contains("local index 42"));
+  }
+
+  #[test]
+  fn missing_program_role_returns_a_typed_error_instead_of_panicking() {
+    let error = program_entry_for_role(&[], CalxProgramRootRole::Init).expect_err("missing role must remain a typed error");
+    assert!(matches!(
+      error,
+      CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+        kind: CalxKernelBoundaryErrorKind::Entry,
+        ..
+      })
+    ));
   }
 }

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -17,8 +17,10 @@ use crate::calcit::{Calcit, CalcitFnArgs, CalcitLocal, CalcitProc, CalcitSyntax,
 use crate::program::{CompiledProgram, DefId};
 
 use super::{
-  CalxDefinitionRef, CalxEligibleCallGraph, CalxFallbackReport, CalxHostImports, CalxImportContract, CalxScalarType,
-  analyze_calx_eligibility_with_imports, extract_fn_parts, import_contract, lookup_compiled_def, source_path,
+  CalxDefinitionRef, CalxEligibleCallGraph, CalxEligibleFunction, CalxEligibleProgram, CalxFallbackReport, CalxHostImports,
+  CalxImportContract, CalxProgramCompilationUnit, CalxProgramEligibilityReport, CalxProgramRootRole, CalxScalarType,
+  analyze_calx_eligibility_with_imports, analyze_calx_program_eligibility_with_imports, extract_fn_parts, import_contract,
+  lookup_compiled_def, source_path,
 };
 
 /// A mismatch discovered while converting a graph that already passed the
@@ -72,6 +74,63 @@ impl Error for CalxKernelCompileError {
       Self::Build(error) => Some(error),
       Self::Validation(error) => Some(error),
     }
+  }
+}
+
+/// Program-level compile phases keep whole-program eligibility separate from
+/// compiler/VM integration failures. Only `Eligibility` is an expected
+/// rejection of user code.
+#[derive(Debug)]
+pub enum CalxProgramCompileError {
+  Eligibility(CalxProgramEligibilityReport),
+  Lowering(CalxLoweringError),
+  Build(CalxBuildError),
+  Validation(CalxProgramError),
+}
+
+impl fmt::Display for CalxProgramCompileError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Eligibility(report) => write!(
+        f,
+        "Calx program eligibility rejected entry `{}` with {} program issue(s) and {} root issue(s)",
+        report.entry_name,
+        report.program_issues.len(),
+        report.root_issues.len()
+      ),
+      Self::Lowering(error) => error.fmt(f),
+      Self::Build(error) => write!(f, "Calx program build failed: {error}"),
+      Self::Validation(error) => write!(f, "Calx program validation failed: {error}"),
+    }
+  }
+}
+
+impl Error for CalxProgramCompileError {
+  fn source(&self) -> Option<&(dyn Error + 'static)> {
+    match self {
+      Self::Eligibility(_) => None,
+      Self::Lowering(error) => Some(error),
+      Self::Build(error) => Some(error),
+      Self::Validation(error) => Some(error),
+    }
+  }
+}
+
+impl From<CalxLoweringError> for CalxProgramCompileError {
+  fn from(error: CalxLoweringError) -> Self {
+    Self::Lowering(error)
+  }
+}
+
+impl From<CalxBuildError> for CalxProgramCompileError {
+  fn from(error: CalxBuildError) -> Self {
+    Self::Build(error)
+  }
+}
+
+impl From<CalxProgramError> for CalxProgramCompileError {
+  fn from(error: CalxProgramError) -> Self {
+    Self::Validation(error)
   }
 }
 
@@ -340,47 +399,289 @@ impl CalxPreparedKernel {
   }
 
   pub fn run(&self, args: &[Calcit]) -> Result<Calcit, CalxKernelRunError> {
-    if args.len() != self.artifact.params.len() {
-      return Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
-        kind: CalxKernelBoundaryErrorKind::Arity,
-        message: format!("expected {} arguments, found {}", self.artifact.params.len(), args.len()),
-      }));
-    }
-    let mut vm_args = Vec::with_capacity(args.len());
-    for (index, (value, expected)) in args.iter().zip(&self.artifact.params).enumerate() {
-      let converted = match (expected, value) {
-        (CalxScalarType::F64, Calcit::Number(value)) => VmValue::F64(*value),
-        (CalxScalarType::Bool, Calcit::Bool(value)) => VmValue::Bool(*value),
-        (CalxScalarType::F64Buffer, Calcit::F64Buffer(values)) => VmValue::f64_buffer_copy_from_slice(values),
-        _ => {
-          return Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
-            kind: CalxKernelBoundaryErrorKind::ArgumentType,
-            message: format!(
-              "argument {index} expected {}, found {}",
-              expected.as_str(),
-              brief_type_of_value(value)
-            ),
-          }));
-        }
-      };
-      vm_args.push(converted);
-    }
-
+    let vm_args = convert_calx_arguments(args, &self.artifact.params)?;
     let mut vm = self.instantiate()?;
     let output = vm.run_typed(vm_args).map_err(CalxKernelRunError::Runtime)?;
-    match (self.artifact.result, output) {
-      (None, CalxRunResult::Void) => Ok(Calcit::Unit),
-      (Some(CalxScalarType::F64), CalxRunResult::Value(VmValue::F64(value))) => Ok(Calcit::Number(value)),
-      (Some(CalxScalarType::Bool), CalxRunResult::Value(VmValue::Bool(value))) => Ok(Calcit::Bool(value)),
-      (Some(CalxScalarType::F64Buffer), CalxRunResult::Value(VmValue::F64Buffer(values))) => {
-        Ok(Calcit::F64Buffer(std::sync::Arc::from(values.as_ref())))
-      }
-      (expected, actual) => Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
-        kind: CalxKernelBoundaryErrorKind::ResultType,
-        message: format!("validated result contract {expected:?} produced {actual:?}"),
-      })),
-    }
+    convert_calx_result(self.artifact.result, output)
   }
+}
+
+fn convert_calx_arguments(args: &[Calcit], expected_params: &[CalxScalarType]) -> Result<Vec<VmValue>, CalxKernelRunError> {
+  if args.len() != expected_params.len() {
+    return Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+      kind: CalxKernelBoundaryErrorKind::Arity,
+      message: format!("expected {} arguments, found {}", expected_params.len(), args.len()),
+    }));
+  }
+  args
+    .iter()
+    .zip(expected_params)
+    .enumerate()
+    .map(|(index, (value, expected))| match (expected, value) {
+      (CalxScalarType::F64, Calcit::Number(value)) => Ok(VmValue::F64(*value)),
+      (CalxScalarType::Bool, Calcit::Bool(value)) => Ok(VmValue::Bool(*value)),
+      (CalxScalarType::F64Buffer, Calcit::F64Buffer(values)) => Ok(VmValue::f64_buffer_copy_from_slice(values)),
+      _ => Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+        kind: CalxKernelBoundaryErrorKind::ArgumentType,
+        message: format!(
+          "argument {index} expected {}, found {}",
+          expected.as_str(),
+          brief_type_of_value(value)
+        ),
+      })),
+    })
+    .collect()
+}
+
+fn convert_calx_result(expected: Option<CalxScalarType>, output: CalxRunResult) -> Result<Calcit, CalxKernelRunError> {
+  match (expected, output) {
+    (None, CalxRunResult::Void) => Ok(Calcit::Unit),
+    (Some(CalxScalarType::F64), CalxRunResult::Value(VmValue::F64(value))) => Ok(Calcit::Number(value)),
+    (Some(CalxScalarType::Bool), CalxRunResult::Value(VmValue::Bool(value))) => Ok(Calcit::Bool(value)),
+    (Some(CalxScalarType::F64Buffer), CalxRunResult::Value(VmValue::F64Buffer(values))) => {
+      Ok(Calcit::F64Buffer(std::sync::Arc::from(values.as_ref())))
+    }
+    (expected, actual) => Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
+      kind: CalxKernelBoundaryErrorKind::ResultType,
+      message: format!("validated result contract {expected:?} produced {actual:?}"),
+    })),
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxProgramEntry {
+  pub role: CalxProgramRootRole,
+  pub definition: CalxDefinitionRef,
+  pub vm_name: Arc<str>,
+  pub params: Vec<CalxScalarType>,
+  pub result: Option<CalxScalarType>,
+}
+
+/// Immutable result of whole-program eligibility, lowering, construction, and
+/// strict VM validation. Runtime state and callbacks are deliberately absent.
+#[derive(Debug, Clone)]
+pub struct CalxCompiledProgramArtifact {
+  eligible: CalxEligibleProgram,
+  entries: Vec<CalxProgramEntry>,
+  program: ValidatedProgram,
+  import_contract: Vec<CalxImportContract>,
+}
+
+impl CalxCompiledProgramArtifact {
+  pub fn eligible_program(&self) -> &CalxEligibleProgram {
+    &self.eligible
+  }
+
+  pub fn entries(&self) -> &[CalxProgramEntry] {
+    &self.entries
+  }
+
+  pub fn validated_program(&self) -> &ValidatedProgram {
+    &self.program
+  }
+
+  pub fn import_contract(&self) -> &[CalxImportContract] {
+    &self.import_contract
+  }
+}
+
+/// Whole-program artifact with current typed host callbacks attached.
+#[derive(Debug, Clone)]
+pub struct CalxPreparedProgram {
+  artifact: Rc<CalxCompiledProgramArtifact>,
+  host_bindings: CalxHostBindings,
+}
+
+impl CalxPreparedProgram {
+  pub fn artifact(&self) -> &Rc<CalxCompiledProgramArtifact> {
+    &self.artifact
+  }
+
+  pub fn instantiate(&self) -> Result<CalxProgramInstance, CalxKernelRunError> {
+    let vm = CalxVM::from_validated_program(self.artifact.program.clone(), self.host_bindings.clone())
+      .map_err(CalxKernelRunError::Instantiate)?;
+    Ok(CalxProgramInstance {
+      artifact: self.artifact.clone(),
+      vm,
+    })
+  }
+}
+
+/// One reusable VM instance. Running multiple lifecycle roots on this value
+/// preserves VM-owned state instead of rebuilding the program per root.
+pub struct CalxProgramInstance {
+  artifact: Rc<CalxCompiledProgramArtifact>,
+  vm: CalxVM,
+}
+
+impl CalxProgramInstance {
+  pub fn run_root(&mut self, role: CalxProgramRootRole, args: &[Calcit]) -> Result<Calcit, CalxKernelRunError> {
+    let entry = self
+      .artifact
+      .entries
+      .iter()
+      .find(|entry| entry.role == role)
+      .expect("validated Calx program contract must contain each lifecycle role");
+    let vm_args = convert_calx_arguments(args, &entry.params)?;
+    let output = self
+      .vm
+      .run_typed_entry(&entry.vm_name, vm_args)
+      .map_err(CalxKernelRunError::Runtime)?;
+    convert_calx_result(entry.result, output)
+  }
+}
+
+/// Prove, lower, build, and validate all lifecycle roots as one strict Calx
+/// program. No partial artifact is returned when eligibility fails.
+pub fn compile_calx_program(
+  program: &CompiledProgram,
+  unit: &CalxProgramCompilationUnit,
+) -> Result<CalxPreparedProgram, CalxProgramCompileError> {
+  compile_calx_program_with_imports(program, unit, &CalxHostImports::new())
+}
+
+/// Compile a whole program with one explicit set of typed host capabilities.
+pub fn compile_calx_program_with_imports(
+  program: &CompiledProgram,
+  unit: &CalxProgramCompilationUnit,
+  imports: &CalxHostImports,
+) -> Result<CalxPreparedProgram, CalxProgramCompileError> {
+  let eligible = analyze_calx_program_eligibility_with_imports(program, unit, imports).map_err(CalxProgramCompileError::Eligibility)?;
+  let names = eligible
+    .functions
+    .iter()
+    .map(|function| (function.definition.clone(), function.definition.qualified()))
+    .collect::<BTreeMap<_, _>>();
+  let signatures = eligible
+    .functions
+    .iter()
+    .map(|function| (function.definition.clone(), (function.params.clone(), function.result)))
+    .collect::<BTreeMap<_, _>>();
+  let plans = eligible
+    .functions
+    .iter()
+    .map(|function| {
+      plan_function(
+        program,
+        function.definition.clone(),
+        &function.params,
+        function.result,
+        &names,
+        &signatures,
+        imports,
+      )
+    })
+    .collect::<Result<Vec<_>, CalxLoweringError>>()?;
+
+  let used_imports = collect_used_imports(&eligible.functions);
+  let mut builder = ProgramBuilder::new();
+  let import_ids = declare_used_imports(&mut builder, &used_imports, imports)?;
+  for plan in &plans {
+    let function = emit_function(plan, &import_ids).map_err(|error| match error {
+      CalxKernelCompileError::Lowering(error) => CalxProgramCompileError::Lowering(error),
+      CalxKernelCompileError::Build(error) => CalxProgramCompileError::Build(error),
+      CalxKernelCompileError::Validation(error) => CalxProgramCompileError::Validation(error),
+      CalxKernelCompileError::Eligibility(_) => unreachable!("emission cannot perform eligibility analysis"),
+    })?;
+    builder.function(function)?;
+  }
+  let validated_program = ValidatedProgram::try_from_program(builder.build()?)?;
+
+  let error_context = eligible.roots.first().map(|root| root.definition.clone()).ok_or_else(|| {
+    CalxProgramCompileError::Lowering(lower_error(
+      &CalxDefinitionRef::new("<program>", "<root>"),
+      None,
+      "eligible program contains no lifecycle roots",
+    ))
+  })?;
+  let entries = eligible
+    .roots
+    .iter()
+    .map(|root| {
+      let signature = signatures.get(&root.definition).ok_or_else(|| {
+        CalxProgramCompileError::Lowering(lower_error(
+          &root.definition,
+          None,
+          "eligible program does not contain its lifecycle root",
+        ))
+      })?;
+      let vm_name = names.get(&root.definition).ok_or_else(|| {
+        CalxProgramCompileError::Lowering(lower_error(
+          &root.definition,
+          None,
+          "eligible lifecycle root has no Calx function name",
+        ))
+      })?;
+      Ok(CalxProgramEntry {
+        role: root.role,
+        definition: root.definition.clone(),
+        vm_name: Arc::from(vm_name.as_str()),
+        params: signature.0.clone(),
+        result: signature.1,
+      })
+    })
+    .collect::<Result<Vec<_>, CalxProgramCompileError>>()?;
+  let host_bindings = attach_used_imports(&used_imports, imports, &error_context)?;
+  Ok(CalxPreparedProgram {
+    artifact: Rc::new(CalxCompiledProgramArtifact {
+      eligible,
+      entries,
+      program: validated_program,
+      import_contract: import_contract(imports),
+    }),
+    host_bindings,
+  })
+}
+
+fn collect_used_imports(functions: &[CalxEligibleFunction]) -> BTreeSet<CalxDefinitionRef> {
+  functions
+    .iter()
+    .flat_map(|function| function.host_imports.iter().cloned())
+    .collect()
+}
+
+fn declare_used_imports(
+  builder: &mut ProgramBuilder,
+  used_imports: &BTreeSet<CalxDefinitionRef>,
+  imports: &CalxHostImports,
+) -> Result<BTreeMap<CalxDefinitionRef, ImportId>, CalxProgramCompileError> {
+  let mut import_ids = BTreeMap::new();
+  for target in used_imports {
+    let import = imports.get(target).ok_or_else(|| {
+      CalxProgramCompileError::Lowering(lower_error(
+        target,
+        None,
+        "eligible host import has no compile-time capability binding",
+      ))
+    })?;
+    let id = builder.import_at(
+      import.name(),
+      import.params().iter().copied().map(CalxScalarType::vm_type).collect(),
+      import.result().map(CalxScalarType::vm_type),
+      Some(SourceSpan::synthetic(source_origin(target, None))),
+    )?;
+    import_ids.insert(target.clone(), id);
+  }
+  Ok(import_ids)
+}
+
+fn attach_used_imports(
+  used_imports: &BTreeSet<CalxDefinitionRef>,
+  imports: &CalxHostImports,
+  error_context: &CalxDefinitionRef,
+) -> Result<CalxHostBindings, CalxProgramCompileError> {
+  let mut host_bindings = CalxHostBindings::new();
+  for target in used_imports {
+    let import = imports.get(target).ok_or_else(|| {
+      CalxProgramCompileError::Lowering(lower_error(
+        error_context,
+        None,
+        format!("compiled host import `{}` has no current capability binding", target.qualified()),
+      ))
+    })?;
+    host_bindings.insert(import.name().into(), import.binding().clone());
+  }
+  Ok(host_bindings)
 }
 
 /// Prove, lower, build, and validate one closed scalar kernel call graph.

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -5,9 +5,10 @@ use crate::call_stack::CallStackList;
 use crate::codegen::calx::{
   CALX_PROGRAM_ABI_EDITION, CalxCacheMissReason, CalxCompileCache, CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport,
   CalxHostImports, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError, CalxProgramCompilationUnit,
-  CalxProgramEligibilityCode, CalxProgramRoot, CalxProgramRootRole, CalxScalarType, CalxValue, analyze_calx_eligibility,
-  analyze_calx_eligibility_with_imports, analyze_calx_program_eligibility, analyze_calx_program_eligibility_with_imports,
-  compile_calx_kernel, compile_calx_kernel_measured, compile_calx_kernel_with_imports,
+  CalxProgramCompileError, CalxProgramEligibilityCode, CalxProgramRoot, CalxProgramRootRole, CalxScalarType, CalxValue,
+  analyze_calx_eligibility, analyze_calx_eligibility_with_imports, analyze_calx_program_eligibility,
+  analyze_calx_program_eligibility_with_imports, compile_calx_kernel, compile_calx_kernel_measured, compile_calx_kernel_with_imports,
+  compile_calx_program, compile_calx_program_with_imports,
 };
 use crate::data::cirru::code_to_calcit;
 use crate::run_program_with_docs;
@@ -640,6 +641,124 @@ fn reload (-> f64)
   );
   let missing = vm.run_typed_entry("main", vec![]).expect_err("named entry must not fall back");
   assert_eq!(missing.message, "main function is required");
+}
+
+#[test]
+fn calx_program_lowering_executes_distinct_roots_without_a_dispatcher() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-lowering";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed program fixtures");
+  let unit = calx_program_unit(namespace, "fibonacci", "affine");
+
+  let prepared = compile_calx_program(&snapshot, &unit).expect("lower both eligible roots");
+  let artifact = prepared.artifact();
+  assert_eq!(artifact.entries().len(), 2);
+  assert_eq!(artifact.validated_program().functions().len(), 3);
+  assert!(
+    artifact
+      .validated_program()
+      .functions()
+      .iter()
+      .all(|function| function.name.as_ref() != "main")
+  );
+  assert_eq!(artifact.entries()[0].vm_name.as_ref(), "tests.calx-program-lowering/fibonacci");
+  assert_eq!(artifact.entries()[1].vm_name.as_ref(), "tests.calx-program-lowering/affine");
+
+  let mut instance = prepared.instantiate().expect("instantiate checked Calx program");
+  let init_args = [Calcit::Number(10.0)];
+  let init_result = instance
+    .run_root(CalxProgramRootRole::Init, &init_args)
+    .expect("run exact init root");
+  let native_init = run_program_with_docs(Arc::from(namespace), Arc::from("fibonacci"), &init_args).expect("run native init root");
+  assert_eq!(init_result, native_init);
+
+  let reload_args = [Calcit::Number(3.0), Calcit::Number(4.0), Calcit::Number(5.0)];
+  let reload_result = instance
+    .run_root(CalxProgramRootRole::Reload, &reload_args)
+    .expect("run exact reload root");
+  let native_reload = run_program_with_docs(Arc::from(namespace), Arc::from("affine"), &reload_args).expect("run native reload root");
+  assert_eq!(reload_result, native_reload);
+  assert_eq!(
+    instance
+      .run_root(CalxProgramRootRole::Init, &init_args)
+      .expect("reused instance must reset to the selected root"),
+    native_init
+  );
+
+  let boundary = instance
+    .run_root(CalxProgramRootRole::Init, &[Calcit::Nil])
+    .expect_err("Nil must not enter the strict program boundary");
+  assert!(matches!(
+    boundary,
+    CalxKernelRunError::Boundary(ref error) if error.kind == CalxKernelBoundaryErrorKind::ArgumentType
+  ));
+}
+
+#[test]
+fn calx_program_lowering_preserves_shared_root_roles_on_one_function() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-lowering-shared";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed program fixtures");
+  let unit = calx_program_unit(namespace, "affine", "affine");
+
+  let prepared = compile_calx_program(&snapshot, &unit).expect("lower shared eligible root once");
+  let entries = prepared.artifact().entries();
+  assert_eq!(entries.len(), 2);
+  assert_eq!(entries[0].role, CalxProgramRootRole::Init);
+  assert_eq!(entries[1].role, CalxProgramRootRole::Reload);
+  assert_eq!(entries[0].definition, entries[1].definition);
+  assert_eq!(entries[0].vm_name, entries[1].vm_name);
+  assert_eq!(prepared.artifact().validated_program().functions().len(), 2);
+
+  let args = [Calcit::Number(3.0), Calcit::Number(4.0), Calcit::Number(5.0)];
+  let mut instance = prepared.instantiate().expect("instantiate shared-root program");
+  let init = instance
+    .run_root(CalxProgramRootRole::Init, &args)
+    .expect("run shared definition as init");
+  let reload = instance
+    .run_root(CalxProgramRootRole::Reload, &args)
+    .expect("run shared definition as reload");
+  assert_eq!(init, reload);
+}
+
+#[test]
+fn calx_program_lowering_keeps_eligibility_failure_separate_from_integration_errors() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-lowering-failure";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed program fixtures");
+  let unit = calx_program_unit(namespace, "range-sum", "missing");
+
+  let error = compile_calx_program(&snapshot, &unit).expect_err("an ineligible root must reject program compilation");
+  assert!(matches!(
+    error,
+    CalxProgramCompileError::Eligibility(ref report)
+      if report.root_issues.len() == 1 && report.root_issues[0].root_roles == vec![CalxProgramRootRole::Reload]
+  ));
+}
+
+#[test]
+fn calx_program_lowering_returns_unit_without_a_nil_completion_value() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-lowering-unit";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed unit fixture");
+  let unit = calx_program_unit(namespace, "host-observe", "host-observe");
+
+  let prepared = compile_calx_program(&snapshot, &unit).expect("lower Unit lifecycle root");
+  let mut instance = prepared.instantiate().expect("instantiate Unit program");
+  assert_eq!(
+    instance
+      .run_root(CalxProgramRootRole::Init, &[Calcit::Number(1.0)])
+      .expect("run Unit root"),
+    Calcit::Unit
+  );
 }
 
 #[test]
@@ -1384,6 +1503,34 @@ fn calx_program_eligibility_keeps_host_capabilities_explicit_across_roots() {
       CalxDefinitionRef::new(namespace, "host-trap"),
     ])
   );
+}
+
+#[test]
+fn calx_program_lowering_attaches_one_typed_capability_set_to_both_roots() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-lowering-imports";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed import fixtures");
+  let imports = calx_test_host_imports(namespace);
+  let unit = calx_program_unit(namespace, "imported-pipeline", "imported-trap");
+
+  let prepared = compile_calx_program_with_imports(&snapshot, &unit, &imports).expect("lower roots with typed host capabilities");
+  assert_eq!(prepared.artifact().validated_program().imports().len(), 3);
+  let mut instance = prepared.instantiate().expect("attach current typed callbacks");
+  CALX_VOID_IMPORT_CALLS.store(0, Ordering::SeqCst);
+  assert_eq!(
+    instance
+      .run_root(CalxProgramRootRole::Init, &[Calcit::Number(3.0)])
+      .expect("run imported init root"),
+    Calcit::Number(7.0)
+  );
+  assert_eq!(CALX_VOID_IMPORT_CALLS.load(Ordering::SeqCst), 1);
+
+  let trap = instance
+    .run_root(CalxProgramRootRole::Reload, &[Calcit::Number(3.0)])
+    .expect_err("host trap remains a runtime error without fallback");
+  assert!(matches!(trap, CalxKernelRunError::Runtime(_)));
 }
 
 #[test]


### PR DESCRIPTION
## English

### Summary

- add program-level compile errors, artifacts, prepared programs, and reusable VM instances
- atomically reuse calcit-calx-program/1 eligibility, the existing lowering planner/emitter, ProgramBuilder, and strict validation for both lifecycle roots
- emit one validated program with fully qualified function names and no synthetic main dispatcher
- preserve init/reload roles and exact strict signatures, including shared roots with one deduplicated emitted function closure
- invoke the selected role through calx-vm 0.5.1 run_typed_entry on one VM instance
- attach one explicit typed host capability set across both roots and preserve eligibility/runtime-trap separation
- document the library-level boundary and add editing history

### Coverage

- distinct init/reload roots with recursive and multi-function call closures
- repeated root execution on one VM instance
- shared init/reload definition without duplicate emission
- strict argument rejection and Unit completion without Nil
- typed imports shared across roots and runtime traps without fallback
- whole-program eligibility rejection remains a compile-phase result
- existing kernel lowering/parity remains covered

### Validation

- cargo fmt
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked: 800 library, 325 CLI, 23 Wasm tests passed
- yarn compile
- yarn check-all: 31/31 agent interface, 237/237 core tests, native/JS/Wasm and quality gates passed
- yarn check-agent-interface: 31/31

### Boundaries

No runtime :calx mode, lifecycle scheduler, program cache/watch invalidation, Dynamic/Nil escape hatch, mixed fallback, or platform FFI implementation is added.

Part of #943. Progresses #887.

## 中文

### 摘要

- 增加 program-level 编译错误、artifact、prepared program 与可复用 VM instance
- 对两个生命周期 roots 原子复用 calcit-calx-program/1 eligibility、现有 lowering planner/emitter、ProgramBuilder 与 strict validation
- 生成一份使用完整限定函数名的 validated program，不合成 main dispatcher
- 保留 init/reload 角色与准确 strict signatures；共享 root 时只生成一份去重后的函数闭包
- 在同一个 VM instance 上通过 calx-vm 0.5.1 run_typed_entry 调用选定角色
- 两个 roots 共享一组显式 typed host capabilities，并保持 eligibility 与 runtime trap 分离
- 更新库级边界文档与 editing history

### 覆盖

- 不同 init/reload roots，包含递归与多函数调用闭包
- 同一 VM instance 上重复执行 root
- init/reload 共享 definition 时不重复生成
- 严格拒绝错误参数，Unit completion 不使用 Nil
- 两根共享 typed imports，runtime trap 不回退
- 整程序 eligibility rejection 仍属于编译阶段结果
- 现有 kernel lowering/parity 继续回归

### 验证

- cargo fmt
- cargo clippy --all-targets --locked -- -D warnings
- cargo test --locked：800 项 library、325 项 CLI、23 项 Wasm 测试通过
- yarn compile
- yarn check-all：agent interface 31/31、core tests 237/237，native/JS/Wasm 与质量门禁全部通过
- yarn check-agent-interface：31/31

### 边界

不增加 runtime :calx mode、生命周期 scheduler、program cache/watch invalidation、Dynamic/Nil 逃生口、mixed fallback 或平台 FFI 实现。

属于 #943 的一部分，并推进 #887。