### PR TITLE
Reject invalid explicit WASM exports / 拒绝无效的显式 WASM export

### DIFF
--- a/editing-history/2026-09-12-2052-wasm-explicit-export-extraction.md
+++ b/editing-history/2026-09-12-2052-wasm-explicit-export-extraction.md
@@ -1,0 +1,24 @@
+# 显式 WASM dependency export 的提取失败不可省略
+
+## 问题
+
+PR #1016 将目标 namespace 的 function extraction failure 改为 codegen error，但位于依赖 namespace 的 `DefWasmExport` 仍可能在第一遍被省略，导致输出模块缺少明确请求的 export。
+
+## 修改
+
+- 将 extraction failure 的拒绝条件统一为：definition 属于 `init_ns`，或其 preprocessed form 是 `DefWasmExport`。
+- 普通、非显式 dependency definition 仍可在无法提取函数结构时省略；它没有外部 export 契约。
+- 增加低层 Rust predicate 回归，分别覆盖目标 definition、显式 dependency export 与普通 dependency。
+
+## 测试放置
+
+该分支判断发生在 compiled-program function extraction/export bookkeeping 层，无法通过已经成功生成的 Calcit/WASM 用户语义构造，因此保留为小型 Rust 边界测试；主 WASM Calcit execution suite 继续验证端到端行为。
+
+## 验证
+
+- `cargo test --all-targets --quiet`
+- `cargo clippy --all-targets -- -D warnings`
+- `corepack yarn install --immutable`
+- `corepack yarn procs-link`
+- `corepack yarn check-all`
+- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -152,7 +152,7 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
           fn_defs.push((ns.to_string(), def_name.to_string(), args, body));
         }
         Err(e) => {
-          if ns == init_ns {
+          if must_reject_extraction_failure(init_ns, ns, &compiled.preprocessed_code) {
             return Err(format!("[wasm] target function {ns}/{def_name} is not compilable: {e}"));
           }
           eprintln!("[wasm] omitting unsupported dependency {ns}/{def_name}: {e}");
@@ -421,6 +421,10 @@ fn extract_fn_parts(code: &Calcit) -> Result<(CalcitFnArgs, Vec<Calcit>), String
 
 fn is_wasm_export_def(code: &Calcit) -> bool {
   matches!(code, Calcit::List(xs) if matches!(xs.first(), Some(Calcit::Syntax(CalcitSyntax::DefWasmExport, _))))
+}
+
+fn must_reject_extraction_failure(init_ns: &str, ns: &str, code: &Calcit) -> bool {
+  ns == init_ns || is_wasm_export_def(code)
 }
 
 fn is_wasm_import_def(code: &Calcit) -> bool {
@@ -3237,5 +3241,32 @@ fn collect_strings_from_expr(expr: &Calcit, strings: &mut Vec<String>) {
       }
     }
     _ => {}
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use super::must_reject_extraction_failure;
+  use crate::calcit::{Calcit, CalcitList, CalcitSyntax};
+
+  fn declaration(head: CalcitSyntax) -> Calcit {
+    let items = [Calcit::Syntax(head, Arc::from("dependency.ns"))];
+    Calcit::List(Arc::new(CalcitList::from(&items[..])))
+  }
+
+  #[test]
+  fn extraction_failure_rejects_target_and_explicit_dependency_export() {
+    let ordinary_dependency = declaration(CalcitSyntax::Defn);
+    let explicit_dependency_export = declaration(CalcitSyntax::DefWasmExport);
+
+    assert!(must_reject_extraction_failure("target.ns", "target.ns", &ordinary_dependency));
+    assert!(must_reject_extraction_failure(
+      "target.ns",
+      "dependency.ns",
+      &explicit_dependency_export
+    ));
+    assert!(!must_reject_extraction_failure("target.ns", "dependency.ns", &ordinary_dependency));
   }
 }


### PR DESCRIPTION
## 中文

### 背景

PR #1016 合并后的 CodeRabbit review 指出：第一遍函数提取失败时，位于依赖 namespace 的显式 `defwasm-export` 仍会被省略，因此调用方明确要求的 export 可能静默消失。

### 修改

- 目标 namespace 的函数提取失败继续直接终止 WASM codegen。
- 依赖 namespace 中的显式 `defwasm-export` 提取失败也直接终止 codegen。
- 普通且未承担 export 契约的依赖仍允许省略。
- 增加一个低层边界测试，覆盖上述三个分支。

### 验证

- `cargo test --all-targets --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `corepack yarn install --immutable`
- `corepack yarn procs-link`
- `corepack yarn check-all`
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`

Closes #1013

## English

### Context

Post-merge CodeRabbit review on PR #1016 found that an explicit `defwasm-export` in a dependency namespace could still be omitted when first-pass function extraction failed. This could silently remove an export explicitly requested by the caller.

### Changes

- Keep rejecting extraction failures in the target namespace.
- Also reject extraction failures for explicit dependency `defwasm-export` definitions.
- Continue allowing ordinary dependency definitions without an export contract to be omitted.
- Add a focused low-level boundary test for all three branches.

### Validation

- `cargo test --all-targets --quiet`
- `cargo clippy --all-targets -- -D warnings`
- `corepack yarn install --immutable`
- `corepack yarn procs-link`
- `corepack yarn check-all`
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`

Closes #1013
