### PR TITLE
feat(wasi): 支持 Calcit 标准输出 / support Calcit stdio

### DIFF
--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -10,7 +10,7 @@
       :defs $ {}
         'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn main! () $ + 1 2
+            defn main! () (println |WASI-stdout: "|你好") (echo |WASI-echo) (eprintln |WASI-stderr: 42) (+ 1 2)
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)

--- a/editing-history/202609122355-wasi-preview1-stdio.md
+++ b/editing-history/202609122355-wasi-preview1-stdio.md
@@ -1,0 +1,19 @@
+# WASI Preview 1 标准输出 / WASI Preview 1 stdio
+
+## 中文
+
+- 为 WASI command target 登记真实类型的 `wasi_snapshot_preview1.fd_write` 导入，同时让通用宿主导入描述支持非 `f64` 参数与返回值。
+- `println`、`eprintln` 与 `echo` 保持 Calcit 表层 API，通过私有运行时适配层分别写入 stdout/stderr；多参数使用空格连接并补换行。
+- 写入按照 UTF-8 字节长度执行，并循环处理短写；WASI errno、零进展或无效的超长写入会 trap，避免产生被静默截断的输出。
+- `calcit/test-wasi-command.cirru` 在定义级测试中保留返回值语义，`scripts/test-wasi-preprocess.sh` 使用 Wasmtime 捕获并核对 Unicode stdout 与数值 stderr。
+
+验证：`cargo fmt --check`、`cargo test wasi_target_registers_the_preview1_fd_write_abi --lib`、`bash scripts/test-wasi-preprocess.sh`。
+
+## English
+
+- Registered the accurately typed `wasi_snapshot_preview1.fd_write` import for the WASI command target and generalized host-import declarations beyond the former all-`f64` signature.
+- Kept `println`, `eprintln`, and `echo` as target-independent Calcit APIs, lowering them through a private runtime adapter to stdout or stderr with space-separated arguments and a trailing newline.
+- Writes use UTF-8 byte lengths and retry short writes. WASI errors, zero progress, and invalid oversized writes trap instead of silently truncating output.
+- `calcit/test-wasi-command.cirru` retains return-value semantics in definition-attached tests, while `scripts/test-wasi-preprocess.sh` captures and verifies Unicode stdout and numeric stderr under Wasmtime.
+
+Verified with `cargo fmt --check`, `cargo test wasi_target_registers_the_preview1_fd_write_abi --lib`, and `bash scripts/test-wasi-preprocess.sh`.

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -7,6 +7,8 @@ readonly FIXTURE="calcit/test-wasi-preprocess.cirru"
 readonly WASM_BIN="${CARGO_TARGET_DIR:-target}/${TARGET}/debug/cr-wasm.wasm"
 readonly COMMAND_FIXTURE="calcit/test-wasi-command.cirru"
 readonly COMMAND_OUT="${CARGO_TARGET_DIR:-target}/wasi-command-smoke"
+readonly COMMAND_STDOUT="${COMMAND_OUT}/stdout.txt"
+readonly COMMAND_STDERR="${COMMAND_OUT}/stderr.txt"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
@@ -32,7 +34,12 @@ if [[ -e "$CHECK_ONLY_OUT/program.wasm" ]]; then
   exit 1
 fi
 "$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --emit-path "$COMMAND_OUT"
-wasmtime run "$COMMAND_OUT/program.wasm"
+wasmtime run "$COMMAND_OUT/program.wasm" >"$COMMAND_STDOUT" 2>"$COMMAND_STDERR"
+grep -Fxq "WASI-stdout: 你好" "$COMMAND_STDOUT"
+grep -Fxq "WASI-echo" "$COMMAND_STDOUT"
+grep -Fxq "WASI-stderr: 42" "$COMMAND_STDERR"
+[ "$(wc -l <"$COMMAND_STDOUT")" -eq 2 ]
+[ "$(wc -l <"$COMMAND_STDERR")" -eq 1 ]
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
   echo "cr-wasm unexpectedly accepted an unknown target" >&2

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -44,7 +44,10 @@ mod runtime;
 mod structs;
 
 use methods::{emit_call_args, emit_method_invoke};
