### PR TITLE
feat(calx): compile strict String values / 编译严格 String 值

### DIFF
--- a/docs/run/calx-program-target.md
+++ b/docs/run/calx-program-target.md
@@ -25,7 +25,7 @@ Type and syntax variant classification uses exhaustive Rust matches. The larger 
 The initial stages are:
 
 1. the existing Number/Bool/`F64Buffer` kernel foundation;
-2. program entries, `Unit`, string/tag values, and typed imports;
+2. program entries, `Unit`, strict `String` values, and typed imports; `Tag`/`Symbol` remain planned and distinct;
 3. nominal struct/enum values, exhaustive match, and nominal `Option`/`Result`;
 4. typed persistent List/Map/Set;
 5. statically typed functions, closures, HOF, and arity features;
@@ -51,6 +51,8 @@ Whole-program eligibility checks `init` and `reload` as one atomic unit. It dedu
 This edition now has a library-level lowering and execution foundation. `compile_calx_program` atomically proves the unit, lowers its merged reachable definitions into one validated program, and records each lifecycle role with its exact fully qualified VM function name and strict signature. A `CalxProgramInstance` can then invoke either role through calx-vm 0.5.1 named-entry execution. Shared roots keep both roles while reusing one emitted function body; no synthetic `main` dispatcher is generated.
 
 This API now offers an embedding-owned, revision-safe cache for immutable whole-program artifacts. Cache hits revalidate reachable source stamps and reattach current typed callbacks; they do not preserve VM instances or live state. The API still does not select a runtime backend or own lifecycle/watch scheduling. Existing `:mode :native` and `:mode :js` behavior is unchanged; the contract does not prematurely expose a `:calx` runtime mode. [calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) records the completed VM prerequisite and downstream release validation.
+
+The program profile now admits exact Calcit `String` values in function boundaries, literals, typed locals, `if`/`&let`/`do`, fixed direct and tail calls, lifecycle roots, and exact typed host imports. The compatibility kernel analyzers deliberately continue to reject `String`, so `calcit-calx-kernel/1` and `/2` are unchanged. `Tag` and `Symbol` are not text aliases and remain rejected before lowering. Boundary conversion copies immutable text content between Calcit's `Arc<str>` and calx-vm's `Rc<str>`; this edition makes no zero-copy claim and adds no concatenation, slicing, hashing, ordering, parsing, or formatting operations.
 
 ### Hard boundaries
 
@@ -88,7 +90,7 @@ Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次�
 初始阶段为：
 
 1. 已有 Number/Bool/`F64Buffer` kernel foundation；
-2. program entries、`Unit`、string/tag values 和 typed imports；
+2. program entries、`Unit`、严格 `String` 值和 typed imports；`Tag`/`Symbol` 继续作为彼此独立的后续能力；
 3. nominal struct/enum values、exhaustive match 和 nominal `Option`/`Result`；
 4. typed persistent List/Map/Set；
 5. 静态 typed functions、closures、HOF 和 arity features；
