### PR TITLE
feat(wasi): 支持进程退出 / support process exit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,6 +112,7 @@ jobs:
           && ln -s ../../ node_modules/@calcit/procs
           && cp -v scripts/main.mjs js-out/
           && node js-out/main.mjs
+          && bash scripts/test-js-command.sh
 
       - name: Detect documentation changes
         id: docs_changes

--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -8,6 +8,22 @@
   :files $ {}
     'app.main $ %{} 'FileEntry
       :defs $ {}
+        'exit-7! $ %{} 'CodeEntry (:doc "|以状态码 7 终止进程，用于验证 command 退出边界。")
+          :code $ quote
+            defn exit-7! () $ quit! 7
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :control :wasi
+        'exit-invalid! $ %{} 'CodeEntry (:doc "|以越界状态码终止进程，用于验证各 command backend 拒绝隐式取模。")
+          :code $ quote
+            defn exit-invalid! () $ quit! 256
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :control :wasi
         'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println |WASI-stdout: "|你好") (echo |WASI-echo) (eprintln |WASI-stderr: 42)

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -475,6 +475,8 @@ calcit wasi calcit.cirru --emit-path target/wasi-command
 
 WASI command 当前可通过与原生、JavaScript 相同的 `get-env` 和 `get-args` API 读取环境变量与命令参数。`get-env` 返回 `Option<String>`；`get-args` 返回包含第 0 项的完整 `List<String>`。Preview 1 的缓冲区和指针 ABI 只存在于编译器内部，不进入 Calcit 源码接口。
 
+command init definition 正常返回时，进程状态为 `0`；调用 `quit!` 可显式设置 `0..255` 的整数退出状态。WASI target 会在内部调用 Preview 1 `proc_exit`，Calcit 源码无需感知该 ABI。
+
 ## Markdown code checking
 
 Use `docs check-md` to validate fenced code blocks in markdown files:

--- a/editing-history/202609130126-wasi-process-exit.md
+++ b/editing-history/202609130126-wasi-process-exit.md
@@ -1,0 +1,17 @@
+# WASI 进程退出语义 / WASI process exit semantics
+
+## 中文
+
+- 将 `quit!` 的可移植退出码约束统一为 `0..255` 的整数；原生与 JavaScript 后端拒绝小数、非有限数和越界值。
+- WASI command target 引入 Preview 1 `proc_exit`，把 `quit!` 显式 lowering 为宿主进程退出；core WASM 仍保持无进程退出能力并 trap。
+- 使用同一个 Calcit command fixture 验证原生、JavaScript 与 WASI 均返回状态码 `7`，让用户可见语义由 Calcit definition 定义，脚本只检查宿主边界。
+
+验证：`cargo fmt --all -- --check`、`cargo clippy --all-targets -- -D warnings`、`cargo test -q`、`yarn compile`、`bash scripts/test-js-command.sh`、`bash scripts/test-wasi-preprocess.sh`。
+
+## English
+
+- Unified the portable `quit!` contract around integer exit codes in `0..255`; native and JavaScript backends reject fractional, non-finite, and out-of-range values.
+- Added Preview 1 `proc_exit` to the WASI command target and lower `quit!` to host process termination. Core WASM retains no process-exit capability and traps.
+- Reused one Calcit command fixture to verify exit status `7` across native, JavaScript, and WASI. The Calcit definition expresses the user-facing behavior while scripts only check host boundaries.
+
+Verified with `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -q`, `yarn compile`, `bash scripts/test-js-command.sh`, and `bash scripts/test-wasi-preprocess.sh`.