-use runtime::{HostImport, ModuleFunctionLayout, build_runtime_fns, build_wasm_module, core_host_import, host_imports_for_target};
+use runtime::{
+  HostImport, ModuleFunctionLayout, build_runtime_fns, build_wasi_write_all_fn, build_wasm_module, core_host_import,
+  host_imports_for_target,
+};
 use structs::{
   emit_enum_assoc, emit_enum_count, emit_enum_new, emit_enum_nth, emit_named_enum_new, emit_struct_contains, emit_struct_count,
   emit_struct_def, emit_struct_field_tag, emit_struct_get, emit_struct_get_name, emit_struct_matches, emit_struct_new, emit_struct_nth,
@@ -208,7 +211,8 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
       host_imports.push(HostImport {
         module,
         name,
-        arity: arity as usize,
+        params: vec![ValType::F64; arity as usize],
+        results: vec![ValType::F64],
       });
       let qualified = format!("{ns}/{def_name}");
       wasm_import_names.insert(qualified.clone(), index);
@@ -229,6 +233,14 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
     *tag_index.get("list").expect("list tag must exist") as i32,
     *tag_index.get("string").expect("string tag must exist") as i32,
   );
+  if target == WasmTarget::Wasi {
+    let fd_write_idx = *index_host_imports(&host_imports)
+      .get(&("wasi_snapshot_preview1".into(), "fd_write".into()))
+      .expect("WASI fd_write import must be registered");
+    let wasi_write_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_write_all".into(), wasi_write_idx);
+    compiled_fns.push(build_wasi_write_all_fn(fd_write_idx));
+  }
 
   // Emit __str_new(src_ptr: i32, byte_len: i32) → f64 now that we know the string tag id.
   // This is a runtime helper exported for JS FFI: copies bytes into a tagged heap string.
@@ -286,7 +298,7 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
   let struct_field_tags = collect_struct_field_tags_from_program(&program_data, &tag_index);
 
   // Build string literal pool: assigns each unique string a memory offset.
-  let (string_pool, string_data_segment, heap_start) = build_string_pool(&fn_defs, &tag_index);
+  let (string_pool, string_data_segment, heap_start) = build_string_pool(&fn_defs, &tag_index, target);
 
   // Scan for defatom definitions — each gets a mutable WASM global (f64).
   let mut atom_initial_values: Vec<f64> = Vec::new();
@@ -333,6 +345,7 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
     value_imports,
     fn_table_index,
     host_imports: index_host_imports(&host_imports),
+    target,
   };
 
   // Second pass: target failures reject the artifact. Dependency failures keep
