### PR TITLE
fix(types): preserve trusted core macro provenance / 保留可信 core 宏来源

### DIFF
--- a/editing-history/202609112147-core-macro-unsafe-coerce-provenance.md
+++ b/editing-history/202609112147-core-macro-unsafe-coerce-provenance.md
@@ -1,0 +1,5 @@
+# Preserve core macro provenance for `unsafe-coerce`
+
+- Strict definition tests wrap test bodies in generated project definitions, so the wrapper namespace cannot identify the source of syntax emitted by nested macros.
+- `Calcit::Syntax` retains the namespace where that syntax was authored. A trusted `calcit.core` macro expansion can therefore be distinguished from a project macro or direct project source without granting the generated wrapper `:js-ffi`.
+- The regression test exercises `calcit.test/is=` through the real definition-test runner. Existing unscoped and lexically scoped fixtures continue to protect the project-source boundary.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -610,10 +610,14 @@ fn public_check_reaches_unused_definitions_without_changing_entry_check_semantic
 #[test]
 fn strict_mode_runs_definition_tests_with_generated_function_schemas() {
   run_with_large_stack(|| {
+    builtins::effects::init_effects_states();
+    injection::inject_platform_apis();
     let namespace = format!("app.strict-definition-test-{}", std::process::id());
     let mut project = snapshot::Snapshot::default();
-    let mut file =
-      snapshot::create_file_from_snippet(&format!("ns {namespace}\n\ndefn checked () true")).expect("test project should parse");
+    let mut file = snapshot::create_file_from_snippet(&format!(
+      "ns {namespace}\n  :require\n    calcit.test :refer $ is=\n\ndefn checked () true"
+    ))
+    .expect("test project should parse");
     let checked = file.defs.get_mut("checked").expect("checked should exist");
     checked.schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
       generics: Arc::new(vec![]),
@@ -625,8 +629,8 @@ fn strict_mode_runs_definition_tests_with_generated_function_schemas() {
       features: Arc::new(HashSet::new()),
     })));
     checked.tests.push(snapshot::TestEntry {
-      name: "strict-wrapper".to_owned(),
-      code: Cirru::Leaf(Arc::from("true")),
+      name: "core-assert-equality".to_owned(),
+      code: Cirru::List(vec![Cirru::leaf("is="), Cirru::leaf("1"), Cirru::leaf("1")]),
       tags: HashSet::new(),
     });
     project.files.insert(namespace.clone(), file);
@@ -649,8 +653,9 @@ fn strict_mode_runs_definition_tests_with_generated_function_schemas() {
     };
     let _strict = StrictTypesReset::enabled();
 
-    run_tests(&options, &project, &project_namespaces)
-      .expect("strict mode should execute definition tests through a typed synthetic wrapper");
+    run_tests(&options, &project, &project_namespaces).expect(
+      "strict mode should preserve trusted core macro provenance while executing a definition test through a typed synthetic wrapper",
+    );
   });
 }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -8784,6 +8784,11 @@ pub fn preprocess_unsafe_coerce(
   if strict_types_enabled()
     && should_emit_project_source_lint(ctx.file_ns)
     && ctx.file_ns != calcit::CORE_NS
+    // Syntax emitted by a trusted core macro keeps the namespace of the
+    // macro's source. The surrounding definition can still be a generated
+    // project test, so use this provenance instead of granting `gen%` an FFI
+    // capability or exempting generated definitions wholesale.
+    && head_ns != calcit::CORE_NS
     && !current_function_has_js_ffi_feature()
   {
     return Err(CalcitErr::use_msg_stack_location_with_code(


### PR DESCRIPTION
## 中文

修复 #951。严格模式下，`calcit.test/is=` 展开的 `calcit.core/assert=` 内部 `unsafe-coerce` 现在依据 syntax 自身保留的 `calcit.core` 来源判断，不再错误归因到 definition test 的项目级 `gen%`。

边界保持不变：不会授予生成 wrapper `:js-ffi`，不会豁免项目宏，也不会放宽直接项目源码中的 `unsafe-coerce`。既有 unscoped/scoped 负正例仍覆盖该边界。

新增 definition-test runner 回归，使用真实 `calcit.test/is=` 宏链和 typed synthetic wrapper。

验证：

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- 当前分支构建的 `calcit` 对 `calcit-http` 执行 `--check-only` 通过
- 当前分支构建的 `calcit` 实际运行 `calcit-http`，加载 release dylib，`assert= |calcit-http-native-ok $ native-smoke` 通过

## English

Fixes #951. In strict mode, the internal `unsafe-coerce` emitted by `calcit.core/assert=` through `calcit.test/is=` is now classified using the syntax node’s preserved `calcit.core` provenance instead of being misattributed to the project-level generated definition-test wrapper.

The boundary remains narrow: the generated wrapper receives no `:js-ffi` capability, project macros are not exempted, and direct project-source `unsafe-coerce` remains rejected. Existing scoped/unscoped fixtures continue to cover that boundary.

The regression exercises the real definition-test runner, `calcit.test/is=` macro chain, and typed synthetic wrapper.

Validation:

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- `calcit-http --check-only` with the binary built from this branch
- real `calcit-http` runtime with its release dylib; `assert= |calcit-http-native-ok $ native-smoke` passed