### PR TITLE
fix(types): bind result map callback contracts

### DIFF
--- a/editing-history/202609112336-result-map-receiver-contract.md
+++ b/editing-history/202609112336-result-map-receiver-contract.md
@@ -1,0 +1,5 @@
+# Bind Result map callbacks from the receiver
+
+- Add a checked `result:map` contract that preserves `Result<T,E>`, `Fn(T)->U`, and `Result<U,E>` relations after receiver preprocessing.
+- Prevent reachable `FsPath` core methods from emitting callback argument mismatch warnings in strict consumer checks.
+- Cover both the contract shape and a strict `fs:path` end-to-end preprocessing regression.

--- a/editing-history/202609112350-result-map-enum-receiver.md
+++ b/editing-history/202609112350-result-map-enum-receiver.md
@@ -1,0 +1,5 @@
+# Check resolved Result enum receivers
+
+- Extend the checked `result:map` contract to accept resolved `calcit.core/Result<T,E>` enum values as well as source-level type references.
+- Preserve nominal identity so user-defined enums named `Result` do not acquire the core contract.
+- Cover constructor-produced Result locals and their callback input, output, and error type relations.

--- a/src/bin/cr_tests/type_fail.rs
+++ b/src/bin/cr_tests/type_fail.rs
@@ -163,6 +163,26 @@ fn result_generic_declaration_order_preserves_ok_and_err_payload_types() {
 }
 
 #[test]
