### PR TITLE
修复 JS LazyValue 依赖排序 / Fix JS LazyValue dependency ordering

### DIFF
--- a/editing-history/202609101435-js-lazy-value-dependency-order.md
+++ b/editing-history/202609101435-js-lazy-value-dependency-order.md
@@ -1,0 +1,27 @@
+# JS LazyValue dependency ordering / JS LazyValue 依赖排序
+
+## Problem / 问题
+
+The JavaScript backend could initialize a top-level `impl-traits` alias before the local `defimpl` value it referenced. `CompiledDef::deps` contained the complete relation, but the previous insertion-based sorter could still place an early lexical dependent ahead of dependencies discovered later.
+
+JavaScript 后端可能在其引用的本地 `defimpl` 值之前初始化顶层 `impl-traits` 别名。虽然 `CompiledDef::deps` 已包含直接依赖，旧的单遍插入排序仍可能把字典序靠前的依赖方放到后续出现的依赖之前。
+
+## Change / 修改
+
+- Replace the depth-limited insertion heuristic with a deterministic dependency-first DFS ordering.
+- Add a regression graph matching the constructor → attached type → enum/impl initialization chain.
+
+- 用确定性的依赖优先 DFS 排序替换深度受限的单遍插入启发式。
+- 添加覆盖“构造器 → 附加 trait 的类型 → enum/impl”初始化链的回归测试。
+
+## Verification / 验证
+
+- `cargo test codegen::emit_js::deps::tests`
+- `cargo test`
+- `cargo clippy -- -D warnings`
+- `yarn compile`
+- `yarn check-agent-interface`
+- `yarn check-all`
+- Built the patched `calcit` binary and used it to generate/run both JavaScript and strict type checks for `calcit-lang/calcit.algebra`.
+
+- 使用修复后的 `calcit` 二进制生成并运行 `calcit-lang/calcit.algebra` 的 JavaScript 后端，同时验证严格类型检查。

--- a/src/codegen/emit_js/deps.rs
+++ b/src/codegen/emit_js/deps.rs
@@ -67,19 +67,45 @@ fn sort_names_by_graph(mut def_names: Vec<Arc<str>>, deps_graph: &HashMap<Arc<st
   def_names.sort();
 
   let mut result: Vec<Arc<str>> = Vec::with_capacity(def_names.len());
-  'outer: for name in def_names {
-    for (idx, existing) in result.iter().enumerate() {
-      if depends_on(existing, &name, deps_graph, 3) {
-        result.insert(idx, name.to_owned());
-        continue 'outer;
-      }
-    }
-    result.push(name.to_owned());
+  let mut visiting: HashSet<Arc<str>> = HashSet::new();
+  let mut visited: HashSet<Arc<str>> = HashSet::new();
+  for name in &def_names {
+    visit_dependency(name, deps_graph, &mut visiting, &mut visited, &mut result);
   }
 
   result
 }
 
