### PR TITLE
Define layered Calcit semantics for humans and AI Agents / 明确面向人和 AI Agent 的 Calcit 分层语义

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,9 @@
 - **双语协作记录**：关联 Issue 与 PR 的标题、正文和阶段性进度保持中英双语，便于跨项目追踪同一设计方向。
 - **PR 双语分段**：新建或更新 PR 时，正文必须分别提供完整的中文段落和英文段落，不把两种语言混写在同一段中；已有 PR 不要求追溯改写。
 - **文档与注释语言**：新增或修改面向用户的仓库文档使用中文；源代码中的注释和 doc comment 使用英文。已有内容不要求仅为统一语言而改写。
+- **分层语义**：以 `RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md` 为共同契约。Cirru/Snapshot 保存结构化 source；表层语言拥有用户语义；macro 展开和 typed core 只做保持语义的解析、证明与 lowering；native/JS/Calx backend 实现共同语义或明确报告 unsupported。不得让 backend 限制静默变成新的表层类型规则。
+- **开放值语义**：内部 Unknown/Unresolved、用户显式 Dynamic 与 JsObject/host value 是不同概念。Dynamic 可以被保存、传递和包装，只有具体使用其内容时才要求 decode/narrow/unsafe 证据；优先修正通用类型关系，不扩展普通/动态两套平行 API。
+- **Agent 可执行修复**：编译器内部 lowering 不直接写回 Snapshot。只有能唯一回到 source AST、证明保持求值与失败语义、并携带 revision/fingerprint 前置条件的建议才能成为自动 fix；不得自动插入 `unsafe-coerce`、扩大 Dynamic、选择业务默认值或修改测试预期。
 
 ### 仓库职责与拆分模块追踪
 

--- a/RFCs/07-26-agent-machine-protocol-rfc.md
+++ b/RFCs/07-26-agent-machine-protocol-rfc.md
@@ -93,6 +93,33 @@ adapters and existing scripts.
 实现应为 EDN/JSON 各保留一组同构 fixture，并至少覆盖该嵌套案例、空 Set/空
 List、`nil`、Quote 和带类型名的 Enum/Struct。
 
+### 3.2 Semantic layer、origin 与 source fix
+
+机器结果需要区分用户 source、compiler-owned core lowering、backend 和 host boundary。诊断或改写不能只给出
+生成节点的位置，再要求 Agent 从展开文本或生成 JS 猜测原始 source。
+
+在现有 envelope 中渐进加入下列 typed 字段：
+
+```cirru
+{}
+  :semantic-layer :surface
+  :definition 'app.core/main!
+  :path |code@3.2
+  :fingerprint |opaque-subtree-hash
+  :origin-chain $ []
+  :diagnostic-code |E_EXAMPLE
+  :replacement nil
+```
+
+- `:semantic-layer` 使用 `:surface`、`:core`、`:backend` 或 `:host-boundary`；
+- `:origin-chain` 保存 macro/lowering 节点回到调用点和 source AST 的路径；
+- 自动 source fix 必须指向唯一表层节点，并携带当前 revision 与 subtree fingerprint；
+- replacement 使用 quoted AST；无法证明等价或无法唯一回溯时必须为 `nil`；
+- human renderer 可以解释 core/backend 细节，但 machine consumer 只依赖 typed 字段与稳定 diagnostic/rule ID。
+
+完整分层语义与可应用修复边界见 `09-12-layered-semantics-and-agent-fixes-rfc.md`。具体 fix command 和
+transaction 闭环由 #998 实现，本节不提前承诺尚未交付的子命令。
+
 ## 4. 统一 Definition Descriptor
 
 query、docs、静态分析与 builtin fallback 应从同一只读描述视图组装结果：

--- a/RFCs/07-26-agent-machine-protocol-rfc.md
+++ b/RFCs/07-26-agent-machine-protocol-rfc.md
@@ -98,17 +98,23 @@ List、`nil`、Quote 和带类型名的 Enum/Struct。
 机器结果需要区分用户 source、compiler-owned core lowering、backend 和 host boundary。诊断或改写不能只给出
 生成节点的位置，再要求 Agent 从展开文本或生成 JS 猜测原始 source。
 
-在现有 envelope 中渐进加入下列 typed 字段：
+在现有 envelope 的 `:data` 中渐进加入下列 typed 字段：
 
 ```cirru
 {}
-  :semantic-layer :surface
-  :definition 'app.core/main!
-  :path |code@3.2
-  :fingerprint |opaque-subtree-hash
-  :origin-chain $ []
-  :diagnostic-code |E_EXAMPLE
-  :replacement nil
+  :schema-version 1
+  :command :fix.preview
+  :revision |opaque-content-hash
+  :data $ {}
+    :semantic-layer :surface
+    :definition 'app.core/main!
+    :path |code@3.2
+    :fingerprint |opaque-subtree-hash
+    :origin-chain $ []
+    :diagnostic-code |E_EXAMPLE
+    :replacement nil
+  :diagnostics $ []
+  :next $ []
 ```
 
 - `:semantic-layer` 使用 `:surface`、`:core`、`:backend` 或 `:host-boundary`；

--- a/RFCs/08-21-static-type-system-evolution-roadmap.md
+++ b/RFCs/08-21-static-type-system-evolution-roadmap.md
@@ -14,6 +14,11 @@ Calcit 长期继续借鉴 Rust 与 MoonBit：使用名义数据类型、Enum、O
 多后端特点；不因为 Rust 成功就引入与当前 value model 不相容的 borrow checker，也不因为 JS
 生态复杂就复制 TypeScript 的结构类型、union 与 overload。
 
+2026-09-12 补充：本路线只描述类型能力的演进顺序。表层语言、macro 展开后的 typed core、backend/host
+boundary 的 owner，以及 Dynamic 安全携带和 Agent source fix 的共同契约，以
+`09-12-layered-semantics-and-agent-fixes-rfc.md` 为准。后续优先让推导和共同语义取代 compiler special case，
+不再用新增 analyzer、质量分类或平行 `*-dynamic` API 推动类型系统演进。
+
 路线优先级是：先堵住精度静默丢失和 FFI unsafe 边界，再完善控制流与局部推断，然后根据真实
 抽象需求扩展 trait。每一步必须通过生态 quality baseline 与真实消费者回归渐进落地。
 

