### PR TITLE
feat(types): report bounded Dynamic provenance

### DIFF
--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -150,6 +150,14 @@ the argument before the relational call, or isolate genuinely open behavior in
 an adapter whose contract does not claim that relationship. Compatibility mode
 keeps accepting the call while projects migrate.
 
+When the nearest typed operation is statically known, the human diagnostic adds
+one bounded Dynamic-origin note. For example, a `Map<K,Dynamic>` lookup names
+`calcit.core/get`, its receiver type and source path, then recommends giving the
+map value a concrete schema or decoding it at the open boundary. Direct
+`Dynamic` arguments keep the concise message. Structured preprocess
+diagnostics expose the same deterministic entry in `provenance`; the array is
+empty when no reliable origin is available.
+
 For a strict-only release check, load every resolved dependency with `--deps`; loader acceptance proves that no legacy macro schema remains:
 
 ```bash

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -259,6 +259,14 @@ the callee is intentionally open, put that operation behind a small adapter
 whose structured contract does not claim the generic relationship. With
 `--compat-types`, the existing compatibility behavior is unchanged.
 
+If a typed operation directly introduced the open value, the error includes a
+single bounded origin and migration direction. The first supported trace is
+`Map<K,Dynamic> -> get -> Option<Dynamic> -> generic consumer`: human output
+names the receiver and source path, while JSON diagnostics include a
+`provenance` array with `operation`, `definition`, `path`, `type`,
+`output_type`, `flow`, and `migration`. Direct `Dynamic` arguments do not gain
+a speculative trace.
+
 `E_DYNAMIC_NOMINAL_ARGUMENT` rejects a project call when an explicitly open
 `Dynamic` value, or a matching container with a `Dynamic` member, enters an
 argument whose contract contains a closed Struct or Enum. Decode text with

--- a/editing-history/202609120045-dynamic-generic-provenance.md
+++ b/editing-history/202609120045-dynamic-generic-provenance.md
@@ -1,0 +1,7 @@
+# Add bounded Dynamic provenance
+
+- Attach one deterministic provenance entry when `Map<K,Dynamic>` flows through typed `get` into `E_ERASED_GENERIC_RELATION`.
+- Keep direct Dynamic arguments concise and avoid speculative or unbounded traces.
+- Expose operation, definition, path, receiver/output types, flow, and migration guidance in structured diagnostics.
+- Keep `CalcitErr` below clippy's large-error threshold while carrying optional provenance.
+- Serialize the existing global strict-mode regression with the shared preprocess test guard.

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -281,6 +281,8 @@ struct ContextDiagnostic {
   message: String,
   path: Option<String>,
   intent: Option<String>,
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  provenance: Vec<calcit::calcit::CalcitErrProvenance>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1556,6 +1558,7 @@ fn handle_type(input_path: &str, opts: &QueryTypeCommand) -> Result<(), String> 
       message: "`:any` is a legacy alias for `:dynamic`; the canonical type and generated schema use `'Dynamic`. Do not use it to model polymorphism.".to_owned(),
       path: None,
       intent: Some("migration".to_owned()),
+      provenance: vec![],
     }]
   } else {
     vec![]
@@ -2091,6 +2094,7 @@ fn warning_to_context_diagnostic(warning: &LocatedWarning) -> ContextDiagnostic 
       &warning.location().coord.iter().map(|idx| *idx as usize).collect::<Vec<_>>(),
     )),
     intent: None,
+    provenance: vec![],
   }
 }
 
@@ -2114,6 +2118,7 @@ fn type_at_expected_mismatch_diagnostic(
     ),
     path: Some(path.to_owned()),
     intent: None,
+    provenance: vec![],
   })
 }
 