+fn visit_dependency(
+  name: &Arc<str>,
+  deps_graph: &HashMap<Arc<str>, HashSet<Arc<str>>>,
+  visiting: &mut HashSet<Arc<str>>,
+  visited: &mut HashSet<Arc<str>>,
+  result: &mut Vec<Arc<str>>,
+) {
+  if visited.contains(name) || !visiting.insert(name.clone()) {
+    return;
+  }
+
+  let mut dependencies: Vec<Arc<str>> = deps_graph
+    .get(name)
+    .into_iter()
+    .flatten()
+    .filter(|dependency| deps_graph.contains_key(*dependency))
+    .cloned()
+    .collect();
+  dependencies.sort();
+  for dependency in &dependencies {
+    visit_dependency(dependency, deps_graph, visiting, visited, result);
+  }
+
+  visiting.remove(name);
+  if visited.insert(name.clone()) {
+    result.push(name.clone());
+  }
+}
+
+#[cfg(test)]
 fn depends_on(x: &str, y: &str, deps: &HashMap<Arc<str>, HashSet<Arc<str>>>, decay: usize) -> bool {
   if decay == 0 {
     return false;
@@ -99,6 +125,35 @@ fn depends_on(x: &str, y: &str, deps: &HashMap<Arc<str>, HashSet<Arc<str>>>, dec
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::calcit::{CalcitList, CalcitSymbolInfo, DYNAMIC_TYPE};
+  use crate::program::{CompiledDef, CompiledDefKind};
+
+  fn symbol(name: &str) -> Calcit {
+    Calcit::Symbol {
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("app.main"),
+        at_def: Arc::from("fixture"),
+      }),
+      location: None,
+    }
+  }
+
+  fn lazy_value(def_id: DefId, codegen_form: Calcit, deps: Vec<DefId>) -> CompiledDef {
+    CompiledDef {
+      def_id,
+      version_id: 0,
+      kind: CompiledDefKind::LazyValue,
+      preprocessed_code: codegen_form.clone(),
+      codegen_form,
+      deps,
+      type_summary: None,
+      source_code: None,
+      schema: DYNAMIC_TYPE.clone(),
+      doc: Arc::from(""),
+      examples: vec![],
+    }
+  }
 
   #[test]
   fn depends_on_transitively() {
@@ -119,5 +174,45 @@ mod tests {
 
     let sorted = sort_by_deps(&deps);
     assert_eq!(sorted, vec![Arc::<str>::from("a"), Arc::<str>::from("b")]);
+  }
+
+  #[test]
+  fn sort_compiled_lazy_values_recovers_codegen_dependencies() {
+    let file = CompiledFileData {
+      defs: HashMap::from([
+        (
+          Arc::from("%constructor"),
+          lazy_value(
+            DefId(4),
+            Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("attached-type")]))),
+            vec![DefId(1)],
+          ),
+        ),
+        (
+          Arc::from("attached-type"),
+          lazy_value(
+            DefId(1),
+            Calcit::List(Arc::new(CalcitList::Vector(vec![
+              symbol("impl-traits"),
+              symbol("base-type"),
+              symbol("trait-impl"),
+            ]))),
+            vec![DefId(2), DefId(3)],
+          ),
+        ),
+        (Arc::from("base-type"), lazy_value(DefId(2), Calcit::Number(1.0), vec![])),
+        (Arc::from("trait-impl"), lazy_value(DefId(3), Calcit::Number(2.0), vec![])),
+      ]),
+    };
+
+    let sorted = sort_compiled_defs_by_deps(&file);
+    let attached_index = sorted.iter().position(|name| name.as_ref() == "attached-type").unwrap();
+    let base_index = sorted.iter().position(|name| name.as_ref() == "base-type").unwrap();
+    let impl_index = sorted.iter().position(|name| name.as_ref() == "trait-impl").unwrap();
+    let constructor_index = sorted.iter().position(|name| name.as_ref() == "%constructor").unwrap();
+
+    assert!(base_index < attached_index);
+    assert!(impl_index < attached_index);
+    assert!(attached_index < constructor_index);
   }
 }


### PR DESCRIPTION
## 中文

修复 JS 后端同文件 `LazyValue` 的初始化依赖排序。旧实现是深度最多为 3 的单遍插入启发式：当字典序靠前的构造函数依赖后续的 trait 附加定义时，附加定义虽然会被插到构造函数之前，但它自身已经遍历过的 enum / `defimpl` 依赖不会同步前移，最终生成 JS 在 impl 初始化前调用 `impl-traits`。

本 PR：

- 改用确定性的依赖优先 DFS 拓扑排序；
- 对循环依赖安全终止，并保持稳定的字典序遍历；
- 添加覆盖“构造器 → 附加类型 → enum/impl”链的回归测试；
- 用正在迁移到 Calcit 0.14.7 严格类型的 `calcit-lang/calcit.algebra` 做跨项目 native/JS 回归。

关联：Closes #957

## English

Fix same-file `LazyValue` initialization ordering in the JavaScript backend. The previous depth-limited, single-pass insertion heuristic could place an attached trait definition before an early lexical constructor without moving the already-visited enum and `defimpl` dependencies before that attachment. Generated JavaScript then called `impl-traits` with an uninitialized impl value.

This PR:

- replaces the heuristic with deterministic dependency-first DFS topological ordering;
- terminates safely on cycles while preserving stable lexical traversal;
- adds a regression graph for constructor → attached type → enum/impl;
- validates native and JavaScript execution against the real `calcit-lang/calcit.algebra` 0.14.7 strict migration.

## Verification / 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`
- `yarn check-all`
- patched `calcit`: `calcit.algebra` strict-zero check, native tests, JS generation and Node execution