--- a/scripts/test-js-command.sh
+++ b/scripts/test-js-command.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Verify the shared Calcit command fixture through the JavaScript backend.
+set -euo pipefail
+
+readonly CALCIT_BIN="${CALCIT_BIN:-target/debug/calcit}"
+readonly FIXTURE="calcit/test-wasi-command.cirru"
+readonly OUTPUT_DIR="target/js-command-smoke"
+readonly STDOUT_FILE="$OUTPUT_DIR/stdout.txt"
+readonly STDERR_FILE="$OUTPUT_DIR/stderr.txt"
+readonly INVALID_EXIT_STDERR="$OUTPUT_DIR/invalid-exit-stderr.txt"
+
+"$CALCIT_BIN" --emit-path "$OUTPUT_DIR" "$FIXTURE" js
+CALCIT_WASI_TEST_ENV=环境 node --input-type=module --eval \
+  'import("./target/js-command-smoke/app.main.mjs").then((module) => module.main_$x_())' \
+  alpha "参数" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+grep -Fxq "WASI-stdout: 你好" "$STDOUT_FILE"
+grep -Fxq "WASI-env: 环境" "$STDOUT_FILE"
+grep -Fxq "WASI-arg: alpha" "$STDOUT_FILE"
+grep -Fxq "WASI-arg: 参数" "$STDOUT_FILE"
+grep -Fxq "WASI-stderr: 42" "$STDERR_FILE"
+
+"$CALCIT_BIN" --init-fn app.main/exit-7! --emit-path "$OUTPUT_DIR" "$FIXTURE" js
+js_exit_status=0
+node --input-type=module --eval \
+  'import("./target/js-command-smoke/app.main.mjs").then((module) => module.exit_7_$x_())' \
+  >/dev/null 2>&1 || js_exit_status=$?
+if [[ "$js_exit_status" -ne 7 ]]; then
+  echo "JavaScript quit! returned status $js_exit_status instead of 7" >&2
+  exit 1
+fi
+
+"$CALCIT_BIN" --init-fn app.main/exit-invalid! --emit-path "$OUTPUT_DIR" "$FIXTURE" js
+if node --input-type=module --eval \
+  'import("./target/js-command-smoke/app.main.mjs").then((module) => module.exit_invalid_$x_())' \
+  >/dev/null 2>"$INVALID_EXIT_STDERR"; then
+  echo "JavaScript quit! unexpectedly accepted exit status 256" >&2
+  exit 1
+fi
+grep -Fq "integer exit code in 0..255" "$INVALID_EXIT_STDERR"

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -10,6 +10,9 @@ readonly COMMAND_OUT="${CARGO_TARGET_DIR:-target}/wasi-command-smoke"
 readonly COMMAND_STDOUT="${COMMAND_OUT}/stdout.txt"
 readonly COMMAND_STDERR="${COMMAND_OUT}/stderr.txt"
 readonly COMMAND_MISSING_STDOUT="${COMMAND_OUT}/missing-env-stdout.txt"
+readonly EXIT_OUT="${CARGO_TARGET_DIR:-target}/wasi-exit-smoke"
+readonly INVALID_EXIT_OUT="${CARGO_TARGET_DIR:-target}/wasi-invalid-exit-smoke"
+readonly INVALID_EXIT_STDERR="${INVALID_EXIT_OUT}/stderr.txt"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
@@ -49,6 +52,35 @@ grep -Fxq "WASI-stderr: 42" "$COMMAND_STDERR"
 [ "$(wc -l <"$COMMAND_STDERR")" -eq 1 ]
 wasmtime run --env A=x "$COMMAND_OUT/program.wasm" >"$COMMAND_MISSING_STDOUT" 2>/dev/null
 grep -Fxq "WASI-env: missing" "$COMMAND_MISSING_STDOUT"
+
+native_exit_status=0
+"$CALCIT_BIN" --init-fn app.main/exit-7! "$COMMAND_FIXTURE" >/dev/null 2>&1 || native_exit_status=$?
+if [[ "$native_exit_status" -ne 7 ]]; then
+  echo "native quit! returned status $native_exit_status instead of 7" >&2
+  exit 1
+fi
+
+if native_invalid_error=$("$CALCIT_BIN" --init-fn app.main/exit-invalid! "$COMMAND_FIXTURE" 2>&1); then
+  echo "native quit! unexpectedly accepted exit status 256" >&2
+  exit 1
+fi
+grep -Fq "integer exit code in 0..255" <<<"$native_invalid_error"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/exit-7! --emit-path "$EXIT_OUT"
+wasi_exit_status=0
+wasmtime run "$EXIT_OUT/program.wasm" >/dev/null 2>&1 || wasi_exit_status=$?
+if [[ "$wasi_exit_status" -ne 7 ]]; then
+  echo "WASI quit! returned status $wasi_exit_status instead of 7" >&2
+  exit 1
+fi
+
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/exit-invalid! --emit-path "$INVALID_EXIT_OUT"
+if wasmtime run "$INVALID_EXIT_OUT/program.wasm" >/dev/null 2>"$INVALID_EXIT_STDERR"; then
+  echo "WASI quit! unexpectedly accepted exit status 256" >&2
+  exit 1
+fi
+grep -Fq "unreachable" "$INVALID_EXIT_STDERR"
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
   echo "cr-wasm unexpectedly accepted an unknown target" >&2

