### PR TITLE
fix(edit): round-trip Tag value schemas / 保持 Tag 值 schema 往返

### DIFF
--- a/editing-history/202609102225-tag-value-schema-roundtrip.md
+++ b/editing-history/202609102225-tag-value-schema-roundtrip.md
@@ -1,0 +1,27 @@
+# Tag value schema round-trip / Tag 值 schema 往返
+
+## Context / 背景
+
+`calcit edit schema ... --code "quote 'Tag"` accepted the direct primitive
+schema and stored a `CalcitTypeAnnotation::Tag`. Snapshot serialization then
+produced the canonical `:: 'Tag` form, but serialized-content validation
+rejected that same form. The edit command therefore reported success while a
+subsequent `calcit edit format` could not canonicalize the snapshot.
+
+`calcit edit schema ... --code "quote 'Tag"` 会接受直接 primitive schema 并
+保存为 `CalcitTypeAnnotation::Tag`。Snapshot 序列化随后生成规范形式
+`:: 'Tag`，但 serialized-content validation 又拒绝该形式，导致编辑命令报告成功
+后，`calcit edit format` 无法 canonicalize 同一 snapshot。
+
+## Decision / 决策
+
+Treat `Tag` like the other concrete primitive value schemas during standalone
+schema validation. Unknown standalone names still become `Dynamic` and remain
+rejected, so accepting canonical `Tag` does not weaken typo detection. Tests
+cover direct editor input, serialized validation, canonical formatting, and
+reload of the preserved type.
+
+在 standalone schema validation 中把 `Tag` 与其他 concrete primitive value
+schema 一致处理。未知名称仍会解析为 `Dynamic` 并继续被拒绝，因此接受规范
+`Tag` 不会削弱拼写错误检测。测试覆盖 editor 直接输入、序列化校验、规范格式化
+以及保留类型后的重新加载。

--- a/editing-history/202609102225-tag-value-schema-roundtrip.md
+++ b/editing-history/202609102225-tag-value-schema-roundtrip.md
@@ -18,10 +18,10 @@ subsequent `calcit edit format` could not canonicalize the snapshot.
 Treat `Tag` like the other concrete primitive value schemas during standalone
 schema validation. Unknown standalone names still become `Dynamic` and remain
 rejected, so accepting canonical `Tag` does not weaken typo detection. Tests
-cover direct editor input, serialized validation, canonical formatting, and
-reload of the preserved type.
+cover direct editor input, serialized validation, the actual `edit format`
+handler, and reload of the preserved type.
 
 在 standalone schema validation 中把 `Tag` 与其他 concrete primitive value
 schema 一致处理。未知名称仍会解析为 `Dynamic` 并继续被拒绝，因此接受规范
-`Tag` 不会削弱拼写错误检测。测试覆盖 editor 直接输入、序列化校验、规范格式化
-以及保留类型后的重新加载。
+`Tag` 不会削弱拼写错误检测。测试覆盖 editor 直接输入、序列化校验、实际的
+`edit format` handler，以及保留类型后的重新加载。

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -3258,6 +3258,32 @@ mod tests {
   }
 
   #[test]
