### PR TITLE
Fail closed on unsupported WASM definitions / WASM 未支持定义改为失败关闭

### DIFF
--- a/editing-history/2026-09-12-2027-wasm-fail-closed.md
+++ b/editing-history/2026-09-12-2027-wasm-fail-closed.md
@@ -1,0 +1,25 @@
+# WASM unsupported 路径改为失败关闭
+
+## 背景
+
+WASM emitter 此前为了维持函数索引，在普通 function lowering 失败时生成固定返回 `0.0` 的 body；匿名或嵌套 closure 也会生成 `nil` placeholder。这会让 unsupported 语义表现为看似成功的业务值。
+
+## 修改
+
+- `init_ns` 中的函数无法提取或 lowering 时，codegen 在写入 artifact 前返回包含 namespace/definition 的错误。
+- 依赖 namespace 中已经分配索引但 lowering 失败的函数保留相同 arity 和 table slot，body 改为 WASM `unreachable` trap。
+- 通用匿名/嵌套 closure value 不再生成 `nil`，而是返回明确 unsupported；已有 HOF 专用 lowering 保持不变。
+- `scripts/test-wasm.sh` 复用现有 Calcit fixtures，验证目标 namespace 失败不写文件，以及实际调用 unsupported dependency 时 trap 而非返回 `0.0`。
+- 通用 WASM suite runner 根据模块 import 描述补齐 host function stub，再覆盖已有 math/io 行为，使渐进 suite 能随 host import 集合扩展而继续实例化模块。
+- 渐进 suite 在 `set -e` 下显式捕获 codegen exit；目标 lowering 的明确 unsupported 作为待实现切片列出，真正的 build/runtime 失败仍使 suite 失败。
+
+## 测试放置
+
+用户可观察的已支持 WASM 语义继续由 `calcit/test-wasm.cirru` 执行。新增 Node.js 断言仅检查 WebAssembly trap/ABI 边界；目标 lowering 失败复用 `calcit/test-struct.cirru`，不为这项低层边界增加 Rust 语义测试或新的统计 gate。
+
+## 验证
+
+- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`
+- `cargo test --all-targets --quiet`
+- `cargo clippy --all-targets -- -D warnings`
+- `corepack yarn check-all`

--- a/scripts/test-wasm-fail-closed.mjs
+++ b/scripts/test-wasm-fail-closed.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Verify that an unsupported dependency slot traps instead of returning a placeholder value.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const wasmPath = process.argv[2];
+if (!wasmPath) {
+  throw new Error("expected a WASM artifact path");
+}
+
+const module = new WebAssembly.Module(readFileSync(wasmPath));
+const imports = {};
+for (const descriptor of WebAssembly.Module.imports(module)) {
+  if (descriptor.kind !== "function") {
+    throw new Error(`unsupported test import kind: ${descriptor.kind}`);
+  }
+  imports[descriptor.module] ??= {};
+  imports[descriptor.module][descriptor.name] = () => 0;
+}
+
+const instance = new WebAssembly.Instance(module, imports);
+const unsupported = Object.entries(instance.exports).find(([name]) => name === "vals" || name.endsWith("/vals"))?.[1];
+assert.equal(typeof unsupported, "function", "expected calcit.core/vals to remain addressable as a dependency slot");
+assert.throws(() => unsupported(), WebAssembly.RuntimeError, "unsupported dependency must trap instead of returning 0.0");
+
+console.log("  unsupported dependency trap  OK");

--- a/scripts/test-wasm-run.mjs
+++ b/scripts/test-wasm-run.mjs
@@ -11,38 +11,48 @@ const wasm = readFileSync(wasmPath);
 const mod = new WebAssembly.Module(wasm);
 
 const wasmLog = [];
+const imports = {};
+for (const descriptor of WebAssembly.Module.imports(mod)) {
+  if (descriptor.kind !== "function") {
+    throw new Error(`unsupported test import kind: ${descriptor.kind}`);
+  }
+  imports[descriptor.module] ??= {};
+  imports[descriptor.module][descriptor.name] = () => 0;
+}
 
-const inst = new WebAssembly.Instance(mod, {
-  math: {
-    pow: Math.pow,
-    sin: Math.sin,
-    cos: Math.cos,
-  },
-  io: {
-    log_value: (v) => {
-      const mem = new DataView(inst.exports.memory.buffer);
-      const ptr = v | 0;
-      const HEAP_MAGIC = 0xca1c17a9 | 0;
-      if (ptr >= 16 && ptr < mem.byteLength - 8) {
-        const magic = mem.getInt32(ptr - 8, true);
-        if (magic === HEAP_MAGIC) {
-          const typeTag = mem.getInt32(ptr - 4, true);
-          if (typeTag === 10) {
-            const byteLen = mem.getFloat64(ptr, true);
-            const bytes = new Uint8Array(mem.buffer, ptr + 8, byteLen);
-            const str = new TextDecoder().decode(bytes);
-            process.stdout.write(str + "\n");
-            wasmLog.push(str);
-            return 0;
-          }
+imports.math = {
+  ...imports.math,
+  pow: Math.pow,
+  sin: Math.sin,
+  cos: Math.cos,
+};
+imports.io = {
+  ...imports.io,
+  log_value: (v) => {
+    const mem = new DataView(inst.exports.memory.buffer);
+    const ptr = v | 0;
+    const HEAP_MAGIC = 0xca1c17a9 | 0;
+    if (ptr >= 16 && ptr < mem.byteLength - 8) {
+      const magic = mem.getInt32(ptr - 8, true);
+      if (magic === HEAP_MAGIC) {
+        const typeTag = mem.getInt32(ptr - 4, true);
+        if (typeTag === 10) {
+          const byteLen = mem.getFloat64(ptr, true);
+          const bytes = new Uint8Array(mem.buffer, ptr + 8, byteLen);
+          const str = new TextDecoder().decode(bytes);
+          process.stdout.write(str + "\n");
+          wasmLog.push(str);
+          return 0;
         }
       }
-      process.stdout.write(String(v) + "\n");
-      wasmLog.push(v);
-      return 0;
-    },
+    }
+    process.stdout.write(String(v) + "\n");
+    wasmLog.push(v);
+    return 0;
   },
-});
+};
+
+const inst = new WebAssembly.Instance(mod, imports);
 
 const e = inst.exports;
 

--- a/scripts/test-wasm-suite.sh
+++ b/scripts/test-wasm-suite.sh
@@ -38,12 +38,20 @@ total=${#TEST_FILES[@]}
 for f in "${TEST_FILES[@]}"; do
   label=$(basename "$f" .cirru)
 
-  # Compile to WASM — allow "skipping" warnings, fail only on real errors
-  compile_out=$("$BIN" "$f" 2>&1)
-  compile_exit=$?
-  if [[ $compile_exit -ne 0 ]] || echo "$compile_out" | grep -qE "^error|thread.*panicked"; then
+  # Compile to WASM and distinguish explicit unsupported targets from harness failures.
+  if compile_out=$("$BIN" "$f" 2>&1); then
+    compile_exit=0
+  else
+    compile_exit=$?
+  fi
+  if [[ $compile_exit -ne 0 ]] && grep -Fq "[wasm] target function" <<<"$compile_out"; then
+    echo "  [$label] UNSUPPORTED"
+    ((skip++)) || true
+    continue
+  fi
+  if [[ $compile_exit -ne 0 ]] || grep -qE "^error|thread.*panicked" <<<"$compile_out"; then
     echo "  [$label] BUILD-FAIL"
-    echo "$compile_out" | grep -E "^error|panicked" | head -3
+    grep -E "^error|panicked|Error:" <<<"$compile_out" | head -3
     ((fail++)) || true
     continue
   fi
@@ -57,6 +65,6 @@ for f in "${TEST_FILES[@]}"; do
 done
 
 echo ""
-echo "=== WASM suite: $pass/$total passed, $fail failed ==="
+echo "=== WASM suite: $pass passed, $skip unsupported, $fail failed ($total total) ==="
 
 [[ $fail -eq 0 ]]

--- a/scripts/test-wasm.sh
+++ b/scripts/test-wasm.sh
@@ -15,13 +15,15 @@ else
 fi
 ENTRY="calcit/test-wasm.cirru"
 FAIL_ENTRY="calcit/type-fail/schema-required-arity.cirru"
+LOWERING_FAIL_ENTRY="calcit/test-struct.cirru"
 
 run_codegen() {
   local entry="$1"
+  shift
   if [[ -n "$BIN" ]]; then
-    "$BIN" "$entry"
+    "$BIN" "$entry" "$@"
   else
-    bash scripts/cargo-with-sdk.sh run --bin cr-wasm -- "$entry"
+    bash scripts/cargo-with-sdk.sh run --bin cr-wasm -- "$entry" "$@"
   fi
 }
 
@@ -30,6 +32,7 @@ run_codegen "$ENTRY" 2>&1
 
 # Step 2: validate and run with Node.js
 node scripts/test-wasm.mjs
+node scripts/test-wasm-fail-closed.mjs js-out/program.wasm
 
 # Step 3: a preprocessing failure must stop codegen with a non-zero result.
 if failure_out=$(run_codegen "$FAIL_ENTRY" 2>&1); then
@@ -41,5 +44,25 @@ if ! grep -Fq "WASM preprocessing failed for type-fail-schema-required-arity.mai
   ! grep -Fq "type-fail-schema-required-arity.main/bad-arity" <<<"$failure_out"; then
   echo "WASM preprocessing failure lost its definition context" >&2
   echo "$failure_out" >&2
+  exit 1
+fi
+
+# Step 4: target lowering failures must reject the artifact before writing it.
+LOWERING_FAIL_OUT=$(mktemp -d "${TMPDIR:-/tmp}/calcit-wasm-fail-closed.XXXXXX")
+trap 'rm -rf "$LOWERING_FAIL_OUT"' EXIT
+if lowering_failure_out=$(run_codegen "$LOWERING_FAIL_ENTRY" --emit-path "$LOWERING_FAIL_OUT" 2>&1); then
+  echo "WASM codegen unexpectedly accepted an unsupported target namespace" >&2
+  exit 1
+fi
+
+if [[ -e "$LOWERING_FAIL_OUT/program.wasm" ]]; then
+  echo "WASM codegen wrote an artifact after target lowering failed" >&2
+  exit 1
+fi
+
+if ! grep -Fq "[wasm] target function test-struct.main/" <<<"$lowering_failure_out" ||
+  ! grep -Fq "is not compilable" <<<"$lowering_failure_out"; then
+  echo "WASM target lowering failure lost its definition context" >&2
+  echo "$lowering_failure_out" >&2
   exit 1
 fi

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -152,7 +152,10 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
           fn_defs.push((ns.to_string(), def_name.to_string(), args, body));
         }
         Err(e) => {
-          eprintln!("[wasm] skipping {ns}/{def_name}: {e}");
+          if ns == init_ns {
+            return Err(format!("[wasm] target function {ns}/{def_name} is not compilable: {e}"));
+          }
+          eprintln!("[wasm] omitting unsupported dependency {ns}/{def_name}: {e}");
         }
       }
     }
@@ -310,8 +313,8 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
     fn_table_index,
   };
 
-  // Second pass: compile. If a function fails, we still reserve its slot
-  // with a trivial body so indices remain stable.
+  // Second pass: target failures reject the artifact. Dependency failures keep
+  // a trapping slot so preassigned call and table indices remain stable.
   for (ns, def_name, args, body) in &fn_defs {
     let explicit_export = program_data
       .get(ns.as_str())
@@ -328,17 +331,17 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
     match result {
       Ok(func) => compiled_fns.push(func),
       Err(e) => {
-        if explicit_export {
-          return Err(format!("[wasm] exported function {ns}/{def_name} is not compilable: {e}"));
+        if ns == init_ns || explicit_export {
+          return Err(format!("[wasm] target function {ns}/{def_name} is not compilable: {e}"));
         }
-        eprintln!("[wasm] skipping {ns}/{def_name}: {e}");
+        eprintln!("[wasm] trapping unsupported dependency {ns}/{def_name}: {e}");
         let (arity, _) = compute_fn_arity(args);
         compiled_fns.push(CompiledFn {
           export_name: Some(export_name),
           params: vec![ValType::F64; arity as usize],
           results: vec![ValType::F64],
           locals: vec![],
-          instructions: vec![f64_const(0.0)],
+          instructions: vec![Instruction::Unreachable],
         });
       }
     }
@@ -1071,9 +1074,7 @@ fn emit_expr(ctx: &mut WasmGenCtx, expr: &Calcit) -> Result<(), String> {
           .ok_or_else(|| format!("fn value not in table: {qualified}"))?;
         ctx.emit(f64_const(slot as f64));
       } else {
-        // Anonymous inline closure (no def_ref) — captured upvalues not representable.
-        eprintln!("[wasm] anonymous closure (no def_ref): emitting nil placeholder");
-        ctx.emit(f64_const(0.0));
+        return Err("anonymous closure values are not yet supported in WASM codegen".into());
       }
     }
     // `[]` used as a bare expression (not in call position) evaluates to an empty list.
@@ -1122,15 +1123,7 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
       CalcitSyntax::ParseCirruEdnAs | CalcitSyntax::TryParseCirruEdnAs | CalcitSyntax::DecodeMapAs | CalcitSyntax::TryDecodeMapAs => {
         Err(format!("{syn} is not yet supported in WASM codegen"))
       }
-      CalcitSyntax::Defn => {
-        // A `fn`/`defn` form in value position creates a closure capturing outer variables.
-        // Closures with captured upvalues can't be represented as static WASM function
-        // indices in the current codegen. Emit nil as a placeholder so the outer function
-        // still compiles; callers that invoke the returned "closure" will receive nil.
-        eprintln!("[wasm] closure-as-value: emitting nil placeholder for nested fn/defn");
-        ctx.emit(f64_const(0.0));
-        Ok(())
-      }
+      CalcitSyntax::Defn => Err("nested fn/defn closure values are not yet supported in WASM codegen".into()),
       CalcitSyntax::Quote | CalcitSyntax::Quasiquote => {
         // Quote creates a runtime value (quoted symbol/expression).
         // In WASM, emit nil as a placeholder — quote values appear mainly in


### PR DESCRIPTION
## 中文

### 背景

WASM emitter 在普通 function lowering 失败时曾生成固定返回 `0.0` 的函数 body，匿名或嵌套 closure 也可能生成 `nil` placeholder。这会让 unsupported 语义表现成成功值，妨碍类型驱动的 WASM 能力扩展。

### 修改

- `init_ns` 中的函数无法提取或 lowering 时，在写入 artifact 前返回包含 namespace/definition 的错误。
- 依赖 namespace 中需要保留索引的失败函数改为 WASM `unreachable` trap，不再返回 `0.0`。
- 通用匿名/嵌套 closure value 返回明确 unsupported；已有 HOF 专用 lowering 保持不变。
- 主 WASM 检查复用现有 Calcit fixtures，验证目标 lowering 失败不写文件，以及调用 unsupported dependency 会 trap。
- 通用 Node runner 根据模块声明补齐 host function imports；渐进 suite 能区分 PASS、UNSUPPORTED 和真正的 harness/runtime failure。

### 测试说明

已支持的用户语义继续由 `calcit/test-wasm.cirru` 实际执行。新增 JavaScript/shell 断言只覆盖 artifact、trap、function index 与 host import 等 backend 边界，因此没有增加重复的 Rust 语义测试或覆盖率统计 gate。

### 验证

- `cargo test --all-targets --quiet`：767 + 340 + 23 + 4 全部通过
- `cargo clippy --all-targets -- -D warnings`
- `corepack yarn check-all`
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`
- shell 与 Node 脚本语法检查
- 渐进 inventory 当前诚实显示 2 PASS、6 UNSUPPORTED、2 个既有 standalone fixture 缺口，不再由 zero stub 伪装为通过

