### PR TITLE
feat(wasi): 同步等待边界 / synchronous wait boundary

### DIFF
--- a/calcit/test-wasi-command.cirru
+++ b/calcit/test-wasi-command.cirru
@@ -292,6 +292,77 @@
           :schema $ :: 'Fn
             {} (:return 'Unit)
               :args $ []
+        'wait-error? $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn wait-error? (duration)
+              match (wait-ms duration)
+                (:ok _) false
+                (:err message) (string? message)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'Number
+          :tags $ #{} :core :io :time :unit :wasi
+          :tests $ []
+            %{} 'TestEntry (:name |rejects-negative)
+              :code $ quote
+                assert= true $ wait-error? -1
+              :tags $ #{} :core :time :unit :wasi
+            %{} 'TestEntry (:name |rejects-fractional)
+              :code $ quote
+                assert= true $ wait-error? 1.5
+              :tags $ #{} :core :time :unit :wasi
+            %{} 'TestEntry (:name |rejects-overflow)
+              :code $ quote
+                assert= true $ wait-error? 4294967296
+              :tags $ #{} :core :time :unit :wasi
+        'wait-failure-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn wait-failure-main! () $ if (wait-error? 1) (println "|WASI-wait-error: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :io :time :wasi
+        'wait-fixed-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn wait-fixed-main! () $ if
+              and (wait-success? 0) (wait-success? 4294967295)
+              println "|WASI-fixed-wait: ok"
+              quit! 1
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :io :time :wasi
+        'wait-main! $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn wait-main! () $ if (wait-success? 1) (println "|WASI-wait: ok") (quit! 1)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+          :tags $ #{} :io :time :wasi
+        'wait-success? $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn wait-success? (duration)
+              match (wait-ms duration)
+                (:ok _) true
+                (:err _) false
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Bool)
+              :args $ [] 'Number
+          :tags $ #{} :core :io :time :unit :wasi
+          :tests $ []
+            %{} 'TestEntry (:name |zero-succeeds)
+              :code $ quote
+                assert= true $ wait-success? 0
+              :tags $ #{} :core :time :unit :wasi
+            %{} 'TestEntry (:name |positive-succeeds)
+              :code $ quote
+                assert= true $ wait-success? 1
+              :tags $ #{} :core :time :unit :wasi
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require

--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -461,6 +461,10 @@ let
 这些文件效果支持 native 与生成的 JavaScript。WASI command 还支持基于 preopen 的
 文本读写与 `.read-dir`；core WASM 明确拒绝宿主文件效果，`.walk-dir` 尚未接入 WASI。
 
+`wait-ms` 是同步等待接口，接收 `0..4294967295` 的整数毫秒并返回
+`Result<Unit,String>`。零值不触发 host；小数、负数、溢出或缺少阻塞能力都进入错误
+分支。不要把它改写为 `timeout-call`：后者是独立的 JavaScript callback API。
+
 `option:let` 使用普通 `let` 的 binding pair 结构。每个右侧和最终 body 都必须保持
 Option 容器；Result 错误类型需要转换时显式使用 `.map-err`。
 

--- a/docs/architectures/wasi-wait.cirru
+++ b/docs/architectures/wasi-wait.cirru
@@ -1,0 +1,33 @@
+{}
+  :schema-version 1
+  :feature 'wasi-wait
+  :doc "|提供单位明确、同步且跨 backend 一致的 wait-ms Result API；Preview 1 poll_oneoff 只作为 WASI command 的内部 adapter，timeout-call 保持独立。"
+  :roots $ #{} 'calcit.core/wait-ms
+  :definitions $ {}
+    'calcit.core/&wait-ms $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|内部同步等待边界；显式接收 Result 原型和宿主错误前缀，供 public wrapper 与 backend lowering 使用。"
+      :params $ [] 'result-type 'milliseconds 'host-error
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'EnumDef 'Number 'String
+          :return $ :: 'Result 'Unit 'String
+      :code $ quote &runtime-implementation
+    'calcit.core/wait-ms $ {}
+      :mode :ensure
+      :kind :fn
+      :doc "|同步等待整数毫秒并返回 Result<Unit,String>；允许 0..4294967295，不做隐式舍入。"
+      :params $ [] 'milliseconds
+      :schema $ :: 'Fn
+        {}
+          :args $ [] 'Number
+          :return $ :: 'Result 'Unit 'String
+      :code $ quote
+        defn wait-ms (milliseconds)
+          if
+            and (round? milliseconds) (>= milliseconds 0) (<= milliseconds 4294967295)
+            &wait-ms Result milliseconds "|wait-ms failed"
+            %err "|wait-ms expected an integer millisecond duration in 0..4294967295"
+  :edges $ #{}
+    :: :call 'calcit.core/wait-ms 'calcit.core/&wait-ms

--- a/docs/installation/host-capability-boundary.md
+++ b/docs/installation/host-capability-boundary.md
@@ -73,6 +73,7 @@ no-op or fabricated success value.
 | JSON parse/stringify | yes | yes | yes | unavailable | String `.parse-json` / Result wrappers; core JSON procedures |
 | Current Unix time in milliseconds | yes | unavailable | unavailable | WASI Preview 1 realtime clock; core WASM unavailable | `unix-time-ms` |
 | Monotonic milliseconds for elapsed-time measurement | yes | unavailable | unavailable | WASI Preview 1 monotonic clock; core WASM unavailable | `cpu-time`（只比较同一进程内两次调用的差值） |
+| 同步等待 | 当前线程 sleep | host injection 或 `Atomics.wait` | 主线程通常不可用并返回错误 | WASI Preview 1 `poll_oneoff`；core WASM unavailable | `wait-ms`，返回 `Result<Unit,String>` |
 | Construct and inspect a path value without I/O | yes | yes | yes | value-level support only | `fs:path`, `FsPath .to-string` |
 | `FsPath .read-text` / `.write-text` | yes | host injection | browser `localStorage` adapter | WASI Preview 1 preopen；core WASM unavailable | `FsPath` Result-returning methods |
 | `FsPath .read-dir` | yes | host injection | unavailable | WASI Preview 1 preopen；core WASM unavailable | `FsPath` Result-returning methods |
@@ -107,6 +108,14 @@ The matrix records what exists today, not an entitlement for every backend.
   经过时间，其绝对起点没有跨宿主语义。WASI command 通过 Preview 1
   `clock_time_get` 实现这两个入口，并在宿主返回错误时直接失败，不伪造数值。
   更高层的日期、时区行为仍属于 `calcit.std`。