@@ -496,6 +509,8 @@ struct WasmCompileEnv {
   fn_table_index: HashMap<String, u32>,
   /// Target-approved host imports keyed by `(module, field)`.
   host_imports: HashMap<(String, String), u32>,
+  /// Selected output ABI. Surface Calcit calls stay target-independent.
+  target: WasmTarget,
 }
 
 fn extract_fn_parts(code: &Calcit) -> Result<(CalcitFnArgs, Vec<Calcit>), String> {
@@ -623,6 +638,8 @@ struct WasmGenCtx {
   fn_table_index: HashMap<String, u32>,
   /// Target-approved host imports keyed by `(module, field)`.
   host_imports: HashMap<(String, String), u32>,
+  /// Selected output ABI. Surface Calcit calls stay target-independent.
+  target: WasmTarget,
   /// Statically known closures retain the lexical local bindings visible at creation.
   /// They are specialized at known call sites instead of receiving a dynamic heap ABI.
   lambda_locals: HashMap<String, Arc<InlineClosure>>,
@@ -649,6 +666,7 @@ impl WasmGenCtx {
       value_imports: env.value_imports,
       fn_table_index: env.fn_table_index,
       host_imports: env.host_imports,
+      target: env.target,
       lambda_locals: HashMap::new(),
     }
   }
@@ -1459,6 +1477,9 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
       let name = sym.as_ref();
       // IO functions: call host log_value for each arg, return nil
       if matches!(name, "println" | "eprintln" | "echo") {
+        if ctx.target == WasmTarget::Wasi {
+          return emit_wasi_print(ctx, name, &args_list);
+        }
         let log_idx = resolve_host_import(ctx, "io", "log_value")?;
         for arg in &args_list {
           emit_expr(ctx, arg)?;
@@ -1509,6 +1530,9 @@ fn emit_call_expr(ctx: &mut WasmGenCtx, xs: &crate::calcit::CalcitList) -> Resul
       // Registered procs (eprintln, println, echo, etc.)
       let name = name.as_ref();
       if matches!(name, "println" | "eprintln" | "echo") {
+        if ctx.target == WasmTarget::Wasi {
+          return emit_wasi_print(ctx, name, &args_list);
+        }
         let log_idx = resolve_host_import(ctx, "io", "log_value")?;
         for arg in &args_list {
           emit_expr(ctx, arg)?;
@@ -2435,7 +2459,7 @@ fn emit_type_predicate(ctx: &mut WasmGenCtx, type_name: &str, args: &[Calcit]) -
 /// Emit a call to a host-imported function by name.
 fn emit_host_call(ctx: &mut WasmGenCtx, name: &str, args: &[Calcit]) -> Result<(), String> {
   let import = core_host_import(name).ok_or_else(|| format!("unknown host import: {name}"))?;
-  let expected_arity = import.arity;
+  let expected_arity = import.params.len();
   if args.len() != expected_arity {
     return Err(format!("{name} expects {expected_arity} args, got {}", args.len()));
   }
@@ -2443,6 +2467,48 @@ fn emit_host_call(ctx: &mut WasmGenCtx, name: &str, args: &[Calcit]) -> Result<(
     emit_expr(ctx, arg)?;
   }
   ctx.emit(Instruction::Call(resolve_host_import(ctx, &import.module, &import.name)?));
+  Ok(())
+}
+
+fn emit_wasi_write_string(ctx: &mut WasmGenCtx, fd: i32, ptr: u32) {
+  let len = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalGet(ptr));
+  ctx.emit(Instruction::F64Load(mem_arg_f64(0)));
+  ctx.emit(Instruction::I32TruncF64U);
+  ctx.emit(Instruction::LocalSet(len));
+  ctx.emit(Instruction::I32Const(fd));
+  ctx.emit(Instruction::LocalGet(ptr));
+  ctx.emit(Instruction::I32Const(8));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalGet(len));
+  ctx.call_rt("__rt_wasi_write_all");
+}
+
+fn emit_wasi_write_literal(ctx: &mut WasmGenCtx, fd: i32, text: &str) -> Result<(), String> {
+  let ptr = *ctx
+    .string_pool
+    .get(text)
+    .ok_or_else(|| format!("internal WASI output literal missing from string pool: {text:?}"))?;
+  let ptr_local = ctx.alloc_i32(ptr as i32);
+  emit_wasi_write_string(ctx, fd, ptr_local);
+  Ok(())
+}
+
+/// Lower Calcit console output through a private Preview 1 adapter.
+fn emit_wasi_print(ctx: &mut WasmGenCtx, name: &str, args: &[Calcit]) -> Result<(), String> {
+  let fd = if name == "eprintln" { 2 } else { 1 };
+  for (index, arg) in args.iter().enumerate() {
+    if index > 0 {
+      emit_wasi_write_literal(ctx, fd, " ")?;
+    }
+    emit_expr(ctx, arg)?;
+    let value = ctx.alloc_local();
+    ctx.emit(Instruction::LocalSet(value));
+    let ptr = emit_turn_string_from_local(ctx, value);
+    emit_wasi_write_string(ctx, fd, ptr);
+  }
+  emit_wasi_write_literal(ctx, fd, "\n")?;
+  ctx.emit(f64_const(0.0));
   Ok(())
 }
 
@@ -3282,12 +3348,17 @@ fn collect_tags_from_expr(expr: &Calcit, tags: &mut Vec<String>) {
 fn build_string_pool(
   fn_defs: &[(String, String, CalcitFnArgs, Vec<Calcit>)],
   tag_index: &HashMap<String, u32>,
+  target: WasmTarget,
 ) -> (HashMap<String, u32>, Vec<u8>, i32) {
   let mut strings: Vec<String> = Vec::new();
   for (_, _, _, body) in fn_defs {
     for expr in body {
       collect_strings_from_expr(expr, &mut strings);
     }
+  }
+  if target == WasmTarget::Wasi {
+    strings.push(" ".into());
+    strings.push("\n".into());
   }
   strings.sort();
   strings.dedup();
@@ -3422,8 +3493,9 @@ mod tests {
   use std::str::FromStr;
   use std::sync::Arc;
 
-  use super::{HostImport, WasmTarget, index_host_imports, must_reject_extraction_failure};
+  use super::{HostImport, WasmTarget, host_imports_for_target, index_host_imports, must_reject_extraction_failure};
   use crate::calcit::{Calcit, CalcitList, CalcitSyntax};
+  use wasm_encoder::ValType;
 
   fn declaration(head: CalcitSyntax) -> Calcit {
     let items = [Calcit::Syntax(head, Arc::from("dependency.ns"))];
@@ -3457,14 +3529,28 @@ mod tests {
       HostImport {
         module: "io".into(),
         name: "log_value".into(),
-        arity: 1,
+        params: vec![ValType::F64],
+        results: vec![ValType::F64],
       },
       HostImport {
         module: "io".into(),
         name: "log_value".into(),
-        arity: 2,
+        params: vec![ValType::F64; 2],
+        results: vec![ValType::F64],
       },
     ];
     assert_eq!(index_host_imports(&imports).get(&("io".into(), "log_value".into())), Some(&0));
+  }
+
+  #[test]
+  fn wasi_target_registers_the_preview1_fd_write_abi() {
+    let imports = host_imports_for_target(WasmTarget::Wasi);
+    let [fd_write] = imports.as_slice() else {
+      panic!("WASI stdio slice must register exactly fd_write");
+    };
+    assert_eq!(fd_write.module, "wasi_snapshot_preview1");
+    assert_eq!(fd_write.name, "fd_write");
+    assert_eq!(fd_write.params, vec![ValType::I32; 4]);
+    assert_eq!(fd_write.results, vec![ValType::I32]);
   }
 }

--- a/src/codegen/emit_wasm/lists.rs
+++ b/src/codegen/emit_wasm/lists.rs
@@ -1744,6 +1744,7 @@ mod sort_tests {
         value_imports: HashMap::new(),
         fn_table_index: HashMap::new(),
         host_imports: HashMap::new(),
+        target: WasmTarget::Core,
       },
     )
   }

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -6,7 +6,8 @@ use wasm_encoder::{BlockType, Ieee64};
 pub(super) struct HostImport {
   pub(super) module: String,
   pub(super) name: String,
-  pub(super) arity: usize,
+  pub(super) params: Vec<ValType>,
+  pub(super) results: Vec<ValType>,
 }
 
 pub(super) struct ModuleFunctionLayout {
@@ -15,65 +16,75 @@ pub(super) struct ModuleFunctionLayout {
 }
 
 /// List of host-imported functions.
-/// These are provided by the JS environment and indexed before user functions.
+/// These are provided by the selected host and indexed before user functions.
 static CORE_HOST_IMPORTS: LazyLock<Vec<HostImport>> = LazyLock::new(|| {
   vec![
     HostImport {
       module: "math".into(),
       name: "pow".into(),
-      arity: 2,
+      params: vec![ValType::F64; 2],
+      results: vec![ValType::F64],
     },
     HostImport {
       module: "math".into(),
       name: "sin".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
     HostImport {
       module: "math".into(),
       name: "cos".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
     // IO: log a single value (f64) — host reads memory to decode type
     HostImport {
       module: "io".into(),
       name: "log_value".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
     // IO: log a string directly (ptr to heap string) — more efficient than log_value for strings
     HostImport {
       module: "io".into(),
       name: "log_str".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
     // IO: read file contents as string (ptr to path in heap)
     HostImport {
       module: "io".into(),
       name: "read_file_str".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
     // IO: check if file exists (ptr to path in heap) — returns 1.0 if exists, 0.0 otherwise
     HostImport {
       module: "io".into(),
       name: "file_exists".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
     // IO: parse JSON string (ptr to JSON string in heap) — returns parsed value or nil on error
     HostImport {
       module: "io".into(),
       name: "parse_json".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
     // IO: get current time in milliseconds
     HostImport {
       module: "io".into(),
       name: "current_time".into(),
-      arity: 0,
+      params: vec![],
+      results: vec![ValType::F64],
     },
     // IO: get environment variable (ptr to key in heap) — returns value string or nil
     HostImport {
       module: "io".into(),
       name: "get_env".into(),
-      arity: 1,
+      params: vec![ValType::F64],
+      results: vec![ValType::F64],
     },
   ]
 });
@@ -81,12 +92,78 @@ static CORE_HOST_IMPORTS: LazyLock<Vec<HostImport>> = LazyLock::new(|| {
 pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
   match target {
     WasmTarget::Core => CORE_HOST_IMPORTS.to_vec(),
-    WasmTarget::Wasi => vec![],
+    WasmTarget::Wasi => vec![HostImport {
+      module: "wasi_snapshot_preview1".into(),
+      name: "fd_write".into(),
+      params: vec![ValType::I32; 4],
+      results: vec![ValType::I32],
+    }],
   }
 }
 
 pub(super) fn core_host_import(name: &str) -> Option<&'static HostImport> {
   CORE_HOST_IMPORTS.iter().find(|import| import.name == name)
+}
+
+/// Build the internal Preview 1 writer used by Calcit console operations.
+/// The iovec and result word use the 16-byte scratch area below `HEAP_BASE`.
+pub(super) fn build_wasi_write_all_fn(fd_write_idx: u32) -> CompiledFn {
+  // params: 0=fd, 1=remaining byte pointer, 2=remaining byte length
+  // local: 3=bytes written by the current call
+  let instructions = vec![
+    Instruction::Block(BlockType::Empty),
+    Instruction::Loop(BlockType::Empty),
+    Instruction::LocalGet(2),
+    Instruction::I32Eqz,
+    Instruction::BrIf(1),
+    // ciovec { buf: 0, buf_len: 4 }, nwritten at 8.
+    Instruction::I32Const(0),
+    Instruction::LocalGet(1),
+    Instruction::I32Store(mem_arg_i32(0)),
+    Instruction::I32Const(4),
+    Instruction::LocalGet(2),
+    Instruction::I32Store(mem_arg_i32(0)),
+    Instruction::LocalGet(0),
+    Instruction::I32Const(0),
+    Instruction::I32Const(1),
+    Instruction::I32Const(8),
+    Instruction::Call(fd_write_idx),
+    // A host error or a zero-byte successful write cannot make progress.
+    Instruction::If(BlockType::Empty),
+    Instruction::Unreachable,
+    Instruction::End,
+    Instruction::I32Const(8),
+    Instruction::I32Load(mem_arg_i32(0)),
+    Instruction::LocalTee(3),
+    Instruction::I32Eqz,
+    Instruction::If(BlockType::Empty),
+    Instruction::Unreachable,
+    Instruction::End,
+    Instruction::LocalGet(3),
+    Instruction::LocalGet(2),
+    Instruction::I32GtU,
+    Instruction::If(BlockType::Empty),
+    Instruction::Unreachable,
+    Instruction::End,
+    Instruction::LocalGet(1),
+    Instruction::LocalGet(3),
+    Instruction::I32Add,
+    Instruction::LocalSet(1),
+    Instruction::LocalGet(2),
+    Instruction::LocalGet(3),
+    Instruction::I32Sub,
+    Instruction::LocalSet(2),
+    Instruction::Br(0),
+    Instruction::End,
+    Instruction::End,
+  ];
+  CompiledFn {
+    export_name: None,
+    params: vec![ValType::I32; 3],
+    results: vec![],
+    locals: vec![ValType::I32],
+    instructions,
+  }
 }
 
 /// Maximum arity covered by canonical call_indirect type entries.
@@ -121,8 +198,7 @@ pub(super) fn build_wasm_module(
     types.ty().function(vec![ValType::F64; arity as usize], vec![ValType::F64]);
   }
   for imp in host_imports {
-    let params: Vec<ValType> = vec![ValType::F64; imp.arity];
-    types.ty().function(params, vec![ValType::F64]);
+    types.ty().function(imp.params.clone(), imp.results.clone());
   }
   for f in fns {
     types.ty().function(f.params.clone(), f.results.clone());


### PR DESCRIPTION
## 中文

这是 #1020 的第一片可审阅实现，先完成 WASI command 的 stdout/stderr 能力。

- 为 WASI target 登记真实类型的 `wasi_snapshot_preview1.fd_write`，宿主导入不再局限于全 `f64` 签名。
- Calcit 源码继续使用 `println`、`eprintln`、`echo`；Preview 1 ABI 只存在于私有生成层。
- 多参数保持空格分隔与结尾换行，stdout/stderr 分流。
- 按 UTF-8 字节写入并循环处理短写；errno、零进展和无效超长写入会 trap。
- 定义级 `:tests` 保留 Calcit 返回值语义，脚本在 Wasmtime 下捕获并核对 Unicode stdout、`echo` 与数值 stderr。

验证：

- `cargo test`
- `bash scripts/test-wasm.sh`
- `bash scripts/test-wasi-preprocess.sh`
- `cargo fmt --check`

推进 #1020；args/env/exit 将继续拆成后续 PR。

## English

This is the first reviewable slice of #1020, adding stdout/stderr support to WASI command modules.

- Registers the accurately typed `wasi_snapshot_preview1.fd_write` import; host imports are no longer restricted to all-`f64` signatures.
- Calcit source keeps using `println`, `eprintln`, and `echo`; the Preview 1 ABI remains private to generated code.
- Preserves space-separated arguments, trailing newlines, and stdout/stderr routing.
- Writes UTF-8 bytes and retries short writes; errno, zero progress, and invalid oversized writes trap.
- Definition-attached `:tests` retain Calcit return-value semantics, while the Wasmtime boundary test captures Unicode stdout, `echo`, and numeric stderr.

Verification:

- `cargo test`
- `bash scripts/test-wasm.sh`
- `bash scripts/test-wasi-preprocess.sh`
- `cargo fmt --check`

Progresses #1020; args/env/exit remain in follow-up PRs.