@@ -114,6 +116,8 @@ Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次�
 本 edition 现在具备库级 lowering 与执行基础。`compile_calx_program` 会原子证明整个 unit，把合并后的可达 definitions lowering 为一份 validated program，并为每个生命周期角色记录准确的完整限定 VM 函数名与 strict signature。随后 `CalxProgramInstance` 通过 calx-vm 0.5.1 的 named-entry execution 调用任一角色。两个 roots 指向同一 definition 时仍保留两个角色，但只复用一份已生成函数体；不会合成 `main` dispatcher。
 
 该 API 现在提供由 embedding 显式拥有、revision-safe 的 immutable whole-program artifact cache。命中时重新校验 reachable source stamps 并挂载当前 typed callbacks，不保留 VM instance 或 live state。它仍不选择 runtime backend，也不负责 lifecycle/watch scheduling。已有 `:mode :native`、`:mode :js` 行为保持不变；本契约不提前暴露 `:calx` runtime mode。[calx-vm #70](https://github.com/calcit-lang/calx-vm/issues/70) 记录已完成的 VM 前置能力与下游发布验证。
+
+program profile 现在接受严格的 Calcit `String`：覆盖函数边界、literal、typed local、`if`/`&let`/`do`、固定 direct/tail call、lifecycle roots 与精确 typed host imports。兼容 kernel analyzer 仍刻意拒绝 `String`，因此 `calcit-calx-kernel/1`、`/2` 语义不变。`Tag`、`Symbol` 不是文本别名，继续在 lowering 前拒绝。边界转换会在 Calcit `Arc<str>` 与 calx-vm `Rc<str>` 之间复制 immutable text 内容；本 edition 不承诺 zero-copy，也不加入拼接、切片、hash、排序、解析或格式化操作。
 
 ### 硬边界
 

--- a/docs/run/calx-target.md
+++ b/docs/run/calx-target.md
@@ -86,6 +86,10 @@ name；direct tail call 与 `recur` 降为 `return-call`。
 `F64Buffer` 不复用 byte `Buffer` 或 persistent `List`，也不做隐式 element conversion。`Nil`、Dynamic
 或任意不匹配的 runtime value 会在进入 VM 之前被拒绝，不会被编码为占位值。
 
+本文的 kernel compatibility profile 仍不接受 `String`。独立的 `calcit-calx-program/1` profile 已支持严格
+Calcit `String`，并通过复制内容在 `Arc<str>` 与 calx-vm `Rc<str>` 之间转换；它不改变 kernel ABI，也不把
+`Tag`/`Symbol` 当作 String。详见 [Calx program backend](./calx-program-target.md)。
+
 ## 首批接受范围
 
 - function boundary 与 local：`Number`、`Bool`、immutable `F64Buffer`；函数结果额外接受 `Unit`，映射为 void；

--- a/editing-history/202609101411-calx-program-string-values.md
+++ b/editing-history/202609101411-calx-program-string-values.md
@@ -1,0 +1,19 @@
+# Calx program String values / Calx 程序 String 值
+
+Issue: [#955](https://github.com/calcit-lang/calcit/issues/955)
+
+## English
+
+- Added a private eligibility profile boundary: public kernel analysis keeps rejecting `String`, while whole-program analysis may admit exact typed `String` values.
+- Lowered String literals, locals, branches, bindings, direct/tail calls, lifecycle roots, and exact typed host imports to calx-vm 0.5.1 `Str` values.
+- Kept `Tag` and `Symbol` distinct and ineligible; runtime boundary mismatches fail before VM execution.
+- Documented the `Arc<str>` to/from `Rc<str>` content copy and deliberately made no zero-copy or String-operation claim.
+- Added source-backed native/Calx differential tests plus whole-program cache callback-reattachment coverage.
+
+## 中文
+
+- 增加内部 eligibility profile 边界：公开 kernel analysis 继续拒绝 `String`，只有整程序 analysis 可以接受精确 typed `String`。
+- 将 String literal、local、branch、binding、direct/tail call、lifecycle root 与精确 typed host import lowering 到 calx-vm 0.5.1 的 `Str` 值。
+- `Tag`、`Symbol` 保持独立且不合格；runtime boundary 类型不匹配会在 VM 执行前失败。
+- 记录 `Arc<str>` 与 `Rc<str>` 之间复制内容的边界语义，不承诺 zero-copy，也不扩展 String operations。
+- 增加 source-backed native/Calx 差分测试，以及整程序 cache 命中后重新挂载当前 callback 的覆盖。

--- a/src/codegen/calx.rs
+++ b/src/codegen/calx.rs
@@ -56,8 +56,12 @@ pub const CALX_TYPED_BUFFER_KERNEL_ABI_EDITION: &str = "calcit-calx-kernel/2";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CalxScalarType {
+  /// IEEE-754 64-bit floating-point number.
   F64,
+  /// Strict boolean value.
   Bool,
+  /// Immutable text value supported by the program profile only.
+  String,
   /// Immutable concrete buffer; the historic enum name is retained for API compatibility.
   F64Buffer,
 }
@@ -67,6 +71,7 @@ impl CalxScalarType {
     match self {
       Self::F64 => "F64",
       Self::Bool => "Bool",
+      Self::String => "String",
       Self::F64Buffer => "F64Buffer",
     }
   }
@@ -75,6 +80,7 @@ impl CalxScalarType {
     match self {
       Self::F64 => VmType::F64,
       Self::Bool => VmType::Bool,
+      Self::String => VmType::Str,
       Self::F64Buffer => VmType::F64Buffer,
     }
   }
@@ -99,7 +105,7 @@ impl CalxDefinitionRef {
   }
 }
 
-/// One explicitly approved scalar host capability for a Calx kernel.
+/// One explicitly approved scalar host capability for a Calx compilation.
 ///
 /// The Calcit definition is supplied as the key in [`CalxHostImports`]. Its
 /// typed snapshot signature must exactly match this declaration before the
@@ -318,7 +324,7 @@ fn write_eligible_functions(output: &mut String, functions: &[CalxEligibleFuncti
 }
 
 /// Proves that one explicit entry and its reachable direct-call closure belong
-/// to the first Calx scalar subset.
+/// to the kernel compatibility subset.
 ///
 /// Any issue returns a sorted [`CalxFallbackReport`]. The eligible graph is
 /// published only when every reachable definition succeeds.
@@ -338,10 +344,41 @@ pub fn analyze_calx_eligibility_with_imports(
   definition: impl Into<Arc<str>>,
   imports: &CalxHostImports,
 ) -> Result<CalxEligibleCallGraph, CalxFallbackReport> {
+  analyze_calx_eligibility_for_profile(program, namespace, definition, imports, CalxEligibilityProfile::Kernel)
+}
+
+pub(super) fn analyze_calx_program_entry_with_imports(
+  program: &CompiledProgram,
+  namespace: impl Into<Arc<str>>,
+  definition: impl Into<Arc<str>>,
+  imports: &CalxHostImports,
+) -> Result<CalxEligibleCallGraph, CalxFallbackReport> {
+  analyze_calx_eligibility_for_profile(program, namespace, definition, imports, CalxEligibilityProfile::Program)
+}
+
+fn analyze_calx_eligibility_for_profile(
+  program: &CompiledProgram,
+  namespace: impl Into<Arc<str>>,
+  definition: impl Into<Arc<str>>,
+  imports: &CalxHostImports,
+  profile: CalxEligibilityProfile,
+) -> Result<CalxEligibleCallGraph, CalxFallbackReport> {
   let entry = CalxDefinitionRef::new(namespace, definition);
-  let mut analyzer = EligibilityAnalyzer::new(program, entry.clone(), imports);
+  let mut analyzer = EligibilityAnalyzer::new(program, entry.clone(), imports, profile);
   analyzer.visit(entry.clone(), vec![entry.clone()]);
   analyzer.finish()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CalxEligibilityProfile {
+  Kernel,
+  Program,
+}
+
+impl CalxEligibilityProfile {
+  const fn allows_string(self) -> bool {
+    matches!(self, Self::Program)
+  }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -353,6 +390,7 @@ struct FunctionSignature {
 struct EligibilityAnalyzer<'a> {
   program: &'a CompiledProgram,
   imports: &'a CalxHostImports,
+  profile: CalxEligibilityProfile,
   entry: CalxDefinitionRef,
   visited: BTreeSet<CalxDefinitionRef>,
   functions: BTreeMap<CalxDefinitionRef, CalxEligibleFunction>,
@@ -360,10 +398,16 @@ struct EligibilityAnalyzer<'a> {
 }
 
 impl<'a> EligibilityAnalyzer<'a> {
-  fn new(program: &'a CompiledProgram, entry: CalxDefinitionRef, imports: &'a CalxHostImports) -> Self {
+  fn new(
+    program: &'a CompiledProgram,
+    entry: CalxDefinitionRef,
+    imports: &'a CalxHostImports,
+    profile: CalxEligibilityProfile,
+  ) -> Self {
     Self {
       program,
       imports,
+      profile,
       entry,
       visited: BTreeSet::new(),
       functions: BTreeMap::new(),
@@ -399,7 +443,7 @@ impl<'a> EligibilityAnalyzer<'a> {
       return;
     }
 
-    let signature = analyze_signature(compiled, &target, &call_path, &mut self.issues);
+    let signature = analyze_signature(compiled, &target, &call_path, self.profile, &mut self.issues);
     let parts = extract_fn_parts(compiled, &target, &call_path, &mut self.issues);
     let mut direct_calls = BTreeSet::new();
     let mut host_imports = BTreeSet::new();
@@ -438,6 +482,7 @@ impl<'a> EligibilityAnalyzer<'a> {
         direct_calls: &mut direct_calls,
         host_imports: &mut host_imports,
         imports: self.imports,
+        profile: self.profile,
         issues: &mut self.issues,
       };
       body_result = analyze_sequence(&body, true, &mut context);
@@ -546,6 +591,7 @@ fn analyze_signature(
   compiled: &CompiledDef,
   target: &CalxDefinitionRef,
   call_path: &[CalxDefinitionRef],
+  profile: CalxEligibilityProfile,
   issues: &mut Vec<CalxFallbackIssue>,
 ) -> Option<FunctionSignature> {
   let CalcitTypeAnnotation::Fn(signature) = compiled.schema.as_ref() else {
@@ -593,6 +639,7 @@ fn analyze_signature(
       target,
       source_path(&compiled.preprocessed_code),
       call_path,
+      profile,
       issues,
     ) {
       params.push(value_type);
@@ -604,6 +651,7 @@ fn analyze_signature(
     target,
     source_path(&compiled.preprocessed_code),
     call_path,
+    profile,
     issues,
   );
   if params.len() == signature.arg_types.len() && result.is_some() {
@@ -616,17 +664,21 @@ fn analyze_signature(
   }
 }
 
-fn signature_without_issues(compiled: &CompiledDef) -> Option<FunctionSignature> {
+fn signature_without_issues(compiled: &CompiledDef, profile: CalxEligibilityProfile) -> Option<FunctionSignature> {
   let CalcitTypeAnnotation::Fn(signature) = compiled.schema.as_ref() else {
     return None;
   };
   if !signature.generics.is_empty() || !signature.where_bounds.is_empty() || signature.rest_type.is_some() {
     return None;
   }
-  let params: Option<Vec<_>> = signature.arg_types.iter().map(|value| map_slot_type_quiet(value)).collect();
+  let params: Option<Vec<_>> = signature
+    .arg_types
+    .iter()
+    .map(|value| map_slot_type_quiet(value, profile))
+    .collect();
   Some(FunctionSignature {
     params: params?,
-    result: map_result_type_quiet(&signature.return_type)?,
+    result: map_result_type_quiet(&signature.return_type, profile)?,
   })
 }
 
@@ -700,6 +752,7 @@ struct ExpressionContext<'a> {
   direct_calls: &'a mut BTreeSet<CalxDefinitionRef>,
   host_imports: &'a mut BTreeSet<CalxDefinitionRef>,
   imports: &'a CalxHostImports,
+  profile: CalxEligibilityProfile,
   issues: &'a mut Vec<CalxFallbackIssue>,
 }
 
@@ -724,6 +777,7 @@ fn analyze_expression(expression: &Calcit, tail: bool, context: &mut ExpressionC
   match expression {
     Calcit::Number(_) => Some(Some(CalxScalarType::F64)),
     Calcit::Bool(_) => Some(Some(CalxScalarType::Bool)),
+    Calcit::Str(_) if context.profile.allows_string() => Some(Some(CalxScalarType::String)),
     Calcit::Unit => Some(None),
     Calcit::Nil => {
       issue(
@@ -740,6 +794,7 @@ fn analyze_expression(expression: &Calcit, tail: bool, context: &mut ExpressionC
       context.function,
       local.location.as_ref().map(|path| path.as_ref().clone()),
       context.call_path,
+      context.profile,
       context.issues,
     )
     .map(Some),
@@ -884,6 +939,7 @@ fn analyze_let(args: &[Calcit], tail: bool, context: &mut ExpressionContext<'_>)
           context.function,
           local.location.as_ref().map(|path| path.as_ref().clone()),
           context.call_path,
+          context.profile,
           context.issues,
         )
         .map(Some),
@@ -1083,7 +1139,7 @@ fn analyze_direct_call(
     return None;
   }
   context.direct_calls.insert(target.clone());
-  let Some(signature) = signature_without_issues(compiled) else {
+  let Some(signature) = signature_without_issues(compiled, context.profile) else {
     analyze_unknown_args(args, context);
     return None;
   };
@@ -1136,7 +1192,7 @@ fn analyze_host_import_call(
     );
     return None;
   }
-  let declared = analyze_signature(compiled, &target, context.call_path, context.issues)?;
+  let declared = analyze_signature(compiled, &target, context.call_path, context.profile, context.issues)?;
   if declared.params != import.params || declared.result != import.result {
     analyze_unknown_args(args, context);
     issue(
@@ -1194,11 +1250,13 @@ fn map_slot_type(
   target: &CalxDefinitionRef,
   source_path: Option<Vec<u16>>,
   call_path: &[CalxDefinitionRef],
+  profile: CalxEligibilityProfile,
   issues: &mut Vec<CalxFallbackIssue>,
 ) -> Option<CalxScalarType> {
   match annotation {
     CalcitTypeAnnotation::Number => Some(CalxScalarType::F64),
     CalcitTypeAnnotation::Bool => Some(CalxScalarType::Bool),
+    CalcitTypeAnnotation::String if profile.allows_string() => Some(CalxScalarType::String),
     CalcitTypeAnnotation::F64Buffer => Some(CalxScalarType::F64Buffer),
     CalcitTypeAnnotation::Dynamic => {
       push_expression_issue(
@@ -1242,29 +1300,31 @@ fn map_result_type(
   target: &CalxDefinitionRef,
   source_path: Option<Vec<u16>>,
   call_path: &[CalxDefinitionRef],
+  profile: CalxEligibilityProfile,
   issues: &mut Vec<CalxFallbackIssue>,
 ) -> Option<Option<CalxScalarType>> {
   if matches!(annotation, CalcitTypeAnnotation::Unit) {
     Some(None)
   } else {
-    map_slot_type(annotation, boundary, target, source_path, call_path, issues).map(Some)
+    map_slot_type(annotation, boundary, target, source_path, call_path, profile, issues).map(Some)
   }
 }
 
-fn map_slot_type_quiet(annotation: &CalcitTypeAnnotation) -> Option<CalxScalarType> {
+fn map_slot_type_quiet(annotation: &CalcitTypeAnnotation, profile: CalxEligibilityProfile) -> Option<CalxScalarType> {
   match annotation {
     CalcitTypeAnnotation::Number => Some(CalxScalarType::F64),
     CalcitTypeAnnotation::Bool => Some(CalxScalarType::Bool),
+    CalcitTypeAnnotation::String if profile.allows_string() => Some(CalxScalarType::String),
     CalcitTypeAnnotation::F64Buffer => Some(CalxScalarType::F64Buffer),
     _ => None,
   }
 }
 
-fn map_result_type_quiet(annotation: &CalcitTypeAnnotation) -> Option<Option<CalxScalarType>> {
+fn map_result_type_quiet(annotation: &CalcitTypeAnnotation, profile: CalxEligibilityProfile) -> Option<Option<CalxScalarType>> {
   if matches!(annotation, CalcitTypeAnnotation::Unit) {
     Some(None)
   } else {
-    map_slot_type_quiet(annotation).map(Some)
+    map_slot_type_quiet(annotation, profile).map(Some)
   }
 }
 
@@ -1348,6 +1408,7 @@ mod tests {
         direct_calls: &mut BTreeSet::new(),
         host_imports: &mut BTreeSet::new(),
         imports: &CalxHostImports::new(),
+        profile: CalxEligibilityProfile::Kernel,
         issues: &mut issues,
       };
       assert_eq!(analyze_proc(CalcitProc::NativeF64BufferGet, &args, false, &mut context), None);

--- a/src/codegen/calx/coverage.rs
+++ b/src/codegen/calx/coverage.rs
@@ -39,7 +39,7 @@ impl CalxCoverageOwner {
 pub enum CalxCoverageStage {
   /// Already supported by the strict kernel compatibility path.
   KernelFoundation,
-  /// Program entry, `Unit`, text/tag scalars, and typed imports.
+  /// Program entry, `Unit`, strict text values, and typed imports.
   ProgramFoundation,
   /// Nominal struct/enum values, exhaustive match, Option, and Result.
   NominalData,
@@ -83,7 +83,8 @@ pub fn classify_calx_type_surface(annotation: &CalcitTypeAnnotation) -> CalxCove
 
   match annotation {
     Bool | Number | F64Buffer | Unit => KERNEL,
-    String | Symbol | Tag | Buffer => PROGRAM,
+    String => coverage(CalxCoverageOwner::CalxCore, CalxCoverageStage::ProgramFoundation),
+    Symbol | Tag | Buffer => PROGRAM,
     List(_) | Map(_, _) | Set(_) => COLLECTIONS,
     StructValue(_) | EnumValue(_) | Struct(_, _) | Enum(_, _) => NOMINAL,
     Fn(_) | Variadic(_) => CALLABLES,
@@ -236,6 +237,13 @@ mod tests {
 
   #[test]
   fn value_families_follow_their_rollout_slices() {
+    assert_eq!(
+      classify_calx_type_surface(&CalcitTypeAnnotation::String),
+      coverage(CalxCoverageOwner::CalxCore, CalxCoverageStage::ProgramFoundation)
+    );
+    for annotation in [CalcitTypeAnnotation::Tag, CalcitTypeAnnotation::Symbol] {
+      assert_eq!(classify_calx_type_surface(&annotation), PROGRAM);
+    }
     assert_eq!(classify_calx_proc_surface(CalcitProc::NativeListCount), COLLECTIONS);
     assert_eq!(classify_calx_proc_surface(CalcitProc::NativeMapAssoc), COLLECTIONS);
     assert_eq!(classify_calx_proc_surface(CalcitProc::NativeEnumNth), NOMINAL);

--- a/src/codegen/calx/lowering.rs
+++ b/src/codegen/calx/lowering.rs
@@ -421,6 +421,7 @@ fn convert_calx_arguments(args: &[Calcit], expected_params: &[CalxScalarType]) -
     .map(|(index, (value, expected))| match (expected, value) {
       (CalxScalarType::F64, Calcit::Number(value)) => Ok(VmValue::F64(*value)),
       (CalxScalarType::Bool, Calcit::Bool(value)) => Ok(VmValue::Bool(*value)),
+      (CalxScalarType::String, Calcit::Str(value)) => Ok(VmValue::Str(Rc::from(value.as_ref()))),
       (CalxScalarType::F64Buffer, Calcit::F64Buffer(values)) => Ok(VmValue::f64_buffer_copy_from_slice(values)),
       _ => Err(CalxKernelRunError::Boundary(CalxKernelBoundaryError {
         kind: CalxKernelBoundaryErrorKind::ArgumentType,
@@ -439,6 +440,7 @@ fn convert_calx_result(expected: Option<CalxScalarType>, output: CalxRunResult) 
     (None, CalxRunResult::Void) => Ok(Calcit::Unit),
     (Some(CalxScalarType::F64), CalxRunResult::Value(VmValue::F64(value))) => Ok(Calcit::Number(value)),
     (Some(CalxScalarType::Bool), CalxRunResult::Value(VmValue::Bool(value))) => Ok(Calcit::Bool(value)),
+    (Some(CalxScalarType::String), CalxRunResult::Value(VmValue::Str(value))) => Ok(Calcit::Str(Arc::from(value.as_ref()))),
     (Some(CalxScalarType::F64Buffer), CalxRunResult::Value(VmValue::F64Buffer(values))) => {
       Ok(Calcit::F64Buffer(std::sync::Arc::from(values.as_ref())))
     }
@@ -1067,6 +1069,7 @@ struct PlannedExpression {
 enum PlannedExpressionKind {
   Number(f64),
   Bool(bool),
+  String(Arc<str>),
   Unit,
   Local(u16),
   Sequence(Vec<PlannedExpression>),
@@ -1222,6 +1225,11 @@ fn plan_expression(expression: &Calcit, tail: bool, context: &mut PlanningContex
   match expression {
     Calcit::Number(value) => Ok(planned(Some(CalxScalarType::F64), path, PlannedExpressionKind::Number(*value))),
     Calcit::Bool(value) => Ok(planned(Some(CalxScalarType::Bool), path, PlannedExpressionKind::Bool(*value))),
+    Calcit::Str(value) => Ok(planned(
+      Some(CalxScalarType::String),
+      path,
+      PlannedExpressionKind::String(value.clone()),
+    )),
     Calcit::Unit => Ok(planned(None, path, PlannedExpressionKind::Unit)),
     Calcit::Local(local) => Ok(planned(
       scalar_local_type(local, context.function)?,
@@ -1487,6 +1495,7 @@ fn scalar_local_type(local: &CalcitLocal, function: &CalxDefinitionRef) -> Resul
   match local.type_info.as_ref() {
     crate::calcit::CalcitTypeAnnotation::Number => Ok(Some(CalxScalarType::F64)),
     crate::calcit::CalcitTypeAnnotation::Bool => Ok(Some(CalxScalarType::Bool)),
+    crate::calcit::CalcitTypeAnnotation::String => Ok(Some(CalxScalarType::String)),
     crate::calcit::CalcitTypeAnnotation::F64Buffer => Ok(Some(CalxScalarType::F64Buffer)),
     other => Err(lower_error(
       function,
@@ -1576,6 +1585,9 @@ fn emit_expression(
     }
     PlannedExpressionKind::Bool(value) => {
       body.constant(VmValue::Bool(*value))?;
+    }
+    PlannedExpressionKind::String(value) => {
+      body.constant(VmValue::Str(Rc::from(value.as_ref())))?;
     }
     PlannedExpressionKind::Unit => {}
     PlannedExpressionKind::Local(idx) => {

--- a/src/codegen/calx/program_eligibility.rs
+++ b/src/codegen/calx/program_eligibility.rs
@@ -12,7 +12,7 @@ use crate::snapshot::SnapshotTarget;
 
 use super::{
   CALX_PROGRAM_ABI_EDITION, CalxDefinitionRef, CalxEligibleFunction, CalxFallbackIssue, CalxHostImports, CalxProgramCompilationUnit,
-  CalxProgramRoot, CalxProgramRootRole, analyze_calx_eligibility_with_imports, calx_kernel_abi_edition, write_eligible_functions,
+  CalxProgramRoot, CalxProgramRootRole, analyze_calx_program_entry_with_imports, calx_kernel_abi_edition, write_eligible_functions,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -168,7 +168,7 @@ pub fn analyze_calx_program_eligibility_with_imports(
   let mut functions = BTreeMap::<CalxDefinitionRef, CalxEligibleFunction>::new();
   let mut root_issues = vec![];
   for (root, roles) in roots_by_definition {
-    match analyze_calx_eligibility_with_imports(program, root.namespace.clone(), root.definition.clone(), imports) {
+    match analyze_calx_program_entry_with_imports(program, root.namespace.clone(), root.definition.clone(), imports) {
       Ok(graph) => {
         for function in graph.functions {
           functions.entry(function.definition.clone()).or_insert(function);

--- a/src/program/tests.rs
+++ b/src/program/tests.rs
@@ -538,6 +538,197 @@ fn calx_program_unit(namespace: &str, init: &str, reload: &str) -> CalxProgramCo
   }
 }
 
+fn install_calx_string_program_fixture(namespace: &str) {
+  let string = || CalcitTypeAnnotation::String;
+  let mut source_defs = calx_test_defs_from_source(namespace, include_str!("../../tests/fixtures/calx/string-values.cirru"));
+  install_calx_test_defs(
+    namespace,
+    vec![
+      (
+        "string-id",
+        source_defs.remove("string-id").expect("string-id source"),
+        calx_test_fn_schema(vec![string()], string()),
+      ),
+      (
+        "host-echo",
+        source_defs.remove("host-echo").expect("host-echo source"),
+        calx_test_fn_schema(vec![string()], string()),
+      ),
+      (
+        "init",
+        source_defs.remove("init").expect("init source"),
+        calx_test_fn_schema(vec![CalcitTypeAnnotation::Bool, string()], string()),
+      ),
+      (
+        "reload",
+        source_defs.remove("reload").expect("reload source"),
+        calx_test_fn_schema(vec![string()], string()),
+      ),
+    ],
+  );
+  for definition in ["init", "reload"] {
+    compile_calx_test_entry(namespace, definition);
+  }
+}
+
+fn calx_test_echo_string(args: &[CalxValue]) -> Result<CalxValue, CalxError> {
+  let [CalxValue::Str(value)] = args else {
+    return Err(CalxError::new_raw("fixture echo expected one Str".to_owned()));
+  };
+  Ok(CalxValue::Str(value.clone()))
+}
+
+fn calx_test_replace_string(args: &[CalxValue]) -> Result<CalxValue, CalxError> {
+  let [CalxValue::Str(_)] = args else {
+    return Err(CalxError::new_raw("fixture replacement expected one Str".to_owned()));
+  };
+  Ok(CalxValue::Str(std::rc::Rc::from("replacement")))
+}
+
+fn calx_test_string_imports(namespace: &str) -> CalxHostImports {
+  calx_test_string_imports_with_callback(namespace, calx_test_echo_string)
+}
+
+fn calx_test_string_imports_with_callback(
+  namespace: &str,
+  callback: fn(&[CalxValue]) -> Result<CalxValue, CalxError>,
+) -> CalxHostImports {
+  let mut imports = CalxHostImports::new();
+  imports.insert(
+    CalxDefinitionRef::new(namespace, "host-echo"),
+    CalxHostImport::value(
+      "fixture.echo-string",
+      vec![CalxScalarType::String],
+      CalxScalarType::String,
+      callback,
+    )
+    .expect("valid String host import"),
+  );
+  imports
+}
+
+#[test]
+fn calx_program_string_cache_reattaches_current_callback() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-string-cache";
+  install_calx_string_program_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed String cache fixture");
+  let unit = calx_program_unit(namespace, "reload", "reload");
+  let imports_a = calx_test_string_imports(namespace);
+  let imports_b = calx_test_string_imports_with_callback(namespace, calx_test_replace_string);
+  let mut cache = CalxProgramCompileCache::new(1);
+
+  let first = cache
+    .prepare(&snapshot, &unit, &imports_a)
+    .expect("compile String program artifact");
+  let first_artifact = first.program().artifact().clone();
+  let second = cache
+    .prepare(&snapshot, &unit, &imports_b)
+    .expect("reuse String artifact with current callback");
+  assert!(second.report().cache_hit);
+  assert!(std::rc::Rc::ptr_eq(&first_artifact, second.program().artifact()));
+  let mut instance = second.program().instantiate().expect("instantiate cached String program");
+  assert_eq!(
+    instance
+      .run_root(CalxProgramRootRole::Init, &[Calcit::Str(Arc::from("stale"))])
+      .expect("run current String callback"),
+    Calcit::Str(Arc::from("replacement"))
+  );
+}
+
+#[test]
+fn calx_program_string_values_cross_lifecycle_calls_locals_and_imports() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-string";
+  install_calx_string_program_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed String program fixture");
+  let unit = calx_program_unit(namespace, "init", "reload");
+  let imports = calx_test_string_imports(namespace);
+
+  let eligible =
+    analyze_calx_program_eligibility_with_imports(&snapshot, &unit, &imports).expect("String belongs to the whole-program profile");
+  assert!(
+    eligible
+      .functions
+      .iter()
+      .any(|function| function.params == [CalxScalarType::String] && function.result == Some(CalxScalarType::String))
+  );
+
+  let prepared = compile_calx_program_with_imports(&snapshot, &unit, &imports).expect("compile String lifecycle program");
+  let mut instance = prepared.instantiate().expect("instantiate String lifecycle program");
+  for (role, definition, args, expected) in [
+    (
+      CalxProgramRootRole::Init,
+      "init",
+      vec![Calcit::Bool(true), Calcit::Str(Arc::from("hello Calx"))],
+      Calcit::Str(Arc::from("hello Calx")),
+    ),
+    (
+      CalxProgramRootRole::Init,
+      "init",
+      vec![Calcit::Bool(false), Calcit::Str(Arc::from("ignored"))],
+      Calcit::Str(Arc::from("fallback")),
+    ),
+    (
+      CalxProgramRootRole::Reload,
+      "reload",
+      vec![Calcit::Str(Arc::from("hello Calx"))],
+      Calcit::Str(Arc::from("hello Calx")),
+    ),
+  ] {
+    let calx = instance.run_root(role, &args).expect("run String lifecycle root");
+    let native = run_program_with_docs(Arc::from(namespace), Arc::from(definition), &args).expect("run native String lifecycle root");
+    assert_eq!(calx, native);
+    assert_eq!(calx, expected);
+  }
+
+  let boundary = instance
+    .run_root(CalxProgramRootRole::Init, &[Calcit::Bool(true), Calcit::tag("hello")])
+    .expect_err("Tag must remain distinct from String at the program boundary");
+  assert!(matches!(
+    boundary,
+    CalxKernelRunError::Boundary(ref error) if error.kind == CalxKernelBoundaryErrorKind::ArgumentType
+  ));
+}
+
+#[test]
+fn calx_string_is_program_only_and_tag_symbol_schemas_remain_rejected() {
+  let _guard = lock_program_test_state();
+  reset_program_test_state();
+  let namespace = "tests.calx-program-string-profile";
+  install_calx_string_program_fixture(namespace);
+  let snapshot = clone_compiled_program_snapshot().expect("clone typed String profile fixture");
+
+  let kernel_report = analyze_calx_eligibility(&snapshot, namespace, "init").expect_err("kernel profile must stay String-free");
+  assert!(
+    kernel_report
+      .issues
+      .iter()
+      .any(|issue| issue.code == CalxFallbackCode::UnsupportedType)
+  );
+
+  for unsupported in [CalcitTypeAnnotation::Tag, CalcitTypeAnnotation::Symbol] {
+    let mut changed = snapshot.clone();
+    changed
+      .get_mut(namespace)
+      .expect("fixture namespace")
+      .defs
+      .get_mut("init")
+      .expect("init definition")
+      .schema = calx_test_fn_schema(vec![CalcitTypeAnnotation::Bool, unsupported.clone()], unsupported);
+    let report = analyze_calx_program_eligibility(&changed, &calx_program_unit(namespace, "init", "init"))
+      .expect_err("Tag and Symbol must remain outside the program profile");
+    assert!(
+      report
+        .root_issues
+        .iter()
+        .any(|root| root.issue.code == CalxFallbackCode::UnsupportedType)
+    );
+  }
+}
+
 #[test]
 fn calx_program_eligibility_merges_lifecycle_call_closures() {
   let _guard = lock_program_test_state();

--- a/tests/fixtures/calx/string-values.cirru
+++ b/tests/fixtures/calx/string-values.cirru
@@ -1,0 +1,13 @@
+defn string-id (value)
+  , value
+
+defn host-echo (value)
+  , value
+
+defn init (flag input)
+  &let
+    selected $ if flag input |fallback
+    string-id selected
+
+defn reload (input)
+  host-echo input


### PR DESCRIPTION
## English

Closes #955. Continues #943 and the program-backend parent #887.

### What changed

- add an internal eligibility profile so whole-program compilation admits exact `String` while the public kernel compatibility APIs keep rejecting it
- lower String literals, boundaries, typed locals, `if`/`&let`/`do`, fixed direct/tail calls, lifecycle roots, and exact typed host imports to calx-vm 0.5.1 `Str`
- keep `Tag` and `Symbol` distinct and rejected before lowering; reject runtime boundary mismatches before VM execution
- verify source-backed native/Calx equivalence, literal execution, both lifecycle roles, current callback reattachment on whole-program cache hits, and negative profile/type cases
- document the deliberate `Arc<str>` ↔ `Rc<str>` content copy and the absence of zero-copy/String operations in this slice

Existing `calcit-calx-kernel/1`, `/2`, and `calcit-calx-program/1` editions are unchanged. No calx-vm release is required.

### Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (807 library, 325 CLI, 23 wasm tests)
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`

## 中文

关闭 #955，继续推进 #943 与 program backend 父议题 #887。

### 变更内容

- 增加内部 eligibility profile：整程序编译接受精确 `String`，公开 kernel compatibility API 仍继续拒绝
- 将 String literal、边界、typed local、`if`/`&let`/`do`、固定 direct/tail call、lifecycle root 与精确 typed host import lowering 到 calx-vm 0.5.1 `Str`
- `Tag`、`Symbol` 保持独立并在 lowering 前拒绝；runtime boundary 类型不匹配在 VM 执行前失败
- 以 source-backed 测试验证 native/Calx 等价、literal 实际执行、两个 lifecycle roles、整程序 cache 命中后的当前 callback 重挂载，以及负向 profile/type 场景
- 文档明确 `Arc<str>` ↔ `Rc<str>` 会复制内容，本阶段不承诺 zero-copy，也不加入 String operations

既有 `calcit-calx-kernel/1`、`/2` 与 `calcit-calx-program/1` edition 均不变；无需发布新的 calx-vm。

### 验证

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`（807 library、325 CLI、23 wasm tests）
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface`