### PR TITLE
docs: document Calcit-first test placement / 记录 Calcit-first 测试放置规则

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,7 @@ jobs:
         env:
           RUST_MIN_STACK: "16777216"
       - name: "run definition-attached core tests"
-        run: cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit
+        run: cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --require-match
       - name: "prevent bundled core type-debt regressions"
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json
       - name: "prevent bundled core Dynamic classification drift"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: "check wasm32 library dependency boundary"
         run: cargo check --lib --target wasm32-unknown-unknown
       - name: "run definition-attached core tests"
-        run: cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit
+        run: cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --require-match
       - name: "prevent bundled core type-debt regressions"
         run: cargo run --bin calcit -- src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json
       - name: "prevent bundled core Dynamic classification drift"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,14 @@
 - **一致性**：复用现有模式，保持日志和错误信息风格统一。
 - **测试覆盖**：新功能必须补齐正常路径与异常分支的测试用例。
 
+### 测试放置（Calcit-first）
+
+- **优先 definition `:tests`**：用户可观察的语言语义、类型推导、macro 展开、core API、runtime 行为与跨 backend 契约，默认写成 Calcit definition 的 `:tests`，用用户会写的表达式断言输入与预期结果，便于 reviewer 直接看到契约。
+- **Rust 测试的边界**：parser/serializer、内部数据结构、host/FFI 边界、内存与并发 invariant、错误恢复，以及无法通过稳定 Calcit 接口合理构造的低层条件留在 Rust。backend-specific 实现可保留 Rust 精确测试，但应同时有 Calcit 侧共享语义测试。
+- **迁移而非重复**：修改已有行为时，若 Rust 测试只是在间接验证可由 Calcit 表达的语义，优先迁移到 `:tests`；确认 Calcit 覆盖等价或更强后，可以删除重复的 Rust 测试。
+- **不追指标**：不新增 Rust/Calcit 测试数量比例、coverage 百分比或统计 analyzer；测试位置由可 review 的语义边界决定。
+- **CI 防呆**：CI 继续执行 definition-attached tests，并用 `--require-match` 或等价机制避免选择条件错误时出现“零测试通过”。新增或修改语义的 PR 需说明测试放在 `:tests` 的原因，或必须留在 Rust 的具体低层理由。详见 `docs/features/testing.md`。
+
 ### 依赖版本引用
 
 - **版本号是 source of truth**：正式依赖、CLI 和 GitHub Actions 必须优先使用明确、已发布的精确版本或 release tag（例如 `v1.4.0`）。不要在版本位置使用裸 commit hash 代替版本号，也不要用 `@<sha> # v1.4.0` 这类注释让 hash 代理版本语义。

--- a/docs/features/testing.md
+++ b/docs/features/testing.md
@@ -136,6 +136,41 @@ so the full `yarn try-js` flow continues to verify JavaScript bit operations,
 while its ordinary API assertions live beside the core definitions. WASM
 exports and FFI checks similarly remain in the dedicated WASM fixtures.
 
+## Choose the Test Surface (Calcit-first)
+
+Place user-observable behavior in definition `:tests`; keep Rust tests for the
+low-level boundaries a Calcit program cannot reasonably construct.
+
+- Prefer `:tests` for language semantics, type inference, macro expansion, core
+  APIs, runtime behavior, and cross-backend contracts. Write the same
+  expressions a user would, so reviewers see the input and expected result
+  directly.
+- Keep Rust tests for parsers/serializers, internal data structures, host/FFI
+  boundaries, memory or concurrency invariants, error recovery, and conditions
+  without a stable Calcit surface.
+- A backend-specific implementation may keep precise Rust tests, but should also
+  have a Calcit-side test for the shared semantic. Add target execution or
+  codegen evidence when JS, IR, or WASM is involved.
+- When behavior changes, migrate a Rust test to `:tests` if it only verifies
+  semantics Calcit can express; remove the duplicate once Calcit coverage is
+  equivalent or stronger.
+- Do not add Rust/Calcit test-count ratios, coverage percentages, or a
+  statistics analyzer. Placement follows reviewable semantic boundaries.
+
+Example: the strict Tag slice attaches a `:tests` to `calcit.core/&compare` for
+the user-observable Tag/String distinction, while the Calx lowering keeps a Rust
+backend fixture because no user-facing Calx runtime exists yet.
+
+### PR checklist
+
+- Why does this coverage belong in `:tests`, or what concrete low-level reason
+  keeps it in Rust?
+- Do the Calcit tests assert the relevant success, failure, or boundary branch
+  with user-level expressions?
+- If a Rust test only restates the same external semantics, was it migrated or
+  removed?
+- Do Native and the relevant JS/IR/WASM checks still pass?
+
 ## Core Test Placement
 
 For a core function, macro, or builtin whose behavior can be expressed in one