@@ -2276,7 +2281,10 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
     .collect::<Vec<_>>();
   if let Some(error) = compile_error {
     diagnostics.push(ContextDiagnostic {
-      code: error.code.unwrap_or_else(|| format!("E_{}", error.kind.to_string().to_uppercase())),
+      code: error
+        .code
+        .clone()
+        .unwrap_or_else(|| format!("E_{}", error.kind.to_string().to_uppercase())),
       phase: "preprocess",
       severity: "error",
       message: error.msg,
@@ -2285,6 +2293,7 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
         .as_ref()
         .map(|location| semantic_code_path(&location.coord.iter().map(|idx| *idx as usize).collect::<Vec<_>>())),
       intent: None,
+      provenance: *error.provenance,
     });
   }
   if inferred.is_none() {
@@ -2295,6 +2304,7 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
       message: "Static inference could not determine a type for this expression without executing the program".to_owned(),
       path: Some(semantic_path.clone()),
       intent: dynamic_intent.map(str::to_owned),
+      provenance: vec![],
     });
   }
   if let (Some(actual), Some((required, source))) = (inferred.as_ref(), expected.as_ref())
@@ -2564,6 +2574,7 @@ fn context_docs(definition: &str, diagnostics: &mut Vec<ContextDiagnostic>) -> C
         message: error.lines().next().unwrap_or(&error).to_owned(),
         path: None,
         intent: None,
+        provenance: vec![],
       });
       ContextCollection::new(0, vec![])
     }
@@ -2616,6 +2627,7 @@ fn weak_type_diagnostics(entry: &snapshot::CodeEntry, budget: usize) -> Vec<Cont
         message: format!("{} ({})", occurrence.kind.as_str(), occurrence.detail),
         path: Some(occurrence.path),
         intent: Some(occurrence.intent.as_str().to_owned()),
+        provenance: vec![],
       }
     })
     .collect::<Vec<_>>();
@@ -2630,6 +2642,7 @@ fn weak_type_diagnostics(entry: &snapshot::CodeEntry, budget: usize) -> Vec<Cont
       ),
       path: None,
       intent: None,
+      provenance: vec![],
     });
   }
   diagnostics
@@ -2656,6 +2669,7 @@ fn build_regular_context(
         message: "definition has no trusted static type coverage".to_owned(),
         path: Some("schema".to_owned()),
         intent: None,
+        provenance: vec![],
       },
     );
   }
@@ -2667,6 +2681,7 @@ fn build_regular_context(
       message: issue.clone(),
       path: Some("schema".to_owned()),
       intent: None,
+      provenance: vec![],
     });
   }
 
@@ -2679,6 +2694,7 @@ fn build_regular_context(
       message: error.clone(),
       path: None,
       intent: None,
+      provenance: vec![],
     });
   }
 
@@ -2693,6 +2709,7 @@ fn build_regular_context(
           message: error,
           path: Some("code".to_owned()),
           intent: None,
+          provenance: vec![],
         });
         vec![]
       }
@@ -2845,6 +2862,7 @@ fn build_special_builtin_context(
         message: "dynamic values are intentional at this JS FFI boundary".to_owned(),
         path: Some("schema".to_owned()),
         intent: Some("intentional-js-ffi".to_owned()),
+        provenance: vec![],
       },
     );
   }

--- a/src/calcit.rs
+++ b/src/calcit.rs
@@ -33,6 +33,7 @@ use cirru_edn::EdnAnyRef;
 use cirru_edn::{Edn, EdnTag};
 use cirru_parser::Cirru;
 use im_ternary_tree::TernaryTreeList;
+use serde::Serialize;
 
 pub use calcit_impl::CalcitImpl;
 pub use calcit_struct::CalcitStructDef;
