### PR TITLE
对齐 schema alias 的 Native runtime 验证 / Align Native runtime validation for schema aliases

### DIFF
--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -18,12 +18,23 @@ parent: core/features
 
 `Dynamic` 适合 JS FFI、框架开放数据、宏和确实无法提前知道的外部输入。普通函数不要用多个 `Dynamic` 表示“它们应该是同一个类型”：输入和返回关联时用 `:generics` 与 TypeVar；只需要能力时用 trait 与 `:where`；同质集合写出元素类型；有限异构数据定义为 Enum；可缺失值使用 `Option<T>`，带失败信息使用 `Result<T, E>`。
 
-每次执行和编译会在 stderr 输出 Dynamic 用量提示。它是趋势信号，不会替代具体路径检查：
+普通执行和编译不计算 Dynamic 使用率；预处理 warning/error 是类型判断来源。迁移存量项目时再显式运行定位命令：
 
 ```bash
 calcit analyze check-types --summary-only
 calcit analyze weak-types --only schema-dynamic,unresolved-type-slot,code-dynamic --intent unresolved --format json
 ```
+
+## Schema 类型别名在各后端一致展开
+
+非 Dynamic definition schema 可以通过完整的 `'namespace/definition` 名称作为类型别名使用。别名只复用底层类型关系，不创建新的运行时包装；需要名义身份时仍应使用 `defstruct` 或 `defenum`。
+
+```bash
+calcit edit def app.schema/Items --code 'quote $ def Items &unit'
+calcit edit schema app.schema/Items --code "quote \$ :: 'List 'Number"
+```
+
+此后 `'app.schema/Items` 可用于 Struct 字段、Enum payload、callback 或 trait 边界。静态检查、Native 构造验证和 JavaScript codegen 都按同一底层 schema 判断值；不要为 Native 单独增加 coercion。类型别名不能接收泛型实参，循环别名也不会退化成 Dynamic，而是作为无法证明的类型关系拒绝。
 
 兼容性的多态 collection facade 可能仍在 core schema 中保留局部 `Dynamic`，或者使用彼此独立、无法表达容器成员关系的泛型，但已知 receiver 会在预处理阶段专门化。例如 `update` 对 `List<T>` 要求 `Number` 索引和 `T -> T` updater，对 `Map<K,V>` 要求 `K` 键和 `V -> V` updater；Struct 则按静态字段类型检查。`filter`、`any?` 与 `every?` 对 List/Set 要求 `T -> Bool` predicate，`each` 则约束 callback 输入为 `T`、允许任意返回类型；`map` 对 List/Set 要求 `T -> U` mapper，并把 Set receiver lowering 到 `&set:map`。`foldl` 与 `reduce` 从初始值恢复 accumulator `U`，并要求 reducer 为 `U, T -> U`；原生 `foldl` 只有在 reducer 具有具体且兼容的 `Fn` 签名时才把初始 accumulator 类型保留为返回类型，`DynFn` 仍推断为 `Dynamic`。普通 `apply f args` 只会在 `args` 是非 Dynamic 的同质 `List<T>`、`T` 能满足 `f` 的全部 fixed/rest 输入、且展开长度能证明 callable arity 时恢复 `f` 的具体或泛型返回类型；若参数位置异构、固定参数调用的 list 长度未知、callable 未知，或存在 trait-bounded 泛型，则兼容返回仍为 `Dynamic`，应改为直接调用、先归一化参数，或在审核过的开放边界显式保留 Dynamic。双参数 `sort` 与 `&list:sort` 保留 `List<T>`，并要求 comparator 为 `T, T -> Number`；函数形式的 `&list:sort-by` 要求 selector 为 `T -> K`，同时保留 Tag 字段选择器兼容路径。List 的 `.apply` 要求函数列表中的每一项共享 `T -> U` 契约，并返回 `List<U>`；它的 direct/method 诊断会用 receiver/input 已绑定的 `T` 显示具体 callback 类型，异构输入或函数列表必须先归一化或拆成多次调用。`interleave` 同样只接受两份 `List<T>` 并返回 `List<T>`；异构数据必须先归一化，或在经过审核的开放边界显式声明 `List<Dynamic>`。单参数自然排序不受影响，Syntax collection 继续使用 phase-aware 开放契约。Map callback 接收运行时的异构 `[key value]` pair；迭代、predicate 与 fold 输入只承诺 `List<Dynamic>`，而 `map` 同时要求 callback 返回另一个 `List<Dynamic>` pair，不会把不同的 `K` / `V` 伪装成同一种成员类型。旧 `map-kv` 还允许 nil/任意 Enum 作为 drop sentinel，因此返回只能是显式兼容边界：兼容模式警告，strict 模式拒绝。typed code 应统一改用 `filter-map-kv`，以 `MapEntryDecision :keep key value` 或 `:drop` 让输出 key/value 与 callback payload 保持可证明关联。`get` 同样要求 List/String/Enum 的 `Number` 索引或 Map 的 `K` 键，`includes?` 要求 List/Set 的成员 `T`、Map 的值 `V` 或 String substring；`contains?` 要求 List/String/Enum 的 `Number` 索引、Map 的键 `K` 或 Set 的成员 `T`。`assoc` 会同时约束 List 的索引/成员、Map 的键/值、静态 Struct 字段的值类型，以及 Enum 的 `Number` payload index；Enum payload 可以异构，因此新值在没有精确 variant/slot evidence 时仍保持开放。`dissoc` 会检查全部 rest 参数：List 只能接收 `Number` 索引，Map 的每个键都必须是 `K`。用户函数 schema 的 `:rest` 会逐项检查。原生 proc 按运行时契约区分两类 typed variadic：`&map:dissoc`、`&list:concat` 与 `&merge` 会检查每一个 rest 参数，并在容器不匹配时显示完整成员类型；`[]` 与 `#{}` 的 `Variadic<T>` 只用于推断公共成员类型，异构字面量仍有意回退为 `Dynamic`。未标注的 inline callback 若能从函数体恢复返回类型，也会参与这项检查。不要把 receiver 擦除为 `Dynamic` 来绕过这些关系：在 FFI/open-data adapter 中先校验或转换，再进入集合操作。
 

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -18,7 +18,7 @@ parent: core/features
 
 `Dynamic` 适合 JS FFI、框架开放数据、宏和确实无法提前知道的外部输入。普通函数不要用多个 `Dynamic` 表示“它们应该是同一个类型”：输入和返回关联时用 `:generics` 与 TypeVar；只需要能力时用 trait 与 `:where`；同质集合写出元素类型；有限异构数据定义为 Enum；可缺失值使用 `Option<T>`，带失败信息使用 `Result<T, E>`。
 