+  fn schema_edit_tag_value_survives_canonical_snapshot_formatting() {
+    let fixture = TestSnapshot::from_fixture();
+    let path = fixture.snapshot_string();
+    let opts = EditSchemaCommand {
+      target: "app.main/test-fn".to_owned(),
+      file: None,
+      code: Some("quote 'Tag".to_owned()),
+      clear: false,
+    };
+
+    handle_schema(&opts, &path).expect("Tag value schema should be written");
+    let snapshot = load_snapshot(&path).expect("edited snapshot should load");
+    assert!(matches!(
+      snapshot.files["app.main"].defs["test-fn"].schema.as_ref(),
+      CalcitTypeAnnotation::Tag
+    ));
+
+    save_snapshot(&snapshot, &path).expect("canonical formatting should preserve the Tag schema");
+    let formatted = load_snapshot(&path).expect("canonically formatted snapshot should reload");
+    assert!(matches!(
+      formatted.files["app.main"].defs["test-fn"].schema.as_ref(),
+      CalcitTypeAnnotation::Tag
+    ));
+  }
+
+  #[test]
   fn schema_edit_preserves_unrelated_legacy_schema_serialization() {
     let fixture = TestSnapshot::from_fixture();
     let source = r#"#! /usr/bin/env calcit

--- a/src/bin/cli_handlers/edit.rs
+++ b/src/bin/cli_handlers/edit.rs
@@ -2840,11 +2840,14 @@ fn print_import_usage_tips(rule: &Cirru, source_ns: &str) {
 mod tests {
   use super::{
     TransactionOperationReport, bump_semver_value, collect_format_advisories, count_legacy_any_schema_fields,
-    count_legacy_inherent_impls, handle_add_import, handle_add_test, handle_imports, handle_rm_test, handle_schema, load_snapshot,
-    parse_examples_input, parse_import_rules_input, parse_input_to_cirru, parse_schema_input, parse_transaction_operations,
-    rename_definition_declaration, run_staged_transaction_with, save_schema_preserving_snapshot, save_snapshot,
+    count_legacy_inherent_impls, handle_add_import, handle_add_test, handle_format, handle_imports, handle_rm_test, handle_schema,
+    load_snapshot, parse_examples_input, parse_import_rules_input, parse_input_to_cirru, parse_schema_input,
+    parse_transaction_operations, rename_definition_declaration, run_staged_transaction_with, save_schema_preserving_snapshot,
+    save_snapshot,
   };
-  use crate::cli_args::{EditAddImportCommand, EditAddTestCommand, EditImportsCommand, EditRmTestCommand, EditSchemaCommand};
+  use crate::cli_args::{
+    EditAddImportCommand, EditAddTestCommand, EditFormatCommand, EditImportsCommand, EditRmTestCommand, EditSchemaCommand,
+  };
   use crate::cli_handlers::test_support::TestProject;
   use calcit::calcit::CalcitTypeAnnotation;
   use cirru_edn::Edn;
@@ -3275,7 +3278,7 @@ mod tests {
       CalcitTypeAnnotation::Tag
     ));
 
-    save_snapshot(&snapshot, &path).expect("canonical formatting should preserve the Tag schema");
+    handle_format(&EditFormatCommand {}, &path).expect("edit format should preserve the Tag schema");
     let formatted = load_snapshot(&path).expect("canonically formatted snapshot should reload");
     assert!(matches!(
       formatted.files["app.main"].defs["test-fn"].schema.as_ref(),

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1501,7 +1501,7 @@ fn validate_standalone_type_schema(schema: &Cirru) -> Result<(), String> {
   {
     return Ok(());
   }
-  if matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic | CalcitTypeAnnotation::Tag) {
+  if matches!(annotation.as_ref(), CalcitTypeAnnotation::Dynamic) {
     return Err(format!(
       "Unsupported standalone type schema: {}",
       cirru_parser::format(std::slice::from_ref(schema), true.into()).unwrap_or_else(|_| format!("{schema:?}"))
@@ -3628,6 +3628,12 @@ mod tests {
     let quoted_string = Cirru::Leaf(Arc::from("'String"));
     let parsed_quoted_string = parse_schema_annotation_for_write(&quoted_string).expect("'String leaf should parse");
     assert!(matches!(parsed_quoted_string.as_ref(), CalcitTypeAnnotation::String));
+    let quoted_tag = Cirru::Leaf(Arc::from("'Tag"));
+    let parsed_quoted_tag = parse_schema_annotation_for_write(&quoted_tag).expect("'Tag leaf should parse");
+    assert!(matches!(parsed_quoted_tag.as_ref(), CalcitTypeAnnotation::Tag));
+    let serialized_tag = parse_one(":: 'Tag");
+    let parsed_serialized_tag = parse_schema_annotation_for_write(&serialized_tag).expect("serialized Tag schema should parse");
+    assert!(matches!(parsed_serialized_tag.as_ref(), CalcitTypeAnnotation::Tag));
 
     for (legacy, replacement) in [
       ("'Record", "'Struct"),


### PR DESCRIPTION
## Summary / 概要

- accept canonical standalone `Tag` schemas during serialized snapshot validation
- keep unknown standalone names rejected through the existing `Dynamic` fallback
- add coverage for direct schema parsing and the full edit → canonical format → reload path
- record the validation contract in editing history

- 在 serialized snapshot validation 中接受规范的 standalone `Tag` schema
- 保持未知 standalone 名称通过既有 `Dynamic` fallback 被拒绝
- 覆盖直接 schema 解析以及 edit → canonical format → reload 完整链路
- 在 editing history 记录校验契约

Closes #953

## Validation / 验证

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` — 809 library + 326 CLI + 23 WASM tests passed
- `yarn compile`
- `yarn check-all` — native, JS, WASM, static quality and benchmark checks passed
- `yarn check-agent-interface` — 31/31 protocol scenarios passed; timings and stdout byte counts recorded by the command