@@ -1031,6 +1032,18 @@ impl fmt::Display for CalcitErrKind {
   }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CalcitErrProvenance {
+  pub kind: String,
+  pub operation: String,
+  pub definition: Option<String>,
+  pub path: Option<String>,
+  pub r#type: String,
+  pub output_type: String,
+  pub flow: String,
+  pub migration: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CalcitErr {
   pub kind: CalcitErrKind,
@@ -1040,7 +1053,9 @@ pub struct CalcitErr {
   pub location: Option<Arc<NodeLocation>>,
   pub stack: CallStackList,
   /// Additional hint for error, such as usage examples
-  pub hint: Option<String>,
+  pub hint: Option<Box<str>>,
+  /// A bounded, deterministic explanation of where an open type entered the failing relation.
+  pub provenance: Box<Vec<CalcitErrProvenance>>,
 }
 
 impl fmt::Display for CalcitErr {
@@ -1071,6 +1086,7 @@ impl From<String> for CalcitErr {
       stack: CallStackList::default(),
       location: None,
       hint: None,
+      provenance: Box::default(),
     }
   }
 }
@@ -1085,6 +1101,7 @@ impl CalcitErr {
       stack: CallStackList::default(),
       location: None,
       hint: None,
+      provenance: Box::default(),
     }
   }
 
@@ -1097,6 +1114,7 @@ impl CalcitErr {
       stack: CallStackList::default(),
       location: None,
       hint: None,
+      provenance: Box::default(),
     })
   }
 
@@ -1109,6 +1127,7 @@ impl CalcitErr {
       stack: CallStackList::default(),
       location: None,
       hint: None,
+      provenance: Box::default(),
     })
   }
 
@@ -1121,6 +1140,7 @@ impl CalcitErr {
       stack: CallStackList::default(),
       location,
       hint: None,
+      provenance: Box::default(),
     })
   }
   pub fn use_msg_stack<T: Into<String>>(kind: CalcitErrKind, msg: T, stack: &CallStackList) -> Self {
@@ -1132,6 +1152,7 @@ impl CalcitErr {
       stack: stack.to_owned(),
       location: None,
       hint: None,
+      provenance: Box::default(),
     }
   }
   pub fn use_msg_stack_location<T: Into<String>>(
@@ -1148,6 +1169,7 @@ impl CalcitErr {
       stack: stack.to_owned(),
       location: location.map(Arc::new),
       hint: None,
+      provenance: Box::default(),
     }
   }
 
@@ -1165,7 +1187,8 @@ impl CalcitErr {
       warnings: Box::default(),
       stack: stack.to_owned(),
       location: location.map(Arc::new),
-      hint: Some(hint.into()),
+      hint: Some(hint.into().into_boxed_str()),
+      provenance: Box::default(),
     }
   }
 
@@ -1184,6 +1207,7 @@ impl CalcitErr {
       stack: stack.to_owned(),
       location: location.map(Arc::new),
       hint: None,
+      provenance: Box::default(),
     }
   }
 
@@ -1196,7 +1220,8 @@ impl CalcitErr {
       warnings: Box::default(),
       stack: CallStackList::default(),
       location: None,
-      hint: Some(hint.into()),
+      hint: Some(hint.into().into_boxed_str()),
+      provenance: Box::default(),
     })
   }
 
@@ -1214,7 +1239,8 @@ impl CalcitErr {
       warnings: Box::default(),
       stack: CallStackList::default(),
       location: None,
-      hint: Some(hint.into()),
+      hint: Some(hint.into().into_boxed_str()),
+      provenance: Box::default(),
     })
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,7 @@ pub fn run_program_with_docs(init_ns: Arc<str>, init_def: Arc<str>, params: &[Ca
       stack: CallStackList::default(),
       location: None,
       hint: None,
+      provenance: Box::default(),
     });
   }
 

--- a/src/public_api_check.rs
+++ b/src/public_api_check.rs
@@ -51,6 +51,7 @@ fn error_diagnostic(error: &CalcitErr, definition_id: &str) -> Value {
       "coord": location.coord.to_vec(),
     })),
     "hint": error.hint,
+    "provenance": error.provenance,
   })
 }
 
