### PR TITLE
feat(wasi): 支持参数与环境变量 / support arguments and environment

### DIFF
--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -10,7 +10,11 @@
       :defs $ {}
         'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn main! () (println |WASI-stdout: "|你好") (echo |WASI-echo) (eprintln |WASI-stderr: 42) (+ 1 2)
+            defn main! () (println |WASI-stdout: "|你好") (echo |WASI-echo) (eprintln |WASI-stderr: 42)
+              println |WASI-env: $ option:unwrap-or (get-env |CALCIT_WASI_TEST_ENV) |missing
+              each (get-args)
+                fn (arg) (println |WASI-arg: arg)
+              + 1 2
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Number)
@@ -32,6 +36,20 @@
               :code $ quote
                 assert= 3 $ needs-arg 3
               :tags $ #{} :core :unit :wasi :wasm
+        'read-args $ %{} 'CodeEntry (:doc "|读取当前宿主进程的完整参数列表。")
+          :code $ quote
+            defn read-args () $ get-args
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ []
+              :features $ #{} :env :io
+              :return $ :: 'List 'String
+          :tests $ []
+            %{} 'TestEntry (:name |returns-strings)
+              :code $ quote
+                assert= true $ every? (read-args) string?
+              :tags $ #{} :core :env :unit :wasi :wasm
         'reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () &unit

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -473,6 +473,8 @@ calcit wasi calcit.cirru --emit-path target/wasi-command
 
 两个命令都支持 `--entry`、`--init-fn`、`--reload-fn` 和 `--check-only`。`--check-only` 会执行与实际生成相同的 target validation，但不会写出 `program.wasm`。WASI command 的 init definition 必须为零参数；不支持的宿主能力以稳定的 `E_WASM_CAPABILITY` 失败，不会退回 core module 的 JavaScript imports。
 
+WASI command 当前可通过与原生、JavaScript 相同的 `get-env` 和 `get-args` API 读取环境变量与命令参数。`get-env` 返回 `Option<String>`；`get-args` 返回包含第 0 项的完整 `List<String>`。Preview 1 的缓冲区和指针 ABI 只存在于编译器内部，不进入 Calcit 源码接口。
+
 ## Markdown code checking
 
 Use `docs check-md` to validate fenced code blocks in markdown files:

--- a/editing-history/202609130046-wasi-args-env.md
+++ b/editing-history/202609130046-wasi-args-env.md
@@ -1,0 +1,19 @@
+# WASI 命令参数与环境变量 / WASI arguments and environment
+
+## 中文
+
+- 新增严格类型的 `get-args -> List<String>`，并在原生与 JavaScript 后端返回宿主传入的完整参数列表；无法转换为 UTF-8 的原生参数会返回 effect error。
+- WASI command target 通过私有 Preview 1 适配层实现 `args_sizes_get`、`args_get`、`environ_sizes_get` 与 `environ_get`，对 Calcit 仍只暴露 `List<String>` 和 `Option<String>`。
+- WASI errno 或越界、未终止的宿主缓冲区会 trap；未设置的环境变量保持 `%none`，不被宿主错误混淆。
+- 用户语义由 core 与 command fixture 的 definition `:tests` 覆盖；shell 只核对 Wasmtime 的 Unicode 参数、环境变量和 ABI 边界。
+
+验证：`cargo fmt --all -- --check`、`cargo clippy --all-targets -- -D warnings`、`cargo test -q`、`yarn compile`、`yarn check-js-runtime`、core unit tests、core quality baseline，以及 `bash scripts/test-wasi-preprocess.sh`。
+
+## English
+
+- Added the strictly typed `get-args -> List<String>` API and return the complete host argument vector on native and JavaScript backends. Native arguments that cannot be converted to UTF-8 produce an effect error.
+- Implemented `args_sizes_get`, `args_get`, `environ_sizes_get`, and `environ_get` for the WASI command target behind a private Preview 1 adapter; Calcit still exposes only `List<String>` and `Option<String>`.
+- WASI errno values and out-of-bounds or unterminated host buffers trap. An unset environment variable remains `%none` and is not confused with a host failure.
+- Core and command-fixture definition `:tests` cover user semantics; the shell test is limited to Unicode arguments, environment values, and the Wasmtime ABI boundary.
+
+Verified with `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -q`, `yarn compile`, `yarn check-js-runtime`, core unit tests, the core quality baseline, and `bash scripts/test-wasi-preprocess.sh`.

