### PR TITLE
fix(js): resolve external trait expression types / 解析表达式外部 trait 类型

### DIFF
--- a/editing-history/202609112200-expression-trait-ref-js-lowering.md
+++ b/editing-history/202609112200-expression-trait-ref-js-lowering.md
@@ -1,0 +1,6 @@
+# Resolve expression-level trait references before JS lowering
+
+- `unsafe-coerce` and `assert-type` synthesize their result from an expression-level type form. A qualified trait name previously remained a generic `TypeRef`, so external-object method calls fell through to dynamic dispatch even though the trait source and FFI metadata were available.
+- Qualified, zero-argument `TypeRef` values are now checked against source-backed `deftrait` declarations during expression type synthesis. Successful lookups retain the exact `namespace/definition` provenance used by external-object metadata and JavaScript name mappings.
+- Unknown references and non-trait definitions remain ordinary `TypeRef` values; the compiler does not invent a trait or broaden dynamic method specialization.
+- Real Respo validation confirms `respo.dom/DomCanvasElement.get-context` lowers to the mapped JavaScript `getContext` call and succeeds with a mock Canvas runtime.

--- a/editing-history/202609112200-expression-trait-ref-js-lowering.md
+++ b/editing-history/202609112200-expression-trait-ref-js-lowering.md
@@ -3,4 +3,5 @@
 - `unsafe-coerce` and `assert-type` synthesize their result from an expression-level type form. A qualified trait name previously remained a generic `TypeRef`, so external-object method calls fell through to dynamic dispatch even though the trait source and FFI metadata were available.
 - Qualified, zero-argument `TypeRef` values are now checked against source-backed `deftrait` declarations during expression type synthesis. Successful lookups retain the exact `namespace/definition` provenance used by external-object metadata and JavaScript name mappings.
 - Unknown references and non-trait definitions remain ordinary `TypeRef` values; the compiler does not invent a trait or broaden dynamic method specialization.
+- The source-backed trait lookup is shared with local type inference so both resolution paths stay consistent.
 - Real Respo validation confirms `respo.dom/DomCanvasElement.get-context` lowers to the mapped JavaScript `getContext` call and succeeds with a mock Canvas runtime.

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -842,6 +842,26 @@ fn resolve_namespace_type_refs_for_body(annotation: Arc<CalcitTypeAnnotation>, d
   })
 }
 
+/// Resolve a qualified source-backed trait reference when an expression-level
+/// type assertion carries it outside a function schema. Structs and enums have
+/// global `TypeRef` resolvers; traits need the same source lookup so JS
+/// external-object lowering does not fall back to dynamic method dispatch.
+fn resolve_program_trait_refs_for_body(annotation: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnnotation> {
+  map_type_refs_for_body(annotation, &|name, resolved_args| {
+    let normalized = name.trim_start_matches('\'').trim_start_matches(':');
+    let Some((ns, def)) = normalized.rsplit_once('/') else {
+      return Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args));
+    };
+    if !resolved_args.is_empty() {
+      return Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args));
+    }
+    program::lookup_def_code(ns, def)
+      .and_then(|code| resolve_trait_def_from_source_code(&code))
+      .map(|trait_def| Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def.with_definition_ref(ns, def)))))
+      .unwrap_or_else(|| Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args)))
+  })
+}
+
 fn unwrap_named_body_parameter_type(annotation: Arc<CalcitTypeAnnotation>, parameter: Option<&Arc<str>>) -> Arc<CalcitTypeAnnotation> {
   let Some(parameter) = parameter else {
     return annotation;
@@ -12720,6 +12740,39 @@ mod tests {
       },
     );
     Arc::new(trait_def)
+  }
+
+  #[test]
+  fn qualified_expression_type_ref_resolves_source_backed_external_trait() {
+    let _guard = lock_preprocess_test_state();
+    seed_external_field_trait(true);
+    let type_form = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::Quote, Arc::from("tests.external-field")),
+      external_field_test_symbol("tests.external-field/HostElement"),
+    ]);
+    let expression = Calcit::from(vec![
+      Calcit::Syntax(CalcitSyntax::UnsafeCoerce, Arc::from("tests.external-field")),
+      Calcit::Nil,
+      type_form,
+    ]);
+    let resolved = infer_type_from_expr(&expression, &ScopeTypes::new()).expect("unsafe-coerce should retain its declared trait type");
+
+    let CalcitTypeAnnotation::Trait(trait_def) = resolved.as_ref() else {
+      panic!("qualified external trait should resolve from source, got {resolved:?}");
+    };
+    assert_eq!(trait_def.definition_ref.as_deref(), Some("tests.external-field/HostElement"));
+    assert!(trait_is_external_object(trait_def.as_ref()));
+  }
+
+  #[test]
+  fn unresolved_expression_type_ref_is_not_invented_as_a_trait() {
+    let _guard = lock_preprocess_test_state();
+    let unresolved = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("tests.external-field/MissingType"),
+      Arc::new(vec![]),
+    ));
+    let resolved = resolve_program_trait_refs_for_body(unresolved.clone());
+    assert_eq!(resolved, unresolved);
   }
 
   struct JsFfiFeaturePolicyGuard;

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -616,6 +616,10 @@ fn resolve_trait_def_from_source_code(code: &Calcit) -> Option<CalcitTrait> {
   None
 }
 
