### PR TITLE
test(wasm): prove static Option/Result methods / 验证静态 Option/Result 方法

### DIFF
--- a/calcit/test-wasm.cirru
+++ b/calcit/test-wasm.cirru
@@ -1077,6 +1077,25 @@
             defn test-sqrt (x) (sqrt x)
           :examples $ []
           :schema $ :: 'Dynamic
+        'test-static-option-result-methods $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defwasm-export test-static-option-result-methods () $ let
+                option-value $ .unwrap-or
+                  .map (%some 3) wasm-add-four
+                  , 0
+                result-value $ .unwrap-or
+                  .map (%ok 5) wasm-add-four
+                  , 0
+              + option-value result-value
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+          :tests $ []
+            %{} 'TestEntry (:name |lowers-static-trait-methods)
+              :code $ quote
+                assert= 16 $ test-static-option-result-methods
+              :tags $ #{} :core :unit :wasm
         'test-str-character-count $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn test-str-character-count () $ &str:count "|A😀"
@@ -1314,6 +1333,17 @@
               , 1 0
           :examples $ []
           :schema $ :: 'Dynamic
+        'wasm-add-four $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn wasm-add-four (x)
+              hint-fn $ {}
+                :args $ [] 'Number
+                :return 'Number
+              + x 4
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'Number
         'wasm-ffi-add $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defwasm-export wasm-ffi-add (a b) (&+ a b)

--- a/editing-history/202609122212-wasm-static-option-result-methods.md
+++ b/editing-history/202609122212-wasm-static-option-result-methods.md
@@ -1,0 +1,18 @@
+# Wasm 静态 Option/Result 方法语义
+
+## 发现
+
+Calcit typed core 已经会把已知 `Option` / `Result` receiver 上的 `.map` 和 `.unwrap-or` 解析为具体的 `option:*` / `result:*` 定义。Wasm 后端现有 Enum 表示与具名函数引用也能执行这条路径，不需要 runtime trait registry 或新的 backend 类型规则；此前缺少的是跨 native、JS、Wasm 的用户语义契约。
+
+无捕获的具名回调可以经现有函数表传入 `option:map` / `result:map`。局部闭包作为普通函数参数仍需要后续统一的静态函数特化，不能为了本切片增加 Option/Result 专属闭包规则。
+
+## 变更
+
+- 新增一个带完整 schema 的数值回调。
+- 新增 `test-static-option-result-methods`，通过用户侧 `.map` / `.unwrap-or` 写法同时验证 `Option` 与 `Result`。
+- 把主要断言放在 definition `:tests`，并把同一 export 接入 Wasm 端到端检查。
+
+## 验证重点
+
+- typed preprocessing 选择具体 Option/Result method target，而不是 runtime trait dispatch。
+- `Option.some` 与 `Result.ok` 复用现有 Enum layout，并在 Wasm 中得到与 Calcit 相同的数值结果。

--- a/scripts/test-wasm.mjs
+++ b/scripts/test-wasm.mjs
@@ -528,6 +528,7 @@ check("test-number-compare-method()", -1, e["test-number-compare-method"]);
 check("test-string-compare-method()", -1, e["test-string-compare-method"]);
 check("test-option-unwrap-or()", 7, e["test-option-unwrap-or"]);
 check("test-result-unwrap-or()", 7, e["test-result-unwrap-or"]);
+check("test-static-option-result-methods()", 16, e["test-static-option-result-methods"]);
 check("test-str-contains-true()", 1, e["test-str-contains-true"]); // idx 1 < len 5
 check("test-str-contains-false()", 0, e["test-str-contains-false"]); // idx 10 >= len 5
 check("test-str-find-index-found()", 1, e["test-str-find-index-found"]); // "ell" at byte 1


### PR DESCRIPTION
## 中文

### 结果

这次验证确认：typed core 已经会把已知 `Option` / `Result` receiver 上的 `.map` 和 `.unwrap-or` 静态解析为具体实现；现有 Wasm Enum layout 与具名函数引用能够执行该路径，不需要 runtime trait registry 或新增 backend 类型规则。

### 变更

- 增加带完整 schema 的 `wasm-add-four` typed callback。
- 增加 `test-static-option-result-methods`，以用户侧 method 写法同时执行 `Option.some` 和 `Result.ok` 的 `.map` / `.unwrap-or`。
- 把主断言放进 definition `:tests`，同一个 export 再进入 Wasm 端到端检查。
- 记录当前边界：局部 inline closure 传入普通静态函数需要后续通用函数特化，不在 Option/Result 后端增加专属规则。

### 验证

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --quiet`
- `corepack yarn check-all`

Closes #1015

## English

### Result

This verification confirms that typed core already resolves `.map` and `.unwrap-or` on known `Option` / `Result` receivers to concrete implementations. The existing Wasm enum layout and named function references execute this path without a runtime trait registry or a second backend type policy.

### Changes

- Add a fully typed `wasm-add-four` callback.
- Add `test-static-option-result-methods`, exercising `.map` / `.unwrap-or` for both `Option.some` and `Result.ok` through user-facing method syntax.
- Keep the primary assertion in definition `:tests`, then run the same export in the Wasm end-to-end suite.
- Record the current boundary: passing local inline closures through ordinary static functions needs general function specialization later and should not introduce Option/Result-specific backend rules.

### Verification

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --quiet`
- `corepack yarn check-all`

Closes #1015