--- a/editing-history/202609130111-wasi-scratch-memory.md
+++ b/editing-history/202609130111-wasi-scratch-memory.md
@@ -1,0 +1,17 @@
+# WASI 临时内存复用 / Reusable WASI scratch memory
+
+## 中文
+
+- 将 WASI 参数与环境变量适配器的宿主原始缓冲区移出 Calcit 托管 bump heap，改为从线性内存顶部按调用复用的临时区域。
+- 在预留临时区域时同时估算本次适配器仍会产生的托管对象空间，必要时通过 `memory.grow` 扩容，避免字符串与列表分配覆盖宿主缓冲区。
+- 使用 64 位中间值检查 Preview 1 返回的数量和缓冲区大小，并验证参数指针有序、互不重叠且以 NUL 结尾。
+
+验证：`cargo fmt --all -- --check`、`cargo clippy --all-targets -- -D warnings`、`bash scripts/test-wasi-preprocess.sh`。
+
+## English
+
+- Moved raw host buffers used by the WASI arguments and environment adapters out of the Calcit managed bump heap into a per-call scratch region reused from the top of linear memory.
+- Reserve enough room for managed objects allocated while the adapter is active and grow memory when needed, preventing strings and lists from overlapping the host buffer.
+- Use 64-bit intermediate sizes for Preview 1 counts and buffers, and validate that argument pointers are ordered, non-overlapping, and NUL-terminated.
+
+Verified with `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `bash scripts/test-wasi-preprocess.sh`.

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -9,6 +9,7 @@ readonly COMMAND_FIXTURE="calcit/test-wasi-command.cirru"
 readonly COMMAND_OUT="${CARGO_TARGET_DIR:-target}/wasi-command-smoke"
 readonly COMMAND_STDOUT="${COMMAND_OUT}/stdout.txt"
 readonly COMMAND_STDERR="${COMMAND_OUT}/stderr.txt"
+readonly COMMAND_MISSING_STDOUT="${COMMAND_OUT}/missing-env-stdout.txt"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
@@ -34,12 +35,20 @@ if [[ -e "$CHECK_ONLY_OUT/program.wasm" ]]; then
   exit 1
 fi
 "$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --emit-path "$COMMAND_OUT"
-wasmtime run "$COMMAND_OUT/program.wasm" >"$COMMAND_STDOUT" 2>"$COMMAND_STDERR"
+wasmtime run \
+  --env CALCIT_WASI_TEST_ENV=环境 \
+  "$COMMAND_OUT/program.wasm" \
+  alpha "参数" >"$COMMAND_STDOUT" 2>"$COMMAND_STDERR"
 grep -Fxq "WASI-stdout: 你好" "$COMMAND_STDOUT"
 grep -Fxq "WASI-echo" "$COMMAND_STDOUT"
+grep -Fxq "WASI-env: 环境" "$COMMAND_STDOUT"
+grep -Fxq "WASI-arg: alpha" "$COMMAND_STDOUT"
+grep -Fxq "WASI-arg: 参数" "$COMMAND_STDOUT"
 grep -Fxq "WASI-stderr: 42" "$COMMAND_STDERR"
-[ "$(wc -l <"$COMMAND_STDOUT")" -eq 2 ]
+[ "$(grep -Fc "WASI-arg: " "$COMMAND_STDOUT")" -eq 3 ]
 [ "$(wc -l <"$COMMAND_STDERR")" -eq 1 ]
+wasmtime run --env A=x "$COMMAND_OUT/program.wasm" >"$COMMAND_MISSING_STDOUT" 2>/dev/null
+grep -Fxq "WASI-env: missing" "$COMMAND_MISSING_STDOUT"
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
   echo "cr-wasm unexpectedly accepted an unknown target" >&2

--- a/scripts/wasm-validation.md
+++ b/scripts/wasm-validation.md
@@ -59,7 +59,7 @@ calcit wasm calcit.cirru --emit-path js-out
 
 ```bash
 calcit wasi calcit/test-wasi-command.cirru --emit-path target/wasi-command
