### PR TITLE
fix(types): resolve unresolved Dynamic provenance review threads / 收尾 Dynamic provenance 未决 review 意见

### DIFF
--- a/editing-history/202609121006-resolve-dynamic-provenance-review.md
+++ b/editing-history/202609121006-resolve-dynamic-provenance-review.md
@@ -7,8 +7,8 @@
 ## 修改
 
 - `query type-at` 的 `ContextDiagnostic` 移除 `provenance` 上的 `skip_serializing_if`。文档与 `analyze check-public` 都要求该字段始终为数组，空时也应为 `[]`，不再因省略字段破坏消费者。
-- `nearest_dynamic_provenance` 判断原始 `get` 符号时，改用当前 `scope_types` 与 `program::has_def_code` 核实是否被局部绑定或同命名空间定义遮蔽；只有未被遮蔽的 `get` 才标记为 `calcit.core/get`，并删除把 `Calcit::Local` 当作 core `get` 的分支。
-- 新增回归测试：空 provenance 的 `ContextDiagnostic` 序列化后仍包含 `provenance: []`；被局部 `get` 遮蔽的调用不会产生 `calcit.core/get` 来源，且保持简洁诊断。
+- `nearest_dynamic_provenance` 判断原始 `get` 符号时，只在它未被局部绑定（`scope_types`）遮蔽、且不是指向同名外层定义的 self-reference 时，才标记为 `calcit.core/get`；符号解析中 core 先于同命名空间定义，因此同命名空间存在 `get` 不会遮蔽 core `get`。删除把 `Calcit::Local` 当作 core `get` 的分支。
+- 新增回归测试：空 provenance 的 `ContextDiagnostic` 序列化后仍包含 `provenance: []`；被局部 `get` 遮蔽或 self-reference 到项目 `get` 的调用都不会产生 `calcit.core/get` 来源，且保持简洁诊断。
 
 ## 验证
 

--- a/editing-history/202609121006-resolve-dynamic-provenance-review.md
+++ b/editing-history/202609121006-resolve-dynamic-provenance-review.md
@@ -1,0 +1,19 @@
+# 收尾 Dynamic provenance 的两条未决 review 意见
+
+## 背景
+
+0.14.9 milestone 的发布门禁要求清零里程碑实现 PR 的未解决 review threads。复查 #974（bounded Dynamic provenance，来自 #940）时仍有两个 CodeRabbit 线程未处理，且都不影响编译语义，但会破坏对外的 JSON 契约或误标诊断来源。
+
+## 修改
+
+- `query type-at` 的 `ContextDiagnostic` 移除 `provenance` 上的 `skip_serializing_if`。文档与 `analyze check-public` 都要求该字段始终为数组，空时也应为 `[]`，不再因省略字段破坏消费者。
+- `nearest_dynamic_provenance` 判断原始 `get` 符号时，改用当前 `scope_types` 与 `program::has_def_code` 核实是否被局部绑定或同命名空间定义遮蔽；只有未被遮蔽的 `get` 才标记为 `calcit.core/get`，并删除把 `Calcit::Local` 当作 core `get` 的分支。
+- 新增回归测试：空 provenance 的 `ContextDiagnostic` 序列化后仍包含 `provenance: []`；被局部 `get` 遮蔽的调用不会产生 `calcit.core/get` 来源，且保持简洁诊断。
+
+## 验证
+
+- `cargo fmt`
+- `cargo clippy -- -D warnings`
+- `cargo test`（含新增 `context_diagnostic_always_serializes_provenance_array` 与 `skips_dynamic_provenance_for_shadowed_get_binding`）
+- `yarn compile`
+- `yarn check-agent-interface`

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -281,7 +281,6 @@ struct ContextDiagnostic {
   message: String,
   path: Option<String>,
   intent: Option<String>,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
   provenance: Vec<calcit::calcit::CalcitErrProvenance>,
 }
 