-普通执行和编译不计算 Dynamic 使用率；预处理 warning/error 是类型判断来源。迁移存量项目时再显式运行定位命令：
+每次执行和编译会在 stderr 输出 Dynamic 用量提示。它是趋势信号，不会替代具体路径检查：
 
 ```bash
 calcit analyze check-types --summary-only

--- a/editing-history/202609120215-align-runtime-schema-alias-validation.md
+++ b/editing-history/202609120215-align-runtime-schema-alias-validation.md
@@ -1,0 +1,16 @@
+# 对齐 runtime schema alias 验证
+
+## 问题
+
+静态类型关系会把 `'namespace/definition` 展开为 definition 的非 Dynamic schema，但 Native runtime 的 Struct/Enum payload 验证只把 `TypeRef` 当作名义 Struct/Enum 名称。相同的 List 或 Fn schema 以内联形式可以通过，改成别名后却在 Native 构造阶段失败；JavaScript 后端没有这项偏差。
+
+## 修改
+
+- 在统一的 runtime value/type relation 中保留名义 Struct/Enum 快速路径，并在不匹配时使用现有 schema alias resolver 展开底层类型。
+- 复用静态关系已有的 alias guard，使循环别名确定地返回不匹配，不递归溢出，也不退化为 Dynamic。
+- 回归测试覆盖 collection、callable、trait 和循环 alias；不为某个 constructor 增加专用例外。
+- 中文类型指南说明 alias 没有额外运行时包装，Native 与 JavaScript 使用同一底层 schema 语义。
+
+## 结果
+
+Struct 字段和 Enum payload 等现有 runtime 验证入口自动获得一致行为。迁移项目不需要为 Native 添加 coercion，也没有引入新的分析分类或独立类型模型。

