### PR TITLE
feat(wasm): expose calcit wasm and calcit wasi / 提供公开 WASM 与 WASI 命令

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,8 +51,8 @@ jobs:
 
       - name: "verify WASM exports and FFI"
         run: >
-          cargo build --bin cr-wasm
-          && CR_WASM_BIN="./target/debug/cr-wasm" bash scripts/test-wasm.sh
+          cargo build --bin calcit
+          && CALCIT_BIN="./target/debug/calcit" bash scripts/test-wasm.sh
 
       - name: "try js"
         run: >

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,8 +91,8 @@ jobs:
 
       - name: "verify WASM exports and FFI"
         run: >
-          cargo build --bin cr-wasm
-          && CR_WASM_BIN="./target/debug/cr-wasm" bash scripts/test-wasm.sh
+          cargo build --bin calcit
+          && CALCIT_BIN="./target/debug/calcit" bash scripts/test-wasm.sh
 
       - uses: giraffate/clippy-action@v1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ calcit docs agents --full
 - `calcit <entry>`、`calcit <entry> js` 默认都是**单次执行**（once）。
 - 需要监听时，显式传 `-w` 或 `--watch`（如 `calcit -w <entry>`、`calcit <entry> js -w`）。
 - `calcit <entry> ir` 仅用于编译器与生成结果调试，不作为普通项目的运行或验证方式。
-- WASM codegen 是仓库内部验证后端，不向用户提供命令；维护者统一通过 `yarn try-wasm` 验证。
+- WASM codegen 通过 `calcit wasm`（browser/embedded core module）与 `calcit wasi`（WASI command module）提供公开 preview 命令；两者必须共享加载、预处理、target validation 与 codegen 语义。`cr-wasm` 仅为仓库内部过渡兼容 wrapper，维护者继续通过 `yarn try-wasm` 与 `scripts/test-wasi-preprocess.sh` 验证。
 
 ### calcit eval 基础与常见踩坑
 

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -103,6 +103,8 @@ calcit .calcit/snippets/demo.cirru query config
 
 `calcit [snapshot-file]` 默认选择 `entries.default` 并按它的 `:mode`（`:native` / `:js`）单次运行；`--entry <name>` 选择其他入口。显式 `js` 保留为覆盖方式。只有明确需要监听时才加 `-w` / `--watch`。`calcit ir` 只用于编译器/生成结果调试，不作为日常构建或完成证明。这里的 snapshot 文件不要与 `--entry <named-entry>` 混淆。
 
+WASM 使用目标明确的公开 preview 子命令：`calcit wasm <snapshot>` 生成 browser/embedded core module，`calcit wasi <snapshot>` 生成 WASI command module。Agent 应先读取对应 `--help`，再用 `--check-only` 获取稳定的 target/capability 错误；不要调用内部 `cr-wasm` 或从 binary 名称猜测宿主契约。
+
 ## 1. 30 秒项目盘点
 
 如果用户已经给出 `namespace/definition`，可直接从 `query context` 开始；否则依次执行：

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -462,6 +462,17 @@ calcit --disable-stack
 
 `calcit ir` emits an internal representation for compiler debugging. Ordinary application development and CI do not need it; inspect `calcit ir --help` only when debugging that layer.
 
+## WASM preview 命令
+
+`calcit wasm` 生成面向 browser/embedded host 的 core module；`calcit wasi` 生成可由 Wasmtime 等 WASI host 启动的 command module。两个命令把 Snapshot 路径放在子命令之后，并分别通过 help 暴露输出契约：
+
+```bash
+calcit wasm calcit.cirru --emit-path js-out
+calcit wasi calcit.cirru --emit-path target/wasi-command
+```
+
+两个命令都支持 `--entry`、`--init-fn`、`--reload-fn` 和 `--check-only`。`--check-only` 会执行与实际生成相同的 target validation，但不会写出 `program.wasm`。WASI command 的 init definition 必须为零参数；不支持的宿主能力以稳定的 `E_WASM_CAPABILITY` 失败，不会退回 core module 的 JavaScript imports。
+
 ## Markdown code checking
 
 Use `docs check-md` to validate fenced code blocks in markdown files:

--- a/docs/run/upgrade.md
+++ b/docs/run/upgrade.md
@@ -728,7 +728,7 @@ let
 
 建议在升级验证中显式覆盖两类负向用例：只有 `TraitA/.method` 时，`assert-traits value TraitB` 和 `&trait-call TraitB :method value` 都必须失败。
 
-WASM 仍只是仓库内部验证后端，不承诺 trait runtime table。能在预处理阶段消除的 trait 元数据仍可参与编译；残留的 `&impl::new`、`impl-traits` 或 `&assert-traits` 会明确报出“不支持 runtime trait table”，而不是静默返回 `nil`。业务项目以 JS 为主，并用 native 执行宏和预处理。
+WASM 现在通过 `calcit wasm` 与 `calcit wasi` 提供公开 preview 命令，但仍不承诺 trait runtime table。能在预处理阶段消除的 trait 元数据仍可参与编译；残留的 `&impl::new`、`impl-traits` 或 `&assert-traits` 会明确报出“不支持 runtime trait table”，而不是静默返回 `nil`。现有 JS 生态可以继续以 JS 为主；希望迁移到 WASM 的项目应先用 `--check-only` 获取明确的 unsupported 边界，再逐步收窄宿主能力。
 
 ---
 

