### PR TITLE
feat: reconcile Dynamic usage metrics / 对齐 Dynamic 使用指标

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -517,7 +517,7 @@ calcit cirru show-guide
 
 不要用多个 `'Dynamic` 假装多态：参数与返回共享类型时声明 `:generics`/TypeVar，只依赖能力时增加 trait `:where`，同质 collection/ref 保留 type arg，有限异构值使用 enum。类型写法统一用 quoted symbols，例如 `'String`、`'Number`、`'List` 和 `'Dynamic`；`:any`、`:dynamic` 等旧 tag 写法仅为兼容输入，运行 `calcit edit format` 后会在类型位置规范化。只有明确的 FFI、global state 或 macro 边界保留 dynamic，并尽快在进入 typed code 时 validate/convert。
 
-每次 `calcit` 执行或编译都会在 stderr 审计项目自身的 Dynamic 类型位置：少量仅提示，达到较高占比会告警。该提示不写入 stdout，也不替代 `analyze check-types` / `analyze weak-types`；Agent 应先查看告警，再用 `calcit analyze weak-types --intent unresolved --format json` 定位并逐步收窄类型。
+每次 `calcit` 执行或编译都会在 stderr 审计项目自身的 Dynamic 类型位置：少量仅提示，达到较高占比会告警。该提示不写入 stdout，也不替代 `analyze check-types` / `analyze weak-types`。先用 `calcit analyze weak-types --only schema-dynamic,code-dynamic --summary-only --format json` 读取 `data.summary.dynamic_usage`：其分子、分母与默认启动提示同范围，`intents` 必须合计为 `dynamic_positions` 且 `reconciled` 为 true。随后再按 `--intent unresolved` 定位并逐步收窄真正的未解决债务；不要把 intentional JS FFI/macro/type-slot 边界或 quality 的组合预算误判为计数矛盾。
 
 `:: :tag ...` 是匿名 Enum 字面量；当已有 Enum 定义在头部时，直接使用 `Enum :tag ...`，类型分析会检查变体和 payload，并在预处理阶段降为命名构造。只有需要显式携带运行时 enum prototype、跨模块动态构造或兼容旧代码时才使用 `%:: Enum :tag ...`。不要为了绕过类型检查而主动选择 `%::`。
 

--- a/docs/features/static-analysis.md
+++ b/docs/features/static-analysis.md
@@ -245,7 +245,13 @@ warning remains a completion-gate failure until the body is implemented.
 `raise "|TODO..."` does not emit `W_TODO`, because ordinary exception behavior
 and implementation-completion status are separate concerns.
 
