### PR TITLE
feat(calx): cache whole-program artifacts / 缓存整程序产物

### DIFF
--- a/docs/run/calx-compile-cache.md
+++ b/docs/run/calx-compile-cache.md
@@ -1,6 +1,8 @@
 # Revision-safe Calx compile cache design / revision-safe Calx 编译缓存设计
 
-Tracking: [calcit#552](https://github.com/calcit-lang/calcit/issues/552) and [calx-vm#39](https://github.com/calcit-lang/calx-vm/issues/39)
+Tracking: [calcit#552](https://github.com/calcit-lang/calcit/issues/552),
+[calcit#950](https://github.com/calcit-lang/calcit/issues/950), and
+[calx-vm#39](https://github.com/calcit-lang/calx-vm/issues/39)
 
 Implementation status: the embedding-owned in-memory artifact cache described
 here is implemented in Calcit core. Benchmark execution and the cross-machine
@@ -41,6 +43,12 @@ callback、capability state、buffer input、VM instance、stack/frame 和 runti
 当前 Calx `ValidatedProgram` 含单线程 `Rc` 值，因此 artifact 也以 `Rc` 在一个 embedding thread 内共享，
 不承诺 `Send`/`Sync`；跨线程宿主应各自持有 cache，不能用 `Arc` 伪装线程安全。
 
+整程序路径沿用同一边界：`CalxCompiledProgramArtifact` 只增加已合并 lifecycle call graph、具名 entries
+和相同的 definition/import schema stamps；`CalxPreparedProgram` 每次重新挂载 callbacks，随后才可建立
+`CalxProgramInstance`。`CalxProgramCompileCache` 缓存前者，不缓存 instance、VM globals、平台 handle、
+WebSocket connection 或 capability state。因此这是 compile-artifact reuse，不是 runtime mode、watch
+scheduler 或 live-state migration。
+
 ### Revision key 与命中算法
 
 缓存由 embedding 显式创建并传入，不使用进程级 singleton。顶层 slot key 包含：
@@ -48,6 +56,10 @@ callback、capability state、buffer input、VM instance、stack/frame 和 runti
 1. fully-qualified entry；
 2. Calx kernel ABI edition；
 3. 排序后的 typed import declaration contract（definition、export name、参数与结果类型），不含 callback identity。
+
+整程序 slot key 则包含完整且规范化的 `CalxProgramCompilationUnit` identity：program ABI edition、selected
+entry、host target，以及按 role/definition 排序的完整 lifecycle roots；随后同样包含 typed import contract。
+root 顺序本身不改变语义，但 root role、root set、selected entry、target、ABI 或 import declaration 的变化都 miss。
 
 每个 artifact 另外保存排序后的 reachable definition stamps。当前 `CompiledDef::version_id` 尚未提供可用的
 内容 revision（现有路径仍写入 `0`），因此首版不能把它单独当作 correctness key。stamp 必须保存并比较：
@@ -85,10 +97,19 @@ let stats = cache.stats();
 cache.clear();
 ```
 
+整程序使用独立 embedding-owned cache，避免改变已有 kernel compatibility API：
+
+```rust
+let mut cache = CalxProgramCompileCache::new(4);
+let preparation = cache.prepare(program, unit, imports)?;
+let mut instance = preparation.program().instantiate()?;
+let value = instance.run_root(CalxProgramRootRole::Init, args)?;
+```
+
 `capacity` 首版按 artifact 个数设置硬上限，使用确定性的 LRU eviction；不得无界增长。stats 至少包含 hit、
 miss、miss reason、eviction、clear、entry count、reachable function count、syntax/instruction count 与估算字节数。
 miss reason 固定区分 `empty`、`entry-changed`、`callee-changed`、`schema-changed`、`abi-changed`、
-`import-contract-changed`、`dependency-missing` 和 `evicted`。命中报告明确标记跳过 eligibility、planning、
+`program-unit-changed`、`import-contract-changed`、`dependency-missing` 和 `evicted`。命中报告明确标记跳过 eligibility、planning、
 program construction、validation/lowering，但仍记录 revision validation 与 binding attachment 成本。
 `capacity == 0` 是受支持的 always-miss 模式：仍完整编译并重新附着 bindings，但不保存 artifact 或
 tombstone。`clear()` 清空 artifact 与 ledger、递增 clear counter，并保留其余历史 counters 供 embedding
@@ -106,6 +127,7 @@ artifact eviction 统计，之后该旧 key 按 `empty` 处理。
 - hot reload 改 entry、direct/transitive callee 或 schema 必须 miss；无关 definition 改动必须 hit；
 - callback A 编译后，以相同声明传 callback B 命中缓存，执行必须只调用 B；
 - import declaration 改动必须 miss，callback identity 改动本身不能污染 source-derived key；
+- whole-program root role/set、selected entry、host target 或 program ABI 变化必须 miss；
 - capacity、LRU eviction、显式 clear 与 stats 必须可测试；
 - eviction provenance 必须覆盖 capacity=1 下插入 A、插入 B、查询 A 得到 `evicted`；ledger 溢出后最旧
   tombstone 查询得到 `empty`；重新插入或 clear 后旧 tombstone 不得继续报告 `evicted`；
@@ -152,6 +174,12 @@ current Calx `ValidatedProgram` contains single-threaded `Rc` values, so an arti
 also shared with `Rc` inside one embedding thread and makes no `Send`/`Sync` promise. Cross-thread hosts own separate
 caches rather than using `Arc` to imply thread safety that the VM does not provide.
 
+The whole-program path keeps the same boundary. `CalxCompiledProgramArtifact` adds only the merged lifecycle call
+graph, named entries, and the same definition/import-schema stamps. `CalxPreparedProgram` reattaches callbacks on
+every request before it can create a `CalxProgramInstance`. `CalxProgramCompileCache` stores the former and never an
+instance, VM globals, platform handle, WebSocket connection, or capability state. This is compile-artifact reuse,
+not a runtime mode, watch scheduler, or live-state migration mechanism.
+
 ### Revision key and hit algorithm
 
 The embedding creates and passes the cache explicitly; there is no process singleton. The top-level slot key
@@ -160,6 +188,11 @@ contains:
 1. the fully qualified entry;
 2. the Calx kernel ABI edition;
 3. the sorted typed-import declaration contract (definition, export name, parameter types, and result type), excluding callback identity.
+
+A whole-program slot key contains the complete normalized `CalxProgramCompilationUnit` identity: program ABI
+edition, selected entry, host target, and the complete lifecycle roots sorted by role and definition. It then adds
+the typed import contract. Root ordering alone has no semantics, while a root role/set, selected entry, target, ABI,
+or import declaration change always misses.
 
 Each artifact also stores sorted reachable-definition stamps. `CompiledDef::version_id` is not yet a usable content
 revision because current paths still write `0`, so the first implementation must not use it as the sole correctness
@@ -199,10 +232,20 @@ let stats = cache.stats();
 cache.clear();
 ```
 
+Whole programs use a separate embedding-owned cache so the existing kernel compatibility API remains unchanged:
+
+```rust
+let mut cache = CalxProgramCompileCache::new(4);
+let preparation = cache.prepare(program, unit, imports)?;
+let mut instance = preparation.program().instantiate()?;
+let value = instance.run_root(CalxProgramRootRole::Init, args)?;
+```
+
 The first `capacity` is a hard artifact-count limit with deterministic LRU eviction; growth is never unbounded.
 Stats include hits, misses, miss reasons, evictions, clears, entry count, reachable function count,
 syntax/instruction count, and estimated bytes. Stable miss reasons distinguish `empty`, `entry-changed`,
-`callee-changed`, `schema-changed`, `abi-changed`, `import-contract-changed`, `dependency-missing`, and `evicted`.
+`callee-changed`, `schema-changed`, `abi-changed`, `program-unit-changed`, `import-contract-changed`,
+`dependency-missing`, and `evicted`.
 A hit reports that eligibility, planning, program construction, and validation/lowering were skipped while still
 recording revision-validation and binding-attachment cost.
 Capacity zero is a supported always-miss mode: compilation and fresh binding attachment still occur, but no artifact
@@ -223,6 +266,7 @@ an artifact eviction, and a later lookup of that forgotten key reports `empty`.
 - Hot reloads of the entry, a direct/transitive callee, or a schema must miss; an unrelated definition change must hit.
 - After compiling with callback A, a hit with the same declaration and callback B must execute only B.
 - Import declaration changes must miss; callback identity itself must not contaminate the source-derived key.
+- Whole-program root roles/sets, selected entry, host target, or program ABI changes must miss.
 - Capacity, deterministic LRU eviction, explicit clear, and stats must be covered.
 - Eviction-provenance coverage inserts A then B at capacity one and expects an A lookup to report `evicted`; after
   the ledger overflows its oldest tombstone reports `empty`; reinsertion and clear must not leave a stale `evicted`

--- a/docs/run/calx-program-target.md
+++ b/docs/run/calx-program-target.md
@@ -50,7 +50,7 @@ Whole-program eligibility checks `init` and `reload` as one atomic unit. It dedu
 
 This edition now has a library-level lowering and execution foundation. `compile_calx_program` atomically proves the unit, lowers its merged reachable definitions into one validated program, and records each lifecycle role with its exact fully qualified VM function name and strict signature. A `CalxProgramInstance` can then invoke either role through calx-vm 0.5.1 named-entry execution. Shared roots keep both roles while reusing one emitted function body; no synthetic `main` dispatcher is generated.
 
-This API does not yet select a runtime backend, own lifecycle scheduling, or add program caching/watch invalidation. Existing `:mode :native` and `:mode :js` behavior is unchanged; the contract does not prematurely expose a `:calx` runtime mode. [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) records the completed VM prerequisite and downstream release validation.
+This API now offers an embedding-owned, revision-safe cache for immutable whole-program artifacts. Cache hits revalidate reachable source stamps and reattach current typed callbacks; they do not preserve VM instances or live state. The API still does not select a runtime backend or own lifecycle/watch scheduling. Existing `:mode :native` and `:mode :js` behavior is unchanged; the contract does not prematurely expose a `:calx` runtime mode. [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) records the completed VM prerequisite and downstream release validation.
 
 ### Hard boundaries
 
@@ -113,7 +113,7 @@ Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次�
 
 本 edition 现在具备库级 lowering 与执行基础。`compile_calx_program` 会原子证明整个 unit，把合并后的可达 definitions lowering 为一份 validated program，并为每个生命周期角色记录准确的完整限定 VM 函数名与 strict signature。随后 `CalxProgramInstance` 通过 calx-vm 0.5.1 的 named-entry execution 调用任一角色。两个 roots 指向同一 definition 时仍保留两个角色，但只复用一份已生成函数体；不会合成 `main` dispatcher。
 
-该 API 尚不选择 runtime backend，不负责生命周期调度，也不增加 program cache/watch invalidation。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。[calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 记录已完成的 VM 前置能力与下游发布验证。
+该 API 现在提供由 embedding 显式拥有、revision-safe 的 immutable whole-program artifact cache。命中时重新校验 reachable source stamps 并挂载当前 typed callbacks，不保留 VM instance 或 live state。它仍不选择 runtime backend，也不负责 lifecycle/watch scheduling。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。[calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 记录已完成的 VM 前置能力与下游发布验证。
 
 ### 硬边界
 

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -205,7 +205,9 @@ remaining, index-stream bounds, fractional/negative/non-finite indices, and valu
 
 当前 API 仍是 Rust embedding，不是 `calcit` CLI 的正式 backend。首批没有 collection/nominal value、closure、
 持久化 cache、VM pool 或 selection policy，也还没有基于 benchmark 的自动 offload。embedding-owned、
-容量有界、revision-safe 的 validated-artifact cache 已实现，但 cache-hit 性能报告仍等待独立 harness。
+容量有界、revision-safe 的 validated-artifact cache 已覆盖 kernel 与 whole-program compilation unit，
+但 program cache-hit 性能报告仍等待独立 harness。两者都只缓存 immutable compile artifact，命中时重新挂载
+typed callbacks；不缓存 VM instance 或 live state。
 correctness corpus 已覆盖 scalar
 kernel、zero/single-result typed imports、generated program、trap 与 fallback。分阶段 benchmark matrix、
 采样 crossover point 和首份 scalar baseline 已建立；[calx-vm #39](https://github.com/calcit-lang/calx-vm/issues/39)

--- a/editing-history/202609101233-calx-program-artifact-cache.md
+++ b/editing-history/202609101233-calx-program-artifact-cache.md
@@ -1,0 +1,19 @@
+# Revision-safe Calx program artifact cache / revision-safe Calx 程序产物缓存
+
+## English
+
+- Extended the existing embedding-owned cache invariants from one-entry kernels to the versioned whole-program compilation unit.
+- Kept cache keys callback-free while covering program ABI, selected entry, host target, lifecycle root roles/definitions, and typed import declarations.
+- Added structural stamps for every reachable compiled definition and imported Calcit schema; unrelated changes remain hits, while root/callee/schema/missing-dependency changes rebuild or fail atomically.
+- Reattached current typed callbacks on every request and kept `CalxProgramInstance`, VM globals, platform handles, connections, and capability state outside cached artifacts.
+- Added deterministic LRU, capacity-zero, clear, counters, miss reasons, artifact-size gauges, and positive/negative regression coverage without changing the kernel compatibility API.
+- Isolated an existing effects-graph fixture with the shared program-state test guard so the expanded cache suite stays deterministic under parallel `cargo test` execution.
+
+## 中文
+
+- 将已有 embedding-owned 单入口 kernel cache 的不变量扩展到有版本的 whole-program compilation unit。
+- cache key 不含 callback identity，但覆盖 program ABI、selected entry、host target、lifecycle root role/definition 与 typed import declarations。
+- 为全部 reachable compiled definitions 与 imported Calcit schema 增加结构 stamp；无关修改继续命中，root/callee/schema/依赖缺失则重建或原子失败。
+- 每次请求重新挂载当前 typed callbacks；`CalxProgramInstance`、VM globals、平台 handles、连接与 capability state 均不进入缓存 artifact。
+- 增加确定性 LRU、capacity-zero、clear、计数、miss reasons、artifact-size gauges 及正反回归，不改变 kernel compatibility API。
+- 为既有 effects-graph fixture 补上共享 program-state 测试守卫，保证扩展后的 cache suite 在并行 `cargo test` 下仍具确定性。

--- a/editing-history/202609101233-calx-program-artifact-cache.md
+++ b/editing-history/202609101233-calx-program-artifact-cache.md
@@ -7,6 +7,7 @@
 - Added structural stamps for every reachable compiled definition and imported Calcit schema; unrelated changes remain hits, while root/callee/schema/missing-dependency changes rebuild or fail atomically.
 - Reattached current typed callbacks on every request and kept `CalxProgramInstance`, VM globals, platform handles, connections, and capability state outside cached artifacts.
 - Added deterministic LRU, capacity-zero, clear, counters, miss reasons, artifact-size gauges, and positive/negative regression coverage without changing the kernel compatibility API.
+- Strengthened review coverage with a capacity-two A/B/access-A/C sequence that distinguishes true recency eviction from FIFO behavior.
 - Isolated an existing effects-graph fixture with the shared program-state test guard so the expanded cache suite stays deterministic under parallel `cargo test` execution.
 
 ## 中文
@@ -16,4 +17,5 @@
 - 为全部 reachable compiled definitions 与 imported Calcit schema 增加结构 stamp；无关修改继续命中，root/callee/schema/依赖缺失则重建或原子失败。
 - 每次请求重新挂载当前 typed callbacks；`CalxProgramInstance`、VM globals、平台 handles、连接与 capability state 均不进入缓存 artifact。
 - 增加确定性 LRU、capacity-zero、clear、计数、miss reasons、artifact-size gauges 及正反回归，不改变 kernel compatibility API。
+- 根据 review 补充 capacity-two 的 A/B、访问 A、插入 C 序列，使测试能明确区分真正的 recency eviction 与 FIFO。
 - 为既有 effects-graph fixture 补上共享 program-state 测试守卫，保证扩展后的 cache suite 在并行 `cargo test` 下仍具确定性。

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -13,7 +13,10 @@ mod lowering;
 mod program_contract;
 mod program_eligibility;
 
-pub use cache::{CalxCacheMissReason, CalxCachePreparation, CalxCachePrepareReport, CalxCompileCache, CalxCompileCacheStats};
+pub use cache::{
+  CalxCacheMissReason, CalxCachePreparation, CalxCachePrepareReport, CalxCompileCache, CalxCompileCacheStats,
+  CalxProgramCachePreparation, CalxProgramCachePrepareReport, CalxProgramCompileCache,
+};
 pub use calx_vm::{Calx as CalxValue, CalxBuildError, CalxError, CalxProgramError};
 pub use coverage::{
   CALX_COVERAGE_PROC_COUNT_V1, CalxCoverage, CalxCoverageOwner, CalxCoverageStage, classify_calx_proc_surface,

--- a/src/codegen/calx/cache.rs
+++ b/src/codegen/calx/cache.rs
@@ -8,10 +8,14 @@ use std::time::{Duration, Instant};
 use crate::program::CompiledProgram;
 
 use super::lowering::{
-  CalxCompiledArtifact, CalxKernelCompileError, CalxKernelCompileTimings, CalxPreparedKernel,
-  compile_calx_artifact_with_imports_measured, prepare_calx_artifact,
+  CalxCompiledArtifact, CalxCompiledProgramArtifact, CalxKernelCompileError, CalxKernelCompileTimings, CalxPreparedKernel,
+  CalxPreparedProgram, CalxProgramCompileError, compile_calx_artifact_with_imports_measured,
+  compile_calx_program_artifact_with_imports, prepare_calx_artifact, prepare_calx_program_artifact,
 };
-use super::{CALX_KERNEL_ABI_EDITION, CalxDefinitionRef, CalxHostImports, CalxImportContract, import_contract, lookup_compiled_def};
+use super::{
+  CALX_KERNEL_ABI_EDITION, CalxDefinitionRef, CalxHostImports, CalxImportContract, CalxProgramCompilationUnit, CalxProgramRootRole,
+  import_contract, lookup_compiled_def,
+};
 
 /// Stable reason assigned to one source-derived cache miss.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -21,6 +25,7 @@ pub enum CalxCacheMissReason {
   CalleeChanged,
   SchemaChanged,
   AbiChanged,
+  ProgramUnitChanged,
   ImportContractChanged,
   DependencyMissing,
   Evicted,
@@ -34,10 +39,49 @@ impl CalxCacheMissReason {
       Self::CalleeChanged => "callee-changed",
       Self::SchemaChanged => "schema-changed",
       Self::AbiChanged => "abi-changed",
+      Self::ProgramUnitChanged => "program-unit-changed",
       Self::ImportContractChanged => "import-contract-changed",
       Self::DependencyMissing => "dependency-missing",
       Self::Evicted => "evicted",
     }
+  }
+}
+
+/// Per-request evidence for whole-program artifact preparation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalxProgramCachePrepareReport {
+  pub cache_hit: bool,
+  pub miss_reason: Option<CalxCacheMissReason>,
+  pub skipped_eligibility: bool,
+  pub skipped_planning: bool,
+  pub skipped_program_construction: bool,
+  pub skipped_validation_lowering: bool,
+  pub revision_validation: Duration,
+  pub binding_attachment: Duration,
+}
+
+/// A freshly prepared whole program and the cache decision that produced it.
+#[derive(Debug)]
+pub struct CalxProgramCachePreparation {
+  program: CalxPreparedProgram,
+  report: CalxProgramCachePrepareReport,
+}
+
+impl CalxProgramCachePreparation {
+  pub fn program(&self) -> &CalxPreparedProgram {
+    &self.program
+  }
+
+  pub fn report(&self) -> &CalxProgramCachePrepareReport {
+    &self.report
+  }
+
+  pub fn into_program(self) -> CalxPreparedProgram {
+    self.program
+  }
+
+  pub fn into_parts(self) -> (CalxPreparedProgram, CalxProgramCachePrepareReport) {
+    (self.program, self.report)
   }
 }
 
@@ -314,6 +358,240 @@ impl CalxCompileCache {
   }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CalxProgramUnitKey {
+  abi_edition: Arc<str>,
+  entry_name: Arc<str>,
+  host_target: Option<Arc<str>>,
+  roots: Vec<(CalxProgramRootRole, CalxDefinitionRef)>,
+}
+
+impl CalxProgramUnitKey {
+  fn current(unit: &CalxProgramCompilationUnit) -> Self {
+    let mut roots = unit
+      .roots
+      .iter()
+      .map(|root| (root.role, root.definition.clone()))
+      .collect::<Vec<_>>();
+    roots.sort();
+    Self {
+      abi_edition: unit.abi_edition.clone(),
+      entry_name: unit.entry_name.clone(),
+      host_target: unit.host_target.map(|target| Arc::from(target.as_str())),
+      roots,
+    }
+  }
+
+  fn same_except_abi(&self, other: &Self) -> bool {
+    self.entry_name == other.entry_name && self.host_target == other.host_target && self.roots == other.roots
+  }
+
+  fn same_program_family(&self, other: &Self) -> bool {
+    self.entry_name == other.entry_name || self.roots == other.roots
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CalxProgramCacheSlotKey {
+  unit: CalxProgramUnitKey,
+  imports: Vec<CalxImportContract>,
+}
+
+impl CalxProgramCacheSlotKey {
+  fn current(unit: &CalxProgramCompilationUnit, imports: &CalxHostImports) -> Self {
+    Self {
+      unit: CalxProgramUnitKey::current(unit),
+      imports: import_contract(imports),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+struct CalxProgramCacheEntry {
+  artifact: Rc<CalxCompiledProgramArtifact>,
+  last_used: u64,
+}
+
+/// Explicit, capacity-bounded LRU cache for immutable whole-program artifacts.
+///
+/// Each prepare revalidates reachable source stamps and reattaches the current
+/// typed host callbacks. VM instances and live capability state are never cached.
+#[derive(Debug)]
+pub struct CalxProgramCompileCache {
+  capacity: usize,
+  clock: u64,
+  entries: BTreeMap<CalxProgramCacheSlotKey, CalxProgramCacheEntry>,
+  recently_evicted: BTreeMap<CalxProgramCacheSlotKey, u64>,
+  counters: CalxCacheCounters,
+}
+
+impl CalxProgramCompileCache {
+  /// Create a bounded cache. Capacity zero is a supported always-miss mode.
+  pub fn new(capacity: usize) -> Self {
+    Self {
+      capacity,
+      clock: 0,
+      entries: BTreeMap::new(),
+      recently_evicted: BTreeMap::new(),
+      counters: CalxCacheCounters::default(),
+    }
+  }
+
+  pub fn capacity(&self) -> usize {
+    self.capacity
+  }
+
+  /// Validate the complete program identity and source closure, compiling only on a miss.
+  pub fn prepare(
+    &mut self,
+    program: &CompiledProgram,
+    unit: &CalxProgramCompilationUnit,
+    imports: &CalxHostImports,
+  ) -> Result<CalxProgramCachePreparation, CalxProgramCompileError> {
+    let key = CalxProgramCacheSlotKey::current(unit, imports);
+    let revision_started = Instant::now();
+    let candidate = self.entries.get(&key).map(|entry| entry.artifact.clone());
+    let miss_reason = match candidate.as_ref() {
+      Some(artifact) => validate_program_stamps(program, artifact),
+      None => Some(self.classify_absent_slot(&key)),
+    };
+    let revision_validation = revision_started.elapsed();
+
+    if let (Some(artifact), None) = (candidate, miss_reason) {
+      let binding_started = Instant::now();
+      let prepared = prepare_calx_program_artifact(artifact, imports)?;
+      let binding_attachment = binding_started.elapsed();
+      let tick = self.next_tick();
+      if let Some(entry) = self.entries.get_mut(&key) {
+        entry.last_used = tick;
+      }
+      self.counters.hits += 1;
+      return Ok(CalxProgramCachePreparation {
+        program: prepared,
+        report: CalxProgramCachePrepareReport {
+          cache_hit: true,
+          miss_reason: None,
+          skipped_eligibility: true,
+          skipped_planning: true,
+          skipped_program_construction: true,
+          skipped_validation_lowering: true,
+          revision_validation,
+          binding_attachment,
+        },
+      });
+    }
+
+    let reason = miss_reason.unwrap_or(CalxCacheMissReason::Empty);
+    self.record_miss(reason);
+    let artifact = compile_calx_program_artifact_with_imports(program, unit, imports)?;
+    let binding_started = Instant::now();
+    let prepared = prepare_calx_program_artifact(artifact.clone(), imports)?;
+    let binding_attachment = binding_started.elapsed();
+    self.insert(key, artifact);
+    Ok(CalxProgramCachePreparation {
+      program: prepared,
+      report: CalxProgramCachePrepareReport {
+        cache_hit: false,
+        miss_reason: Some(reason),
+        skipped_eligibility: false,
+        skipped_planning: false,
+        skipped_program_construction: false,
+        skipped_validation_lowering: false,
+        revision_validation,
+        binding_attachment,
+      },
+    })
+  }
+
+  /// Remove artifacts and eviction provenance while retaining counters.
+  pub fn clear(&mut self) {
+    self.entries.clear();
+    self.recently_evicted.clear();
+    self.counters.clears += 1;
+  }
+
+  pub fn stats(&self) -> CalxCompileCacheStats {
+    let mut stats = CalxCompileCacheStats {
+      hits: self.counters.hits,
+      misses: self.counters.misses,
+      misses_by_reason: self.counters.misses_by_reason.clone(),
+      evictions: self.counters.evictions,
+      clears: self.counters.clears,
+      entry_count: self.entries.len(),
+      recently_evicted_count: self.recently_evicted.len(),
+      ..CalxCompileCacheStats::default()
+    };
+    for entry in self.entries.values() {
+      stats.reachable_function_count += entry.artifact.reachable_definition_count();
+      stats.syntax_instruction_count += entry.artifact.syntax_instruction_count();
+      stats.lowered_instruction_count += entry.artifact.lowered_instruction_count();
+      stats.estimated_bytes += entry.artifact.estimated_bytes();
+    }
+    stats
+  }
+
+  fn classify_absent_slot(&self, key: &CalxProgramCacheSlotKey) -> CalxCacheMissReason {
+    if self.recently_evicted.contains_key(key) {
+      return CalxCacheMissReason::Evicted;
+    }
+    for active in self.entries.keys() {
+      if active.unit.same_except_abi(&key.unit) && active.unit.abi_edition != key.unit.abi_edition {
+        return CalxCacheMissReason::AbiChanged;
+      }
+      if active.unit == key.unit && active.imports != key.imports {
+        return CalxCacheMissReason::ImportContractChanged;
+      }
+    }
+    for active in self.entries.keys() {
+      if active.unit.same_program_family(&key.unit) && active.unit != key.unit {
+        return CalxCacheMissReason::ProgramUnitChanged;
+      }
+    }
+    CalxCacheMissReason::Empty
+  }
+
+  fn record_miss(&mut self, reason: CalxCacheMissReason) {
+    self.counters.misses += 1;
+    *self.counters.misses_by_reason.entry(reason).or_insert(0) += 1;
+  }
+
+  fn insert(&mut self, key: CalxProgramCacheSlotKey, artifact: Rc<CalxCompiledProgramArtifact>) {
+    self.recently_evicted.remove(&key);
+    if self.capacity == 0 {
+      return;
+    }
+    if !self.entries.contains_key(&key)
+      && self.entries.len() >= self.capacity
+      && let Some(evicted) = least_recent_program_key(&self.entries)
+    {
+      self.entries.remove(&evicted);
+      self.counters.evictions += 1;
+      self.record_evicted(evicted);
+    }
+    let tick = self.next_tick();
+    self.entries.insert(key, CalxProgramCacheEntry { artifact, last_used: tick });
+  }
+
+  fn record_evicted(&mut self, key: CalxProgramCacheSlotKey) {
+    if self.capacity == 0 {
+      return;
+    }
+    let tick = self.next_tick();
+    self.recently_evicted.insert(key, tick);
+    while self.recently_evicted.len() > self.capacity {
+      let Some(oldest) = least_recent_program_tombstone(&self.recently_evicted) else {
+        break;
+      };
+      self.recently_evicted.remove(&oldest);
+    }
+  }
+
+  fn next_tick(&mut self) -> u64 {
+    self.clock = self.clock.wrapping_add(1);
+    self.clock
+  }
+}
+
 fn validate_reachable_stamps(program: &CompiledProgram, artifact: &CalxCompiledArtifact) -> Option<CalxCacheMissReason> {
   for stamp in &artifact.reachable_stamps {
     let Some(current) = lookup_compiled_def(program, &stamp.definition) else {
@@ -341,6 +619,39 @@ fn validate_reachable_stamps(program: &CompiledProgram, artifact: &CalxCompiledA
   None
 }
 
+fn validate_program_stamps(program: &CompiledProgram, artifact: &CalxCompiledProgramArtifact) -> Option<CalxCacheMissReason> {
+  let roots = artifact
+    .eligible_program()
+    .roots
+    .iter()
+    .map(|root| &root.definition)
+    .collect::<std::collections::BTreeSet<_>>();
+  for stamp in &artifact.reachable_stamps {
+    let Some(current) = lookup_compiled_def(program, &stamp.definition) else {
+      return Some(CalxCacheMissReason::DependencyMissing);
+    };
+    if current.schema != stamp.schema {
+      return Some(CalxCacheMissReason::SchemaChanged);
+    }
+    if current.def_id != stamp.def_id || current.preprocessed_code != stamp.preprocessed_code {
+      return Some(if roots.contains(&stamp.definition) {
+        CalxCacheMissReason::EntryChanged
+      } else {
+        CalxCacheMissReason::CalleeChanged
+      });
+    }
+  }
+  for stamp in &artifact.import_schema_stamps {
+    let Some(current) = lookup_compiled_def(program, &stamp.definition) else {
+      return Some(CalxCacheMissReason::DependencyMissing);
+    };
+    if current.schema != stamp.schema {
+      return Some(CalxCacheMissReason::SchemaChanged);
+    }
+  }
+  None
+}
+
 fn least_recent_key(entries: &BTreeMap<CalxCacheSlotKey, CalxCacheEntry>) -> Option<CalxCacheSlotKey> {
   entries
     .iter()
@@ -349,6 +660,20 @@ fn least_recent_key(entries: &BTreeMap<CalxCacheSlotKey, CalxCacheEntry>) -> Opt
 }
 
 fn least_recent_tombstone(entries: &BTreeMap<CalxCacheSlotKey, u64>) -> Option<CalxCacheSlotKey> {
+  entries
+    .iter()
+    .min_by(|(left_key, left), (right_key, right)| left.cmp(right).then_with(|| left_key.cmp(right_key)))
+    .map(|(key, _)| key.clone())
+}
+
+fn least_recent_program_key(entries: &BTreeMap<CalxProgramCacheSlotKey, CalxProgramCacheEntry>) -> Option<CalxProgramCacheSlotKey> {
+  entries
+    .iter()
+    .min_by(|(left_key, left), (right_key, right)| left.last_used.cmp(&right.last_used).then_with(|| left_key.cmp(right_key)))
+    .map(|(key, _)| key.clone())
+}
+
+fn least_recent_program_tombstone(entries: &BTreeMap<CalxProgramCacheSlotKey, u64>) -> Option<CalxProgramCacheSlotKey> {
   entries
     .iter()
     .min_by(|(left_key, left), (right_key, right)| left.cmp(right).then_with(|| left_key.cmp(right_key)))

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -465,6 +465,8 @@ pub struct CalxCompiledProgramArtifact {
   eligible: CalxEligibleProgram,
   entries: Vec<CalxProgramEntry>,
   program: ValidatedProgram,
+  pub(super) reachable_stamps: Vec<CalxDefinitionStamp>,
+  pub(super) import_schema_stamps: Vec<CalxImportSchemaStamp>,
   import_contract: Vec<CalxImportContract>,
 }
 
@@ -483,6 +485,49 @@ impl CalxCompiledProgramArtifact {
 
   pub fn import_contract(&self) -> &[CalxImportContract] {
     &self.import_contract
+  }
+
+  pub fn reachable_definition_count(&self) -> usize {
+    self.reachable_stamps.len()
+  }
+
+  pub fn syntax_instruction_count(&self) -> usize {
+    self.program.functions().iter().map(|function| function.syntax.len()).sum()
+  }
+
+  pub fn lowered_instruction_count(&self) -> usize {
+    self.program.functions().iter().map(|function| function.instrs.len()).sum()
+  }
+
+  /// Deterministic shallow estimate for bounded-cache observability.
+  pub fn estimated_bytes(&self) -> usize {
+    let mut bytes = std::mem::size_of::<Self>();
+    bytes += self.entries.len() * std::mem::size_of::<CalxProgramEntry>();
+    bytes += self.reachable_stamps.len() * std::mem::size_of::<CalxDefinitionStamp>();
+    bytes += self.import_schema_stamps.len() * std::mem::size_of::<CalxImportSchemaStamp>();
+    bytes += self.import_contract.len() * std::mem::size_of::<CalxImportContract>();
+    for entry in &self.entries {
+      bytes += entry.definition.namespace.len() + entry.definition.definition.len() + entry.vm_name.len();
+      bytes += entry.params.len() * std::mem::size_of::<CalxScalarType>();
+    }
+    for stamp in &self.reachable_stamps {
+      bytes += stamp.definition.namespace.len() + stamp.definition.definition.len();
+      bytes += std::mem::size_of_val(&stamp.preprocessed_code) + std::mem::size_of_val(stamp.schema.as_ref());
+    }
+    for stamp in &self.import_schema_stamps {
+      bytes += stamp.definition.namespace.len() + stamp.definition.definition.len();
+      bytes += std::mem::size_of_val(stamp.schema.as_ref());
+    }
+    for contract in &self.import_contract {
+      bytes += contract.definition.namespace.len() + contract.definition.definition.len() + contract.export_name.len();
+      bytes += contract.params.len() * std::mem::size_of::<CalxScalarType>();
+    }
+    for function in self.program.functions() {
+      bytes += function.name.len();
+      bytes += std::mem::size_of_val(function.syntax.as_slice());
+      bytes += std::mem::size_of_val(function.instrs.as_slice());
+    }
+    bytes
   }
 }
 
@@ -551,6 +596,15 @@ pub fn compile_calx_program_with_imports(
   unit: &CalxProgramCompilationUnit,
   imports: &CalxHostImports,
 ) -> Result<CalxPreparedProgram, CalxProgramCompileError> {
+  let artifact = compile_calx_program_artifact_with_imports(program, unit, imports)?;
+  prepare_calx_program_artifact(artifact, imports)
+}
+
+pub(super) fn compile_calx_program_artifact_with_imports(
+  program: &CompiledProgram,
+  unit: &CalxProgramCompilationUnit,
+  imports: &CalxHostImports,
+) -> Result<Rc<CalxCompiledProgramArtifact>, CalxProgramCompileError> {
   let eligible = analyze_calx_program_eligibility_with_imports(program, unit, imports).map_err(CalxProgramCompileError::Eligibility)?;
   let names = eligible
     .functions
@@ -592,13 +646,6 @@ pub fn compile_calx_program_with_imports(
   }
   let validated_program = ValidatedProgram::try_from_program(builder.build()?)?;
 
-  let error_context = eligible.roots.first().map(|root| root.definition.clone()).ok_or_else(|| {
-    CalxProgramCompileError::Lowering(lower_error(
-      &CalxDefinitionRef::new("<program>", "<root>"),
-      None,
-      "eligible program contains no lifecycle roots",
-    ))
-  })?;
   let entries = eligible
     .roots
     .iter()
@@ -626,16 +673,77 @@ pub fn compile_calx_program_with_imports(
       })
     })
     .collect::<Result<Vec<_>, CalxProgramCompileError>>()?;
+  let reachable_stamps = eligible
+    .functions
+    .iter()
+    .map(|function| {
+      let compiled = lookup_compiled_def(program, &function.definition).ok_or_else(|| {
+        CalxProgramCompileError::Lowering(lower_error(
+          &function.definition,
+          None,
+          "eligible definition disappeared before program artifact stamping",
+        ))
+      })?;
+      Ok(CalxDefinitionStamp {
+        definition: function.definition.clone(),
+        def_id: compiled.def_id,
+        preprocessed_code: compiled.preprocessed_code.clone(),
+        schema: compiled.schema.clone(),
+      })
+    })
+    .collect::<Result<Vec<_>, CalxProgramCompileError>>()?;
+  let import_schema_stamps = used_imports
+    .iter()
+    .map(|definition| {
+      let compiled = lookup_compiled_def(program, definition).ok_or_else(|| {
+        CalxProgramCompileError::Lowering(lower_error(
+          definition,
+          None,
+          "eligible host import disappeared before program artifact stamping",
+        ))
+      })?;
+      Ok(CalxImportSchemaStamp {
+        definition: definition.clone(),
+        schema: compiled.schema.clone(),
+      })
+    })
+    .collect::<Result<Vec<_>, CalxProgramCompileError>>()?;
+  Ok(Rc::new(CalxCompiledProgramArtifact {
+    eligible,
+    entries,
+    program: validated_program,
+    reachable_stamps,
+    import_schema_stamps,
+    import_contract: import_contract(imports),
+  }))
+}
+
+pub(super) fn prepare_calx_program_artifact(
+  artifact: Rc<CalxCompiledProgramArtifact>,
+  imports: &CalxHostImports,
+) -> Result<CalxPreparedProgram, CalxProgramCompileError> {
+  if import_contract(imports) != artifact.import_contract {
+    let context = artifact
+      .eligible
+      .roots
+      .first()
+      .map(|root| root.definition.clone())
+      .unwrap_or_else(|| CalxDefinitionRef::new("<program>", "<root>"));
+    return Err(CalxProgramCompileError::Lowering(lower_error(
+      &context,
+      None,
+      "typed host import declarations changed while attaching a compiled program artifact",
+    )));
+  }
+  let used_imports = collect_used_imports(&artifact.eligible.functions);
+  let error_context = artifact
+    .eligible
+    .roots
+    .first()
+    .map(|root| root.definition.clone())
+    .unwrap_or_else(|| CalxDefinitionRef::new("<program>", "<root>"));
   let host_bindings = attach_used_imports(&used_imports, imports, &error_context)?;
-  Ok(CalxPreparedProgram {
-    artifact: Rc::new(CalxCompiledProgramArtifact {
-      eligible,
-      entries,
-      program: validated_program,
-      import_contract: import_contract(imports),
-    }),
-    host_bindings,
-  })
+  Ok(CalxPreparedProgram { artifact, host_bindings })
 }
 
 fn collect_used_imports(functions: &[CalxEligibleFunction]) -> BTreeSet<CalxDefinitionRef> {

--- a/src/codegen/calx/program_contract.rs
+++ b/src/codegen/calx/program_contract.rs
@@ -1,8 +1,8 @@
 //! Versioned compilation-unit contract for the Calx program backend.
 //!
 //! This module selects lifecycle roots from one configured Snapshot entry. It
-//! does not lower or execute them: the current VM still exposes the kernel
-//! compatibility entry named `main` only.
+//! does not lower or execute them; lowering maps each role to an exact named
+//! strict VM entry while keeping lifecycle scheduling outside the compiler.
 
 use std::fmt;
 use std::sync::Arc;

--- a/src/effects_graph.rs
+++ b/src/effects_graph.rs
@@ -2315,6 +2315,7 @@ mod tests {
 
   #[test]
   fn expand_store_schema_when_msg_buffer_available() {
+    let _guard = crate::program::lock_program_test_state();
     let path = std::path::Path::new("/Users/jon.chen/repo/termina/msg-buffer/calcit.cirru");
     if !path.exists() {
       return;

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -1766,6 +1766,25 @@ fn calx_program_cache_keys_complete_units_and_bounds_lru_state() {
     ],
     ..unit_a.clone()
   };
+  let mut unit_c = calx_program_unit(namespace, "affine", "fibonacci");
+  unit_c.entry_name = Arc::from("third");
+
+  let mut recency = CalxProgramCompileCache::new(2);
+  recency.prepare(&snapshot, &unit_a, &imports).expect("insert LRU program A");
+  recency.prepare(&snapshot, &unit_b, &imports).expect("insert LRU program B");
+  assert!(
+    recency
+      .prepare(&snapshot, &unit_a, &imports)
+      .expect("refresh program A")
+      .report()
+      .cache_hit
+  );
+  recency.prepare(&snapshot, &unit_c, &imports).expect("insert program C and evict B");
+  let evicted_b = recency
+    .prepare(&snapshot, &unit_b, &imports)
+    .expect("recompile evicted LRU program B");
+  assert_eq!(evicted_b.report().miss_reason, Some(CalxCacheMissReason::Evicted));
+
   let mut bounded = CalxProgramCompileCache::new(1);
   bounded.prepare(&snapshot, &unit_a, &imports).expect("insert program A");
   bounded.prepare(&snapshot, &unit_b, &imports).expect("insert program B and evict A");

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -5,8 +5,8 @@ use crate::call_stack::CallStackList;
 use crate::codegen::calx::{
   CALX_PROGRAM_ABI_EDITION, CalxCacheMissReason, CalxCompileCache, CalxDefinitionRef, CalxError, CalxFallbackCode, CalxHostImport,
   CalxHostImports, CalxKernelBoundaryErrorKind, CalxKernelCompileError, CalxKernelRunError, CalxProgramCompilationUnit,
-  CalxProgramCompileError, CalxProgramEligibilityCode, CalxProgramRoot, CalxProgramRootRole, CalxScalarType, CalxValue,
-  analyze_calx_eligibility, analyze_calx_eligibility_with_imports, analyze_calx_program_eligibility,
+  CalxProgramCompileCache, CalxProgramCompileError, CalxProgramEligibilityCode, CalxProgramRoot, CalxProgramRootRole, CalxScalarType,
+  CalxValue, analyze_calx_eligibility, analyze_calx_eligibility_with_imports, analyze_calx_program_eligibility,
   analyze_calx_program_eligibility_with_imports, compile_calx_kernel, compile_calx_kernel_measured, compile_calx_kernel_with_imports,
   compile_calx_program, compile_calx_program_with_imports,
 };
@@ -1531,6 +1531,263 @@ fn calx_program_lowering_attaches_one_typed_capability_set_to_both_roots() {
     .run_root(CalxProgramRootRole::Reload, &[Calcit::Number(3.0)])
     .expect_err("host trap remains a runtime error without fallback");
   assert!(matches!(trap, CalxKernelRunError::Runtime(_)));
+}
+
+#[test]
+fn calx_program_cache_hits_and_reattaches_current_callbacks() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-cache-imports";
+  install_calx_typed_import_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed program cache fixture");
+  let unit = calx_program_unit(namespace, "imported-pipeline", "imported-pipeline");
+  let imports_a = calx_test_host_imports_with_scale(namespace, "fixture.scale", calx_test_scale);
+  let imports_b = calx_test_host_imports_with_scale(namespace, "fixture.scale", calx_test_scale_three);
+  let mut cache = CalxProgramCompileCache::new(2);
+
+  let first = cache
+    .prepare(&snapshot, &unit, &imports_a)
+    .expect("compile initial program artifact");
+  assert_eq!(first.report().miss_reason, Some(CalxCacheMissReason::Empty));
+  assert!(!first.report().cache_hit);
+  let first_artifact = first.program().artifact().clone();
+  let mut first_instance = first.program().instantiate().expect("instantiate first callback set");
+  assert_eq!(
+    first_instance
+      .run_root(CalxProgramRootRole::Init, &[Calcit::Number(3.0)])
+      .expect("run callback A"),
+    Calcit::Number(7.0)
+  );
+
+  let second = cache.prepare(&snapshot, &unit, &imports_b).expect("reuse artifact with callback B");
+  assert!(second.report().cache_hit);
+  assert!(second.report().miss_reason.is_none());
+  assert!(second.report().skipped_eligibility);
+  assert!(second.report().skipped_planning);
+  assert!(second.report().skipped_program_construction);
+  assert!(second.report().skipped_validation_lowering);
+  assert!(std::rc::Rc::ptr_eq(&first_artifact, second.program().artifact()));
+  let mut second_instance = second.program().instantiate().expect("instantiate replacement callback set");
+  assert_eq!(
+    second_instance
+      .run_root(CalxProgramRootRole::Reload, &[Calcit::Number(3.0)])
+      .expect("run callback B"),
+    Calcit::Number(10.0),
+    "program cache hits must attach current callbacks rather than cached capability state"
+  );
+
+  let mut host_schema_changed = snapshot.clone();
+  host_schema_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("host-scale")
+    .expect("host import definition")
+    .schema = calx_test_fn_schema(vec![CalcitTypeAnnotation::Bool], CalcitTypeAnnotation::Number);
+  assert!(matches!(
+    cache.prepare(&host_schema_changed, &unit, &imports_b),
+    Err(CalxProgramCompileError::Eligibility(_))
+  ));
+
+  let changed_contract = calx_test_host_imports_with_scale(namespace, "fixture.scale.v2", calx_test_scale_three);
+  let third = cache
+    .prepare(&snapshot, &unit, &changed_contract)
+    .expect("changed declaration recompiles the program artifact");
+  assert_eq!(third.report().miss_reason, Some(CalxCacheMissReason::ImportContractChanged));
+  assert!(!std::rc::Rc::ptr_eq(&first_artifact, third.program().artifact()));
+
+  let stats = cache.stats();
+  assert_eq!(stats.hits, 1);
+  assert_eq!(stats.misses, 3);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::SchemaChanged), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::ImportContractChanged), 1);
+  assert_eq!(stats.entry_count, 2);
+  assert!(stats.reachable_function_count >= 2);
+  assert!(stats.syntax_instruction_count > 0);
+  assert!(stats.lowered_instruction_count > 0);
+  assert!(stats.estimated_bytes > 0);
+}
+
+#[test]
+fn calx_program_cache_revalidates_roots_callees_schemas_and_missing_dependencies() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-cache-revisions";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone program revision fixture");
+  let unit = calx_program_unit(namespace, "range-sum", "affine");
+  let imports = CalxHostImports::new();
+  let mut cache = CalxProgramCompileCache::new(1);
+
+  let initial = cache.prepare(&snapshot, &unit, &imports).expect("compile initial program");
+  let initial_artifact = initial.program().artifact().clone();
+
+  let mut unrelated = snapshot.clone();
+  unrelated
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("polynomial")
+    .expect("unrelated definition")
+    .def_id
+    .0 += 10_000;
+  let unrelated_hit = cache.prepare(&unrelated, &unit, &imports).expect("unrelated change remains a hit");
+  assert!(unrelated_hit.report().cache_hit);
+  assert!(std::rc::Rc::ptr_eq(&initial_artifact, unrelated_hit.program().artifact()));
+
+  let mut body_changed = unrelated.clone();
+  body_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("range-sum")
+    .expect("init root")
+    .preprocessed_code = Calcit::Nil;
+  assert!(matches!(
+    cache.prepare(&body_changed, &unit, &imports),
+    Err(CalxProgramCompileError::Eligibility(_))
+  ));
+  let after_failed_body = cache
+    .prepare(&unrelated, &unit, &imports)
+    .expect("failed body rebuild must not replace the accepted artifact");
+  assert!(after_failed_body.report().cache_hit);
+  assert!(std::rc::Rc::ptr_eq(&initial_artifact, after_failed_body.program().artifact()));
+
+  let mut root_changed = unrelated.clone();
+  root_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("range-sum")
+    .expect("init root")
+    .def_id
+    .0 += 20_000;
+  let root_miss = cache.prepare(&root_changed, &unit, &imports).expect("root change recompiles");
+  assert_eq!(root_miss.report().miss_reason, Some(CalxCacheMissReason::EntryChanged));
+
+  let mut callee_changed = root_changed.clone();
+  callee_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("affine-helper")
+    .expect("shared reachable callee")
+    .def_id
+    .0 += 30_000;
+  let callee_miss = cache.prepare(&callee_changed, &unit, &imports).expect("callee change recompiles");
+  assert_eq!(callee_miss.report().miss_reason, Some(CalxCacheMissReason::CalleeChanged));
+  let accepted_artifact = callee_miss.program().artifact().clone();
+
+  let mut schema_changed = callee_changed.clone();
+  schema_changed
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .get_mut("affine-helper")
+    .expect("shared reachable callee")
+    .schema = DYNAMIC_TYPE.clone();
+  assert!(matches!(
+    cache.prepare(&schema_changed, &unit, &imports),
+    Err(CalxProgramCompileError::Eligibility(_))
+  ));
+
+  let mut dependency_missing = callee_changed.clone();
+  dependency_missing
+    .get_mut(namespace)
+    .expect("fixture namespace")
+    .defs
+    .remove("affine-helper");
+  assert!(matches!(
+    cache.prepare(&dependency_missing, &unit, &imports),
+    Err(CalxProgramCompileError::Eligibility(_))
+  ));
+
+  let recovered = cache
+    .prepare(&callee_changed, &unit, &imports)
+    .expect("failed rebuilds leave the last accepted artifact reusable");
+  assert!(recovered.report().cache_hit);
+  assert!(std::rc::Rc::ptr_eq(&accepted_artifact, recovered.program().artifact()));
+  let stats = cache.stats();
+  assert_eq!(stats.miss_count(CalxCacheMissReason::EntryChanged), 2);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::CalleeChanged), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::SchemaChanged), 1);
+  assert_eq!(stats.miss_count(CalxCacheMissReason::DependencyMissing), 1);
+  assert_eq!(stats.entry_count, 1, "failed compilation must not publish a partial artifact");
+}
+
+#[test]
+fn calx_program_cache_keys_complete_units_and_bounds_lru_state() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-cache-unit";
+  install_calx_scalar_kernel_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone program unit fixture");
+  let imports = CalxHostImports::new();
+  let unit_a = calx_program_unit(namespace, "range-sum", "affine");
+  let mut target_changed = unit_a.clone();
+  target_changed.host_target = Some(SnapshotTarget::Browser);
+  let mut entry_changed = unit_a.clone();
+  entry_changed.entry_name = Arc::from("worker");
+  let mut roles_changed = unit_a.clone();
+  roles_changed.roots.swap(0, 1);
+  roles_changed.roots[0].role = CalxProgramRootRole::Init;
+  roles_changed.roots[1].role = CalxProgramRootRole::Reload;
+  let mut root_set_changed = unit_a.clone();
+  root_set_changed.roots[1].definition = CalxDefinitionRef::new(namespace, "polynomial");
+
+  let mut identity_cache = CalxProgramCompileCache::new(8);
+  identity_cache.prepare(&snapshot, &unit_a, &imports).expect("compile base unit");
+  for changed in [&target_changed, &entry_changed, &roles_changed, &root_set_changed] {
+    let preparation = identity_cache
+      .prepare(&snapshot, changed, &imports)
+      .expect("changed complete unit recompiles");
+    assert_eq!(preparation.report().miss_reason, Some(CalxCacheMissReason::ProgramUnitChanged));
+  }
+
+  let mut wrong_abi = unit_a.clone();
+  wrong_abi.abi_edition = Arc::from("calcit-calx-program/unknown");
+  assert!(matches!(
+    identity_cache.prepare(&snapshot, &wrong_abi, &imports),
+    Err(CalxProgramCompileError::Eligibility(_))
+  ));
+  assert_eq!(identity_cache.stats().miss_count(CalxCacheMissReason::AbiChanged), 1);
+
+  let unit_b = CalxProgramCompilationUnit {
+    entry_name: Arc::from("second"),
+    roots: vec![
+      CalxProgramRoot {
+        role: CalxProgramRootRole::Init,
+        definition: CalxDefinitionRef::new(namespace, "fibonacci"),
+      },
+      CalxProgramRoot {
+        role: CalxProgramRootRole::Reload,
+        definition: CalxDefinitionRef::new(namespace, "polynomial"),
+      },
+    ],
+    ..unit_a.clone()
+  };
+  let mut bounded = CalxProgramCompileCache::new(1);
+  bounded.prepare(&snapshot, &unit_a, &imports).expect("insert program A");
+  bounded.prepare(&snapshot, &unit_b, &imports).expect("insert program B and evict A");
+  assert_eq!(bounded.stats().entry_count, 1);
+  assert_eq!(bounded.stats().evictions, 1);
+  let evicted = bounded.prepare(&snapshot, &unit_a, &imports).expect("recompile evicted program A");
+  assert_eq!(evicted.report().miss_reason, Some(CalxCacheMissReason::Evicted));
+
+  bounded.clear();
+  assert_eq!(bounded.stats().entry_count, 0);
+  assert_eq!(bounded.stats().recently_evicted_count, 0);
+  assert_eq!(bounded.stats().clears, 1);
+  let after_clear = bounded.prepare(&snapshot, &unit_a, &imports).expect("compile after clear");
+  assert_eq!(after_clear.report().miss_reason, Some(CalxCacheMissReason::Empty));
+
+  let mut disabled = CalxProgramCompileCache::new(0);
+  for _ in 0..2 {
+    let preparation = disabled.prepare(&snapshot, &unit_a, &imports).expect("zero-capacity compile");
+    assert_eq!(preparation.report().miss_reason, Some(CalxCacheMissReason::Empty));
+  }
+  assert_eq!(disabled.stats().entry_count, 0);
+  assert_eq!(disabled.stats().misses, 2);
 }
 
 #[test]


### PR DESCRIPTION
## English

Closes #950.

### Summary

- add an embedding-owned, capacity-bounded LRU cache for immutable whole-program Calx artifacts
- key and revalidate complete program units, reachable definitions, and typed import schemas
- reattach current host callbacks on every preparation while keeping VM instances and live state outside the cache
- preserve failed-rebuild atomicity and add deterministic miss, eviction, clear, and zero-capacity coverage
- document the compile-artifact boundary and isolate an existing effects-graph fixture with the shared program-state test guard

### Verification

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- yarn compile
- yarn check-all
- yarn check-agent-interface

## 中文

关闭 #950。

### 摘要

- 为不可变 Calx whole-program artifact 增加由 embedding 持有、容量有界的 LRU cache
- 以完整 program unit、reachable definitions 与 typed import schemas 建立 key 并做 revision 校验
- 每次 preparation 都重新挂载当前 host callbacks，VM instance 与 live state 不进入 cache
- 保持失败重编译的原子性，并覆盖确定性的 miss、eviction、clear 与 capacity-zero 行为
- 补充 compile-artifact 边界文档，并用共享 program-state 测试守卫隔离既有 effects-graph fixture

### 验证

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- yarn compile
- yarn check-all
- yarn check-agent-interface