--- a/editing-history/202609122322-public-wasm-wasi-cli.md
+++ b/editing-history/202609122322-public-wasm-wasi-cli.md
@@ -1,0 +1,17 @@
+# 公开 WASM/WASI CLI / Public WASM/WASI CLI
+
+## 中文
+
+- 增加 `calcit wasm <snapshot>` 与 `calcit wasi <snapshot>` 两个公开 preview 子命令，让输出类型和宿主契约可以从命令与 help 直接发现。
+- 把原 `cr-wasm` 的 Snapshot 加载、entry 选择、预处理、target validation 与 codegen 移到共享模块；`cr-wasm` 仅保留为内部兼容 wrapper。
+- 共享 loader 登记项目 namespace，并保留 Snapshot 自带的 core namespace，使公开命令遵循 `calcit` 默认严格诊断，同时不把 bundled core 的兼容定义误判为用户代码。
+- 仓库的 core WASM 脚本和 CI 改用 `calcit wasm`；WASI command 生成与 fail-closed 检查改用 `calcit wasi`。旧 core fixture 暂时显式使用 `--compat-types`，新 WASI fixture 保持严格默认。
+- 本机已安装的 `wasm32-wasip1` 用于继续验证 `cr-wasm.wasm` 自举路径；生成的 WASI command 由 Wasmtime 启动。
+
+## English
+
+- Added public preview commands `calcit wasm <snapshot>` and `calcit wasi <snapshot>` so output kinds and host contracts are discoverable through command names and help.
+- Moved Snapshot loading, entry selection, preprocessing, target validation, and codegen out of `cr-wasm` into one shared module. `cr-wasm` remains only as an internal compatibility wrapper.
+- The shared loader registers project namespaces and preserves source-provided core namespaces. Public commands therefore honor the strict `calcit` default without treating bundled compatibility definitions as user code.
+- Migrated core WASM scripts and CI to `calcit wasm`; migrated WASI command emission and fail-closed checks to `calcit wasi`. The legacy core fixture temporarily opts into `--compat-types`, while the new WASI fixture stays strict by default.
+- The locally installed `wasm32-wasip1` target continues to validate the `cr-wasm.wasm` bootstrap path, and Wasmtime starts the emitted WASI command.

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -9,6 +9,7 @@ readonly COMMAND_FIXTURE="calcit/test-wasi-command.cirru"
 readonly COMMAND_OUT="${CARGO_TARGET_DIR:-target}/wasi-command-smoke"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
+readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
 
 command -v wasmtime >/dev/null
 
@@ -23,14 +24,14 @@ WASMTIME_NEW_CLI=0 wasmtime run \
 
 # The generated command module keeps the Preview 1 bridge internal and starts
 # through the conventional no-argument `_start` export.
-cargo build --bin cr-wasm
+cargo build --bin cr-wasm --bin calcit
 cargo run --bin calcit -- "$COMMAND_FIXTURE" test --tag wasi --require-match
-"$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --check-only --emit-path "$CHECK_ONLY_OUT"
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --check-only --emit-path "$CHECK_ONLY_OUT"
 if [[ -e "$CHECK_ONLY_OUT/program.wasm" ]]; then
   echo "WASI check-only unexpectedly wrote a module" >&2
   exit 1
 fi
-"$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --emit-path "$COMMAND_OUT"
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --emit-path "$COMMAND_OUT"
 wasmtime run "$COMMAND_OUT/program.wasm"
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
@@ -39,13 +40,13 @@ if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); 
 fi
 grep -Fq "E_WASM_TARGET" <<<"$target_error"
 