--- a/scripts/wasm-validation.md
+++ b/scripts/wasm-validation.md
@@ -79,6 +79,8 @@ yarn try-wasm
 - `core` 是默认值，保持浏览器或嵌入式宿主现有的 `math`、`io` imports 和导出行为。
 - `wasi` 生成 command module，并增加无参数、无返回值的 `_start` 入口。当前支持 `println`、`eprintln`、`echo`、`get-env` 和 `get-args`；`get-args` 返回宿主传入的完整参数列表，包含第 0 项。
 
+command init definition 正常返回时状态为 `0`；`quit!` 接受 `0..255` 的整数，并映射到 WASI `proc_exit`。该限制与原生、JavaScript 后端一致，避免宿主各自执行隐式饱和或取模。
+
 WASI 目标不会接受 `defwasm-import` 声明的任意宿主函数，也不会继承 core 目标的 JS `io` imports。遇到尚未注册的宿主能力时，codegen 以 `E_WASM_CAPABILITY` 失败；无效目标或 command 入口形状以 `E_WASM_TARGET` 失败。后续退出、时钟、随机数和预开放文件系统均从集中式 capability registry 接入，Preview 1 的 ABI 名称不会成为 Calcit 源码 API。
 
 ## 声明式 WASM FFI

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -8,7 +8,6 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use crate::{
   builtins::meta::type_of,
   calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitProc, format_proc_examples_hint},
-  util::number::f64_to_i32,
 };
 
 #[derive(Clone, Debug, Copy)]
@@ -90,20 +89,21 @@ pub fn call_get_calcit_backend(_xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
 }
 
 pub fn quit(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
-  match xs.first() {
-    Some(Calcit::Number(n)) => match f64_to_i32(*n) {
-      Ok(code) => exit(code),
-      Err(e) => unreachable!("quit failed to get code from f64, {}", e),
-    },
-    Some(a) => {
+  match xs {
+    [Calcit::Number(n)] if n.is_finite() && n.fract() == 0.0 && (0.0..=255.0).contains(n) => exit(*n as i32),
+    [Calcit::Number(n)] => CalcitErr::err_str(
+      CalcitErrKind::Type,
+      format!("quit requires an integer exit code in 0..255, got: {n}"),
+    ),
+    [a] => {
       let msg = format!(
-        "quit requires an i32 number, but received: {}",
+        "quit requires an integer exit code in 0..255, but received: {}",
         type_of(std::slice::from_ref(a))?.lisp_str()
       );
       let hint = format_proc_examples_hint(&CalcitProc::Quit).unwrap_or_default();
       CalcitErr::err_str_with_hint(CalcitErrKind::Type, msg, hint)
     }
-    None => CalcitErr::err_str(CalcitErrKind::Arity, "quit expected a code, got nothing"),
+    _ => CalcitErr::err_str(CalcitErrKind::Arity, format!("quit expected 1 argument, got {}", xs.len())),
   }
 }
 

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -7457,7 +7457,7 @@
             quote $ quasiquote ([] ~x ~@xs)
           :schema $ :: 'Dynamic
           :tags $ #{} :builtin :internal :syntax
-        'quit! $ %{} 'CodeEntry (:doc "|internal function for quitting program\nSyntax: (quit! exit-code)\nParams: exit-code (number, optional, defaults to 0)\nReturns: never returns (exits program)\nTerminates the program with specified exit code")
+        'quit! $ %{} 'CodeEntry (:doc "|以指定状态码终止宿主进程。语法：(quit! exit-code)。exit-code 必须是 0..255 的整数；函数不会返回。")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -2360,8 +2360,33 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
       emit_expr(ctx, &args[0])
     }
 
-    // quit! — trap (abort) the WASM instance
     CalcitProc::Quit => {
+      expect_arity(1, args, "quit!")?;
+      emit_expr(ctx, &args[0])?;
+      let code = ctx.alloc_local();
+      ctx.emit(Instruction::LocalSet(code));
+      if ctx.target == WasmTarget::Wasi {
+        ctx.emit(Instruction::LocalGet(code));
+        ctx.emit(f64_const(0.0));
+        ctx.emit(Instruction::F64Lt);
+        ctx.emit(Instruction::LocalGet(code));
+        ctx.emit(f64_const(255.0));
+        ctx.emit(Instruction::F64Gt);
+        ctx.emit(Instruction::I32Or);
+        ctx.emit(Instruction::LocalGet(code));
+        ctx.emit(Instruction::LocalGet(code));
+        ctx.emit(Instruction::F64Trunc);
+        ctx.emit(Instruction::F64Ne);
+        ctx.emit(Instruction::I32Or);
+        ctx.emit(Instruction::If(wasm_encoder::BlockType::Empty));
+        ctx.emit(Instruction::Unreachable);
+        ctx.emit(Instruction::End);
+        ctx.emit(Instruction::LocalGet(code));
+        ctx.emit(Instruction::I32TruncF64U);
+        ctx.emit(Instruction::Call(resolve_host_import(ctx, "wasi_snapshot_preview1", "proc_exit")?));
+      }
+      // Core WASM has no process-exit capability, and a conforming WASI host
+      // never returns from proc_exit. Trap if either path reaches this point.
       ctx.emit(Instruction::Unreachable);
       ctx.emit(f64_const(0.0)); // unreachable, but keeps type stack valid
       Ok(())
@@ -3627,6 +3652,7 @@ mod tests {
         ("args_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("environ_sizes_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("environ_get", vec![ValType::I32; 2], vec![ValType::I32]),
+        ("proc_exit", vec![ValType::I32], vec![]),
       ]
     );
     assert!(imports.iter().all(|import| import.module == "wasi_snapshot_preview1"));

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -123,6 +123,12 @@ pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
         params: vec![ValType::I32; 2],
         results: vec![ValType::I32],
       },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "proc_exit".into(),
+        params: vec![ValType::I32],
+        results: vec![],
+      },
     ],
   }
 }

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1580,11 +1580,14 @@ export let cpu_time = (): number => {
   return performance.now();
 };
 