Closes #1013

## English

### Background

When ordinary function lowering failed, the WASM emitter used to generate a function body returning constant `0.0`. Anonymous or nested closures could also become `nil` placeholders. Unsupported semantics could therefore look like successful values and obscure the next type-directed WASM work.

### Changes

- A function extraction or lowering failure in `init_ns` now returns an error with namespace/definition identity before the artifact is written.
- Failed dependency-namespace functions that must retain assigned indices now use a WASM `unreachable` trap instead of returning `0.0`.
- Generic anonymous/nested closure values return explicit unsupported errors; existing specialized HOF lowering remains unchanged.
- The primary WASM check reuses existing Calcit fixtures to verify that target lowering failures write no artifact and unsupported dependency calls trap.
- The generic Node runner fills function imports from module declarations, while the progressive suite distinguishes PASS, UNSUPPORTED, and genuine harness/runtime failures.

### Test placement

Supported user semantics continue to execute through `calcit/test-wasm.cirru`. New JavaScript/shell assertions cover backend-only artifact, trap, function-index, and host-import boundaries, so this change adds neither duplicate Rust semantic tests nor a coverage-statistics gate.

### Validation

- `cargo test --all-targets --quiet`: 767 + 340 + 23 + 4 passed
- `cargo clippy --all-targets -- -D warnings`
- `corepack yarn check-all`
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`
- Shell and Node script syntax checks
- The progressive inventory now honestly reports 2 PASS, 6 UNSUPPORTED, and 2 existing standalone-fixture gaps instead of allowing zero stubs to appear successful

Closes #1013