+fn strict_fs_path_core_methods_bind_result_map_callback_payloads() {
+  run_with_large_stack(|| {
+    let main_schema = Arc::new(CalcitTypeAnnotation::Fn(Arc::new(CalcitFnTypeAnnotation {
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      arg_types: vec![],
+      return_type: Arc::new(CalcitTypeAnnotation::TypeRef(Arc::from("calcit.core/FsPath"), Arc::new(vec![]))),
+      fn_kind: SchemaKind::Fn,
+      rest_type: None,
+      features: Arc::new(HashSet::new()),
+    })));
+    let _strict = StrictTypesReset::enabled();
+    injection::inject_platform_apis();
+    let entries = load_snippet_entries_with_main_schema("fs:path |.", Some(main_schema));
+
+    run_check_only(&entries).expect("reachable FsPath methods should bind result:map callbacks without core warnings");
+  });
+}
+
+#[test]
 fn legacy_map_kv_contract_warns_in_compatibility_and_fails_in_strict_mode() {
   run_with_large_stack(|| {
     let snippets = [

--- a/src/runner/preprocess/checked_call_contract.rs
+++ b/src/runner/preprocess/checked_call_contract.rs
@@ -50,6 +50,25 @@ fn callback_return_type(callback: &Calcit, scope_types: &ScopeTypes) -> Option<A
   }
 }
 
+fn core_result_type_args(type_value: &CalcitTypeAnnotation) -> Option<&[Arc<CalcitTypeAnnotation>]> {
+  match type_value {
+    CalcitTypeAnnotation::TypeRef(name, args)
+      if matches!(
+        name.trim_start_matches('\'').trim_start_matches(':'),
+        "Result" | "calcit.core/Result"
+      ) && args.len() == 2 =>
+    {
+      Some(args.as_ref())
+    }
+    CalcitTypeAnnotation::Enum(enum_def, args)
+      if enum_def.definition_ref().is_some_and(|name| name.as_ref() == "calcit.core/Result") && args.len() == 2 =>
+    {
+      Some(args.as_ref())
+    }
+    _ => None,
+  }
+}
+
 pub(crate) fn checked_call_contract_arity(fn_ns: &str, fn_def: &str) -> Option<usize> {
   if fn_ns != calcit::CORE_NS {
     return None;
@@ -111,6 +130,18 @@ pub(crate) fn resolve_checked_call_contract(
       let payload = resolve_type_value(items.get(1)?, scope_types)?;
       Some(core_type_ref("Option", vec![payload]))
     })?;
+  if fn_def == "result:map" {
+    let type_args = core_result_type_args(receiver_type.as_ref())?;
+    let input_type = type_args[0].clone();
+    let error_type = type_args[1].clone();
+    let output_type =
+      callback_return_type(args.get(1)?, scope_types).unwrap_or_else(|| Arc::new(T::TypeVar(Arc::from("ResultMapOutput"))));
+    return Some(CheckedCallContract {
+      expected_types: Some(vec![receiver_type.clone(), fn_type(vec![input_type], output_type.clone())]),
+      return_type: core_type_ref("Result", vec![output_type, error_type]),
+      lowering: None,
+    });
+  }
   match (fn_def, receiver_type.as_ref()) {
     ("option:fold", T::TypeRef(_, type_args) | T::Enum(_, type_args)) if receiver_type.is_option_type() => {
       let input_type = type_args.first()?.clone();
@@ -124,23 +155,6 @@ pub(crate) fn resolve_checked_call_contract(
           fn_type(vec![input_type], output_type.clone()),
         ]),
         return_type: output_type,
-        lowering: None,
-      })
-    }
-    ("result:map", T::TypeRef(name, type_args))
-      if type_args.len() == 2
-        && matches!(
-          name.trim_start_matches('\'').trim_start_matches(':'),
-          "Result" | "calcit.core/Result"
-        ) =>
-    {
-      let input_type = type_args[0].clone();
-      let error_type = type_args[1].clone();
-      let output_type =
-        callback_return_type(args.get(1)?, scope_types).unwrap_or_else(|| Arc::new(T::TypeVar(Arc::from("ResultMapOutput"))));
-      Some(CheckedCallContract {
-        expected_types: Some(vec![receiver_type.clone(), fn_type(vec![input_type], output_type.clone())]),
-        return_type: core_type_ref("Result", vec![output_type, error_type]),
         lowering: None,
       })
     }
@@ -269,7 +283,41 @@ pub(crate) fn resolve_checked_call_contract(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::calcit::{CalcitLocal, CalcitSymbolInfo};
+  use crate::calcit::{CalcitEnumDef, CalcitLocal, CalcitStructDef, CalcitStructValue, CalcitSymbolInfo};
+  use cirru_edn::EdnTag;
+
+  fn symbol(name: &str) -> Calcit {
+    Calcit::Symbol {
+      sym: Arc::from(name),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests"),
+        at_def: Arc::from("checked_call_contract"),
+      }),
+      location: None,
+    }
+  }
+
+  fn result_enum(namespace: &str) -> Arc<CalcitEnumDef> {
+    Arc::new(
+      CalcitEnumDef::from_struct(CalcitStructValue {
+        struct_ref: Arc::new(CalcitStructDef {
+          definition_ref: None,
+          name: EdnTag::new("Result"),
+          fields: Arc::new(vec![EdnTag::new("err"), EdnTag::new("ok")]),
+          field_types: Arc::new(vec![crate::calcit::DYNAMIC_TYPE.clone(); 2]),
+          generics: Arc::new(vec![Arc::from("T"), Arc::from("E")]),
+          where_bounds: Arc::new(vec![]),
+          impls: vec![],
+        }),
+        values: Arc::new(vec![
+          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("E")]))),
+          Calcit::List(Arc::new(CalcitList::Vector(vec![symbol("T")]))),
+        ]),
+      })
+      .expect("valid Result enum")
+      .with_definition_ref(namespace, "Result"),
+    )
+  }
 
   fn local(name: &str, type_info: Arc<CalcitTypeAnnotation>) -> Calcit {
     Calcit::Local(CalcitLocal {
@@ -350,6 +398,49 @@ mod tests {
     assert_eq!(callback.return_type, output.clone());
     assert_eq!(contract.return_type, core_type_ref("Result", vec![output, error]));
     assert_eq!(contract.lowering, None);
+  }
+
+  #[test]
+  fn result_map_contract_checks_constructor_produced_core_result_locals() {
+    let input = Arc::new(CalcitTypeAnnotation::String);
+    let error = Arc::new(CalcitTypeAnnotation::Tag);
+    let output = Arc::new(CalcitTypeAnnotation::Number);
+    let receiver = Arc::new(CalcitTypeAnnotation::Enum(
+      result_enum(calcit::CORE_NS),
+      Arc::new(vec![input.clone(), error.clone()]),
+    ));
+    let mapper = Arc::new(CalcitTypeAnnotation::from_function_parts(vec![input.clone()], output.clone()));
+    let args = CalcitList::from(&[local("constructed", receiver.clone()), local("measure", mapper)] as &[Calcit]);
+
+    let contract = resolve_checked_call_contract(calcit::CORE_NS, "result:map", &args, &ScopeTypes::new())
+      .expect("constructor-produced core Result should retain its checked map contract");
+    let expected_types = contract.expected_types.as_ref().expect("result:map should bind checking evidence");
+    assert_eq!(expected_types[0], receiver);
+    let CalcitTypeAnnotation::Fn(callback) = expected_types[1].as_ref() else {
+      panic!("result:map callback should be checked as a function");
+    };
+    assert_eq!(callback.arg_types.as_slice(), &[input]);
+    assert_eq!(callback.return_type, output.clone());
+    assert_eq!(contract.return_type, core_type_ref("Result", vec![output, error]));
+
+    let user_receiver = Arc::new(CalcitTypeAnnotation::Enum(
+      result_enum("app.models"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::String), Arc::new(CalcitTypeAnnotation::Tag)]),
+    ));
+    let user_args = CalcitList::from(&[
+      local("user-result", user_receiver),
+      local(
+        "measure",
+        Arc::new(CalcitTypeAnnotation::from_function_parts(
+          vec![Arc::new(CalcitTypeAnnotation::String)],
+          Arc::new(CalcitTypeAnnotation::Number),
+        )),
+      ),
+    ] as &[Calcit]);
+    assert!(
+      resolve_checked_call_contract(calcit::CORE_NS, "result:map", &user_args, &ScopeTypes::new()).is_none(),
+      "a user enum with the same short name must not acquire the core Result contract"
+    );
   }
 
   #[test]

--- a/src/runner/preprocess/checked_call_contract.rs
+++ b/src/runner/preprocess/checked_call_contract.rs
@@ -55,7 +55,7 @@ pub(crate) fn checked_call_contract_arity(fn_ns: &str, fn_def: &str) -> Option<u
     return None;
   }
   match fn_def {
-    "get" | "filter" | "map" | "map-list-kv" => Some(2),
+    "get" | "filter" | "map" | "map-list-kv" | "result:map" => Some(2),
     "option:fold" | "update" => Some(3),
     _ => None,
   }
