### PR TITLE
fix(js): lower native list aliases to runtime exports / 修复原生列表别名生成

### DIFF
--- a/editing-history/202609102211-js-native-list-runtime-aliases.md
+++ b/editing-history/202609102211-js-native-list-runtime-aliases.md
@@ -1,0 +1,26 @@
+# JS native list runtime aliases / JS 原生列表运行时别名
+
+## Context / 背景
+
+`&list:append`, `&list:prepend`, and `&list:butlast` are distinct
+`CalcitProc` variants for the native and WASM backends. The JavaScript runtime,
+however, intentionally exposes the same implementations under the public
+`append`, `prepend`, and `butlast` exports. Generic JS proc-name escaping emitted
+references such as `_$n_list_$o_append`, which do not exist in
+`@calcit/procs` and only fail later when an ESM bundler resolves imports.
+
+`&list:append`、`&list:prepend` 与 `&list:butlast` 在 native/WASM 后端使用独立的
+`CalcitProc` 变体，但 JavaScript runtime 复用公开的 `append`、`prepend` 与
+`butlast` 导出。通用名称转义会生成不存在的 `_$n_list_$o_append` 等引用，直到
+下游 ESM bundler 解析导入时才暴露错误。
+
+## Decision / 决策
+
+Map the three internal variants to their existing public runtime exports at the
+JS emitter's proc-value boundary. This covers both direct calls and higher-order
+uses without duplicating runtime implementations or changing native/WASM
+semantics. Regression tests assert both emitted forms for every alias.
+
+在 JS emitter 的 proc value 边界将三个内部变体映射到已有公开 runtime 导出，
+同时覆盖直接调用与高阶函数值，不复制实现，也不改变 native/WASM 语义。回归测试
+逐一断言两种生成形式。

--- a/src/codegen/emit_js.rs
+++ b/src/codegen/emit_js.rs
@@ -349,10 +349,19 @@ fn to_js_code(
       }
       Calcit::Proc(s) => {
         let proc_prefix = get_proc_prefix(ns);
+        let runtime_proc = match s {
+          // These internal list primitives share the public runtime
+          // implementations; @calcit/procs does not export encoded
+          // `&list:*` bindings for them.
+          CalcitProc::NativeListAppend => CalcitProc::Append,
+          CalcitProc::NativeListPrepend => CalcitProc::Prepend,
+          CalcitProc::NativeListButlast => CalcitProc::Butlast,
+          _ => *s,
+        };
         // println!("gen proc {} under {}", s, ns,);
         // let resolved = Some(ResolvedDef(String::from(primes::CORE_NS), s.to_owned()));
         // gen_symbol_code(s, primes::CORE_NS, &resolved, ns, xs, local_defs)
-        Ok(format!("{proc_prefix}{}", escape_var(s.as_ref())))
+        Ok(format!("{proc_prefix}{}", escape_var(runtime_proc.as_ref())))
       }
       Calcit::Registered(alias) => {
         let proc_prefix = get_proc_prefix(ns);
@@ -2745,6 +2754,28 @@ mod tests {
     .expect("bare empty map should compile");
 
     assert_eq!(code, "$clt._$n__$M_()");
+  }
+
+  #[test]
+  fn native_list_aliases_use_existing_runtime_exports() {
+    let local_defs: HashSet<Arc<str>> = HashSet::new();
+    let file_imports = RefCell::new(ImportsDict::new());
+    let tags = RefCell::new(HashSet::new());
+
+    for (native, runtime_name) in [
+      (CalcitProc::NativeListAppend, "append"),
+      (CalcitProc::NativeListPrepend, "prepend"),
+      (CalcitProc::NativeListButlast, "butlast"),
+    ] {
+      let proc_code = to_js_code(&Calcit::Proc(native), "tests.emit-js", &local_defs, &file_imports, &tags, None)
+        .expect("native list alias should compile as a function value");
+      assert_eq!(proc_code, format!("$clt.{runtime_name}"));
+
+      let form = Calcit::from(vec![Calcit::Proc(native), symbol("xs"), symbol("value")]);
+      let call_code =
+        to_js_code(&form, "tests.emit-js", &local_defs, &file_imports, &tags, None).expect("native list alias call should compile");
+      assert_eq!(call_code, format!("$clt.{runtime_name}(xs, value)"));
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Summary / 概要

- lower `&list:append` to the existing JavaScript runtime `append` export
- apply the same mapping to the isomorphic `&list:prepend` and `&list:butlast` aliases
- cover direct calls and higher-order proc values with emitter regression tests
- record the backend contract in editing history

- 将 `&list:append` lowering 到 JavaScript runtime 已有的 `append` 导出
- 同步处理同构的 `&list:prepend` 与 `&list:butlast` 别名
- 用 emitter 回归测试覆盖直接调用与高阶 proc value
- 在 editing history 记录后端契约

Closes #952

## Validation / 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` — 809 library + 325 CLI + 23 WASM tests passed
- `yarn compile`
- `yarn check-all`
- `yarn check-agent-interface` — 31/31 protocol scenarios passed; timings and stdout byte counts recorded by the command