-if entry_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target wasi --init-fn app.main/needs-arg --check-only 2>&1); then
+if entry_error=$("$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/needs-arg --check-only 2>&1); then
   echo "WASI target unexpectedly accepted a command entry with arguments" >&2
   exit 1
 fi
 grep -Fq "E_WASM_TARGET" <<<"$entry_error"
 
-if capability_error=$("$NATIVE_WASM_BIN" calcit/test-wasm.cirru --target wasi --check-only 2>&1); then
+if capability_error=$("$CALCIT_BIN" --compat-types wasi calcit/test-wasm.cirru --check-only 2>&1); then
   echo "WASI target unexpectedly accepted a custom host import" >&2
   exit 1
 fi

--- a/scripts/test-wasm-suite-extended.sh
+++ b/scripts/test-wasm-suite-extended.sh
@@ -7,24 +7,24 @@
 # Goal: gradually grow this entry as more procs / syntax are supported in WASM.
 #
 # Usage: bash scripts/test-wasm-suite-extended.sh
-# Set CR_WASM_BIN to override the cr-wasm binary path.
+# Set CALCIT_BIN to override the calcit binary path.
 set -euo pipefail
 
-if [[ -n "${CR_WASM_BIN:-}" ]]; then
-  BIN="$CR_WASM_BIN"
-elif [[ -x ./target/release/cr-wasm ]]; then
-  BIN="./target/release/cr-wasm"
-elif [[ -x ./target/debug/cr-wasm ]]; then
-  BIN="./target/debug/cr-wasm"
+if [[ -n "${CALCIT_BIN:-}" ]]; then
+  BIN="$CALCIT_BIN"
+elif [[ -x ./target/release/calcit ]]; then
+  BIN="./target/release/calcit"
+elif [[ -x ./target/debug/calcit ]]; then
+  BIN="./target/debug/calcit"
 else
-  bash scripts/cargo-with-sdk.sh build --bin cr-wasm --release 2>&1
-  BIN="./target/release/cr-wasm"
+  bash scripts/cargo-with-sdk.sh build --bin calcit --release 2>&1
+  BIN="./target/release/calcit"
 fi
 
 ENTRY="calcit/test-wasm-suite.cirru"
 
 echo "[extended] compiling $ENTRY"
-"$BIN" "$ENTRY" 2>&1 | grep -E "skipping|wrote|panicked|preprocessing failed" || true
+"$BIN" --compat-types wasm "$ENTRY" 2>&1 | grep -E "skipping|wrote|panicked|preprocessing failed" || true
 
 echo ""
 echo "[extended] running main!"

--- a/scripts/test-wasm-suite.sh
+++ b/scripts/test-wasm-suite.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 # Progressive WASM test suite: compile each eligible test file and run main!().
 # Usage: bash scripts/test-wasm-suite.sh
-# Set CR_WASM_BIN to override the cr-wasm binary path.
+# Set CALCIT_BIN to override the calcit binary path.
 set -euo pipefail
 
-if [[ -n "${CR_WASM_BIN:-}" ]]; then
-  BIN="$CR_WASM_BIN"
-elif [[ -x ./target/release/cr-wasm ]]; then
-  BIN="./target/release/cr-wasm"
-elif [[ -x ./target/debug/cr-wasm ]]; then
-  BIN="./target/debug/cr-wasm"
+if [[ -n "${CALCIT_BIN:-}" ]]; then
+  BIN="$CALCIT_BIN"
+elif [[ -x ./target/release/calcit ]]; then
+  BIN="./target/release/calcit"
+elif [[ -x ./target/debug/calcit ]]; then
+  BIN="./target/debug/calcit"
 else
   # Fall back to cargo build
-  bash scripts/cargo-with-sdk.sh build --bin cr-wasm --release 2>&1
-  BIN="./target/release/cr-wasm"
+  bash scripts/cargo-with-sdk.sh build --bin calcit --release 2>&1
+  BIN="./target/release/calcit"
 fi
 
 # Test files to try — pure-computation, no host FFI dependency
@@ -39,7 +39,7 @@ for f in "${TEST_FILES[@]}"; do
   label=$(basename "$f" .cirru)
 
   # Compile to WASM and distinguish explicit unsupported targets from harness failures.
-  if compile_out=$("$BIN" "$f" 2>&1); then
+  if compile_out=$("$BIN" --compat-types wasm "$f" 2>&1); then
     compile_exit=0
   else
     compile_exit=$?

--- a/scripts/test-wasm.sh
+++ b/scripts/test-wasm.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Verify WASM codegen: generate binary .wasm and validate with Node.js.
 # Usage: bash scripts/test-wasm.sh
-# Set CR_WASM_BIN to override the cr-wasm binary path (default: release then debug build).
+# Set CALCIT_BIN to override the calcit binary path (default: release then debug build).
 set -euo pipefail
 
-if [[ -n "${CR_WASM_BIN:-}" ]]; then
-  BIN="$CR_WASM_BIN"
-elif [[ -x ./target/release/cr-wasm ]]; then
-  BIN="./target/release/cr-wasm"
-elif [[ -x ./target/debug/cr-wasm ]]; then
-  BIN="./target/debug/cr-wasm"
+if [[ -n "${CALCIT_BIN:-}" ]]; then
+  BIN="$CALCIT_BIN"
+elif [[ -x ./target/release/calcit ]]; then
+  BIN="./target/release/calcit"
+elif [[ -x ./target/debug/calcit ]]; then
+  BIN="./target/debug/calcit"
 else
   BIN=""
 fi
@@ -21,9 +21,9 @@ run_codegen() {
   local entry="$1"
   shift
   if [[ -n "$BIN" ]]; then
-    "$BIN" "$entry" "$@"
+    "$BIN" --compat-types wasm "$entry" "$@"
   else
-    bash scripts/cargo-with-sdk.sh run --bin cr-wasm -- "$entry" "$@"
+    bash scripts/cargo-with-sdk.sh run --bin calcit -- --compat-types wasm "$entry" "$@"
   fi
 }
 

--- a/scripts/wasm-validation.md
+++ b/scripts/wasm-validation.md
@@ -1,8 +1,10 @@
-# Internal WASM Codegen Validation
+# WASM 编译与验证
 
 ## 概述
 
-这是 Calcit 仓库内部的 codegen 验证后端，用于测试编译器、数据布局和运行时假设。它不是公开的 Calcit 编译目标，也不构成用户 CLI 契约。内部 binary 由 `internal-wasm` feature gate 保护，只通过仓库测试脚本调用。
+Calcit 通过两个公开 preview 子命令暴露 WASM codegen：`calcit wasm` 生成 browser/embedded core module，`calcit wasi` 生成 WASI command module。两者共享同一套 Snapshot 加载、预处理、target validation 与 codegen 实现；当前支持范围仍以本文和明确的 unsupported 错误为准。
+
+仓库继续保留 `cr-wasm` 作为过渡期内部兼容 wrapper，供旧脚本和 WASI 自举回归使用。新的人类与 Agent 工作流应使用 `calcit wasm` / `calcit wasi`，不要依据内部 binary 名称猜测输出契约。
 
 ## 支持的子集
 
@@ -45,25 +47,37 @@
 - Atom / Ref
 - 可变参数 (`&`) 和可选参数 (`?`)
 
-## 内部验证方式
+## 编译与验证方式
+
+生成 browser/embedded core module：
+
+```bash
+calcit wasm calcit.cirru --emit-path js-out
+```
+
+生成并运行 WASI command module：
+
+```bash
+calcit wasi calcit/test-wasi-command.cirru --emit-path target/wasi-command
+wasmtime run target/wasi-command/program.wasm
+```
+
+两个命令都支持 `--check-only`，只执行同一套 target validation，不写出 `program.wasm`。`--help` 会分别说明输出类型和 command entry 约束。
+
+仓库全量验证：
 
 ```bash
 yarn try-wasm
 ```
 
-脚本会通过 `internal-wasm` feature 构建内部 runner，生成 `js-out/program.wasm`，再使用 Node.js 验证导出函数。不支持的函数会把 skip 信息写到 stderr。
+脚本通过公开 `calcit wasm` 命令生成 `js-out/program.wasm`，再使用 Node.js 验证导出函数。不支持的函数会把 skip 信息写到 stderr。
 
 ## Core 与 WASI command 目标
 
-`cr-wasm` 的 `--target` 明确区分两种宿主契约：
+公开命令名称明确区分两种宿主契约：
 
 - `core` 是默认值，保持浏览器或嵌入式宿主现有的 `math`、`io` imports 和导出行为。
 - `wasi` 生成 command module，并增加无参数、无返回值的 `_start` 入口。当前阶段可在 Wasmtime 中运行不需要宿主效果的 Calcit 程序。
-
-```bash
-cr-wasm calcit/test-wasi-command.cirru --target wasi --emit-path target/wasi-command
-wasmtime run target/wasi-command/program.wasm
-```
 
 WASI 目标不会接受 `defwasm-import` 声明的任意宿主函数，也不会继承 core 目标的 JS `io` imports。遇到尚未注册的宿主能力时，codegen 以 `E_WASM_CAPABILITY` 失败；无效目标或 command 入口形状以 `E_WASM_TARGET` 失败。后续 stdio、参数、环境变量、退出、时钟、随机数和预开放文件系统均从集中式 capability registry 接入，Preview 1 的 ABI 名称不会成为 Calcit 源码 API。
 
@@ -140,7 +154,8 @@ defn fibo (n)
 - `src/codegen/emit_wasm.rs` — WASM 二进制代码生成（via wasm-encoder）
 - `src/codegen.rs` — 模块注册
 - `src/cli_args.rs` — `EmitWasmCommand` CLI 定义
-- `src/bin/cr_wasm.rs` — feature-gated 内部 runner
+- `src/wasm_cli.rs` — 两个公开命令与兼容 wrapper 共用的加载和编译流程
+- `src/bin/cr_wasm.rs` — 过渡期内部兼容 wrapper
 - `calcit/test-wasm.cirru` — 测试用例
 - `scripts/test-wasm.sh` — WASM 验证脚本（生成 + Node.js 验证，集成在 `yarn check-all` 中）
 - `scripts/test-wasm.mjs` — Node.js 测试运行器

--- a/src/bin/cr.rs
+++ b/src/bin/cr.rs
@@ -272,10 +272,34 @@ fn main() -> Result<(), String> {
   }
 }
 