--- a/RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md
+++ b/RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md
@@ -1,0 +1,231 @@
+# RFC：Calcit 分层语义与 Agent 可执行修复契约
+
+状态：Draft — 0.14.13
+
+日期：2026-09-12
+
+关联：#997、#998、#999、#989、#992–#996
+
+## 1. 目标
+
+Calcit 的语言语义面向人，程序存储和工具协议同时面向人和机器。两者不要求只有一层实现：
+
+```text
+Cirru/Snapshot 结构化程序
+  → 人编写和审查的表层语言
+  → macro 展开、名称解析和类型分析后的 core language
+  → native / JS / Calx backend
+  → 显式 host/FFI 边界
+```
+
+分层的目的不是增加多套规则，而是让每条语义只有一个 owner。表层语言定义用户看到的行为；core
+language 保存已经证明的关系；backend 实现共同语义或明确拒绝尚未支持的子集；host boundary 验证
+编译器无法从外部实现中证明的事实。
+
+本 RFC 是 #998 结构化 fix 协议和 #999 自动迁移的语义前提，不新增第二套类型系统、平行 runtime
+IR 或新的质量统计体系。
+
+## 2. 结构化程序层
+
+`calcit.cirru` 是 Cirru EDN Snapshot，也是 definition、schema、examples、tests 和配置的结构化事实来源。
+它不是生成 JS、pretty-print 文本或 macro 展开树的序列化副本。
+
+这一层拥有：
+
+- 稳定的 definition identity；
+- definition 内部的 quoted source AST；
+- schema、examples、tests 与文档；
+- Snapshot revision 和可定位 subtree 的 fingerprint；
+- 通过 `calcit query` / `calcit edit` / `calcit tree` 暴露的事务读写。
+
+数字 path 只在某个 revision 内有效。Agent 或迁移工具写入前必须同时验证 revision，必要时验证 subtree
+fingerprint；冲突时重新查询，不能根据旧坐标猜测新目标。
+
+## 3. 表层语言
+
+表层语言是兼容性和文档的主要对象。它包括用户直接使用的 syntax、macro、函数、method、nominal
+Struct/Enum、trait、Option/Result、集合和显式 FFI adapter。
+
+表层语言拥有：
+
+- 求值顺序、副作用次数和错误行为；
+- 公共函数与 method 的参数、返回值和失败契约；
+- 哪些位置允许开放数据，哪些位置需要具体类型；
+- macro 对调用者承诺的语义，而不是某次实现生成的内部树；
+- 可由用户直接阅读的 examples 与 definition `:tests`。
+
+编译器优化、backend 限制或实现方便不能静默改变这些行为。需要改变表层契约时，应先提供版本化迁移和
+可审查的 source fix；仅有 lowering 能处理新形式，不等于迁移已经完成。
+
+## 4. 展开后的 typed core
+
+core language 是 macro 展开、名称解析、控制流分析和必要的类型导向归约之后，由 compiler 拥有的
+语义表示。它可以包含用户不会手写的 primitive、resolved definition、字段索引或静态 method target。
+
+这一层拥有：
+
+- 已解析的 definition/type/method identity；
+- 局部推断和公共 schema 共同建立的类型关系；
+- 明确的求值顺序、分支和调用关系；
+- backend eligibility 所需的能力证据；
+- 每个生成节点回到表层 source AST 的 origin chain。
+
+core language 不拥有另一套用户类型规则。类型导向 lowering 必须保持表层求值次数、顺序、返回值与失败
+行为。无法证明等价时保留原表达或给出诊断，不以 Dynamic fallback 伪装成已成功 specialization。
+
+compiler-owned lowering 不直接写回 Snapshot。即使某段展开树是正确的，也可能丢失 macro 所表达的人类
+意图；只有能唯一回到表层节点、并证明表层语义等价的建议才能成为 source fix。
+
+## 5. backend 与 host boundary
+
+native 和 JS 是公开语义 backend。它们对共同支持的表层程序必须产生一致的可观察结果；生成成功只证明
+lowering 完成，不证明生成模块可以加载或程序行为正确，因此共同语义需要实际执行验证。
+
+Calx 可以只支持 typed core 的明确子集。它必须：
+
+- 在 lowering 前验证整个可达单元；
+- 对未支持的 syntax/type/capability 给出结构化诊断；
+- 保留原始 definition、source path 和 origin chain；
+- 不静默转回 native/JS，也不发展独立的表层类型政策。
+
+JS/native FFI、网络数据和硬件输入属于 host boundary。外部声明提供静态契约，但编译器无法证明声明与
+宿主实现或实际数据一致；adapter 必须通过 decode/validation 将外部事实转换成普通 Calcit nominal
+data、Option 或 Result。backend bug、外部数据错误和应用业务错误应分别验证，不能都归为用户类型问题。
+
+## 6. Unknown、Dynamic 与宿主对象
+
+这三个概念承担不同职责：
+
+### 6.1 Unknown/Unresolved
+
+Unknown/Unresolved 是编译器尚未建立充分证据的内部状态，例如未绑定 TypeVar、缺少上下文的空集合或未解析
+type slot。它不是用户 schema，不进入普通 runtime value，也不能像 Dynamic 一样匹配任意类型。
+
+编译器应继续利用 expected type、调用参数和控制流求解它；严格模式最终仍无法求解时给出稳定错误。兼容模式
+若必须降为 Dynamic，应同时保留 evidence-loss 诊断，不能让该 fallback 反过来影响严格语义。
+
+### 6.2 Dynamic
+
+Dynamic 是用户明确选择的开放 Calcit 值。它允许内容暂时未知，但不意味着内容可以被当成任意具体类型。
+
+允许的基本关系是：
+
+- 保存、返回或跨函数传递 Dynamic；
+- 放入明确声明的开放 Map/List；
+- 包装和传递 `Option<Dynamic>` / `Result<Dynamic, E>`；
+- 参与不观察其具体内容、且契约明确的结构操作。
+
+将 Dynamic 当作 Number/String、访问具体 Struct 字段、调用需要特定 trait 的能力，必须先 decode、narrow，
+或进入显式 unsafe boundary。泛型函数若真正对 `'T` 参数化，可以用 `Dynamic` 实例化 `'T`；若函数通过
+`'T` 声称了内容相等、具体 trait 或其他无法证明的关系，则继续拒绝。
+
+因此 #994–#996 的目标是修复“安全携带未知 payload”与“具体使用 payload”之间的界线，而不是复制一套
+`*-dynamic` 标准库。
+
+### 6.3 JsObject 与其他 host value
+
+`JsObject` 表示宿主拥有、Calcit 不知道内部形状的值。它与普通 Dynamic 分离：Dynamic 仍是 Calcit runtime
+value，JsObject 的属性、方法、生命周期和空值行为受 JS 边界契约控制。其他 native/hardware resource 也应
+采用同样的 opaque handle + typed adapter 思路，不把宿主事实伪装成普通类型推导结果。
+
+## 7. 可读的共同语义例子
+
+每项新语义先用表层 Calcit 例子说明，再决定 core lowering 与 backend 实现。例子至少覆盖三类结果：接受并
+执行、编译期拒绝、当前 backend 明确不支持。
+
+开放值读取的目标契约示例：
+
+```cirru.no-check
+let
+    data $ assert-type ({} (:count 1) (:title |demo)) (:: 'Map 'Tag 'Dynamic)
+    value $ .get data :count
+  ; Transport value as Option<Dynamic>; narrow/decode before Number operations.
+  consume-open-option value
+```
+
+具体类型边界示例：
+
+```cirru.no-check
+defn parse-device-message (raw)
+  ; The adapter returns Result<DeviceMessage, DecodeError>.
+  decode-device-message raw
+```
+
+这些示例在相关能力落地前使用 `cirru.no-check`，不能把文档片段可解析冒充为实现已经通过。实现 PR 应把
+对应行为移入 definition `:tests` 或专用成功/失败 fixture，并精确记录实际执行的 backend。
+
+## 8. Agent 语义协议
+
+Agent 不应从 human diagnostics、生成 JS 或格式化文本反推语义。query、diagnostic、expansion trace 和 fix
+suggestion 应共享 versioned typed result，并至少能表达：
+
+```cirru
+{}
+  :schema-version 1
+  :command :analyze.semantic
+  :revision |opaque-snapshot-hash
+  :data $ {}
+    :definition 'app.core/main!
+    :semantic-layer :surface
+    :path |code@3.2
+    :fingerprint |opaque-subtree-hash
+    :diagnostic-code |E_EXAMPLE
+    :origin-chain $ []
+    :replacement nil
+  :diagnostics $ []
+  :next $ []
+```
+
+协议规则：
+
+- EDN 是 Calcit 值的权威机器表示，JSON 是稳定兼容投影；两者来自同一个 typed result；
+- stdout 只包含一个完整机器值，日志、进度和提示进入 stderr；
+- `:semantic-layer` 至少能区分 `:surface`、`:core`、`:backend`、`:host-boundary`；
+- `:origin-chain` 从当前节点指向 macro 调用和原始 source 节点；
+- 无唯一 source origin 或无法证明等价的建议，`:replacement` 必须为 nil；
+- 可应用 replacement 使用 quoted AST 和 revision/fingerprint 前置条件，不使用行号 patch；
+- 相同 revision、scope 和 rule 的结果必须确定且可重复。
+
+这些字段是能力契约，不要求所有命令在 #997 一次实现完成。#998 负责落地最小 fix suggestion 与原子应用闭环。
+
+## 9. Source fix 与积极迁移
+
+Calcit 生态规模仍小，且维护中的消费者多数在 JS 路径，因此 0.15.0 可以采用较积极的表层收敛，但必须满足：
+
+1. breaking change 的 fix 先由已发布的 0.14.x 工具链提供；
+2. fix 在 Snapshot source AST 上工作，不编辑生成 JS；
+3. 同一规则重复运行幂等，stale revision 或歧义不写入；
+4. 先在 staged Snapshot 完成 parse/schema/preprocess，再执行相关 Calcit、native、JS 和项目构建验证；
+5. 自动 PR 同时展示人可读 semantic diff 和 stable rule ID；
+6. 含业务默认值、unsafe、错误处理选择或求值变化的建议只报告，不自动应用；
+7. 生态迁移完成后删除被取代的 helper、compiler special case 和旧文档，避免永久维护两种表层写法。
+
+“可自动应用”和“需要 review”是操作结论，不发展成新的质量评分或统计目标。迁移成功以行为一致、差异可读和
+旧规则能够删除为准。
+
+## 10. 验证矩阵
+
+| 契约 | 主要验证 | 不能单独作为证明 |
+|---|---|---|
+| 表层类型与行为 | definition `:tests`、成功/失败 fixture | Rust helper 单测 |
+| macro 语义 | 表层调用 + 展开 origin fixture | 某一次 pretty-print 展开文本 |
+| typed core lowering | 等价前后行为、求值顺序、source mapping | 仅比较内部 enum variant |
+| native/JS 共同语义 | 同一 Calcit case 的实际执行 | check-only、JS emit 成功 |
+| Calx 子集 | coverage validation + 执行或明确 unsupported | 清单分类本身 |
+| host/FFI | adapter contract、错误路径、真实或 faithful fake host | 类型声明本身 |
+| source fix | before/after/must-not-rewrite、幂等和 post-check | suggestion 数量或应用率 |
+
+Rust 测试继续承担 parser/serializer、内部数据结构、原子写入、冲突和 backend 低层 invariant。用户可观察语义
+默认通过 Calcit 表达；测试选择为零不能报告成功。
+
+## 11. 与既有路线的关系
+
+- `08-21-static-type-system-evolution-roadmap.md` 继续描述类型能力顺序；本 RFC 补充分层 owner 和开放值契约。
+- `07-26-agent-machine-protocol-rfc.md` 继续拥有 typed result/EDN/JSON envelope；本 RFC 增加 semantic layer、
+  origin chain 和 source fix 的约束。
+- `07-26-safe-structured-editing-rfc.md` 继续拥有 revision、fingerprint、transaction 和 atomic write。
+- `04-13-call-arg-literal-rewrite-rfc.md` 与类型导向优化继续属于 compiler-owned lowering，不自动成为 source fix。
+- Calx program contract 继续限定 backend 支持子集，并复用这里的表层身份与诊断规则。
+
+后续新增语言规则应先回答它属于哪一层、替代了什么旧规则、用户需要理解什么，以及能否删除已有特例。若只能
+通过增加新 analyzer、平行 API 或 backend-specific 表层政策解释，默认回到共同语义重新设计。

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -165,6 +165,18 @@ entry 不存在或 Snapshot 配置无效时仍输出结构化诊断并以非零�
 
 ## 2. 最小心智模型
 