-`analyze.weak-types` uses protocol `schema_version: 5`: v2 added nil intent classes, v3 added the closed `unresolved-type-slot` kind plus `W_UNRESOLVED_TYPE_SLOT`, v4 added the closed `unsafe-coerce` kind, `explicit-unsafe` intent, target-schema detail, and `W_JS_FFI_UNCHECKED_COERCE`, and v5 adds the per-occurrence static boundary `evidence` object. Consumers should reject older versions when they require these fields rather than accepting an older envelope and silently missing the new debt.
+`analyze.weak-types` 使用 `schema_version: 6`。v2 增加 nil intent 分类，v3 增加封闭的 `unresolved-type-slot` kind 与 `W_UNRESOLVED_TYPE_SLOT`，v4 增加封闭的 `unsafe-coerce` kind、`explicit-unsafe` intent、目标 schema 细节与 `W_JS_FFI_UNCHECKED_COERCE`，v5 增加每个 occurrence 的静态边界 `evidence`，v6 增加 `data.summary.dynamic_usage` 对账对象。消费者依赖新字段时应拒绝旧版本，不能接受旧 envelope 后静默漏掉新债务。
+
+启动提示的 Dynamic 分子统计当前项目 Snapshot 中持久化 definition 的所有显式 Dynamic 位置：schema annotation node 会递归计入容器成员、函数参数/返回/rest、nominal type argument，以及 macro 的 `Expr`/expansion 位置；代码中的显式 `:dynamic`/`:any` marker 也计入。分母是同一范围内的全部 schema annotation node 加这些显式代码 marker。普通值 definition 只要有 schema 也属于范围；运行时生成且没有写入 Snapshot 的 definition、未选择的 namespace，以及默认未包含的依赖不计入。JS FFI、macro syntax 与显式 type-slot Dynamic 等已审阅边界仍计入分子，不会因为 intent 合理而从使用率中消失。
+
+要精确复现启动提示，运行 `calcit analyze weak-types --only schema-dynamic,code-dynamic --summary-only --format json`。`data.summary.dynamic_usage.dynamic_positions` 与 `total_positions` 对应同一分子和分母，`intents` 使用现有 weak-type intent taxonomy 划分分子；`unattributed_unresolved` 暂存尚无 occurrence path 的位置，且也合入 `intents.unresolved`。只有 `reconciled: true` 且全部 intent 计数之和等于 `dynamic_positions` 才表示对账成立。`--ns`、`--ns-prefix` 或 `--deps` 会同时改变明细与该对账对象的范围；要复现默认启动提示，不要加 scope 参数。
+
+这些数字表达不同问题，因此不要求彼此相等：启动分子包含全部显式 Dynamic；`weak-types --intent unresolved` 只显示未解决位置；quality 的 `schemaDynamic` 还保留需要预算审阅的 macro syntax，而 `unresolved` 会合并 unresolved schema/code Dynamic、未绑定 type slot 与 nil 债务。human quality output 在 `schemaDynamic` 与 `unresolved` 不同时会提示这项策略差异。
 
 Use `--summary-only` when only aggregate counts are needed. Human output stops after the aggregate section; JSON keeps `data.summary` and the scope revision while returning an empty `data.definitions` array. `defstruct`, `defenum`, `deftrait`, and `defimpl` have explicit definition-kind schemas: `StructDef`, `EnumDef`, `Trait`, and `Impl`. Legacy snapshots that used `Dynamic` at these roots are normalized on load and written back with the marker. Their fields, enum payloads, and methods are still analyzed normally, but the declaration root itself neither creates a `schema-dynamic` finding nor increases Dynamic usage counts.
 

--- a/docs/run/library-quality.md
+++ b/docs/run/library-quality.md
@@ -92,6 +92,8 @@ calcit calcit.cirru analyze weak-types \
 
 `check-types` 与 `weak-types` 是定位报告；`analyze quality` 是带非零失败退出的发布门禁。新类库直接使用零容忍：
 
+启动时显示的 Dynamic 使用率、`weak-types --intent unresolved` 命中数和 quality 预算具有不同策略。前者覆盖项目 Snapshot 的全部显式 Dynamic schema/code 位置，包括已审阅边界；第二项只定位 unresolved intent；quality 的 `schemaDynamic` 包含受审阅的 macro syntax，而 `unresolved` 还会合并未绑定 type slot 与 nil 债务。用 `calcit calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --summary-only --format json` 的 `data.summary.dynamic_usage` 对账启动分子和分母，不要要求这三组指标互相相等。
+
 ```bash
 calcit calcit.cirru analyze quality
 ```