+fn lookup_source_backed_trait_def(ns: &str, def: &str) -> Option<CalcitTrait> {
+  program::lookup_def_code(ns, def).and_then(|code| resolve_trait_def_from_source_code(&code))
+}
+
 fn parse_trait_name_from_source(form: &Calcit) -> Option<EdnTag> {
   match form {
     Calcit::Symbol { sym, .. } | Calcit::Str(sym) => Some(EdnTag::from(sym.as_ref())),
@@ -855,8 +859,7 @@ fn resolve_program_trait_refs_for_body(annotation: Arc<CalcitTypeAnnotation>) ->
     if !resolved_args.is_empty() {
       return Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args));
     }
-    program::lookup_def_code(ns, def)
-      .and_then(|code| resolve_trait_def_from_source_code(&code))
+    lookup_source_backed_trait_def(ns, def)
       .map(|trait_def| Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def.with_definition_ref(ns, def)))))
       .unwrap_or_else(|| Arc::new(CalcitTypeAnnotation::TypeRef(name.clone(), resolved_args)))
   })

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -29,8 +29,8 @@ use cirru_edn::EdnTag;
 
 use super::{
   ScopeTypes, checked_call_contract::resolve_checked_call_contract, find_method_entry_for_type, find_trait_field_type,
-  get_impls_from_type, resolve_local_type_refs_for_body, resolve_namespace_type_refs_for_body, resolve_program_trait_refs_for_body,
-  resolve_trait_def_from_source_code, selected_trait_method, tag_annotation, trait_is_external_object, trait_list_from_type,
+  get_impls_from_type, lookup_source_backed_trait_def, resolve_local_type_refs_for_body, resolve_namespace_type_refs_for_body,
+  resolve_program_trait_refs_for_body, selected_trait_method, tag_annotation, trait_is_external_object, trait_list_from_type,
 };
 
 // ---------------------------------------------------------------------------
@@ -123,9 +123,7 @@ fn resolve_trait_type_ref(value: Arc<CalcitTypeAnnotation>) -> Arc<CalcitTypeAnn
   let Some((ns, def)) = name.rsplit_once('/') else {
     return value;
   };