+### 2.0 Source、core 与 backend 不是同一棵可写树
+
+Agent 修改的是 Snapshot 中的表层 quoted AST。macro 展开、名称解析、类型导向 lowering 和 backend 生成结果是
+编译器拥有的语义视图，只用于理解、诊断和验证；不能把展开树或生成 JS 直接回写成 source。
+
+诊断若来自 core/backend，应沿 origin 回到真实 definition/path。只有建议能唯一定位表层节点、证明求值顺序与
+失败行为不变，并携带当前 revision/fingerprint 时，才允许自动应用。无法回溯的建议只报告；不得自动加入
+`unsafe-coerce`、扩大 Dynamic、选择业务默认值或修改 `:tests` 预期。
+
+完整契约见 `../RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md`。未来 `calcit fix` 只会复用这些编译器证据和
+结构化 transaction，不要求 Agent 解析 human warning 或自己逆向 macro expansion。
+
 | 概念       | 含义                                                         | 操作习惯                                      |
 | ---------- | ------------------------------------------------------------ | --------------------------------------------- |
 | Snapshot   | 整个项目的 EDN 数据树                                        | 只通过 `calcit` 修改                              |

--- a/docs/run/calx-program-target.md
+++ b/docs/run/calx-program-target.md
@@ -8,6 +8,8 @@ Calx is planned as an execution backend for the statically analyzable Calcit lan
 
 The compiler consumes a typed, macro-expanded `CompiledProgram` snapshot. Calcit owns parsing, source/Snapshot handling, preprocessing, type analysis, macro expansion, reachability, lowering, lifecycle, and user-facing diagnostics. Calx owns strict program validation, core values and operations, typed imports, execution, traps, and source mapping.
 
+The shared surface/core/backend ownership contract is defined in `RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md`. Calx coverage is a backend subset of that contract: it must not introduce an independent surface type policy, and unsupported results must retain the original Calcit definition/path.
+
 Platform and application FFI stays outside Calx. I/O, JS/native modules, watch mode, long-lived connections, package loading, and capability state enter a compiled program only through explicit typed host imports.
 
 ### Coverage contract
