### PR TITLE
test: cover Result map nominal boundary

### DIFF
--- a/editing-history/202609120007-result-map-nominal-boundary.md
+++ b/editing-history/202609120007-result-map-nominal-boundary.md
@@ -1,0 +1,5 @@
+# Cover the Result reference boundary
+
+- Keep the short `Result<T,E>` reference accepted because embedded core API schemas still preserve that form during preprocessing.
+- Add a regression proving that an explicitly user-qualified `Result` reference does not acquire the core `result:map` contract.
+- Retain exact definition identity for resolved enum values, covering the nominal boundary without restoring the `fs:path` warnings.

--- a/src/runner/preprocess/checked_call_contract.rs
+++ b/src/runner/preprocess/checked_call_contract.rs
@@ -441,6 +441,25 @@ mod tests {
       resolve_checked_call_contract(calcit::CORE_NS, "result:map", &user_args, &ScopeTypes::new()).is_none(),
       "a user enum with the same short name must not acquire the core Result contract"
     );
+
+    let user_ref = Arc::new(CalcitTypeAnnotation::TypeRef(
+      Arc::from("app.models/Result"),
+      Arc::new(vec![Arc::new(CalcitTypeAnnotation::String), Arc::new(CalcitTypeAnnotation::Tag)]),
+    ));
+    let args = CalcitList::from(&[
+      local("user-result-ref", user_ref),
+      local(
+        "measure",
+        Arc::new(CalcitTypeAnnotation::from_function_parts(
+          vec![Arc::new(CalcitTypeAnnotation::String)],
+          Arc::new(CalcitTypeAnnotation::Number),
+        )),
+      ),
+    ] as &[Calcit]);
+    assert!(
+      resolve_checked_call_contract(calcit::CORE_NS, "result:map", &args, &ScopeTypes::new()).is_none(),
+      "an explicitly user-qualified Result reference must not acquire the core contract"
+    );
   }
 
   #[test]


### PR DESCRIPTION
Follow-up to #970 and its final CodeRabbit outside-diff comment.

The suggested qualified-only TypeRef match was tested and rejected because embedded core APIs such as try-read-dir still preserve the short Result<T,E> form during preprocessing; applying it restores the two #969 fs:path warnings.

This PR records the actual safe boundary with a regression: explicitly user-qualified app.models/Result references do not acquire the core result:map contract. Resolved enums continue to require exact calcit.core/Result definition identity.

Validation:
- cargo fmt --check
- cargo test result_map_contract --lib
- cargo test strict_fs_path_core_methods_bind_result_map_callback_payloads
- cargo clippy --all-targets -- -D warnings
- full cargo test passed on the same code before rebasing this test-only commit onto merged main