### PR TITLE
feat(docs): add compact Agent mutation contract

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -29,13 +29,39 @@ Calcit 0.14 起，普通运行、检查和代码生成默认启用严格预处�
 `--compat-types` 暂时恢复旧 warning 行为；`--strict-types` 表示进一步执行零类型债务 quality gate，
 不能与 `--compat-types` 同时使用。Agent 不应把兼容开关写进新项目或长期 CI。
 
+## Mutation contract v1
+
+这是每次进入 Calcit 仓库、首次写入前必须读取的紧凑安全契约：
+
+1. 当前仓库的 `AGENTS.md`、README 和用户要求优先；CLI 参数若变化，查 live `--help`，不要绕过结构化工具。
+2. `calcit.cirru` 是 Cirru EDN Snapshot，绝不能用文本 patch、正则脚本或 formatter 修改；只用 `calcit edit`、`calcit tree`、`calcit cursor` 和 `calcit config`。
+3. 写入前运行 `calcit -v`、检查 `deps.cirru :calcit-version` 并用 `calcit query config` 确认目标 Snapshot/entry；版本不匹配时改用固定 CLI 或显式升级，不能绕过门禁。
+4. 同一 Snapshot 的 mutation 必须串行；原子多步变更使用 transaction、dry-run 和 `--expect-revision`，并行工作使用独立 worktree/Snapshot。
+5. target、path 和替换内容必须来自 `query` / `tree show`；修改前展示真实 subtree，修改后重新 show/search，并运行项目规定的 check、test 和目标 codegen。
+6. 不得把 `CURSOR`、`FOLDED:*`、chunk 标题、path annotation 或 `preview_tree` 写回 Snapshot；机器读取 cursor 时只信 `tree` 字段。
+7. 发现语言/编译器/CLI 缺陷，向 Calcit 核心仓库提交最小复现；发现模块缺陷，先用解析后的模块路径和 Git remote 确认 owner，再提交到模块仓库。不能猜仓库，也不能只留在聊天或提交说明中。
+
+按需加载权威细节：
+
+```bash
+calcit docs agents --full
+calcit docs read edit-tree.md 'Atomic Transactions'
+calcit docs read edit-tree.md 'Persistent Tree Cursor'
+calcit docs read query.md --full
+calcit docs read project-structure.md --full
+calcit docs read library-quality.md --full
+```
+
+`calcit docs agents --contract` 输出本节、contract version 和稳定 digest。digest 未变化时可在新仓库只重读本契约；首次使用、digest 变化或任务触及未覆盖能力时读取 `--full` 或上述相关 section。`--full` 始终是权威完整指南。
+
 ## 0. 开始修改前
 
 1. 先遵守当前仓库的 `AGENTS.md`、README 和用户要求；本文只补充 Calcit 源码操作规则。若仓库示例被当前 CLI 以 `Unrecognized argument` 拒绝，保持原约束意图，用该子命令的 live `--help` 换成当前参数，不要因此绕过 `calcit` 直接改 Snapshot。
-2. 每个任务第一次执行 `calcit edit`、`calcit tree` 或 cursor mutation 前，必须先读取当前 CLI 内嵌的完整指南：
+2. 每个任务第一次执行 `calcit edit`、`calcit tree` 或 cursor mutation 前，必须先读取当前 CLI 内嵌的紧凑 mutation contract；首次使用、digest 变化或任务超出契约覆盖范围时再读取完整指南：
 
    ```bash
-   calcit docs agents --full
+   calcit docs agents --contract
+   calcit docs agents --full # first orientation, changed digest, or task-specific need
    ```
 
 3. `calcit.cirru` 是 **Cirru EDN 树形 Snapshot**，不是按行维护的文本源码。旧项目若只有 `compact.cirru`，先按 upgrade 指南迁移；当前工具会拒绝旧文件名。不要用 line patch、正则脚本或 formatter 直接改 Snapshot；使用 `calcit edit`、`calcit tree`、`calcit cursor`。

--- a/docs/docs-validation.md
+++ b/docs/docs-validation.md
@@ -135,6 +135,9 @@ calcit docs graph orphans
 # Agents frontmatter should not leak into output
 calcit docs agents
 
