### PR TITLE
feat(wasi): establish command target bridge / 建立 command target bridge

### DIFF
--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -1,0 +1,25 @@
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --contract` before mutations; use `--full` for first orientation or changed contract digest. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |app)
+  :entries $ {}
+    :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :native) (:reload-fn 'app.main/reload!) (:target :wasm)
+      :feature-policy $ {}
+      :modules $ []
+      :type-slots $ {}
+  :files $ {}
+    'app.main $ %{} 'FileEntry
+      :defs $ {}
+        'main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn main! () $ + 1 2
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+          :tests $ []
+            %{} 'TestEntry (:name |returns-three)
+              :code $ quote
+                assert= 3 $ main!
+              :tags $ #{} :core :unit :wasi :wasm
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns app.main $ :require

--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -32,6 +32,13 @@
               :code $ quote
                 assert= 3 $ needs-arg 3
               :tags $ #{} :core :unit :wasi :wasm
+        'reload! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn reload! () &unit
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require

--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -20,6 +20,18 @@
               :code $ quote
                 assert= 3 $ main!
               :tags $ #{} :core :unit :wasi :wasm
+        'needs-arg $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn needs-arg (x) x
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ [] 'Number
+          :tests $ []
+            %{} 'TestEntry (:name |returns-input)
+              :code $ quote
+                assert= 3 $ needs-arg 3
+              :tags $ #{} :core :unit :wasi :wasm
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require

--- a/editing-history/202609122236-wasi-command-target-bridge.md
+++ b/editing-history/202609122236-wasi-command-target-bridge.md
@@ -1,0 +1,17 @@
+# WASI command target bridge
+
+## 中文
+
+- `cr-wasm` 现在显式接受 `--target core|wasi`，默认 `core` 保持现有浏览器与嵌入式宿主 ABI。
+- `wasi` 目标增加标准 `_start: () -> ()` command 入口，入口调用选中的零参数 Calcit `init-fn`，忽略 Calcit 返回值。
+- host imports 由 target 选择并集中登记。首个 WASI bridge 不继承 core 的 JS `math`/`io` imports，也拒绝任意 `defwasm-import`，缺失能力以 `E_WASM_CAPABILITY` fail closed。
+- Preview 1 只作为内部 core-module 兼容层；公开 Calcit API 后续按 args/env/stdio/exit 等 capability 建模，避免泄漏具体 ABI 名称。
+- 用户可观察的 command 语义放在 `calcit/test-wasi-command.cirru` 的 definition `:tests`；shell 只负责验证 target 错误、capability 错误与 Wasmtime 启动。
+
+## English
+
+- `cr-wasm` now accepts an explicit `--target core|wasi`; `core` remains the default and preserves the existing browser/embedded host ABI.
+- The `wasi` target adds a standard `_start: () -> ()` command entry that calls the selected zero-argument Calcit `init-fn` and discards its Calcit return value.
+- Host imports are selected and registered per target. The initial WASI bridge neither inherits the core target's JS `math`/`io` imports nor permits arbitrary `defwasm-import`; missing capabilities fail closed with `E_WASM_CAPABILITY`.
+- Preview 1 remains an internal core-module compatibility layer. Public Calcit APIs will be modeled as capabilities such as args/env/stdio/exit without leaking concrete ABI names.
+- User-visible command semantics live in definition `:tests` in `calcit/test-wasi-command.cirru`; shell checks are limited to target errors, capability errors, and Wasmtime startup.

--- a/editing-history/202609122236-wasi-command-target-bridge.md
+++ b/editing-history/202609122236-wasi-command-target-bridge.md
@@ -5,6 +5,7 @@
 - `cr-wasm` 现在显式接受 `--target core|wasi`，默认 `core` 保持现有浏览器与嵌入式宿主 ABI。
 - `wasi` 目标增加标准 `_start: () -> ()` command 入口，入口调用选中的零参数 Calcit `init-fn`，忽略 Calcit 返回值。
 - host imports 由 target 选择并集中登记。首个 WASI bridge 不继承 core 的 JS `math`/`io` imports，也拒绝任意 `defwasm-import`，缺失能力以 `E_WASM_CAPABILITY` fail closed。
+- import 索引保留 registry 中最先登记的 capability，用户声明不能用重复 module/field 静默覆盖编译器内建 lowering。
 - Preview 1 只作为内部 core-module 兼容层；公开 Calcit API 后续按 args/env/stdio/exit 等 capability 建模，避免泄漏具体 ABI 名称。
 - 用户可观察的 command 语义放在 `calcit/test-wasi-command.cirru` 的 definition `:tests`；shell 只负责验证 target 错误、capability 错误与 Wasmtime 启动。
 
@@ -13,5 +14,6 @@
 - `cr-wasm` now accepts an explicit `--target core|wasi`; `core` remains the default and preserves the existing browser/embedded host ABI.
 - The `wasi` target adds a standard `_start: () -> ()` command entry that calls the selected zero-argument Calcit `init-fn` and discards its Calcit return value.
 - Host imports are selected and registered per target. The initial WASI bridge neither inherits the core target's JS `math`/`io` imports nor permits arbitrary `defwasm-import`; missing capabilities fail closed with `E_WASM_CAPABILITY`.
+- Import indexing preserves the first capability registered for a module/field pair, so a user declaration cannot silently shadow compiler-owned lowering.
 - Preview 1 remains an internal core-module compatibility layer. Public Calcit APIs will be modeled as capabilities such as args/env/stdio/exit without leaking concrete ABI names.
 - User-visible command semantics live in definition `:tests` in `calcit/test-wasi-command.cirru`; shell checks are limited to target errors, capability errors, and Wasmtime startup.

--- a/editing-history/202609122236-wasi-command-target-bridge.md
+++ b/editing-history/202609122236-wasi-command-target-bridge.md
@@ -8,6 +8,7 @@
 - import 索引保留 registry 中最先登记的 capability，用户声明不能用重复 module/field 静默覆盖编译器内建 lowering。
 - Preview 1 只作为内部 core-module 兼容层；公开 Calcit API 后续按 args/env/stdio/exit 等 capability 建模，避免泄漏具体 ABI 名称。
 - 用户可观察的 command 语义放在 `calcit/test-wasi-command.cirru` 的 definition `:tests`；shell 只负责验证 target 错误、capability 错误与 Wasmtime 启动。
+- `--check-only` 与 emit 共享相同的 WASI target validation，但不会写出 module，避免检查通过后真正生成才因 entry/capability 失败。
 
 ## English
 
@@ -17,3 +18,4 @@
 - Import indexing preserves the first capability registered for a module/field pair, so a user declaration cannot silently shadow compiler-owned lowering.
 - Preview 1 remains an internal core-module compatibility layer. Public Calcit APIs will be modeled as capabilities such as args/env/stdio/exit without leaking concrete ABI names.
 - User-visible command semantics live in definition `:tests` in `calcit/test-wasi-command.cirru`; shell checks are limited to target errors, capability errors, and Wasmtime startup.
+- `--check-only` and emission share the same WASI target validation without writing a module during checks, preventing entries or capabilities from passing checks only to fail during generation.

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 readonly TARGET="wasm32-wasip1"
 readonly FIXTURE="calcit/test-wasi-preprocess.cirru"
 readonly WASM_BIN="${CARGO_TARGET_DIR:-target}/${TARGET}/debug/cr-wasm.wasm"
+readonly COMMAND_FIXTURE="calcit/test-wasi-command.cirru"
+readonly COMMAND_OUT="${CARGO_TARGET_DIR:-target}/wasi-command-smoke"
+readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 
 command -v wasmtime >/dev/null
 
@@ -16,3 +19,22 @@ WASMTIME_NEW_CLI=0 wasmtime run \
   --dir "$PWD/calcit::/workspace" \
   "$WASM_BIN" \
   -- --check-only "/workspace/$(basename "$FIXTURE")"
+
+# The generated command module keeps the Preview 1 bridge internal and starts
+# through the conventional no-argument `_start` export.
+cargo build --bin cr-wasm
+cargo run --bin calcit -- "$COMMAND_FIXTURE" test --tag wasi --require-match
+"$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --emit-path "$COMMAND_OUT"
+wasmtime run "$COMMAND_OUT/program.wasm"
+
+if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
+  echo "cr-wasm unexpectedly accepted an unknown target" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_TARGET" <<<"$target_error"
+
+if capability_error=$("$NATIVE_WASM_BIN" calcit/test-wasm.cirru --target wasi --emit-path "$COMMAND_OUT" 2>&1); then
+  echo "WASI target unexpectedly accepted a custom host import" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_CAPABILITY" <<<"$capability_error"

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -7,6 +7,7 @@ readonly FIXTURE="calcit/test-wasi-preprocess.cirru"
 readonly WASM_BIN="${CARGO_TARGET_DIR:-target}/${TARGET}/debug/cr-wasm.wasm"
 readonly COMMAND_FIXTURE="calcit/test-wasi-command.cirru"
 readonly COMMAND_OUT="${CARGO_TARGET_DIR:-target}/wasi-command-smoke"
+readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 
 command -v wasmtime >/dev/null
@@ -24,6 +25,11 @@ WASMTIME_NEW_CLI=0 wasmtime run \
 # through the conventional no-argument `_start` export.
 cargo build --bin cr-wasm
 cargo run --bin calcit -- "$COMMAND_FIXTURE" test --tag wasi --require-match
+"$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --check-only --emit-path "$CHECK_ONLY_OUT"
+if [[ -e "$CHECK_ONLY_OUT/program.wasm" ]]; then
+  echo "WASI check-only unexpectedly wrote a module" >&2
+  exit 1
+fi
 "$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --emit-path "$COMMAND_OUT"
 wasmtime run "$COMMAND_OUT/program.wasm"
 
@@ -33,13 +39,13 @@ if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); 
 fi
 grep -Fq "E_WASM_TARGET" <<<"$target_error"
 
-if entry_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --init-fn app.main/needs-arg --emit-path "$COMMAND_OUT" 2>&1); then
+if entry_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --init-fn app.main/needs-arg --check-only 2>&1); then
   echo "WASI target unexpectedly accepted a command entry with arguments" >&2
   exit 1
 fi
 grep -Fq "E_WASM_TARGET" <<<"$entry_error"
 
-if capability_error=$("$NATIVE_WASM_BIN" calcit/test-wasm.cirru --target wasi --emit-path "$COMMAND_OUT" 2>&1); then
+if capability_error=$("$NATIVE_WASM_BIN" calcit/test-wasm.cirru --target wasi --check-only 2>&1); then
   echo "WASI target unexpectedly accepted a custom host import" >&2
   exit 1
 fi

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -33,6 +33,12 @@ if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); 
 fi
 grep -Fq "E_WASM_TARGET" <<<"$target_error"
 
+if entry_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --init-fn app.main/needs-arg --emit-path "$COMMAND_OUT" 2>&1); then
+  echo "WASI target unexpectedly accepted a command entry with arguments" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_TARGET" <<<"$entry_error"
+
 if capability_error=$("$NATIVE_WASM_BIN" calcit/test-wasm.cirru --target wasi --emit-path "$COMMAND_OUT" 2>&1); then
   echo "WASI target unexpectedly accepted a custom host import" >&2
   exit 1

--- a/scripts/wasm-validation.md
+++ b/scripts/wasm-validation.md
@@ -53,6 +53,20 @@ yarn try-wasm
 
 脚本会通过 `internal-wasm` feature 构建内部 runner，生成 `js-out/program.wasm`，再使用 Node.js 验证导出函数。不支持的函数会把 skip 信息写到 stderr。
 
+## Core 与 WASI command 目标
+
+`cr-wasm` 的 `--target` 明确区分两种宿主契约：
+
+- `core` 是默认值，保持浏览器或嵌入式宿主现有的 `math`、`io` imports 和导出行为。
+- `wasi` 生成 command module，并增加无参数、无返回值的 `_start` 入口。当前阶段可在 Wasmtime 中运行不需要宿主效果的 Calcit 程序。
+
+```bash
+cr-wasm calcit/test-wasi-command.cirru --target wasi --emit-path target/wasi-command
+wasmtime run target/wasi-command/program.wasm
+```
+
+WASI 目标不会接受 `defwasm-import` 声明的任意宿主函数，也不会继承 core 目标的 JS `io` imports。遇到尚未注册的宿主能力时，codegen 以 `E_WASM_CAPABILITY` 失败；无效目标或 command 入口形状以 `E_WASM_TARGET` 失败。后续 stdio、参数、环境变量、退出、时钟、随机数和预开放文件系统均从集中式 capability registry 接入，Preview 1 的 ABI 名称不会成为 Calcit 源码 API。
+
 ## 声明式 WASM FFI
 
 `defwasm-export` 标记提供给宿主程序的稳定入口；它和 `defn` 使用同一函数形状。若带该标记的定义无法被 WASM codegen 编译，编译会失败，避免把错误的占位函数暴露给宿主：

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -130,14 +130,14 @@ fn main() -> Result<(), String> {
   .map_err(|e| e.msg)?;
 
   if cli_args.check_only {
-    run_check_only(&entries)?;
+    run_check_only(&entries, target)?;
     return Ok(());
   }
 
   run_wasm_codegen(&entries, &cli_args.emit_path, target)
 }
 
-fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
+fn run_check_only(entries: &ProgramEntries, target: codegen::emit_wasm::WasmTarget) -> Result<(), String> {
   let started_time = Instant::now();
   let check_warnings: &RefCell<Vec<LocatedWarning>> = &RefCell::new(vec![]);
 
@@ -167,6 +167,11 @@ fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
     }
   }
 
+  if target == codegen::emit_wasm::WasmTarget::Wasi {
+    preprocess_wasm_namespace(entries, check_warnings)?;
+    codegen::emit_wasm::validate_wasm_target(&entries.init_ns, &entries.init_def, target)?;
+  }
+
   let warnings = check_warnings.borrow();
   if !warnings.is_empty() {
     eprintln!("\n{} ({} warnings)", "Warnings:".yellow(), warnings.len());
@@ -190,6 +195,16 @@ fn run_wasm_codegen(entries: &ProgramEntries, emit_path: &str, target: codegen::
 
   let check_warnings: &RefCell<Vec<LocatedWarning>> = &RefCell::new(vec![]);
 
+  preprocess_wasm_namespace(entries, check_warnings)?;
+
+  codegen::emit_wasm::emit_wasm(&entries.init_ns, &entries.init_def, emit_path, target)?;
+
+  let duration = Instant::now().duration_since(started_time);
+  println!("{}", format!("took {}ms", duration.as_micros() as f64 / 1000.0).dimmed());
+  Ok(())
+}
+
+fn preprocess_wasm_namespace(entries: &ProgramEntries, check_warnings: &RefCell<Vec<LocatedWarning>>) -> Result<(), String> {
   // WASM codegen exports every compilable function, so preprocess all defs in target namespace.
   let all_defs = program::list_source_def_names(&entries.init_ns);
   for def_name in &all_defs {
@@ -204,10 +219,5 @@ fn run_wasm_codegen(entries: &ProgramEntries, emit_path: &str, target: codegen::
       ));
     }
   }
-
-  codegen::emit_wasm::emit_wasm(&entries.init_ns, &entries.init_def, emit_path, target)?;
-
-  let duration = Instant::now().duration_since(started_time);
-  println!("{}", format!("took {}ms", duration.as_micros() as f64 / 1000.0).dimmed());
   Ok(())
 }

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -18,6 +18,7 @@ use calcit::call_stack::CallStackList;
 use calcit::util::string::strip_shebang;
 use calcit::{ProgramEntries, builtins, call_stack, codegen, program, runner, snapshot, util};
 use colored::Colorize;
+use std::str::FromStr;
 
 #[derive(FromArgs, PartialEq, Debug, Clone)]
 /// Standalone WASM codegen command.
@@ -37,6 +38,9 @@ struct WasmArgs {
   /// check-only mode: validate without codegen
   #[argh(switch)]
   check_only: bool,
+  /// output target: core (browser/embedded, default) or wasi (command module)
+  #[argh(option, default = "String::from(\"core\")")]
+  target: String,
   /// print version only
   #[argh(switch, short = 'v')]
   version: bool,
@@ -52,6 +56,7 @@ fn main() -> Result<(), String> {
     println!("{}", calcit::cli_args::CALCIT_VERSION);
     return Ok(());
   }
+  let target = codegen::emit_wasm::WasmTarget::from_str(&cli_args.target)?;
 
   builtins::effects::init_effects_states();
 
@@ -129,7 +134,7 @@ fn main() -> Result<(), String> {
     return Ok(());
   }
 
-  run_wasm_codegen(&entries, &cli_args.emit_path)
+  run_wasm_codegen(&entries, &cli_args.emit_path, target)
 }
 
 fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
@@ -179,7 +184,7 @@ fn run_check_only(entries: &ProgramEntries) -> Result<(), String> {
   Ok(())
 }
 
-fn run_wasm_codegen(entries: &ProgramEntries, emit_path: &str) -> Result<(), String> {
+fn run_wasm_codegen(entries: &ProgramEntries, emit_path: &str, target: codegen::emit_wasm::WasmTarget) -> Result<(), String> {
   let started_time = Instant::now();
   codegen::set_codegen_mode(true);
 
@@ -200,7 +205,7 @@ fn run_wasm_codegen(entries: &ProgramEntries, emit_path: &str) -> Result<(), Str
     }
   }
 
-  codegen::emit_wasm::emit_wasm(&entries.init_ns, emit_path)?;
+  codegen::emit_wasm::emit_wasm(&entries.init_ns, &entries.init_def, emit_path, target)?;
 
   let duration = Instant::now().duration_since(started_time);
   println!("{}", format!("took {}ms", duration.as_micros() as f64 / 1000.0).dimmed());

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -139,6 +139,7 @@ impl FromStr for WasmTarget {
 
 pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTarget) -> Result<(), String> {
   let program_data = program::clone_compiled_program_snapshot()?;
+  validate_wasm_target_in_program(&program_data, init_ns, init_def, target)?;
 
   // First pass: extract all function signatures from all namespaces
   let mut fn_defs: Vec<(String, String, CalcitFnArgs, Vec<Calcit>)> = Vec::new(); // (ns, def_name, args, body)
@@ -185,10 +186,6 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
   if fn_defs.is_empty() {
     return Err(format!("namespace not found or no functions: {init_ns}"));
   }
-  if target == WasmTarget::Wasi && fn_defs.iter().any(|(_, name, _, _)| name == "_start") {
-    return Err("E_WASM_TARGET: `_start` is reserved for the generated WASI command entry".into());
-  }
-
   // Build the import table before assigning user function indices. Built-in imports
   // stay first so internal lowering keeps its stable indices; user declarations
   // append after them.
@@ -202,11 +199,6 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
     for (def_name, compiled) in &file_info.defs {
       if !is_wasm_import_def(&compiled.preprocessed_code) {
         continue;
-      }
-      if target == WasmTarget::Wasi {
-        return Err(format!(
-          "E_WASM_CAPABILITY: `{ns}/{def_name}` declares a custom WASM import; the `wasi` target only permits registered capabilities"
-        ));
       }
       let (module, name, args) = parse_wasm_import_def(&compiled.preprocessed_code).ok_or_else(|| {
         format!("[wasm] invalid import declaration {ns}/{def_name}: expected `defwasm-import name (args) |module |field`")
@@ -426,6 +418,53 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
   fs::write(&wasm_file, &wasm_bytes).map_err(|e| format!("failed to write WASM: {e}"))?;
   println!("wrote WASM to: {}", wasm_file.display());
 
+  Ok(())
+}
+
+pub fn validate_wasm_target(init_ns: &str, init_def: &str, target: WasmTarget) -> Result<(), String> {
+  let program_data = program::clone_compiled_program_snapshot()?;
+  validate_wasm_target_in_program(&program_data, init_ns, init_def, target)
+}
+
+fn validate_wasm_target_in_program(
+  program_data: &program::CompiledProgram,
+  init_ns: &str,
+  init_def: &str,
+  target: WasmTarget,
+) -> Result<(), String> {
+  if target == WasmTarget::Core {
+    return Ok(());
+  }
+
+  for (ns, file_info) in program_data {
+    for (def_name, compiled) in &file_info.defs {
+      if compiled.kind != program::CompiledDefKind::Fn {
+        continue;
+      }
+      if is_wasm_import_def(&compiled.preprocessed_code) {
+        return Err(format!(
+          "E_WASM_CAPABILITY: `{ns}/{def_name}` declares a custom WASM import; the `wasi` target only permits registered capabilities"
+        ));
+      }
+      if def_name.as_ref() == "_start" {
+        return Err("E_WASM_TARGET: `_start` is reserved for the generated WASI command entry".into());
+      }
+    }
+  }
+
+  let qualified_init = format!("{init_ns}/{init_def}");
+  let compiled_init = program_data
+    .get(init_ns)
+    .and_then(|file| file.defs.get(init_def))
+    .ok_or_else(|| format!("E_WASM_TARGET: command entry `{qualified_init}` was not compiled"))?;
+  let (args, _) = extract_fn_parts(&compiled_init.preprocessed_code)
+    .map_err(|reason| format!("E_WASM_TARGET: command entry `{qualified_init}` is not a function: {reason}"))?;
+  let (init_arity, _) = compute_fn_arity(&args);
+  if init_arity != 0 {
+    return Err(format!(
+      "E_WASM_TARGET: WASI command entry `{qualified_init}` must take no arguments, got {init_arity}"
+    ));
+  }
   Ok(())
 }
 

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -185,6 +185,9 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
   if fn_defs.is_empty() {
     return Err(format!("namespace not found or no functions: {init_ns}"));
   }
+  if target == WasmTarget::Wasi && fn_defs.iter().any(|(_, name, _, _)| name == "_start") {
+    return Err("E_WASM_TARGET: `_start` is reserved for the generated WASI command entry".into());
+  }
 
   // Build the import table before assigning user function indices. Built-in imports
   // stay first so internal lowering keeps its stable indices; user declarations

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -340,11 +340,7 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
     atom_globals,
     value_imports,
     fn_table_index,
-    host_imports: host_imports
-      .iter()
-      .enumerate()
-      .map(|(index, import)| ((import.module.clone(), import.name.clone()), index as u32))
-      .collect(),
+    host_imports: index_host_imports(&host_imports),
   };
 
   // Second pass: target failures reject the artifact. Dependency failures keep
@@ -2419,6 +2415,14 @@ fn resolve_host_import(ctx: &WasmGenCtx, module: &str, name: &str) -> Result<u32
     .ok_or_else(|| format!("E_WASM_CAPABILITY: host capability `{module}/{name}` is unavailable for this WASM target"))
 }
 
+fn index_host_imports(imports: &[HostImport]) -> HashMap<(String, String), u32> {
+  let mut indices = HashMap::new();
+  for (index, import) in imports.iter().enumerate() {
+    indices.entry((import.module.clone(), import.name.clone())).or_insert(index as u32);
+  }
+  indices
+}
+
 fn emit_binary(ctx: &mut WasmGenCtx, instr: Instruction<'static>, args: &[Calcit]) -> Result<(), String> {
   if args.len() != 2 {
     return Err(format!("{instr:?} expects 2 args, got {}", args.len()));
@@ -3379,7 +3383,7 @@ mod tests {
   use std::str::FromStr;
   use std::sync::Arc;
 
-  use super::{WasmTarget, must_reject_extraction_failure};
+  use super::{HostImport, WasmTarget, index_host_imports, must_reject_extraction_failure};
   use crate::calcit::{Calcit, CalcitList, CalcitSyntax};
 
   fn declaration(head: CalcitSyntax) -> Calcit {
@@ -3406,5 +3410,22 @@ mod tests {
     assert_eq!(WasmTarget::from_str("core"), Ok(WasmTarget::Core));
     assert_eq!(WasmTarget::from_str("wasi"), Ok(WasmTarget::Wasi));
     assert!(WasmTarget::from_str("browser").unwrap_err().starts_with("E_WASM_TARGET:"));
+  }
+
+  #[test]
+  fn host_import_index_keeps_the_registered_capability() {
+    let imports = [
+      HostImport {
+        module: "io".into(),
+        name: "log_value".into(),
+        arity: 1,
+      },
+      HostImport {
+        module: "io".into(),
+        name: "log_value".into(),
+        arity: 2,
+      },
+    ];
+    assert_eq!(index_host_imports(&imports).get(&("io".into(), "log_value".into())), Some(&0));
   }
 }

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -21,6 +21,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use wasm_encoder::{
@@ -43,7 +44,7 @@ mod runtime;
 mod structs;
 
 use methods::{emit_call_args, emit_method_invoke};
-use runtime::{HOST_IMPORTS, HostImport, build_runtime_fns, build_wasm_module};
+use runtime::{HostImport, ModuleFunctionLayout, build_runtime_fns, build_wasm_module, core_host_import, host_imports_for_target};
 use structs::{
   emit_enum_assoc, emit_enum_count, emit_enum_new, emit_enum_nth, emit_named_enum_new, emit_struct_contains, emit_struct_count,
   emit_struct_def, emit_struct_field_tag, emit_struct_get, emit_struct_get_name, emit_struct_matches, emit_struct_new, emit_struct_nth,
@@ -117,7 +118,26 @@ use maps::*;
 use sets::*;
 use strings::*;
 
-pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum WasmTarget {
+  #[default]
+  Core,
+  Wasi,
+}
+
+impl FromStr for WasmTarget {
+  type Err = String;
+
+  fn from_str(value: &str) -> Result<Self, Self::Err> {
+    match value {
+      "core" => Ok(Self::Core),
+      "wasi" => Ok(Self::Wasi),
+      _ => Err(format!("E_WASM_TARGET: unknown WASM target `{value}`; expected `core` or `wasi`")),
+    }
+  }
+}
+
+pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTarget) -> Result<(), String> {
   let program_data = program::clone_compiled_program_snapshot()?;
 
   // First pass: extract all function signatures from all namespaces
@@ -169,7 +189,7 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
   // Build the import table before assigning user function indices. Built-in imports
   // stay first so internal lowering keeps its stable indices; user declarations
   // append after them.
-  let mut host_imports = HOST_IMPORTS.to_vec();
+  let mut host_imports = host_imports_for_target(target);
   let mut wasm_import_names: HashMap<String, u32> = HashMap::new();
   let mut wasm_import_arities: HashMap<String, u32> = HashMap::new();
   for &ns in &ns_order {
@@ -179,6 +199,11 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
     for (def_name, compiled) in &file_info.defs {
       if !is_wasm_import_def(&compiled.preprocessed_code) {
         continue;
+      }
+      if target == WasmTarget::Wasi {
+        return Err(format!(
+          "E_WASM_CAPABILITY: `{ns}/{def_name}` declares a custom WASM import; the `wasi` target only permits registered capabilities"
+        ));
       }
       let (module, name, args) = parse_wasm_import_def(&compiled.preprocessed_code).ok_or_else(|| {
         format!("[wasm] invalid import declaration {ns}/{def_name}: expected `defwasm-import name (args) |module |field`")
@@ -312,6 +337,11 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
     atom_globals,
     value_imports,
     fn_table_index,
+    host_imports: host_imports
+      .iter()
+      .enumerate()
+      .map(|(index, import)| ((import.module.clone(), import.name.clone()), index as u32))
+      .collect(),
   };
 
   // Second pass: target failures reject the artifact. Dependency failures keep
@@ -348,6 +378,28 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
     }
   }
 
+  if target == WasmTarget::Wasi {
+    let qualified_init = format!("{init_ns}/{init_def}");
+    let init_index = env
+      .fn_index
+      .get(&qualified_init)
+      .copied()
+      .ok_or_else(|| format!("E_WASM_TARGET: command entry `{qualified_init}` was not compiled"))?;
+    let init_arity = env.fn_arity.get(&qualified_init).copied().unwrap_or(0);
+    if init_arity != 0 {
+      return Err(format!(
+        "E_WASM_TARGET: WASI command entry `{qualified_init}` must take no arguments, got {init_arity}"
+      ));
+    }
+    compiled_fns.push(CompiledFn {
+      export_name: Some("_start".into()),
+      params: vec![],
+      results: vec![],
+      locals: vec![],
+      instructions: vec![Instruction::Call(init_index), Instruction::Drop],
+    });
+  }
+
   if compiled_fns.is_empty() {
     return Err("no functions could be compiled to WASM".into());
   }
@@ -360,7 +412,10 @@ pub fn emit_wasm(init_ns: &str, emit_path: &str) -> Result<(), String> {
     &string_data_segment,
     &atom_initial_values,
     str_tag_id,
-    runtime_fn_count,
+    ModuleFunctionLayout {
+      runtime_fn_count,
+      table_fn_count: fn_defs.len() as u32,
+    },
   )?;
 
   // Write output
@@ -401,6 +456,8 @@ struct WasmCompileEnv {
   value_imports: HashMap<String, Calcit>,
   /// qualified function name → funcref table slot index (0-based, for call_indirect)
   fn_table_index: HashMap<String, u32>,
+  /// Target-approved host imports keyed by `(module, field)`.
+  host_imports: HashMap<(String, String), u32>,
 }
 
 fn extract_fn_parts(code: &Calcit) -> Result<(CalcitFnArgs, Vec<Calcit>), String> {
@@ -526,6 +583,8 @@ struct WasmGenCtx {
   value_imports: HashMap<String, Calcit>,
   /// qualified function name → funcref table slot index (for call_indirect)
   fn_table_index: HashMap<String, u32>,
+  /// Target-approved host imports keyed by `(module, field)`.
+  host_imports: HashMap<(String, String), u32>,
   /// Statically known closures retain the lexical local bindings visible at creation.
   /// They are specialized at known call sites instead of receiving a dynamic heap ABI.
   lambda_locals: HashMap<String, Arc<InlineClosure>>,
@@ -551,6 +610,7 @@ impl WasmGenCtx {
       atom_globals: env.atom_globals,
       value_imports: env.value_imports,
       fn_table_index: env.fn_table_index,
+      host_imports: env.host_imports,
       lambda_locals: HashMap::new(),
     }
   }
@@ -1361,10 +1421,7 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
       let name = sym.as_ref();
       // IO functions: call host log_value for each arg, return nil
       if matches!(name, "println" | "eprintln" | "echo") {
-        let log_idx = HOST_IMPORTS
-          .iter()
-          .position(|imp| imp.module == "io" && imp.name == "log_value")
-          .expect("log_value host import") as u32;
+        let log_idx = resolve_host_import(ctx, "io", "log_value")?;
         for arg in &args_list {
           emit_expr(ctx, arg)?;
           ctx.emit(Instruction::Call(log_idx));
@@ -1414,10 +1471,7 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
       // Registered procs (eprintln, println, echo, etc.)
       let name = name.as_ref();
       if matches!(name, "println" | "eprintln" | "echo") {
-        let log_idx = HOST_IMPORTS
-          .iter()
-          .position(|imp| imp.module == "io" && imp.name == "log_value")
-          .expect("log_value host import") as u32;
+        let log_idx = resolve_host_import(ctx, "io", "log_value")?;
         for arg in &args_list {
           emit_expr(ctx, arg)?;
           ctx.emit(Instruction::Call(log_idx));
@@ -2342,19 +2396,24 @@ fn emit_type_predicate(ctx: &mut WasmGenCtx, type_name: &str, args: &[Calcit]) -
 
 /// Emit a call to a host-imported function by name.
 fn emit_host_call(ctx: &mut WasmGenCtx, name: &str, args: &[Calcit]) -> Result<(), String> {
-  let import_idx = HOST_IMPORTS
-    .iter()
-    .position(|imp| imp.name == name)
-    .ok_or_else(|| format!("unknown host import: {name}"))?;
-  let expected_arity = HOST_IMPORTS[import_idx].arity;
+  let import = core_host_import(name).ok_or_else(|| format!("unknown host import: {name}"))?;
+  let expected_arity = import.arity;
   if args.len() != expected_arity {
     return Err(format!("{name} expects {expected_arity} args, got {}", args.len()));
   }
   for arg in args {
     emit_expr(ctx, arg)?;
   }
-  ctx.emit(Instruction::Call(import_idx as u32));
+  ctx.emit(Instruction::Call(resolve_host_import(ctx, &import.module, &import.name)?));
   Ok(())
+}
+
+fn resolve_host_import(ctx: &WasmGenCtx, module: &str, name: &str) -> Result<u32, String> {
+  ctx
+    .host_imports
+    .get(&(module.to_owned(), name.to_owned()))
+    .copied()
+    .ok_or_else(|| format!("E_WASM_CAPABILITY: host capability `{module}/{name}` is unavailable for this WASM target"))
 }
 
 fn emit_binary(ctx: &mut WasmGenCtx, instr: Instruction<'static>, args: &[Calcit]) -> Result<(), String> {
@@ -3314,9 +3373,10 @@ fn collect_strings_from_expr(expr: &Calcit, strings: &mut Vec<String>) {
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use std::sync::Arc;
 
-  use super::must_reject_extraction_failure;
+  use super::{WasmTarget, must_reject_extraction_failure};
   use crate::calcit::{Calcit, CalcitList, CalcitSyntax};
 
   fn declaration(head: CalcitSyntax) -> Calcit {
@@ -3336,5 +3396,12 @@ mod tests {
       &explicit_dependency_export
     ));
     assert!(!must_reject_extraction_failure("target.ns", "dependency.ns", &ordinary_dependency));
+  }
+
+  #[test]
+  fn wasm_target_parser_is_explicit_and_stable() {
+    assert_eq!(WasmTarget::from_str("core"), Ok(WasmTarget::Core));
+    assert_eq!(WasmTarget::from_str("wasi"), Ok(WasmTarget::Wasi));
+    assert!(WasmTarget::from_str("browser").unwrap_err().starts_with("E_WASM_TARGET:"));
   }
 }

--- a/src/codegen/emit_wasm/lists.rs
+++ b/src/codegen/emit_wasm/lists.rs
@@ -1743,6 +1743,7 @@ mod sort_tests {
         atom_globals: HashMap::new(),
         value_imports: HashMap::new(),
         fn_table_index: HashMap::new(),
+        host_imports: HashMap::new(),
       },
     )
   }

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -9,9 +9,14 @@ pub(super) struct HostImport {
   pub(super) arity: usize,
 }
 
+pub(super) struct ModuleFunctionLayout {
+  pub(super) runtime_fn_count: u32,
+  pub(super) table_fn_count: u32,
+}
+
 /// List of host-imported functions.
 /// These are provided by the JS environment and indexed before user functions.
-pub(super) static HOST_IMPORTS: LazyLock<Vec<HostImport>> = LazyLock::new(|| {
+static CORE_HOST_IMPORTS: LazyLock<Vec<HostImport>> = LazyLock::new(|| {
   vec![
     HostImport {
       module: "math".into(),
@@ -73,17 +78,28 @@ pub(super) static HOST_IMPORTS: LazyLock<Vec<HostImport>> = LazyLock::new(|| {
   ]
 });
 
+pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
+  match target {
+    WasmTarget::Core => CORE_HOST_IMPORTS.to_vec(),
+    WasmTarget::Wasi => vec![],
+  }
+}
+
+pub(super) fn core_host_import(name: &str) -> Option<&'static HostImport> {
+  CORE_HOST_IMPORTS.iter().find(|import| import.name == name)
+}
+
 /// Maximum arity covered by canonical call_indirect type entries.
 /// Types 0..MAX_CANONICAL_ARITY are reserved: type N = (f64 × N) → f64.
 pub(super) const MAX_CANONICAL_ARITY: u32 = 8;
 
 /// Build a binary WASM module from compiled functions.
-/// Host imports occupy the first function indices (0..HOST_IMPORTS.len()),
-/// then user functions follow at indices HOST_IMPORTS.len()..
+/// Host imports occupy the first function indices, then generated functions follow.
 ///
-/// `runtime_fn_count`: how many leading entries in `fns` are runtime helper
-/// functions (not user-defined calcit functions). Only the user calcit fns
-/// (fns[runtime_fn_count..]) are registered in the funcref table.
+/// `layout.runtime_fn_count`: how many leading entries in `fns` are runtime helper
+/// functions (not user-defined calcit functions). User functions immediately
+/// after that prefix are registered in the funcref table.
+/// `layout.table_fn_count` excludes target-specific entry adapters such as `_start`.
 pub(super) fn build_wasm_module(
   fns: &[CompiledFn],
   host_imports: &[HostImport],
@@ -91,11 +107,10 @@ pub(super) fn build_wasm_module(
   string_data: &[u8],
   atom_initial_values: &[f64],
   string_tag_id: i32,
-  runtime_fn_count: u32,
+  layout: ModuleFunctionLayout,
 ) -> Result<Vec<u8>, String> {
   let mut module = Module::new();
   let num_imports = host_imports.len() as u32;
-  let user_fn_count = fns.len() as u32 - runtime_fn_count;
 
   // Type section:
   //   0..MAX_CANONICAL_ARITY  — canonical HOF callback types: (f64×N) → f64
@@ -137,8 +152,8 @@ pub(super) fn build_wasm_module(
   let mut tables = TableSection::new();
   tables.table(TableType {
     element_type: RefType::FUNCREF,
-    minimum: user_fn_count as u64,
-    maximum: Some(user_fn_count as u64),
+    minimum: layout.table_fn_count as u64,
+    maximum: Some(layout.table_fn_count as u64),
     table64: false,
     shared: false,
   });
@@ -200,8 +215,10 @@ pub(super) fn build_wasm_module(
 
   // Element section: populate the funcref table with user calcit function indices.
   // table slot i → function index (num_imports + runtime_fn_count + i).
-  if user_fn_count > 0 {
-    let fn_indices: Vec<u32> = (0..user_fn_count).map(|i| num_imports + runtime_fn_count + i).collect();
+  if layout.table_fn_count > 0 {
+    let fn_indices: Vec<u32> = (0..layout.table_fn_count)
+      .map(|i| num_imports + layout.runtime_fn_count + i)
+      .collect();
     let mut elements = ElementSection::new();
     elements.active(Some(0), &ConstExpr::i32_const(0), Elements::Functions(fn_indices.as_slice().into()));
     module.section(&elements);


### PR DESCRIPTION
## 中文

### 变更

- 为 `cr-wasm` 增加显式 `--target core|wasi`，默认 `core` 保持现有浏览器/嵌入式 ABI。
- 为 `wasi` 目标生成无参数、无返回值的 `_start` command 入口，并校验选中的 `init-fn` 必须是零参数函数。
- 将 host import 选择集中到 target registry；WASI 目标不继承 JS `math`/`io` imports，也拒绝任意 `defwasm-import`。
- 使用稳定的 `E_WASM_TARGET` 与 `E_WASM_CAPABILITY` 区分 target/entry 和 capability 错误。
- 新增 Calcit definition `:tests` command 契约，并扩展 WASI CI 脚本验证 Wasmtime 启动及负向边界。
- 补充中文内部验证文档，明确 Preview 1 仅为可替换的内部 bridge。

### 边界

本 PR 建立 command module 与 capability fail-closed 基础，不实现 stdio/args/env/exit。后续能力由 #1020 通过同一个集中 registry 接入；Calcit 源码 API 不暴露 `wasi_snapshot_preview1` 名称。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --quiet`（770 + 340 + 23 + 4）
- `corepack yarn check-all`
- `cargo run --bin calcit -- calcit/test-wasi-command.cirru test --tag wasi --require-match`
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`
- `bash scripts/test-wasi-preprocess.sh`（本机已安装 `wasm32-wasip1`）
- Wasmtime 18.0.3 启动生成的 `_start` command module

Closes #1019

## English

### Changes

- Add explicit `--target core|wasi` selection to `cr-wasm`, preserving the existing browser/embedded ABI under the default `core` target.
- Emit a no-argument, no-result `_start` command entry for the `wasi` target and require the selected `init-fn` to take zero arguments.
- Centralize host-import selection in a target registry. The WASI target neither inherits JS `math`/`io` imports nor accepts arbitrary `defwasm-import` declarations.
- Distinguish target/entry and capability failures with stable `E_WASM_TARGET` and `E_WASM_CAPABILITY` codes.
- Add a Calcit definition `:tests` command contract and extend the WASI CI script to verify Wasmtime startup and negative boundaries.
- Document the internal validation flow and keep Preview 1 explicitly replaceable as an internal bridge.

### Boundary

This PR establishes the command-module and fail-closed capability foundation; it does not implement stdio/args/env/exit. #1020 will add those capabilities through the same centralized registry, without exposing `wasi_snapshot_preview1` names to Calcit source APIs.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --quiet` (770 + 340 + 23 + 4)
- `corepack yarn check-all`
- `cargo run --bin calcit -- calcit/test-wasi-command.cirru test --tag wasi --require-match`
- `CR_WASM_BIN=./target/debug/cr-wasm bash scripts/test-wasm.sh`
- `bash scripts/test-wasi-preprocess.sh` (with `wasm32-wasip1` installed locally)
- Generated `_start` command module launched with Wasmtime 18.0.3

Closes #1019