--- a/editing-history/202609121333-calcit-first-test-placement.md
+++ b/editing-history/202609121333-calcit-first-test-placement.md
@@ -1,0 +1,16 @@
+# 记录 Calcit-first 测试放置规则
+
+## 背景
+
+近期编译器改动更依赖 Rust 单元测试，而 definition `:tests` 增长较少，review 时需要先理解 Rust 内部结构，也削弱了从 Calcit 程序视角验证语言行为的机会（calcit#989）。
+
+## 修改
+
+- 在 `AGENTS.md` 新增「测试放置（Calcit-first）」小节：用户可观察语义默认写 definition `:tests`；parser/serializer、内部结构、host/FFI 边界、内存/并发 invariant 与错误恢复留在 Rust；backend-specific 实现同时要有 Calcit 侧共享语义测试；不新增比例或 coverage 指标。
+- 在 `docs/features/testing.md` 新增 `Choose the Test Surface (Calcit-first)` 与 PR checklist，并以 Tag 切片（`calcit.core/&compare` 的 `:tests` + Calx Rust fixture）作为示例。
+- CI 与 `yarn try-core-tests` 的 definition-attached core test 命令加 `--require-match`，避免 tag/scope 选择错误时出现“零测试通过”。
+
+## 验证
+
+- `cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --summary-only --require-match`（241 通过）
+- 文档改动，无需 Rust 构建验证；CI 继续执行 definition-attached tests。

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "check-strict-default": "cargo build --bin calcit && node scripts/check-strict-default.mjs",
     "check-agent-interface": "cargo build --bin calcit && node scripts/check-agent-interface.mjs",
     "try-all": "yarn check-all",
-    "try-core-tests": "cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --summary-only",
+    "try-core-tests": "cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --summary-only --require-match",
     "check-core-quality": "cargo run --bin calcit -- src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json",
     "generate-core-dynamic-classification": "node scripts/core-dynamic-classification.mjs --write",
     "check-core-dynamic-classification": "node scripts/core-dynamic-classification.mjs --check",


### PR DESCRIPTION
Closes #989.

## English

### Changes

- Add a "Calcit-first test placement" section to `AGENTS.md`: user-observable semantics default to definition `:tests`; Rust stays for parsers/serializers, internal structures, host/FFI boundaries, memory/concurrency invariants, and error recovery; backend-specific implementations keep precise Rust tests but add a Calcit-side shared semantic test; no count/coverage metrics.
- Add a `Choose the Test Surface (Calcit-first)` section and a PR checklist to `docs/features/testing.md`, citing the strict Tag slice (a `calcit.core/&compare` `:tests` plus a Calx Rust backend fixture) as the concrete example.
- Add `--require-match` to the definition-attached core test commands in `test.yaml`, `publish.yaml`, and `yarn try-core-tests`, so a wrong tag/scope selection cannot pass as an empty suite.

### Validation

- `cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --summary-only --require-match` runs 241 tests.
- Docs and CI-workflow only; the existing Native/JS/WASM gates are unchanged.

## 中文

### 修改

- 在 `AGENTS.md` 新增「测试放置（Calcit-first）」：用户可观察语义默认写 definition `:tests`；Rust 保留 parser/serializer、内部结构、host/FFI 边界、内存/并发 invariant 与错误恢复；backend-specific 实现保留 Rust 精确测试但补 Calcit 侧共享语义测试；不新增数量/coverage 指标。
- 在 `docs/features/testing.md` 新增 `Choose the Test Surface (Calcit-first)` 与 PR checklist，并以 strict Tag 切片（`calcit.core/&compare` 的 `:tests` 加 Calx Rust fixture）作为具体示例。
- 在 `test.yaml`、`publish.yaml` 与 `yarn try-core-tests` 的 definition-attached core test 命令加 `--require-match`，避免 tag/scope 选错时以“零测试通过”。

### 验证

- `cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --summary-only --require-match` 运行 241 个测试。
- 仅文档与 CI workflow 改动；既有 Native/JS/WASM 门禁不变。