+fn resolve_public_wasm_options(
+  cli_args: &ToplevelCalcit,
+  input: Option<&str>,
+  emit_path: Option<&str>,
+  init_fn: Option<&str>,
+  reload_fn: Option<&str>,
+  entry: Option<&str>,
+  check_only: bool,
+) -> calcit::wasm_cli::WasmCliOptions {
+  calcit::wasm_cli::WasmCliOptions {
+    input: input.unwrap_or(&cli_args.input).to_owned(),
+    emit_path: emit_path.unwrap_or(&cli_args.emit_path).to_owned(),
+    init_fn: init_fn.or(cli_args.init_fn.as_deref()).map(str::to_owned),
+    reload_fn: reload_fn.or(cli_args.reload_fn.as_deref()).map(str::to_owned),
+    entry: entry.or(cli_args.entry.as_deref()).map(str::to_owned),
+    check_only: check_only || cli_args.check_only,
+  }
+}
+
 fn run_cli() -> Result<(), String> {
   let cli_args: ToplevelCalcit = argh::from_env();
-  cli_handlers::warn_on_global_temp_snapshot_path(&cli_args.input);
-  calcit::project_state::set_active_project_directory_from_snapshot(&cli_args.input);
+  let active_input = match &cli_args.subcommand {
+    Some(CalcitCommand::EmitWasm(command)) => command.input.as_deref().unwrap_or(&cli_args.input),
+    Some(CalcitCommand::EmitWasi(command)) => command.input.as_deref().unwrap_or(&cli_args.input),
+    _ => &cli_args.input,
+  };
+  cli_handlers::warn_on_global_temp_snapshot_path(active_input);
+  calcit::project_state::set_active_project_directory_from_snapshot(active_input);
 
   cli_handlers::set_cursor_after_mode(&cli_args.cursor_after)?;
 
@@ -325,6 +349,34 @@ fn run_cli() -> Result<(), String> {
 
   // Handle standalone commands that don't need full program loading
   match &cli_args.subcommand {
+    Some(CalcitCommand::EmitWasm(command)) => {
+      return calcit::wasm_cli::run(
+        &resolve_public_wasm_options(
+          &cli_args,
+          command.input.as_deref(),
+          command.emit_path.as_deref(),
+          command.init_fn.as_deref(),
+          command.reload_fn.as_deref(),
+          command.entry.as_deref(),
+          command.check_only,
+        ),
+        codegen::emit_wasm::WasmTarget::Core,
+      );
+    }
+    Some(CalcitCommand::EmitWasi(command)) => {
+      return calcit::wasm_cli::run(
+        &resolve_public_wasm_options(
+          &cli_args,
+          command.input.as_deref(),
+          command.emit_path.as_deref(),
+          command.init_fn.as_deref(),
+          command.reload_fn.as_deref(),
+          command.entry.as_deref(),
+          command.check_only,
+        ),
+        codegen::emit_wasm::WasmTarget::Wasi,
+      );
+    }
     Some(CalcitCommand::Query(query_cmd)) => {
       return cli_handlers::handle_query_command(query_cmd, &cli_args.input);
     }

--- a/src/bin/cr_wasm.rs
+++ b/src/bin/cr_wasm.rs
@@ -1,27 +1,18 @@
-use std::cell::RefCell;
-use std::fs;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Instant;
-
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)]
 mod injection;
 
-#[cfg(not(target_arch = "wasm32"))]
-#[path = "../type_coverage.rs"]
-mod type_coverage;
-
-use argh::FromArgs;
-use calcit::calcit::LocatedWarning;
-use calcit::call_stack::CallStackList;
-use calcit::util::string::strip_shebang;
-use calcit::{ProgramEntries, builtins, call_stack, codegen, program, runner, snapshot, util};
-use colored::Colorize;
 use std::str::FromStr;
 
+use argh::FromArgs;
+use calcit::builtins;
+use calcit::codegen::emit_wasm::WasmTarget;
+#[cfg(not(target_arch = "wasm32"))]
+use calcit::runner;
+use calcit::wasm_cli::{self, WasmCliOptions};
+
 #[derive(FromArgs, PartialEq, Debug, Clone)]
-/// Standalone WASM codegen command.
+/// Internal compatibility wrapper for WASM codegen.
 struct WasmArgs {
   /// emit path for generated artifacts, defaults to "js-out/"
   #[argh(option, default = "String::from(\"js-out/\")")]
@@ -56,168 +47,22 @@ fn main() -> Result<(), String> {
     println!("{}", calcit::cli_args::CALCIT_VERSION);
     return Ok(());
   }
-  let target = codegen::emit_wasm::WasmTarget::from_str(&cli_args.target)?;
+  let target = WasmTarget::from_str(&cli_args.target)?;
 
   builtins::effects::init_effects_states();
 
   #[cfg(not(target_arch = "wasm32"))]
   injection::inject_platform_apis();
 
-  let core_snapshot = calcit::load_core_snapshot()?;
-
-  let input_path = PathBuf::from(&cli_args.input);
-  calcit::validate_snapshot_path(&input_path)?;
-  let input_path_str = input_path.to_string_lossy().to_string();
-  if !input_path.exists() {
-    return Err(format!("{} does not exist", input_path.display()));
-  }
-
-  let mut content = fs::read_to_string(&input_path).unwrap_or_else(|_| panic!("expected Cirru snapshot: {}", input_path.display()));
-  strip_shebang(&mut content);
-  let data = cirru_edn::parse(&content).map_err(|e| {
-    eprintln!("\nFailed to parse entry file '{}':", input_path.display());
-    eprintln!("{e}");
-    format!("Failed to parse entry file '{}'", input_path.display())
-  })?;
-  let mut snapshot = snapshot::load_snapshot_data(&data, &input_path_str)?;
-
-  snapshot.select_entry(cli_args.entry.as_deref())?;
-  if cli_args.entry.is_some() {
-    println!("running entry: {}", snapshot.active_entry_name());
-  }
-
-  let base_dir = input_path.parent().expect("extract parent");
-  let module_folder = calcit::project_module_folder(base_dir);
-
-  let module_paths = snapshot.active_entry()?.modules.clone();
-  for module_path in &module_paths {
-    let module_data = calcit::load_module(module_path, base_dir, &module_folder)?;
-    calcit::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
-  }
-
-  let selected_entry = snapshot.active_entry()?;
-  let config_init = selected_entry.init_fn.to_string();
-  let config_reload = selected_entry.reload_fn.to_string();
-  let init_fn = cli_args.init_fn.as_deref().unwrap_or(&config_init);
-  let reload_fn = cli_args.reload_fn.as_deref().unwrap_or(&config_reload);
-  let (init_ns, init_def) = util::string::extract_ns_def(init_fn)?;
-  let (reload_ns, reload_def) = util::string::extract_ns_def(reload_fn)?;
-  let entries: ProgramEntries = ProgramEntries {
-    init_fn: Arc::from(init_fn),
-    reload_fn: Arc::from(reload_fn),
-    init_def: init_def.into(),
-    init_ns: init_ns.into(),
-    reload_ns: reload_ns.into(),
-    reload_def: reload_def.into(),
-  };
-
-  for (k, v) in core_snapshot.files {
-    snapshot.files.insert(k.to_owned(), v.to_owned());
-  }
-
-  {
-    let mut prgm = { program::PROGRAM_CODE_DATA.write().expect("open program data") };
-    *prgm = program::extract_program_data(&snapshot)?;
-  }
-
-  let check_warnings: &RefCell<Vec<LocatedWarning>> = &RefCell::new(vec![]);
-  runner::preprocess::ensure_ns_def_compiled(
-    calcit::calcit::CORE_NS,
-    calcit::calcit::BUILTIN_IMPLS_ENTRY,
-    check_warnings,
-    &CallStackList::default(),
+  wasm_cli::run(
+    &WasmCliOptions {
+      input: cli_args.input,
+      emit_path: cli_args.emit_path,
+      init_fn: cli_args.init_fn,
+      reload_fn: cli_args.reload_fn,
+      entry: cli_args.entry,
+      check_only: cli_args.check_only,
+    },
+    target,
   )
-  .map_err(|e| e.msg)?;
-
-  if cli_args.check_only {
-    run_check_only(&entries, target)?;
-    return Ok(());
-  }
-
-  run_wasm_codegen(&entries, &cli_args.emit_path, target)
-}
-
-fn run_check_only(entries: &ProgramEntries, target: codegen::emit_wasm::WasmTarget) -> Result<(), String> {
-  let started_time = Instant::now();
-  let check_warnings: &RefCell<Vec<LocatedWarning>> = &RefCell::new(vec![]);
-
-  eprintln!("{}", "Check-only mode: validating code...".dimmed());
-
-  match runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, &entries.init_def, check_warnings, &CallStackList::default()) {
-    Ok(_) => {
-      println!("  {} {}", "✓".green(), format!("{} preprocessed", entries.init_fn).dimmed());
-    }
-    Err(failure) => {
-      eprintln!("\n{} preprocessing init_fn", "✗".red());
-      let headline = failure.headline();
-      call_stack::display_stack_with_docs(&headline, &failure.stack, failure.location.as_ref(), failure.hint.as_deref())?;
-      return Err(headline);
-    }
-  }
-
-  match runner::preprocess::ensure_ns_def_compiled(&entries.reload_ns, &entries.reload_def, check_warnings, &CallStackList::default()) {
-    Ok(_) => {
-      println!("  {} {}", "✓".green(), format!("{} preprocessed", entries.reload_fn).dimmed());
-    }
-    Err(failure) => {
-      eprintln!("\n{} preprocessing reload_fn", "✗".red());
-      let headline = failure.headline();
-      call_stack::display_stack_with_docs(&headline, &failure.stack, failure.location.as_ref(), failure.hint.as_deref())?;
-      return Err(headline);
-    }
-  }
-
-  if target == codegen::emit_wasm::WasmTarget::Wasi {
-    preprocess_wasm_namespace(entries, check_warnings)?;
-    codegen::emit_wasm::validate_wasm_target(&entries.init_ns, &entries.init_def, target)?;
-  }
-
-  let warnings = check_warnings.borrow();
-  if !warnings.is_empty() {
-    eprintln!("\n{} ({} warnings)", "Warnings:".yellow(), warnings.len());
-    LocatedWarning::print_list(&warnings);
-    return Err(format!("Found {} warnings during preprocessing", warnings.len()));
-  }
-
-  let duration = Instant::now().duration_since(started_time);
-  println!(
-    "\n{} {}",
-    "✓ Check passed".green().bold(),
-    format!("({}ms)", duration.as_micros() as f64 / 1000.0).dimmed()
-  );
-
-  Ok(())
-}
-
-fn run_wasm_codegen(entries: &ProgramEntries, emit_path: &str, target: codegen::emit_wasm::WasmTarget) -> Result<(), String> {
-  let started_time = Instant::now();
-  codegen::set_codegen_mode(true);
-
-  let check_warnings: &RefCell<Vec<LocatedWarning>> = &RefCell::new(vec![]);
-
-  preprocess_wasm_namespace(entries, check_warnings)?;
-
-  codegen::emit_wasm::emit_wasm(&entries.init_ns, &entries.init_def, emit_path, target)?;
-
-  let duration = Instant::now().duration_since(started_time);
-  println!("{}", format!("took {}ms", duration.as_micros() as f64 / 1000.0).dimmed());
-  Ok(())
-}
-
-fn preprocess_wasm_namespace(entries: &ProgramEntries, check_warnings: &RefCell<Vec<LocatedWarning>>) -> Result<(), String> {
-  // WASM codegen exports every compilable function, so preprocess all defs in target namespace.
-  let all_defs = program::list_source_def_names(&entries.init_ns);
-  for def_name in &all_defs {
-    if let Err(failure) =
-      runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, def_name, check_warnings, &CallStackList::default())
-    {
-      let headline = failure.headline();
-      call_stack::display_stack_with_docs(&headline, &failure.stack, failure.location.as_ref(), failure.hint.as_deref())?;
-      return Err(format!(
-        "WASM preprocessing failed for {}/{}: {headline}",
-        entries.init_ns, def_name
-      ));
-    }
-  }
-  Ok(())
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -83,6 +83,10 @@ pub struct ToplevelCalcit {
 pub enum CalcitCommand {
   /// emit JavaScript rather than interpreting
   EmitJs(EmitJsCommand),
+  /// emit a browser or embedded WebAssembly core module
+  EmitWasm(EmitWasmCommand),
+  /// emit a WebAssembly command module for a WASI host
+  EmitWasi(EmitWasiCommand),
   /// emit Cirru EDN representation of program to program-ir.cirru
   EmitIr(EmitIrCommand),
   /// evaluate snippet
@@ -219,6 +223,54 @@ pub struct EmitJsCommand {
   #[argh(switch, short = 'w')]
   pub watch: bool,
   /// check-only mode for JS emit
+  #[argh(switch)]
+  pub check_only: bool,
+}
+
+/// emit a browser or embedded WebAssembly core module
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand, name = "wasm")]
+pub struct EmitWasmCommand {
+  /// input source file, defaults to "calcit.cirru"
+  #[argh(positional)]
+  pub input: Option<String>,
+  /// output directory for program.wasm; defaults to the top-level emit path
+  #[argh(option)]
+  pub emit_path: Option<String>,
+  /// select a configured entry
+  #[argh(option)]
+  pub entry: Option<String>,
+  /// override the configured initialization definition
+  #[argh(option)]
+  pub init_fn: Option<String>,
+  /// override the configured reload definition
+  #[argh(option)]
+  pub reload_fn: Option<String>,
+  /// validate the core module without writing program.wasm
+  #[argh(switch)]
+  pub check_only: bool,
+}
+
+/// emit a WebAssembly command module for a WASI host
+#[derive(FromArgs, PartialEq, Debug, Clone)]
+#[argh(subcommand, name = "wasi")]
+pub struct EmitWasiCommand {
+  /// input source file, defaults to "calcit.cirru"
+  #[argh(positional)]
+  pub input: Option<String>,
+  /// output directory for program.wasm; defaults to the top-level emit path
+  #[argh(option)]
+  pub emit_path: Option<String>,
+  /// select a configured entry
+  #[argh(option)]
+  pub entry: Option<String>,
+  /// override the configured initialization definition; it must take no arguments
+  #[argh(option)]
+  pub init_fn: Option<String>,
+  /// override the configured reload definition
+  #[argh(option)]
+  pub reload_fn: Option<String>,
+  /// validate the WASI command without writing program.wasm
   #[argh(switch)]
   pub check_only: bool,
 }
@@ -2662,4 +2714,30 @@ pub struct ConfigRmTypeSlotCommand {
   /// slot name, with or without a leading colon
   #[argh(positional)]
   pub slot: String,
+}
+
+#[cfg(test)]
+mod wasm_command_tests {
+  use super::*;
+
+  #[test]
+  fn parses_public_wasm_commands_with_distinct_targets() {
+    let wasm = ToplevelCalcit::from_args(&["calcit"], &["wasm", "app.cirru", "--emit-path", "target/core", "--check-only"])
+      .expect("parse calcit wasm");
+    let Some(CalcitCommand::EmitWasm(options)) = wasm.subcommand else {
+      panic!("expected wasm subcommand");
+    };
+    assert_eq!(options.input.as_deref(), Some("app.cirru"));
+    assert_eq!(options.emit_path.as_deref(), Some("target/core"));
+    assert!(options.check_only);
+
+    let wasi =
+      ToplevelCalcit::from_args(&["calcit"], &["wasi", "command.cirru", "--init-fn", "app.main/main!"]).expect("parse calcit wasi");
+    let Some(CalcitCommand::EmitWasi(options)) = wasi.subcommand else {
+      panic!("expected wasi subcommand");
+    };
+    assert_eq!(options.input.as_deref(), Some("command.cirru"));
+    assert_eq!(options.init_fn.as_deref(), Some("app.main/main!"));
+    assert!(!options.check_only);
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod project_state;
 pub mod runner;
 pub mod snapshot;
 pub mod util;
+pub mod wasm_cli;
 
 use calcit::{CalcitErrKind, LocatedWarning};
 use call_stack::CallStackList;

--- a/src/wasm_cli.rs
+++ b/src/wasm_cli.rs
@@ -1,0 +1,189 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use colored::Colorize;
+
+use crate::calcit::LocatedWarning;
+use crate::call_stack::CallStackList;
+use crate::codegen::emit_wasm::WasmTarget;
+use crate::util::string::strip_shebang;
+use crate::{ProgramEntries, call_stack, codegen, program, runner, snapshot, util};
+
+#[derive(Clone, Debug)]
+pub struct WasmCliOptions {
+  pub input: String,
+  pub emit_path: String,
+  pub init_fn: Option<String>,
+  pub reload_fn: Option<String>,
+  pub entry: Option<String>,
+  pub check_only: bool,
+}
+
+pub fn run(options: &WasmCliOptions, target: WasmTarget) -> Result<(), String> {
+  let core_snapshot = crate::load_core_snapshot()?;
+
+  let input_path = PathBuf::from(&options.input);
+  crate::validate_snapshot_path(&input_path)?;
+  let input_path_str = input_path.to_string_lossy().to_string();
+  if !input_path.exists() {
+    return Err(format!("{} does not exist", input_path.display()));
+  }
+
+  let mut content = fs::read_to_string(&input_path).unwrap_or_else(|_| panic!("expected Cirru snapshot: {}", input_path.display()));
+  strip_shebang(&mut content);
+  let data = cirru_edn::parse(&content).map_err(|e| {
+    eprintln!("\nFailed to parse entry file '{}':", input_path.display());
+    eprintln!("{e}");
+    format!("Failed to parse entry file '{}'", input_path.display())
+  })?;
+  let mut snapshot = snapshot::load_snapshot_data(&data, &input_path_str)?;
+  let project_namespaces: HashSet<String> = snapshot.files.keys().cloned().collect();
+
+  snapshot.select_entry(options.entry.as_deref())?;
+  if options.entry.is_some() {
+    println!("running entry: {}", snapshot.active_entry_name());
+  }
+
+  let base_dir = input_path.parent().expect("extract parent");
+  let module_folder = crate::project_module_folder(base_dir);
+
+  let module_paths = snapshot.active_entry()?.modules.clone();
+  for module_path in &module_paths {
+    let module_data = crate::load_module(module_path, base_dir, &module_folder)?;
+    crate::merge_project_module_files(&mut snapshot, &module_data, module_path)?;
+  }
+
+  let selected_entry = snapshot.active_entry()?;
+  let config_init = selected_entry.init_fn.to_string();
+  let config_reload = selected_entry.reload_fn.to_string();
+  let init_fn = options.init_fn.as_deref().unwrap_or(&config_init);
+  let reload_fn = options.reload_fn.as_deref().unwrap_or(&config_reload);
+  let (init_ns, init_def) = util::string::extract_ns_def(init_fn)?;
+  let (reload_ns, reload_def) = util::string::extract_ns_def(reload_fn)?;
+  let entries = ProgramEntries {
+    init_fn: Arc::from(init_fn),
+    reload_fn: Arc::from(reload_fn),
+    init_def: init_def.into(),
+    init_ns: init_ns.into(),
+    reload_ns: reload_ns.into(),
+    reload_def: reload_def.into(),
+  };
+
+  for (namespace, file) in core_snapshot.files {
+    snapshot.files.entry(namespace).or_insert(file);
+  }
+  runner::preprocess::set_project_namespaces(&project_namespaces);
+
+  {
+    let mut program_data = program::PROGRAM_CODE_DATA.write().expect("open program data");
+    *program_data = program::extract_program_data(&snapshot)?;
+  }
+
+  let check_warnings = RefCell::new(vec![]);
+  runner::preprocess::ensure_ns_def_compiled(
+    crate::calcit::CORE_NS,
+    crate::calcit::BUILTIN_IMPLS_ENTRY,
+    &check_warnings,
+    &CallStackList::default(),
+  )
+  .map_err(|e| e.msg)?;
+
+  if options.check_only {
+    run_check_only(&entries, target)
+  } else {
+    run_wasm_codegen(&entries, &options.emit_path, target)
+  }
+}
+
+fn run_check_only(entries: &ProgramEntries, target: WasmTarget) -> Result<(), String> {
+  let started_time = Instant::now();
+  let check_warnings = RefCell::new(vec![]);
+
+  eprintln!("{}", "Check-only mode: validating code...".dimmed());
+
+  preprocess_entry(&entries.init_ns, &entries.init_def, &entries.init_fn, "init_fn", &check_warnings)?;
+  preprocess_entry(
+    &entries.reload_ns,
+    &entries.reload_def,
+    &entries.reload_fn,
+    "reload_fn",
+    &check_warnings,
+  )?;
+
+  if target == WasmTarget::Wasi {
+    preprocess_wasm_namespace(entries, &check_warnings)?;
+    codegen::emit_wasm::validate_wasm_target(&entries.init_ns, &entries.init_def, target)?;
+  }
+
+  let warnings = check_warnings.borrow();
+  if !warnings.is_empty() {
+    eprintln!("\n{} ({} warnings)", "Warnings:".yellow(), warnings.len());
+    LocatedWarning::print_list(&warnings);
+    return Err(format!("Found {} warnings during preprocessing", warnings.len()));
+  }
+
+  let duration = Instant::now().duration_since(started_time);
+  println!(
+    "\n{} {}",
+    "✓ Check passed".green().bold(),
+    format!("({}ms)", duration.as_micros() as f64 / 1000.0).dimmed()
+  );
+
+  Ok(())
+}
+
+fn preprocess_entry(
+  namespace: &str,
+  definition: &str,
+  display_name: &str,
+  entry_kind: &str,
+  check_warnings: &RefCell<Vec<LocatedWarning>>,
+) -> Result<(), String> {
+  match runner::preprocess::ensure_ns_def_compiled(namespace, definition, check_warnings, &CallStackList::default()) {
+    Ok(_) => {
+      println!("  {} {}", "✓".green(), format!("{display_name} preprocessed").dimmed());
+      Ok(())
+    }
+    Err(failure) => {
+      eprintln!("\n{} preprocessing {entry_kind}", "✗".red());
+      let headline = failure.headline();
+      call_stack::display_stack_with_docs(&headline, &failure.stack, failure.location.as_ref(), failure.hint.as_deref())?;
+      Err(headline)
+    }
+  }
+}
+
+fn run_wasm_codegen(entries: &ProgramEntries, emit_path: &str, target: WasmTarget) -> Result<(), String> {
+  let started_time = Instant::now();
+  codegen::set_codegen_mode(true);
+
+  let check_warnings = RefCell::new(vec![]);
+  preprocess_wasm_namespace(entries, &check_warnings)?;
+  codegen::emit_wasm::emit_wasm(&entries.init_ns, &entries.init_def, emit_path, target)?;
+
+  let duration = Instant::now().duration_since(started_time);
+  println!("{}", format!("took {}ms", duration.as_micros() as f64 / 1000.0).dimmed());
+  Ok(())
+}
+
+fn preprocess_wasm_namespace(entries: &ProgramEntries, check_warnings: &RefCell<Vec<LocatedWarning>>) -> Result<(), String> {
+  // WASM codegen exports every compilable function, so preprocess all defs in target namespace.
+  let all_defs = program::list_source_def_names(&entries.init_ns);
+  for def_name in &all_defs {
+    if let Err(failure) =
+      runner::preprocess::ensure_ns_def_compiled(&entries.init_ns, def_name, check_warnings, &CallStackList::default())
+    {
+      let headline = failure.headline();
+      call_stack::display_stack_with_docs(&headline, &failure.stack, failure.location.as_ref(), failure.hint.as_deref())?;
+      return Err(format!(
+        "WASM preprocessing failed for {}/{}: {headline}",
+        entries.init_ns, def_name
+      ));
+    }
+  }
+  Ok(())
+}


### PR DESCRIPTION
## 中文

### 背景

`cr-wasm` 已完成 core/WASI target bridge，但内部 binary 不适合作为长期用户和 Agent 契约。本 PR 完成 #1031，把两种输出放到统一 `calcit` CLI，并保持一个共享实现。

### 修改

- 增加 `calcit wasm <snapshot>`，生成 browser/embedded core module。
- 增加 `calcit wasi <snapshot>`，生成带 `_start` 的 WASI command module。
- 两个子命令与过渡期 `cr-wasm` 共用 Snapshot 加载、entry 选择、预处理、target validation 与 codegen。
- 子命令参数优先，已有顶层 input/emit/entry/init/reload/check-only 参数作为兼容 fallback；不会静默忽略顶层 `--check-only`。
- 公开命令遵循默认严格类型诊断，并正确登记项目 namespace；旧 core fixture 仅在仓库兼容回归中显式使用 `--compat-types`。
- core/WASI 脚本与 Actions 改用公开命令；更新中文用户/Agent 文档和 AGENTS.md。

### 测试

- `cargo test --all-targets`：771 + 340 + 17 + 4 通过。
- `cargo clippy --all-targets -- -D warnings`。
- `corepack yarn check-all`。
- `CALCIT_BIN=./target/debug/calcit bash scripts/test-wasm.sh`：Calcit definition `:tests` 与 Node core WASM suite 通过。
- `bash scripts/test-wasi-preprocess.sh`：本机 `wasm32-wasip1` 自举、严格 Calcit `:tests`、无输出 check-only、Wasmtime `_start` 与 fail-closed 错误通过。
- `bash scripts/check-docs-md.sh`：65 个文件、331 个代码块通过。
- `cargo check --bin cr-wasm --target wasm32-wasip1`。

用户可观察的 WASM 语义沿用 `calcit/test-wasm.cirru` 和 `calcit/test-wasi-command.cirru` 的 definition `:tests`；新增 Rust 测试只验证无法由 Calcit definition 表达的 CLI parsing 分流。

Closes #1031

## English

### Context

`cr-wasm` already carries the core/WASI target bridge, but an internal binary is not a suitable long-term contract for users or agents. This PR completes #1031 by exposing both output kinds through the unified `calcit` CLI while retaining one shared implementation.

### Changes

- Add `calcit wasm <snapshot>` for browser/embedded core modules.
- Add `calcit wasi <snapshot>` for WASI command modules with `_start`.
- Share Snapshot loading, entry selection, preprocessing, target validation, and codegen across both public commands and the transitional `cr-wasm` wrapper.
- Prefer subcommand arguments while retaining existing top-level input/emit/entry/init/reload/check-only arguments as compatibility fallbacks; top-level `--check-only` is never silently ignored.
- Honor strict diagnostics by default and register project namespaces correctly. Only the legacy core fixture explicitly uses `--compat-types` in repository compatibility coverage.
- Migrate core/WASI scripts and Actions to the public commands; update Chinese user/agent documentation and AGENTS.md.

### Validation

- `cargo test --all-targets`: 771 + 340 + 17 + 4 passed.
- `cargo clippy --all-targets -- -D warnings`.
- `corepack yarn check-all`.
- `CALCIT_BIN=./target/debug/calcit bash scripts/test-wasm.sh`: Calcit definition `:tests` and the Node core WASM suite passed.
- `bash scripts/test-wasi-preprocess.sh`: local `wasm32-wasip1` bootstrap, strict Calcit `:tests`, output-free check-only, Wasmtime `_start`, and fail-closed errors passed.
- `bash scripts/check-docs-md.sh`: 65 files and 331 code blocks passed.
- `cargo check --bin cr-wasm --target wasm32-wasip1`.

User-visible WASM semantics continue to live in definition `:tests` in `calcit/test-wasm.cirru` and `calcit/test-wasi-command.cirru`. The added Rust test only covers CLI parsing dispatch that cannot be expressed through a Calcit definition.

Closes #1031