@@ -124,6 +124,23 @@ pub(crate) fn resolve_checked_call_contract(
           fn_type(vec![input_type], output_type.clone()),
         ]),
         return_type: output_type,
+        lowering: None,
+      })
+    }
+    ("result:map", T::TypeRef(name, type_args))
+      if type_args.len() == 2
+        && matches!(
+          name.trim_start_matches('\'').trim_start_matches(':'),
+          "Result" | "calcit.core/Result"
+        ) =>
+    {
+      let input_type = type_args[0].clone();
+      let error_type = type_args[1].clone();
+      let output_type =
+        callback_return_type(args.get(1)?, scope_types).unwrap_or_else(|| Arc::new(T::TypeVar(Arc::from("ResultMapOutput"))));
+      Some(CheckedCallContract {
+        expected_types: Some(vec![receiver_type.clone(), fn_type(vec![input_type], output_type.clone())]),
+        return_type: core_type_ref("Result", vec![output_type, error_type]),
         lowering: None,
       })
     }
@@ -310,6 +327,28 @@ mod tests {
     assert_eq!(callback.arg_types.as_slice(), &[key, value]);
     assert_eq!(callback.return_type, output.clone());
     assert_eq!(contract.return_type, Arc::new(CalcitTypeAnnotation::List(output)));
+    assert_eq!(contract.lowering, None);
+  }
+
+  #[test]
+  fn result_map_contract_preserves_ok_error_and_callback_output_types() {
+    let input = Arc::new(CalcitTypeAnnotation::Tag);
+    let error = Arc::new(CalcitTypeAnnotation::String);
+    let output = Arc::new(CalcitTypeAnnotation::Number);
+    let receiver = core_type_ref("Result", vec![input.clone(), error.clone()]);
+    let mapper = Arc::new(CalcitTypeAnnotation::from_function_parts(vec![input.clone()], output.clone()));
+    let args = CalcitList::from(&[local("result", receiver.clone()), local("measure", mapper)] as &[Calcit]);
+
+    let contract = resolve_checked_call_contract(calcit::CORE_NS, "result:map", &args, &ScopeTypes::new())
+      .expect("typed result:map should have a checked contract");
+    let expected_types = contract.expected_types.as_ref().expect("result:map should bind checking evidence");
+    assert_eq!(expected_types[0], receiver);
+    let CalcitTypeAnnotation::Fn(callback) = expected_types[1].as_ref() else {
+      panic!("result:map callback should be checked as a function");
+    };
+    assert_eq!(callback.arg_types.as_slice(), &[input]);
+    assert_eq!(callback.return_type, output.clone());
+    assert_eq!(contract.return_type, core_type_ref("Result", vec![output, error]));
     assert_eq!(contract.lowering, None);
   }
 


### PR DESCRIPTION
## Summary

- specialize the checked `result:map` contract from its processed `Result<T,E>` receiver
- propagate the receiver's ok payload into inline callbacks and preserve the error/output types
- cover the contract shape and the strict `fs:path` consumer regression

## Validation

- reproduced with a fresh crates.io `calcit 0.14.8` install: two `W_FN_ARG_TYPE_MISMATCH` warnings, exit 1
- fixed binary: `printf 'fs:path |.\n' | calcit exec` completes without warnings, exit 0
- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `yarn check-all`

Closes #969