+- 同步等待：`wait-ms` 接收 `0..4294967295` 范围内的整数毫秒，返回
+  `Result<Unit,String>`。零值立即成功且不触发宿主调用；小数、负数、溢出和宿主失败
+  都进入错误分支，不做隐式舍入。Native 阻塞当前线程，生成的 JavaScript 优先使用
+  host injection、否则尝试 `Atomics.wait`，WASI command 通过 Preview 1 `poll_oneoff`
+  使用相对单调时钟；core WASM 明确拒绝。异步 callback API `timeout-call` 保持独立。
+  `async-sleep` 是 fire-and-forget 的兼容任务，单位和生命周期也不同，因此 migration/fix
+  不得把这两个旧入口自动改写成 `wait-ms`。类型驱动工具只能报告语义差异并给出两个候选方向：
+  需要阻塞顺序时由用户显式改成 `wait-ms`，需要异步调度时保留 callback/task API。
 - 安全随机数：`secure-random-bytes` 接收 `0..65536` 范围内的整数长度，返回
   `Result<Buffer,String>`。Native 使用系统 CSPRNG，生成的 JavaScript 使用 Web
   Crypto，WASI command 使用 Preview 1 `random_get`；core WASM 会明确拒绝该宿主能力。

--- a/docs/installation/host-capability-boundary.md
+++ b/docs/installation/host-capability-boundary.md
@@ -111,7 +111,8 @@ The matrix records what exists today, not an entitlement for every backend.
 - 同步等待：`wait-ms` 接收 `0..4294967295` 范围内的整数毫秒，返回
   `Result<Unit,String>`。零值立即成功且不触发宿主调用；小数、负数、溢出和宿主失败
   都进入错误分支，不做隐式舍入。Native 阻塞当前线程，生成的 JavaScript 优先使用
-  host injection、否则尝试 `Atomics.wait`，WASI command 通过 Preview 1 `poll_oneoff`
+  host injection、否则尝试 `Atomics.wait`；同步 injection 不得返回 Promise/thenable，异步结果会立即转为错误，
+  不能先报告成功再丢失稍后的 rejection。WASI command 通过 Preview 1 `poll_oneoff`
   使用相对单调时钟；core WASM 明确拒绝。异步 callback API `timeout-call` 保持独立。
   `async-sleep` 是 fire-and-forget 的兼容任务，单位和生命周期也不同，因此 migration/fix
   不得把这两个旧入口自动改写成 `wait-ms`。类型驱动工具只能报告语义差异并给出两个候选方向：

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -394,6 +394,7 @@ lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
 - `recur` - tail recursion
 - `generate-id!` - unique ID generation
 - `cpu-time` - timing
+- `wait-ms`：同步等待整数毫秒，返回 `Result<Unit,String>`；与异步 `timeout-call` 无关
 - `&get-os`, `&get-calcit-backend` - environment info
 
 ### EDN/Data Operations
@@ -413,6 +414,7 @@ lowered to indexed access; an undeclared field is a diagnostic, not `nil`.
 - `ffi:task`, `FfiTask .cancel` / `.cancel-with` - nominal native async task lifecycle API
 - `ffi:response`, `FfiResponse .resolve` / `.reject` - nominal exactly-once native response API
 - `get-env` - environment variables
+- `wait-ms`：跨 backend 的同步等待边界；零值不调用宿主，缺少能力时返回错误
 - `raise` - throw error
 - `quit!` - exit program
 

--- a/docs/run/cli-options.md
+++ b/docs/run/cli-options.md
@@ -479,6 +479,8 @@ command init definition 正常返回时，进程状态为 `0`；调用 `quit!` �
 
 WASI command 也复用 `unix-time-ms` 与 `cpu-time`。前者读取系统实时时钟；后者读取单调时钟，只保证同一进程内两次读数的差值有意义。两者均返回毫秒数；Preview 1 的纳秒结果与错误码由编译器内部转换和检查，宿主失败时不会返回 `0` 或 `nil`。
 
+同步等待使用 `wait-ms`，参数必须是 `0..4294967295` 范围内的整数毫秒，返回 `Result<Unit,String>`。零值立即成功且不调用 host；WASI command 把非零等待转换为 Preview 1 `poll_oneoff` 的相对单调时钟订阅，并验证返回事件。小数、负数、溢出和宿主错误都进入 `Result :err`，不做舍入或伪造成功。`calcit wasm` 的 core module 没有默认阻塞等待协议，会以 `E_WASM_CAPABILITY` 拒绝。该 API 不改变 JavaScript callback 形式的 `timeout-call`，也不等同于 fire-and-forget 的 `async-sleep`；由于控制流、单位和生命周期都不同，自动 fix 不应改写这两个旧入口，只能提示用户选择同步 `wait-ms` 或异步 callback/task API。
+
 安全随机字节统一通过 `secure-random-bytes` 获取。参数必须是 `0..65536` 范围内的整数，返回值为 `Result<Buffer,String>`；WASI command 由 Preview 1 `random_get` 填充缓冲区，宿主错误保留为 `Result` 的错误分支。Native 与生成的 JavaScript 保持相同的公开值形状，分别使用系统 CSPRNG 与 Web Crypto。`calcit wasm` 的 core module 没有默认随机数宿主协议，会以 `E_WASM_CAPABILITY` 明确拒绝。
 
 WASI command 可通过 `FsPath .read-text` 与 `.write-text` 访问 host 显式预开放的目录。Calcit 路径使用 guest 侧名称，例如 host 以 `--dir ./data::/workspace` 授权后，程序访问 `workspace/input.txt`；编译器会选择最长匹配的 preopen，并只把剩余相对路径交给 Preview 1 `path_open`：

--- a/docs/type-guidance.md
+++ b/docs/type-guidance.md
@@ -111,6 +111,10 @@ String 本身不携带文件系统语义；`try-read-file`、`try-read-dir`、
 这些文件效果支持 native 与生成的 JavaScript。WASI command 支持基于 preopen 的
 文本读写和 `.read-dir`；core WASM 明确拒绝宿主文件效果，`.walk-dir` 尚未接入 WASI。
 
+需要同步等待时使用 `wait-ms`，让缺少宿主能力或等待失败继续保留在
+`Result<Unit,String>` 中。参数是明确的整数毫秒，不接受隐式舍入；异步调度仍使用
+独立的 callback/task API，不把两种控制流混成一个动态接口。
+
 Native 异步 FFI capability 也遵循相同边界原则。模块适配层用 `ffi:task`、
 `ffi:response` 把不透明 AnyRef 提升为 nominal `FfiTask`、`FfiResponse`，业务层调用
 `.cancel`、`.cancel-with`、`.resolve`、`.reject`。raw 字段保持 `Dynamic`，但

