### PR TITLE
feat(wasi): 编译类型化目录枚举 / lower typed directory enumeration

### DIFF
--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -99,6 +99,50 @@
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
+        'filesystem-read-dir-error-main! $ %{} 'CodeEntry (:doc "|通过 WASI 假宿主验证畸形目录记录仍返回 Result :err。")
+          :code $ quote
+            defn filesystem-read-dir-error-main! () $ if (filesystem-read-dir-error? |workspace/listing) (println "|WASI-read-dir-error: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :file :wasi
+        'filesystem-read-dir-error? $ %{} 'CodeEntry (:doc "|验证目录枚举失败仍以 Result :err 表达。")
+          :code $ quote
+            defn filesystem-read-dir-error? (path)
+              match
+                .read-dir $ fs:path path
+                (:ok _) false
+                (:err _) true
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'String
+          :tags $ #{} :file :unit :wasi
+          :tests $ []
+            %{} 'TestEntry (:name |missing-directory)
+              :code $ quote
+                assert= true $ filesystem-read-dir-error? |/calcit-wasi-filesystem-does-not-exist
+              :tags $ #{} :file :unit :wasi
+        'filesystem-read-dir-main! $ %{} 'CodeEntry (:doc "|通过真实与假 WASI 宿主验证目录分页、UTF-8 名称和确定排序。")
+          :code $ quote
+            defn filesystem-read-dir-main! () $ match
+              .read-dir $ fs:path |workspace/listing
+              (:ok paths)
+                if
+                  and
+                    = 3 $ count paths
+                    = |workspace/listing/a.txt $ &struct:nth (&list:nth paths 0) 0 :value
+                    = |workspace/listing/b.txt $ &struct:nth (&list:nth paths 1) 0 :value
+                    = "|workspace/listing/子.txt" $ &struct:nth (&list:nth paths 2) 0 :value
+                  println "|WASI-read-dir: ok"
+                  quit! 1
+              (:err _) (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :file :wasi
         'filesystem-read-error? $ %{} 'CodeEntry (:doc "|验证 FsPath 文本读取失败仍以 Result :err 表达，不把 host error 泄漏为异常。")
           :code $ quote
             defn filesystem-read-error? (path)

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -458,7 +458,8 @@ let
 `FsPath` 上的 `.read-text`、`.read-dir`、`.walk-dir` 与 `.write-text` 返回
 `Result<...,String>`；String 不提供文件效果方法。`try-read-file`、`try-read-dir`、
 `try-write-file` 以及底层 raising procedures 仍作为兼容入口。
-这些文件效果支持 native 与生成的 JavaScript；WASM 尚未提供宿主文件效果。
+这些文件效果支持 native 与生成的 JavaScript。WASI command 还支持基于 preopen 的
+文本读写与 `.read-dir`；core WASM 明确拒绝宿主文件效果，`.walk-dir` 尚未接入 WASI。
 
 `option:let` 使用普通 `let` 的 binding pair 结构。每个右侧和最终 body 都必须保持
 Option 容器；Result 错误类型需要转换时显式使用 `.map-err`。

--- a/docs/architectures/wasi-preopened-filesystem.cirru
+++ b/docs/architectures/wasi-preopened-filesystem.cirru
@@ -1,7 +1,7 @@
 {}
   :schema-version 1
   :feature 'wasi-preopened-filesystem
-  :doc "|让 FsPath 的 Result API 直接经过类型化 runtime boundary；WASI lowering 在内部解析 host preopen，拒绝未授权绝对路径与越界路径，不向 Calcit 暴露 descriptor。第一切片覆盖 UTF-8 read/write，read-dir 与递归 walk 后续接入同一边界。"
+  :doc "|让 FsPath 的 Result API 直接经过类型化 runtime boundary；WASI lowering 在内部解析 host preopen，拒绝未授权绝对路径与越界路径，不向 Calcit 暴露 descriptor。第一切片覆盖 UTF-8 read/write，后续切片已接入即时 read-dir，递归 walk 继续复用同一边界。"
   :roots $ #{} 'calcit.core/fs-path:read-text 'calcit.core/fs-path:write-text
   :definitions $ {}
     'calcit.core/&fs-read-text $ {}

--- a/docs/architectures/wasi-read-dir.cirru
+++ b/docs/architectures/wasi-read-dir.cirru
@@ -1,0 +1,30 @@
+{}
+  :schema-version 1
+  :feature 'wasi-read-dir
+  :doc "|让 FsPath 的即时子目录枚举复用 preopen capability boundary；Preview 1 的 descriptor、cookie 分页、截断记录与 UTF-8 校验全部封装在 WASI adapter 内，表层只观察确定排序的 Result<List<FsPath>,String>。"
+  :roots $ #{} 'calcit.core/fs-path:read-dir
+  :definitions $ {}
+    'calcit.core/&fs-read-dir $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|内部目录枚举边界；显式接收 Result 与 FsPath 定义、guest path 和宿主错误前缀。"
+      :params $ [] 'result-type 'path-type 'path 'host-error
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'EnumDef 'StructDef 'String 'String
+          :return $ :: 'Result (:: 'List 'FsPath) 'String
+      :code $ quote &runtime-implementation
+    'calcit.core/fs-path:read-dir $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|枚举 FsPath 的即时子项，并以确定顺序返回 Result<List<FsPath>,String>。"
+      :params $ [] 'self
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'FsPath
+          :return $ :: 'Result (:: 'List 'FsPath) 'String
+      :code $ quote
+        defn fs-path:read-dir (self)
+          &fs-read-dir Result FsPath (:value self) "|fs-path:read-dir failed"
+  :edges $ #{}
+    :: :call 'calcit.core/fs-path:read-dir 'calcit.core/&fs-read-dir

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -343,7 +343,7 @@ let
     %ok &unit
 ```
 
-`fs:path` constructs a nominal `FsPath` without normalizing or touching the filesystem. Its `.read-text`, `.read-dir`, `.walk-dir`, and `.write-text` methods return `Result`, so expected I/O failures stay in the typed flow; `.read-dir` lists immediate children and `.walk-dir` recurses. String has no file-effect methods. The `try-read-*`/`try-write-file` functions and raw raising procedures remain compatibility entries. Native and generated JavaScript support these host file effects; WASM does not yet expose them.
+`fs:path` 构造 nominal `FsPath`，不会规范化路径或触碰文件系统。`.read-text`、`.read-dir`、`.walk-dir` 与 `.write-text` 都返回 `Result`，因此预期内的 I/O 失败留在类型流中；`.read-dir` 只枚举即时子项，`.walk-dir` 递归枚举。String 不提供文件效果方法，`try-read-*`、`try-write-file` 与 raw raising procedure 仅保留为兼容入口。Native 与生成的 JavaScript 支持这些文件效果；WASI command 目前支持文本读写和 `.read-dir`，core WASM 会明确拒绝，`.walk-dir` 仍待后续实现。
 
 ## Math Operations
 

--- a/docs/features/common-patterns.md
+++ b/docs/features/common-patterns.md
@@ -343,7 +343,7 @@ let
     %ok &unit
 ```
 
-`fs:path` 构造 nominal `FsPath`，不会规范化路径或触碰文件系统。`.read-text`、`.read-dir`、`.walk-dir` 与 `.write-text` 都返回 `Result`，因此预期内的 I/O 失败留在类型流中；`.read-dir` 只枚举即时子项，`.walk-dir` 递归枚举。String 不提供文件效果方法，`try-read-*`、`try-write-file` 与 raw raising procedure 仅保留为兼容入口。Native 与生成的 JavaScript 支持这些文件效果；WASI command 目前支持文本读写和 `.read-dir`，core WASM 会明确拒绝，`.walk-dir` 仍待后续实现。
+`fs:path` 构造 nominal `FsPath`，不会规范化路径或触碰文件系统。`.read-text`、`.read-dir`、`.walk-dir` 与 `.write-text` 都返回 `Result`，因此预期内的 I/O 失败留在类型流中；`.read-dir` 只枚举即时子项，`.walk-dir` 递归枚举。String 不提供文件效果方法，`try-read-*`、`try-write-file` 与 raw raising procedure 仅保留为兼容入口。Native 与 Node-hosted 的生成 JavaScript 支持这些文件效果；browser JavaScript 不提供 `.read-dir` 与 `.walk-dir`。WASI command 目前支持文本读写和 `.read-dir`，core WASM 会明确拒绝，`.walk-dir` 仍待后续实现。
 
 ## Math Operations
 

--- a/docs/installation/host-capability-boundary.md
+++ b/docs/installation/host-capability-boundary.md
@@ -75,7 +75,8 @@ no-op or fabricated success value.
 | Monotonic milliseconds for elapsed-time measurement | yes | unavailable | unavailable | WASI Preview 1 monotonic clock; core WASM unavailable | `cpu-time`（只比较同一进程内两次调用的差值） |
 | Construct and inspect a path value without I/O | yes | yes | yes | value-level support only | `fs:path`, `FsPath .to-string` |
 | `FsPath .read-text` / `.write-text` | yes | host injection | browser `localStorage` adapter | WASI Preview 1 preopen；core WASM unavailable | `FsPath` Result-returning methods |
-| `FsPath .read-dir` / `.walk-dir` | yes | host injection | unavailable | unavailable | `FsPath` Result-returning methods |
+| `FsPath .read-dir` | yes | host injection | unavailable | WASI Preview 1 preopen；core WASM unavailable | `FsPath` Result-returning methods |
+| `FsPath .walk-dir` | yes | host injection | unavailable | unavailable | `FsPath` Result-returning methods |
 | Process and signal lifecycle | `calcit.std` native module | Node adapter | unavailable | unavailable | typed process/signal APIs in `calcit.std` |
 | Repeating timer and timezone/date | `calcit.std` native module | Node adapter | browser adapter | unavailable | typed timer/date APIs in `calcit.std` |
 | Glob | focused native module | Node adapter | unavailable | unavailable | focused glob module; do not infer browser support |
@@ -97,10 +98,11 @@ The matrix records what exists today, not an entitlement for every backend.
 - Filesystem paths: construct `FsPath` with `fs:path`; use `.read-text`,
   `.write-text`, `.read-dir`, and `.walk-dir`. String-path `try-read-*` and raw
   raising procedures are compatibility or implementation entries.
-- 文件系统：WASI command 的 `.read-text` / `.write-text` 只解析 host 显式授予的
+- 文件系统：WASI command 的 `.read-text` / `.write-text` / `.read-dir` 只解析 host 显式授予的
   preopen，选择最长 guest 路径前缀，并拒绝绝对路径、`..` 越界、非法 UTF-8 与
-  无法推进的 partial I/O。descriptor 生命周期完全留在 adapter 内部；目录读取与
-  walk 仍保持 unavailable，直到复用同一权限解析边界。
+  无法推进的 partial I/O。`.read-dir` 通过 cookie 分页枚举即时子项、过滤 `.` 与
+  `..` 并按完整 guest path 排序；descriptor 生命周期完全留在 adapter 内部。
+  递归 `.walk-dir` 仍保持 unavailable。
 - 时钟：`unix-time-ms` 返回 Unix epoch 以来的系统时间；`cpu-time` 用于测量
   经过时间，其绝对起点没有跨宿主语义。WASI command 通过 Preview 1
   `clock_time_get` 实现这两个入口，并在宿主返回错误时直接失败，不伪造数值。

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -406,10 +406,10 @@ lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
 ### Effects/IO
 
 - `echo`, `println` - output
-- `fs:path` - construct a nominal `FsPath` from a UTF-8 String without normalization
-- `FsPath .read-text`, `.read-dir`, `.walk-dir`, `.write-text` - recoverable file effects returning `Result` (native/JS; unavailable in WASM)
-- `try-read-file`, `try-read-dir`, `try-write-file` - String-path compatibility functions returning `Result`
-- `read-file`, `read-dir`, `write-file` - raising compatibility primitives (native/JS; unavailable in WASM)
+- `fs:path`：从 UTF-8 String 构造 nominal `FsPath`，不执行路径规范化
+- `FsPath .read-text`、`.read-dir`、`.walk-dir`、`.write-text`：返回 `Result` 的可恢复文件效果；WASI command 支持文本读写与 `.read-dir`，core WASM 不可用，`.walk-dir` 尚未接入 WASI
+- `try-read-file`、`try-read-dir`、`try-write-file`：基于 String path 的兼容函数，返回 `Result`
+- `read-file`、`read-dir`、`write-file`：保留异常语义的兼容 primitives（native/JS；WASM 不可用）
 - `ffi:task`, `FfiTask .cancel` / `.cancel-with` - nominal native async task lifecycle API
 - `ffi:response`, `FfiResponse .resolve` / `.reject` - nominal exactly-once native response API
 - `get-env` - environment variables

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -488,7 +488,7 @@ calcit wasi calcit.cirru --emit-path target/wasi-command
 wasmtime run --dir ./data::/workspace target/wasi-command/program.wasm
 ```
 
-未提供 preopen、以 `/` 开头的绝对路径、包含完整 `..` 分段的越界路径、非法 UTF-8、I/O 错误和无法继续推进的 partial I/O 都返回 `Result :err`。当前 WASI 文本读取单文件上限为 4 MiB，超过限制同样返回错误，避免模块为不受控输入分配过量线性内存。Calcit 不接触 raw descriptor；`calcit wasm` 的 core module 也不会继承文件权限，而是在 codegen 阶段以 `E_WASM_CAPABILITY` 拒绝。`.read-dir` 与 `.walk-dir` 尚未接入 WASI。
+未提供 preopen、以 `/` 开头的绝对路径、包含完整 `..` 分段的越界路径、非法 UTF-8、I/O 错误和无法继续推进的 partial I/O 都返回 `Result :err`。当前 WASI 文本读取单文件上限为 4 MiB。`.read-dir` 枚举即时子项，沿 Preview 1 cookie 处理分页和截断记录，过滤 `.`、`..` 后按完整 guest path 排序；单次最多返回 4096 项，累计路径字节最多 4 MiB，单个 UTF-8 名称最多 4096 字节。超过限制同样返回错误，避免模块为不受控输入分配过量线性内存。Calcit 不接触 raw descriptor；`calcit wasm` 的 core module 也不会继承文件权限，而是在 codegen 阶段以 `E_WASM_CAPABILITY` 拒绝。递归 `.walk-dir` 尚未接入 WASI。
 
 ## Markdown code checking
 

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -108,7 +108,8 @@ let
 `.read-dir`、`.walk-dir` 或 `.write-text`，这些方法返回 `Result<...,String>`。
 String 本身不携带文件系统语义；`try-read-file`、`try-read-dir`、
 `try-write-file` 与底层 raising procedures 仅保留为兼容入口。
-这些文件效果支持 native 与生成的 JavaScript；WASM 尚未提供宿主文件效果。
+这些文件效果支持 native 与生成的 JavaScript。WASI command 支持基于 preopen 的
+文本读写和 `.read-dir`；core WASM 明确拒绝宿主文件效果，`.walk-dir` 尚未接入 WASI。
 
 Native 异步 FFI capability 也遵循相同边界原则。模块适配层用 `ffi:task`、
 `ffi:response` 把不透明 AnyRef 提升为 nominal `FfiTask`、`FfiResponse`，业务层调用

--- a/editing-history/202609130412-wasi-read-dir.md
+++ b/editing-history/202609130412-wasi-read-dir.md
@@ -1,0 +1,7 @@
+# WASI 目录枚举
+
+- `FsPath .read-dir` 改为直接调用 typed `&fs-read-dir` boundary，避免依赖尚不能在 WASM 中展开的 `result:map` 闭包；旧的 String `try-read-dir` 保持兼容。
+- Native、生成的 JavaScript 与 WASI command 都返回 `Result<List<FsPath>,String>`，即时子项按完整路径确定排序；core WASM 在 codegen 阶段报告 `E_WASM_CAPABILITY`。
+- Preview 1 adapter 复用最长 preopen 匹配与路径越界验证，通过 `path_open` 的 directory flag 和 `FD_READDIR` right 获取私有 descriptor。
+- `fd_readdir` 按官方 24 字节 dirent 布局解析，沿 `d_next` cookie 分页；完整页末尾的截断记录留给下一页，不完整的终页、无进展 cookie、非法 UTF-8、NUL/斜杠名称与越界计数均返回错误。
+- 单次枚举限制为 4096 项、累计完整 guest path 4 MiB、单名称 4096 字节。Calcit `:tests` 覆盖 Result 错误语义；真实 Wasmtime 与假宿主覆盖 Unicode、排序、分页、截断和畸形记录。

--- a/editing-history/202609130526-wasi-read-dir-review.md
+++ b/editing-history/202609130526-wasi-read-dir-review.md
@@ -1,0 +1,20 @@
+# WASI 目录枚举 review 修正
+
+## 背景
+
+PR #1042 的 review 指出平台文档、`FsPath` tag lowering 与目录结果内存容量存在三个边界缺口。目录 adapter 虽限制条目数和路径总字节数，但此前没有在动态分配前统一保证线性内存容量。
+
+## 变更
+
+- 文档明确生成的 JavaScript 文件枚举只适用于 Node host，browser 不支持 `.read-dir` 与 `.walk-dir`。
+- WASM lowering 从 `&fs-read-dir` 的 `FsPath` struct reference 参数解析 tag，避免依赖字符串查表及其潜在 panic。
+- 在读取目录前按公开上限预留 list、buffer、带 padding 的路径 String、每项 `FsPath` 和成功 Result 所需容量。
+- 地址空间溢出或 `memory.grow` 失败时关闭目录 descriptor 并返回失败状态，由公开边界保留为 `Result :err`。
+- 确定性 Preview 1 host 回归检查目录 adapter 已扩展到有界分配所需的线性内存。
+
+## 验证
+
+- `cargo fmt --check`
+- `cargo test --lib`
+- `bash scripts/test-wasi-preprocess.sh`
+- `yarn check-all`

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -213,7 +213,7 @@ const scenarios = [
       const wrongOrigin = result.data.definitions.some(
         (definition) => definition.source !== "core" || definition.origin.package !== "calcit" || definition.origin.module !== "builtin",
       );
-      if (result.data.summary.matches !== 32 || wrongOrigin) {
+      if (result.data.summary.matches !== 31 || wrongOrigin) {
         throw new Error("core-only query.search count or origins changed");
       }
     },
@@ -235,7 +235,7 @@ const scenarios = [
     args: ["calcit/test.cirru", "query", "search", "%none", "--exact", "--source", "all", "--format", "json"],
     check(result) {
       const sources = new Set(result.data.definitions.map((definition) => definition.source));
-      if (result.data.summary.matches !== 57 || [...sources].sort().join(",") !== "core,deps,project") {
+      if (result.data.summary.matches !== 56 || [...sources].sort().join(",") !== "core,deps,project") {
         throw new Error("all-source query.search count or origins changed");
       }
     },

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -97,6 +97,22 @@ try {
   assert.equal(typedWrite.tag, runtimeA.newTag("ok"));
   assert.deepEqual(typedWrite.extra, [undefined]);
   assert.deepEqual(writes.at(-1), ["typed.txt", "内容"]);
+  const fsPathName = runtimeA.newTag("FsPath");
+  const fsPathField = runtimeA.newTag("value");
+  const fsPathType = new runtimeA.CalcitStructDef(fsPathName, [fsPathField], [todoType]);
+  globalThis.__calcit_injections__.read_dir = (path, recursive) => {
+    assert.equal(recursive, false);
+    return [`${path}/z`, `${path}/a`];
+  };
+  const typedDirectory = runtimeA._$n_fs_read_dir(todoEnum, fsPathType, "typed", "read-dir failed");
+  assert.equal(typedDirectory.tag, runtimeA.newTag("ok"));
+  const typedPaths = runtimeA.listToArray(typedDirectory.extra[0]);
+  assert.deepEqual(
+    typedPaths.map((path) => path.values[0]),
+    ["typed/a", "typed/z"],
+    "typed directory reads must preserve deterministic sorting and nominal FsPath values",
+  );
+  assert.ok(typedPaths.every((path) => path.structRef === fsPathType));
   globalThis.__calcit_injections__.read_file = () => {
     throw new Error("denied");
   };

--- a/scripts/test-wasi-clock-host.mjs
+++ b/scripts/test-wasi-clock-host.mjs
@@ -72,6 +72,9 @@ const wasi = {
   fd_read() {
     throw new Error("clock fixture unexpectedly read a file");
   },
+  fd_readdir() {
+    throw new Error("clock fixture unexpectedly read a directory");
+  },
   fd_close() {
     throw new Error("clock fixture unexpectedly closed a file");
   },

--- a/scripts/test-wasi-filesystem-host.mjs
+++ b/scripts/test-wasi-filesystem-host.mjs
@@ -92,6 +92,9 @@ const wasi = {
     view().setUint32(readPtr, length, true);
     return 0;
   },
+  fd_readdir() {
+    throw new Error("filesystem text fixture unexpectedly read a directory");
+  },
   fd_write(fd, iovsPtr, iovsLength, writtenPtr) {
     assert.equal(iovsLength, 1);
     const ptr = view().getUint32(iovsPtr, true);

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -32,6 +32,10 @@ readonly FILESYSTEM_UTF8_STDOUT="${FILESYSTEM_UTF8_OUT}/stdout.txt"
 readonly FILESYSTEM_ABSOLUTE_OUT="${CARGO_TARGET_DIR:-target}/wasi-filesystem-absolute"
 readonly FILESYSTEM_ABSOLUTE_STDOUT="${FILESYSTEM_ABSOLUTE_OUT}/stdout.txt"
 readonly CORE_FILESYSTEM_OUT="${CARGO_TARGET_DIR:-target}/core-filesystem-reject"
+readonly READ_DIR_OUT="${CARGO_TARGET_DIR:-target}/wasi-read-dir-smoke"
+readonly READ_DIR_STDOUT="${READ_DIR_OUT}/stdout.txt"
+readonly READ_DIR_ERROR_OUT="${CARGO_TARGET_DIR:-target}/wasi-read-dir-error"
+readonly CORE_READ_DIR_OUT="${CARGO_TARGET_DIR:-target}/core-read-dir-reject"
 readonly CHECK_ONLY_OUT="${CARGO_TARGET_DIR:-target}/wasi-check-only-smoke"
 readonly NATIVE_WASM_BIN="${CARGO_TARGET_DIR:-target}/debug/cr-wasm"
 readonly CALCIT_BIN="${CARGO_TARGET_DIR:-target}/debug/calcit"
@@ -132,6 +136,10 @@ grep -Fq "E_WASM_CAPABILITY" <<<"$random_capability_error"
 
 printf '%s' 'WASI-file: 你好' >"$WASI_FS_HOST_DIR/input.txt"
 printf '\377\n' >"$WASI_FS_HOST_DIR/invalid.txt"
+mkdir -p "$WASI_FS_HOST_DIR/listing"
+: >"$WASI_FS_HOST_DIR/listing/b.txt"
+: >"$WASI_FS_HOST_DIR/listing/a.txt"
+: >"$WASI_FS_HOST_DIR/listing/子.txt"
 "$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-main! --emit-path "$FILESYSTEM_OUT"
 wasmtime run \
   --dir "$WASI_FS_HOST_DIR::/workspace" \
@@ -139,6 +147,14 @@ wasmtime run \
 grep -Fxq "WASI-filesystem: ok" "$FILESYSTEM_STDOUT"
 grep -Fxq 'WASI-written: 好' "$WASI_FS_HOST_DIR/output.txt"
 node scripts/test-wasi-filesystem-host.mjs "$FILESYSTEM_OUT/program.wasm"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-read-dir-main! --emit-path "$READ_DIR_OUT"
+wasmtime run \
+  --dir "$WASI_FS_HOST_DIR::/workspace" \
+  "$READ_DIR_OUT/program.wasm" >"$READ_DIR_STDOUT"
+grep -Fxq "WASI-read-dir: ok" "$READ_DIR_STDOUT"
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-read-dir-error-main! --emit-path "$READ_DIR_ERROR_OUT"
+node scripts/test-wasi-read-dir-host.mjs "$READ_DIR_OUT/program.wasm" "$READ_DIR_ERROR_OUT/program.wasm"
 
 "$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/filesystem-denied-main! --emit-path "$FILESYSTEM_DENIED_OUT"
 wasmtime run "$FILESYSTEM_DENIED_OUT/program.wasm" >"$FILESYSTEM_DENIED_STDOUT"
@@ -169,6 +185,14 @@ if filesystem_capability_error=$(
   exit 1
 fi
 grep -Fq "E_WASM_CAPABILITY" <<<"$filesystem_capability_error"
+
+if read_dir_capability_error=$(
+  "$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app.main/filesystem-read-dir-main! --emit-path "$CORE_READ_DIR_OUT" 2>&1
+); then
+  echo "core WASM unexpectedly accepted filesystem directory reads" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_CAPABILITY" <<<"$read_dir_capability_error"
 
 if target_error=$("$NATIVE_WASM_BIN" "$COMMAND_FIXTURE" --target unknown 2>&1); then
   echo "cr-wasm unexpectedly accepted an unknown target" >&2

--- a/scripts/test-wasi-random-host.mjs
+++ b/scripts/test-wasi-random-host.mjs
@@ -64,6 +64,9 @@ const wasi = {
   fd_read() {
     throw new Error("random fixture unexpectedly read a file");
   },
+  fd_readdir() {
+    throw new Error("random fixture unexpectedly read a directory");
+  },
   fd_close() {
     throw new Error("random fixture unexpectedly closed a file");
   },

--- a/scripts/test-wasi-read-dir-host.mjs
+++ b/scripts/test-wasi-read-dir-host.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [successWasmPath, errorWasmPath] = process.argv.slice(2);
+if (successWasmPath == null || errorWasmPath == null) {
+  throw new Error("usage: node scripts/test-wasi-read-dir-host.mjs <success.wasm> <error.wasm>");
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const preopenName = encoder.encode("/workspace");
+let memory;
+let stdout = [];
+let readdirCalls = 0;
+
+const view = () => new DataView(memory.buffer);
+const bytes = () => new Uint8Array(memory.buffer);
+const decode = (ptr, length) => decoder.decode(bytes().subarray(ptr, ptr + length));
+
+const writeDirent = (ptr, next, name) => {
+  const encoded = encoder.encode(name);
+  view().setBigUint64(ptr, BigInt(next), true);
+  view().setBigUint64(ptr + 8, 0n, true);
+  view().setUint32(ptr + 16, encoded.length, true);
+  view().setUint8(ptr + 20, 4);
+  bytes().set(encoded, ptr + 24);
+  return 24 + encoded.length;
+};
+
+const wasi = {
+  args_sizes_get(argcPtr, argvSizePtr) {
+    view().setUint32(argcPtr, 0, true);
+    view().setUint32(argvSizePtr, 0, true);
+    return 0;
+  },
+  args_get: () => 0,
+  environ_sizes_get(countPtr, sizePtr) {
+    view().setUint32(countPtr, 0, true);
+    view().setUint32(sizePtr, 0, true);
+    return 0;
+  },
+  environ_get: () => 0,
+  proc_exit(code) {
+    throw new Error(`unexpected proc_exit(${code})`);
+  },
+  clock_time_get() {
+    throw new Error("directory fixture unexpectedly requested a clock");
+  },
+  random_get() {
+    throw new Error("directory fixture unexpectedly requested random bytes");
+  },
+  fd_prestat_get(fd, prestatPtr) {
+    if (fd !== 3) return 8;
+    view().setUint8(prestatPtr, 0);
+    view().setUint32(prestatPtr + 4, preopenName.length, true);
+    return 0;
+  },
+  fd_prestat_dir_name(fd, namePtr, nameLength) {
+    assert.equal(fd, 3);
+    assert.equal(nameLength, preopenName.length);
+    bytes().set(preopenName, namePtr);
+    return 0;
+  },
+  path_open(fd, _dirFlags, pathPtr, pathLength, oflags, rightsBase, rightsInheriting, _fdFlags, openedFdPtr) {
+    assert.equal(fd, 3);
+    assert.equal(decode(pathPtr, pathLength), "listing");
+    assert.equal(oflags, 2);
+    assert.equal(rightsBase, 1n << 14n);
+    assert.equal(rightsInheriting, 1n << 14n);
+    view().setUint32(openedFdPtr, 5, true);
+    return 0;
+  },
+  fd_filestat_get() {
+    throw new Error("directory fixture unexpectedly requested file metadata");
+  },
+  fd_read() {
+    throw new Error("directory fixture unexpectedly read a file");
+  },
+  fd_readdir(fd, bufferPtr, bufferLength, cookie, usedPtr) {
+    assert.equal(fd, 5);
+    assert.equal(bufferLength, 64 * 1024);
+    readdirCalls += 1;
+    if (cookie === 0n) {
+      let offset = 0;
+      for (let next = 1; next <= 2621; next += 1) {
+        offset += writeDirent(bufferPtr + offset, next, ".");
+      }
+      assert.equal(offset, bufferLength - 11);
+      bytes().fill(0, bufferPtr + offset, bufferPtr + bufferLength);
+      view().setUint32(usedPtr, bufferLength, true);
+      return 0;
+    }
+    assert.equal(cookie, 2621n);
+    let offset = 0;
+    offset += writeDirent(bufferPtr + offset, 2622, "b.txt");
+    offset += writeDirent(bufferPtr + offset, 2623, "子.txt");
+    offset += writeDirent(bufferPtr + offset, 2624, "a.txt");
+    offset += writeDirent(bufferPtr + offset, 2625, "..");
+    view().setUint32(usedPtr, offset, true);
+    return 0;
+  },
+  fd_write(fd, iovsPtr, iovsLength, writtenPtr) {
+    assert.equal(fd, 1);
+    assert.equal(iovsLength, 1);
+    const ptr = view().getUint32(iovsPtr, true);
+    const length = view().getUint32(iovsPtr + 4, true);
+    stdout.push(...bytes().subarray(ptr, ptr + length));
+    view().setUint32(writtenPtr, length, true);
+    return 0;
+  },
+  fd_close(fd) {
+    assert.equal(fd, 5);
+    return 0;
+  },
+};
+
+const successModule = await WebAssembly.compile(await readFile(successWasmPath));
+const successInstance = await WebAssembly.instantiate(successModule, { wasi_snapshot_preview1: wasi });
+memory = successInstance.exports.memory;
+successInstance.exports._start();
+assert.equal(decoder.decode(Uint8Array.from(stdout)), "WASI-read-dir: ok\n");
+assert.equal(readdirCalls, 2, "directory adapter must continue from the last complete cookie");
+
+const errorModule = await WebAssembly.compile(await readFile(errorWasmPath));
+const assertMalformedDirectoryReturnsError = async (fdReaddir) => {
+  stdout = [];
+  const malformedWasi = { ...wasi, fd_readdir: fdReaddir };
+  const errorInstance = await WebAssembly.instantiate(errorModule, { wasi_snapshot_preview1: malformedWasi });
+  memory = errorInstance.exports.memory;
+  errorInstance.exports._start();
+  assert.equal(decoder.decode(Uint8Array.from(stdout)), "WASI-read-dir-error: ok\n");
+};
+
+await assertMalformedDirectoryReturnsError((fd, bufferPtr, _bufferLength, _cookie, usedPtr) => {
+  assert.equal(fd, 5);
+  view().setBigUint64(bufferPtr, 1n, true);
+  view().setBigUint64(bufferPtr + 8, 0n, true);
+  view().setUint32(bufferPtr + 16, 4097, true);
+  view().setUint32(usedPtr, 24, true);
+  return 0;
+});
+
+await assertMalformedDirectoryReturnsError((fd, bufferPtr, _bufferLength, _cookie, usedPtr) => {
+  assert.equal(fd, 5);
+  view().setBigUint64(bufferPtr, 1n, true);
+  view().setBigUint64(bufferPtr + 8, 0n, true);
+  view().setUint32(bufferPtr + 16, 5, true);
+  bytes().set(encoder.encode("ab"), bufferPtr + 24);
+  view().setUint32(usedPtr, 26, true);
+  return 0;
+});
+
+await assertMalformedDirectoryReturnsError((fd, bufferPtr, _bufferLength, _cookie, usedPtr) => {
+  assert.equal(fd, 5);
+  view().setBigUint64(bufferPtr, 1n, true);
+  view().setBigUint64(bufferPtr + 8, 0n, true);
+  view().setUint32(bufferPtr + 16, 1, true);
+  view().setUint8(bufferPtr + 24, 0xff);
+  view().setUint32(usedPtr, 25, true);
+  return 0;
+});
+
+await assertMalformedDirectoryReturnsError((fd, bufferPtr, _bufferLength, _cookie, usedPtr) => {
+  assert.equal(fd, 5);
+  view().setBigUint64(bufferPtr, 1n, true);
+  view().setBigUint64(bufferPtr + 8, 0n, true);
+  view().setUint32(bufferPtr + 16, 0, true);
+  view().setUint32(usedPtr, 24, true);
+  return 0;
+});

--- a/scripts/test-wasi-read-dir-host.mjs
+++ b/scripts/test-wasi-read-dir-host.mjs
@@ -120,6 +120,7 @@ memory = successInstance.exports.memory;
 successInstance.exports._start();
 assert.equal(decoder.decode(Uint8Array.from(stdout)), "WASI-read-dir: ok\n");
 assert.equal(readdirCalls, 2, "directory adapter must continue from the last complete cookie");
+assert.ok(memory.buffer.byteLength >= 4_517_944, "directory adapter must reserve its bounded managed allocations");
 
 const errorModule = await WebAssembly.compile(await readFile(errorWasmPath));
 const assertMalformedDirectoryReturnsError = async (fdReaddir) => {

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -419,6 +419,7 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     RegisterCalcitBuiltinImpls => meta::register_calcit_builtin_impls(args),
     ReadFile => effects::read_file(args),
     NativeFsReadText => effects::fs_read_text(args),
+    NativeFsReadDir => effects::fs_read_dir(args),
     ReadDir => effects::read_dir(args),
     WriteFile => effects::write_file(args),
     NativeFsWriteText => effects::fs_write_text(args),

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -7,7 +7,7 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::{
   builtins::meta::{new_named_enum_value, type_of},
-  calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitProc, format_proc_examples_hint},
+  calcit::{Calcit, CalcitErr, CalcitErrKind, CalcitList, CalcitProc, CalcitStructValue, format_proc_examples_hint},
 };
 
 const MAX_SECURE_RANDOM_BYTES: usize = 65_536;
@@ -239,6 +239,65 @@ pub fn fs_read_text(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
   };
   let result = match fs::read_to_string(&**path) {
     Ok(content) => new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::new_str(content)]),
+    Err(error) => new_named_enum_value(&[
+      result_type.to_owned(),
+      Calcit::tag("err"),
+      Calcit::new_str(format!("{host_error}: {error}")),
+    ]),
+  }?;
+  Ok(result)
+}
+
+/// List immediate children as nominal filesystem paths and preserve host failures as Result values.
+pub fn fs_read_dir(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  let [
+    result_type @ Calcit::EnumDef(_),
+    Calcit::StructDef(path_type),
+    Calcit::Str(path),
+    Calcit::Str(host_error),
+  ] = xs
+  else {
+    return CalcitErr::err_str(
+      CalcitErrKind::Type,
+      "&fs-read-dir expected Result and FsPath definitions, a path string, and a host error prefix",
+    );
+  };
+  let result = match fs::read_dir(&**path) {
+    Ok(entries) => {
+      let mut paths = vec![];
+      for entry in entries {
+        match entry {
+          Ok(entry) => match entry.path().into_os_string().into_string() {
+            Ok(path) => paths.push(path),
+            Err(_) => {
+              return new_named_enum_value(&[
+                result_type.to_owned(),
+                Calcit::tag("err"),
+                Calcit::new_str(format!("{host_error}: directory entry is not valid UTF-8")),
+              ]);
+            }
+          },
+          Err(error) => {
+            return new_named_enum_value(&[
+              result_type.to_owned(),
+              Calcit::tag("err"),
+              Calcit::new_str(format!("{host_error}: {error}")),
+            ]);
+          }
+        }
+      }
+      paths.sort();
+      let values = paths
+        .into_iter()
+        .map(|child| {
+          Calcit::Struct(CalcitStructValue {
+            struct_ref: std::sync::Arc::new(path_type.to_owned()),
+            values: std::sync::Arc::new(vec![Calcit::new_str(child)]),
+          })
+        })
+        .collect::<Vec<_>>();
+      new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::from(values)])
+    }
     Err(error) => new_named_enum_value(&[
       result_type.to_owned(),
       Calcit::tag("err"),

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -126,6 +126,8 @@ pub enum CalcitProc {
   ReadFile,
   #[strum(serialize = "&fs-read-text")]
   NativeFsReadText,
+  #[strum(serialize = "&fs-read-dir")]
+  NativeFsReadDir,
   #[strum(serialize = "read-dir")]
   ReadDir,
   #[strum(serialize = "write-file")]
@@ -1374,6 +1376,13 @@ impl CalcitProc {
           Arc::new(vec![some_tag("string"), some_tag("string")]),
         )),
         arg_types: vec![some_tag("enum-def"), some_tag("string"), some_tag("string")],
+      }),
+      NativeFsReadDir => Some(ProcTypeSignature {
+        return_type: Arc::new(CalcitTypeAnnotation::TypeRef(
+          Arc::from("Result"),
+          Arc::new(vec![list_of(type_var("T")), some_tag("string")]),
+        )),
+        arg_types: vec![some_tag("enum-def"), some_tag("struct-def"), some_tag("string"), some_tag("string")],
       }),
       ReadDir => Some(ProcTypeSignature {
         return_type: list_of(some_tag("string")),

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -713,6 +713,14 @@
             {} (:return 'String)
               :args $ [] 'List
           :tags $ #{} :builtin :internal
+        '&fs-read-dir $ %{} 'CodeEntry (:doc "|内部目录枚举边界；显式接收 Result 与 FsPath 定义、guest path 和宿主错误前缀。")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'EnumDef 'StructDef 'String 'String
+              :return $ :: 'Result (:: 'List 'FsPath) 'String
+          :tags $ #{} :builtin :file :internal :io
         '&fs-read-text $ %{} 'CodeEntry (:doc "|内部 UTF-8 文件读取边界；显式接收 Result 原型和宿主错误前缀，供 FsPath wrapper 与 backend lowering 使用。")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -5551,12 +5559,10 @@
                 assert= (&{} 1 1 2 2 3 3)
                   frequencies $ [] 1 2 2 3 3 3
               :tags $ #{} :core :unit
-        'fs-path:read-dir $ %{} 'CodeEntry (:doc "|List immediate children as Result<List<FsPath>,String>.")
+        'fs-path:read-dir $ %{} 'CodeEntry (:doc "|枚举 FsPath 的即时子项，并以确定顺序返回 Result<List<FsPath>,String>。")
           :code $ quote
             defn fs-path:read-dir (self)
-              result:map
-                try-read-dir (:value self) (%none)
-                fn (paths) (map paths fs:path)
+              &fs-read-dir Result FsPath (:value self) "|fs-path:read-dir failed"
           :examples $ []
           :schema $ :: 'Fn
             {}

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -46,8 +46,8 @@ mod structs;
 use methods::{emit_call_args, emit_method_invoke};
 use runtime::{
   HostImport, ModuleFunctionLayout, build_runtime_fns, build_utf8_valid_fn, build_wasi_get_args_fn, build_wasi_get_env_fn,
-  build_wasi_open_path_fn, build_wasi_read_text_fn, build_wasi_write_all_fn, build_wasi_write_text_fn, build_wasm_module,
-  core_host_import, host_imports_for_target,
+  build_wasi_open_path_fn, build_wasi_read_dir_fn, build_wasi_read_text_fn, build_wasi_write_all_fn, build_wasi_write_text_fn,
+  build_wasm_module, core_host_import, host_imports_for_target,
 };
 use structs::{
   emit_enum_assoc, emit_enum_count, emit_enum_new, emit_enum_nth, emit_named_enum_new, emit_struct_contains, emit_struct_count,
@@ -275,6 +275,19 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
       wasi_import("fd_read"),
       wasi_import("fd_close"),
       utf8_valid_idx,
+      str_tag_id,
+    ));
+    let read_dir_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_read_dir".into(), read_dir_idx);
+    compiled_fns.push(build_wasi_read_dir_fn(
+      open_path_idx,
+      wasi_import("fd_readdir"),
+      wasi_import("fd_close"),
+      utf8_valid_idx,
+      *runtime_fn_index
+        .get("__rt_str_compare")
+        .expect("string comparison helper must exist"),
+      *tag_index.get("list").expect("list tag must exist") as i32,
       str_tag_id,
     ));
     let write_text_idx = num_imports + compiled_fns.len() as u32;
@@ -2391,6 +2404,7 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
     }
     CalcitProc::NativeSecureRandomBytes => emit_wasi_secure_random_bytes(ctx, args),
     CalcitProc::NativeFsReadText => emit_wasi_fs_read_text(ctx, args),
+    CalcitProc::NativeFsReadDir => emit_wasi_fs_read_dir(ctx, args),
     CalcitProc::NativeFsWriteText => emit_wasi_fs_write_text(ctx, args),
 
     // @atom deref: just emit the argument (which should already be a GlobalGet)
@@ -2742,6 +2756,79 @@ fn emit_wasi_fs_read_text(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), S
   ctx.emit(Instruction::F64ConvertI32U);
   ctx.emit(Instruction::LocalSet(content));
   emit_result_enum(ctx, "ok", content)?;
+  ctx.emit(Instruction::End);
+  Ok(())
+}
+
+/// Lower the typed filesystem directory boundary through a private Preview 1 helper.
+fn emit_wasi_fs_read_dir(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  expect_arity(4, args, "&fs-read-dir")?;
+  if ctx.target != WasmTarget::Wasi {
+    return Err("E_WASM_CAPABILITY: filesystem directory reads are unavailable for the core WASM target".into());
+  }
+  let path = emit_ptr_to_i32(ctx, &args[2])?;
+  let host_error = ctx.alloc_local();
+  emit_expr(ctx, &args[3])?;
+  ctx.emit(Instruction::LocalSet(host_error));
+  ctx.emit(Instruction::LocalGet(path));
+  ctx.call_rt("__rt_wasi_read_dir");
+  let list = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalTee(list));
+  ctx.emit(Instruction::I32Eqz);
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  emit_result_enum(ctx, "err", host_error)?;
+  ctx.emit(Instruction::Else);
+
+  let count = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::LocalGet(list));
+  ctx.emit(Instruction::F64Load(mem_arg_f64(0)));
+  ctx.emit(Instruction::I32TruncF64U);
+  ctx.emit(Instruction::LocalSet(count));
+  let index = ctx.alloc_local_typed(ValType::I32);
+  ctx.emit(Instruction::I32Const(0));
+  ctx.emit(Instruction::LocalSet(index));
+  ctx.emit(Instruction::Block(wasm_encoder::BlockType::Empty));
+  ctx.emit(Instruction::Loop(wasm_encoder::BlockType::Empty));
+  ctx.emit(Instruction::LocalGet(index));
+  ctx.emit(Instruction::LocalGet(count));
+  ctx.emit(Instruction::I32GeU);
+  ctx.emit(Instruction::BrIf(1));
+  let value = ctx.alloc_local();
+  emit_list_load_elem(ctx, list, index);
+  ctx.emit(Instruction::LocalSet(value));
+  let struct_ptr = ctx.alloc_local_typed(ValType::I32);
+  emit_bump_alloc(ctx, 24, struct_ptr, "struct");
+  ctx.emit(Instruction::LocalGet(struct_ptr));
+  ctx.emit(f64_const(1.0));
+  ctx.emit(Instruction::F64Store(mem_arg_f64(0)));
+  ctx.emit(Instruction::LocalGet(struct_ptr));
+  ctx.emit(f64_const(get_type_tag(ctx, "FsPath")));
+  ctx.emit(Instruction::F64Store(mem_arg_f64(8)));
+  ctx.emit(Instruction::LocalGet(struct_ptr));
+  ctx.emit(Instruction::LocalGet(value));
+  ctx.emit(Instruction::F64Store(mem_arg_f64(16)));
+  ctx.emit(Instruction::LocalGet(list));
+  ctx.emit(Instruction::LocalGet(index));
+  ctx.emit(Instruction::I32Const(1));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::I32Const(8));
+  ctx.emit(Instruction::I32Mul);
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalGet(struct_ptr));
+  ctx.emit(Instruction::F64ConvertI32U);
+  ctx.emit(Instruction::F64Store(mem_arg_f64(0)));
+  ctx.emit(Instruction::LocalGet(index));
+  ctx.emit(Instruction::I32Const(1));
+  ctx.emit(Instruction::I32Add);
+  ctx.emit(Instruction::LocalSet(index));
+  ctx.emit(Instruction::Br(0));
+  ctx.emit(Instruction::End);
+  ctx.emit(Instruction::End);
+  let list_value = ctx.alloc_local();
+  ctx.emit(Instruction::LocalGet(list));
+  ctx.emit(Instruction::F64ConvertI32U);
+  ctx.emit(Instruction::LocalSet(list_value));
+  emit_result_enum(ctx, "ok", list_value)?;
   ctx.emit(Instruction::End);
   Ok(())
 }
@@ -3856,6 +3943,11 @@ mod tests {
         ),
         ("fd_filestat_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("fd_read", vec![ValType::I32; 4], vec![ValType::I32]),
+        (
+          "fd_readdir",
+          vec![ValType::I32, ValType::I32, ValType::I32, ValType::I64, ValType::I32],
+          vec![ValType::I32],
+        ),
         ("fd_close", vec![ValType::I32], vec![ValType::I32]),
       ]
     );

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -2802,7 +2802,7 @@ fn emit_wasi_fs_read_dir(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), St
   ctx.emit(f64_const(1.0));
   ctx.emit(Instruction::F64Store(mem_arg_f64(0)));
   ctx.emit(Instruction::LocalGet(struct_ptr));
-  ctx.emit(f64_const(get_type_tag(ctx, "FsPath")));
+  emit_expr(ctx, &args[1])?;
   ctx.emit(Instruction::F64Store(mem_arg_f64(8)));
   ctx.emit(Instruction::LocalGet(struct_ptr));
   ctx.emit(Instruction::LocalGet(value));

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -5,6 +5,10 @@ use wasm_encoder::{BlockType, Ieee64};
 const WASI_PREOPEN_FD_LIMIT: i32 = 64;
 const WASI_PREOPEN_NAME_LIMIT: i32 = 4096;
 const WASI_TEXT_FILE_LIMIT: i64 = 4 * 1024 * 1024;
+const WASI_DIR_BUFFER_SIZE: i32 = 64 * 1024;
+const WASI_DIR_ENTRY_LIMIT: i32 = 4096;
+const WASI_DIR_NAME_LIMIT: i32 = 4096;
+const WASI_DIR_PATH_BYTES_LIMIT: i32 = 4 * 1024 * 1024;
 
 #[derive(Clone, Debug)]
 pub(super) struct HostImport {
@@ -183,6 +187,12 @@ pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
         module: "wasi_snapshot_preview1".into(),
         name: "fd_read".into(),
         params: vec![ValType::I32; 4],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
+        name: "fd_readdir".into(),
+        params: vec![ValType::I32, ValType::I32, ValType::I32, ValType::I64, ValType::I32],
         results: vec![ValType::I32],
       },
       HostImport {
@@ -1012,6 +1022,441 @@ pub(super) fn build_wasi_write_text_fn(open_path_idx: u32, fd_write_idx: u32, fd
   b.emit(Instruction::Call(fd_close_idx));
   b.emit(Instruction::I32Eqz);
   b.finish(vec![ValType::I32, ValType::I32], vec![ValType::I32])
+}
+
+fn emit_wasi_dir_failure(builder: &mut RuntimeFnBuilder, fd: u32, fd_close_idx: u32) {
+  builder.emit(Instruction::LocalGet(fd));
+  builder.emit(Instruction::Call(fd_close_idx));
+  builder.emit(Instruction::Drop);
+  builder.emit(Instruction::I32Const(0));
+  builder.emit(Instruction::Return);
+}
+
+/// Read a bounded Preview 1 directory into a sorted list of Calcit String pointers.
+/// Returns zero on validation, authority, UTF-8, capacity, or host failures.
+pub(super) fn build_wasi_read_dir_fn(
+  open_path_idx: u32,
+  fd_readdir_idx: u32,
+  fd_close_idx: u32,
+  utf8_valid_idx: u32,
+  str_compare_idx: u32,
+  list_tag: i32,
+  string_tag: i32,
+) -> CompiledFn {
+  let mut b = RuntimeFnBuilder::new(1);
+  let path_len = b.alloc_i32();
+  let separator_len = b.alloc_i32();
+  let fd = b.alloc_i32();
+  let list_size = b.alloc_i32();
+  let list = b.alloc_i32();
+  let buffer_size = b.alloc_i32();
+  let buffer = b.alloc_i32();
+  let count = b.alloc_i32();
+  let cookie = b.alloc_i64();
+  let page_cookie = b.alloc_i64();
+  let used = b.alloc_i32();
+  let offset = b.alloc_i32();
+  let remaining = b.alloc_i32();
+  let next_cookie = b.alloc_i64();
+  let name_len = b.alloc_i32();
+  let name = b.alloc_i32();
+  let complete = b.alloc_i32();
+  let truncated = b.alloc_i32();
+  let skip = b.alloc_i32();
+  let name_index = b.alloc_i32();
+  let name_byte = b.alloc_i32();
+  let new_len = b.alloc_i32();
+  let total_path_bytes = b.alloc_i32();
+  let padded = b.alloc_i32();
+  let string_size = b.alloc_i32();
+  let string = b.alloc_i32();
+  let string_data = b.alloc_i32();
+  let insert_at = b.alloc_i32();
+  let previous = b.alloc_i32();
+
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::F64Load(mem_arg_f64(0)));
+  b.emit(Instruction::I32TruncF64U);
+  b.emit(Instruction::LocalTee(path_len));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::I32Const(WASI_DIR_PATH_BYTES_LIMIT));
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(separator_len));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(-1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(separator_len));
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I32Const(2));
+  b.emit(Instruction::I64Const(1_i64 << 14));
+  b.emit(Instruction::Call(open_path_idx));
+  b.emit(Instruction::LocalTee(fd));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32LtS);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::I32Const(8 + WASI_DIR_ENTRY_LIMIT * 8));
+  b.emit(Instruction::LocalSet(list_size));
+  rt_emit_alloc_dynamic(&mut b, list_size, list, list_tag);
+  b.emit(Instruction::I32Const(WASI_DIR_BUFFER_SIZE));
+  b.emit(Instruction::LocalSet(buffer_size));
+  rt_emit_alloc_dynamic(&mut b, buffer_size, buffer, 0);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(count));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(total_path_bytes));
+  b.emit(Instruction::I64Const(0));
+  b.emit(Instruction::LocalSet(cookie));
+
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(cookie));
+  b.emit(Instruction::LocalSet(page_cookie));
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::I32Const(WASI_DIR_BUFFER_SIZE));
+  b.emit(Instruction::LocalGet(cookie));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Call(fd_readdir_idx));
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::LocalTee(used));
+  b.emit(Instruction::I32Const(WASI_DIR_BUFFER_SIZE));
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(used));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(offset));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(complete));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(truncated));
+
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::LocalGet(used));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(used));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::LocalTee(remaining));
+  b.emit(Instruction::I32Const(24));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(truncated));
+  b.emit(Instruction::Br(2));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I64Load(mem_arg_f64(0)));
+  b.emit(Instruction::LocalSet(next_cookie));
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load(mem_arg_i32(16)));
+  b.emit(Instruction::LocalTee(name_len));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Const(WASI_DIR_NAME_LIMIT));
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(remaining));
+  b.emit(Instruction::I32Const(24));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(truncated));
+  b.emit(Instruction::Br(2));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(next_cookie));
+  b.emit(Instruction::LocalGet(cookie));
+  b.emit(Instruction::I64Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(buffer));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(24));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(name));
+  b.emit(Instruction::LocalGet(name));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::Call(utf8_valid_idx));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(name_index));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(name_index));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(name));
+  b.emit(Instruction::LocalGet(name_index));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::LocalTee(name_byte));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::LocalGet(name_byte));
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::I32Or);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(name_index));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(name_index));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::LocalSet(skip));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(name));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'.' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::LocalSet(skip));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Const(2));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(name));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(0)));
+  b.emit(Instruction::I32Const(b'.' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::LocalGet(name));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(1)));
+  b.emit(Instruction::I32Const(b'.' as i32));
+  b.emit(Instruction::I32Eq);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::LocalSet(skip));
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(skip));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32Const(WASI_DIR_ENTRY_LIMIT));
+  b.emit(Instruction::I32GeU);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::LocalGet(separator_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalTee(new_len));
+  b.emit(Instruction::LocalGet(total_path_bytes));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalTee(total_path_bytes));
+  b.emit(Instruction::I32Const(WASI_DIR_PATH_BYTES_LIMIT));
+  b.emit(Instruction::I32GtU);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(new_len));
+  b.emit(Instruction::I32Const(7));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(-8));
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::LocalSet(padded));
+  b.emit(Instruction::LocalGet(padded));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(string_size));
+  rt_emit_alloc_dynamic(&mut b, string_size, string, string_tag);
+  b.emit(Instruction::LocalGet(string));
+  b.emit(Instruction::LocalGet(new_len));
+  b.emit(Instruction::F64ConvertI32U);
+  b.emit(Instruction::F64Store(mem_arg_f64(0)));
+  b.emit(Instruction::LocalGet(string));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalTee(string_data));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::MemoryCopy { dst_mem: 0, src_mem: 0 });
+  b.emit(Instruction::LocalGet(separator_len));
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(string_data));
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(b'/' as i32));
+  b.emit(Instruction::I32Store8(mem_arg_byte(0)));
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(string_data));
+  b.emit(Instruction::LocalGet(path_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(separator_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(name));
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::MemoryCopy { dst_mem: 0, src_mem: 0 });
+
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::LocalSet(insert_at));
+  b.emit(Instruction::Block(BlockType::Empty));
+  b.emit(Instruction::Loop(BlockType::Empty));
+  b.emit(Instruction::LocalGet(insert_at));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(list));
+  b.emit(Instruction::LocalGet(insert_at));
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::F64Load(mem_arg_f64(0)));
+  b.emit(Instruction::I32TruncF64U);
+  b.emit(Instruction::LocalSet(previous));
+  b.emit(Instruction::LocalGet(string));
+  b.emit(Instruction::LocalGet(previous));
+  b.emit(Instruction::Call(str_compare_idx));
+  b.emit(Instruction::F64Const(Ieee64::from(0.0)));
+  b.emit(Instruction::F64Ge);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(list));
+  b.emit(Instruction::LocalGet(insert_at));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(previous));
+  b.emit(Instruction::F64ConvertI32U);
+  b.emit(Instruction::F64Store(mem_arg_f64(0)));
+  b.emit(Instruction::LocalGet(insert_at));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Sub);
+  b.emit(Instruction::LocalSet(insert_at));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(list));
+  b.emit(Instruction::LocalGet(insert_at));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::I32Const(8));
+  b.emit(Instruction::I32Mul);
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(string));
+  b.emit(Instruction::F64ConvertI32U);
+  b.emit(Instruction::F64Store(mem_arg_f64(0)));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(count));
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(next_cookie));
+  b.emit(Instruction::LocalSet(cookie));
+  b.emit(Instruction::LocalGet(complete));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(complete));
+  b.emit(Instruction::LocalGet(offset));
+  b.emit(Instruction::I32Const(24));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalGet(name_len));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(offset));
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(truncated));
+  b.emit(Instruction::LocalGet(used));
+  b.emit(Instruction::I32Const(WASI_DIR_BUFFER_SIZE));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::I32And);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(used));
+  b.emit(Instruction::I32Const(WASI_DIR_BUFFER_SIZE));
+  b.emit(Instruction::I32LtU);
+  b.emit(Instruction::BrIf(1));
+  b.emit(Instruction::LocalGet(complete));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::LocalGet(cookie));
+  b.emit(Instruction::LocalGet(page_cookie));
+  b.emit(Instruction::I64Eq);
+  b.emit(Instruction::I32Or);
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
+  b.emit(Instruction::End);
+  b.emit(Instruction::Br(0));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::LocalGet(fd));
+  b.emit(Instruction::Call(fd_close_idx));
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(list));
+  b.emit(Instruction::LocalGet(count));
+  b.emit(Instruction::F64ConvertI32U);
+  b.emit(Instruction::F64Store(mem_arg_f64(0)));
+  b.emit(Instruction::LocalGet(list));
+  b.finish(vec![ValType::I32], vec![ValType::I32])
 }
 
 /// Reserve a temporary region at the top of linear memory without advancing

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -9,6 +9,10 @@ const WASI_DIR_BUFFER_SIZE: i32 = 64 * 1024;
 const WASI_DIR_ENTRY_LIMIT: i32 = 4096;
 const WASI_DIR_NAME_LIMIT: i32 = 4096;
 const WASI_DIR_PATH_BYTES_LIMIT: i32 = 4 * 1024 * 1024;
+// Covers allocation headers, the list, read buffer, padded strings, FsPath
+// wrappers, and the successful Result value at the public boundary.
+const WASI_DIR_MANAGED_BYTES_LIMIT: i64 =
+  56 + WASI_DIR_BUFFER_SIZE as i64 + WASI_DIR_PATH_BYTES_LIMIT as i64 + 63 * WASI_DIR_ENTRY_LIMIT as i64;
 
 #[derive(Clone, Debug)]
 pub(super) struct HostImport {
@@ -1073,6 +1077,8 @@ pub(super) fn build_wasi_read_dir_fn(
   let string_data = b.alloc_i32();
   let insert_at = b.alloc_i32();
   let previous = b.alloc_i32();
+  let managed_size = b.alloc_i64();
+  let reserve_status = b.alloc_i32();
 
   b.emit(Instruction::LocalGet(0));
   b.emit(Instruction::F64Load(mem_arg_f64(0)));
@@ -1117,6 +1123,14 @@ pub(super) fn build_wasi_read_dir_fn(
   b.emit(Instruction::If(BlockType::Empty));
   b.emit(Instruction::I32Const(0));
   b.emit(Instruction::Return);
+  b.emit(Instruction::End);
+
+  b.emit(Instruction::I64Const(WASI_DIR_MANAGED_BYTES_LIMIT));
+  b.emit(Instruction::LocalSet(managed_size));
+  rt_emit_try_reserve_managed(&mut b, managed_size, reserve_status);
+  b.emit(Instruction::LocalGet(reserve_status));
+  b.emit(Instruction::If(BlockType::Empty));
+  emit_wasi_dir_failure(&mut b, fd, fd_close_idx);
   b.emit(Instruction::End);
 
   b.emit(Instruction::I32Const(8 + WASI_DIR_ENTRY_LIMIT * 8));
@@ -1520,6 +1534,52 @@ fn rt_emit_reserve_scratch(builder: &mut RuntimeFnBuilder, size_local: u32, mana
   builder.emit(Instruction::I64Sub);
   builder.emit(Instruction::I32WrapI64);
   builder.emit(Instruction::LocalSet(dst_local));
+}
+
+/// Ensure bounded managed allocations fit in memory without trapping.
+/// `status_local` is zero on success and non-zero on address overflow or a
+/// failed `memory.grow`, so Result-returning adapters can fail explicitly.
+fn rt_emit_try_reserve_managed(builder: &mut RuntimeFnBuilder, size_local: u32, status_local: u32) {
+  let memory_bytes = builder.alloc_i64();
+  let required_bytes = builder.alloc_i64();
+
+  builder.emit(Instruction::I32Const(0));
+  builder.emit(Instruction::LocalSet(status_local));
+  builder.emit(Instruction::MemorySize(0));
+  builder.emit(Instruction::I64ExtendI32U);
+  builder.emit(Instruction::I64Const(16));
+  builder.emit(Instruction::I64Shl);
+  builder.emit(Instruction::LocalSet(memory_bytes));
+  builder.emit(Instruction::GlobalGet(HEAP_PTR_GLOBAL));
+  builder.emit(Instruction::I64ExtendI32U);
+  builder.emit(Instruction::LocalGet(size_local));
+  builder.emit(Instruction::I64Add);
+  builder.emit(Instruction::LocalSet(required_bytes));
+  builder.emit(Instruction::LocalGet(required_bytes));
+  builder.emit(Instruction::I64Const(u32::MAX as i64));
+  builder.emit(Instruction::I64GtU);
+  builder.emit(Instruction::If(BlockType::Empty));
+  builder.emit(Instruction::I32Const(1));
+  builder.emit(Instruction::LocalSet(status_local));
+  builder.emit(Instruction::Else);
+  builder.emit(Instruction::LocalGet(required_bytes));
+  builder.emit(Instruction::LocalGet(memory_bytes));
+  builder.emit(Instruction::I64GtU);
+  builder.emit(Instruction::If(BlockType::Empty));
+  builder.emit(Instruction::LocalGet(required_bytes));
+  builder.emit(Instruction::LocalGet(memory_bytes));
+  builder.emit(Instruction::I64Sub);
+  builder.emit(Instruction::I64Const(65535));
+  builder.emit(Instruction::I64Add);
+  builder.emit(Instruction::I64Const(16));
+  builder.emit(Instruction::I64ShrU);
+  builder.emit(Instruction::I32WrapI64);
+  builder.emit(Instruction::MemoryGrow(0));
+  builder.emit(Instruction::I32Const(-1));
+  builder.emit(Instruction::I32Eq);
+  builder.emit(Instruction::LocalSet(status_local));
+  builder.emit(Instruction::End);
+  builder.emit(Instruction::End);
 }
 
 fn rt_emit_trap_on_errno(builder: &mut RuntimeFnBuilder) {

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1783,6 +1783,23 @@ export let _$n_fs_read_text = (resultType: CalcitEnumDef, path: string, hostErro
     return new CalcitEnumValue(newTag("err"), [`${hostError}: ${message}`], resultType);
   }
 };
+/** List immediate children as nominal filesystem paths and preserve host failures as Result values. */
+export let _$n_fs_read_dir = (
+  resultType: CalcitEnumDef,
+  pathType: CalcitStructDef,
+  path: string,
+  hostError: string,
+): CalcitEnumValue => {
+  try {
+    const paths = Array.from(read_dir(path, false).items()).map(
+      (child) => new CalcitStructValue(pathType.name, pathType.fields, [child], pathType),
+    );
+    return new CalcitEnumValue(newTag("ok"), [new CalcitSliceList(paths)], resultType);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return new CalcitEnumValue(newTag("err"), [`${hostError}: ${message}`], resultType);
+  }
+};
 export let read_dir = (path: string, recursive: boolean): CalcitSliceList => {
   if (!inNodeJs) {
     throw new Error("read_dir is unavailable in browser JavaScript hosts");


### PR DESCRIPTION
## 中文

把 `FsPath .read-dir` 接到与文本读写相同的类型化宿主边界，并为 WASI command 实现 Preview 1 `fd_readdir` lowering。公开语义保持为 `Result<List<FsPath>,String>`；native、生成的 JavaScript 与 WASI 都返回按完整 guest path 确定排序的即时子项，core WASM 继续明确报告 `E_WASM_CAPABILITY`。

WASI adapter 复用最长 preopen 匹配与路径越界校验，在内部管理 directory descriptor 和 cookie 分页。实现验证 24 字节 dirent 布局、UTF-8、NUL/斜杠、截断终页和 cookie 进展，并限制为最多 4096 项、累计路径 4 MiB、单名称 4096 字节。完整页末尾的截断记录会从最后一个完整 cookie 继续读取。

用户可见的 Result 错误语义放在 Calcit definition `:tests`；WASI ABI、分页、Unicode、排序、畸形记录和 core capability isolation 留在真实 Wasmtime 与假宿主脚本。旧的 String `try-read-dir` 保持兼容，未增加新的 analyzer 或动态类型统计规则。

验证：

- `yarn check-all`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- 12 个 WASI Calcit definition-attached tests
- 真实 Wasmtime preopen 目录枚举及假宿主分页/畸形记录回归

## English

Connects `FsPath .read-dir` to the same typed host boundary as text I/O and lowers it to WASI Preview 1 `fd_readdir` for WASI command modules. The public contract remains `Result<List<FsPath>,String>`; native, generated JavaScript, and WASI return immediate children in deterministic full guest-path order, while core WASM continues to report `E_WASM_CAPABILITY` explicitly.

The WASI adapter reuses longest-preopen matching and traversal validation while keeping directory descriptors and cookie pagination private. It validates the 24-byte dirent layout, UTF-8, NUL/slash names, truncated terminal pages, and cookie progress. Enumeration is bounded to 4096 entries, 4 MiB of aggregate guest-path bytes, and 4096 bytes per name. A truncated tail on a full page resumes from the last complete cookie.

User-visible Result error semantics live in Calcit definition-attached `:tests`; low-level WASI ABI, pagination, Unicode, sorting, malformed records, and core capability isolation stay in real Wasmtime and fake-host scripts. The legacy String `try-read-dir` remains compatible, and this change adds no analyzer or dynamic-type accounting rules.

Validation:

- `yarn check-all`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- 12 WASI Calcit definition-attached tests
- real Wasmtime preopen enumeration plus fake-host pagination and malformed-record regressions

Closes #1041
