### PR TITLE
feat(wasi): 类型化预开放文件读写 / typed preopened file I/O

### DIFF
--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -62,6 +62,66 @@
             {} (:return 'Unit)
               :args $ []
           :tags $ #{} :control :wasi
+        'filesystem-absolute-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn filesystem-absolute-main! () $ if (filesystem-read-error? |/workspace/input.txt) (println "|WASI-filesystem-absolute: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        'filesystem-denied-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn filesystem-denied-main! () $ if (filesystem-read-error? |workspace/input.txt) (println "|WASI-filesystem-denied: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        'filesystem-invalid-utf8-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn filesystem-invalid-utf8-main! () $ if (filesystem-read-error? |workspace/invalid.txt) (println "|WASI-filesystem-invalid-utf8: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        'filesystem-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn filesystem-main! () $ let
+                input $ .read-text (fs:path |workspace/input.txt)
+                output $ .write-text (fs:path |workspace/output.txt) "|WASI-written: 好"
+                input-ok? $ match input
+                  (:ok content) (= content "|WASI-file: 你好")
+                  (:err _) false
+                output-ok? $ match output
+                  (:ok _) true
+                  (:err _) false
+              if (and input-ok? output-ok?) (println "|WASI-filesystem: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        'filesystem-read-error? $ %{} 'CodeEntry (:doc "|验证 FsPath 文本读取失败仍以 Result :err 表达，不把 host error 泄漏为异常。")
+          :code $ quote
+            defn filesystem-read-error? (path)
+              match
+                .read-text $ fs:path path
+                (:ok _) false
+                (:err _) true
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'String
+          :tests $ []
+            %{} 'TestEntry (:name |missing-path)
+              :code $ quote
+                assert= true $ filesystem-read-error? |/calcit-wasi-filesystem-does-not-exist/input.txt
+              :tags $ #{} :file :unit :wasi
+        'filesystem-traversal-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn filesystem-traversal-main! () $ if (filesystem-read-error? |workspace/../secret.txt) (println "|WASI-filesystem-traversal: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
         'main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! () (println |WASI-stdout: "|你好") (echo |WASI-echo) (eprintln |WASI-stderr: 42)

--- a/docs/architectures/wasi-preopened-filesystem.cirru
+++ b/docs/architectures/wasi-preopened-filesystem.cirru
@@ -1,0 +1,79 @@
+{}
+  :schema-version 1
+  :feature 'wasi-preopened-filesystem
+  :doc "|让 FsPath 的 Result API 直接经过类型化 runtime boundary；WASI lowering 在内部解析 host preopen，拒绝未授权绝对路径与越界路径，不向 Calcit 暴露 descriptor。第一切片覆盖 UTF-8 read/write，read-dir 与递归 walk 后续接入同一边界。"
+  :roots $ #{} 'calcit.core/fs-path:read-text 'calcit.core/fs-path:write-text
+  :definitions $ {}
+    'calcit.core/&fs-read-text $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|内部 UTF-8 文件读取边界；显式接收 Result 原型和宿主错误前缀，供 FsPath wrapper 与 backend lowering 使用。"
+      :params $ [] 'result-type 'path 'host-error
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'EnumDef 'String 'String
+          :return $ :: 'Result 'String 'String
+      :code $ quote &runtime-implementation
+    'calcit.core/&fs-write-text $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|内部 UTF-8 文件写入边界；显式接收 Result 原型和宿主错误前缀，供 FsPath wrapper 与 backend lowering 使用。"
+      :params $ [] 'result-type 'path 'content 'host-error
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'EnumDef 'String 'String 'String
+          :return $ :: 'Result 'Unit 'String
+      :code $ quote &runtime-implementation
+    'calcit.core/fs-path:read-text $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|读取 FsPath 指向的 UTF-8 文本，并以 Result<String,String> 返回。"
+      :params $ [] 'self
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'FsPath
+          :return $ :: 'Result 'String 'String
+      :code $ quote
+        defn fs-path:read-text (self)
+          &fs-read-text Result (:value self) "|fs-path:read-text failed"
+    'calcit.core/fs-path:write-text $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|把 UTF-8 文本写入 FsPath，并以 Result<Unit,String> 返回。"
+      :params $ [] 'self 'content
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'FsPath 'String
+          :return $ :: 'Result 'Unit 'String
+      :code $ quote
+        defn fs-path:write-text (self content)
+          &fs-write-text Result (:value self) content "|fs-path:write-text failed"
+    'calcit.core/try-read-file $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|兼容 String path 的 UTF-8 读取入口，复用 FsPath 的类型化 runtime boundary。"
+      :params $ [] 'path
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'String
+          :return $ :: 'Result 'String 'String
+      :code $ quote
+        defn try-read-file (path)
+          &fs-read-text Result path "|try-read-file failed"
+    'calcit.core/try-write-file $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|兼容 String path 的 UTF-8 写入入口，复用 FsPath 的类型化 runtime boundary。"
+      :params $ [] 'path 'content
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'String 'String
+          :return $ :: 'Result 'Unit 'String
+      :code $ quote
+        defn try-write-file (path content)
+          &fs-write-text Result path content "|try-write-file failed"
+  :edges $ #{}
+    :: :call 'calcit.core/fs-path:read-text 'calcit.core/&fs-read-text
+    :: :call 'calcit.core/fs-path:write-text 'calcit.core/&fs-write-text
+    :: :call 'calcit.core/try-read-file 'calcit.core/&fs-read-text
+    :: :call 'calcit.core/try-write-file 'calcit.core/&fs-write-text

--- a/docs/installation/host-capability-boundary.md
+++ b/docs/installation/host-capability-boundary.md
@@ -74,7 +74,7 @@ no-op or fabricated success value.
 | Current Unix time in milliseconds | yes | unavailable | unavailable | WASI Preview 1 realtime clock; core WASM unavailable | `unix-time-ms` |
 | Monotonic milliseconds for elapsed-time measurement | yes | unavailable | unavailable | WASI Preview 1 monotonic clock; core WASM unavailable | `cpu-time`（只比较同一进程内两次调用的差值） |
 | Construct and inspect a path value without I/O | yes | yes | yes | value-level support only | `fs:path`, `FsPath .to-string` |
-| `FsPath .read-text` / `.write-text` | yes | host injection | browser `localStorage` adapter | unavailable | `FsPath` Result-returning methods |
+| `FsPath .read-text` / `.write-text` | yes | host injection | browser `localStorage` adapter | WASI Preview 1 preopen；core WASM unavailable | `FsPath` Result-returning methods |
 | `FsPath .read-dir` / `.walk-dir` | yes | host injection | unavailable | unavailable | `FsPath` Result-returning methods |
 | Process and signal lifecycle | `calcit.std` native module | Node adapter | unavailable | unavailable | typed process/signal APIs in `calcit.std` |
 | Repeating timer and timezone/date | `calcit.std` native module | Node adapter | browser adapter | unavailable | typed timer/date APIs in `calcit.std` |
@@ -97,6 +97,10 @@ The matrix records what exists today, not an entitlement for every backend.
 - Filesystem paths: construct `FsPath` with `fs:path`; use `.read-text`,
   `.write-text`, `.read-dir`, and `.walk-dir`. String-path `try-read-*` and raw
   raising procedures are compatibility or implementation entries.
+- 文件系统：WASI command 的 `.read-text` / `.write-text` 只解析 host 显式授予的
+  preopen，选择最长 guest 路径前缀，并拒绝绝对路径、`..` 越界、非法 UTF-8 与
+  无法推进的 partial I/O。descriptor 生命周期完全留在 adapter 内部；目录读取与
+  walk 仍保持 unavailable，直到复用同一权限解析边界。
 - 时钟：`unix-time-ms` 返回 Unix epoch 以来的系统时间；`cpu-time` 用于测量
   经过时间，其绝对起点没有跨宿主语义。WASI command 通过 Preview 1
   `clock_time_get` 实现这两个入口，并在宿主返回错误时直接失败，不伪造数值。

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -481,6 +481,15 @@ WASI command 也复用 `unix-time-ms` 与 `cpu-time`。前者读取系统实时�
 
 安全随机字节统一通过 `secure-random-bytes` 获取。参数必须是 `0..65536` 范围内的整数，返回值为 `Result<Buffer,String>`；WASI command 由 Preview 1 `random_get` 填充缓冲区，宿主错误保留为 `Result` 的错误分支。Native 与生成的 JavaScript 保持相同的公开值形状，分别使用系统 CSPRNG 与 Web Crypto。`calcit wasm` 的 core module 没有默认随机数宿主协议，会以 `E_WASM_CAPABILITY` 明确拒绝。
 
+WASI command 可通过 `FsPath .read-text` 与 `.write-text` 访问 host 显式预开放的目录。Calcit 路径使用 guest 侧名称，例如 host 以 `--dir ./data::/workspace` 授权后，程序访问 `workspace/input.txt`；编译器会选择最长匹配的 preopen，并只把剩余相对路径交给 Preview 1 `path_open`：
+
+```bash
+calcit wasi calcit.cirru --emit-path target/wasi-command
+wasmtime run --dir ./data::/workspace target/wasi-command/program.wasm
+```
+
+未提供 preopen、以 `/` 开头的绝对路径、包含完整 `..` 分段的越界路径、非法 UTF-8、I/O 错误和无法继续推进的 partial I/O 都返回 `Result :err`。当前 WASI 文本读取单文件上限为 4 MiB，超过限制同样返回错误，避免模块为不受控输入分配过量线性内存。Calcit 不接触 raw descriptor；`calcit wasm` 的 core module 也不会继承文件权限，而是在 codegen 阶段以 `E_WASM_CAPABILITY` 拒绝。`.read-dir` 与 `.walk-dir` 尚未接入 WASI。
+
 ## Markdown code checking
 
 Use `docs check-md` to validate fenced code blocks in markdown files:

--- a/editing-history/202609130311-wasi-preopened-filesystem.md
+++ b/editing-history/202609130311-wasi-preopened-filesystem.md
@@ -1,0 +1,22 @@
+# WASI 预开放文件系统第一切片
+
+## 背景
+
+`FsPath` 已在 Native 与生成的 JavaScript 中提供类型化的文本读写，但 WASI command 尚未连接 host preopen。旧的 String compatibility wrapper 还依赖 `try` 捕获异常，也不适合作为 WASM lowering 边界。
+
+## 变更
+
+- 新增内部 `&fs-read-text` 与 `&fs-write-text`，统一返回 nominal `Result`；`FsPath` 与兼容 String wrapper 直接复用这一边界。
+- Native 使用系统 UTF-8 文件 API，JavaScript 继续使用显式 `__calcit_injections__`，宿主失败转换为 `Result :err`。
+- WASI Preview 1 adapter 枚举 preopen，选择最长 guest 路径前缀，只把剩余相对路径传给 `path_open`。
+- 拒绝绝对路径、NUL 与完整 `..` 分段；无 preopen、I/O 错误、非法 UTF-8、零进度或越界 partial I/O 均返回错误，不向 Calcit 暴露 descriptor。
+- 文本读取限制为 4 MiB，避免不受限的 host 文件大小直接推动线性内存分配；目录读取仍留在后续切片。
+
+## 验证
+
+- Calcit definition-attached `:tests` 验证缺失路径保持 `Result :err`。
+- Native core unit tests：257 passed。
+- JavaScript runtime identity 覆盖成功读写、Unit payload 与 host failure。
+- 确定性 Preview 1 假宿主覆盖最长 preopen、UTF-8 内容以及多次 partial read/write。
+- 真实 Wasmtime 覆盖 named preopen 成功、无 preopen fail-closed、绝对路径、`..` 越界和非法 UTF-8。
+- core WASM 对文件能力保持 `E_WASM_CAPABILITY` 拒绝。

--- a/editing-history/202609130423-wasi-filesystem-review.md
+++ b/editing-history/202609130423-wasi-filesystem-review.md
@@ -1,0 +1,5 @@
+# WASI 文件边界 review 修复
+
+- 为 `&fs-read-text` 与 `&fs-write-text` 补齐 `:file` effect 标签，使 effect graph 能识别内部文件边界。
+- `fd_filestat_get` 的 64 字节输出改写入线性内存顶部的保留 scratch 区，避免覆盖从 `HEAP_BASE` 开始的静态字符串。
+- 假宿主精确断言 filestat 指针位于 scratch 区，覆盖这条底层内存布局契约。

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -87,6 +87,22 @@ try {
   const todoEnum = new runtimeA.CalcitEnumDef(new runtimeA.CalcitStructValue(todoName, [todoField], [todoType]));
   const todoEnumValue = new runtimeA.CalcitEnumValue(todoField, [""], todoEnum);
   const anonymousEnumValue = new runtimeA.CalcitEnumValue(todoField, [""]);
+  globalThis.__calcit_injections__.read_file = (path) => `typed:${path}`;
+  globalThis.__calcit_injections__.write_file = (path, content) => writes.push([path, content]);
+  const typedRead = runtimeA._$n_fs_read_text(todoEnum, "typed.txt", "read failed");
+  assert.equal(typedRead.tag, runtimeA.newTag("ok"));
+  assert.deepEqual(typedRead.extra, ["typed:typed.txt"]);
+  assert.equal(typedRead.enumPrototype, todoEnum);
+  const typedWrite = runtimeA._$n_fs_write_text(todoEnum, "typed.txt", "内容", "write failed");
+  assert.equal(typedWrite.tag, runtimeA.newTag("ok"));
+  assert.deepEqual(typedWrite.extra, [undefined]);
+  assert.deepEqual(writes.at(-1), ["typed.txt", "内容"]);
+  globalThis.__calcit_injections__.read_file = () => {
+    throw new Error("denied");
+  };
+  const typedFailure = runtimeA._$n_fs_read_text(todoEnum, "typed.txt", "read failed");
+  assert.equal(typedFailure.tag, runtimeA.newTag("err"));
+  assert.deepEqual(typedFailure.extra, ["read failed: denied"]);
   assert.equal(todoRecord.toString(), "(%{} 'TodoState (:draft |))");
   assert.equal(todoStruct.toString(), "(%struct-def 'TodoState (:draft 'String))");
   assert.equal(todoEnum.toString(), "(%enum-def 'TodoState)");

--- a/scripts/test-wasi-clock-host.mjs
+++ b/scripts/test-wasi-clock-host.mjs
@@ -57,6 +57,24 @@ const wasi = {
   random_get() {
     throw new Error("clock fixture unexpectedly requested random bytes");
   },
+  fd_prestat_get() {
+    throw new Error("clock fixture unexpectedly requested a filesystem preopen");
+  },
+  fd_prestat_dir_name() {
+    throw new Error("clock fixture unexpectedly requested a preopen name");
+  },
+  path_open() {
+    throw new Error("clock fixture unexpectedly opened a filesystem path");
+  },
+  fd_filestat_get() {
+    throw new Error("clock fixture unexpectedly requested file metadata");
+  },
+  fd_read() {
+    throw new Error("clock fixture unexpectedly read a file");
+  },
+  fd_close() {
+    throw new Error("clock fixture unexpectedly closed a file");
+  },
 };
 
 const module = await WebAssembly.compile(await readFile(wasmPath));

--- a/scripts/test-wasi-filesystem-host.mjs
+++ b/scripts/test-wasi-filesystem-host.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [wasmPath] = process.argv.slice(2);
+if (wasmPath == null) {
+  throw new Error("usage: node scripts/test-wasi-filesystem-host.mjs <program.wasm>");
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const preopenNames = new Map([
+  [3, encoder.encode("/workspace")],
+  [4, encoder.encode(".")],
+]);
+const input = encoder.encode("WASI-file: 你好");
+const output = [];
+const openedPaths = [];
+let inputOffset = 0;
+let readCalls = 0;
+let writeCalls = 0;
+let memory;
+
+const view = () => new DataView(memory.buffer);
+const bytes = () => new Uint8Array(memory.buffer);
+const decode = (ptr, length) => decoder.decode(bytes().subarray(ptr, ptr + length));
+
+const wasi = {
+  args_sizes_get(argcPtr, argvSizePtr) {
+    view().setUint32(argcPtr, 0, true);
+    view().setUint32(argvSizePtr, 0, true);
+    return 0;
+  },
+  args_get: () => 0,
+  environ_sizes_get(countPtr, sizePtr) {
+    view().setUint32(countPtr, 0, true);
+    view().setUint32(sizePtr, 0, true);
+    return 0;
+  },
+  environ_get: () => 0,
+  proc_exit(code) {
+    throw new Error(`unexpected proc_exit(${code})`);
+  },
+  clock_time_get() {
+    throw new Error("filesystem fixture unexpectedly requested a clock");
+  },
+  random_get() {
+    throw new Error("filesystem fixture unexpectedly requested random bytes");
+  },
+  fd_prestat_get(fd, prestatPtr) {
+    const preopenName = preopenNames.get(fd);
+    if (preopenName == null) return 8;
+    view().setUint8(prestatPtr, 0);
+    view().setUint32(prestatPtr + 4, preopenName.length, true);
+    return 0;
+  },
+  fd_prestat_dir_name(fd, namePtr, nameLength) {
+    const preopenName = preopenNames.get(fd);
+    assert.ok(preopenName != null);
+    assert.equal(nameLength, preopenName.length);
+    bytes().set(preopenName, namePtr);
+    return 0;
+  },
+  path_open(fd, _dirFlags, pathPtr, pathLength, oflags, _rightsBase, _rightsInheriting, _fdFlags, openedFdPtr) {
+    assert.equal(fd, 3);
+    const path = decode(pathPtr, pathLength);
+    openedPaths.push(path);
+    if (path === "input.txt" && oflags === 0) {
+      view().setUint32(openedFdPtr, 5, true);
+      return 0;
+    }
+    if (path === "output.txt" && oflags === 9) {
+      view().setUint32(openedFdPtr, 6, true);
+      return 0;
+    }
+    return 44;
+  },
+  fd_filestat_get(fd, statPtr) {
+    assert.equal(fd, 5);
+    view().setBigUint64(statPtr + 32, BigInt(input.length), true);
+    return 0;
+  },
+  fd_read(fd, iovsPtr, iovsLength, readPtr) {
+    assert.equal(fd, 5);
+    assert.equal(iovsLength, 1);
+    const ptr = view().getUint32(iovsPtr, true);
+    const requested = view().getUint32(iovsPtr + 4, true);
+    const length = Math.min(requested, 2, input.length - inputOffset);
+    bytes().set(input.subarray(inputOffset, inputOffset + length), ptr);
+    inputOffset += length;
+    readCalls += 1;
+    view().setUint32(readPtr, length, true);
+    return 0;
+  },
+  fd_write(fd, iovsPtr, iovsLength, writtenPtr) {
+    assert.equal(iovsLength, 1);
+    const ptr = view().getUint32(iovsPtr, true);
+    const requested = view().getUint32(iovsPtr + 4, true);
+    if (fd === 1) {
+      const chunk = bytes().slice(ptr, ptr + requested);
+      output.push(...chunk);
+      view().setUint32(writtenPtr, requested, true);
+      return 0;
+    }
+    assert.equal(fd, 6);
+    const length = Math.min(requested, 3);
+    output.push(...bytes().subarray(ptr, ptr + length));
+    writeCalls += 1;
+    view().setUint32(writtenPtr, length, true);
+    return 0;
+  },
+  fd_close(fd) {
+    assert.ok(fd === 5 || fd === 6);
+    return 0;
+  },
+};
+
+const module = await WebAssembly.compile(await readFile(wasmPath));
+const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+memory = instance.exports.memory;
+instance.exports._start();
+
+assert.deepEqual(openedPaths, ["input.txt", "output.txt"]);
+assert.ok(readCalls > 1, "read adapter must handle partial fd_read progress");
+assert.ok(writeCalls > 1, "write adapter must handle partial fd_write progress");
+assert.equal(decoder.decode(Uint8Array.from(output)), "WASI-written: 好WASI-filesystem: ok\n");
+
+const zeroReadWasi = {
+  ...wasi,
+  fd_read(_fd, _iovsPtr, _iovsLength, readPtr) {
+    view().setUint32(readPtr, 0, true);
+    return 0;
+  },
+};
+const zeroReadInstance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: zeroReadWasi });
+memory = zeroReadInstance.exports.memory;
+assert.throws(() => zeroReadInstance.exports._start(), /unexpected proc_exit\(1\)/);
+
+inputOffset = 0;
+const zeroWriteWasi = {
+  ...wasi,
+  fd_write(fd, iovsPtr, iovsLength, writtenPtr) {
+    if (fd === 6) {
+      view().setUint32(writtenPtr, 0, true);
+      return 0;
+    }
+    return wasi.fd_write(fd, iovsPtr, iovsLength, writtenPtr);
+  },
+};
+const zeroWriteInstance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: zeroWriteWasi });
+memory = zeroWriteInstance.exports.memory;
+assert.throws(() => zeroWriteInstance.exports._start(), /unexpected proc_exit\(1\)/);

--- a/scripts/test-wasi-filesystem-host.mjs
+++ b/scripts/test-wasi-filesystem-host.mjs
@@ -76,6 +76,7 @@ const wasi = {
   },
   fd_filestat_get(fd, statPtr) {
     assert.equal(fd, 5);
+    assert.equal(statPtr, memory.buffer.byteLength - 64, "filestat must use reserved scratch memory");
     view().setBigUint64(statPtr + 32, BigInt(input.length), true);
     return 0;
   },

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -21,9 +21,23 @@ readonly RANDOM_OUT="${CARGO_TARGET_DIR:-target}/wasi-random-smoke"
 readonly RANDOM_STDOUT="${RANDOM_OUT}/stdout.txt"
 readonly FIXED_RANDOM_OUT="${CARGO_TARGET_DIR:-target}/wasi-fixed-random-smoke"
 readonly CORE_RANDOM_OUT="${CARGO_TARGET_DIR:-target}/core-random-reject"
+readonly FILESYSTEM_OUT="${CARGO_TARGET_DIR:-target}/wasi-filesystem-smoke"
+readonly FILESYSTEM_STDOUT="${FILESYSTEM_OUT}/stdout.txt"
+readonly FILESYSTEM_DENIED_OUT="${CARGO_TARGET_DIR:-target}/wasi-filesystem-denied"
+readonly FILESYSTEM_DENIED_STDOUT="${FILESYSTEM_DENIED_OUT}/stdout.txt"
+readonly FILESYSTEM_TRAVERSAL_OUT="${CARGO_TARGET_DIR:-target}/wasi-filesystem-traversal"
+readonly FILESYSTEM_TRAVERSAL_STDOUT="${FILESYSTEM_TRAVERSAL_OUT}/stdout.txt"
+readonly FILESYSTEM_UTF8_OUT="${CARGO_TARGET_DIR:-target}/wasi-filesystem-invalid-utf8"
+readonly FILESYSTEM_UTF8_STDOUT="${FILESYSTEM_UTF8_OUT}/stdout.txt"
+readonly FILESYSTEM_ABSOLUTE_OUT="${CARGO_TARGET_DIR:-target}/wasi-filesystem-absolute"
+readonly FILESYSTEM_ABSOLUTE_STDOUT="${FILESYSTEM_ABSOLUTE_OUT}/stdout.txt"
+readonly CORE_FILESYSTEM_OUT="${CARGO_TARGET_DIR:-target}/core-filesystem-reject"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
+WASI_FS_HOST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/calcit-wasi-fs.XXXXXX")
+readonly WASI_FS_HOST_DIR
+trap 'rm -rf "$WASI_FS_HOST_DIR"' EXIT
 
 command -v wasmtime >/dev/null
 
@@ -115,6 +129,46 @@ if random_capability_error=$("$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app
   exit 1
 fi
 grep -Fq "E_WASM_CAPABILITY" <<<"$random_capability_error"
+
+printf '%s' 'WASI-file: 你好' >"$WASI_FS_HOST_DIR/input.txt"
+printf '\377\n' >"$WASI_FS_HOST_DIR/invalid.txt"
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-main! --emit-path "$FILESYSTEM_OUT"
+wasmtime run \
+  --dir "$WASI_FS_HOST_DIR::/workspace" \
+  "$FILESYSTEM_OUT/program.wasm" >"$FILESYSTEM_STDOUT"
+grep -Fxq "WASI-filesystem: ok" "$FILESYSTEM_STDOUT"
+grep -Fxq 'WASI-written: 好' "$WASI_FS_HOST_DIR/output.txt"
+node scripts/test-wasi-filesystem-host.mjs "$FILESYSTEM_OUT/program.wasm"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-denied-main! --emit-path "$FILESYSTEM_DENIED_OUT"
+wasmtime run "$FILESYSTEM_DENIED_OUT/program.wasm" >"$FILESYSTEM_DENIED_STDOUT"
+grep -Fxq "WASI-filesystem-denied: ok" "$FILESYSTEM_DENIED_STDOUT"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-traversal-main! --emit-path "$FILESYSTEM_TRAVERSAL_OUT"
+wasmtime run \
+  --dir "$WASI_FS_HOST_DIR::/workspace" \
+  "$FILESYSTEM_TRAVERSAL_OUT/program.wasm" >"$FILESYSTEM_TRAVERSAL_STDOUT"
+grep -Fxq "WASI-filesystem-traversal: ok" "$FILESYSTEM_TRAVERSAL_STDOUT"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-invalid-utf8-main! --emit-path "$FILESYSTEM_UTF8_OUT"
+wasmtime run \
+  --dir "$WASI_FS_HOST_DIR::/workspace" \
+  "$FILESYSTEM_UTF8_OUT/program.wasm" >"$FILESYSTEM_UTF8_STDOUT"
+grep -Fxq "WASI-filesystem-invalid-utf8: ok" "$FILESYSTEM_UTF8_STDOUT"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-absolute-main! --emit-path "$FILESYSTEM_ABSOLUTE_OUT"
+wasmtime run \
+  --dir "$WASI_FS_HOST_DIR::/workspace" \
+  "$FILESYSTEM_ABSOLUTE_OUT/program.wasm" >"$FILESYSTEM_ABSOLUTE_STDOUT"
+grep -Fxq "WASI-filesystem-absolute: ok" "$FILESYSTEM_ABSOLUTE_STDOUT"
+
+if filesystem_capability_error=$(
+  "$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app.main/filesystem-main! --emit-path "$CORE_FILESYSTEM_OUT" 2>&1
+); then
+  echo "core WASM unexpectedly accepted filesystem effects" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_CAPABILITY" <<<"$filesystem_capability_error"
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
   echo "cr-wasm unexpectedly accepted an unknown target" >&2

--- a/scripts/test-wasi-random-host.mjs
+++ b/scripts/test-wasi-random-host.mjs
@@ -49,6 +49,24 @@ const wasi = {
     bytes().set([0, 127, 128, 255], ptr);
     return 0;
   },
+  fd_prestat_get() {
+    throw new Error("random fixture unexpectedly requested a filesystem preopen");
+  },
+  fd_prestat_dir_name() {
+    throw new Error("random fixture unexpectedly requested a preopen name");
+  },
+  path_open() {
+    throw new Error("random fixture unexpectedly opened a filesystem path");
+  },
+  fd_filestat_get() {
+    throw new Error("random fixture unexpectedly requested file metadata");
+  },
+  fd_read() {
+    throw new Error("random fixture unexpectedly read a file");
+  },
+  fd_close() {
+    throw new Error("random fixture unexpectedly closed a file");
+  },
 };
 
 const module = await WebAssembly.compile(await readFile(wasmPath));

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -418,8 +418,10 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     NativeGetCalcitBackend => effects::call_get_calcit_backend(args),
     RegisterCalcitBuiltinImpls => meta::register_calcit_builtin_impls(args),
     ReadFile => effects::read_file(args),
+    NativeFsReadText => effects::fs_read_text(args),
     ReadDir => effects::read_dir(args),
     WriteFile => effects::write_file(args),
+    NativeFsWriteText => effects::fs_write_text(args),
     // external data format
     ParseCirru => meta::parse_cirru(args),
     ParseCirruList => meta::parse_cirru_list(args),

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -229,6 +229,25 @@ pub fn read_file(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   }
 }
 