--- a/editing-history/202609130458-wasi-wait.md
+++ b/editing-history/202609130458-wasi-wait.md
@@ -1,0 +1,21 @@
+# WASI 同步等待边界
+
+## 背景
+
+WASI command 已有时钟读取能力，但缺少单位明确、能够表达宿主失败的同步等待接口。已有的 `timeout-call` 与 `async-sleep` 分别使用 callback 和 fire-and-forget 语义，不能安全地自动迁移为阻塞等待。
+
+## 变更
+
+- 新增 `wait-ms Number -> Result<Unit,String>`，只接受 `0..4294967295` 范围内的整数毫秒；零值立即成功且不触发宿主。
+- Native 使用当前线程 sleep；生成的 JavaScript 优先使用显式 host injection，并保留 `Atomics.wait` fallback。
+- WASI command 通过 Preview 1 `poll_oneoff` 发起相对单调时钟订阅，并验证返回事件；core WASM 以 `E_WASM_CAPABILITY` 明确拒绝。
+- 保持 `timeout-call` 与 `async-sleep` 的现有控制流，不提供语义不可靠的自动 migration。
+- 更新能力边界、CLI、类型指引和 Agent 文档，并补充结构化架构描述。
+
+## 验证
+
+- Calcit definition-attached `:tests` 覆盖零值、正值、小数、负数与溢出。
+- JavaScript runtime identity 覆盖 injection、零值绕过、Node fallback 与宿主失败。
+- 确定性 Preview 1 假宿主验证 ABI 布局、最大时长、零值绕过和错误返回。
+- 真实 Wasmtime 验证短等待成功；core WASM 验证能力拒绝。
+- `cargo fmt --check`、772 项 Rust library tests、Native 与 `wasm32-wasip1` clippy、WASI 回归和 `yarn check-all` 通过。

