### PR TITLE
fix(cli): Unicode 安全查询摘要 / Unicode-safe query summaries

### DIFF
--- a/editing-history/202609130541-unicode-query-summary.md
+++ b/editing-history/202609130541-unicode-query-summary.md
@@ -1,0 +1,18 @@
+# Unicode 安全的 query 摘要
+
+## 背景
+
+`query defs` 等人类可读查询按 UTF-8 字节位置截断文本。截断点落入中文字符内部时，Rust String slice 会 panic，导致用户与 Agent 都无法取得定义清单。
+
+## 变更
+
+- 统一按 Unicode 字符数量定位摘要前缀，不再使用未经边界检查的字节索引。
+- `query defs` 继续保持单行摘要和 ASCII `...` 格式。
+- 同时修正 query definition expression、schema preview、symbol context 与节点预览中的同类截断路径，避免相同 panic 转移到相邻命令。
+- Agent CLI 集成回归直接运行包含中文文档的 WASI fixture，验证完整中文摘要与长摘要省略号格式。
+
+## 验证
+
+- `calcit/test-wasi-command.cirru query defs app.main` 不再 panic，并保留中文文档。
+- `src/cirru/calcit-core.cirru query defs calcit.core` 完整执行成功。
+- `yarn check-agent-interface`：32/32 machine scenarios 及 Unicode human-output regression 通过。

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -678,6 +678,21 @@ for (const scenario of scenarios) {
   });
 }
 
