### PR TITLE
feat(wasi): 支持系统与单调时钟 / support system and monotonic clocks

### DIFF
--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -8,6 +8,44 @@
   :files $ {}
     'app.main $ %{} 'FileEntry
       :defs $ {}
+        'clock-fixed-main! $ %{} 'CodeEntry (:doc "|用确定性的 WASI 假宿主验证时钟编号与纳秒到毫秒的换算。")
+          :code $ quote
+            defn clock-fixed-main! () $ if
+              and
+                = 1234 $ unix-time-ms
+                = 5678 $ cpu-time
+              println "|WASI-fixed-clocks: ok"
+              quit! 1
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :time :wasi
+        'clock-main! $ %{} 'CodeEntry (:doc "|输出系统时钟与单调时钟，用于验证 WASI capability wiring。")
+          :code $ quote
+            defn clock-main! () $ if (clocks-valid?) (println "|WASI-clocks: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :time :wasi
+        'clocks-valid? $ %{} 'CodeEntry (:doc "|验证系统时钟为正数，且单调时钟在同一进程内不会倒退。")
+          :code $ quote
+            defn clocks-valid? () $ let
+                wall $ unix-time-ms
+                before $ cpu-time
+                after $ cpu-time
+              and (number? wall) (> wall 0) (number? before) (number? after) (>= after before)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ []
+          :tags $ #{} :core :time :unit :wasi :wasm
+          :tests $ []
+            %{} 'TestEntry (:name |valid-readings)
+              :code $ quote
+                assert= true $ clocks-valid?
+              :tags $ #{} :core :time :unit :wasi :wasm
         'exit-7! $ %{} 'CodeEntry (:doc "|以状态码 7 终止进程，用于验证 command 退出边界。")
           :code $ quote
             defn exit-7! () $ quit! 7
@@ -66,6 +104,20 @@
               :code $ quote
                 assert= true $ every? (read-args) string?
               :tags $ #{} :core :env :unit :wasi :wasm
+        'read-clocks $ %{} 'CodeEntry (:doc "|读取系统时钟与单调时钟的毫秒值。")
+          :code $ quote
+            defn read-clocks () $ [] (unix-time-ms) (cpu-time)
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ []
+              :return $ :: 'List 'Number
+          :tags $ #{} :time :wasi
+          :tests $ []
+            %{} 'TestEntry (:name |returns-numbers)
+              :code $ quote
+                assert= true $ every? (read-clocks) number?
+              :tags $ #{} :core :time :unit :wasi :wasm
         'reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () &unit

--- a/docs/installation/host-capability-boundary.md
+++ b/docs/installation/host-capability-boundary.md
@@ -71,8 +71,8 @@ no-op or fabricated success value.
 | --- | --- | --- | --- | --- | --- |
 | Pure Calcit data/control and typed `Option`/`Result` composition | yes | yes | yes | supported subset | core definitions and methods |
 | JSON parse/stringify | yes | yes | yes | unavailable | String `.parse-json` / Result wrappers; core JSON procedures |
-| Current Unix time in milliseconds | yes | unavailable | unavailable | Preview 1 realtime clock | `unix-time-ms` |
-| Monotonic milliseconds for elapsed-time measurement | yes | unavailable | unavailable | Preview 1 monotonic clock | `cpu-time`（只比较同一进程内两次调用的差值） |
+| Current Unix time in milliseconds | yes | unavailable | unavailable | WASI Preview 1 realtime clock; core WASM unavailable | `unix-time-ms` |
+| Monotonic milliseconds for elapsed-time measurement | yes | unavailable | unavailable | WASI Preview 1 monotonic clock; core WASM unavailable | `cpu-time`（只比较同一进程内两次调用的差值） |
 | Construct and inspect a path value without I/O | yes | yes | yes | value-level support only | `fs:path`, `FsPath .to-string` |
 | `FsPath .read-text` / `.write-text` | yes | host injection | browser `localStorage` adapter | unavailable | `FsPath` Result-returning methods |
 | `FsPath .read-dir` / `.walk-dir` | yes | host injection | unavailable | unavailable | `FsPath` Result-returning methods |

--- a/docs/installation/host-capability-boundary.md
+++ b/docs/installation/host-capability-boundary.md
@@ -71,7 +71,8 @@ no-op or fabricated success value.
 | --- | --- | --- | --- | --- | --- |
 | Pure Calcit data/control and typed `Option`/`Result` composition | yes | yes | yes | supported subset | core definitions and methods |
 | JSON parse/stringify | yes | yes | yes | unavailable | String `.parse-json` / Result wrappers; core JSON procedures |
-| Current Unix time in milliseconds | yes | unavailable | unavailable | unavailable | `unix-time-ms` (native-only exception; do not infer cross-backend support) |
+| Current Unix time in milliseconds | yes | unavailable | unavailable | Preview 1 realtime clock | `unix-time-ms` |
+| Monotonic milliseconds for elapsed-time measurement | yes | unavailable | unavailable | Preview 1 monotonic clock | `cpu-time`（只比较同一进程内两次调用的差值） |
 | Construct and inspect a path value without I/O | yes | yes | yes | value-level support only | `fs:path`, `FsPath .to-string` |
 | `FsPath .read-text` / `.write-text` | yes | host injection | browser `localStorage` adapter | unavailable | `FsPath` Result-returning methods |
 | `FsPath .read-dir` / `.walk-dir` | yes | host injection | unavailable | unavailable | `FsPath` Result-returning methods |
@@ -85,12 +86,8 @@ no-op or fabricated success value.
 | Native dylib sync/async/blocking/resource transport | C-safe FFI v1 | not applicable | not applicable | separate future adapter | raw runtime boundary plus typed library methods |
 
 The matrix records what exists today, not an entitlement for every backend.
-For example, `unix-time-ms` is a canonical native core API but remains an
-explicit backend-coverage exception. New code must not copy that exception
-without a reviewed reason and a planned unsupported diagnostic.
-
-该矩阵描述当前事实，不承诺所有能力必须补齐所有后端。特别是 `unix-time-ms`
-目前是 native-only 的 core 例外；新增 API 不得据此绕过跨后端审查。
+该矩阵描述当前事实，不承诺所有能力必须补齐所有后端。新增 API 不得因某个
+现存能力已覆盖多个 backend，就绕过跨后端审查与 unsupported diagnostic。
 
 ## Canonical core APIs / 当前 core 规范入口
 
@@ -99,9 +96,10 @@ without a reviewed reason and a planned unsupported diagnostic.
 - Filesystem paths: construct `FsPath` with `fs:path`; use `.read-text`,
   `.write-text`, `.read-dir`, and `.walk-dir`. String-path `try-read-*` and raw
   raising procedures are compatibility or implementation entries.
-- Clock: `unix-time-ms` is the native canonical clock primitive, with the
-  backend limitation shown above. Higher-level date/timezone behavior belongs
-  in `calcit.std`.
+- 时钟：`unix-time-ms` 返回 Unix epoch 以来的系统时间；`cpu-time` 用于测量
+  经过时间，其绝对起点没有跨宿主语义。WASI command 通过 Preview 1
+  `clock_time_get` 实现这两个入口，并在宿主返回错误时直接失败，不伪造数值。
+  更高层的日期、时区行为仍属于 `calcit.std`。
 - Native async/resource values: expose `FfiTask`, `FfiResponse`, and other
   nominal capabilities through methods. Keep raw `&ffi-*`, handles, status
   codes, and symbol strings at module/runtime boundaries.

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -477,6 +477,8 @@ WASI command 当前可通过与原生、JavaScript 相同的 `get-env` 和 `get-
 
 command init definition 正常返回时，进程状态为 `0`；调用 `quit!` 可显式设置 `0..255` 的整数退出状态。WASI target 会在内部调用 Preview 1 `proc_exit`，Calcit 源码无需感知该 ABI。
 
+WASI command 也复用 `unix-time-ms` 与 `cpu-time`。前者读取系统实时时钟；后者读取单调时钟，只保证同一进程内两次读数的差值有意义。两者均返回毫秒数；Preview 1 的纳秒结果与错误码由编译器内部转换和检查，宿主失败时不会返回 `0` 或 `nil`。
+
 ## Markdown code checking
 
 Use `docs check-md` to validate fenced code blocks in markdown files:

--- a/editing-history/202609130153-wasi-clocks.md
+++ b/editing-history/202609130153-wasi-clocks.md
@@ -1,0 +1,7 @@
+# WASI 系统时钟与单调时钟
+
+- 将现有 `unix-time-ms` lowering 到 WASI Preview 1 realtime clock，将 `cpu-time` lowering 到 monotonic clock；两者继续向 Calcit 返回毫秒数。
+- `cpu-time` 的跨宿主契约只保证单调读数可用于同一进程内的差值计算，不约定绝对起点。Preview 1 返回非零错误码时直接 trap，避免伪造 `0` 或 `nil`。
+- 用户可观察的时钟语义放在 Calcit definition `:tests` 中；真实 Wasmtime smoke 验证 capability wiring，Node 假宿主精确验证 clock id、precision、纳秒到毫秒换算与错误路径。
+
+验证：`cargo fmt --all -- --check`、`cargo clippy --all-targets --all-features -- -D warnings`、`cargo test -q`、`yarn compile`、`bash scripts/test-wasi-preprocess.sh`。

--- a/editing-history/202609130214-clarify-wasi-only-clocks.md
+++ b/editing-history/202609130214-clarify-wasi-only-clocks.md
@@ -1,0 +1,4 @@
+# 明确时钟能力仅属于 WASI
+
+- 能力矩阵明确区分 WASI Preview 1 command 与 core WASM module，避免把 `clock_time_get` 支持误读为所有 WASM target 都可用。
+- `unix-time-ms` 与 `cpu-time` 在 `calcit wasi` 下可用；`calcit wasm` 仍以稳定的 `E_WASM_CAPABILITY` 拒绝这两个宿主能力。

--- a/scripts/test-wasi-clock-host.mjs
+++ b/scripts/test-wasi-clock-host.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [wasmPath] = process.argv.slice(2);
+if (wasmPath == null) {
+  throw new Error("usage: node scripts/test-wasi-clock-host.mjs <program.wasm>");
+}
+
+let memory;
+let stdout = "";
+const requestedClocks = [];
+
+const view = () => new DataView(memory.buffer);
+const bytes = () => new Uint8Array(memory.buffer);
+
+const wasi = {
+  args_sizes_get(argcPtr, argvSizePtr) {
+    view().setUint32(argcPtr, 0, true);
+    view().setUint32(argvSizePtr, 0, true);
+    return 0;
+  },
+  args_get() {
+    return 0;
+  },
+  environ_sizes_get(countPtr, sizePtr) {
+    view().setUint32(countPtr, 0, true);
+    view().setUint32(sizePtr, 0, true);
+    return 0;
+  },
+  environ_get() {
+    return 0;
+  },
+  fd_write(fd, iovsPtr, iovsLength, writtenPtr) {
+    assert.equal(fd, 1);
+    let written = 0;
+    for (let i = 0; i < iovsLength; i += 1) {
+      const ptr = view().getUint32(iovsPtr + i * 8, true);
+      const length = view().getUint32(iovsPtr + i * 8 + 4, true);
+      stdout += new TextDecoder().decode(bytes().subarray(ptr, ptr + length));
+      written += length;
+    }
+    view().setUint32(writtenPtr, written, true);
+    return 0;
+  },
+  proc_exit(code) {
+    throw new Error(`unexpected proc_exit(${code})`);
+  },
+  clock_time_get(clockId, precision, resultPtr) {
+    requestedClocks.push([clockId, precision]);
+    const nanoseconds = clockId === 0 ? 1_234_000_000n : clockId === 1 ? 5_678_000_000n : null;
+    if (nanoseconds == null) {
+      return 28;
+    }
+    view().setBigUint64(resultPtr, nanoseconds, true);
+    return 0;
+  },
+};
+
+const module = await WebAssembly.compile(await readFile(wasmPath));
+const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+memory = instance.exports.memory;
+instance.exports._start();
+
+assert.equal(stdout, "WASI-fixed-clocks: ok\n");
+assert.deepEqual(requestedClocks, [
+  [0, 1_000_000n],
+  [1, 1_000_000n],
+]);
+
+const failingWasi = { ...wasi, clock_time_get: () => 5 };
+const failingInstance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: failingWasi });
+memory = failingInstance.exports.memory;
+assert.throws(() => failingInstance.exports._start(), WebAssembly.RuntimeError);

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -13,6 +13,10 @@ readonly COMMAND_MISSING_STDOUT="${COMMAND_OUT}/missing-env-stdout.txt"
 readonly EXIT_OUT="${CARGO_TARGET_DIR:-target}/wasi-exit-smoke"
 readonly INVALID_EXIT_OUT="${CARGO_TARGET_DIR:-target}/wasi-invalid-exit-smoke"
 readonly INVALID_EXIT_STDERR="${INVALID_EXIT_OUT}/stderr.txt"
+readonly CLOCK_OUT="${CARGO_TARGET_DIR:-target}/wasi-clock-smoke"
+readonly CLOCK_STDOUT="${CLOCK_OUT}/stdout.txt"
+readonly FIXED_CLOCK_OUT="${CARGO_TARGET_DIR:-target}/wasi-fixed-clock-smoke"
+readonly CORE_CLOCK_OUT="${CARGO_TARGET_DIR:-target}/core-clock-reject"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
@@ -81,6 +85,19 @@ if wasmtime run "$INVALID_EXIT_OUT/program.wasm" >/dev/null 2>"$INVALID_EXIT_STD
   exit 1
 fi
 grep -Fq "unreachable" "$INVALID_EXIT_STDERR"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/clock-main! --emit-path "$CLOCK_OUT"
+wasmtime run "$CLOCK_OUT/program.wasm" >"$CLOCK_STDOUT"
+grep -Fxq "WASI-clocks: ok" "$CLOCK_STDOUT"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/clock-fixed-main! --emit-path "$FIXED_CLOCK_OUT"
+node scripts/test-wasi-clock-host.mjs "$FIXED_CLOCK_OUT/program.wasm"
+
+if clock_capability_error=$("$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app.main/clock-main! --emit-path "$CORE_CLOCK_OUT" 2>&1); then
+  echo "core WASM unexpectedly accepted process clocks" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_CAPABILITY" <<<"$clock_capability_error"
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
   echo "cr-wasm unexpectedly accepted an unknown target" >&2

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -4010,7 +4010,7 @@
               :code $ quote
                 assert= 4 $ count |good
               :tags $ #{} :core :unit
-        'cpu-time $ %{} 'CodeEntry (:doc "|internal function for getting CPU time\nSyntax: (cpu-time)\nParams: none\nReturns: number\nReturns current CPU time in milliseconds for performance measurement")
+        'cpu-time $ %{} 'CodeEntry (:doc "|返回单调时钟的毫秒读数，用于测量经过时间。只比较同一进程内两次调用的差值，不依赖绝对起点。")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn
@@ -8649,7 +8649,7 @@
                 assert= (#{} 1 2 3)
                   union (#{} 1) (#{} 2) (#{} 3)
               :tags $ #{} :core :unit
-        'unix-time-ms $ %{} 'CodeEntry (:doc "|Return the current Unix timestamp in milliseconds.\nSyntax: (unix-time-ms)\nReturns: number")
+        'unix-time-ms $ %{} 'CodeEntry (:doc "|返回 Unix epoch 以来的系统时间，单位为毫秒。系统时钟可能被宿主校准，不保证单调递增。")
           :code $ quote &runtime-implementation
           :examples $ []
           :schema $ :: 'Fn

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -2353,6 +2353,14 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
       ctx.call_rt("__rt_wasi_get_args");
       Ok(())
     }
+    CalcitProc::UnixTimeMs => {
+      expect_arity(0, args, "unix-time-ms")?;
+      emit_wasi_clock_ms(ctx, 0, "unix-time-ms")
+    }
+    CalcitProc::CpuTime => {
+      expect_arity(0, args, "cpu-time")?;
+      emit_wasi_clock_ms(ctx, 1, "cpu-time")
+    }
 
     // @atom deref: just emit the argument (which should already be a GlobalGet)
     CalcitProc::AtomDeref => {
@@ -2586,6 +2594,30 @@ fn emit_wasi_write_literal(ctx: &mut WasmGenCtx, fd: i32, text: &str) -> Result<
     .ok_or_else(|| format!("internal WASI output literal missing from string pool: {text:?}"))?;
   let ptr_local = ctx.alloc_i32(ptr as i32);
   emit_wasi_write_string(ctx, fd, ptr_local);
+  Ok(())
+}
+
+/// Read a Preview 1 clock into the runtime scratch area and return milliseconds.
+fn emit_wasi_clock_ms(ctx: &mut WasmGenCtx, clock_id: i32, proc_name: &str) -> Result<(), String> {
+  if ctx.target != WasmTarget::Wasi {
+    return Err(format!("E_WASM_CAPABILITY: {proc_name} is unavailable for the core WASM target"));
+  }
+  ctx.emit(Instruction::I32Const(clock_id));
+  ctx.emit(Instruction::I64Const(1_000_000));
+  ctx.emit(Instruction::I32Const(0));
+  ctx.emit(Instruction::Call(resolve_host_import(
+    ctx,
+    "wasi_snapshot_preview1",
+    "clock_time_get",
+  )?));
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Empty));
+  ctx.emit(Instruction::Unreachable);
+  ctx.emit(Instruction::End);
+  ctx.emit(Instruction::I32Const(0));
+  ctx.emit(Instruction::I64Load(mem_arg_f64(0)));
+  ctx.emit(Instruction::F64ConvertI64U);
+  ctx.emit(f64_const(1_000_000.0));
+  ctx.emit(Instruction::F64Div);
   Ok(())
 }
 
@@ -3653,6 +3685,7 @@ mod tests {
         ("environ_sizes_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("environ_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("proc_exit", vec![ValType::I32], vec![]),
+        ("clock_time_get", vec![ValType::I32, ValType::I64, ValType::I32], vec![ValType::I32],),
       ]
     );
     assert!(imports.iter().all(|import| import.module == "wasi_snapshot_preview1"));

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -129,6 +129,12 @@ pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
         params: vec![ValType::I32],
         results: vec![],
       },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "clock_time_get".into(),
+        params: vec![ValType::I32, ValType::I64, ValType::I32],
+        results: vec![ValType::I32],
+      },
     ],
   }
 }


### PR DESCRIPTION
## 中文

### 改动

- 将现有 `unix-time-ms` lowering 到 WASI Preview 1 realtime clock，将 `cpu-time` lowering 到 monotonic clock；Preview 1 ABI 保持在编译器内部。
- 将宿主返回的纳秒 `u64` 转换为 Calcit 毫秒 `Number`，非零 errno 直接 trap，不返回伪造的 `0` 或 `nil`；core WASM 继续以 `E_WASM_CAPABILITY` 拒绝进程时钟。
- 在 Calcit definition `:tests` 中验证用户可观察的数值与单调语义；真实 Wasmtime smoke 验证 wiring，确定性 Node 假宿主验证 clock id、precision、换算和错误路径。
- 更新 core API 与 WASI CLI 文档，明确 `cpu-time` 只保证同一进程内差值有意义，不约定绝对起点。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -q`（772 + 340 + 17 + 4）
- `yarn compile`
- `bash scripts/test-wasi-preprocess.sh`

这是 #1021 的 clocks 切片；安全随机仍留在该 issue 的后续 PR。

## English

### Changes

- Lower the existing `unix-time-ms` API to the WASI Preview 1 realtime clock and `cpu-time` to the monotonic clock while keeping the Preview 1 ABI private to the compiler.
- Convert the host's nanosecond `u64` to a Calcit millisecond `Number`; trap on non-zero errno instead of fabricating `0` or `nil`. Core WASM continues to reject process clocks with `E_WASM_CAPABILITY`.
- Verify user-observable numeric and monotonic semantics in Calcit definition `:tests`; use a real Wasmtime smoke test for wiring and a deterministic Node host for clock IDs, precision, conversion, and failure behavior.
- Update the core API and WASI CLI documentation to state that only differences between `cpu-time` readings in the same process are meaningful; its absolute origin is unspecified.

### Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -q` (772 + 340 + 17 + 4)
- `yarn compile`
- `bash scripts/test-wasi-preprocess.sh`

This is the clocks slice of #1021; secure randomness remains in that issue for a follow-up PR.

Refs #1021