+/// Read UTF-8 text and preserve filesystem failures as nominal Result values.
+pub fn fs_read_text(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  let [result_type @ Calcit::EnumDef(_), Calcit::Str(path), Calcit::Str(host_error)] = xs else {
+    return CalcitErr::err_str(
+      CalcitErrKind::Type,
+      "&fs-read-text expected the Result enum definition, a path string, and a host error prefix",
+    );
+  };
+  let result = match fs::read_to_string(&**path) {
+    Ok(content) => new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::new_str(content)]),
+    Err(error) => new_named_enum_value(&[
+      result_type.to_owned(),
+      Calcit::tag("err"),
+      Calcit::new_str(format!("{host_error}: {error}")),
+    ]),
+  }?;
+  Ok(result)
+}
+
 pub fn read_dir(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   if xs.len() > 2 {
     return CalcitErr::err_str(
@@ -303,6 +322,31 @@ pub fn write_file(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
       CalcitErr::err_str_with_hint(CalcitErrKind::Arity, msg, hint)
     }
   }
+}
+
+/// Write UTF-8 text and preserve filesystem failures as nominal Result values.
+pub fn fs_write_text(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  let [
+    result_type @ Calcit::EnumDef(_),
+    Calcit::Str(path),
+    Calcit::Str(content),
+    Calcit::Str(host_error),
+  ] = xs
+  else {
+    return CalcitErr::err_str(
+      CalcitErrKind::Type,
+      "&fs-write-text expected the Result enum definition, path and content strings, and a host error prefix",
+    );
+  };
+  let result = match fs::write(&**path, &**content) {
+    Ok(()) => new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::Unit]),
+    Err(error) => new_named_enum_value(&[
+      result_type.to_owned(),
+      Calcit::tag("err"),
+      Calcit::new_str(format!("{host_error}: {error}")),
+    ]),
+  }?;
+  Ok(result)
 }
 
 #[cfg(test)]

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -124,10 +124,14 @@ pub enum CalcitProc {
   RegisterCalcitBuiltinImpls,
   #[strum(serialize = "read-file")]
   ReadFile,
+  #[strum(serialize = "&fs-read-text")]
+  NativeFsReadText,
   #[strum(serialize = "read-dir")]
   ReadDir,
   #[strum(serialize = "write-file")]
   WriteFile,
+  #[strum(serialize = "&fs-write-text")]
+  NativeFsWriteText,
   #[strum(serialize = "list?")]
   ListQuestion,
   #[strum(serialize = "tag?")]
@@ -1364,6 +1368,13 @@ impl CalcitProc {
         return_type: some_tag("string"),
         arg_types: vec![some_tag("string")],
       }),