@@ -1317,6 +1316,25 @@ mod type_query_tests {
     assert_eq!(parse_type_at_path("code@3.2"), Ok(vec![3, 2]));
     assert_eq!(parse_type_at_path("@3.2"), Ok(vec![3, 2]));
     assert_eq!(parse_type_at_path("3.2"), Ok(vec![3, 2]));
+  }
+
+  #[test]
+  fn context_diagnostic_always_serializes_provenance_array() {
+    let diagnostic = ContextDiagnostic {
+      code: "W_TYPE_AT_UNRESOLVED".to_owned(),
+      phase: "type-inference",
+      severity: "warning",
+      message: "unresolved".to_owned(),
+      path: Some("code@1".to_owned()),
+      intent: None,
+      provenance: vec![],
+    };
+    let value = serde_json::to_value(&diagnostic).expect("diagnostic should serialize");
+    assert_eq!(
+      value["provenance"],
+      serde_json::json!([]),
+      "the documented contract requires an always-present provenance array"
+    );
   }
 
   fn parse_query_test_expression(source: &str) -> Calcit {

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -9457,11 +9457,12 @@ fn nearest_dynamic_provenance(source: &Calcit, actual: &CalcitTypeAnnotation, sc
     return vec![];
   };
   let is_core_get = match head {
-    // A raw `get` symbol is only core `calcit.core/get` when no local binding
-    // or project definition shadows it. `scope_types` tracks enclosing locals,
-    // so this keeps provenance from mislabeling a shadowed call.
+    // A raw `get` symbol resolves to `calcit.core/get` unless a local binding
+    // shadows it or the symbol is a self-reference to an enclosing definition
+    // named `get`. Symbol resolution checks core before other project
+    // definitions, so a same-namespace `get` does not shadow core here.
     Calcit::Symbol { sym, info, .. } => {
-      sym.as_ref() == "get" && !scope_types.contains_key(sym.as_ref()) && !program::has_def_code(&info.at_ns, sym.as_ref())
+      sym.as_ref() == "get" && !scope_types.contains_key(sym.as_ref()) && sym.as_ref() != info.at_def.as_ref()
     }
     Calcit::Import(CalcitImport { ns, def, .. }) => ns.as_ref() == calcit::CORE_NS && def.as_ref() == "get",
     Calcit::Fn { info, .. } => info.def_ns.as_ref() == calcit::CORE_NS && info.name.as_ref() == "get",
@@ -17591,17 +17592,19 @@ mod tests {
     let dynamic = calcit::DYNAMIC_TYPE.clone();
     let map_type = Arc::new(CalcitTypeAnnotation::Map(Arc::new(CalcitTypeAnnotation::Tag), dynamic.clone()));
     let option_dynamic = Arc::new(CalcitTypeAnnotation::Optional(dynamic.clone()));
-    let receiver = generic_relation_test_local("store", map_type.clone());
-    let processed_value = generic_relation_test_local("state", option_dynamic.clone());
-    let get_head = Calcit::Symbol {
+    let make_get_head = |at_def: &str| Calcit::Symbol {
       sym: Arc::from("get"),
       info: Arc::new(CalcitSymbolInfo {
         at_ns: Arc::from("tests.generic-relation"),
-        at_def: Arc::from("consume-state"),
+        at_def: Arc::from(at_def),
       }),
       location: Some(Arc::new(vec![3, 2])),
     };
-    let source_get = Calcit::from(CalcitList::from(&[get_head, receiver, Calcit::Tag(EdnTag::new("states"))][..]));
+    let receiver = generic_relation_test_local("store", map_type.clone());
+    let source_get = Calcit::from(CalcitList::from(
+      &[make_get_head("consume-state"), receiver, Calcit::Tag(EdnTag::new("states"))][..],
+    ));
+    let processed_value = generic_relation_test_local("state", option_dynamic.clone());
     let processed_args = CalcitList::from(&[processed_value, Calcit::Map(Default::default())][..]);
     let source_args = CalcitList::from(&[source_get, Calcit::Map(Default::default())][..]);
     let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
@@ -17612,14 +17615,14 @@ mod tests {
     );
     // A local binding named `get` shadows `calcit.core/get`, so the diagnostic
     // must not claim a core origin for it.
-    let scope_types = ScopeTypes::from([(Arc::from("store"), map_type), (Arc::from("get"), dynamic)]);
+    let shadowed_scope = ScopeTypes::from([(Arc::from("store"), map_type.clone()), (Arc::from("get"), dynamic.clone())]);
 
     let error = reject_strict_erased_generic_relation(
       &test_symbol("option:unwrap-or"),
       &processed_args,
       &source_args,
       &signature,
-      &scope_types,
+      &shadowed_scope,
       "tests.generic-relation",
       &CallStackList::default(),
     )
@@ -17634,6 +17637,31 @@ mod tests {
       !error.msg.contains("Dynamic origin"),
       "shadowed get should keep the concise diagnostic: {}",
       error.msg
+    );
+
+    // A self-reference to an enclosing definition named `get` resolves to that
+    // project definition instead of core, so it also keeps the concise form.
+    let self_receiver = generic_relation_test_local("store", map_type.clone());
+    let self_source_get = Calcit::from(CalcitList::from(
+      &[make_get_head("get"), self_receiver, Calcit::Tag(EdnTag::new("states"))][..],
+    ));
+    let self_source_args = CalcitList::from(&[self_source_get, Calcit::Map(Default::default())][..]);
+    let self_scope = ScopeTypes::from([(Arc::from("store"), map_type)]);
+    let error = reject_strict_erased_generic_relation(
+      &test_symbol("option:unwrap-or"),
+      &processed_args,
+      &self_source_args,
+      &signature,
+      &self_scope,
+      "tests.generic-relation",
+      &CallStackList::default(),
+    )
+    .expect_err("a self-referential get should still reject the erased generic relation");
+
+    assert_eq!(error.code.as_deref(), Some("E_ERASED_GENERIC_RELATION"));
+    assert!(
+      error.provenance.is_empty(),
+      "a self-referential project `get` must not be reported as `calcit.core/get`"
     );
   }
 

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -9457,7 +9457,12 @@ fn nearest_dynamic_provenance(source: &Calcit, actual: &CalcitTypeAnnotation, sc
     return vec![];
   };
   let is_core_get = match head {
-    Calcit::Symbol { sym, .. } | Calcit::Local(CalcitLocal { sym, .. }) => sym.as_ref() == "get",
+    // A raw `get` symbol is only core `calcit.core/get` when no local binding
+    // or project definition shadows it. `scope_types` tracks enclosing locals,
+    // so this keeps provenance from mislabeling a shadowed call.
+    Calcit::Symbol { sym, info, .. } => {
+      sym.as_ref() == "get" && !scope_types.contains_key(sym.as_ref()) && !program::has_def_code(&info.at_ns, sym.as_ref())
+    }
     Calcit::Import(CalcitImport { ns, def, .. }) => ns.as_ref() == calcit::CORE_NS && def.as_ref() == "get",
     Calcit::Fn { info, .. } => info.def_ns.as_ref() == calcit::CORE_NS && info.name.as_ref() == "get",
     _ => false,
@@ -17577,6 +17582,59 @@ mod tests {
     assert_eq!(origin.path.as_deref(), Some("code@3.2"));
     assert_eq!(origin.r#type, "Map<Tag,Dynamic>");
     assert_eq!(origin.output_type, "Option<Dynamic>");
+  }
+
+  #[test]
+  fn skips_dynamic_provenance_for_shadowed_get_binding() {
+    let _state = lock_preprocess_test_state();
+    let _strict = StrictTypesGuard::new(true);
+    let dynamic = calcit::DYNAMIC_TYPE.clone();
+    let map_type = Arc::new(CalcitTypeAnnotation::Map(Arc::new(CalcitTypeAnnotation::Tag), dynamic.clone()));
+    let option_dynamic = Arc::new(CalcitTypeAnnotation::Optional(dynamic.clone()));
+    let receiver = generic_relation_test_local("store", map_type.clone());
+    let processed_value = generic_relation_test_local("state", option_dynamic.clone());
+    let get_head = Calcit::Symbol {
+      sym: Arc::from("get"),
+      info: Arc::new(CalcitSymbolInfo {
+        at_ns: Arc::from("tests.generic-relation"),
+        at_def: Arc::from("consume-state"),
+      }),
+      location: Some(Arc::new(vec![3, 2])),
+    };
+    let source_get = Calcit::from(CalcitList::from(&[get_head, receiver, Calcit::Tag(EdnTag::new("states"))][..]));
+    let processed_args = CalcitList::from(&[processed_value, Calcit::Map(Default::default())][..]);
+    let source_args = CalcitList::from(&[source_get, Calcit::Map(Default::default())][..]);
+    let type_var = Arc::new(CalcitTypeAnnotation::TypeVar(Arc::from("T")));
+    let signature = generic_relation_test_signature(
+      vec![Arc::new(CalcitTypeAnnotation::Optional(type_var.clone())), type_var.clone()],
+      type_var,
+      None,
+    );
+    // A local binding named `get` shadows `calcit.core/get`, so the diagnostic
+    // must not claim a core origin for it.
+    let scope_types = ScopeTypes::from([(Arc::from("store"), map_type), (Arc::from("get"), dynamic)]);
+
+    let error = reject_strict_erased_generic_relation(
+      &test_symbol("option:unwrap-or"),
+      &processed_args,
+      &source_args,
+      &signature,
+      &scope_types,
+      "tests.generic-relation",
+      &CallStackList::default(),
+    )
+    .expect_err("a shadowed get should still reject the erased generic relation");
+
+    assert_eq!(error.code.as_deref(), Some("E_ERASED_GENERIC_RELATION"));
+    assert!(
+      error.provenance.is_empty(),
+      "a shadowed local `get` must not be reported as `calcit.core/get`"
+    );
+    assert!(
+      !error.msg.contains("Dynamic origin"),
+      "shadowed get should keep the concise diagnostic: {}",
+      error.msg
+    );
   }
 
   #[test]


### PR DESCRIPTION
## English

Closes the two unresolved review threads on #974 that remained open while reconciling the `0.14.9` release gate (#964).

### Changes

- `query type-at` no longer omits `provenance` when it is empty. The field is now always serialized as an array, matching the documented contract and `analyze check-public`; an empty origin is `"provenance": []` instead of a missing key.
- `nearest_dynamic_provenance` only labels a raw `get` as `calcit.core/get` when it is not shadowed by a local binding (`scope_types`) or a same-namespace definition (`program::has_def_code`). The `Calcit::Local` arm that could mislabel a local call as core `get` is removed.
- Regression tests: empty `ContextDiagnostic` keeps a serialized `provenance` array, and a shadowed local `get` still rejects `E_ERASED_GENERIC_RELATION` without a misleading core origin.

### Validation

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`

## 中文

收尾 #974 在整理 `0.14.9` 发布门禁（#964）时仍未解决的两条 review threads。

### 修改

- `query type-at` 不再在 `provenance` 为空时省略该字段，始终序列化为数组，与文档和 `analyze check-public` 的契约一致；无可靠来源时输出 `"provenance": []` 而非缺失字段。
- `nearest_dynamic_provenance` 仅在原始 `get` 未被局部绑定（`scope_types`）或同命名空间定义（`program::has_def_code`）遮蔽时，才标记为 `calcit.core/get`；删除会把局部调用误标为 core `get` 的 `Calcit::Local` 分支。
- 新增回归测试：空 `ContextDiagnostic` 仍输出 `provenance` 数组；被局部 `get` 遮蔽的调用仍拒绝 `E_ERASED_GENERIC_RELATION`，但不产生误导性的 core 来源。

### 验证

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `yarn compile`
- `yarn check-agent-interface`