+# Compact mutation contract should print a version, digest, and bounded rules
+calcit docs agents --contract
+
 # Module Agents and module docs should both participate in ranking
 calcit docs search render --module respo.calcit
 calcit docs search clear-cache --module respo.calcit

--- a/docs/run/agent-advanced.md
+++ b/docs/run/agent-advanced.md
@@ -239,7 +239,8 @@ echo 'range 10' | calcit exec
 - `calcit docs search keyword` — 在 `docs/` 与 `~/.config/calcit/docs` 中 grep markdown
 - `# see: calcit cirru show-guide` — 读取 Cirru 语法指南
 - `calcit docs read path.md` — 读取任意文档文件
-- `calcit docs agents [<heading> ...] [--full]` — 结构化 Agent 指南
+- `calcit docs agents --contract` — 每个仓库边界重读的版本化 mutation contract
+- `calcit docs agents [<heading> ...] [--full]` — 权威完整 Agent 指南与按 heading 查询
 - `calcit docs read` / `sections` / `remote-libs` 等 — 见 [debugging.md](./debugging.md)
 
 ---

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -41,7 +41,7 @@ related:
 开始修改前先读取当前 Agent 指南：
 
 ```bash
-calcit docs agents --full
+calcit docs agents --contract
 ```
 
 检查并规范化目标 Snapshot：

--- a/docs/run/quick-start.md
+++ b/docs/run/quick-start.md
@@ -19,7 +19,7 @@ parent: core/run
 
 # 快速开始（新 LLM 必读）
 
-**硬前置步骤：在执行任何 `calcit edit` / `calcit tree` 修改前，必须先运行一次 `calcit docs agents --full`。**
+**硬前置步骤：在执行任何 `calcit edit` / `calcit tree` 修改前，必须先运行 `calcit docs agents --contract`。首次使用、contract digest 变化或任务超出紧凑契约范围时再运行 `calcit docs agents --full`。**
 
 这不是建议项，而是进入实际修改前的检查项。跳过这一步，往往会直接沿用旧用法假设，尤其容易误判 `calcit tree replace --path ''`、imports 输入格式和 watcher 验收边界。
 

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -227,7 +227,7 @@ caps --help
 更新依赖前先读取当前 Agent/CLI 指南，避免沿用旧命令边界：
 
 ```bash
-calcit docs agents --full
+calcit docs agents --contract
 ```
 
 ### Step C：检查并更新 `deps.cirru`

--- a/editing-history/202609120025-compact-agent-mutation-contract.md
+++ b/editing-history/202609120025-compact-agent-mutation-contract.md
@@ -1,0 +1,7 @@
+# Add a compact Agent mutation contract
+
+- Add `calcit docs agents --contract`, extracting a bounded safety-critical section from the authoritative embedded Agent guide.
+- Print contract version, embedded guide source, stable MD5 content digest, byte length, and line count before the contract body.
+- Keep the contract structurally embedded in the full guide so the two views cannot drift, and test its mandatory rules and size budget.
+- Update Snapshot guidance and workflow docs to require the compact contract at repository boundaries while reserving `--full` for orientation, digest changes, and task-specific detail.
+- Extend the Agent interface smoke test to verify the real CLI contract output and output-size bound.

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -642,6 +642,19 @@ for (const scenario of scenarios) {
   });
 }
 