+      NativeFsReadText => Some(ProcTypeSignature {
+        return_type: Arc::new(CalcitTypeAnnotation::TypeRef(
+          Arc::from("Result"),
+          Arc::new(vec![some_tag("string"), some_tag("string")]),
+        )),
+        arg_types: vec![some_tag("enum-def"), some_tag("string"), some_tag("string")],
+      }),
       ReadDir => Some(ProcTypeSignature {
         return_type: list_of(some_tag("string")),
         arg_types: vec![some_tag("string"), some_tag("bool")],
@@ -1371,6 +1382,13 @@ impl CalcitProc {
       WriteFile => Some(ProcTypeSignature {
         return_type: some_tag("unit"),
         arg_types: vec![some_tag("string"), some_tag("string")],
+      }),
+      NativeFsWriteText => Some(ProcTypeSignature {
+        return_type: Arc::new(CalcitTypeAnnotation::TypeRef(
+          Arc::from("Result"),
+          Arc::new(vec![some_tag("unit"), some_tag("string")]),
+        )),
+        arg_types: vec![some_tag("enum-def"), some_tag("string"), some_tag("string"), some_tag("string")],
       }),
       Raise => Some(ProcTypeSignature {
         return_type: dynamic_tag(),

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -713,6 +713,20 @@
             {} (:return 'String)
               :args $ [] 'List
           :tags $ #{} :builtin :internal
+        '&fs-read-text $ %{} 'CodeEntry (:doc "|内部 UTF-8 文件读取边界；显式接收 Result 原型和宿主错误前缀，供 FsPath wrapper 与 backend lowering 使用。")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'EnumDef 'String 'String
+              :return $ :: 'Result 'String 'String
+        '&fs-write-text $ %{} 'CodeEntry (:doc "|内部 UTF-8 文件写入边界；显式接收 Result 原型和宿主错误前缀，供 FsPath wrapper 与 backend lowering 使用。")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'EnumDef 'String 'String 'String
+              :return $ :: 'Result 'Unit 'String
         '&get-args $ %{} 'CodeEntry (:doc "|读取宿主进程参数的内部实现。")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -5547,10 +5561,10 @@
               :args $ [] 'FsPath
               :return $ :: 'Result (:: 'List 'FsPath) 'String
           :tags $ #{} :file :internal :io
-        'fs-path:read-text $ %{} 'CodeEntry (:doc "|Read an FsPath as UTF-8 text and return Result<String,String>.")
+        'fs-path:read-text $ %{} 'CodeEntry (:doc "|读取 FsPath 指向的 UTF-8 文本并返回 Result<String,String>；WASI 只访问 host 显式授予的 preopen。")
           :code $ quote
             defn fs-path:read-text (self)
-              try-read-file $ :value self
+              &fs-read-text Result (:value self) "|fs-path:read-text failed"
           :examples $ []
           :schema $ :: 'Fn
             {}
@@ -5577,10 +5591,10 @@
               :args $ [] 'FsPath
               :return $ :: 'Result (:: 'List 'FsPath) 'String
           :tags $ #{} :file :internal :io
-        'fs-path:write-text $ %{} 'CodeEntry (:doc "|Write UTF-8 text to an FsPath and return Result<Unit,String>.")
+        'fs-path:write-text $ %{} 'CodeEntry (:doc "|把 UTF-8 文本写入 FsPath 并返回 Result<Unit,String>；WASI 只访问 host 显式授予的 preopen。")
           :code $ quote
             defn fs-path:write-text (self content)
-              try-write-file (:value self) content
+              &fs-write-text Result (:value self) content "|fs-path:write-text failed"
           :examples $ []
           :schema $ :: 'Fn
             {}
@@ -8584,24 +8598,18 @@
             {}
               :args $ [] 'String (:: 'Option 'Bool)
               :return $ :: 'Result (:: 'List 'String) 'String
-        'try-read-file $ %{} 'CodeEntry (:doc "|Compatibility function that reads a UTF-8 path String as Result<String,String>. New code should construct FsPath with fs:path and call .read-text. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
+        'try-read-file $ %{} 'CodeEntry (:doc "|兼容 String path 的 UTF-8 读取入口，复用 FsPath 的类型化 runtime boundary；新代码应使用 FsPath .read-text。")
           :code $ quote
-            defn try-read-file (path)
-              try
-                %ok $ read-file path
-                fn (message) (%err message)
+            defn try-read-file (path) (&fs-read-text Result path "|try-read-file failed")
           :examples $ []
             quote $ try-read-file |/calcit-result-contract-does-not-exist/file
           :schema $ :: 'Fn
             {}
               :args $ [] 'String
               :return $ :: 'Result 'String 'String
-        'try-write-file $ %{} 'CodeEntry (:doc "|Compatibility function that writes UTF-8 content to a path String as Result<Unit,String>. New code should construct FsPath with fs:path and call .write-text. Native and JavaScript hosts with file injections are supported; WASM file effects are not yet supported.")
+        'try-write-file $ %{} 'CodeEntry (:doc "|兼容 String path 的 UTF-8 写入入口，复用 FsPath 的类型化 runtime boundary；新代码应使用 FsPath .write-text。")
           :code $ quote
-            defn try-write-file (path content)
-              try
-                %ok $ write-file path content
-                fn (message) (%err message)
+            defn try-write-file (path content) (&fs-write-text Result path content "|try-write-file failed")
           :examples $ []
             quote $ try-write-file |/calcit-result-contract-does-not-exist/file |content
           :schema $ :: 'Fn

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -720,6 +720,7 @@
             {}
               :args $ [] 'EnumDef 'String 'String
               :return $ :: 'Result 'String 'String
+          :tags $ #{} :builtin :file :internal :io
         '&fs-write-text $ %{} 'CodeEntry (:doc "|内部 UTF-8 文件写入边界；显式接收 Result 原型和宿主错误前缀，供 FsPath wrapper 与 backend lowering 使用。")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -727,6 +728,7 @@
             {}
               :args $ [] 'EnumDef 'String 'String 'String
               :return $ :: 'Result 'Unit 'String
+          :tags $ #{} :builtin :file :internal :io
         '&get-args $ %{} 'CodeEntry (:doc "|读取宿主进程参数的内部实现。")
           :code $ quote &runtime-implementation
           :examples $ []

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -45,8 +45,9 @@ mod structs;
 
 use methods::{emit_call_args, emit_method_invoke};
 use runtime::{
-  HostImport, ModuleFunctionLayout, build_runtime_fns, build_wasi_get_args_fn, build_wasi_get_env_fn, build_wasi_write_all_fn,
-  build_wasm_module, core_host_import, host_imports_for_target,
+  HostImport, ModuleFunctionLayout, build_runtime_fns, build_utf8_valid_fn, build_wasi_get_args_fn, build_wasi_get_env_fn,
+  build_wasi_open_path_fn, build_wasi_read_text_fn, build_wasi_write_all_fn, build_wasi_write_text_fn, build_wasm_module,
+  core_host_import, host_imports_for_target,
 };
 use structs::{
   emit_enum_assoc, emit_enum_count, emit_enum_new, emit_enum_nth, emit_named_enum_new, emit_struct_contains, emit_struct_count,
@@ -256,6 +257,33 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
         .get(&("wasi_snapshot_preview1".into(), name.into()))
         .unwrap_or_else(|| panic!("WASI {name} import must be registered"))
     };
+    let utf8_valid_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_utf8_valid".into(), utf8_valid_idx);
+    compiled_fns.push(build_utf8_valid_fn());
+    let open_path_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_open_path".into(), open_path_idx);
+    compiled_fns.push(build_wasi_open_path_fn(
+      wasi_import("fd_prestat_get"),
+      wasi_import("fd_prestat_dir_name"),
+      wasi_import("path_open"),
+    ));
+    let read_text_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_read_text".into(), read_text_idx);
+    compiled_fns.push(build_wasi_read_text_fn(
+      open_path_idx,
+      wasi_import("fd_filestat_get"),
+      wasi_import("fd_read"),
+      wasi_import("fd_close"),
+      utf8_valid_idx,
+      str_tag_id,
+    ));
+    let write_text_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_write_text".into(), write_text_idx);
+    compiled_fns.push(build_wasi_write_text_fn(
+      open_path_idx,
+      wasi_import("fd_write"),
+      wasi_import("fd_close"),
+    ));
     let get_args_idx = num_imports + compiled_fns.len() as u32;
     runtime_fn_index.insert("__rt_wasi_get_args".into(), get_args_idx);
     compiled_fns.push(build_wasi_get_args_fn(
@@ -2362,6 +2390,8 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
       emit_wasi_clock_ms(ctx, 1, "cpu-time")
     }
     CalcitProc::NativeSecureRandomBytes => emit_wasi_secure_random_bytes(ctx, args),
+    CalcitProc::NativeFsReadText => emit_wasi_fs_read_text(ctx, args),
+    CalcitProc::NativeFsWriteText => emit_wasi_fs_write_text(ctx, args),
 
     // @atom deref: just emit the argument (which should already be a GlobalGet)
     CalcitProc::AtomDeref => {
@@ -2685,6 +2715,58 @@ fn emit_wasi_secure_random_bytes(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Resul
   ctx.emit(Instruction::LocalSet(buffer));
   emit_result_enum(ctx, "ok", buffer)?;
   ctx.emit(Instruction::End);
+  ctx.emit(Instruction::End);
+  Ok(())
+}
+
+/// Lower the typed filesystem read boundary through private Preview 1 helpers.
+fn emit_wasi_fs_read_text(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  expect_arity(3, args, "&fs-read-text")?;
+  if ctx.target != WasmTarget::Wasi {
+    return Err("E_WASM_CAPABILITY: filesystem reads are unavailable for the core WASM target".into());
+  }
+  let path = emit_ptr_to_i32(ctx, &args[1])?;
+  let host_error = ctx.alloc_local();
+  emit_expr(ctx, &args[2])?;
+  ctx.emit(Instruction::LocalSet(host_error));
+  ctx.emit(Instruction::LocalGet(path));
+  ctx.call_rt("__rt_wasi_read_text");
+  let content_ptr = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalTee(content_ptr));
+  ctx.emit(Instruction::I32Eqz);
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  emit_result_enum(ctx, "err", host_error)?;
+  ctx.emit(Instruction::Else);
+  let content = ctx.alloc_local();
+  ctx.emit(Instruction::LocalGet(content_ptr));
+  ctx.emit(Instruction::F64ConvertI32U);
+  ctx.emit(Instruction::LocalSet(content));
+  emit_result_enum(ctx, "ok", content)?;
+  ctx.emit(Instruction::End);
+  Ok(())
+}
+
+/// Lower the typed filesystem write boundary through private Preview 1 helpers.
+fn emit_wasi_fs_write_text(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  expect_arity(4, args, "&fs-write-text")?;
+  if ctx.target != WasmTarget::Wasi {
+    return Err("E_WASM_CAPABILITY: filesystem writes are unavailable for the core WASM target".into());
+  }
+  let path = emit_ptr_to_i32(ctx, &args[1])?;
+  let content = emit_ptr_to_i32(ctx, &args[2])?;
+  let host_error = ctx.alloc_local();
+  emit_expr(ctx, &args[3])?;
+  ctx.emit(Instruction::LocalSet(host_error));
+  ctx.emit(Instruction::LocalGet(path));
+  ctx.emit(Instruction::LocalGet(content));
+  ctx.call_rt("__rt_wasi_write_text");
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  let unit = ctx.alloc_local();
+  ctx.emit(f64_const(0.0));
+  ctx.emit(Instruction::LocalSet(unit));
+  emit_result_enum(ctx, "ok", unit)?;
+  ctx.emit(Instruction::Else);
+  emit_result_enum(ctx, "err", host_error)?;
   ctx.emit(Instruction::End);
   Ok(())
 }
@@ -3755,6 +3837,26 @@ mod tests {
         ("proc_exit", vec![ValType::I32], vec![]),
         ("clock_time_get", vec![ValType::I32, ValType::I64, ValType::I32], vec![ValType::I32],),
         ("random_get", vec![ValType::I32, ValType::I32], vec![ValType::I32]),
+        ("fd_prestat_get", vec![ValType::I32; 2], vec![ValType::I32]),
+        ("fd_prestat_dir_name", vec![ValType::I32; 3], vec![ValType::I32]),
+        (
+          "path_open",
+          vec![
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I32,
+            ValType::I64,
+            ValType::I64,
+            ValType::I32,
+            ValType::I32,
+          ],
+          vec![ValType::I32],
+        ),
+        ("fd_filestat_get", vec![ValType::I32; 2], vec![ValType::I32]),
+        ("fd_read", vec![ValType::I32; 4], vec![ValType::I32]),
+        ("fd_close", vec![ValType::I32], vec![ValType::I32]),
       ]
     );
     assert!(imports.iter().all(|import| import.module == "wasi_snapshot_preview1"));

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -764,8 +764,10 @@ pub(super) fn build_wasi_read_text_fn(
   let padded = b.alloc_i32();
   let payload = b.alloc_i32();
   let managed_size = b.alloc_i64();
-  let zero_scratch = b.alloc_i64();
+  let zero_size = b.alloc_i64();
   let unused_scratch = b.alloc_i32();
+  let filestat_size = b.alloc_i64();
+  let filestat = b.alloc_i32();
   let string = b.alloc_i32();
   let data = b.alloc_i32();
   let offset = b.alloc_i32();
@@ -782,8 +784,13 @@ pub(super) fn build_wasi_read_text_fn(
   b.emit(Instruction::I32Const(0));
   b.emit(Instruction::Return);
   b.emit(Instruction::End);
+  b.emit(Instruction::I64Const(64));
+  b.emit(Instruction::LocalSet(filestat_size));
+  b.emit(Instruction::I64Const(0));
+  b.emit(Instruction::LocalSet(zero_size));
+  rt_emit_reserve_scratch(&mut b, filestat_size, zero_size, filestat);
   b.emit(Instruction::LocalGet(fd));
-  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalGet(filestat));
   b.emit(Instruction::Call(fd_filestat_get_idx));
   b.emit(Instruction::If(BlockType::Empty));
   b.emit(Instruction::LocalGet(fd));
@@ -792,7 +799,9 @@ pub(super) fn build_wasi_read_text_fn(
   b.emit(Instruction::I32Const(0));
   b.emit(Instruction::Return);
   b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(filestat));
   b.emit(Instruction::I32Const(32));
+  b.emit(Instruction::I32Add);
   b.emit(Instruction::I64Load(mem_arg_f64(0)));
   b.emit(Instruction::LocalTee(file_size_i64));
   b.emit(Instruction::I64Const(WASI_TEXT_FILE_LIMIT));
@@ -822,9 +831,7 @@ pub(super) fn build_wasi_read_text_fn(
   b.emit(Instruction::I64Const(8));
   b.emit(Instruction::I64Add);
   b.emit(Instruction::LocalSet(managed_size));
-  b.emit(Instruction::I64Const(0));
-  b.emit(Instruction::LocalSet(zero_scratch));
-  rt_emit_reserve_scratch(&mut b, zero_scratch, managed_size, unused_scratch);
+  rt_emit_reserve_scratch(&mut b, zero_size, managed_size, unused_scratch);
   rt_emit_alloc_dynamic(&mut b, payload, string, string_tag);
   b.emit(Instruction::LocalGet(string));
   b.emit(Instruction::LocalGet(file_size));

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -2,6 +2,10 @@ use super::*;
 use std::sync::LazyLock;
 use wasm_encoder::{BlockType, Ieee64};
 
+const WASI_PREOPEN_FD_LIMIT: i32 = 64;
+const WASI_PREOPEN_NAME_LIMIT: i32 = 4096;
+const WASI_TEXT_FILE_LIMIT: i64 = 4 * 1024 * 1024;
+
 #[derive(Clone, Debug)]
 pub(super) struct HostImport {
   pub(super) module: String,
@@ -141,6 +145,52 @@ pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
         params: vec![ValType::I32, ValType::I32],
         results: vec![ValType::I32],
       },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "fd_prestat_get".into(),
+        params: vec![ValType::I32, ValType::I32],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "fd_prestat_dir_name".into(),
+        params: vec![ValType::I32, ValType::I32, ValType::I32],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "path_open".into(),
+        params: vec![
+          ValType::I32,
+          ValType::I32,
+          ValType::I32,
+          ValType::I32,
+          ValType::I32,
+          ValType::I64,
+          ValType::I64,
+          ValType::I32,
+          ValType::I32,
+        ],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "fd_filestat_get".into(),
+        params: vec![ValType::I32, ValType::I32],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "fd_read".into(),
+        params: vec![ValType::I32; 4],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "fd_close".into(),
+        params: vec![ValType::I32],
+        results: vec![ValType::I32],
+      },
     ],
   }
 }
@@ -208,6 +258,753 @@ pub(super) fn build_wasi_write_all_fn(fd_write_idx: u32) -> CompiledFn {
     locals: vec![ValType::I32],
     instructions,
   }
+}
+
+/// Resolve a relative Calcit path against the most specific Preview 1 preopen
+/// and open it without exposing either the preopen or opened descriptor.
+/// Returns -1 for validation, authority, or host failures.
+pub(super) fn build_wasi_open_path_fn(fd_prestat_get_idx: u32, fd_prestat_dir_name_idx: u32, path_open_idx: u32) -> CompiledFn {
+  // params: path logical pointer, oflags, rights_base
+  let mut b = RuntimeFnBuilder::new(3);
+  let path_data = b.alloc_i32();
+  let path_len = b.alloc_i32();
+  let index = b.alloc_i32();
+  let segment_start = b.alloc_i32();
+  let byte = b.alloc_i32();
+  let scratch_size = b.alloc_i64();
+  let managed_size = b.alloc_i64();
+  let scratch = b.alloc_i32();
+  let fd = b.alloc_i32();
+  let name_len = b.alloc_i32();
+  let name_start = b.alloc_i32();
+  let normalized_len = b.alloc_i32();
+  let compare_index = b.alloc_i32();
+  let matched = b.alloc_i32();
+  let best_prefix = b.alloc_i32();
+  let best_fd = b.alloc_i32();
+  let candidate_rel_ptr = b.alloc_i32();
+  let candidate_rel_len = b.alloc_i32();
+  let best_rel_ptr = b.alloc_i32();
+  let best_rel_len = b.alloc_i32();
+
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(path_data));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::F64Load(mem_arg_f64(0)));
+  b.emit(Instruction::I32TruncF64U);
+  b.emit(Instruction::LocalTee(path_len));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  // Absolute paths are never reinterpreted relative to a preopen.
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+
+  // Reject NUL and every complete `..` component before consulting authority.
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(segment_start));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Result(ValType::I32)));
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::Else);
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalTee(byte));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(byte));
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(segment_start));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::I32Const(2));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::LocalGet(segment_start));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'.' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::LocalGet(segment_start));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(1)));
+  b.emit(Instruction::I32Const(b'.' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(segment_start));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::I64Const(WASI_PREOPEN_NAME_LIMIT as i64));
+  b.emit(Instruction::LocalSet(scratch_size));
+  b.emit(Instruction::I64Const(0));
+  b.emit(Instruction::LocalSet(managed_size));
+  rt_emit_reserve_scratch(&mut b, scratch_size, managed_size, scratch);
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::LocalSet(best_prefix));
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::LocalSet(best_fd));
+  b.emit(Instruction::I32Const(3));
+  b.emit(Instruction::LocalSet(fd));
+
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::I32Const(WASI_PREOPEN_FD_LIMIT));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Call(fd_prestat_get_idx));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalTee(name_len));
+  b.emit(Instruction::I32Const(WASI_PREOPEN_NAME_LIMIT));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::Call(fd_prestat_dir_name_idx));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(name_start));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::Else);
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(name_start));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::LocalGet(name_start));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::LocalSet(normalized_len));
+
+  // A guest preopen named `.` grants relative paths. Named roots require an
+  // exact first-component match and the longest matching root wins.
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(matched));
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::LocalGet(name_start));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'.' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(matched));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(normalized_len));
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::LocalSet(candidate_rel_ptr));
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::LocalSet(candidate_rel_len));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(matched));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(matched));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(compare_index));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(compare_index));
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::LocalGet(compare_index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::LocalGet(name_start));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(compare_index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Ne);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(matched));
+  b.emit(Instruction::Br(2));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(compare_index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(compare_index));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(path_data));
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(candidate_rel_ptr));
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::LocalSet(candidate_rel_len));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(matched));
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::LocalGet(best_prefix));
+  b.emit(Instruction::I32GtS);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(normalized_len));
+  b.emit(Instruction::LocalSet(best_prefix));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::LocalSet(best_fd));
+  b.emit(Instruction::LocalGet(candidate_rel_ptr));
+  b.emit(Instruction::LocalSet(best_rel_ptr));
+  b.emit(Instruction::LocalGet(candidate_rel_len));
+  b.emit(Instruction::LocalSet(best_rel_len));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(fd));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(best_fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32LtS);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(best_fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalGet(best_rel_ptr));
+  b.emit(Instruction::LocalGet(best_rel_len));
+  b.emit(Instruction::LocalGet(1));
+  b.emit(Instruction::LocalGet(2));
+  b.emit(Instruction::LocalGet(2));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Call(path_open_idx));
+  b.emit(Instruction::If(BlockType::Result(ValType::I32)));
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::Else);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::End);
+  b.finish(vec![ValType::I32, ValType::I32, ValType::I64], vec![ValType::I32])
+}
+
+/// Validate an RFC 3629 UTF-8 byte sequence without constructing a Calcit value.
+pub(super) fn build_utf8_valid_fn() -> CompiledFn {
+  let mut b = RuntimeFnBuilder::new(2);
+  let index = b.alloc_i32();
+  let first = b.alloc_i32();
+  let width = b.alloc_i32();
+  let second_min = b.alloc_i32();
+  let second_max = b.alloc_i32();
+  let continuation = b.alloc_i32();
+
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(1));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::LocalTee(first));
+  b.emit(Instruction::I32Const(0x80));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Br(1));
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(width));
+  b.emit(Instruction::I32Const(0x80));
+  b.emit(Instruction::LocalSet(second_min));
+  b.emit(Instruction::I32Const(0xbf));
+  b.emit(Instruction::LocalSet(second_max));
+  // Two-byte sequences start at C2, excluding overlong C0/C1 encodings.
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xc2));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xdf));
+  b.emit(Instruction::I32LeU);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(2));
+  b.emit(Instruction::LocalSet(width));
+  b.emit(Instruction::End);
+  // Three-byte sequences constrain E0 (overlong) and ED (surrogates).
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xe0));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xef));
+  b.emit(Instruction::I32LeU);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(3));
+  b.emit(Instruction::LocalSet(width));
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xe0));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0xa0));
+  b.emit(Instruction::LocalSet(second_min));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xed));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0x9f));
+  b.emit(Instruction::LocalSet(second_max));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  // Four-byte sequences constrain Unicode to U+10FFFF.
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xf0));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xf4));
+  b.emit(Instruction::I32LeU);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::LocalSet(width));
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xf0));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0x90));
+  b.emit(Instruction::LocalSet(second_min));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(first));
+  b.emit(Instruction::I32Const(0xf4));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0x8f));
+  b.emit(Instruction::LocalSet(second_max));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(width));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(width));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(1));
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(1)));
+  b.emit(Instruction::LocalTee(continuation));
+  b.emit(Instruction::LocalGet(second_min));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::LocalGet(continuation));
+  b.emit(Instruction::LocalGet(second_max));
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::I32Or);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(2));
+  b.emit(Instruction::LocalSet(continuation));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(continuation));
+  b.emit(Instruction::LocalGet(width));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(continuation));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(0xc0));
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::I32Const(0x80));
+  b.emit(Instruction::I32Ne);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(continuation));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(continuation));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(index));
+  b.emit(Instruction::LocalGet(width));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(index));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(1));
+  b.finish(vec![ValType::I32, ValType::I32], vec![ValType::I32])
+}
+
+/// Read one bounded regular file through a private Preview 1 descriptor.
+/// Returns a Calcit String pointer or zero on any validation/host failure.
+pub(super) fn build_wasi_read_text_fn(
+  open_path_idx: u32,
+  fd_filestat_get_idx: u32,
+  fd_read_idx: u32,
+  fd_close_idx: u32,
+  utf8_valid_idx: u32,
+  string_tag: i32,
+) -> CompiledFn {
+  let mut b = RuntimeFnBuilder::new(1);
+  let fd = b.alloc_i32();
+  let file_size_i64 = b.alloc_i64();
+  let file_size = b.alloc_i32();
+  let padded = b.alloc_i32();
+  let payload = b.alloc_i32();
+  let managed_size = b.alloc_i64();
+  let zero_scratch = b.alloc_i64();
+  let unused_scratch = b.alloc_i32();
+  let string = b.alloc_i32();
+  let data = b.alloc_i32();
+  let offset = b.alloc_i32();
+  let read_now = b.alloc_i32();
+
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I64Const((1_i64 << 1) | (1_i64 << 21)));
+  b.emit(Instruction::Call(open_path_idx));
+  b.emit(Instruction::LocalTee(fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32LtS);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Call(fd_filestat_get_idx));
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(32));
+  b.emit(Instruction::I64Load(mem_arg_f64(0)));
+  b.emit(Instruction::LocalTee(file_size_i64));
+  b.emit(Instruction::I64Const(WASI_TEXT_FILE_LIMIT));
+  b.emit(Instruction::I64GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(file_size_i64));
+  b.emit(Instruction::I32WrapI64);
+  b.emit(Instruction::LocalSet(file_size));
+  b.emit(Instruction::LocalGet(file_size));
+  b.emit(Instruction::I32Const(7));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(-8));
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::LocalSet(padded));
+  b.emit(Instruction::LocalGet(padded));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(payload));
+  b.emit(Instruction::LocalGet(payload));
+  b.emit(Instruction::I64ExtendI32U);
+  b.emit(Instruction::I64Const(8));
+  b.emit(Instruction::I64Add);
+  b.emit(Instruction::LocalSet(managed_size));
+  b.emit(Instruction::I64Const(0));
+  b.emit(Instruction::LocalSet(zero_scratch));
+  rt_emit_reserve_scratch(&mut b, zero_scratch, managed_size, unused_scratch);
+  rt_emit_alloc_dynamic(&mut b, payload, string, string_tag);
+  b.emit(Instruction::LocalGet(string));
+  b.emit(Instruction::LocalGet(file_size));
+  b.emit(Instruction::F64ConvertI32U);
+  b.emit(Instruction::F64Store(mem_arg_f64(0)));
+  b.emit(Instruction::LocalGet(string));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(data));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(offset));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::LocalGet(file_size));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalGet(data));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Store(mem_arg_i32(0)));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::LocalGet(file_size));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::I32Store(mem_arg_i32(0)));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::Call(fd_read_idx));
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalTee(read_now));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(read_now));
+  b.emit(Instruction::LocalGet(file_size));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::LocalGet(read_now));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(offset));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(data));
+  b.emit(Instruction::LocalGet(file_size));
+  b.emit(Instruction::Call(utf8_valid_idx));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(string));
+  b.finish(vec![ValType::I32], vec![ValType::I32])
+}
+
+/// Write one complete UTF-8 string through a private Preview 1 descriptor.
+/// Returns one on success and zero on validation, partial-write, or host failure.
+pub(super) fn build_wasi_write_text_fn(open_path_idx: u32, fd_write_idx: u32, fd_close_idx: u32) -> CompiledFn {
+  let mut b = RuntimeFnBuilder::new(2);
+  let fd = b.alloc_i32();
+  let data = b.alloc_i32();
+  let length = b.alloc_i32();
+  let offset = b.alloc_i32();
+  let written = b.alloc_i32();
+
+  b.emit(Instruction::LocalGet(1));
+  b.emit(Instruction::F64Load(mem_arg_f64(0)));
+  b.emit(Instruction::I32TruncF64U);
+  b.emit(Instruction::LocalSet(length));
+  b.emit(Instruction::LocalGet(1));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(data));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I32Const(9)); // CREAT | TRUNC
+  b.emit(Instruction::I64Const(1_i64 << 6)); // FD_WRITE
+  b.emit(Instruction::Call(open_path_idx));
+  b.emit(Instruction::LocalTee(fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32LtS);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(offset));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::LocalGet(length));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalGet(data));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Store(mem_arg_i32(0)));
+  b.emit(Instruction::I32Const(4));
+  b.emit(Instruction::LocalGet(length));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::I32Store(mem_arg_i32(0)));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::Call(fd_write_idx));
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalTee(written));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(written));
+  b.emit(Instruction::LocalGet(length));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::Drop);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::LocalGet(written));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(offset));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::I32Eqz);
+  b.finish(vec![ValType::I32, ValType::I32], vec![ValType::I32])
 }
 
 /// Reserve a temporary region at the top of linear memory without advancing

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1773,6 +1773,16 @@ export let read_file = (path: string): string => {
     return content;
   }
 };