--- a/editing-history/202609120106-dynamic-usage-accounting.md
+++ b/editing-history/202609120106-dynamic-usage-accounting.md
@@ -1,0 +1,20 @@
+# 对齐 Dynamic 使用量、弱类型与质量预算
+
+## 背景
+
+启动提示、`analyze weak-types` 与 `analyze quality` 原本分别显示合理但口径不同的 Dynamic 数字。用户能够看到差异，却无法从一个结构化结果判断变化来自未解决债务、已审阅边界重新分类，还是分析分母变化。
+
+## 修改
+
+- 将 `analyze.weak-types` JSON 协议升级到 v6，在 `data.summary.dynamic_usage` 中提供与启动提示同范围的分子、分母、比例、intent 分类及对账状态。
+- 启动提示改为指向可精确复现自身口径的 `weak-types --only schema-dynamic,code-dynamic --summary-only --format json` 命令。
+- human quality 输出在 `schemaDynamic` 与 `unresolved` 不同时解释两项预算的分类策略。
+- 中文文档明确 Snapshot scope、递归位置规则、依赖和运行时生成 definition 的排除规则，以及 intentional 边界仍计入 Dynamic 使用率的原则。
+- 更新协议消费者与回归测试；同一 fixture 明确覆盖启动 Dynamic 分子、unresolved weak-type 命中和 quality 预算可以不同且仍保持一致分析。
+
+## 验证
+
+- `cargo test --bin calcit analysis_json_envelopes_preserve_filters_and_definition_paths`
+- `cargo test --bin calcit human_report_explains_distinct_dynamic_budgets`
+- `node scripts/check-agent-interface.mjs`
+- 在 `calcit/test.cirru` 上运行 v6 summary，确认 23 个 Dynamic 位置被 22 个 unresolved 与 1 个 intentional JS FFI 完整对账，分母为 56，`reconciled` 为 true。

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -412,8 +412,13 @@ const scenarios = [
       "json",
     ],
     check(result) {
-      if (result.schema_version !== 5 || result.command !== "analyze.weak-types" || result.data.summary.hits === 0) {
+      if (result.schema_version !== 6 || result.command !== "analyze.weak-types" || result.data.summary.hits === 0) {
         throw new Error("weak type result is incomplete");
+      }
+      const usage = result.data.summary.dynamic_usage;
+      const accounted = Object.values(usage.intents).reduce((sum, count) => sum + count, 0);
+      if (!usage.reconciled || accounted !== usage.dynamic_positions || usage.total_positions < usage.dynamic_positions) {
+        throw new Error("weak-types dynamic usage accounting did not reconcile");
       }
       const occurrences = result.data.definitions.flatMap((definition) => definition.occurrences);
       if (!occurrences.every((occurrence) => occurrence.intent === "intentional-js-ffi")) {

--- a/scripts/check-strict-nil-ecosystem.mjs
+++ b/scripts/check-strict-nil-ecosystem.mjs
@@ -63,7 +63,7 @@ const parseCalcitJson = (result, label) => {
     throw new Error(`${label} did not end with a JSON object:\n${output.trim()}`);
   }
   const parsed = JSON.parse(match[1]);
-  if (parsed.command !== "analyze.weak-types" || parsed.schema_version !== 5) {
+  if (parsed.command !== "analyze.weak-types" || parsed.schema_version !== 6) {
     throw new Error(`${label} returned an unexpected analyzer envelope`);
   }
   return parsed.data.summary;

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -2778,7 +2778,7 @@ mod tests {
     };
     let json = type_coverage::format_weak_types_json(&options, &snapshot).expect("unsafe evidence JSON should format");
     let value: serde_json::Value = serde_json::from_str(&json).expect("unsafe evidence JSON should parse");
-    assert_eq!(value["schema_version"], 5);
+    assert_eq!(value["schema_version"], 6);
     assert_eq!(
       value["data"]["definitions"][0]["occurrences"][0]["evidence"]["source_form"],
       "raw-js-value"
@@ -2939,7 +2939,7 @@ mod tests {
     };
     let weak_json = type_coverage::format_weak_types_json(&weak_options, &snapshot).expect("weak type JSON should format");
     let weak_value: serde_json::Value = serde_json::from_str(&weak_json).expect("weak type JSON should parse");
-    assert_eq!(weak_value["schema_version"], 5);
+    assert_eq!(weak_value["schema_version"], 6);
     assert_eq!(weak_value["command"], "analyze.weak-types");
     assert_eq!(weak_value["data"]["filters"]["intent"], "unresolved");
     assert_eq!(weak_value["data"]["definitions"][0]["occurrences"][0]["path"], "schema.args.0");
@@ -2953,6 +2953,38 @@ mod tests {
         .any(|diagnostic| diagnostic["code"] == "W_NIL_TYPE_DEBT")
     );
     assert_eq!(weak_value["data"]["summary"]["intents"]["declared-unit"], 0);
+    let dynamic_usage = &weak_value["data"]["summary"]["dynamic_usage"];
+    assert_eq!(dynamic_usage["dynamic_positions"], 2);
+    assert_eq!(dynamic_usage["total_positions"], 3);
+    assert_eq!(dynamic_usage["intents"]["unresolved"], 2);
+    assert_eq!(dynamic_usage["unattributed_unresolved"], 0);
+    assert_eq!(dynamic_usage["reconciled"], true);
+    assert_eq!(
+      dynamic_usage["intents"]
+        .as_object()
+        .expect("dynamic intent counts should be an object")
+        .values()
+        .map(|value| value.as_u64().expect("dynamic intent count should be unsigned"))
+        .sum::<u64>(),
+      dynamic_usage["dynamic_positions"]
+        .as_u64()
+        .expect("dynamic position count should be unsigned")
+    );
+    assert_eq!(weak_value["data"]["summary"]["hits"], 3);
+    let quality = quality_gate::analyze_quality(
+      &QualityCommand {
+        ns: Some("app.main".to_owned()),
+        ns_prefix: None,
+        deps: false,
+        baseline: None,
+        write_baseline: None,
+        format: "json".to_owned(),
+      },
+      &snapshot,
+    )
+    .expect("quality fixture should analyze");
+    assert_eq!(quality.metrics.schema_dynamic, 2);
+    assert_eq!(quality.metrics.unresolved, 3);
     assert_eq!(check_value["diagnostics"][0]["code"], "W_TYPE_COVERAGE_GAPS");
 
     let mut check_summary_options = check_options.clone();

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -473,6 +473,12 @@ pub fn format_quality_report(outcome: &QualityOutcome) -> String {
       let _ = writeln!(out, "  - {metric}: {actual}");
     }
   }
+  if outcome.metrics.schema_dynamic != outcome.metrics.unresolved {
+    let _ = writeln!(
+      out,
+      "- accounting: schemaDynamic includes unresolved and reviewed macro-syntax schema positions; unresolved combines unresolved-intent schema/code Dynamic, type-slot, and nil positions. Use `analyze weak-types --only schema-dynamic,code-dynamic --summary-only --format json` for startup-numerator reconciliation."
+    );
+  }
   if !outcome.violations.is_empty() {
     let _ = writeln!(out, "- regressions:");
     for violation in &outcome.violations {
@@ -698,5 +704,28 @@ mod tests {
     assert_eq!(violations.len(), 1);
     assert_eq!(violations[0].metric, "codeNil");
     assert_eq!(violations[0].delta, 1);
+  }
+
+  #[test]
+  fn human_report_explains_distinct_dynamic_budgets() {
+    let outcome = QualityOutcome {
+      revision: "md5:test".to_owned(),
+      scope: default_scope(),
+      mode: "zero-debt".to_owned(),
+      baseline_path: None,
+      metrics: QualityMetrics {
+        schema_dynamic: 2,
+        unresolved: 3,
+        ..QualityMetrics::default()
+      },
+      limits: None,
+      deltas: BTreeMap::new(),
+      violations: vec![],
+      passed: false,
+    };
+
+    let report = format_quality_report(&outcome);
+    assert!(report.contains("schemaDynamic includes unresolved and reviewed macro-syntax schema positions"));
+    assert!(report.contains("weak-types --only schema-dynamic,code-dynamic"));
   }
 }

--- a/src/type_coverage.rs
+++ b/src/type_coverage.rs
@@ -291,7 +291,10 @@ fn count_annotation_positions(annotation: &CalcitTypeAnnotation) -> (usize, usiz
       }
       match &signature.expansion {
         MacroExpansionType::Expr(semantic) | MacroExpansionType::Definition(semantic) => add(semantic),
-        MacroExpansionType::Dynamic => dynamic += 1,
+        MacroExpansionType::Dynamic => {
+          total += 1;
+          dynamic += 1;
+        }
         MacroExpansionType::Declarations => {}
       }
     }
@@ -313,31 +316,37 @@ fn count_code_dynamic_markers(code: &Cirru) -> usize {
 }
 
 pub fn collect_dynamic_usage_summary(snapshot: &snapshot::Snapshot) -> Result<DynamicUsageSummary, String> {
-  let mut summary = DynamicUsageSummary {
-    total_positions: 0,
-    dynamic_positions: 0,
-  };
-  visit_scoped_definitions(
+  collect_dynamic_usage_summary_scoped(
     snapshot,
     AnalysisScope {
       namespace: None,
       namespace_prefix: None,
       include_dependencies: false,
     },
-    |_namespace, _definition, entry| {
-      let (schema_total, schema_dynamic) = count_annotation_positions(entry.schema.as_ref());
-      let code_dynamic = count_code_dynamic_markers(&entry.code);
-      summary.total_positions += schema_total + code_dynamic;
-      summary.dynamic_positions += schema_dynamic + code_dynamic;
-    },
-  )?;
+  )
+}
+
+fn collect_dynamic_usage_summary_scoped(
+  snapshot: &snapshot::Snapshot,
+  scope: AnalysisScope<'_>,
+) -> Result<DynamicUsageSummary, String> {
+  let mut summary = DynamicUsageSummary {
+    total_positions: 0,
+    dynamic_positions: 0,
+  };
+  visit_scoped_definitions(snapshot, scope, |_namespace, _definition, entry| {
+    let (schema_total, schema_dynamic) = count_annotation_positions(entry.schema.as_ref());
+    let code_dynamic = count_code_dynamic_markers(&entry.code);
+    summary.total_positions += schema_total + code_dynamic;
+    summary.dynamic_positions += schema_dynamic + code_dynamic;
+  })?;
   Ok(summary)
 }
 
 pub fn format_dynamic_usage_notice(summary: DynamicUsageSummary) -> Option<String> {
   let severity = summary.severity()?;
   Some(format!(
-    "[{}] Dynamic type usage is {}/{} ({:.1}%) of analyzed type positions. Prefer concrete schemas, generics, traits, Option/Result, or named enums; keep Dynamic at documented FFI and framework boundaries. Run `calcit analyze weak-types --intent unresolved` for paths.",
+    "[{}] Dynamic type usage is {}/{} ({:.1}%) of analyzed type positions. Prefer concrete schemas, generics, traits, Option/Result, or named enums; keep Dynamic at documented FFI boundaries. Run `calcit analyze weak-types --only schema-dynamic,code-dynamic --summary-only --format json` to reconcile this numerator by intent.",
     severity,
     summary.dynamic_positions,
     summary.total_positions,
@@ -2659,6 +2668,46 @@ pub fn format_check_types_json(options: &CheckTypesCommand, snapshot: &snapshot:
 
 pub fn format_weak_types_json(options: &WeakTypesCommand, snapshot: &snapshot::Snapshot) -> Result<String, String> {
   let rows = collect_weak_type_rows(options, snapshot)?;
+  let accounting_options = WeakTypesCommand {
+    ns: options.ns.clone(),
+    ns_prefix: options.ns_prefix.clone(),
+    only: Some("schema-dynamic,code-dynamic".to_owned()),
+    intent: None,
+    format: "json".to_owned(),
+    deps: options.deps,
+    summary_only: true,
+  };
+  let accounting_rows = collect_weak_type_rows(&accounting_options, snapshot)?;
+  let usage = collect_dynamic_usage_summary_scoped(
+    snapshot,
+    AnalysisScope {
+      namespace: options.ns.as_deref(),
+      namespace_prefix: options.ns_prefix.as_deref(),
+      include_dependencies: options.deps,
+    },
+  )?;
+  let mut usage_intents = BTreeMap::<&str, usize>::new();
+  for intent in [
+    "unresolved",
+    "intentional-js-ffi",
+    "intentional-macro-syntax",
+    "intentional-type-slot-dynamic",
+  ] {
+    usage_intents.insert(intent, 0);
+  }
+  for occurrence in accounting_rows.iter().flat_map(|row| row.occurrences.iter()) {
+    *usage_intents.entry(occurrence.intent.as_str()).or_insert(0) += 1;
+  }
+  let classified_positions = usage_intents.values().sum::<usize>();
+  if classified_positions > usage.dynamic_positions {
+    return Err(format!(
+      "Dynamic accounting invariant failed: {classified_positions} classified positions exceed the {}-position startup numerator",
+      usage.dynamic_positions
+    ));
+  }
+  let unattributed_unresolved = usage.dynamic_positions - classified_positions;
+  *usage_intents.entry("unresolved").or_insert(0) += unattributed_unresolved;
+  let usage_reconciled = usage_intents.values().sum::<usize>() == usage.dynamic_positions;
   let mut kinds = BTreeMap::<&str, usize>::new();
   let mut intents = BTreeMap::<&str, usize>::new();
   let mut namespaces = BTreeSet::<&str>::new();
@@ -2787,7 +2836,7 @@ pub fn format_weak_types_json(options: &WeakTypesCommand, snapshot: &snapshot::S
     }));
   }
   let envelope = serde_json::json!({
-    "schema_version": 5,
+    "schema_version": 6,
     "command": "analyze.weak-types",
     "revision": analysis_revision(snapshot, &ids)?,
     "data": {
@@ -2805,6 +2854,20 @@ pub fn format_weak_types_json(options: &WeakTypesCommand, snapshot: &snapshot::S
         "hits": hit_count,
         "kinds": kinds,
         "intents": intents,
+        "dynamic_usage": {
+          "dynamic_positions": usage.dynamic_positions,
+          "total_positions": usage.total_positions,
+          "ratio": usage.ratio(),
+          "intents": usage_intents,
+          "unattributed_unresolved": unattributed_unresolved,
+          "reconciled": usage_reconciled,
+          "policy": {
+            "scope": "stored project Snapshot definitions; dependencies only with --deps",
+            "position": "each schema annotation node plus each explicit :dynamic/:any code marker",
+            "nested": "container members, function arguments/return/rest, nominal type arguments, and semantic macro Expr/expansion positions are recursive",
+            "excluded": "runtime-generated definitions and metadata namespaces outside the selected project scope",
+          },
+        },
       },
       "definitions": definitions,
     },
@@ -2836,8 +2899,8 @@ mod tests {
   use cirru_parser::Cirru;
 
   use super::{
-    WeakTypeIntent, WeakTypeKind, classify_unsafe_coerce_source, entry_schema_issues, is_raw_adapter_namespace,
-    scan_schema_dynamic_annotation,
+    WeakTypeIntent, WeakTypeKind, classify_unsafe_coerce_source, count_annotation_positions, entry_schema_issues,
+    is_raw_adapter_namespace, scan_schema_dynamic_annotation,
   };
 
   fn leaf(value: &str) -> Cirru {
@@ -2917,6 +2980,13 @@ mod tests {
     assert_eq!(dynamic_expansion[0].intent, WeakTypeIntent::Unresolved);
     assert_eq!(dynamic_definition.len(), 1);
     assert_eq!(dynamic_definition[0].intent, WeakTypeIntent::Unresolved);
+  }
+
+  #[test]
+  fn dynamic_macro_expansion_is_a_position_in_both_usage_counts() {
+    let annotation = macro_schema(vec![], None, MacroExpansionType::Dynamic);
+
+    assert_eq!(count_annotation_positions(&annotation), (2, 1));
   }
 
   #[test]


### PR DESCRIPTION
## 中文

关闭 #941。

本 PR 将 analyze.weak-types JSON 协议升级到 v6，在 data.summary.dynamic_usage 中提供与默认启动提示同范围的 Dynamic 分子、分母、比例、intent 分类、未归因数量和严格对账状态。启动提示现在直接指向能够复现该口径的 summary 命令；human quality 输出会在 schemaDynamic 与 unresolved 不同时解释预算策略。计数规则同时修正了 Dynamic macro expansion 只进入分子而未进入分母的边界。

文档用中文明确说明 Snapshot scope、递归 schema 位置、显式代码 marker、依赖、运行时生成 definition 与 intentional 边界的处理方式。回归 fixture 验证同一份 Snapshot 中启动分子、unresolved weak-type 命中和 quality 预算可以不同，但结构化 intent 总和仍与启动分子完全一致。协议消费者已同步到 v6。

验证：cargo test；cargo clippy --all-targets -- -D warnings；yarn check-all；并在 calcit/test.cirru 上确认 23/56 被划分为 22 个 unresolved 与 1 个 intentional JS FFI，reconciled 为 true。

## English

Closes #941.

This PR upgrades the analyze.weak-types JSON protocol to v6 and adds data.summary.dynamic_usage with the same Dynamic numerator and denominator as the default startup notice, plus ratio, intent partitions, unattributed count, and an explicit reconciliation flag. The startup notice now points directly to the summary command that reproduces its accounting, while human quality output explains the budget policy whenever schemaDynamic and unresolved differ. The position counter also fixes the edge case where a Dynamic macro expansion increased the numerator without increasing the denominator.

Chinese user documentation now defines the Snapshot scope, recursive schema positions, explicit code markers, dependency behavior, runtime-generated definitions, and intentional boundaries. A regression fixture demonstrates that startup usage, unresolved weak-type hits, and quality budgets may differ for one Snapshot while the structured intent partition still sums exactly to the startup numerator. Protocol consumers now require v6.

Verification: cargo test; cargo clippy --all-targets -- -D warnings; yarn check-all; and a calcit/test.cirru run that reconciles 23/56 as 22 unresolved plus 1 intentional JS FFI with reconciled set to true.