--- a/editing-history/202609120225-reject-applied-schema-aliases.md
+++ b/editing-history/202609120225-reject-applied-schema-aliases.md
@@ -1,0 +1,12 @@
+# 拒绝带实参的 schema alias
+
+## Review 发现
+
+schema alias 本身不声明泛型，但 runtime fallback 最初忽略了 `TypeRef` 携带的 type arguments。这样手写的 `Items<String>` 可能被展开成无参 `Items` 的底层 schema，造成静态与 runtime 规则再次偏离。
+
+## 调整
+
+- 名义 Struct/Enum 仍先按既有逻辑处理 applied arguments。
+- 只有 type arguments 为空时才进入 schema alias fallback。
+- 回归测试同时证明无参 `Items` 接受 List，而带实参的 `Items<String>` 拒绝同一个值。
+- 恢复与 #911 无关的 Dynamic 提示文档行，把后续统一清理留给 analyzer 收敛任务。

--- a/src/builtins/structs.rs
+++ b/src/builtins/structs.rs
@@ -1564,6 +1564,54 @@ mod tests {
   }
 
   #[test]
+  fn struct_field_validation_expands_schema_aliases() {
+    use crate::program::{PROGRAM_CODE_DATA, ProgramDefEntry, ProgramFileData, lock_program_test_state};
+
+    let _guard = lock_program_test_state();
+    crate::calcit::register_program_lookups(
+      crate::program::lookup_runtime_ready,
+      crate::program::lookup_def_code,
+      crate::program::lookup_def_schema,
+    );
+    PROGRAM_CODE_DATA.write().expect("seed Items alias").insert(
+      Arc::from("tests.struct-alias"),
+      ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([(
+          Arc::from("Items"),
+          ProgramDefEntry {
+            code: Calcit::Unit,
+            schema: Arc::new(CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Number))),
+            doc: Arc::from(""),
+            examples: vec![],
+            ffi: None,
+          },
+        )]),
+      },
+    );
+    let box_def = CalcitStructDef {
+      definition_ref: Some(Arc::from("tests.struct-alias/Box")),
+      name: EdnTag::new("Box"),
+      fields: Arc::new(vec![EdnTag::new("items")]),
+      field_types: Arc::new(vec![Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from("tests.struct-alias/Items"),
+        Arc::new(vec![]),
+      ))]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![],
+    };
+
+    let result = call_struct(&[
+      Calcit::StructDef(box_def),
+      Calcit::tag("items"),
+      Calcit::List(Arc::new(CalcitList::default())),
+    ])
+    .expect("a List value should satisfy its schema alias in a Struct field");
+    assert!(matches!(result, Calcit::Struct(_)));
+  }
+
+  #[test]
   fn struct_get_rejects_missing_fields_instead_of_returning_nil() {
     let struct_value = indexed_struct_fixture();
     let err = get(&[struct_value, Calcit::tag("missing")]).expect_err("missing struct field must not become nil");

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -5891,6 +5891,88 @@ mod tests {
   }
 
   #[test]
+  fn runtime_value_validation_expands_schema_aliases_and_rejects_cycles() {
+    use crate::program::{PROGRAM_CODE_DATA, ProgramDefEntry, ProgramFileData, lock_program_test_state};
+
+    let _guard = lock_program_test_state();
+    register_program_lookups(
+      crate::program::lookup_runtime_ready,
+      crate::program::lookup_def_code,
+      crate::program::lookup_def_schema,
+    );
+    let namespace = "tests.runtime-alias";
+    let alias_ref = |name: &'static str| {
+      Arc::new(CalcitTypeAnnotation::TypeRef(
+        Arc::from(format!("{namespace}/{name}")),
+        Arc::new(vec![]),
+      ))
+    };
+    let display_trait = Arc::new(CalcitTrait::new(EdnTag::new("Display"), vec![], vec![]).with_definition_ref(namespace, "Display"));
+    let entry = |schema| ProgramDefEntry {
+      code: Calcit::Nil,
+      schema,
+      doc: Arc::from(""),
+      examples: vec![],
+      ffi: None,
+    };
+    PROGRAM_CODE_DATA.write().expect("seed runtime aliases").insert(
+      Arc::from(namespace),
+      ProgramFileData {
+        import_map: HashMap::new(),
+        defs: HashMap::from([
+          (
+            Arc::from("Items"),
+            entry(Arc::new(CalcitTypeAnnotation::List(Arc::new(CalcitTypeAnnotation::Number)))),
+          ),
+          (
+            Arc::from("Callback"),
+            entry(Arc::new(CalcitTypeAnnotation::from_function_parts(
+              vec![Arc::new(CalcitTypeAnnotation::Number)],
+              Arc::new(CalcitTypeAnnotation::Number),
+            ))),
+          ),
+          (
+            Arc::from("Displayable"),
+            entry(Arc::new(CalcitTypeAnnotation::Trait(display_trait.clone()))),
+          ),
+          (Arc::from("A"), entry(alias_ref("B"))),
+          (Arc::from("B"), entry(alias_ref("A"))),
+        ]),
+      },
+    );
+
+    assert!(value_matches_type_annotation(
+      &Calcit::List(Arc::new(CalcitList::default())),
+      alias_ref("Items").as_ref()
+    ));
+    assert!(value_matches_type_annotation(
+      &Calcit::Proc(CalcitProc::List),
+      alias_ref("Callback").as_ref()
+    ));
+
+    let widget = CalcitStructDef {
+      definition_ref: Some(Arc::from(format!("{namespace}/Widget"))),
+      name: EdnTag::new("Widget"),
+      fields: Arc::new(vec![]),
+      field_types: Arc::new(vec![]),
+      generics: Arc::new(vec![]),
+      where_bounds: Arc::new(vec![]),
+      impls: vec![Arc::new(CalcitImpl {
+        name: EdnTag::new("WidgetDisplay"),
+        origin: Some(display_trait),
+        fields: Arc::new(vec![]),
+        values: Arc::new(vec![]),
+      })],
+    };
+    let widget_value = Calcit::Struct(CalcitStructValue {
+      struct_ref: Arc::new(widget),
+      values: Arc::new(vec![]),
+    });
+    assert!(value_matches_type_annotation(&widget_value, alias_ref("Displayable").as_ref()));
+    assert!(!value_matches_type_annotation(&Calcit::Number(1.0), alias_ref("A").as_ref()));
+  }
+
+  #[test]
   fn phase_aware_macro_signature_round_trips_without_fn_conflation() {
     let mut map = EdnMapView::default();
     map.insert_key("generics", Edn::List(EdnListView(vec![Edn::Symbol(Arc::from("T"))])));
@@ -8408,14 +8490,26 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
       Calcit::Enum(t) => t.sum_type.as_ref().is_some_and(|st| st.name() == expected_enum.name()),
       _ => false,
     },