+
+/** Read UTF-8 text and preserve host failures as nominal Result values. */
+export let _$n_fs_read_text = (resultType: CalcitEnumDef, path: string, hostError: string): CalcitEnumValue => {
+  try {
+    return new CalcitEnumValue(newTag("ok"), [read_file(path)], resultType);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return new CalcitEnumValue(newTag("err"), [`${hostError}: ${message}`], resultType);
+  }
+};
 export let read_dir = (path: string, recursive: boolean): CalcitSliceList => {
   if (!inNodeJs) {
     throw new Error("read_dir is unavailable in browser JavaScript hosts");
@@ -1789,6 +1799,22 @@ export let write_file = (path: string, content: string): void => {
   } else {
     // no actual File API in browser
     localStorage.setItem(path, content);
+  }
+};
+
+/** Write UTF-8 text and preserve host failures as nominal Result values. */
+export let _$n_fs_write_text = (
+  resultType: CalcitEnumDef,
+  path: string,
+  content: string,
+  hostError: string,
+): CalcitEnumValue => {
+  try {
+    write_file(path, content);
+    return new CalcitEnumValue(newTag("ok"), [undefined], resultType);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return new CalcitEnumValue(newTag("err"), [`${hostError}: ${message}`], resultType);
   }
 };
 


### PR DESCRIPTION
## 中文

关闭 #1022。

### 目标

让 `calcit wasi` 生成的 command module 通过 host 显式授予的 Preview 1 preopen，复用现有 `FsPath` 类型化 API 读写 UTF-8 文本；descriptor 与 Preview 1 ABI 保持在编译器内部，不成为 Calcit 公开语义。

### 变更

- 增加内部 `&fs-read-text` / `&fs-write-text` typed Result boundary，Native、JavaScript 与 WASI 保持一致的 `Result<String,String>` / `Result<Unit,String>` 值形状；
- WASI adapter 枚举 preopen、选择最长 guest 路径前缀，拒绝绝对路径、完整 `..` 分段与 NUL，并完整处理 partial read/write；
- 读取端校验完整 RFC 3629 UTF-8，并以 4 MiB 上限避免不受控线性内存分配；
- core WASM 对文件能力继续返回 `E_WASM_CAPABILITY`，不隐式继承 host 权限；
- 增加 Calcit `:tests`、确定性假宿主回归、真实 Wasmtime preopen 回归和中文使用文档。

目录枚举已拆到同一 milestone 的 #1041，复用本 PR 的 private preopen adapter；递归 walk 继续后置。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --lib --target wasm32-unknown-unknown`
- `cargo check --lib --target wasm32-wasip1`
- core definition-attached `:tests`: 257 passed
- WASI definition-attached `:tests`: 11 passed
- `yarn compile && node scripts/check-js-runtime-identity.mjs`
- `bash scripts/test-wasi-preprocess.sh`（包含真实 Wasmtime 与确定性 filesystem host）

## English

Closes #1022.

### Goal

Allow command modules emitted by `calcit wasi` to reuse the existing typed `FsPath` API for UTF-8 text I/O through host-granted Preview 1 preopens. Descriptors and the Preview 1 ABI remain private compiler adapter details rather than public Calcit semantics.

### Changes

- add internal `&fs-read-text` / `&fs-write-text` typed Result boundaries with consistent `Result<String,String>` / `Result<Unit,String>` shapes across Native, JavaScript, and WASI;
- enumerate preopens, select the longest guest-path prefix, reject absolute paths, complete `..` components, and NUL, and handle partial reads/writes to completion;
- validate full RFC 3629 UTF-8 on reads and cap a single WASI text read at 4 MiB to prevent uncontrolled linear-memory allocation;
- keep core WASM capability-free and reject file effects with `E_WASM_CAPABILITY`;
- add Calcit `:tests`, deterministic fake-host regressions, real Wasmtime preopen regressions, and Chinese user documentation.

Directory enumeration is tracked as #1041 in the same milestone and will reuse this PR's private preopen adapter; recursive walk remains deferred.

### Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --lib --target wasm32-unknown-unknown`
- `cargo check --lib --target wasm32-wasip1`
- core definition-attached `:tests`: 257 passed
- WASI definition-attached `:tests`: 11 passed
- `yarn compile && node scripts/check-js-runtime-identity.mjs`
- `bash scripts/test-wasi-preprocess.sh` (real Wasmtime plus deterministic filesystem host coverage)