@@ -360,7 +361,7 @@ mod tests {
   use super::*;
   use std::sync::Arc;
 
-  use calcit::calcit::DYNAMIC_TYPE;
+  use calcit::calcit::{CalcitErrKind, CalcitErrProvenance, DYNAMIC_TYPE};
   use cirru_edn::Edn;
   use cirru_parser::Cirru;
 
@@ -391,5 +392,28 @@ mod tests {
     let malformed_key = Edn::map_from_iter([(Edn::str("target"), Edn::tag("browser"))]);
     assert!(definition_target(&entry_with_ffi(Some(malformed_key))).is_err());
     assert_eq!(definition_target(&entry_with_ffi(None)).unwrap(), None);
+  }
+
+  #[test]
+  fn serializes_bounded_dynamic_provenance() {
+    let mut error = CalcitErr::use_str(CalcitErrKind::Type, "erased relation");
+    error.code = Some("E_ERASED_GENERIC_RELATION".to_owned());
+    *error.provenance = vec![CalcitErrProvenance {
+      kind: "typed-operation".to_owned(),
+      operation: "calcit.core/get".to_owned(),
+      definition: Some("app.main/consume".to_owned()),
+      path: Some("code@3.2".to_owned()),
+      r#type: "Map<Tag,Dynamic>".to_owned(),
+      output_type: "Option<Dynamic>".to_owned(),
+      flow: "Map value -> get return Option<Dynamic> -> generic consumer argument".to_owned(),
+      migration: "Give the map value a concrete schema.".to_owned(),
+    }];
+
+    let diagnostic = error_diagnostic(&error, "app.main/consume");
+    let provenance = diagnostic["provenance"].as_array().expect("provenance array");
+    assert_eq!(provenance.len(), 1);
+    assert_eq!(provenance[0]["definition"], "app.main/consume");
+    assert_eq!(provenance[0]["path"], "code@3.2");
+    assert_eq!(provenance[0]["type"], "Map<Tag,Dynamic>");
   }
 }

--- a/src/runner/macro_capability.rs
+++ b/src/runner/macro_capability.rs
@@ -129,17 +129,20 @@ fn check_policy(policy: CapabilityPolicy, operation: &str, call_stack: &CallStac
     helper_chain(call_stack)
   );
   let mut error = CalcitErr::use_msg_stack_location_with_code(CalcitErrKind::Effect, message, code, call_stack, context.call_location);