-    CalcitTypeAnnotation::TypeRef(expected_name, _) => match value {
-      Calcit::Struct(r) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, r.struct_ref.name.ref_str()),
-      Calcit::Enum(t) => t
-        .sum_type
-        .as_ref()
-        .is_some_and(|st| CalcitTypeAnnotation::type_ref_name_matches(expected_name, st.name().ref_str())),
-      _ => false,
-    },
+    CalcitTypeAnnotation::TypeRef(expected_name, _) => {
+      let nominal_match = match value {
+        Calcit::Struct(r) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, r.struct_ref.name.ref_str()),
+        Calcit::Enum(t) => t
+          .sum_type
+          .as_ref()
+          .is_some_and(|st| CalcitTypeAnnotation::type_ref_name_matches(expected_name, st.name().ref_str())),
+        _ => false,
+      };
+      if nominal_match {
+        true
+      } else if let Some(resolved) = resolve_type_ref_as_schema(expected_name) {
+        let Ok(_guard) = enter_alias_relation(expected_name, expected, false, false) else {
+          return false;
+        };
+        value_matches_type_annotation(value, resolved.as_ref())
+      } else {
+        false
+      }
+    }
     CalcitTypeAnnotation::StructDef(expected_struct) => match value {
       Calcit::StructDef(struct_def) => struct_def.name == expected_struct.name,
       _ => false,

--- a/src/calcit/type_annotation.rs
+++ b/src/calcit/type_annotation.rs
@@ -5945,6 +5945,13 @@ mod tests {
       &Calcit::List(Arc::new(CalcitList::default())),
       alias_ref("Items").as_ref()
     ));