+const contractChild = spawnSync(binary, ["docs", "agents", "--contract"], {
+  cwd: process.cwd(),
+  encoding: "utf8",
+  maxBuffer: 64 * 1024,
+  env: { ...process.env, NO_COLOR: "1" },
+});
+assert.ifError(contractChild.error);
+assert.equal(contractChild.status, 0, contractChild.stderr);
+assert.match(contractChild.stdout, /Agent mutation contract: v1/);
+assert.match(contractChild.stdout, /Agent contract digest: md5:[0-9a-f]{32}/);
+assert.match(contractChild.stdout, /calcit docs read edit-tree\.md 'Atomic Transactions'/);
+assert.ok(Buffer.byteLength(contractChild.stdout) < 5_000, "compact mutation contract should remain bounded");
+
 // Real CLI round trips, including the legacy wire format and negative paths.
 const fixtureDir = mkdtempSync(join(tmpdir(), "calcit-query-def-"));
 try {
@@ -683,5 +696,5 @@ try {
   rmSync(fixtureDir, { recursive: true, force: true });
 }
 
-console.log(`Agent interface smoke passed: ${rows.length}/${scenarios.length}, plus definition protocol round trips`);
+console.log(`Agent interface smoke passed: ${rows.length}/${scenarios.length}, plus mutation contract and definition protocol round trips`);
 console.table(rows);

--- a/src/bin/cli_handlers/command_echo.rs
+++ b/src/bin/cli_handlers/command_echo.rs
@@ -775,6 +775,7 @@ fn push_docs(tokens: &mut Vec<String>, cmd: &DocsCommand) {
       list "heading" => &opts.headings,
       switch "no-subheadings" => opts.no_subheadings,
       switch "full" => opts.full,
+      switch "contract" => opts.contract,
       switch "with-lines" => opts.with_lines,
       switch "refresh" => opts.refresh
     ),

--- a/src/bin/cli_handlers/docs.rs
+++ b/src/bin/cli_handlers/docs.rs
@@ -4,6 +4,7 @@
 
 use calcit::cli_args::{DocsCommand, DocsGraphSubcommand, DocsSubcommand};
 use colored::Colorize;
+use md5::{Digest, Md5};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -25,7 +26,7 @@ use calcit::util;
 use super::atomic_write::stage_atomic_file;
 use super::docs_cache;
 use super::libs::handle_libs_command;
-use super::markdown_read::{RenderMarkdownOptions, render_markdown_sections};
+use super::markdown_read::{RenderMarkdownOptions, build_heading_sections, render_markdown_sections};
 use super::tips::command_guidance_enabled;
 
 const VALID_DOC_CATEGORIES: &[&str] = &[
@@ -168,7 +169,14 @@ pub fn handle_docs_command(cmd: &DocsCommand) -> Result<(), String> {
       opts.with_lines,
       opts.module.as_deref(),
     ),
-    DocsSubcommand::Agents(opts) => handle_agents(&opts.headings, !opts.no_subheadings, opts.full, opts.with_lines, opts.refresh),
+    DocsSubcommand::Agents(opts) => handle_agents(
+      &opts.headings,
+      !opts.no_subheadings,
+      opts.full,
+      opts.contract,
+      opts.with_lines,
+      opts.refresh,
+    ),
     DocsSubcommand::ReadLines(opts) => handle_read_lines(&opts.filename, opts.start, opts.lines, opts.module.as_deref()),
     DocsSubcommand::CheckMd(opts) => handle_check_md(&opts.file, &opts.entry, &opts.dep, opts.quiet, opts.failures_only),
     DocsSubcommand::FormatMd(opts) => handle_format_md(&opts.file, opts.check),
@@ -405,11 +413,32 @@ fn handle_graph_command(command: &DocsGraphSubcommand) -> Result<(), String> {
 
 const AGENTS_DOC_URL: &str = "https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md";
 const EMBEDDED_AGENTS_DOC: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/CalcitAgent.md"));
+const AGENT_MUTATION_CONTRACT_VERSION: u32 = 1;
+const AGENT_MUTATION_CONTRACT_HEADING: &str = "Mutation contract v1";
 
 struct AgentsDocument {
   content: String,
   display_path: String,
   refreshed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentMutationContract {
+  content: String,
+  digest: String,
+}
+
+fn extract_agent_mutation_contract(content: &str) -> Result<AgentMutationContract, String> {
+  let (_, content) = parse_doc_frontmatter(content);
+  let sections = build_heading_sections(&content);
+  let section = sections
+    .iter()
+    .find(|section| section.title == AGENT_MUTATION_CONTRACT_HEADING)
+    .ok_or_else(|| format!("Agents.md is missing the required `{AGENT_MUTATION_CONTRACT_HEADING}` section"))?;
+  let lines = content.lines().collect::<Vec<_>>();
+  let contract = lines[section.line - 1..section.content_end].join("\n") + "\n";
+  let digest = format!("md5:{}", hex::encode(Md5::digest(contract.as_bytes())));
+  Ok(AgentMutationContract { content: contract, digest })
 }
 
 fn get_agents_cache_path() -> Result<PathBuf, String> {
@@ -1097,9 +1126,15 @@ fn handle_agents(
   heading_queries: &[String],
   include_subheadings: bool,
   full: bool,
+  contract: bool,
   with_lines: bool,
   force_refresh: bool,
 ) -> Result<(), String> {
+  if contract && (full || with_lines || !heading_queries.is_empty() || !include_subheadings) {
+    return Err(
+      "`calcit docs agents --contract` cannot be combined with headings, --full, --with-lines, or --no-subheadings".to_string(),
+    );
+  }
   let document = load_agents_document(force_refresh)?;
   if document.refreshed {
     println!("{}", format!("Refreshed remote Agents doc cache from: {AGENTS_DOC_URL}").dimmed());
@@ -1108,6 +1143,22 @@ fn handle_agents(
   validate_doc_frontmatter(&document.display_path, &frontmatter)?;
   let byte_len = content.len();
   let line_len = content.lines().count();
+
+  if contract {
+    let contract = extract_agent_mutation_contract(&document.content)?;
+    println!("{} v{AGENT_MUTATION_CONTRACT_VERSION}", "Agent mutation contract:".dimmed());
+    println!("{} {}", "Agent source:".dimmed(), document.display_path.cyan());
+    println!("{} {}", "Agent contract digest:".dimmed(), contract.digest.cyan());
+    println!(
+      "{} {} bytes, {} lines",
+      "Agent contract length:".dimmed(),
+      contract.content.len().to_string().cyan(),
+      contract.content.lines().count().to_string().cyan()
+    );
+    println!();
+    print!("{}", contract.content);
+    return Ok(());
+  }
 
   println!("{} {}", "Agent source:".dimmed(), document.display_path.cyan());
   println!(

--- a/src/bin/cli_handlers/docs_tests.rs
+++ b/src/bin/cli_handlers/docs_tests.rs
@@ -1,9 +1,9 @@
 use super::{
-  CirruCheckMode, GuideDoc, GuideDocFrontmatter, GuideDocScope, collect_check_md_module_paths, collect_docs_for_query,
-  collect_search_results, extract_cirru_blocks, find_doc_by_query, format_markdown_cirru_blocks, handle_check_md, handle_format_md,
-  list_doc_scopes_for_project, load_agents_document, load_entry_snapshot_for_check_md, load_module_docs_for_project,
-  load_module_docs_from_dir, parse_doc_frontmatter, parse_doc_knowledge_metadata, run_edn_parse_only, score_doc_query, score_doc_shape,
-  validate_doc_frontmatter,
+  AGENT_MUTATION_CONTRACT_VERSION, CirruCheckMode, EMBEDDED_AGENTS_DOC, GuideDoc, GuideDocFrontmatter, GuideDocScope,
+  collect_check_md_module_paths, collect_docs_for_query, collect_search_results, extract_agent_mutation_contract, extract_cirru_blocks,
+  find_doc_by_query, format_markdown_cirru_blocks, handle_check_md, handle_format_md, list_doc_scopes_for_project,
+  load_agents_document, load_entry_snapshot_for_check_md, load_module_docs_for_project, load_module_docs_from_dir,
+  parse_doc_frontmatter, parse_doc_knowledge_metadata, run_edn_parse_only, score_doc_query, score_doc_shape, validate_doc_frontmatter,
 };
 use std::ffi::OsString;
 use std::fs;
@@ -110,6 +110,32 @@ fn agents_docs_default_to_the_version_matched_embedded_guide() {
   assert!(document.content.contains("symbol leaf:    quote new-name"));
   assert!(document.content.contains("calcit cirru parse -e --validate"));
   assert!(document.content.contains("calcit docs search 'cursor'"));
+}
+
+#[test]
+fn compact_agent_contract_is_versioned_bounded_and_embedded_in_the_full_guide() {
+  let contract = extract_agent_mutation_contract(EMBEDDED_AGENTS_DOC).expect("embedded guide should contain the mutation contract");
+  let repeated = extract_agent_mutation_contract(EMBEDDED_AGENTS_DOC).expect("contract extraction should be deterministic");
+
+  assert_eq!(AGENT_MUTATION_CONTRACT_VERSION, 1);
+  assert_eq!(contract, repeated);
+  assert_eq!(contract.digest, "md5:c57c723d4af4e4b3c43c3fd7469b4dae");
+  assert!(contract.content.lines().count() <= 40, "contract should stay cheap to reload");
+  assert!(contract.content.len() <= 5_000, "contract should stay compact");
+  assert!(EMBEDDED_AGENTS_DOC.contains(&contract.content));
+
+  for required in [
+    "AGENTS.md",
+    "绝不能用文本 patch",
+    "deps.cirru :calcit-version",
+    "mutation 必须串行",
+    "修改前展示真实 subtree",
+    "模块仓库",
+    "calcit docs agents --full",
+    "calcit docs read edit-tree.md 'Atomic Transactions'",
+  ] {
+    assert!(contract.content.contains(required), "compact contract is missing `{required}`");
+  }
 }
 
 #[test]

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |calcit)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --contract` before mutations; use `--full` for first orientation or changed contract digest. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |calcit)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'calcit.core/println!) (:mode :native) (:reload-fn 'calcit.core/println!)
       :feature-policy $ {}

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -951,7 +951,7 @@ pub enum DocsSubcommand {
   Sections(DocsSectionsCommand),
   /// read markdown content from calcit guidebook or one installed module
   Read(DocsReadCommand),
-  /// read cached Agents guide (auto-refresh daily)
+  /// read the embedded Agents guide or compact mutation contract
   Agents(DocsAgentsCommand),
   /// read a specific line range from calcit guidebook or installed module docs
   ReadLines(DocsReadLinesCommand),
@@ -1145,7 +1145,7 @@ pub struct DocsReadCommand {
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 #[argh(subcommand, name = "agents")]
-/// read Agents.md with local cache (~/.config/calcit/Agents.md), refresh if older than 1 day
+/// read the embedded Agents guide, compact mutation contract, or refreshed remote guide
 pub struct DocsAgentsCommand {
   /// heading keyword(s) for fuzzy match, can pass multiple; if omitted, list all markdown headings
   #[argh(positional)]
@@ -1156,6 +1156,9 @@ pub struct DocsAgentsCommand {
   /// show full file content directly
   #[argh(switch)]
   pub full: bool,
+  /// show the compact versioned mutation contract
+  #[argh(switch)]
+  pub contract: bool,
   /// show line numbers in heading list and section titles
   #[argh(switch)]
   pub with_lines: bool,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -13,7 +13,7 @@ use crate::calcit::{
 };
 use crate::data::edn::{format_deserialize_error, format_edn_display};
 
-const SNAPSHOT_ABOUT_MESSAGE: &str = "Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.";
+const SNAPSHOT_ABOUT_MESSAGE: &str = "Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --contract` before mutations; use `--full` for first orientation or changed contract digest. Manual edits must follow format and schema conventions, then run `calcit edit format`.";
 
 fn default_version() -> String {
   "0.0.0".to_owned()


### PR DESCRIPTION
Closes #942.

Adds `calcit docs agents --contract`, a 25-line / 1978-byte mutation contract extracted directly from the authoritative embedded Agent guide. The command prints contract v1, embedded guide source, stable MD5 content digest, byte length, and line count.

Safety and consistency:
- retains repository precedence, structured-only Snapshot writes, version/dependency checks, serialized mutations, query/show/verify loop, display-marker exclusions, and issue ownership
- links the relevant full guide sections and keeps `--full` authoritative
- exact digest assertion makes v1 content changes explicit
- real CLI Agent-interface smoke enforces the output and size bound
- Snapshot about text was updated only through `calcit edit format`

Validation:
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (814 lib, 329 CLI, 23 WASM)
- yarn check-all (native, JS, IR, WASM, core 238/238, quality/classification and perf checks)
- repeated `calcit edit format` reports no formatting changes