--- a/editing-history/202609130729-wasi-wait-review.md
+++ b/editing-history/202609130729-wasi-wait-review.md
@@ -1,0 +1,24 @@
+# 收紧 JavaScript 同步等待注入
+
+时间：2026-09-13 07:29 +0800
+
+## 背景
+
+PR #1043 的 review 指出，JavaScript `wait_ms` injection 的返回类型为 `unknown`，若宿主误传异步函数，
+runtime 会在 Promise 真正完成前返回 `%ok`，随后 rejection 既不能进入 Calcit `Result`，也可能成为未处理拒绝。
+
+## 调整
+
+- 检查 injection 返回值是否为 Promise/thenable；发现异步结果时立即返回同步契约错误。
+- 为已返回的 thenable 安装 rejection handler，避免错误被遗留为宿主级 unhandled rejection。
+- 增加 rejecting async injection 回归，并等待一个事件循环阶段证明 rejection 已被消费。
+- 文档明确 JavaScript 同步 wait injection 不接受 Promise/thenable。
+
+## 验证
+
+- `yarn compile`
+- `yarn check-js-runtime`
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --all-targets`
+- `yarn check-all`

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -106,6 +106,13 @@ try {
   const failedWait = runtimeA._$n_wait_ms(todoEnum, 1, "wait failed");
   assert.equal(failedWait.tag, runtimeA.newTag("err"));
   assert.deepEqual(failedWait.extra, ["wait failed: interrupted"]);
+  globalThis.__calcit_injections__.wait_ms = async () => {
+    throw new Error("late rejection");
+  };
+  const asyncWait = runtimeA._$n_wait_ms(todoEnum, 1, "wait failed");
+  assert.equal(asyncWait.tag, runtimeA.newTag("err"));
+  assert.deepEqual(asyncWait.extra, ["wait failed: wait_ms injection must complete synchronously"]);
+  await new Promise((resolve) => setImmediate(resolve));
   globalThis.__calcit_injections__.read_file = (path) => `typed:${path}`;
   globalThis.__calcit_injections__.write_file = (path, content) => writes.push([path, content]);
   const typedRead = runtimeA._$n_fs_read_text(todoEnum, "typed.txt", "read failed");

--- a/scripts/check-js-runtime-identity.mjs
+++ b/scripts/check-js-runtime-identity.mjs
@@ -16,10 +16,12 @@ try {
   const runtimeA = await import(pathToFileURL(join(runtimeAPath, "calcit.procs.mjs")).href);
   const runtimeB = await import(pathToFileURL(join(runtimeBPath, "calcit.procs.mjs")).href);
   const writes = [];
+  const waits = [];
   globalThis.__calcit_injections__ = {
     read_file: (path) => `content:${path}`,
     read_dir: (path, recursive) => [`${path}/z`, `${path}/${recursive ? "deep/a" : "a"}`],
     write_file: (path, content) => writes.push([path, content]),
+    wait_ms: (milliseconds) => waits.push(milliseconds),
   };
   assert.equal(runtimeA.read_file("demo.txt"), "content:demo.txt", "read-file must return the injected host value");
   assert.deepEqual(
@@ -87,6 +89,23 @@ try {
   const todoEnum = new runtimeA.CalcitEnumDef(new runtimeA.CalcitStructValue(todoName, [todoField], [todoType]));
   const todoEnumValue = new runtimeA.CalcitEnumValue(todoField, [""], todoEnum);
   const anonymousEnumValue = new runtimeA.CalcitEnumValue(todoField, [""]);
+  const zeroWait = runtimeA._$n_wait_ms(todoEnum, 0, "wait failed");
+  assert.equal(zeroWait.tag, runtimeA.newTag("ok"));
+  assert.deepEqual(waits, [], "zero wait must not invoke the JavaScript host");
+  const positiveWait = runtimeA._$n_wait_ms(todoEnum, 7, "wait failed");
+  assert.equal(positiveWait.tag, runtimeA.newTag("ok"));
+  assert.deepEqual(waits, [7]);
+  delete globalThis.__calcit_injections__.wait_ms;
+  const nodeWait = runtimeA._$n_wait_ms(todoEnum, 1, "wait failed");
+  assert.equal(nodeWait.tag, runtimeA.newTag("ok"), "Node must provide a blocking Atomics.wait fallback");
+  const invalidWait = runtimeA._$n_wait_ms(todoEnum, 1.5, "wait failed");
+  assert.equal(invalidWait.tag, runtimeA.newTag("err"));
+  globalThis.__calcit_injections__.wait_ms = () => {
+    throw new Error("interrupted");
+  };
+  const failedWait = runtimeA._$n_wait_ms(todoEnum, 1, "wait failed");
+  assert.equal(failedWait.tag, runtimeA.newTag("err"));
+  assert.deepEqual(failedWait.extra, ["wait failed: interrupted"]);
   globalThis.__calcit_injections__.read_file = (path) => `typed:${path}`;
   globalThis.__calcit_injections__.write_file = (path, content) => writes.push([path, content]);
   const typedRead = runtimeA._$n_fs_read_text(todoEnum, "typed.txt", "read failed");

--- a/scripts/test-wasi-clock-host.mjs
+++ b/scripts/test-wasi-clock-host.mjs
@@ -54,6 +54,9 @@ const wasi = {
     view().setBigUint64(resultPtr, nanoseconds, true);
     return 0;
   },
+  poll_oneoff() {
+    throw new Error("clock fixture unexpectedly waited");
+  },
   random_get() {
     throw new Error("clock fixture unexpectedly requested random bytes");
   },

--- a/scripts/test-wasi-filesystem-host.mjs
+++ b/scripts/test-wasi-filesystem-host.mjs
@@ -43,6 +43,9 @@ const wasi = {
   clock_time_get() {
     throw new Error("filesystem fixture unexpectedly requested a clock");
   },
+  poll_oneoff() {
+    throw new Error("filesystem fixture unexpectedly waited");
+  },
   random_get() {
     throw new Error("filesystem fixture unexpectedly requested random bytes");
   },

--- a/scripts/test-wasi-preprocess.sh
+++ b/scripts/test-wasi-preprocess.sh
@@ -17,6 +17,11 @@ readonly CLOCK_OUT="${CARGO_TARGET_DIR:-target}/wasi-clock-smoke"
 readonly CLOCK_STDOUT="${CLOCK_OUT}/stdout.txt"
 readonly FIXED_CLOCK_OUT="${CARGO_TARGET_DIR:-target}/wasi-fixed-clock-smoke"
 readonly CORE_CLOCK_OUT="${CARGO_TARGET_DIR:-target}/core-clock-reject"
+readonly WAIT_OUT="${CARGO_TARGET_DIR:-target}/wasi-wait-smoke"
+readonly WAIT_STDOUT="${WAIT_OUT}/stdout.txt"
+readonly FIXED_WAIT_OUT="${CARGO_TARGET_DIR:-target}/wasi-fixed-wait-smoke"
+readonly FAILED_WAIT_OUT="${CARGO_TARGET_DIR:-target}/wasi-failed-wait-smoke"
+readonly CORE_WAIT_OUT="${CARGO_TARGET_DIR:-target}/core-wait-reject"
 readonly RANDOM_OUT="${CARGO_TARGET_DIR:-target}/wasi-random-smoke"
 readonly RANDOM_STDOUT="${RANDOM_OUT}/stdout.txt"
 readonly FIXED_RANDOM_OUT="${CARGO_TARGET_DIR:-target}/wasi-fixed-random-smoke"
@@ -120,6 +125,22 @@ if clock_capability_error=$("$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app.
   exit 1
 fi
 grep -Fq "E_WASM_CAPABILITY" <<<"$clock_capability_error"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/wait-main! --emit-path "$WAIT_OUT"
+wasmtime run "$WAIT_OUT/program.wasm" >"$WAIT_STDOUT"
+grep -Fxq "WASI-wait: ok" "$WAIT_STDOUT"
+
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/wait-fixed-main! --emit-path "$FIXED_WAIT_OUT"
+"$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/wait-failure-main! --emit-path "$FAILED_WAIT_OUT"
+node scripts/test-wasi-wait-host.mjs "$FIXED_WAIT_OUT/program.wasm" "$FAILED_WAIT_OUT/program.wasm"
+
+if wait_capability_error=$(
+  "$CALCIT_BIN" wasm "$COMMAND_FIXTURE" --init-fn app.main/wait-main! --emit-path "$CORE_WAIT_OUT" 2>&1
+); then
+  echo "core WASM unexpectedly accepted synchronous wait" >&2
+  exit 1
+fi
+grep -Fq "E_WASM_CAPABILITY" <<<"$wait_capability_error"
 
 "$CALCIT_BIN" wasi "$COMMAND_FIXTURE" --init-fn app.main/random-main! --emit-path "$RANDOM_OUT"
 wasmtime run "$RANDOM_OUT/program.wasm" >"$RANDOM_STDOUT"

--- a/scripts/test-wasi-random-host.mjs
+++ b/scripts/test-wasi-random-host.mjs
@@ -43,6 +43,9 @@ const wasi = {
   clock_time_get() {
     throw new Error("random fixture unexpectedly requested a clock");
   },
+  poll_oneoff() {
+    throw new Error("random fixture unexpectedly waited");
+  },
   random_get(ptr, length) {
     assert.equal(length, 4);
     randomDataPtr = ptr;

--- a/scripts/test-wasi-read-dir-host.mjs
+++ b/scripts/test-wasi-read-dir-host.mjs
@@ -46,6 +46,9 @@ const wasi = {
   clock_time_get() {
     throw new Error("directory fixture unexpectedly requested a clock");
   },
+  poll_oneoff() {
+    throw new Error("directory fixture unexpectedly waited");
+  },
   random_get() {
     throw new Error("directory fixture unexpectedly requested random bytes");
   },

--- a/scripts/test-wasi-wait-host.mjs
+++ b/scripts/test-wasi-wait-host.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [successWasmPath, failureWasmPath] = process.argv.slice(2);
+if (successWasmPath == null || failureWasmPath == null) {
+  throw new Error("usage: node scripts/test-wasi-wait-host.mjs <success.wasm> <failure.wasm>");
+}
+
+let memory;
+let stdout = "";
+const waits = [];
+const view = () => new DataView(memory.buffer);
+const bytes = () => new Uint8Array(memory.buffer);
+
+const baseWasi = {
+  args_sizes_get(argcPtr, argvSizePtr) {
+    view().setUint32(argcPtr, 0, true);
+    view().setUint32(argvSizePtr, 0, true);
+    return 0;
+  },
+  args_get: () => 0,
+  environ_sizes_get(countPtr, sizePtr) {
+    view().setUint32(countPtr, 0, true);
+    view().setUint32(sizePtr, 0, true);
+    return 0;
+  },
+  environ_get: () => 0,
+  fd_write(fd, iovsPtr, iovsLength, writtenPtr) {
+    assert.equal(fd, 1);
+    let written = 0;
+    for (let index = 0; index < iovsLength; index += 1) {
+      const ptr = view().getUint32(iovsPtr + index * 8, true);
+      const length = view().getUint32(iovsPtr + index * 8 + 4, true);
+      stdout += new TextDecoder().decode(bytes().subarray(ptr, ptr + length));
+      written += length;
+    }
+    view().setUint32(writtenPtr, written, true);
+    return 0;
+  },
+  proc_exit(code) {
+    throw new Error(`unexpected proc_exit(${code})`);
+  },
+  clock_time_get() {
+    throw new Error("wait fixture unexpectedly read a clock");
+  },
+  random_get() {
+    throw new Error("wait fixture unexpectedly requested random bytes");
+  },
+  fd_prestat_get() {
+    throw new Error("wait fixture unexpectedly requested a filesystem preopen");
+  },
+  fd_prestat_dir_name() {
+    throw new Error("wait fixture unexpectedly requested a preopen name");
+  },
+  path_open() {
+    throw new Error("wait fixture unexpectedly opened a filesystem path");
+  },
+  fd_filestat_get() {
+    throw new Error("wait fixture unexpectedly requested file metadata");
+  },
+  fd_read() {
+    throw new Error("wait fixture unexpectedly read a file");
+  },
+  fd_readdir() {
+    throw new Error("wait fixture unexpectedly enumerated a directory");
+  },
+  fd_close() {
+    throw new Error("wait fixture unexpectedly closed a file");
+  },
+};
+
+const successWasi = {
+  ...baseWasi,
+  poll_oneoff(inputPtr, outputPtr, subscriptions, neventsPtr) {
+    assert.equal(subscriptions, 1);
+    assert.ok(inputPtr >= 16, "wait subscription must use reserved scratch memory");
+    assert.equal(view().getUint8(inputPtr + 8), 0, "subscription must select a clock event");
+    assert.equal(view().getUint32(inputPtr + 16, true), 1, "wait must use the monotonic clock");
+    assert.equal(view().getBigUint64(inputPtr + 24, true), 4_294_967_295_000_000n);
+    assert.equal(view().getBigUint64(inputPtr + 32, true), 1_000_000n);
+    assert.equal(view().getUint16(inputPtr + 40, true), 0, "wait must use a relative timeout");
+    const userdata = view().getBigUint64(inputPtr, true);
+    waits.push(view().getBigUint64(inputPtr + 24, true));
+    view().setBigUint64(outputPtr, userdata, true);
+    view().setUint16(outputPtr + 8, 0, true);
+    view().setUint8(outputPtr + 10, 0);
+    view().setUint32(neventsPtr, 1, true);
+    return 0;
+  },
+};
+
+const successModule = await WebAssembly.compile(await readFile(successWasmPath));
+const successInstance = await WebAssembly.instantiate(successModule, { wasi_snapshot_preview1: successWasi });
+memory = successInstance.exports.memory;
+successInstance.exports._start();
+assert.equal(stdout, "WASI-fixed-wait: ok\n");
+assert.deepEqual(waits, [4_294_967_295_000_000n], "zero wait must not call poll_oneoff");
+
+stdout = "";
+const failureWasi = { ...baseWasi, poll_oneoff: () => 5 };
+const failureModule = await WebAssembly.compile(await readFile(failureWasmPath));
+const failureInstance = await WebAssembly.instantiate(failureModule, { wasi_snapshot_preview1: failureWasi });
+memory = failureInstance.exports.memory;
+failureInstance.exports._start();
+assert.equal(stdout, "WASI-wait-error: ok\n");

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -414,6 +414,7 @@ fn handle_proc_internal(name: CalcitProc, args: &[Calcit], call_stack: &CallStac
     GetEnv => effects::get_env(args),
     GetArgs => effects::get_args(args),
     UnixTimeMs => effects::unix_time_ms(args),
+    NativeWaitMs => effects::wait_ms(args),
     NativeSecureRandomBytes => effects::secure_random_bytes(args),
     NativeGetCalcitBackend => effects::call_get_calcit_backend(args),
     RegisterCalcitBuiltinImpls => meta::register_calcit_builtin_impls(args),

--- a/src/builtins/effects.rs
+++ b/src/builtins/effects.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::process::exit;
 use std::sync::LazyLock;
 use std::sync::RwLock;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Duration;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::{
@@ -11,6 +13,7 @@ use crate::{
 };
 
 const MAX_SECURE_RANDOM_BYTES: usize = 65_536;
+const MAX_WAIT_MILLISECONDS: f64 = u32::MAX as f64;
 
 #[derive(Clone, Debug, Copy)]
 pub enum CliRunningMode {
@@ -169,6 +172,48 @@ pub fn unix_time_ms(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
     .map_err(|e| CalcitErr::use_str(CalcitErrKind::Effect, format!("unix-time-ms failed: {e}")))?
     .as_millis() as f64;
   Ok(Calcit::Number(millis))
+}
+
+/// Block the current thread for a portable integral millisecond duration.
+pub fn wait_ms(xs: &[Calcit]) -> Result<Calcit, CalcitErr> {
+  let [
+    result_type @ Calcit::EnumDef(_),
+    Calcit::Number(milliseconds),
+    Calcit::Str(_host_error),
+  ] = xs
+  else {
+    return CalcitErr::err_str(
+      CalcitErrKind::Type,
+      "&wait-ms expected the Result enum definition, a millisecond duration, and a host error prefix",
+    );
+  };
+  let result =
+    if !milliseconds.is_finite() || milliseconds.fract() != 0.0 || *milliseconds < 0.0 || *milliseconds > MAX_WAIT_MILLISECONDS {
+      new_named_enum_value(&[
+        result_type.to_owned(),
+        Calcit::tag("err"),
+        Calcit::new_str(format!(
+          "wait-ms expected an integer millisecond duration in 0..{}, got: {milliseconds}",
+          u32::MAX
+        )),
+      ])
+    } else {
+      #[cfg(not(target_arch = "wasm32"))]
+      let result = {
+        if *milliseconds > 0.0 {
+          std::thread::sleep(Duration::from_millis(*milliseconds as u64));
+        }
+        new_named_enum_value(&[result_type.to_owned(), Calcit::tag("ok"), Calcit::Unit])
+      };
+      #[cfg(target_arch = "wasm32")]
+      let result = new_named_enum_value(&[
+        result_type.to_owned(),
+        Calcit::tag("err"),
+        Calcit::new_str(format!("{_host_error}: native interpreter blocking wait is unavailable on wasm32")),
+      ]);
+      result
+    }?;
+  Ok(result)
 }
 
 /// Fill a Buffer from the operating system CSPRNG and preserve expected failures as Result values.

--- a/src/calcit/proc_name.rs
+++ b/src/calcit/proc_name.rs
@@ -116,6 +116,8 @@ pub enum CalcitProc {
   GetArgs,
   #[strum(serialize = "unix-time-ms")]
   UnixTimeMs,
+  #[strum(serialize = "&wait-ms")]
+  NativeWaitMs,
   #[strum(serialize = "&secure-random-bytes")]
   NativeSecureRandomBytes,
   #[strum(serialize = "&get-calcit-backend")]
@@ -1425,6 +1427,13 @@ impl CalcitProc {
       UnixTimeMs => Some(ProcTypeSignature {
         return_type: some_tag("number"),
         arg_types: vec![],
+      }),
+      NativeWaitMs => Some(ProcTypeSignature {
+        return_type: Arc::new(CalcitTypeAnnotation::TypeRef(
+          Arc::from("Result"),
+          Arc::new(vec![some_tag("unit"), some_tag("string")]),
+        )),
+        arg_types: vec![some_tag("enum-def"), some_tag("number"), some_tag("string")],
       }),
       NativeSecureRandomBytes => Some(ProcTypeSignature {
         return_type: Arc::new(CalcitTypeAnnotation::TypeRef(

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2580,6 +2580,14 @@
               :generics $ [] 'T
               :return $ :: 'Set 'T
           :tags $ #{} :builtin :internal
+        '&wait-ms $ %{} 'CodeEntry (:doc "|内部同步等待边界；显式接收 Result 原型和宿主错误前缀，供 public wrapper 与 backend lowering 使用。")
+          :code $ quote &runtime-implementation
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'EnumDef 'Number 'String
+              :return $ :: 'Result 'Unit 'String
+          :tags $ #{} :builtin :internal :io :time
         '&{} $ %{} 'CodeEntry (:doc "|internal function for creating maps\nSyntax: (&{} & key-value-pairs)\nParams: key-value-pairs (any, variadic)\nReturns: map\nCreates new map from key-value pairs")
           :code $ quote &runtime-implementation
           :examples $ []
@@ -8909,6 +8917,48 @@
               :generics $ [] 'T
               :required $ [] (:: 'Expr 'T)
           :tags $ #{} :macro
+        'wait-ms $ %{} 'CodeEntry (:doc "|同步等待整数毫秒并返回 Result<Unit,String>；允许 0..4294967295，不做隐式舍入。")
+          :code $ quote
+            defn wait-ms (milliseconds)
+              if
+                and (round? milliseconds) (>= milliseconds 0) (<= milliseconds 4294967295)
+                &wait-ms Result milliseconds "|wait-ms failed"
+                %err "|wait-ms expected an integer millisecond duration in 0..4294967295"
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Number
+              :return $ :: 'Result 'Unit 'String
+          :tags $ #{} :io :time
+          :tests $ []
+            %{} 'TestEntry (:name |zero-succeeds)
+              :code $ quote
+                assert= true $ match (wait-ms 0)
+                  (:ok _) true
+                  (:err _) false
+              :tags $ #{} :core :time :unit :wasi
+            %{} 'TestEntry (:name |positive-succeeds)
+              :code $ quote
+                assert= true $ match (wait-ms 1)
+                  (:ok _) true
+                  (:err _) false
+              :tags $ #{} :core :time :unit :wasi
+            %{} 'TestEntry (:name |rejects-fractional)
+              :code $ quote
+                assert= true $ match (wait-ms 1.5)
+                  (:ok _) false
+                  (:err message) (string? message)
+              :tags $ #{} :core :time :unit :wasi
+            %{} 'TestEntry (:name |rejects-out-of-range)
+              :code $ quote
+                assert= true $ and
+                  match (wait-ms -1)
+                    (:ok _) false
+                    (:err message) (string? message)
+                  match (wait-ms 4294967296)
+                    (:ok _) false
+                    (:err message) (string? message)
+              :tags $ #{} :core :time :unit :wasi
         'when $ %{} 'CodeEntry (:doc "|Conditional macro that evaluates its body only when the test expression is truthy, returning the last body value.")
           :code $ quote
             defmacro when (condition & body)

--- a/src/codegen/emit_wasm.rs
+++ b/src/codegen/emit_wasm.rs
@@ -46,8 +46,8 @@ mod structs;
 use methods::{emit_call_args, emit_method_invoke};
 use runtime::{
   HostImport, ModuleFunctionLayout, build_runtime_fns, build_utf8_valid_fn, build_wasi_get_args_fn, build_wasi_get_env_fn,
-  build_wasi_open_path_fn, build_wasi_read_dir_fn, build_wasi_read_text_fn, build_wasi_write_all_fn, build_wasi_write_text_fn,
-  build_wasm_module, core_host_import, host_imports_for_target,
+  build_wasi_open_path_fn, build_wasi_read_dir_fn, build_wasi_read_text_fn, build_wasi_wait_fn, build_wasi_write_all_fn,
+  build_wasi_write_text_fn, build_wasm_module, core_host_import, host_imports_for_target,
 };
 use structs::{
   emit_enum_assoc, emit_enum_count, emit_enum_new, emit_enum_nth, emit_named_enum_new, emit_struct_contains, emit_struct_count,
@@ -77,6 +77,15 @@ fn mem_arg_f64(offset: u64) -> wasm_encoder::MemArg {
   wasm_encoder::MemArg {
     offset,
     align: 3, // log2(8) = 3
+    memory_index: 0,
+  }
+}
+
+/// MemArg for i64 load/store (8-byte aligned, memory 0).
+fn mem_arg_i64(offset: u64) -> wasm_encoder::MemArg {
+  wasm_encoder::MemArg {
+    offset,
+    align: 3,
     memory_index: 0,
   }
 }
@@ -260,6 +269,9 @@ pub fn emit_wasm(init_ns: &str, init_def: &str, emit_path: &str, target: WasmTar
     let utf8_valid_idx = num_imports + compiled_fns.len() as u32;
     runtime_fn_index.insert("__rt_utf8_valid".into(), utf8_valid_idx);
     compiled_fns.push(build_utf8_valid_fn());
+    let wait_idx = num_imports + compiled_fns.len() as u32;
+    runtime_fn_index.insert("__rt_wasi_wait".into(), wait_idx);
+    compiled_fns.push(build_wasi_wait_fn(wasi_import("poll_oneoff")));
     let open_path_idx = num_imports + compiled_fns.len() as u32;
     runtime_fn_index.insert("__rt_wasi_open_path".into(), open_path_idx);
     compiled_fns.push(build_wasi_open_path_fn(
@@ -2402,6 +2414,7 @@ fn emit_proc_call(ctx: &mut WasmGenCtx, proc: &CalcitProc, args: &[Calcit]) -> R
       expect_arity(0, args, "cpu-time")?;
       emit_wasi_clock_ms(ctx, 1, "cpu-time")
     }
+    CalcitProc::NativeWaitMs => emit_wasi_wait_ms(ctx, args),
     CalcitProc::NativeSecureRandomBytes => emit_wasi_secure_random_bytes(ctx, args),
     CalcitProc::NativeFsReadText => emit_wasi_fs_read_text(ctx, args),
     CalcitProc::NativeFsReadDir => emit_wasi_fs_read_dir(ctx, args),
@@ -2663,6 +2676,61 @@ fn emit_wasi_clock_ms(ctx: &mut WasmGenCtx, clock_id: i32, proc_name: &str) -> R
   ctx.emit(Instruction::F64ConvertI64U);
   ctx.emit(f64_const(1_000_000.0));
   ctx.emit(Instruction::F64Div);
+  Ok(())
+}
+
+/// Lower the typed synchronous wait boundary through Preview 1 `poll_oneoff`.
+fn emit_wasi_wait_ms(ctx: &mut WasmGenCtx, args: &[Calcit]) -> Result<(), String> {
+  expect_arity(3, args, "&wait-ms")?;
+  if ctx.target != WasmTarget::Wasi {
+    return Err("E_WASM_CAPABILITY: wait-ms is unavailable for the core WASM target".into());
+  }
+
+  let milliseconds = ctx.alloc_local();
+  emit_expr(ctx, &args[1])?;
+  ctx.emit(Instruction::LocalSet(milliseconds));
+  let host_error = ctx.alloc_local();
+  emit_expr(ctx, &args[2])?;
+  ctx.emit(Instruction::LocalSet(host_error));
+
+  ctx.emit(Instruction::LocalGet(milliseconds));
+  ctx.emit(Instruction::LocalGet(milliseconds));
+  ctx.emit(Instruction::F64Trunc);
+  ctx.emit(Instruction::F64Ne);
+  ctx.emit(Instruction::LocalGet(milliseconds));
+  ctx.emit(f64_const(0.0));
+  ctx.emit(Instruction::F64Lt);
+  ctx.emit(Instruction::I32Or);
+  ctx.emit(Instruction::LocalGet(milliseconds));
+  ctx.emit(f64_const(u32::MAX as f64));
+  ctx.emit(Instruction::F64Gt);
+  ctx.emit(Instruction::I32Or);
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  emit_result_enum(ctx, "err", host_error)?;
+  ctx.emit(Instruction::Else);
+
+  let unit = ctx.alloc_local();
+  ctx.emit(f64_const(0.0));
+  ctx.emit(Instruction::LocalSet(unit));
+  ctx.emit(Instruction::LocalGet(milliseconds));
+  ctx.emit(f64_const(0.0));
+  ctx.emit(Instruction::F64Eq);
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  emit_result_enum(ctx, "ok", unit)?;
+  ctx.emit(Instruction::Else);
+  ctx.emit(Instruction::LocalGet(milliseconds));
+  ctx.emit(f64_const(1_000_000.0));
+  ctx.emit(Instruction::F64Mul);
+  ctx.emit(Instruction::I64TruncF64U);
+  ctx.call_rt("__rt_wasi_wait");
+  ctx.emit(Instruction::I32Eqz);
+  ctx.emit(Instruction::If(wasm_encoder::BlockType::Result(ValType::F64)));
+  emit_result_enum(ctx, "ok", unit)?;
+  ctx.emit(Instruction::Else);
+  emit_result_enum(ctx, "err", host_error)?;
+  ctx.emit(Instruction::End);
+  ctx.emit(Instruction::End);
+  ctx.emit(Instruction::End);
   Ok(())
 }
 
@@ -3923,6 +3991,7 @@ mod tests {
         ("environ_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("proc_exit", vec![ValType::I32], vec![]),
         ("clock_time_get", vec![ValType::I32, ValType::I64, ValType::I32], vec![ValType::I32],),
+        ("poll_oneoff", vec![ValType::I32; 4], vec![ValType::I32]),
         ("random_get", vec![ValType::I32, ValType::I32], vec![ValType::I32]),
         ("fd_prestat_get", vec![ValType::I32; 2], vec![ValType::I32]),
         ("fd_prestat_dir_name", vec![ValType::I32; 3], vec![ValType::I32]),

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -149,6 +149,12 @@ pub(super) fn host_imports_for_target(target: WasmTarget) -> Vec<HostImport> {
       },
       HostImport {
         module: "wasi_snapshot_preview1".into(),
+        name: "poll_oneoff".into(),
+        params: vec![ValType::I32; 4],
+        results: vec![ValType::I32],
+      },
+      HostImport {
+        module: "wasi_snapshot_preview1".into(),
         name: "random_get".into(),
         params: vec![ValType::I32, ValType::I32],
         results: vec![ValType::I32],
@@ -272,6 +278,91 @@ pub(super) fn build_wasi_write_all_fn(fd_write_idx: u32) -> CompiledFn {
     locals: vec![ValType::I32],
     instructions,
   }
+}
+
+/// Build the Preview 1 relative monotonic-clock adapter used by `wait-ms`.
+/// Returns zero on a single successful clock event and a non-zero status for
+/// host errors or malformed event records.
+pub(super) fn build_wasi_wait_fn(poll_oneoff_idx: u32) -> CompiledFn {
+  // param: 0=relative duration in nanoseconds
+  let mut b = RuntimeFnBuilder::new(1);
+  let scratch_size = b.alloc_i64();
+  let managed_size = b.alloc_i64();
+  let scratch = b.alloc_i32();
+  let event = b.alloc_i32();
+  let nevents = b.alloc_i32();
+  let status = b.alloc_i32();
+
+  b.emit(Instruction::I64Const(88));
+  b.emit(Instruction::LocalSet(scratch_size));
+  b.emit(Instruction::I64Const(0));
+  b.emit(Instruction::LocalSet(managed_size));
+  rt_emit_reserve_scratch(&mut b, scratch_size, managed_size, scratch);
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I32Const(48));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(event));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I32Const(80));
+  b.emit(Instruction::I32Add);
+  b.emit(Instruction::LocalSet(nevents));
+
+  // __wasi_subscription_t: userdata, tagged union, then clock payload.
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I64Const(0x4341_4c43_4954_5741));
+  b.emit(Instruction::I64Store(mem_arg_i64(0)));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Store8(mem_arg_byte(8)));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Store(mem_arg_i32(16)));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::LocalGet(0));
+  b.emit(Instruction::I64Store(mem_arg_i64(24)));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I64Const(1_000_000));
+  b.emit(Instruction::I64Store(mem_arg_i64(32)));
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::I32Const(0));
+  b.emit(Instruction::I32Store16(mem_arg_byte(40)));
+
+  b.emit(Instruction::LocalGet(scratch));
+  b.emit(Instruction::LocalGet(event));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalGet(nevents));
+  b.emit(Instruction::Call(poll_oneoff_idx));
+  b.emit(Instruction::LocalSet(status));
+
+  b.emit(Instruction::LocalGet(status));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::LocalGet(nevents));
+  b.emit(Instruction::I32Load(mem_arg_i32(0)));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::I32Ne);
+  b.emit(Instruction::LocalGet(event));
+  b.emit(Instruction::I64Load(mem_arg_i64(0)));
+  b.emit(Instruction::I64Const(0x4341_4c43_4954_5741));
+  b.emit(Instruction::I64Ne);
+  b.emit(Instruction::I32Or);
+  b.emit(Instruction::LocalGet(event));
+  b.emit(Instruction::I32Load16U(mem_arg_byte(8)));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::I32Or);
+  b.emit(Instruction::LocalGet(event));
+  b.emit(Instruction::I32Load8U(mem_arg_byte(10)));
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::I32Eqz);
+  b.emit(Instruction::I32Or);
+  b.emit(Instruction::If(BlockType::Empty));
+  b.emit(Instruction::I32Const(1));
+  b.emit(Instruction::LocalSet(status));
+  b.emit(Instruction::End);
+  b.emit(Instruction::End);
+  b.emit(Instruction::LocalGet(status));
+  b.finish(vec![ValType::I64], vec![ValType::I32])
 }
 
 /// Resolve a relative Calcit path against the most specific Preview 1 preopen

--- a/src/effects_graph.rs
+++ b/src/effects_graph.rs
@@ -726,7 +726,7 @@ fn classify_by_name(name: &str) -> Option<Vec<String>> {
     "hint-fn" => vec!["async"],
     "println" | "eprintln" | "echo" => vec!["console"],
     "render!" => vec!["render"],
-    "generate-id!" | "cpu-time" | "&get-os" | "async-sleep" => vec!["io"],
+    "generate-id!" | "cpu-time" | "wait-ms" | "&wait-ms" | "&get-os" | "async-sleep" => vec!["io"],
     "try" => vec!["control"],
     "&doseq" => vec!["effect/sequential"],
     // Respo convention: common project-level functions

--- a/src/runner/macro_capability.rs
+++ b/src/runner/macro_capability.rs
@@ -78,6 +78,7 @@ fn proc_policy(proc: CalcitProc) -> Option<CapabilityPolicy> {
     | AddWatch
     | RemoveWatch => MacroCapability::MutableState,
     WriteFile => return Some(CapabilityPolicy::Forbidden(MacroCapability::FsWrite)),
+    NativeWaitMs => return Some(CapabilityPolicy::Forbidden(MacroCapability::Process)),
     Quit => return Some(CapabilityPolicy::Forbidden(MacroCapability::Process)),
     _ => return None,
   };

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1549,7 +1549,15 @@ export let _$n_wait_ms = (resultType: CalcitEnumDef, milliseconds: number, hostE
   try {
     const injection = get_wait_injection();
     if (typeof injection === "function") {
-      injection(milliseconds);
+      const outcome = injection(milliseconds);
+      if (
+        outcome != null &&
+        (typeof outcome === "object" || typeof outcome === "function") &&
+        typeof (outcome as PromiseLike<unknown>).then === "function"
+      ) {
+        void Promise.resolve(outcome).catch((_cause: unknown): void => {});
+        return error(`${hostError}: wait_ms injection must complete synchronously`);
+      }
       return success();
     }
     if (typeof SharedArrayBuffer === "undefined" || typeof Atomics.wait !== "function") {

--- a/ts-src/calcit.procs.mts
+++ b/ts-src/calcit.procs.mts
@@ -1536,6 +1536,32 @@ export let _$n_get_args = (): CalcitList => {
 
 export let get_args = _$n_get_args;
 
+/** Block for an integral millisecond duration and preserve host failures as Result values. */
+export let _$n_wait_ms = (resultType: CalcitEnumDef, milliseconds: number, hostError: string): CalcitEnumValue => {
+  const error = (message: string) => new CalcitEnumValue(newTag("err"), [message], resultType);
+  const success = () => new CalcitEnumValue(newTag("ok"), [undefined], resultType);
+  if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > 4_294_967_295) {
+    return error(`wait-ms expected an integer millisecond duration in 0..4294967295, got: ${milliseconds}`);
+  }
+  if (milliseconds === 0) {
+    return success();
+  }
+  try {
+    const injection = get_wait_injection();
+    if (typeof injection === "function") {
+      injection(milliseconds);
+      return success();
+    }
+    if (typeof SharedArrayBuffer === "undefined" || typeof Atomics.wait !== "function") {
+      return error(`${hostError}: blocking wait is unavailable in this JavaScript host`);
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+    return success();
+  } catch (cause) {
+    return error(`${hostError}: ${cause instanceof Error ? cause.message : String(cause)}`);
+  }
+};
+
 /** Fill a Buffer with Web Crypto and preserve expected failures as Result values. */
 export let _$n_secure_random_bytes = (resultType: CalcitEnumDef, size: number, hostError: string): CalcitEnumValue => {
   const error = (message: string) => new CalcitEnumValue(newTag("err"), [message], resultType);
@@ -1748,14 +1774,23 @@ export type CalcitFileInjections = {
   write_file?: (path: string, content: string) => unknown;
 };
 
+export type CalcitWaitInjections = {
+  wait_ms?: (milliseconds: number) => unknown;
+};
+
+type CalcitHostInjections = CalcitFileInjections & CalcitWaitInjections;
+
 const get_file_injection = <K extends keyof CalcitFileInjections>(name: K): NonNullable<CalcitFileInjections[K]> => {
-  const injections = (globalThis as { __calcit_injections__?: CalcitFileInjections }).__calcit_injections__;
+  const injections = (globalThis as { __calcit_injections__?: CalcitHostInjections }).__calcit_injections__;
   const injection = injections?.[name];
   if (typeof injection !== "function") {
     throw new Error(`${name} is unavailable: the JavaScript host did not provide a __calcit_injections__.${name} function`);
   }
   return injection as NonNullable<CalcitFileInjections[K]>;
 };
+
+const get_wait_injection = (): CalcitWaitInjections["wait_ms"] =>
+  (globalThis as { __calcit_injections__?: CalcitHostInjections }).__calcit_injections__?.wait_ms;
 
 export let read_file = (path: string): string => {
   if (inNodeJs) {


### PR DESCRIPTION
## 中文

Closes #1039。

### 目标

为 Native、生成的 JavaScript 与 WASI command 提供单位明确、失败显式的同步等待边界，同时保持 core WASM fail-closed，并且不混淆现有异步 callback/task 语义。

### 变更

- 新增 `wait-ms Number -> Result<Unit,String>`，仅接受 `0..4294967295` 的整数毫秒；零值立即成功且不调用 host。
- Native 使用当前线程 sleep；生成的 JavaScript 优先使用 `__calcit_injections__.wait_ms`，否则尝试 `Atomics.wait`。
- WASI command 通过 Preview 1 `poll_oneoff` 使用相对单调时钟，并验证单个返回事件的 userdata、errno 与 event type。
- core WASM 以 `E_WASM_CAPABILITY` 明确拒绝同步等待。
- `timeout-call` 与 `async-sleep` 保持原有控制流，不提供语义不可靠的自动 migration。
- 更新能力边界、CLI、类型指引、Agent 文档及结构化架构描述。

### 验证

- `cargo fmt --check`
- `cargo test --lib`：772 passed
- Native 与 `wasm32-wasip1` clippy（`-D warnings`）
- Calcit definition-attached tests：core `wait-ms` 4/4；WASI tag 17/17
- `bash scripts/test-wasi-preprocess.sh`：真实 Wasmtime、确定性 Preview 1 host、core WASM rejection
- `bash scripts/check-docs-md.sh`：65 files / 331 blocks passed
- `yarn check-all`

## English

Closes #1039.

### Goal

Provide a unit-explicit, failure-preserving synchronous wait boundary for Native, generated JavaScript, and WASI commands, while keeping core WASM fail-closed and preserving the distinct semantics of existing asynchronous callback/task APIs.

### Changes

- Add `wait-ms Number -> Result<Unit,String>`, accepting only integral milliseconds in `0..4294967295`; zero succeeds without invoking the host.
- Use current-thread sleep on Native; generated JavaScript prefers `__calcit_injections__.wait_ms` and otherwise attempts `Atomics.wait`.
- Lower WASI commands through Preview 1 `poll_oneoff` with a relative monotonic-clock subscription and validate the single returned event's userdata, errno, and event type.
- Reject synchronous waits on core WASM with `E_WASM_CAPABILITY`.
- Keep `timeout-call` and `async-sleep` unchanged and avoid an unsafe automatic migration across different control-flow semantics.
- Update the capability boundary, CLI, type guidance, agent documentation, and structured architecture description.

### Validation

- `cargo fmt --check`
- `cargo test --lib`: 772 passed
- Native and `wasm32-wasip1` clippy with `-D warnings`
- Calcit definition-attached tests: core `wait-ms` 4/4; WASI tag 17/17
- `bash scripts/test-wasi-preprocess.sh`: real Wasmtime, deterministic Preview 1 host, and core WASM rejection
- `bash scripts/check-docs-md.sh`: 65 files / 331 blocks passed
- `yarn check-all`