@@ -72,6 +74,8 @@ The current executable API and exact kernel ABI are documented in [Experimental 
 Calx 规划为可静态分析的 Calcit 语言核心的执行 backend。一次编译从配置入口集合开始，包含这些入口静态可达的 definitions。Calx 不再只定义为手工挑选的数值 kernel，但现有 strict kernel path 继续作为可执行的兼容基础。
 
 编译器消费已经完成类型分析和宏展开的 `CompiledProgram` snapshot。Calcit 拥有 parsing、source/Snapshot、preprocessing、类型分析、宏展开、reachability、lowering、生命周期和用户侧诊断。Calx 拥有 strict program validation、核心值与操作、typed imports、执行、traps 和 source mapping。
+
+共同的 surface/core/backend owner 契约见 `RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md`。Calx coverage 是该契约的 backend 子集：不得形成独立的表层类型政策；unsupported 结果必须保留原始 Calcit definition/path。
 
 平台与应用 FFI 留在 Calx 外部。I/O、JS/native modules、watch mode、长期连接、包加载和 capability state 只能通过显式 typed host imports 进入已编译程序。
 

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -14,9 +14,18 @@ parent: core/features
 
 # Calcit 类型使用指南
 
+Calcit 的类型规则处于表层语言与 macro 展开后的 typed core 之间，native、JS 和 Calx 复用同一份已经建立的
+类型关系。完整的分层 owner、开放值与 Agent source-fix 契约见
+[`09-12-layered-semantics-and-agent-fixes-rfc.md`](../RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md)。
+
 ## Dynamic 是边界，不是默认多态
 
 `Dynamic` 适合 JS FFI、框架开放数据、宏和确实无法提前知道的外部输入。普通函数不要用多个 `Dynamic` 表示“它们应该是同一个类型”：输入和返回关联时用 `:generics` 与 TypeVar；只需要能力时用 trait 与 `:where`；同质集合写出元素类型；有限异构数据定义为 Enum；可缺失值使用 `Option<T>`，带失败信息使用 `Result<T, E>`。
+
+Dynamic 表示用户明确选择的开放 Calcit 值，不等于编译器尚未推断出的 Unknown/Unresolved，也不等于宿主拥有的
+`JsObject`。开放值可以被保存、传递、放入开放容器或包装进 `Option<Dynamic>`；只有将其当成 Number、String、
+具体 Struct/Enum 或某个 trait 能力使用时，才需要 decode、narrow 或显式 unsafe boundary。真正参数化且不观察
+内容的泛型函数可以携带 Dynamic；声称具体内容关系但没有证据的调用继续拒绝。
 
 普通执行、编译和严格检查只报告可执行的 warning/error，不计算 Dynamic 比例。迁移存量代码时再显式查询具体位置：
 

--- a/editing-history/2026-09-12-1312-layered-semantics-and-agent-fixes.md
+++ b/editing-history/2026-09-12-1312-layered-semantics-and-agent-fixes.md
@@ -1,0 +1,23 @@
+# 分层语义与 Agent 可执行修复契约
+
+关联：#997、milestone 0.14.13。
+
+## 本次调整
+
+- 新增分层语义 RFC，明确 Cirru/Snapshot、表层语言、macro 展开后的 typed core、backend 与 host boundary 的职责。
+- 区分编译器内部 Unknown/Unresolved、用户显式 Dynamic 与 JsObject/host value；开放值允许安全携带，具体内容使用仍需要类型证据。
+- 明确 compiler-owned lowering 不直接写回源码，Agent 自动修复必须具有唯一 source origin、quoted AST replacement 和 revision/fingerprint 前置条件。
+- 将共同契约关联到类型路线、Agent 机器协议、用户类型指南、Calx program backend 与内嵌 Agent 指南。
+- 约束 0.15.0 的积极迁移：breaking change 先由已发布 0.14.x 工具链提供 fix，并在真实 JS consumer 上验证后再删除旧表层写法。
+
+## 设计知识
+
+- 结构化存储解决可靠查询和修改，不等于 runtime 必须动态，也不等于 macro 展开树应成为新的 source。
+- 泛型函数可以安全携带 `Dynamic` 的条件，是它真正参数化且不观察具体内容；需要具体 trait、字段或 primitive 能力时仍应拒绝未证明的关系。
+- backend coverage 是共同表层契约的子集。生成成功不能证明运行正确，native/JS 的共同语义需要实际执行；Calx 未支持能力应给出带 source origin 的 structured diagnostic。
+- 面向 Agent 的效率来自稳定 typed result、精确 scope、幂等 transaction 和可恢复冲突，而不是更多自然语言提示或质量分类。
+
+## 验证
+
+- `bash scripts/check-docs-md.sh`：69 files、331 blocks 全部通过。
+- `git diff --check`：通过。


### PR DESCRIPTION
## 中文

### 目标

落实 #997 的第一阶段，为 Calcit 的结构化 source、面向用户的表层语言、macro 展开后的 typed core、native/JS/Calx backend 与 host boundary 建立共同语义契约，同时约束后续面向 AI Agent 的结构化修复。

### 改动

- 新增分层语义 RFC，明确每一层的 owner、共同不变量和失败方式。
- 区分内部 Unknown/Unresolved、用户显式 Dynamic 与 JsObject/host value；允许安全携带未知 payload，具体使用仍要求类型证据。
- 明确 compiler-owned lowering 不回写 Snapshot；自动 source fix 必须具有唯一 origin、quoted AST replacement 和 revision/fingerprint 前置条件。
- 将契约同步到类型路线、Agent 机器协议、类型指南、Calx program backend、内嵌 Agent 指南和 `AGENTS.md`。
- 为 0.15.0 的积极收敛规定顺序：先由已发布 0.14.x 工具链提供自动 migration，再在维护中的 JS consumer 上验证和删除旧写法。

### 验证

`calcit docs check-md` 检查 69 个文件、331 个代码块，全部通过。完整输出：

<details>
<summary>完整 <code>docs check-md</code> 输出 / Full output</summary>

```text
Command: calcit docs check-md file=docs/CalcitAgent.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/CalcitAgent.md`
docs/CalcitAgent.md  9 blocks, 9 passed  ✓
Results: 9 blocks, 9 passed, 0 failed
Command: calcit docs check-md file=docs/MacroSignature.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/MacroSignature.md`
docs/MacroSignature.md  3 blocks, 3 passed  ✓
Results: 3 blocks, 3 passed, 0 failed
Command: calcit docs check-md file=docs/cirru-syntax.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/cirru-syntax.md`
hello
hello-world
hello world with spaces
docs/cirru-syntax.md  13 blocks, 13 passed  ✓
Results: 13 blocks, 13 passed, 0 failed
Command: calcit docs check-md file=docs/core-dynamic-classification.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/core-dynamic-classification.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/data.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/data/edn.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data/edn.md`
docs/data/edn.md  24 blocks, 24 passed  ✓
Results: 24 blocks, 24 passed, 0 failed
Command: calcit docs check-md file=docs/data/persistent-data.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data/persistent-data.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/data/string.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data/string.md`
docs/data/string.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/docs-indexing.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/docs-indexing.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/docs-validation.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/docs-validation.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/docs.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/docs.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/ecosystem.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/ecosystem.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/features.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/features/anonymous-enums.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/anonymous-enums.md`
(%:: _ :point 10 20)
docs/features/anonymous-enums.md  4 blocks, 4 passed  ✓
Results: 4 blocks, 4 passed, 0 failed
Command: calcit docs check-md file=docs/features/common-patterns.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/common-patterns.md`
(%:: 'Option :some 4)
(%:: 'Option :some 2)
true
true
Result: 5
Error: Division by zero
(%:: 'Option :some ({} (:name |Alice) (:id |001)))
(%:: 'Option :some 1)
({} (:a ({} (:b ({} (:c 100))))))
({} (:a ({} (:b ({} (:c 2))))))
({} (:b 3) (:d 5) (:a 1) (:c 4))
({} (:c 3) (:b 2) (:a 1))
HelloWorld
hello-world
hello world
error in module
HelloWorld
:a,:b,:c
:error in :module
([] |hello-world-test)
([] "|line1\
line2\
line3")
(%:: 'Result :ok 3.14159)
0
([] ({} (:text |buy-milk) (:done false) (:id "|gen_id_9559")) ({} (:text |write-docs) (:id "|gen_id_9561") (:done false)))
3.14
10
3
101
6
6
docs/features/common-patterns.md  23 blocks, 23 passed  ✓
Results: 23 blocks, 23 passed, 0 failed
Command: calcit docs check-md file=docs/features/enums.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/enums.md`
(%:: 'Color :red)
(%:: 'Shape :circle 5)
(%:: 'Shape :rect 3 4)
(%:: 'ApiResult :ok |success)
(%:: 'ApiResult :err |network-error)
78.53975
OK: success
78.53975
Error: network-error
round
84
true
result: 50
failed: negative-input
false
true
docs/features/enums.md  21 blocks, 21 passed  ✓
Results: 21 blocks, 21 passed, 0 failed
Command: calcit docs check-md file=docs/features/error-handling.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/error-handling.md`
caught: something-went-wrong
error: division-by-zero
validation-failed: :negative-age
42
-1
result: 50
failed: negative-input
docs/features/error-handling.md  9 blocks, 9 passed  ✓
Results: 9 blocks, 9 passed, 0 failed
Command: calcit docs check-md file=docs/features/hashmap.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/hashmap.md`
({} (:b 2) (:a 1) (:c 3))
({} (:x 10) (:y 20))
(%:: 'Option :some 1)
(%:: 'Option :none)
true
3
false
(%:: 'Option :some |Alice)
({} (:a 1) (:c 3) (:b 2))
({} (:a 1) (:c 3))
({} (:a 1) (:d 4) (:e 5) (:b 2))
({} (:b 2) (:a 1))
(#{} ([] :b 2) ([] :a 1))
(#{} :x :y)
(#{} 10 20)
true
true
({} (:a 1) (:b 2) (:d 4) (:c 3))
({} (:b 2) (:c 1) (:a 3))
docs/features/hashmap.md  19 blocks, 19 passed  ✓
Results: 19 blocks, 19 passed, 0 failed
Command: calcit docs check-md file=docs/features/imports.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/imports.md`
docs/features/imports.md  4 blocks, 4 passed  ✓
Results: 4 blocks, 4 passed, 0 failed
Command: calcit docs check-md file=docs/features/js-interop.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/js-interop.md`
docs/features/js-interop.md  22 blocks, 22 passed  ✓
Results: 22 blocks, 22 passed, 0 failed
Command: calcit docs check-md file=docs/features/list.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/list.md`
([] 1 2 3 4 5)
([] 0 1 2 3 4)
([] 2 3 4 5 6)
(%:: 'Option :some 10)
(%:: 'Option :some 10)
(%:: 'Option :some 40)
4
(%:: 'Option :some :b)
([] 1 2 3 4)
([] 0 1 2 3)
([] 1 2 3 4 5)
([] 1 2 3 4 5)
([] 1 99 3)
([] 1 3)
([] 2 3 4 5)
([] 1 2 3 4)
([] 2 3)
([] 1 2 3)
([] 4 5)
([] 3 4 5)
([] 1 1 3 4 5)
([] 5 4 3 2 1)
([] 5 4 3 2 1)
([] 4 5)
([] 1 2 3)
(%:: 'Option :some 4)
(%:: 'Option :some 3)
(%:: 'Option :some 2)
([] 2 4 6 8 10)
([] ([] 0 1) ([] 1 2) ([] 2 3) ([] 3 4) ([] 4 5))
([] 1 2 3 4 5)
15
15
true
true
({} (:small ([] 1 2 3)) (:big ([] 4 5)))
hello,world,foo
(#{} 1 3 2)
([] 36 49 64 81)
([] 30 40 50)
([] ([] :a (%:: 'Option :some 1)) ([] :b (%:: 'Option :some 2)) ([] :c (%:: 'Option :some 3)))
(#{} 1 2 3)
docs/features/list.md  21 blocks, 21 passed  ✓
Results: 21 blocks, 21 passed, 0 failed
Command: calcit docs check-md file=docs/features/macros.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/macros.md`
docs/features/macros.md  5 blocks, 5 passed  ✓
Results: 5 blocks, 5 passed, 0 failed
Command: calcit docs check-md file=docs/features/polymorphism.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/polymorphism.md`
(get-env __MISSING_ENV__): environment variable not found
docs/features/polymorphism.md  10 blocks, 10 passed  ✓
Results: 10 blocks, 10 passed, 0 failed
Command: calcit docs check-md file=docs/features/sets.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/sets.md`
New page found
docs/features/sets.md  13 blocks, 13 passed  ✓
Results: 13 blocks, 13 passed, 0 failed
Command: calcit docs check-md file=docs/features/static-analysis.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/static-analysis.md`
[&inspect-type] in app.main/main! @3.5.1
  'x => number
[&inspect-type] in app.main/main! @3.7.1
  'nums => list<number>
[&inspect-type] in app.main/main! @3.8.3.1
  'item => number
[&inspect-type] in app.main/main! @3.8.6.1
  'item => number
docs/features/static-analysis.md  42 blocks, 42 passed  ✓
Results: 42 blocks, 42 passed, 0 failed
Command: calcit docs check-md file=docs/features/structs.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/structs.md`
1
(#{} :x :y)
2
true
(%{} 'Point (:x 10) (:y 2))
(%{} 'Point (:x 1) (:y 2))
(%{} 'Person (:age 21) (:name |Chen) (:position :shanghai))
(%{} 'Point (:x 100) (:y 2))
Chen

(%{} 'Person (:age 20) (:name |Chen) (:position :mainland))
true
true
(%:: 'Option :some (%struct-def 'Point (:x :number) (:y :number)))
true
false
({} (:y 2) (:x 1))
(%{} 'Person (:age 23) (:name |Ye) (:position :mainland))
:Person
(%:: 'Option :some (%struct-def 'Person (:age :number) (:name :string) (:position :tag)))
Handle Cat branch
Sparrow
Sparrow
3000
90
John
docs/features/structs.md  29 blocks, 29 passed  ✓
Results: 29 blocks, 29 passed, 0 failed
Command: calcit docs check-md file=docs/features/testing.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/testing.md`
docs/features/testing.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/features/traits.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/traits.md`

&inspect-methods
Note: list
Value type: :list
Value: ([] 1 2)
Method call syntax: `.method self p1 p2`
  - dot is part of the method name, first arg is the receiver

Impl records (high → low precedence): 9
  #0: &core-list-methods  (.add .any? .append .apply .assoc .assoc-after .assoc-before .bind .butlast .concat .contains? .count .dissoc .drop .each .empty .empty? .filter .filter-not .filter-pair .find .find-index .find-last .find-last-index .first .flatten .foldl .get .get-in .group-by .includes? .index-of .join .join-str .last .last-index-of .map .map-indexed .map-pair .mappend .max .min .nth .pairs-map .prepend .reduce .rest .reverse .slice .sort .sort-by .take .take-last .to-list .to-set)
  #1: Debug  (.debug)
  #2: Eq  (.eq?)
  #3: Add  (.add)
  #4: Len  (.len)
  #5: Mappable  (.map)
  #6: Countable  (.count)
  #7: Contains  (.contains?)
  #8: Sliceable  (.slice)

All methods (unique, high → low): 58
  .add .any? .append .apply .assoc .assoc-after .assoc-before .bind .butlast .concat .contains? .count .dissoc .drop .each .empty .empty? .filter .filter-not .filter-pair .find .find-index .find-last .find-last-index .first .flatten .foldl .get .get-in .group-by .includes? .index-of .join .join-str .last .last-index-of .map .map-indexed .map-pair .mappend .max .min .nth .pairs-map .prepend .reduce .rest .reverse .slice .sort .sort-by .take .take-last .to-list .to-set .debug .eq? .len

docs/features/traits.md  12 blocks, 12 passed  ✓
Results: 12 blocks, 12 passed, 0 failed
Command: calcit docs check-md file=docs/installation.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-async-protocol.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-async-protocol.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-bindings.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-bindings.md`
docs/installation/ffi-bindings.md  5 blocks, 5 passed  ✓
Results: 5 blocks, 5 passed, 0 failed
Command: calcit docs check-md file=docs/installation/ffi-interface-ir.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-interface-ir.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-resource-protocol.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-resource-protocol.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-upgrade-guide.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-upgrade-guide.md`
docs/installation/ffi-upgrade-guide.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/installation/github-actions.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/github-actions.md`
docs/installation/github-actions.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/installation/host-capability-boundary.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/host-capability-boundary.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/modules.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/modules.md`
docs/installation/modules.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/intro.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/intro/from-clojure.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/from-clojure.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/intro/indentation-syntax.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/indentation-syntax.md`
docs/intro/indentation-syntax.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/intro/overview.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/overview.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/intro/realtime-applications.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/realtime-applications.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/quick-reference.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/quick-reference.md`
docs/quick-reference.md  8 blocks, 8 passed  ✓
Results: 8 blocks, 8 passed, 0 failed
Command: calcit docs check-md file=docs/run.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/agent-advanced.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/agent-advanced.md`
docs/run/agent-advanced.md  4 blocks, 4 passed  ✓
Results: 4 blocks, 4 passed, 0 failed
Command: calcit docs check-md file=docs/run/bundle-mode.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/bundle-mode.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-benchmark.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-benchmark.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-compile-cache.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-compile-cache.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-harness-extraction.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-harness-extraction.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-program-target.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-program-target.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-target.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-target.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/caps-extraction-contract.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/caps-extraction-contract.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/cli-options.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/cli-options.md`
docs/run/cli-options.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/debugging.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/debugging.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/docs-libs.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/docs-libs.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/edit-tree.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/edit-tree.md`
docs/run/edit-tree.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/run/entries.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/entries.md`
docs/run/entries.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/eval.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/eval.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/hot-swapping.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/hot-swapping.md`
docs/run/hot-swapping.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/run/library-quality.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/library-quality.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/load-deps.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/load-deps.md`
docs/run/load-deps.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/run/project-structure.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/project-structure.md`
docs/run/project-structure.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/query.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/query.md`
[&inspect-type] in app.main/main! @3.2.6.1.1
  'p => struct Point
([] .contains? .count .eq? .debug .assoc .empty? .to-map)
:Point

docs/run/query.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/quick-start.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/quick-start.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/strict-nil-migration.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/strict-nil-migration.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/structural-strategies.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/structural-strategies.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/upgrade.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/upgrade.md`
(get-env APP_MODE): environment variable not found
development
docs/run/upgrade.md  8 blocks, 8 passed  ✓
Results: 8 blocks, 8 passed, 0 failed
Command: calcit docs check-md file=docs/structural-editor.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/structural-editor.md`
docs/structural-editor.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/type-guidance.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/type-guidance.md`
docs/type-guidance.md  5 blocks, 5 passed  ✓
Results: 5 blocks, 5 passed, 0 failed

Docs check-md: 69 files, 69 passed, 0 failed; 331 blocks, 331 passed, 0 failed：69 files、331 blocks 通过。
：通过。

本 PR 只建立共同契约，不提前实现 #998 的 ，也不扩大当前 Calx slice。#997 保持开启；可执行语义矩阵与 source-fix 闭环将随 #998/#999 分阶段交付后再关闭。

Part of #997

## English

### Goal

Deliver the first phase of #997 by defining a shared semantic contract for structured source, the human-facing surface language, the macro-expanded typed core, native/JS/Calx backends, and host boundaries, while constraining future structured fixes for AI agents.

### Changes

Add a layered-semantics RFC defining ownership, shared invariants, and failure behavior for each layer.
Separate internal Unknown/Unresolved, intentional user Dynamic, and JsObject/host values; unknown payloads may be transported safely while concrete use still requires type evidence.
State that compiler-owned lowering is not written back to the Snapshot. An automatic source fix requires a unique origin, quoted-AST replacement, and revision/fingerprint preconditions.
Connect the contract to the type roadmap, Agent machine protocol, type guidance, Calx program backend, embedded Agent guide, and .
Order assertive 0.15.0 convergence behind a published 0.14.x automatic migration and validation on maintained JS consumers.

### Validation

Command: calcit docs check-md file=docs/CalcitAgent.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/CalcitAgent.md`
docs/CalcitAgent.md  9 blocks, 9 passed  ✓
Results: 9 blocks, 9 passed, 0 failed
Command: calcit docs check-md file=docs/MacroSignature.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/MacroSignature.md`
docs/MacroSignature.md  3 blocks, 3 passed  ✓
Results: 3 blocks, 3 passed, 0 failed
Command: calcit docs check-md file=docs/cirru-syntax.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/cirru-syntax.md`
hello
hello-world
hello world with spaces
docs/cirru-syntax.md  13 blocks, 13 passed  ✓
Results: 13 blocks, 13 passed, 0 failed
Command: calcit docs check-md file=docs/core-dynamic-classification.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/core-dynamic-classification.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/data.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/data/edn.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data/edn.md`
docs/data/edn.md  24 blocks, 24 passed  ✓
Results: 24 blocks, 24 passed, 0 failed
Command: calcit docs check-md file=docs/data/persistent-data.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data/persistent-data.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/data/string.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/data/string.md`
docs/data/string.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/docs-indexing.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/docs-indexing.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/docs-validation.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/docs-validation.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/docs.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/docs.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/ecosystem.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/ecosystem.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/features.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/features/anonymous-enums.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/anonymous-enums.md`
(%:: _ :point 10 20)
docs/features/anonymous-enums.md  4 blocks, 4 passed  ✓
Results: 4 blocks, 4 passed, 0 failed
Command: calcit docs check-md file=docs/features/common-patterns.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/common-patterns.md`
(%:: 'Option :some 4)
(%:: 'Option :some 2)
true
true
Result: 5
Error: Division by zero
(%:: 'Option :some ({} (:name |Alice) (:id |001)))
(%:: 'Option :some 1)
({} (:a ({} (:b ({} (:c 100))))))
({} (:a ({} (:b ({} (:c 2))))))
({} (:b 3) (:a 1) (:c 4) (:d 5))
({} (:b 2) (:a 1) (:c 3))
HelloWorld
hello-world
hello world
error in module
HelloWorld
:a,:b,:c
:error in :module
([] |hello-world-test)
([] "|line1\
line2\
line3")
(%:: 'Result :ok 3.14159)
0
([] ({} (:text |buy-milk) (:id "|gen_id_9559") (:done false)) ({} (:done false) (:id "|gen_id_9561") (:text |write-docs)))
3.14
10
3
101
6
6
docs/features/common-patterns.md  23 blocks, 23 passed  ✓
Results: 23 blocks, 23 passed, 0 failed
Command: calcit docs check-md file=docs/features/enums.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/enums.md`
(%:: 'Color :red)
(%:: 'Shape :circle 5)
(%:: 'Shape :rect 3 4)
(%:: 'ApiResult :ok |success)
(%:: 'ApiResult :err |network-error)
78.53975
OK: success
78.53975
Error: network-error
round
84
true
result: 50
failed: negative-input
false
true
docs/features/enums.md  21 blocks, 21 passed  ✓
Results: 21 blocks, 21 passed, 0 failed
Command: calcit docs check-md file=docs/features/error-handling.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/error-handling.md`
caught: something-went-wrong
error: division-by-zero
validation-failed: :negative-age
42
-1
result: 50
failed: negative-input
docs/features/error-handling.md  9 blocks, 9 passed  ✓
Results: 9 blocks, 9 passed, 0 failed
Command: calcit docs check-md file=docs/features/hashmap.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/hashmap.md`
({} (:b 2) (:c 3) (:a 1))
({} (:x 10) (:y 20))
(%:: 'Option :some 1)
(%:: 'Option :none)
true
3
false
(%:: 'Option :some |Alice)
({} (:b 2) (:a 1) (:c 3))
({} (:a 1) (:c 3))
({} (:b 2) (:a 1) (:e 5) (:d 4))
({} (:a 1) (:b 2))
(#{} ([] :b 2) ([] :a 1))
(#{} :y :x)
(#{} 20 10)
true
true
({} (:b 2) (:c 3) (:d 4) (:a 1))
({} (:b 2) (:c 1) (:a 3))
docs/features/hashmap.md  19 blocks, 19 passed  ✓
Results: 19 blocks, 19 passed, 0 failed
Command: calcit docs check-md file=docs/features/imports.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/imports.md`
docs/features/imports.md  4 blocks, 4 passed  ✓
Results: 4 blocks, 4 passed, 0 failed
Command: calcit docs check-md file=docs/features/js-interop.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/js-interop.md`
docs/features/js-interop.md  22 blocks, 22 passed  ✓
Results: 22 blocks, 22 passed, 0 failed
Command: calcit docs check-md file=docs/features/list.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/list.md`
([] 1 2 3 4 5)
([] 0 1 2 3 4)
([] 2 3 4 5 6)
(%:: 'Option :some 10)
(%:: 'Option :some 10)
(%:: 'Option :some 40)
4
(%:: 'Option :some :b)
([] 1 2 3 4)
([] 0 1 2 3)
([] 1 2 3 4 5)
([] 1 2 3 4 5)
([] 1 99 3)
([] 1 3)
([] 2 3 4 5)
([] 1 2 3 4)
([] 2 3)
([] 1 2 3)
([] 4 5)
([] 3 4 5)
([] 1 1 3 4 5)
([] 5 4 3 2 1)
([] 5 4 3 2 1)
([] 4 5)
([] 1 2 3)
(%:: 'Option :some 4)
(%:: 'Option :some 3)
(%:: 'Option :some 2)
([] 2 4 6 8 10)
([] ([] 0 1) ([] 1 2) ([] 2 3) ([] 3 4) ([] 4 5))
([] 1 2 3 4 5)
15
15
true
true
({} (:big ([] 4 5)) (:small ([] 1 2 3)))
hello,world,foo
(#{} 2 1 3)
([] 36 49 64 81)
([] 30 40 50)
([] ([] :a (%:: 'Option :some 1)) ([] :b (%:: 'Option :some 2)) ([] :c (%:: 'Option :some 3)))
(#{} 3 1 2)
docs/features/list.md  21 blocks, 21 passed  ✓
Results: 21 blocks, 21 passed, 0 failed
Command: calcit docs check-md file=docs/features/macros.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/macros.md`
docs/features/macros.md  5 blocks, 5 passed  ✓
Results: 5 blocks, 5 passed, 0 failed
Command: calcit docs check-md file=docs/features/polymorphism.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/polymorphism.md`
(get-env __MISSING_ENV__): environment variable not found
docs/features/polymorphism.md  10 blocks, 10 passed  ✓
Results: 10 blocks, 10 passed, 0 failed
Command: calcit docs check-md file=docs/features/sets.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/sets.md`
New page found
docs/features/sets.md  13 blocks, 13 passed  ✓
Results: 13 blocks, 13 passed, 0 failed
Command: calcit docs check-md file=docs/features/static-analysis.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/static-analysis.md`
[&inspect-type] in app.main/main! @3.5.1
  'x => number
[&inspect-type] in app.main/main! @3.7.1
  'nums => list<number>
[&inspect-type] in app.main/main! @3.8.3.1
  'item => number
[&inspect-type] in app.main/main! @3.8.6.1
  'item => number
docs/features/static-analysis.md  42 blocks, 42 passed  ✓
Results: 42 blocks, 42 passed, 0 failed
Command: calcit docs check-md file=docs/features/structs.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/structs.md`
1
(#{} :x :y)
2
true
(%{} 'Point (:x 10) (:y 2))
(%{} 'Point (:x 1) (:y 2))
(%{} 'Person (:age 21) (:name |Chen) (:position :shanghai))
(%{} 'Point (:x 100) (:y 2))
Chen

(%{} 'Person (:age 20) (:name |Chen) (:position :mainland))
true
true
(%:: 'Option :some (%struct-def 'Point (:x :number) (:y :number)))
true
false
({} (:x 1) (:y 2))
(%{} 'Person (:age 23) (:name |Ye) (:position :mainland))
:Person
(%:: 'Option :some (%struct-def 'Person (:age :number) (:name :string) (:position :tag)))
Handle Cat branch
Sparrow
Sparrow
3000
90
John
docs/features/structs.md  29 blocks, 29 passed  ✓
Results: 29 blocks, 29 passed, 0 failed
Command: calcit docs check-md file=docs/features/testing.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/testing.md`
docs/features/testing.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/features/traits.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/features/traits.md`

&inspect-methods
Note: list
Value type: :list
Value: ([] 1 2)
Method call syntax: `.method self p1 p2`
  - dot is part of the method name, first arg is the receiver

Impl records (high → low precedence): 9
  #0: &core-list-methods  (.add .any? .append .apply .assoc .assoc-after .assoc-before .bind .butlast .concat .contains? .count .dissoc .drop .each .empty .empty? .filter .filter-not .filter-pair .find .find-index .find-last .find-last-index .first .flatten .foldl .get .get-in .group-by .includes? .index-of .join .join-str .last .last-index-of .map .map-indexed .map-pair .mappend .max .min .nth .pairs-map .prepend .reduce .rest .reverse .slice .sort .sort-by .take .take-last .to-list .to-set)
  #1: Debug  (.debug)
  #2: Eq  (.eq?)
  #3: Add  (.add)
  #4: Len  (.len)
  #5: Mappable  (.map)
  #6: Countable  (.count)
  #7: Contains  (.contains?)
  #8: Sliceable  (.slice)

All methods (unique, high → low): 58
  .add .any? .append .apply .assoc .assoc-after .assoc-before .bind .butlast .concat .contains? .count .dissoc .drop .each .empty .empty? .filter .filter-not .filter-pair .find .find-index .find-last .find-last-index .first .flatten .foldl .get .get-in .group-by .includes? .index-of .join .join-str .last .last-index-of .map .map-indexed .map-pair .mappend .max .min .nth .pairs-map .prepend .reduce .rest .reverse .slice .sort .sort-by .take .take-last .to-list .to-set .debug .eq? .len

docs/features/traits.md  12 blocks, 12 passed  ✓
Results: 12 blocks, 12 passed, 0 failed
Command: calcit docs check-md file=docs/installation.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-async-protocol.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-async-protocol.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-bindings.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-bindings.md`
docs/installation/ffi-bindings.md  5 blocks, 5 passed  ✓
Results: 5 blocks, 5 passed, 0 failed
Command: calcit docs check-md file=docs/installation/ffi-interface-ir.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-interface-ir.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-resource-protocol.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-resource-protocol.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/ffi-upgrade-guide.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/ffi-upgrade-guide.md`
docs/installation/ffi-upgrade-guide.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/installation/github-actions.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/github-actions.md`
docs/installation/github-actions.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/installation/host-capability-boundary.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/host-capability-boundary.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/installation/modules.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/installation/modules.md`
docs/installation/modules.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/intro.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/intro/from-clojure.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/from-clojure.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/intro/indentation-syntax.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/indentation-syntax.md`
docs/intro/indentation-syntax.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/intro/overview.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/overview.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/intro/realtime-applications.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/intro/realtime-applications.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/quick-reference.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/quick-reference.md`
docs/quick-reference.md  8 blocks, 8 passed  ✓
Results: 8 blocks, 8 passed, 0 failed
Command: calcit docs check-md file=docs/run.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/agent-advanced.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/agent-advanced.md`
docs/run/agent-advanced.md  4 blocks, 4 passed  ✓
Results: 4 blocks, 4 passed, 0 failed
Command: calcit docs check-md file=docs/run/bundle-mode.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/bundle-mode.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-benchmark.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-benchmark.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-compile-cache.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-compile-cache.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-harness-extraction.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-harness-extraction.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-program-target.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-program-target.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/calx-target.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/calx-target.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/caps-extraction-contract.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/caps-extraction-contract.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/cli-options.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/cli-options.md`
docs/run/cli-options.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/debugging.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/debugging.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/docs-libs.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/docs-libs.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/edit-tree.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/edit-tree.md`
docs/run/edit-tree.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/run/entries.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/entries.md`
docs/run/entries.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/eval.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/eval.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/hot-swapping.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/hot-swapping.md`
docs/run/hot-swapping.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/run/library-quality.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/library-quality.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/load-deps.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/load-deps.md`
docs/run/load-deps.md  2 blocks, 2 passed  ✓
Results: 2 blocks, 2 passed, 0 failed
Command: calcit docs check-md file=docs/run/project-structure.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/project-structure.md`
docs/run/project-structure.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/query.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/query.md`
[&inspect-type] in app.main/main! @3.2.6.1.1
  'p => struct Point
([] .contains? .count .eq? .debug .assoc .empty? .to-map)
:Point

docs/run/query.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/run/quick-start.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/quick-start.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/strict-nil-migration.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/strict-nil-migration.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/structural-strategies.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/structural-strategies.md`
No cirru code blocks found in the file.
Command: calcit docs check-md file=docs/run/upgrade.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/run/upgrade.md`
(get-env APP_MODE): environment variable not found
development
docs/run/upgrade.md  8 blocks, 8 passed  ✓
Results: 8 blocks, 8 passed, 0 failed
Command: calcit docs check-md file=docs/structural-editor.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/structural-editor.md`
docs/structural-editor.md  1 blocks, 1 passed  ✓
Results: 1 blocks, 1 passed, 0 failed
Command: calcit docs check-md file=docs/type-guidance.md --entry=calcit/test.cirru
# Explanation: validates code snippets in `docs/type-guidance.md`
docs/type-guidance.md  5 blocks, 5 passed  ✓
Results: 5 blocks, 5 passed, 0 failed

Docs check-md: 69 files, 69 passed, 0 failed; 331 blocks, 331 passed, 0 failed: 69 files and 331 blocks passed.
: passed.

This PR establishes the shared contract only. It does not pre-implement the #998  command or broaden the current Calx slice. #997 remains open until the executable semantic matrix and source-fix loop are delivered incrementally through #998/#999.

Part of #997
```

</details>

## English

### Goal

Implement phase one of #997: establish a shared semantic contract for Calcit's structured
source, user-facing surface language, macro-expanded typed core, native/JS/Calx backends, and
host boundary, and constrain later structured fixes for AI Agents.

### Changes

- Add a layered-semantics RFC defining each layer's owner, shared invariants, and failure modes.
- Separate internal Unknown/Unresolved, user-declared Dynamic, and JsObject/host values; allow
  safe transport of unknown payloads while requiring type evidence for concrete use.
- State that compiler-owned lowering does not write back to the Snapshot; automatic source fixes
  require a unique origin, quoted-AST replacement, and revision/fingerprint preconditions.
- Propagate the contract to the type roadmap, Agent machine protocol, type guidance, Calx program
  backend, embedded Agent guide, and `AGENTS.md`.
- Define the order for 0.15.0's active convergence: ship automatic migration in the released
  0.14.x toolchain first, then validate and delete old forms in maintained JS consumers.

### Validation

`calcit docs check-md` passed 69 files and 331 blocks; the full output is collapsed above.

This PR establishes the shared contract only. It does not pre-implement the #998 command or
broaden the current Calx slice. #997 remains open until the executable semantic matrix and
source-fix loop are delivered incrementally through #998/#999.

Part of #997