-  if let Some(code) = program::lookup_def_code(ns, def)
-    && let Some(trait_def) = resolve_trait_def_from_source_code(&code)
-  {
+  if let Some(trait_def) = lookup_source_backed_trait_def(ns, def) {
     return Arc::new(CalcitTypeAnnotation::Trait(Arc::new(trait_def.with_definition_ref(ns, def))));
   }
   if let Some(resolved) = infer_definition_value_type(ns, def)

--- a/src/runner/preprocess/type_inference.rs
+++ b/src/runner/preprocess/type_inference.rs
@@ -29,8 +29,8 @@ use cirru_edn::EdnTag;
 
 use super::{
   ScopeTypes, checked_call_contract::resolve_checked_call_contract, find_method_entry_for_type, find_trait_field_type,
-  get_impls_from_type, resolve_local_type_refs_for_body, resolve_namespace_type_refs_for_body, resolve_trait_def_from_source_code,
-  selected_trait_method, tag_annotation, trait_is_external_object, trait_list_from_type,
+  get_impls_from_type, resolve_local_type_refs_for_body, resolve_namespace_type_refs_for_body, resolve_program_trait_refs_for_body,
+  resolve_trait_def_from_source_code, selected_trait_method, tag_annotation, trait_is_external_object, trait_list_from_type,
 };
 
 // ---------------------------------------------------------------------------
@@ -970,7 +970,8 @@ pub(crate) fn infer_type_from_expr(expr: &Calcit, scope_types: &ScopeTypes) -> O
         // its declared type for the new local binding and later field/method checks.
         Calcit::Syntax(CalcitSyntax::AssertType | CalcitSyntax::UnsafeCoerce, _) => xs
           .get(2)
-          .map(|form| CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[])),
+          .map(|form| CalcitTypeAnnotation::parse_type_annotation_form_with_generics(form, &[]))
+          .map(resolve_program_trait_refs_for_body),
 
         Calcit::Syntax(CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::DecodeMapAs, _) => xs
           .get(2)


### PR DESCRIPTION
## 中文

修复 #960。`unsafe-coerce`/`assert-type` 的表达式级 qualified trait 类型此前停留在普通 `TypeRef`，导致 external-object 方法在 JS codegen 前没有识别为 `ExternalInvoke`，最终生成动态 `invoke_method`。

现在类型综合会从已加载的 source-backed `deftrait` 解析 qualified、无类型参数的 trait reference，并保留准确 `namespace/definition`，供 external-object FFI metadata 和 `:names` 映射使用。未知引用继续保持 `TypeRef`，不会被臆造为 trait。

真实 Respo 验证：

- 基线：`$clt.invoke_method("get-context", ..., "2d")`，mock Canvas 启动抛出 `No implementation ... .get-context`。
- 修复：`create_element("canvas")["getContext"]("2d")`。
- Node 注入 mock `document.createElement/getContext` 后实际导入模块并调用，返回 `canvas/2d`。

验证：

- 聚焦正反例：source-backed external trait 可解析；未知 qualified type 不会被识别为 trait
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- 最新 `main`（含 #965）重放后两项聚焦回归通过

## English

Fixes #960. Expression-level qualified trait annotations from `unsafe-coerce`/`assert-type` previously remained generic `TypeRef` values. External-object calls therefore failed to become `ExternalInvoke` before JS codegen and fell back to dynamic `invoke_method`.

Type synthesis now resolves qualified, zero-argument trait references from loaded source-backed `deftrait` declarations and preserves their exact `namespace/definition` provenance for external-object metadata and `:names` mappings. Unknown references remain ordinary `TypeRef` values and are never invented as traits.

Real Respo validation:

- Baseline emitted `$clt.invoke_method("get-context", ..., "2d")`; mock Canvas startup reproduced `No implementation ... .get-context`.
- Fixed output emits `create_element("canvas")["getContext"]("2d")`.
- A Node runtime with mock `document.createElement/getContext` imported the generated module and returned `canvas/2d`.

Validation:

- Focused positive/negative source-trait resolution tests
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-all`
- Both focused regressions rerun after rebasing onto latest `main` including #965