-export let quit_$x_ = (): void => {
+export let quit_$x_ = (code: number): void => {
+  if (!Number.isInteger(code) || code < 0 || code > 255) {
+    throw new TypeError(`quit! expected an integer exit code in 0..255, got: ${code}`);
+  }
   if (inNodeJs) {
-    process.exit(1);
+    process.exit(code);
   } else {
-    throw new Error("quit!()");
+    throw new Error(`quit!(${code})`);
   }
 };
 


### PR DESCRIPTION
## 中文

### 变更

- 为 WASI command target 注册 Preview 1 `proc_exit`，将 `quit!` lowering 为明确的宿主退出状态。
- 统一 native、JavaScript 与 WASI 的可移植契约：`quit!` 严格接受一个 `0..255` 的整数；core WASM 不具备进程退出能力，仍明确 trap。
- 扩展共享 Calcit command fixture，并在 native、JavaScript 与 Wasmtime 进程边界验证退出状态 `7`。
- 补充中文 CLI/WASM 文档和编辑记录。

### 测试放置

用户可见的入口定义保留在 `calcit/test-wasi-command.cirru`；进程终止无法在同一 definition test runner 内断言，因此 shell smoke 只负责从三个宿主读取实际进程状态。WASM import shape 的 Rust 测试仅覆盖低层 ABI。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q`（772 + 340 + 17 + 4）
- `yarn compile`
- `bash scripts/test-js-command.sh`
- `bash scripts/test-wasi-preprocess.sh`

继续 #1020。

## English

### Changes

- Register Preview 1 `proc_exit` for the WASI command target and lower `quit!` to an explicit host exit status.
- Unify the portable native, JavaScript, and WASI contract: `quit!` strictly accepts one integer in `0..255`. Core WASM has no process-exit capability and continues to trap explicitly.
- Extend the shared Calcit command fixture and verify exit status `7` at the native, JavaScript, and Wasmtime process boundaries.
- Add Chinese CLI/WASM documentation and an editing-history entry.

### Test placement

The user-visible entry definition stays in `calcit/test-wasi-command.cirru`. Process termination cannot be asserted inside the same definition test runner, so shell smoke tests only inspect real process status from the three hosts. The Rust test for the WASM import shape covers only the low-level ABI.

### Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q` (772 + 340 + 17 + 4)
- `yarn compile`
- `bash scripts/test-js-command.sh`
- `bash scripts/test-wasi-preprocess.sh`

Continues #1020.