+    assert!(!value_matches_type_annotation(
+      &Calcit::List(Arc::new(CalcitList::default())),
+      &CalcitTypeAnnotation::TypeRef(
+        Arc::from(format!("{namespace}/Items")),
+        Arc::new(vec![Arc::new(CalcitTypeAnnotation::String)]),
+      )
+    ));
     assert!(value_matches_type_annotation(
       &Calcit::Proc(CalcitProc::List),
       alias_ref("Callback").as_ref()
@@ -8490,7 +8497,7 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
       Calcit::Enum(t) => t.sum_type.as_ref().is_some_and(|st| st.name() == expected_enum.name()),
       _ => false,
     },
-    CalcitTypeAnnotation::TypeRef(expected_name, _) => {
+    CalcitTypeAnnotation::TypeRef(expected_name, expected_args) => {
       let nominal_match = match value {
         Calcit::Struct(r) => CalcitTypeAnnotation::type_ref_name_matches(expected_name, r.struct_ref.name.ref_str()),
         Calcit::Enum(t) => t
@@ -8501,7 +8508,9 @@ pub fn value_matches_type_annotation(value: &Calcit, expected: &CalcitTypeAnnota
       };
       if nominal_match {
         true
-      } else if let Some(resolved) = resolve_type_ref_as_schema(expected_name) {
+      } else if expected_args.is_empty()
+        && let Some(resolved) = resolve_type_ref_as_schema(expected_name)
+      {
         let Ok(_guard) = enter_alias_relation(expected_name, expected, false, false) else {
           return false;
         };


### PR DESCRIPTION
## 中文

### 问题

在 main `69d517170a78b473b9283c5809bcdada8ac33b6e` 上重新执行 #911 的最小复现：静态预处理接受 `'app.repro/Items` 对应的 `List<Number>`，JavaScript codegen 与运行也成功，但 Native `%{}` 构造在 runtime 拒绝同一个空 List。原因是静态关系会展开 definition schema alias，而 `value_matches_type_annotation` 的 `TypeRef` 分支只检查名义 Struct/Enum 名称。

### 修改

- 保留名义 Struct/Enum 的快速路径；无参引用不匹配时通过现有 schema resolver 展开 alias，再进入同一个 runtime value/type relation。
- 带 type arguments 的引用不会进入 alias fallback，避免把非法 applied alias 当作无参 schema 接受。
- 复用现有 alias relation guard，循环 alias 确定地返回不匹配，不递归溢出，也不退化为 Dynamic。
- 增加 Struct 字段构造回归，以及 collection、callable、trait、applied 与循环 alias 的关系测试；没有增加 constructor 专用例外。
- 更新中文类型指南，说明 alias 不创建运行时包装，Native 与 JavaScript 使用同一底层 schema。

### 验证

- `cargo fmt --check`
- `cargo test --lib -- --test-threads=1`（817 passed）
- `cargo test --bin calcit -- --test-threads=1`（334 passed）
- 两项新增 alias 定向测试
- `cargo clippy --all-targets -- -D warnings`
- `cargo run --bin calcit -- docs check-md docs/type-guidance.md --entry calcit/test.cirru --failures-only`
- `yarn check-all`
- 临时 Snapshot Native 与 JS 均成功构造并输出 `Box` 值

Closes #911

## English

### Problem

I reproduced #911 on main `69d517170a78b473b9283c5809bcdada8ac33b6e`: static preprocessing accepted `'app.repro/Items` as `List<Number>`, and JavaScript code generation plus execution succeeded, but the Native `%{}` runtime constructor rejected the same empty List. Static relations expand definition schema aliases, while the `TypeRef` branch in `value_matches_type_annotation` only checked nominal Struct/Enum names.

### Changes

- Preserve the nominal Struct/Enum fast path, then resolve an unparameterized schema alias through the existing resolver and re-enter the same runtime value/type relation when nominal matching fails.
- Keep references with type arguments out of the alias fallback so an invalid applied alias cannot be accepted as its unparameterized schema.
- Reuse the existing alias relation guard so cycles deterministically mismatch without recursion overflow or a Dynamic fallback.
- Add a Struct field construction regression and relation coverage for collection, callable, trait, applied, and cyclic aliases, without constructor-specific exceptions.
- Update the Chinese type guide to explain that aliases add no runtime wrapper and share the same underlying schema across Native and JavaScript.

### Verification

- `cargo fmt --check`
- `cargo test --lib -- --test-threads=1` (817 passed)
- `cargo test --bin calcit -- --test-threads=1` (334 passed)
- Both focused alias regression tests
- `cargo clippy --all-targets -- -D warnings`
- `cargo run --bin calcit -- docs check-md docs/type-guidance.md --entry calcit/test.cirru --failures-only`
- `yarn check-all`
- The temporary Snapshot now constructs and prints the same `Box` value on Native and JavaScript

Closes #911