-wasmtime run target/wasi-command/program.wasm
+wasmtime run --env APP_MODE=release target/wasi-command/program.wasm alpha beta
 ```
 
 两个命令都支持 `--check-only`，只执行同一套 target validation，不写出 `program.wasm`。`--help` 会分别说明输出类型和 command entry 约束。
@@ -77,9 +77,9 @@ yarn try-wasm
 公开命令名称明确区分两种宿主契约：
 
 - `core` 是默认值，保持浏览器或嵌入式宿主现有的 `math`、`io` imports 和导出行为。
-- `wasi` 生成 command module，并增加无参数、无返回值的 `_start` 入口。当前阶段可在 Wasmtime 中运行不需要宿主效果的 Calcit 程序。
+- `wasi` 生成 command module，并增加无参数、无返回值的 `_start` 入口。当前支持 `println`、`eprintln`、`echo`、`get-env` 和 `get-args`；`get-args` 返回宿主传入的完整参数列表，包含第 0 项。
 
-WASI 目标不会接受 `defwasm-import` 声明的任意宿主函数，也不会继承 core 目标的 JS `io` imports。遇到尚未注册的宿主能力时，codegen 以 `E_WASM_CAPABILITY` 失败；无效目标或 command 入口形状以 `E_WASM_TARGET` 失败。后续 stdio、参数、环境变量、退出、时钟、随机数和预开放文件系统均从集中式 capability registry 接入，Preview 1 的 ABI 名称不会成为 Calcit 源码 API。
+WASI 目标不会接受 `defwasm-import` 声明的任意宿主函数，也不会继承 core 目标的 JS `io` imports。遇到尚未注册的宿主能力时，codegen 以 `E_WASM_CAPABILITY` 失败；无效目标或 command 入口形状以 `E_WASM_TARGET` 失败。后续退出、时钟、随机数和预开放文件系统均从集中式 capability registry 接入，Preview 1 的 ABI 名称不会成为 Calcit 源码 API。
 
 ## 声明式 WASM FFI
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -412,6 +412,7 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     Todo => effects::todo(args),
     Quit => effects::quit(args),
     GetEnv => effects::get_env(args),
+    GetArgs => effects::get_args(args),
     UnixTimeMs => effects::unix_time_ms(args),
     NativeGetCalcitBackend => effects::call_get_calcit_backend(args),
     RegisterCalcitBuiltinImpls => meta::register_calcit_builtin_impls(args),

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -7,7 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::{
   builtins::meta::type_of,
-  calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitProc, format_proc_examples_hint},
+  calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitProc, format_proc_examples_hint},
   util::number::f64_to_i32,
 };
 
@@ -138,6 +138,21 @@ pub fn get_env(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     }
     None => CalcitErr::err_str(CalcitErrKind::Arity, "get-env expected an argument, got nothing"),
   }
+}
+
+pub fn get_args(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  if !xs.is_empty() {
+    return CalcitErr::err_str(CalcitErrKind::Arity, format!("get-args expected no arguments, got {}", xs.len()));
+  }
+  let args = env::args_os()
+    .map(|arg| {
+      arg
+        .into_string()
+        .map(|text| Calcit::Str(text.into()))
+        .map_err(|_| CalcitErr::use_str(CalcitErrKind::Effect, "get-args received a non-UTF-8 argument"))
+    })
+    .collect::<Result<Vec<_>, _>>()?;
+  Ok(Calcit::from(CalcitList::from(args.as_slice())))
 }
 
 pub fn unix_time_ms(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -112,6 +112,8 @@ pub enum CalcitProc {
   Quit,
   #[strum(serialize = "&get-env")]
   GetEnv,
+  #[strum(serialize = "&get-args")]
+  GetArgs,
   #[strum(serialize = "unix-time-ms")]
   UnixTimeMs,
   #[strum(serialize = "&get-calcit-backend")]
@@ -1386,6 +1388,10 @@ impl CalcitProc {
       GetEnv => Some(ProcTypeSignature {
         return_type: optional_dynamic(),
         arg_types: vec![some_tag("string"), dynamic_tag()],
+      }),
+      GetArgs => Some(ProcTypeSignature {
+        return_type: list_of(some_tag("string")),
+        arg_types: vec![],
       }),
       UnixTimeMs => Some(ProcTypeSignature {
         return_type: some_tag("number"),

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -713,6 +713,15 @@
             {} (:return 'String)
               :args $ [] 'List
           :tags $ #{} :builtin :internal
+        '&get-args $ %{} 'CodeEntry (:doc "|读取宿主进程参数的内部实现。")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ []
+              :features $ #{} :env :io
+              :return $ :: 'List 'String
+          :tags $ #{} :builtin :env :internal :io
         '&get-calcit-backend $ %{} 'CodeEntry (:doc "|internal function for getting Calcit backend\nSyntax: (&get-calcit-backend)\nParams: none\nReturns: keyword indicating backend\nReturns current backend like :cr (Calcit Runner) or :js (JavaScript)")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -5673,6 +5682,21 @@
                     assert= (%some 1) (get m :a)
                     assert= (%none) (get m :missing)
               :tags $ #{} :core :unit
+        'get-args $ %{} 'CodeEntry (:doc "|读取宿主进程传入的完整参数列表，包含第 0 项。")
+          :code $ quote
+            defn get-args () $ &get-args
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ []
+              :features $ #{} :env :io
+              :return $ :: 'List 'String
+          :tags $ #{} :env :io
+          :tests $ []
+            %{} 'TestEntry (:name |returns-strings)
+              :code $ quote
+                assert= true $ every? (get-args) string?
+              :tags $ #{} :core :env :unit
         'get-char-code $ %{} 'CodeEntry (:doc "|internal function for getting character code\nSyntax: (get-char-code char)\nParams: char (string, single character)\nReturns: number\nReturns Unicode code point of character")
           :code $ quote &runtime-implementation
           :examples $ []

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -45,8 +45,8 @@ mod structs;
 
 use methods::{emit_call_args, emit_method_invoke};
 use runtime::{
-  HostImport, ModuleFunctionLayout, build_runtime_fns, build_wasi_write_all_fn, build_wasm_module, core_host_import,
-  host_imports_for_target,
+  HostImport, ModuleFunctionLayout, build_runtime_fns, build_wasi_get_args_fn, build_wasi_get_env_fn, build_wasi_write_all_fn,
+  build_wasm_module, core_host_import, host_imports_for_target,
 };
 use structs::{
   emit_enum_assoc, emit_enum_count, emit_enum_new, emit_enum_nth, emit_named_enum_new, emit_struct_contains, emit_struct_count,
@@ -248,6 +248,30 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
   let str_new_idx = num_imports + compiled_fns.len() as u32;
   runtime_fn_index.insert("__str_new".to_string(), str_new_idx);
   compiled_fns.push(build_str_new_fn(str_tag_id));
+
+  if target == WasmTarget::Wasi {
+    let import_indices = index_host_imports(&host_imports);
+    let wasi_import = |name: &str| {
+      *import_indices
+        .get(&("wasi_snapshot_preview1".into(), name.into()))
+        .unwrap_or_else(|| panic!("WASI {name} import must be registered"))
+    };
+    let get_args_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_get_args".into(), get_args_idx);
+    compiled_fns.push(build_wasi_get_args_fn(
+      wasi_import("args_sizes_get"),
+      wasi_import("args_get"),
+      str_new_idx,
+      *tag_index.get("list").expect("list tag must exist") as i32,
+    ));
+    let get_env_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_get_env".into(), get_env_idx);
+    compiled_fns.push(build_wasi_get_env_fn(
+      wasi_import("environ_sizes_get"),
+      wasi_import("environ_get"),
+      str_new_idx,
+    ));
+  }
 
   // Pad helpers (need str_tag_id for heap allocation).
   let str_pad_left_idx = num_imports + compiled_fns.len() as u32;
@@ -2281,8 +2305,54 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     CalcitProc::FormatToLisp => emit_format_to_lisp(ctx, args),
     // to-lispy-string — stub, only used in raise/error message paths
     CalcitProc::PrStr => ctx.stub_proc(args),
-    // get-env — returns nil in WASM (env vars not available)
-    CalcitProc::GetEnv => ctx.stub_proc(args),
+    CalcitProc::GetEnv => {
+      if !(1..=2).contains(&args.len()) {
+        return Err(format!("get-env expects 1~2 args, got {}", args.len()));
+      }
+      emit_expr(ctx, &args[0])?;
+      let name = ctx.alloc_local();
+      ctx.emit(Instruction::LocalSet(name));
+      let default = if let Some(default) = args.get(1) {
+        emit_expr(ctx, default)?;
+        let value = ctx.alloc_local();
+        ctx.emit(Instruction::LocalSet(value));
+        Some(value)
+      } else {
+        None
+      };
+      match ctx.target {
+        WasmTarget::Core => {
+          ctx.emit(Instruction::LocalGet(name));
+          ctx.emit(Instruction::Call(resolve_host_import(ctx, "io", "get_env")?));
+        }
+        WasmTarget::Wasi => {
+          ctx.emit(Instruction::LocalGet(name));
+          ctx.emit(Instruction::I32TruncF64U);
+          ctx.call_rt("__rt_wasi_get_env");
+        }
+      }
+      if let Some(default) = default {
+        let value = ctx.alloc_local();
+        ctx.emit(Instruction::LocalSet(value));
+        ctx.emit(Instruction::LocalGet(value));
+        ctx.emit(f64_const(0.0));
+        ctx.emit(Instruction::F64Eq);
+        ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+        ctx.emit(Instruction::LocalGet(default));
+        ctx.emit(Instruction::Else);
+        ctx.emit(Instruction::LocalGet(value));
+        ctx.emit(Instruction::End);
+      }
+      Ok(())
+    }
+    CalcitProc::GetArgs => {
+      expect_arity(0, args, "get-args")?;
+      if ctx.target != WasmTarget::Wasi {
+        return Err("E_WASM_CAPABILITY: process arguments are unavailable for the core WASM target".into());
+      }
+      ctx.call_rt("__rt_wasi_get_args");
+      Ok(())
+    }
 
     // @atom deref: just emit the argument (which should already be a GlobalGet)
     CalcitProc::AtomDeref => {
@@ -3543,14 +3613,22 @@ mod tests {
   }
 
   #[test]
-  fn wasi_target_registers_the_preview1_fd_write_abi() {
+  fn wasi_target_registers_the_preview1_command_abi() {
     let imports = host_imports_for_target(WasmTarget::Wasi);
-    let [fd_write] = imports.as_slice() else {
-      panic!("WASI stdio slice must register exactly fd_write");
-    };
-    assert_eq!(fd_write.module, "wasi_snapshot_preview1");
-    assert_eq!(fd_write.name, "fd_write");
-    assert_eq!(fd_write.params, vec![ValType::I32; 4]);
-    assert_eq!(fd_write.results, vec![ValType::I32]);
+    let signatures = imports
+      .iter()
+      .map(|import| (import.name.as_str(), import.params.clone(), import.results.clone()))
+      .collect::<Vec<_>>();
+    assert_eq!(
+      signatures,
+      vec![
+        ("fd_write", vec![ValType::I32; 4], vec![ValType::I32]),
+        ("args_sizes_get", vec![ValType::I32; 2], vec![ValType::I32]),
+        ("args_get", vec![ValType::I32; 2], vec![ValType::I32]),
+        ("environ_sizes_get", vec![ValType::I32; 2], vec![ValType::I32]),
+        ("environ_get", vec![ValType::I32; 2], vec![ValType::I32]),
+      ]
+    );
+    assert!(imports.iter().all(|import| import.module == "wasi_snapshot_preview1"));
   }
 }

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -92,12 +92,38 @@ static CORE_HOST_IMPORTS: LazyLock<Vec<HostImport>> = LazyLock::new(|| {
 pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
   match target {
     WasmTarget::Core => CORE_HOST_IMPORTS.to_vec(),
-    WasmTarget::Wasi => vec![HostImport {
-      module: "wasi_snapshot_preview1".into(),
-      name: "fd_write".into(),
-      params: vec![ValType::I32; 4],
-      results: vec![ValType::I32],
-    }],
+    WasmTarget::Wasi => vec![
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "fd_write".into(),
+        params: vec![ValType::I32; 4],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "args_sizes_get".into(),
+        params: vec![ValType::I32; 2],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "args_get".into(),
+        params: vec![ValType::I32; 2],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "environ_sizes_get".into(),
+        params: vec![ValType::I32; 2],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "environ_get".into(),
+        params: vec![ValType::I32; 2],
+        results: vec![ValType::I32],
+      },
+    ],
   }
 }
 
@@ -164,6 +190,331 @@ pub(super) fn build_wasi_write_all_fn(fd_write_idx: u32) -> CompiledFn {
     locals: vec![ValType::I32],
     instructions,
   }
+}
+
+fn rt_emit_reserve_raw(builder: &mut RuntimeFnBuilder, size_local: u32, dst_local: u32) {
+  builder.emit(Instruction::GlobalGet(HEAP_PTR_GLOBAL));
+  builder.emit(Instruction::LocalTee(dst_local));
+  builder.emit(Instruction::LocalGet(size_local));
+  builder.emit(Instruction::I32Const(7));
+  builder.emit(Instruction::I32Add);
+  builder.emit(Instruction::I32Const(-8));
+  builder.emit(Instruction::I32And);
+  builder.emit(Instruction::I32Add);
+  builder.emit(Instruction::GlobalSet(HEAP_PTR_GLOBAL));
+}
+
+fn rt_emit_trap_on_errno(builder: &mut RuntimeFnBuilder) {
+  builder.emit(Instruction::If(BlockType::Empty));
+  builder.emit(Instruction::Unreachable);
+  builder.emit(Instruction::End);
+}
+
+/// Build the Preview 1 argv adapter. The host buffers stay private while the
+/// caller receives a normal tagged `List<String>` value.
+pub(super) fn build_wasi_get_args_fn(args_sizes_get_idx: u32, args_get_idx: u32, str_new_idx: u32, list_tag: i32) -> CompiledFn {
+  let mut b = RuntimeFnBuilder::new(0);
+  let count = b.alloc_i32();
+  let buffer_size = b.alloc_i32();
+  let raw_size = b.alloc_i32();
+  let argv = b.alloc_i32();
+  let buffer = b.alloc_i32();
+  let buffer_end = b.alloc_i32();
+  let list_size = b.alloc_i32();
+  let list = b.alloc_i32();
+  let index = b.alloc_i32();
+  let arg_start = b.alloc_i32();
+  let arg_end = b.alloc_i32();
+
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::Call(args_sizes_get_idx));
+  rt_emit_trap_on_errno(&mut b);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalSet(count));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalSet(buffer_size));
+
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::LocalGet(buffer_size));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(raw_size));
+  rt_emit_reserve_raw(&mut b, raw_size, argv);
+  b.emit(Instruction::LocalGet(argv));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(buffer));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::LocalGet(buffer_size));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(buffer_end));
+  b.emit(Instruction::LocalGet(argv));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::Call(args_get_idx));
+  rt_emit_trap_on_errno(&mut b);
+
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::LocalSet(list_size));
+  rt_emit_alloc_dynamic(&mut b, list_size, list, list_tag);
+  b.emit(Instruction::LocalGet(list));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::F64ConvertI32U);
+  b.emit(Instruction::F64Store(mem_arg_f64(0)));
+
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(argv));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalTee(arg_start));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Unreachable);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(arg_start));
+  b.emit(Instruction::LocalSet(arg_end));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(arg_end));
+  b.emit(Instruction::LocalGet(buffer_end));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Unreachable);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(arg_end));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(arg_end));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(arg_end));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(list));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(arg_start));
+  b.emit(Instruction::LocalGet(arg_end));
+  b.emit(Instruction::LocalGet(arg_start));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::Call(str_new_idx));
+  b.emit(Instruction::F64Store(mem_arg_f64(0)));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(list));
+  b.emit(Instruction::F64ConvertI32U);
+  b.finish(vec![], vec![ValType::F64])
+}
+
+/// Build the Preview 1 environment adapter. Missing keys return nil; malformed
+/// host buffers and non-zero WASI errno values trap instead of becoming nil.
+pub(super) fn build_wasi_get_env_fn(environ_sizes_get_idx: u32, environ_get_idx: u32, str_new_idx: u32) -> CompiledFn {
+  let mut b = RuntimeFnBuilder::new(1);
+  let name_len = b.alloc_i32();
+  let name_bytes = b.alloc_i32();
+  let count = b.alloc_i32();
+  let buffer_size = b.alloc_i32();
+  let raw_size = b.alloc_i32();
+  let entries = b.alloc_i32();
+  let buffer = b.alloc_i32();
+  let buffer_end = b.alloc_i32();
+  let index = b.alloc_i32();
+  let entry = b.alloc_i32();
+  let byte_index = b.alloc_i32();
+  let matched = b.alloc_i32();
+  let value_start = b.alloc_i32();
+  let value_end = b.alloc_i32();
+
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::F64Load(mem_arg_f64(0)));
+  b.emit(Instruction::I32TruncF64U);
+  b.emit(Instruction::LocalSet(name_len));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(name_bytes));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::Call(environ_sizes_get_idx));
+  rt_emit_trap_on_errno(&mut b);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalSet(count));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalSet(buffer_size));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::LocalGet(buffer_size));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(raw_size));
+  rt_emit_reserve_raw(&mut b, raw_size, entries);
+  b.emit(Instruction::LocalGet(entries));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(buffer));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::LocalGet(buffer_size));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(buffer_end));
+  b.emit(Instruction::LocalGet(entries));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::Call(environ_get_idx));
+  rt_emit_trap_on_errno(&mut b);
+
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(entries));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalTee(entry));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Unreachable);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(matched));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(byte_index));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(byte_index));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(entry));
+  b.emit(Instruction::LocalGet(byte_index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(buffer_end));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Unreachable);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(entry));
+  b.emit(Instruction::LocalGet(byte_index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::LocalGet(name_bytes));
+  b.emit(Instruction::LocalGet(byte_index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Ne);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(matched));
+  b.emit(Instruction::Br(2));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(byte_index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(byte_index));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(matched));
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(entry));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(buffer_end));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Unreachable);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(entry));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(61));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(entry));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalTee(value_start));
+  b.emit(Instruction::LocalSet(value_end));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(value_end));
+  b.emit(Instruction::LocalGet(buffer_end));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Unreachable);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(value_end));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(value_end));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(value_end));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(value_start));
+  b.emit(Instruction::LocalGet(value_end));
+  b.emit(Instruction::LocalGet(value_start));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::Call(str_new_idx));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(f64_const(0.0));
+  b.finish(vec![ValType::I32], vec![ValType::F64])
 }
 
 /// Maximum arity covered by canonical call_indirect type entries.

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -192,19 +192,79 @@ pub(super) fn build_wasi_write_all_fn(fd_write_idx: u32) -> CompiledFn {
   }
 }
 
-fn rt_emit_reserve_raw(builder: &mut RuntimeFnBuilder, size_local: u32, dst_local: u32) {
-  builder.emit(Instruction::GlobalGet(HEAP_PTR_GLOBAL));
-  builder.emit(Instruction::LocalTee(dst_local));
+/// Reserve a temporary region at the top of linear memory without advancing
+/// the managed bump allocator. `managed_size_local` keeps allocations made
+/// while the adapter is active below the scratch region.
+fn rt_emit_reserve_scratch(builder: &mut RuntimeFnBuilder, size_local: u32, managed_size_local: u32, dst_local: u32) {
+  let aligned_size = builder.alloc_i64();
+  let memory_bytes = builder.alloc_i64();
+  let required_bytes = builder.alloc_i64();
+
   builder.emit(Instruction::LocalGet(size_local));
-  builder.emit(Instruction::I32Const(7));
-  builder.emit(Instruction::I32Add);
-  builder.emit(Instruction::I32Const(-8));
-  builder.emit(Instruction::I32And);
-  builder.emit(Instruction::I32Add);
-  builder.emit(Instruction::GlobalSet(HEAP_PTR_GLOBAL));
+  builder.emit(Instruction::I64Const(7));
+  builder.emit(Instruction::I64Add);
+  builder.emit(Instruction::I64Const(-8));
+  builder.emit(Instruction::I64And);
+  builder.emit(Instruction::LocalSet(aligned_size));
+  builder.emit(Instruction::MemorySize(0));
+  builder.emit(Instruction::I64ExtendI32U);
+  builder.emit(Instruction::I64Const(16));
+  builder.emit(Instruction::I64Shl);
+  builder.emit(Instruction::LocalSet(memory_bytes));
+  builder.emit(Instruction::GlobalGet(HEAP_PTR_GLOBAL));
+  builder.emit(Instruction::I64ExtendI32U);
+  builder.emit(Instruction::LocalGet(managed_size_local));
+  builder.emit(Instruction::I64Add);
+  builder.emit(Instruction::LocalGet(aligned_size));
+  builder.emit(Instruction::I64Add);
+  builder.emit(Instruction::LocalSet(required_bytes));
+  builder.emit(Instruction::LocalGet(required_bytes));
+  builder.emit(Instruction::I64Const(u32::MAX as i64));
+  builder.emit(Instruction::I64GtU);
+  builder.emit(Instruction::If(BlockType::Empty));
+  builder.emit(Instruction::Unreachable);
+  builder.emit(Instruction::End);
+  builder.emit(Instruction::LocalGet(required_bytes));
+  builder.emit(Instruction::LocalGet(memory_bytes));
+  builder.emit(Instruction::I64GtU);
+  builder.emit(Instruction::If(BlockType::Empty));
+  builder.emit(Instruction::LocalGet(required_bytes));
+  builder.emit(Instruction::LocalGet(memory_bytes));
+  builder.emit(Instruction::I64Sub);
+  builder.emit(Instruction::I64Const(65535));
+  builder.emit(Instruction::I64Add);
+  builder.emit(Instruction::I64Const(16));
+  builder.emit(Instruction::I64ShrU);
+  builder.emit(Instruction::I32WrapI64);
+  builder.emit(Instruction::MemoryGrow(0));
+  builder.emit(Instruction::I32Const(-1));
+  builder.emit(Instruction::I32Eq);
+  builder.emit(Instruction::If(BlockType::Empty));
+  builder.emit(Instruction::Unreachable);
+  builder.emit(Instruction::End);
+  builder.emit(Instruction::MemorySize(0));
+  builder.emit(Instruction::I64ExtendI32U);
+  builder.emit(Instruction::I64Const(16));
+  builder.emit(Instruction::I64Shl);
+  builder.emit(Instruction::LocalSet(memory_bytes));
+  builder.emit(Instruction::End);
+  builder.emit(Instruction::LocalGet(memory_bytes));
+  builder.emit(Instruction::LocalGet(aligned_size));
+  builder.emit(Instruction::I64Sub);
+  builder.emit(Instruction::I32WrapI64);
+  builder.emit(Instruction::LocalSet(dst_local));
 }
 
 fn rt_emit_trap_on_errno(builder: &mut RuntimeFnBuilder) {
+  builder.emit(Instruction::If(BlockType::Empty));
+  builder.emit(Instruction::Unreachable);
+  builder.emit(Instruction::End);
+}
+
+fn rt_emit_trap_if_i64_exceeds_memory32(builder: &mut RuntimeFnBuilder, value_local: u32) {
+  builder.emit(Instruction::LocalGet(value_local));
+  builder.emit(Instruction::I64Const(u32::MAX as i64));
+  builder.emit(Instruction::I64GtU);
   builder.emit(Instruction::If(BlockType::Empty));
   builder.emit(Instruction::Unreachable);
   builder.emit(Instruction::End);
@@ -216,7 +276,8 @@ pub(super) fn build_wasi_get_args_fn(args_sizes_get_idx: u32, args_get_idx: u32,
   let mut b = RuntimeFnBuilder::new(0);
   let count = b.alloc_i32();
   let buffer_size = b.alloc_i32();
-  let raw_size = b.alloc_i32();
+  let raw_size = b.alloc_i64();
+  let managed_size = b.alloc_i64();
   let argv = b.alloc_i32();
   let buffer = b.alloc_i32();
   let buffer_end = b.alloc_i32();
@@ -225,6 +286,7 @@ pub(super) fn build_wasi_get_args_fn(args_sizes_get_idx: u32, args_get_idx: u32,
   let index = b.alloc_i32();
   let arg_start = b.alloc_i32();
   let arg_end = b.alloc_i32();
+  let next_arg_min = b.alloc_i32();
 
   b.emit(Instruction::I32Const(0));
   b.emit(Instruction::I32Const(4));
@@ -238,12 +300,26 @@ pub(super) fn build_wasi_get_args_fn(args_sizes_get_idx: u32, args_get_idx: u32,
   b.emit(Instruction::LocalSet(buffer_size));
 
   b.emit(Instruction::LocalGet(count));
-  b.emit(Instruction::I32Const(4));
-  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Const(4));
+  b.emit(Instruction::I64Mul);
   b.emit(Instruction::LocalGet(buffer_size));
-  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Add);
   b.emit(Instruction::LocalSet(raw_size));
-  rt_emit_reserve_raw(&mut b, raw_size, argv);
+  rt_emit_trap_if_i64_exceeds_memory32(&mut b, raw_size);
+  // list header/payload plus per-string headers and worst-case alignment.
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Const(31));
+  b.emit(Instruction::I64Mul);
+  b.emit(Instruction::LocalGet(buffer_size));
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Add);
+  b.emit(Instruction::I64Const(16));
+  b.emit(Instruction::I64Add);
+  b.emit(Instruction::LocalSet(managed_size));
+  rt_emit_reserve_scratch(&mut b, raw_size, managed_size, argv);
   b.emit(Instruction::LocalGet(argv));
   b.emit(Instruction::LocalGet(count));
   b.emit(Instruction::I32Const(4));
@@ -273,6 +349,8 @@ pub(super) fn build_wasi_get_args_fn(args_sizes_get_idx: u32, args_get_idx: u32,
 
   b.emit(Instruction::I32Const(0));
   b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::LocalSet(next_arg_min));
   b.emit(Instruction::Block(BlockType::Empty));
   b.emit(Instruction::Loop(BlockType::Empty));
   b.emit(Instruction::LocalGet(index));
@@ -287,6 +365,12 @@ pub(super) fn build_wasi_get_args_fn(args_sizes_get_idx: u32, args_get_idx: u32,
   b.emit(Instruction::I32Load(mem_arg_i32(0)));
   b.emit(Instruction::LocalTee(arg_start));
   b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Unreachable);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(arg_start));
+  b.emit(Instruction::LocalGet(next_arg_min));
   b.emit(Instruction::I32LtU);
   b.emit(Instruction::If(BlockType::Empty));
   b.emit(Instruction::Unreachable);
@@ -312,6 +396,10 @@ pub(super) fn build_wasi_get_args_fn(args_sizes_get_idx: u32, args_get_idx: u32,
   b.emit(Instruction::Br(0));
   b.emit(Instruction::End);
   b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(arg_end));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(next_arg_min));
   b.emit(Instruction::LocalGet(list));
   b.emit(Instruction::I32Const(8));
   b.emit(Instruction::I32Add);
@@ -345,7 +433,8 @@ pub(super) fn build_wasi_get_env_fn(environ_sizes_get_idx: u32, environ_get_idx:
   let name_bytes = b.alloc_i32();
   let count = b.alloc_i32();
   let buffer_size = b.alloc_i32();
-  let raw_size = b.alloc_i32();
+  let raw_size = b.alloc_i64();
+  let managed_size = b.alloc_i64();
   let entries = b.alloc_i32();
   let buffer = b.alloc_i32();
   let buffer_end = b.alloc_i32();
@@ -375,12 +464,21 @@ pub(super) fn build_wasi_get_env_fn(environ_sizes_get_idx: u32, environ_get_idx:
   b.emit(Instruction::I32Load(mem_arg_i32(0)));
   b.emit(Instruction::LocalSet(buffer_size));
   b.emit(Instruction::LocalGet(count));
-  b.emit(Instruction::I32Const(4));
-  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Const(4));
+  b.emit(Instruction::I64Mul);
   b.emit(Instruction::LocalGet(buffer_size));
-  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Add);
   b.emit(Instruction::LocalSet(raw_size));
-  rt_emit_reserve_raw(&mut b, raw_size, entries);
+  rt_emit_trap_if_i64_exceeds_memory32(&mut b, raw_size);
+  // At most one returned string is allocated while the scratch data is live.
+  b.emit(Instruction::LocalGet(buffer_size));
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Const(23));
+  b.emit(Instruction::I64Add);
+  b.emit(Instruction::LocalSet(managed_size));
+  rt_emit_reserve_scratch(&mut b, raw_size, managed_size, entries);
   b.emit(Instruction::LocalGet(entries));
   b.emit(Instruction::LocalGet(count));
   b.emit(Instruction::I32Const(4));
@@ -1105,6 +1203,13 @@ impl RuntimeFnBuilder {
     let idx = self.next_local;
     self.next_local += 1;
     self.locals.push(ValType::I32);
+    idx
+  }
+
+  fn alloc_i64(&mut self) -> u32 {
+    let idx = self.next_local;
+    self.next_local += 1;
+    self.locals.push(ValType::I64);
     idx
   }
 

--- a/src/runner/macro_capability.rs
+++ b/src/runner/macro_capability.rs
@@ -63,7 +63,7 @@ impl CapabilityPolicy {
 fn proc_policy(proc: CalcitProc) -> Option<CapabilityPolicy> {
   use CalcitProc::*;
   let required = match proc {
-    GetEnv => MacroCapability::EnvRead,
+    GetEnv | GetArgs => MacroCapability::EnvRead,
     ReadFile | ReadDir => MacroCapability::FsRead,
     NativeGetOs | NativeGetCalcitBackend | NativeGetCalcitRunningMode => MacroCapability::PlatformRead,
     UnixTimeMs | CpuTime => MacroCapability::ClockRead,

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -53,6 +53,7 @@ import { CalcitSet } from "./js-set.mjs";
 import { CalcitEnumValue } from "./js-enum-value.mjs";
 import { to_calcit_data, extract_cirru_edn, extract_cirru_edn_for_typed, CalcitCirruQuote } from "./js-cirru.mjs";
 import { TypedEdnSetView } from "./typed-edn.mjs";
+import { initTernaryTreeList } from "@calcit/ternary-tree";
 
 let inNodeJs = typeof process !== "undefined" && process?.release?.name === "node";
 
@@ -1524,6 +1525,13 @@ export let _$n_get_env = (name: string, v0?: CalcitValue): CalcitValue => {
 // Newly generated code calls the internal raw proc; source-level `get-env`
 // remains the typed Option wrapper defined in calcit.core.
 export let get_env = _$n_get_env;
+
+export let _$n_get_args = (): CalcitList => {
+  const args = inNodeJs ? process.argv : [];
+  return new CalcitList(initTernaryTreeList(args));
+};
+
+export let get_args = _$n_get_args;
 
 export let turn_tag = (x: CalcitValue): CalcitTag => {
   if (typeof x === "string") {


### PR DESCRIPTION
## 中文

推进 #1020 的参数与环境变量阶段。

- 新增严格类型的 `get-args -> List<String>`，原生与 JavaScript 后端返回宿主传入的完整 argv（包含第 0 项）。
- WASI command target 通过私有 Preview 1 适配层接入 `args_sizes_get`、`args_get`、`environ_sizes_get` 与 `environ_get`。
- `get-env` 在 WASI 中保持 `Option<String>` 语义；缺失值为 `%none`，WASI errno 或无效宿主缓冲区会 trap，不静默退回 nil。
- Calcit definition `:tests` 覆盖公开语义，Wasmtime 回归只检查 Unicode argv、环境变量与 ABI 边界。
- 补充中文 CLI/WASI 使用文档。

验证：

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`
- `yarn compile`
- `yarn check-js-runtime`
- `cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --summary-only --require-match`
- `target/debug/calcit src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json`
- `bash scripts/test-wasi-preprocess.sh`

## English

Advances the arguments and environment phase of #1020.

- Adds the strictly typed `get-args -> List<String>` API; native and JavaScript backends return the complete host argv, including item zero.
- Connects the WASI command target to `args_sizes_get`, `args_get`, `environ_sizes_get`, and `environ_get` through a private Preview 1 adapter.
- Preserves `Option<String>` semantics for WASI `get-env`: an absent value is `%none`, while WASI errno values or invalid host buffers trap instead of silently becoming nil.
- Covers public semantics with Calcit definition `:tests`; the Wasmtime regression is limited to Unicode argv/environment values and ABI boundaries.
- Updates the Chinese CLI/WASI usage documentation.

Verification:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`
- `yarn compile`
- `yarn check-js-runtime`
- `cargo run --bin calcit -- src/cirru/calcit-core.cirru --compat-types test --tag unit --summary-only --require-match`
- `target/debug/calcit src/cirru/calcit-core.cirru analyze quality --baseline config/calcit-core-quality.cirru --format json`
- `bash scripts/test-wasi-preprocess.sh`