+const unicodeDefsChild = spawnSync(binary, ["calcit/test-wasi-command.cirru", "query", "defs", "app.main"], {
+  cwd: process.cwd(),
+  encoding: "utf8",
+  maxBuffer: 4 * 1024 * 1024,
+  env: { ...process.env, NO_COLOR: "1" },
+});
+assert.ifError(unicodeDefsChild.error);
+assert.equal(unicodeDefsChild.status, 0, unicodeDefsChild.stderr);
+assert.match(unicodeDefsChild.stdout, /用确定性的 WASI 假宿主验证时钟编号与纳秒到毫秒的换算。/);
+assert.match(
+  unicodeDefsChild.stdout,
+  /filesystem-read-error\?.*泄漏\.\.\./,
+  "long definition summaries must keep the ASCII ellipsis format",
+);
+
 const contractChild = spawnSync(binary, ["docs", "agents", "--contract"], {
   cwd: process.cwd(),
   encoding: "utf8",

--- a/src/bin/cli_handlers/query.rs
+++ b/src/bin/cli_handlers/query.rs
@@ -484,10 +484,9 @@ fn preview_node_oneline(node: &Cirru, max_len: usize) -> (String, bool) {
   if text.is_empty() {
     return ("(matched)".to_string(), false);
   }
-  if text.len() > max_len {
-    (text[..max_len].to_string(), true)
-  } else {
-    (text, false)
+  match char_prefix_if_truncated(&text, max_len) {
+    Some(prefix) => (prefix.to_owned(), true),
+    None => (text, false),
   }
 }
 
@@ -2387,14 +2386,22 @@ fn handle_type_at(input_path: &str, opts: &QueryTypeAtCommand) -> Result<(), Str
   Ok(())
 }
 
+fn char_prefix_if_truncated(text: &str, max_chars: usize) -> Option<&str> {
+  text.char_indices().nth(max_chars).map(|(byte_index, _)| &text[..byte_index])
+}
+
 fn truncate_chars(text: &str, max_chars: usize) -> (String, bool) {
-  if max_chars == 0 {
-    return (String::new(), !text.is_empty());
+  match char_prefix_if_truncated(text, max_chars) {
+    Some(prefix) => (format!("{prefix}…"), true),
+    None => (text.to_owned(), false),
   }
-  let Some((byte_index, _)) = text.char_indices().nth(max_chars) else {
-    return (text.to_owned(), false);
-  };
-  (format!("{}…", &text[..byte_index]), true)
+}
+
+fn truncate_chars_with_dots(text: &str, max_chars: usize) -> String {
+  match char_prefix_if_truncated(text, max_chars) {
+    Some(prefix) => format!("{prefix}..."),
+    None => text.to_owned(),
+  }
 }
 
 fn count_cirru_nodes(node: &Cirru) -> usize {
@@ -3499,11 +3506,7 @@ fn handle_defs(input_path: &str, opts: &QueryDefsCommand) -> Result<(), String> 
     };
     if !entry.doc.is_empty() {
       let doc_first_line = entry.doc.lines().next().unwrap_or("");
-      let doc_display = if doc_first_line.len() > 50 {
-        format!("{}...", &doc_first_line[..50])
-      } else {
-        doc_first_line.to_string()
-      };
+      let doc_display = truncate_chars_with_dots(doc_first_line, 50);
       println!(
         "  {}{}{} - {}",
         def.green(),
@@ -4097,11 +4100,7 @@ fn handle_peek(input_path: &str, namespace: &str, definition: &str) -> Result<()
   match &code_entry.code {
     Cirru::List(items) if !items.is_empty() => {
       let preview = code_entry.code.format_one_liner()?;
-      let display = if preview.len() > 120 {
-        format!("{}...", &preview[..120])
-      } else {
-        preview
-      };
+      let display = truncate_chars_with_dots(&preview, 120);
       let _ = writeln!(&mut out, "{} {}", "Expr:".bold(), display.dimmed());
     }
     Cirru::Leaf(_) => {
@@ -4118,11 +4117,7 @@ fn handle_peek(input_path: &str, namespace: &str, definition: &str) -> Result<()
 
   if let Some(cirru) = query_schema_cirru(code_entry.schema.as_ref(), true)? {
     let preview = format_query_schema_oneline(&cirru)?;
-    let display = if preview.len() > 120 {
-      format!("{}...", &preview[..120])
-    } else {
-      preview
-    };
+    let display = truncate_chars_with_dots(&preview, 120);
     let _ = writeln!(&mut out, "{} {}", "Schema:".bold(), display.dimmed());
   } else {
     let _ = writeln!(&mut out, "{} -", "Schema:".bold());
@@ -4536,10 +4531,7 @@ fn get_symbol_context_cirru(code: &Cirru, symbol: &str) -> String {
   if let Some(context_node) = find_smallest_containing(code, symbol) {
     let cirru_str = context_node.format_one_liner().unwrap_or_default();
     let trimmed = cirru_str.trim();
-    if trimmed.len() > 50 {
-      return format!("{}...", &trimmed[..50]);
-    }
-    return trimmed.to_string();
+    return truncate_chars_with_dots(trimmed, 50);
   }
   String::new()
 }


### PR DESCRIPTION
## 中文

Closes #1037。

### 问题

`query defs` 等人类可读查询按 UTF-8 字节位置截断文本。中文字符跨过固定字节位置时，Rust String slice 会触发 `is not a char boundary` panic，导致用户和 Agent 无法读取定义摘要。

### 变更

- 使用统一 helper 按 Unicode 字符数量定位合法 UTF-8 边界。
- `query defs` 保持现有单行摘要和 ASCII `...` 格式。
- 同时修正 definition expression、schema preview、symbol context 与节点预览中的同类裸字节截断，避免相邻命令出现相同 panic。
- Agent CLI 回归直接运行包含中文文档的 WASI fixture，同时验证完整中文摘要和长摘要省略号。

### 测试放置

这是 CLI 文本编码和进程退出行为，不能通过稳定的 Calcit definition `:tests` 构造，因此放在现有 Agent CLI 集成脚本；没有新增 Rust 语义测试或统计机制。

### 验证

- 两个 issue 中的复现命令均成功执行。
- `yarn check-agent-interface`：32/32 machine scenarios，加 Unicode human-output regression。
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn check-all`

## English

Closes #1037.

### Problem

Human-readable queries such as `query defs` truncated text at raw UTF-8 byte offsets. A CJK character crossing the fixed byte offset caused Rust string slicing to panic with `is not a char boundary`, preventing both users and agents from reading definition summaries.

### Changes

- Use one helper to locate a valid UTF-8 boundary by Unicode character count.
- Preserve the existing single-line summary and ASCII `...` format for `query defs`.
- Fix the same raw-byte truncation pattern in definition expression previews, schema previews, symbol contexts, and node previews so the panic does not move to adjacent commands.
- Exercise the real Agent CLI against the WASI fixture containing CJK documentation, checking both an intact Chinese summary and the ellipsis on a longer summary.

### Test placement

This is CLI text encoding and process-exit behavior, which cannot be constructed through stable Calcit definition `:tests`; the regression therefore belongs in the existing Agent CLI integration script. No Rust semantic test or statistics mechanism is added.

### Validation

- Both reproduction commands from the issue complete successfully.
- `yarn check-agent-interface`: 32/32 machine scenarios plus the Unicode human-output regression.
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `yarn check-all`