-  error.hint = Some(if capability.is_allowed() {
-    format!(
-      "Declare `:capabilities $ #{{}} :{}` on the strict Macro signature, or move the effect into generated runtime code.",
-      capability.as_str()
-    )
-  } else {
-    format!(
-      "Compile-time :{} cannot be enabled. Move the operation into generated runtime code or remove the host effect.",
-      capability.as_str()
-    )
-  });
+  error.hint = Some(
+    if capability.is_allowed() {
+      format!(
+        "Declare `:capabilities $ #{{}} :{}` on the strict Macro signature, or move the effect into generated runtime code.",
+        capability.as_str()
+      )
+    } else {
+      format!(
+        "Compile-time :{} cannot be enabled. Move the operation into generated runtime code or remove the host effect.",
+        capability.as_str()
+      )
+    }
+    .into_boxed_str(),
+  );
   Err(error)
 }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -6,11 +6,12 @@ mod type_rewriting;
 use crate::{
   builtins::{self, is_js_syntax_procs, is_proc_name, is_registered_proc},
   calcit::{
-    self, Calcit, CalcitArgLabel, CalcitCallKind, CalcitErr, CalcitErrKind, CalcitFn, CalcitFnArgs, CalcitFnTypeAnnotation, CalcitImpl,
-    CalcitImport, CalcitList, CalcitLocal, CalcitNumberBinaryOp, CalcitProc, CalcitScope, CalcitStructDef, CalcitSymbolInfo,
-    CalcitSyntax, CalcitTrait, CalcitTraitMemberKind, CalcitTypeAnnotation, GENERATED_DEF, ImportInfo, LocatedWarning,
-    MacroExpansionType, MacroSignature, MacroSyntaxType, NodeLocation, ParamShape, ParamShapeToken, RawCodeType, SchemaKind,
-    brief_type_of_value, compare_param_shapes, pop_type_slot_override, push_type_slot_override, register_type_slot,
+    self, Calcit, CalcitArgLabel, CalcitCallKind, CalcitErr, CalcitErrKind, CalcitErrProvenance, CalcitFn, CalcitFnArgs,
+    CalcitFnTypeAnnotation, CalcitImpl, CalcitImport, CalcitList, CalcitLocal, CalcitNumberBinaryOp, CalcitProc, CalcitScope,
+    CalcitStructDef, CalcitSymbolInfo, CalcitSyntax, CalcitTrait, CalcitTraitMemberKind, CalcitTypeAnnotation, GENERATED_DEF,
+    ImportInfo, LocatedWarning, MacroExpansionType, MacroSignature, MacroSyntaxType, NodeLocation, ParamShape, ParamShapeToken,
+    RawCodeType, SchemaKind, brief_type_of_value, compare_param_shapes, pop_type_slot_override, push_type_slot_override,
+    register_type_slot,
   },
   call_stack::{CallStackList, StackKind, find_preferred_macro_location},
   codegen, program, runner,
@@ -2593,6 +2594,7 @@ fn preprocess_list_call(
         reject_strict_erased_generic_relation(
           &head_form,
           &current_args,
+          &args,
           effective_schema.as_ref(),
           scope_types,
           file_ns,
@@ -3159,7 +3161,7 @@ fn preprocess_list_call(
               && let CalcitTypeAnnotation::Fn(signature) = local_type.as_ref()
             {
               reject_strict_dynamic_nominal_argument(&head_form, &updated_args, signature, scope_types, file_ns, call_stack)?;
-              reject_strict_erased_generic_relation(&head_form, &updated_args, signature, scope_types, file_ns, call_stack)?;
+              reject_strict_erased_generic_relation(&head_form, &updated_args, &args, signature, scope_types, file_ns, call_stack)?;
             }
             check_local_fn_call_arg_types(&head_form, local, &updated_args, scope_types, &call_info, check_warnings);
           }
@@ -9437,6 +9439,63 @@ struct ErasedGenericArgument {
   generics: Vec<Arc<str>>,
 }
 
+fn nearest_dynamic_provenance(source: &Calcit, actual: &CalcitTypeAnnotation, scope_types: &ScopeTypes) -> Vec<CalcitErrProvenance> {
+  fn render_type(annotation: &CalcitTypeAnnotation) -> String {
+    match annotation {
+      CalcitTypeAnnotation::Dynamic => "Dynamic".to_owned(),
+      CalcitTypeAnnotation::Tag => "Tag".to_owned(),
+      CalcitTypeAnnotation::Map(key, value) => format!("Map<{},{}>", render_type(key), render_type(value)),
+      CalcitTypeAnnotation::Optional(inner) => format!("Option<{}>", render_type(inner)),
+      _ => annotation.to_brief_string(),
+    }
+  }
+
+  let Calcit::List(call) = source else {
+    return vec![];
+  };
+  let Some(head) = call.first() else {
+    return vec![];
+  };
+  let is_core_get = match head {
+    Calcit::Symbol { sym, .. } | Calcit::Local(CalcitLocal { sym, .. }) => sym.as_ref() == "get",
+    Calcit::Import(CalcitImport { ns, def, .. }) => ns.as_ref() == calcit::CORE_NS && def.as_ref() == "get",
+    Calcit::Fn { info, .. } => info.def_ns.as_ref() == calcit::CORE_NS && info.name.as_ref() == "get",
+    _ => false,
+  };
+  if !is_core_get || call.len() != 3 {
+    return vec![];
+  }
+  let Some(receiver_type) = call.get(1).and_then(|receiver| resolve_type_value(receiver, scope_types)) else {
+    return vec![];
+  };
+  let CalcitTypeAnnotation::Map(_, value_type) = receiver_type.as_ref() else {
+    return vec![];
+  };
+  if !matches!(value_type.as_ref(), CalcitTypeAnnotation::Dynamic) {
+    return vec![];
+  }
+  let location = head.get_location().or_else(|| source.get_location());
+  let definition = location.as_ref().map(|location| format!("{}/{}", location.ns, location.def));
+  let path = location.as_ref().map(|location| {
+    if location.coord.is_empty() {
+      "code".to_owned()
+    } else {
+      format!("code@{}", location.coord.iter().map(u16::to_string).collect::<Vec<_>>().join("."))
+    }
+  });
+  let output_type = render_type(actual);
+  vec![CalcitErrProvenance {
+    kind: "typed-operation".to_owned(),
+    operation: "calcit.core/get".to_owned(),
+    definition,
+    path,
+    r#type: render_type(receiver_type.as_ref()),
+    output_type: output_type.clone(),
+    flow: format!("Map value -> get return {output_type} -> generic consumer argument"),
+    migration: "Give the map value a concrete schema, or decode and narrow it at the open boundary before this call.".to_owned(),
+  }]
+}
+
 fn find_erased_generic_argument(
   signature: &CalcitFnTypeAnnotation,
   args: &CalcitList,
@@ -9483,6 +9542,7 @@ fn find_erased_generic_argument(
 fn reject_strict_erased_generic_relation(
   head: &Calcit,
   args: &CalcitList,
+  source_args: &CalcitList,
   signature: &CalcitFnTypeAnnotation,
   scope_types: &ScopeTypes,
   file_ns: &str,
@@ -9502,18 +9562,35 @@ fn reject_strict_erased_generic_relation(
   };
   let names = generics.iter().map(|name| format!("`'{name}`")).collect::<Vec<_>>().join(", ");
   let argument = args.get(index);
-  Err(CalcitErr::use_msg_stack_location_with_code(
+  let provenance = source_args
+    .get(index)
+    .map(|source| nearest_dynamic_provenance(source, actual.as_ref(), scope_types))
+    .unwrap_or_default();
+  let provenance_note = provenance.first().map(|origin| {
+    let at = match (&origin.definition, &origin.path) {
+      (Some(definition), Some(path)) => format!(" at `{definition}` {path}"),
+      _ => String::new(),
+    };
+    format!(
+      "; Dynamic origin: `{}` receiver is `{}`{at}. Flow: {}. Migration: {}",
+      origin.operation, origin.r#type, origin.flow, origin.migration
+    )
+  });
+  let mut error = CalcitErr::use_msg_stack_location_with_code(
     CalcitErrKind::Type,
     format!(
-      "call to `{head}` passes `{}` at argument {}, so Dynamic erases generic relation {names} required by `{}`; narrow or validate the value before this call, or use an explicit open adapter whose contract does not claim that generic relation",
+      "call to `{head}` passes `{}` at argument {}, so Dynamic erases generic relation {names} required by `{}`; narrow or validate the value before this call, or use an explicit open adapter whose contract does not claim that generic relation{}",
       actual.to_brief_string(),
       index + 1,
       expected.to_brief_string(),
+      provenance_note.as_deref().unwrap_or_default(),
     ),
     "E_ERASED_GENERIC_RELATION",
     call_stack,
     argument.and_then(Calcit::get_location).or_else(|| head.get_location()),
-  ))
+  );
+  error.provenance = Box::new(provenance);
+  Err(error)
 }
 
 fn contains_nominal_contract(annotation: &CalcitTypeAnnotation) -> bool {
@@ -16935,6 +17012,7 @@ mod tests {
 
   #[test]
   fn reprocessed_dynamic_local_parameter_shadows_outer_type() {
+    let _state = lock_preprocess_test_state();
     let ns: Arc<str> = Arc::from("tests.local-shadow");
     let symbol_info = Arc::new(CalcitSymbolInfo {
       at_ns: ns.clone(),
@@ -17382,6 +17460,7 @@ mod tests {
       reject_strict_erased_generic_relation(
         &test_symbol("identity"),
         &dynamic_args,
+        &dynamic_args,
         &identity,
         &scope_types,
         "tests.generic-relation",
@@ -17393,6 +17472,7 @@ mod tests {
     let error = reject_strict_erased_generic_relation(
       &test_symbol("identity"),
       &dynamic_args,
+      &dynamic_args,
       &identity,
       &scope_types,
       "tests.generic-relation",
@@ -17400,6 +17480,10 @@ mod tests {
     )
     .expect_err("strict mode should reject an erased generic relation");
     assert_eq!(error.code.as_deref(), Some("E_ERASED_GENERIC_RELATION"));
+    assert!(
+      error.provenance.is_empty(),
+      "direct Dynamic arguments should keep the concise diagnostic"
+    );
 
     let erased = find_erased_generic_argument(&identity, &dynamic_args, &scope_types).expect("Dynamic should erase T -> T");
     assert_eq!(erased.index, 0);
@@ -17437,6 +17521,62 @@ mod tests {
     );
     let args = CalcitList::from(&[Calcit::Number(1.0), value][..]);
     assert!(find_erased_generic_argument(&relation_plus_open_boundary, &args, &scope_types).is_none());
+  }
+
+  #[test]
+  fn reports_bounded_map_get_dynamic_provenance() {
+    let _state = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let dynamic = calcit::DYNAMIC_TYPE.clone();
+    let map_type = Arc::new(CalcitTypeAnnotation::Map(Arc::new(CalcitTypeAnnotation::Tag), dynamic.clone()));
+    let option_dynamic = Arc::new(CalcitTypeAnnotation::Optional(dynamic));
+    let receiver = generic_relation_test_local("store", map_type.clone());
+    let processed_value = generic_relation_test_local("state", option_dynamic.clone());
+    let get_head = Calcit::Symbol {
+      sym: Arc::from("get"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.generic-relation"),
+        at_def: Arc::from("consume-state"),
+      }),
+      location: Some(Arc::new(vec![3, 2])),
+    };
+    let source_get = Calcit::from(CalcitList::from(&[get_head, receiver, Calcit::Tag(EdnTag::new("states"))][..]));
+    let processed_args = CalcitList::from(&[processed_value, Calcit::Map(Default::default())][..]);
+    let source_args = CalcitList::from(&[source_get, Calcit::Map(Default::default())][..]);
+    let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let signature = generic_relation_test_signature(
+      vec![Arc::new(CalcitTypeAnnotation::Optional(type_var.clone())), type_var.clone()],
+      type_var,
+      None,
+    );
+    let scope_types = ScopeTypes::from([(Arc::from("store"), map_type)]);
+
+    let error = reject_strict_erased_generic_relation(
+      &test_symbol("option:unwrap-or"),
+      &processed_args,
+      &source_args,
+      &signature,
+      &scope_types,
+      "tests.generic-relation",
+      &CallStackList::default(),
+    )
+    .expect_err("Map<Tag,Dynamic> flowing through get should retain its nearest known origin");
+
+    assert_eq!(error.code.as_deref(), Some("E_ERASED_GENERIC_RELATION"));
+    assert!(
+      error
+        .msg
+        .contains("Dynamic origin: `calcit.core/get` receiver is `Map<Tag,Dynamic>`"),
+      "{}",
+      error.msg
+    );
+    assert_eq!(error.provenance.len(), 1, "provenance must stay bounded");
+    let origin = &error.provenance[0];
+    assert_eq!(origin.operation, "calcit.core/get");
+    assert_eq!(origin.definition.as_deref(), Some("tests.generic-relation/consume-state"));
+    assert_eq!(origin.path.as_deref(), Some("code@3.2"));
+    assert_eq!(origin.r#type, "Map<Tag,Dynamic>");
+    assert_eq!(origin.output_type, "Option<Dynamic>");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- attach one deterministic Dynamic-origin entry when `Map<K,Dynamic>` flows through typed `get` into `E_ERASED_GENERIC_RELATION`
- keep direct Dynamic arguments concise and avoid speculative/unbounded traces
- expose operation, definition, path, receiver/output types, flow, and migration in public-check and type-at JSON diagnostics
- preserve the compact error representation and serialize strict-mode tests sharing global state

## Verification

- `cargo test -q` (815 library, 333 CLI, 23 WASM)
- `cargo clippy --all-targets -- -D warnings`
- `yarn check-all`

Closes #940