### PR TITLE
feat(core): 统一安全随机字节能力 / unify secure random bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "cirru_parser",
  "colored",
  "ctrlc",
+ "getrandom 0.3.3",
  "hex",
  "im_ternary_tree",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ exclude = ["lib/*", "calcit/*", "ts-src/*", "js-out/*", "scripts/*", "docs/*", "
 # cirru_edn = { path = "/Users/chenyong/repo/cirru/edn.rs" }
 # cirru_parser = { path = "/Users/chenyong/repo/cirru/parser.rs" }
 argh = "0.1.19"
-getrandom = "0.3.3"
 hex = "0.4.3"
 md-5 = "0.11.0"
 rpds = "1.2.1"
@@ -47,6 +46,7 @@ serde = { version = "1.0.229", features = ["derive"] }
 cirru_parser = "=0.2.15"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+getrandom = "0.3.3"
 notify = "8.0.0"
 notify-debouncer-mini = "0.7.0"
 ureq = "3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = ["lib/*", "calcit/*", "ts-src/*", "js-out/*", "scripts/*", "docs/*", "
 # cirru_edn = { path = "/Users/chenyong/repo/cirru/edn.rs" }
 # cirru_parser = { path = "/Users/chenyong/repo/cirru/parser.rs" }
 argh = "0.1.19"
+getrandom = "0.3.3"
 hex = "0.4.3"
 md-5 = "0.11.0"
 rpds = "1.2.1"

--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -90,6 +90,69 @@
               :code $ quote
                 assert= 3 $ needs-arg 3
               :tags $ #{} :core :unit :wasi :wasm
+        'random-error? $ %{} 'CodeEntry (:doc "|验证越界的安全随机请求返回 String 错误。")
+          :code $ quote
+            defn random-error? (size)
+              tag-match (secure-random-bytes size)
+                (:ok _) false
+                (:err message) (string? message)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'Number
+          :tags $ #{} :core :crypto :unit :wasi :wasm
+          :tests $ []
+            %{} 'TestEntry (:name |rejects-negative-length)
+              :code $ quote
+                assert= true $ random-error? -1
+              :tags $ #{} :core :crypto :unit :wasi :wasm
+            %{} 'TestEntry (:name |rejects-oversized-length)
+              :code $ quote
+                assert= true $ random-error? 65537
+              :tags $ #{} :core :crypto :unit :wasi :wasm
+            %{} 'TestEntry (:name |rejects-fractional-length)
+              :code $ quote
+                assert= true $ random-error? 1.5
+              :tags $ #{} :core :crypto :unit :wasi :wasm
+        'random-fixed-main! $ %{} 'CodeEntry (:doc "|由确定性 WASI 假宿主验证四字节随机请求。")
+          :code $ quote
+            defn random-fixed-main! () $ if (random-success? 4) (println "|secure-random-fixed: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :crypto :wasi
+        'random-main! $ %{} 'CodeEntry (:doc "|验证安全随机 API 的成功与越界 Result 语义。")
+          :code $ quote
+            defn random-main! () $ if
+              and (random-success? 16) (random-error? 65537)
+              println "|secure-random: ok"
+              quit! 1
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :crypto :wasi
+        'random-success? $ %{} 'CodeEntry (:doc "|验证指定长度的安全随机请求返回 Buffer。")
+          :code $ quote
+            defn random-success? (size)
+              tag-match (secure-random-bytes size)
+                (:ok bytes) (buffer? bytes)
+                (:err _) false
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'Number
+          :tags $ #{} :core :crypto :unit :wasi :wasm
+          :tests $ []
+            %{} 'TestEntry (:name |returns-empty-buffer)
+              :code $ quote
+                assert= true $ random-success? 0
+              :tags $ #{} :core :crypto :unit :wasi :wasm
+            %{} 'TestEntry (:name |returns-buffer)
+              :code $ quote
+                assert= true $ random-success? 16
+              :tags $ #{} :core :crypto :unit :wasi :wasm
         'read-args $ %{} 'CodeEntry (:doc "|读取当前宿主进程的完整参数列表。")
           :code $ quote
             defn read-args () $ get-args

--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -93,7 +93,7 @@
         'random-error? $ %{} 'CodeEntry (:doc "|验证越界的安全随机请求返回 String 错误。")
           :code $ quote
             defn random-error? (size)
-              tag-match (secure-random-bytes size)
+              match (secure-random-bytes size)
                 (:ok _) false
                 (:err message) (string? message)
           :examples $ []
@@ -136,7 +136,7 @@
         'random-success? $ %{} 'CodeEntry (:doc "|验证指定长度的安全随机请求返回 Buffer。")
           :code $ quote
             defn random-success? (size)
-              tag-match (secure-random-bytes size)
+              match (secure-random-bytes size)
                 (:ok bytes) (buffer? bytes)
                 (:err _) false
           :examples $ []

--- a/docs/installation/host-capability-boundary.md
+++ b/docs/installation/host-capability-boundary.md
@@ -79,7 +79,8 @@ no-op or fabricated success value.
 | Process and signal lifecycle | `calcit.std` native module | Node adapter | unavailable | unavailable | typed process/signal APIs in `calcit.std` |
 | Repeating timer and timezone/date | `calcit.std` native module | Node adapter | browser adapter | unavailable | typed timer/date APIs in `calcit.std` |
 | Glob | focused native module | Node adapter | unavailable | unavailable | focused glob module; do not infer browser support |
-| Crypto | focused native module | Node adapter | browser crypto adapter | unavailable | focused crypto module or host adapter |
+| 安全随机字节 | 系统 CSPRNG | Web Crypto | Web Crypto | WASI Preview 1 `random_get`；core WASM unavailable | `secure-random-bytes`，返回 `Result<Buffer,String>` |
+| 其他密码学能力 | focused native module | Node adapter | browser crypto adapter | unavailable | focused crypto module or host adapter |
 | HTTP fetch | `calcit-fetch` native module | Node adapter | browser adapter | unavailable | typed task/response APIs in `calcit-fetch` or a host adapter |
 | HTTP and WebSocket servers | `calcit-http` / `calcit-wss` native modules | Node adapter | unavailable | unavailable | typed server/request/response capabilities in focused modules |
 | WebSocket client stream | focused native module | Node adapter | browser adapter | unavailable | typed stream capability in a focused module or host adapter |
@@ -100,6 +101,10 @@ The matrix records what exists today, not an entitlement for every backend.
   经过时间，其绝对起点没有跨宿主语义。WASI command 通过 Preview 1
   `clock_time_get` 实现这两个入口，并在宿主返回错误时直接失败，不伪造数值。
   更高层的日期、时区行为仍属于 `calcit.std`。
+- 安全随机数：`secure-random-bytes` 接收 `0..65536` 范围内的整数长度，返回
+  `Result<Buffer,String>`。Native 使用系统 CSPRNG，生成的 JavaScript 使用 Web
+  Crypto，WASI command 使用 Preview 1 `random_get`；core WASM 会明确拒绝该宿主能力。
+  随机数到领域值的编码、抽样和密码学协议仍放在 Calcit library 或专用模块中。
 - Native async/resource values: expose `FfiTask`, `FfiResponse`, and other
   nominal capabilities through methods. Keep raw `&ffi-*`, handles, status
   codes, and symbol strings at module/runtime boundaries.

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -479,6 +479,8 @@ command init definition 正常返回时，进程状态为 `0`；调用 `quit!` �
 
 WASI command 也复用 `unix-time-ms` 与 `cpu-time`。前者读取系统实时时钟；后者读取单调时钟，只保证同一进程内两次读数的差值有意义。两者均返回毫秒数；Preview 1 的纳秒结果与错误码由编译器内部转换和检查，宿主失败时不会返回 `0` 或 `nil`。
 
+安全随机字节统一通过 `secure-random-bytes` 获取。参数必须是 `0..65536` 范围内的整数，返回值为 `Result<Buffer,String>`；WASI command 由 Preview 1 `random_get` 填充缓冲区，宿主错误保留为 `Result` 的错误分支。Native 与生成的 JavaScript 保持相同的公开值形状，分别使用系统 CSPRNG 与 Web Crypto。`calcit wasm` 的 core module 没有默认随机数宿主协议，会以 `E_WASM_CAPABILITY` 明确拒绝。
+
 ## Markdown code checking
 
 Use `docs check-md` to validate fenced code blocks in markdown files:

--- a/editing-history/202609130220-secure-random-bytes.md
+++ b/editing-history/202609130220-secure-random-bytes.md
@@ -2,5 +2,6 @@
 
 - 在 core 增加 `secure-random-bytes`，以 `Result<Buffer,String>` 统一 Native、JavaScript 与 WASI command 的公开语义，并限制单次请求为 `0..65536` 字节。
 - Native 使用系统 CSPRNG，生成的 JavaScript 使用 Web Crypto，WASI command 通过 Preview 1 `random_get` 填充由 Calcit 管理的 Buffer。
+- 系统 CSPRNG crate 只进入非-wasm32 的 Native interpreter；`wasm32-unknown-unknown` library 不引入隐式随机宿主，保持既有依赖边界。
 - core WASM 不伪造随机数，继续用稳定的 `E_WASM_CAPABILITY` 拒绝缺少宿主协议的调用。
 - 主要语义测试定义在 Calcit Snapshot 的 `:tests` 中；脚本只负责跨后端运行、固定字节验证和宿主错误注入。

--- a/editing-history/202609130220-secure-random-bytes.md
+++ b/editing-history/202609130220-secure-random-bytes.md
@@ -1,0 +1,6 @@
+# 统一安全随机字节能力
+
+- 在 core 增加 `secure-random-bytes`，以 `Result<Buffer,String>` 统一 Native、JavaScript 与 WASI command 的公开语义，并限制单次请求为 `0..65536` 字节。
+- Native 使用系统 CSPRNG，生成的 JavaScript 使用 Web Crypto，WASI command 通过 Preview 1 `random_get` 填充由 Calcit 管理的 Buffer。
+- core WASM 不伪造随机数，继续用稳定的 `E_WASM_CAPABILITY` 拒绝缺少宿主协议的调用。
+- 主要语义测试定义在 Calcit Snapshot 的 `:tests` 中；脚本只负责跨后端运行、固定字节验证和宿主错误注入。

--- a/scripts/test-js-command.sh
+++ b/scripts/test-js-command.sh
@@ -37,3 +37,9 @@ if node --input-type=module --eval \
   exit 1
 fi
 grep -Fq "integer exit code in 0..255" "$INVALID_EXIT_STDERR"
+
+"$CALCIT_BIN" --init-fn app.main/random-main! --emit-path "$OUTPUT_DIR" "$FIXTURE" js
+node --input-type=module --eval \
+  'import("./target/js-command-smoke/app.main.mjs").then((module) => module.random_main_$x_())' \
+  >"$STDOUT_FILE" 2>"$STDERR_FILE"
+grep -Fxq "secure-random: ok" "$STDOUT_FILE"

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -17,6 +17,10 @@ readonly CLOCK_OUT="${CARGO_TARGET_DIR:-target}/wasi-clock-smoke"
 readonly CLOCK_STDOUT="${CLOCK_OUT}/stdout.txt"
 readonly FIXED_CLOCK_OUT="${CARGO_TARGET_DIR:-target}/wasi-fixed-clock-smoke"
 readonly CORE_CLOCK_OUT="${CARGO_TARGET_DIR:-target}/core-clock-reject"
+readonly RANDOM_OUT="${CARGO_TARGET_DIR:-target}/wasi-random-smoke"
+readonly RANDOM_STDOUT="${RANDOM_OUT}/stdout.txt"
+readonly FIXED_RANDOM_OUT="${CARGO_TARGET_DIR:-target}/wasi-fixed-random-smoke"
+readonly CORE_RANDOM_OUT="${CARGO_TARGET_DIR:-target}/core-random-reject"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
@@ -98,6 +102,19 @@ if clock_capability_error=$("$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app.
   exit 1
 fi
 grep -Fq "E_WASM_CAPABILITY" <<<"$clock_capability_error"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/random-main! --emit-path "$RANDOM_OUT"
+wasmtime run "$RANDOM_OUT/program.wasm" >"$RANDOM_STDOUT"
+grep -Fxq "secure-random: ok" "$RANDOM_STDOUT"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/random-fixed-main! --emit-path "$FIXED_RANDOM_OUT"
+node scripts/test-wasi-random-host.mjs "$FIXED_RANDOM_OUT/program.wasm"
+
+if random_capability_error=$("$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app.main/random-main! --emit-path "$CORE_RANDOM_OUT" 2>&1); then
+  echo "core WASM unexpectedly accepted secure random bytes" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_CAPABILITY" <<<"$random_capability_error"
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
   echo "cr-wasm unexpectedly accepted an unknown target" >&2

--- a/scripts/test-wasi-random-host.mjs
+++ b/scripts/test-wasi-random-host.mjs
@@ -3,13 +3,12 @@ import { readFile } from "node:fs/promises";
 
 const [wasmPath] = process.argv.slice(2);
 if (wasmPath == null) {
-  throw new Error("usage: node scripts/test-wasi-clock-host.mjs <program.wasm>");
+  throw new Error("usage: node scripts/test-wasi-random-host.mjs <program.wasm>");
 }
 
 let memory;
 let stdout = "";
-const requestedClocks = [];
-
+let randomDataPtr;
 const view = () => new DataView(memory.buffer);
 const bytes = () => new Uint8Array(memory.buffer);
 
@@ -19,17 +18,13 @@ const wasi = {
     view().setUint32(argvSizePtr, 0, true);
     return 0;
   },
-  args_get() {
-    return 0;
-  },
+  args_get: () => 0,
   environ_sizes_get(countPtr, sizePtr) {
     view().setUint32(countPtr, 0, true);
     view().setUint32(sizePtr, 0, true);
     return 0;
   },
-  environ_get() {
-    return 0;
-  },
+  environ_get: () => 0,
   fd_write(fd, iovsPtr, iovsLength, writtenPtr) {
     assert.equal(fd, 1);
     let written = 0;
@@ -45,17 +40,14 @@ const wasi = {
   proc_exit(code) {
     throw new Error(`unexpected proc_exit(${code})`);
   },
-  clock_time_get(clockId, precision, resultPtr) {
-    requestedClocks.push([clockId, precision]);
-    const nanoseconds = clockId === 0 ? 1_234_000_000n : clockId === 1 ? 5_678_000_000n : null;
-    if (nanoseconds == null) {
-      return 28;
-    }
-    view().setBigUint64(resultPtr, nanoseconds, true);
-    return 0;
+  clock_time_get() {
+    throw new Error("random fixture unexpectedly requested a clock");
   },
-  random_get() {
-    throw new Error("clock fixture unexpectedly requested random bytes");
+  random_get(ptr, length) {
+    assert.equal(length, 4);
+    randomDataPtr = ptr;
+    bytes().set([0, 127, 128, 255], ptr);
+    return 0;
   },
 };
 
@@ -64,13 +56,11 @@ const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1:
 memory = instance.exports.memory;
 instance.exports._start();
 
-assert.equal(stdout, "WASI-fixed-clocks: ok\n");
-assert.deepEqual(requestedClocks, [
-  [0, 1_000_000n],
-  [1, 1_000_000n],
-]);
+assert.equal(stdout, "secure-random-fixed: ok\n");
+assert.equal(view().getFloat64(randomDataPtr - 8, true), 4);
+assert.deepEqual(Array.from(bytes().subarray(randomDataPtr, randomDataPtr + 4)), [0, 127, 128, 255]);
 
-const failingWasi = { ...wasi, clock_time_get: () => 5 };
+const failingWasi = { ...wasi, random_get: () => 5 };
 const failingInstance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: failingWasi });
 memory = failingInstance.exports.memory;
-assert.throws(() => failingInstance.exports._start(), WebAssembly.RuntimeError);
+assert.throws(() => failingInstance.exports._start(), /unexpected proc_exit\(1\)/);

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -414,6 +414,7 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     GetEnv => effects::get_env(args),
     GetArgs => effects::get_args(args),
     UnixTimeMs => effects::unix_time_ms(args),
+    NativeSecureRandomBytes => effects::secure_random_bytes(args),
     NativeGetCalcitBackend => effects::call_get_calcit_backend(args),
     RegisterCalcitBuiltinImpls => meta::register_calcit_builtin_impls(args),
     ReadFile => effects::read_file(args),

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -188,15 +188,25 @@ pub fn secure_random_bytes(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       )),
     ])
   } else {
-    let mut bytes = vec![0; *size as usize];
-    match getrandom::fill(&mut bytes) {
-      Ok(()) => new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::Buffer(bytes)]),
-      Err(error) => new_named_enum_value(&[
-        result_type.to_owned(),
-        Calcit::tag("err"),
-        Calcit::new_str(format!("{host_error}: {error}")),
-      ]),
-    }
+    #[cfg(not(target_arch = "wasm32"))]
+    let result = {
+      let mut bytes = vec![0; *size as usize];
+      match getrandom::fill(&mut bytes) {
+        Ok(()) => new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::Buffer(bytes)]),
+        Err(error) => new_named_enum_value(&[
+          result_type.to_owned(),
+          Calcit::tag("err"),
+          Calcit::new_str(format!("{host_error}: {error}")),
+        ]),
+      }
+    };
+    #[cfg(target_arch = "wasm32")]
+    let result = new_named_enum_value(&[
+      result_type.to_owned(),
+      Calcit::tag("err"),
+      Calcit::new_str(format!("{host_error}: native interpreter CSPRNG is unavailable on wasm32")),
+    ]);
+    result
   }?;
   Ok(result)
 }

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -6,9 +6,11 @@ use std::sync::RwLock;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::{
-  builtins::meta::type_of,
+  builtins::meta::{new_named_enum_value, type_of},
   calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitProc, format_proc_examples_hint},
 };
+
+const MAX_SECURE_RANDOM_BYTES: usize = 65_536;
 
 #[derive(Clone, Debug, Copy)]
 pub enum CliRunningMode {
@@ -167,6 +169,36 @@ pub fn unix_time_ms(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     .map_err(|e| CalcitErr::use_str(CalcitErrKind::Effect, format!("unix-time-ms failed: {e}")))?
     .as_millis() as f64;
   Ok(Calcit::Number(millis))
+}
+
+/// Fill a Buffer from the operating system CSPRNG and preserve expected failures as Result values.
+pub fn secure_random_bytes(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  let [result_type @ Calcit::EnumDef(_), Calcit::Number(size), Calcit::Str(host_error)] = xs else {
+    return CalcitErr::err_str(
+      CalcitErrKind::Type,
+      "&secure-random-bytes expected the Result enum definition, a byte count, and a host error message",
+    );
+  };
+  let result = if !size.is_finite() || size.fract() != 0.0 || *size < 0.0 || *size > MAX_SECURE_RANDOM_BYTES as f64 {
+    new_named_enum_value(&[
+      result_type.to_owned(),
+      Calcit::tag("err"),
+      Calcit::new_str(format!(
+        "secure-random-bytes expected an integer byte count in 0..{MAX_SECURE_RANDOM_BYTES}, got: {size}"
+      )),
+    ])
+  } else {
+    let mut bytes = vec![0; *size as usize];
+    match getrandom::fill(&mut bytes) {
+      Ok(()) => new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::Buffer(bytes)]),
+      Err(error) => new_named_enum_value(&[
+        result_type.to_owned(),
+        Calcit::tag("err"),
+        Calcit::new_str(format!("{host_error}: {error}")),
+      ]),
+    }
+  }?;
+  Ok(result)
 }
 
 pub fn read_file(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -116,6 +116,8 @@ pub enum CalcitProc {
   GetArgs,
   #[strum(serialize = "unix-time-ms")]
   UnixTimeMs,
+  #[strum(serialize = "&secure-random-bytes")]
+  NativeSecureRandomBytes,
   #[strum(serialize = "&get-calcit-backend")]
   NativeGetCalcitBackend,
   #[strum(serialize = "register-calcit-builtin-impls")]
@@ -1396,6 +1398,13 @@ impl CalcitProc {
       UnixTimeMs => Some(ProcTypeSignature {
         return_type: some_tag("number"),
         arg_types: vec![],
+      }),
+      NativeSecureRandomBytes => Some(ProcTypeSignature {
+        return_type: Arc::new(CalcitTypeAnnotation::TypeRef(
+          Arc::from("Result"),
+          Arc::new(vec![some_tag("buffer"), some_tag("string")]),
+        )),
+        arg_types: vec![some_tag("enum-def"), some_tag("number"), some_tag("string")],
       }),
 
       // === Time ===

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -1961,6 +1961,14 @@
             {} (:return 'Unit)
               :args $ []
           :tags $ #{} :builtin :internal
+        '&secure-random-bytes $ %{} 'CodeEntry (:doc "|内部安全随机字节入口；显式接收 Result 类型原型，仅供 public wrapper 与 backend lowering 使用。")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'EnumDef 'Number 'String
+              :return $ :: 'Result 'Buffer 'String
+          :tags $ #{} :builtin :crypto :internal
         '&set:count $ %{} 'CodeEntry (:doc "|internal function for counting set elements\nSyntax: (&set:count set)\nParams: set (set)\nReturns: number\nReturns number of elements in set")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -7825,6 +7833,32 @@
                   [] ([] 0 1 2) ([] 3 4 5) ([] 6 7 8) ([] 9)
                   section-by (range 10) 3
               :tags $ #{} :core :unit
+        'secure-random-bytes $ %{} 'CodeEntry (:doc "|生成指定长度的密码学安全随机字节。长度必须是 0..65536 的整数；失败以 Result<String> 返回，不提供非安全伪随机退化路径。")
+          :code $ quote
+            defn secure-random-bytes (size)
+              if
+                and (round? size) (>= size 0) (<= size 65536)
+                &secure-random-bytes Result size "|secure-random-bytes failed"
+                %err "|secure-random-bytes expected an integer byte count in 0..65536"
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Number
+              :return $ :: 'Result 'Buffer 'String
+          :tags $ #{} :crypto :io
+          :tests $ []
+            %{} 'TestEntry (:name |returns-buffer)
+              :code $ quote
+                assert= true $ tag-match (secure-random-bytes 16)
+                  (:ok bytes) (buffer? bytes)
+                  (:err _) false
+              :tags $ #{} :core :crypto :unit :wasi :wasm
+            %{} 'TestEntry (:name |rejects-invalid-length)
+              :code $ quote
+                assert= true $ tag-match (secure-random-bytes 65537)
+                  (:ok _) false
+                  (:err message) (string? message)
+              :tags $ #{} :core :crypto :unit :wasi :wasm
         'select-keys $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn select-keys (m xs)

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -7849,13 +7849,13 @@
           :tests $ []
             %{} 'TestEntry (:name |returns-buffer)
               :code $ quote
-                assert= true $ tag-match (secure-random-bytes 16)
+                assert= true $ match (secure-random-bytes 16)
                   (:ok bytes) (buffer? bytes)
                   (:err _) false
               :tags $ #{} :core :crypto :unit :wasi :wasm
             %{} 'TestEntry (:name |rejects-invalid-length)
               :code $ quote
-                assert= true $ tag-match (secure-random-bytes 65537)
+                assert= true $ match (secure-random-bytes 65537)
                   (:ok _) false
                   (:err message) (string? message)
               :tags $ #{} :core :crypto :unit :wasi :wasm

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -2361,6 +2361,7 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
       expect_arity(0, args, "cpu-time")?;
       emit_wasi_clock_ms(ctx, 1, "cpu-time")
     }
+    CalcitProc::NativeSecureRandomBytes => emit_wasi_secure_random_bytes(ctx, args),
 
     // @atom deref: just emit the argument (which should already be a GlobalGet)
     CalcitProc::AtomDeref => {
@@ -2618,6 +2619,73 @@ fn emit_wasi_clock_ms(ctx: &mut WasmGenCtx, clock_id: i32, proc_name: &str) -> R
   ctx.emit(Instruction::F64ConvertI64U);
   ctx.emit(f64_const(1_000_000.0));
   ctx.emit(Instruction::F64Div);
+  Ok(())
+}
+
+/// Fill a managed Buffer through Preview 1 and wrap it in the caller's Result type.
+fn emit_wasi_secure_random_bytes(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  expect_arity(3, args, "&secure-random-bytes")?;
+  if ctx.target != WasmTarget::Wasi {
+    return Err("E_WASM_CAPABILITY: secure-random-bytes is unavailable for the core WASM target".into());
+  }
+
+  let size = ctx.alloc_local();
+  emit_expr(ctx, &args[1])?;
+  ctx.emit(Instruction::LocalSet(size));
+  let host_error = ctx.alloc_local();
+  emit_expr(ctx, &args[2])?;
+  ctx.emit(Instruction::LocalSet(host_error));
+
+  ctx.emit(Instruction::LocalGet(size));
+  ctx.emit(Instruction::LocalGet(size));
+  ctx.emit(Instruction::F64Trunc);
+  ctx.emit(Instruction::F64Ne);
+  ctx.emit(Instruction::LocalGet(size));
+  ctx.emit(f64_const(0.0));
+  ctx.emit(Instruction::F64Lt);
+  ctx.emit(Instruction::I32Or);
+  ctx.emit(Instruction::LocalGet(size));
+  ctx.emit(f64_const(65_536.0));
+  ctx.emit(Instruction::F64Gt);
+  ctx.emit(Instruction::I32Or);
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  emit_result_enum(ctx, "err", host_error)?;
+  ctx.emit(Instruction::Else);
+
+  let size_i32 = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalGet(size));
+  ctx.emit(Instruction::I32TruncF64U);
+  ctx.emit(Instruction::LocalSet(size_i32));
+  let allocation_size = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalGet(size_i32));
+  ctx.emit(Instruction::I32Const(7));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::I32Const(-8));
+  ctx.emit(Instruction::I32And);
+  ctx.emit(Instruction::I32Const(8));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalSet(allocation_size));
+  let buffer_ptr = ctx.alloc_local_typed(ValType::I32);
+  emit_bump_alloc_dynamic(ctx, allocation_size, buffer_ptr, "buffer");
+  ctx.emit(Instruction::LocalGet(buffer_ptr));
+  ctx.emit(Instruction::LocalGet(size));
+  ctx.emit(Instruction::F64Store(mem_arg_f64(0)));
+
+  ctx.emit(Instruction::LocalGet(buffer_ptr));
+  ctx.emit(Instruction::I32Const(8));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalGet(size_i32));
+  ctx.emit(Instruction::Call(resolve_host_import(ctx, "wasi_snapshot_preview1", "random_get")?));
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  emit_result_enum(ctx, "err", host_error)?;
+  ctx.emit(Instruction::Else);
+  let buffer = ctx.alloc_local();
+  ctx.emit(Instruction::LocalGet(buffer_ptr));
+  ctx.emit(Instruction::F64ConvertI32U);
+  ctx.emit(Instruction::LocalSet(buffer));
+  emit_result_enum(ctx, "ok", buffer)?;
+  ctx.emit(Instruction::End);
+  ctx.emit(Instruction::End);
   Ok(())
 }
 
@@ -3686,6 +3754,7 @@ mod tests {
         ("environ_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("proc_exit", vec![ValType::I32], vec![]),
         ("clock_time_get", vec![ValType::I32, ValType::I64, ValType::I32], vec![ValType::I32],),
+        ("random_get", vec![ValType::I32, ValType::I32], vec![ValType::I32]),
       ]
     );
     assert!(imports.iter().all(|import| import.module == "wasi_snapshot_preview1"));

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -3474,7 +3474,7 @@ fn emit_match(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
 /// Builtin type tags always registered in tag_index, so `type-of` can return them
 /// and heap objects can carry them in their header slot.
 const BUILTIN_TYPE_TAGS: &[&str] = &[
-  "buf-list", "list", "map", "set", "enum", "struct", "number", "bool", "nil", "tag", "fn", "string", "symbol",
+  "buf-list", "list", "map", "set", "enum", "struct", "number", "bool", "nil", "tag", "fn", "string", "symbol", "buffer",
 ];
 
 fn collect_all_tags_from(fn_defs: &[(String, String, CalcitFnArgs, Vec<Calcit>)]) -> HashMap<String, u32> {

--- a/src/codegen/emit_wasm/heap.rs
+++ b/src/codegen/emit_wasm/heap.rs
@@ -177,6 +177,30 @@ pub(super) fn emit_option_enum(ctx: &mut WasmGenCtx, payload_local: Option<u32>)
   Ok(())
 }
 
+/// Allocate a one-payload Result enum using the same layout as `%::`.
+pub(super) fn emit_result_enum(ctx: &mut WasmGenCtx, tag_name: &str, payload_local: u32) -> Result<(), String> {
+  let tag_id = *ctx
+    .tag_index
+    .get(tag_name)
+    .ok_or_else(|| format!("Result tag missing from WASM tag index: {tag_name}"))? as f64;
+  let ptr_local = ctx.alloc_local_typed(ValType::I32);
+  emit_bump_alloc(ctx, 24, ptr_local, "enum");
+
+  ctx.emit(Instruction::LocalGet(ptr_local));
+  ctx.emit(f64_const(1.0));
+  ctx.emit(Instruction::F64Store(mem_arg_f64(0)));
+  ctx.emit(Instruction::LocalGet(ptr_local));
+  ctx.emit(f64_const(tag_id));
+  ctx.emit(Instruction::F64Store(mem_arg_f64(8)));
+  ctx.emit(Instruction::LocalGet(ptr_local));
+  ctx.emit(Instruction::LocalGet(payload_local));
+  ctx.emit(Instruction::F64Store(mem_arg_f64(16)));
+
+  ctx.emit(Instruction::LocalGet(ptr_local));
+  ctx.emit(Instruction::F64ConvertI32U);
+  Ok(())
+}
+
 // ===========================================================================
 // Shared data-structure helpers
 // ===========================================================================

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -135,6 +135,12 @@ pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
         params: vec![ValType::I32, ValType::I64, ValType::I32],
         results: vec![ValType::I32],
       },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "random_get".into(),
+        params: vec![ValType::I32, ValType::I32],
+        results: vec![ValType::I32],
+      },
     ],
   }
 }

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -107,6 +107,9 @@ export let type_of = (x: any): CalcitTag => {
   if (x instanceof CalcitCirruQuote) {
     return newTag("cirru-quote");
   }
+  if (x instanceof Uint8Array) {
+    return newTag("buffer");
+  }
   if (x === true || x === false) {
     return newTag("bool");
   }
@@ -1533,6 +1536,24 @@ export let _$n_get_args = (): CalcitList => {
 
 export let get_args = _$n_get_args;
 
+/** Fill a Buffer with Web Crypto and preserve expected failures as Result values. */
+export let _$n_secure_random_bytes = (resultType: CalcitEnumDef, size: number, hostError: string): CalcitEnumValue => {
+  const error = (message: string) => new CalcitEnumValue(newTag("err"), [message], resultType);
+  if (!Number.isInteger(size) || size < 0 || size > 65_536) {
+    return error(`secure-random-bytes expected an integer byte count in 0..65536, got: ${size}`);
+  }
+  if (globalThis.crypto?.getRandomValues == null) {
+    return error(`${hostError}: Web Crypto getRandomValues is unavailable`);
+  }
+  try {
+    const bytes = new Uint8Array(size);
+    globalThis.crypto.getRandomValues(bytes);
+    return new CalcitEnumValue(newTag("ok"), [bytes], resultType);
+  } catch (cause) {
+    return error(`${hostError}: ${cause instanceof Error ? cause.message : String(cause)}`);
+  }
+};
+
 export let turn_tag = (x: CalcitValue): CalcitTag => {
   if (typeof x === "string") {
     return newTag(x);
@@ -1716,8 +1737,7 @@ export let enum_$q_ = (x: CalcitValue): boolean => {
   return x instanceof CalcitEnumValue;
 };
 export let buffer_$q_ = (x: CalcitValue): boolean => {
-  console.warn("TODO, detecting buffer");
-  return false;
+  return x instanceof Uint8Array;
 };
 
 export let _$n_str_$o_escape = (x: string) => JSON.stringify(x);

--- a/ts-src/js-primes.mts
+++ b/ts-src/js-primes.mts
@@ -32,6 +32,7 @@ export type CalcitValue =
   | CalcitStructDef
   | CalcitEnumDef
   | CalcitCirruQuote
+  | Uint8Array
   | undefined
   | null;
 


### PR DESCRIPTION
## 中文

### 变更

- 新增 `secure-random-bytes`，公开契约为有界 `Number -> Result<Buffer,String>`，单次最多 65536 字节。
- Native 使用系统 CSPRNG，生成的 JavaScript 使用 Web Crypto，WASI command 使用 Preview 1 `random_get`。
- WASI lowering 复用 Calcit 的 nominal `Result` 与 managed Buffer 布局；宿主 errno 进入 `:err`，core WASM 以 `E_WASM_CAPABILITY` 明确拒绝。
- 补齐 `buffer?` 与 JavaScript `Uint8Array` 的运行时类型识别。
- 主要语义覆盖放在 Calcit definition `:tests`；真实 Wasmtime 只验证 wiring，确定性 Node host 验证固定字节、Buffer 布局与错误注入。
- 更新宿主能力矩阵、CLI 文档与编辑历史。

### 验证

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `yarn compile`
- `bash scripts/test-js-command.sh`
- `bash scripts/test-wasi-preprocess.sh`

关联 #1021；时钟切片已由 #1036 合并，本 PR 完成安全随机切片。同步等待仍按独立设计切片处理，因此暂不自动关闭 issue。

## English

### Changes

- Add `secure-random-bytes` with a bounded `Number -> Result<Buffer,String>` surface contract and a 65,536-byte per-call limit.
- Use the operating-system CSPRNG in native evaluation, Web Crypto in generated JavaScript, and Preview 1 `random_get` in WASI commands.
- Reuse Calcit's nominal `Result` and managed Buffer layouts in WASI lowering; preserve host errno as `:err` and reject core WASM with `E_WASM_CAPABILITY`.
- Complete runtime Buffer recognition for JavaScript `Uint8Array` values.
- Keep primary semantics in Calcit definition `:tests`; use real Wasmtime only for wiring and a deterministic Node host for fixed bytes, Buffer layout, and injected failures.
- Update the host capability matrix, CLI reference, and editing history.

### Verification

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `yarn compile`
- `bash scripts/test-js-command.sh`
- `bash scripts/test-wasi-preprocess.sh`

Refs #1021. The clock slice landed in #1036 and this PR completes the secure-random slice. Synchronous waiting remains a separate design slice, so this PR does not auto-close the issue.
