### PR TITLE
docs: 接受分层语义契约 / accept layered semantics contract

### DIFF
--- a/RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md
+++ b/RFCs/09-12-layered-semantics-and-agent-fixes-rfc.md
@@ -1,6 +1,6 @@
 # RFC：Calcit 分层语义与 Agent 可执行修复契约
 
-状态：Draft — 0.14.13
+状态：Accepted — 0.14.13
 
 日期：2026-09-12
 
@@ -154,6 +154,22 @@ defn parse-device-message (raw)
 
 这些示例在相关能力落地前使用 `cirru.no-check`，不能把文档片段可解析冒充为实现已经通过。实现 PR 应把
 对应行为移入 definition `:tests` 或专用成功/失败 fixture，并精确记录实际执行的 backend。
+
+### 7.1 已落地的代表性证据
+
+下表把分层契约映射到仓库中已经执行的 Calcit 程序。这里记录的是可复用的语义证据，不引入覆盖率、数量目标
+或新的 analyzer。Snapshot 中的 definition 是契约主体；脚本只负责选择 backend、执行产物和防止零测试误报。
+
+| 语义切片 | 表层 Calcit 证据 | backend 证据 | 分层结论 |
+|---|---|---|---|
+| 普通 typed value 与泛型推导 | `calcit/test-types-inference.cirru` 的 `test-generics-identity`、`test-map-inference` 与 `test-struct-inference` | `yarn try-rs` 与 `yarn try-js` 都从 `calcit/test.cirru` 执行这些断言 | 类型关系属于 surface/typed core；JS lowering 不另定义泛型规则 |
+| 开放 Map/List 与 `Option<Dynamic>` | `calcit/test-traits.cirru` 的开放集合读取断言，以及 `calcit.core/get` 的 `reads-open-map-payload` definition test | native/JS 主测试执行前者；`yarn try-core-tests` 用 `--require-match` 执行后者 | 未知 payload 可被保存、读取和包装；具体使用仍需 narrow/decode |
+| macro 展开与求值语义 | `calcit/test-macro.cirru` 的 `test-destruct`、`test-lambda` 等 Calcit 断言 | native/JS 主测试执行同一表层 macro 调用；展开比较只作为 core 形状证据 | surface macro 拥有行为，展开后的 core 必须保持求值与词法作用域 |
+| JS FFI host boundary | `calcit/test-js.cirru` 的 `test-property`、`test-collection` 和显式 `unsafe-coerce` 用例 | `yarn try-js` 生成 JS 后由 Node.js 实际执行；native 不伪装支持 JS host value | `JsObject` 是显式 backend/host 能力，不以 Dynamic 推导替代 adapter 证据 |
+| 当前 WASM typed 子集 | `calcit/test-wasm.cirru` 的 `test-static-option-result-methods` 等带 `:wasm` tag 的 definition tests | `scripts/test-wasm.sh` 先以 `--require-match` 执行 Calcit tests，再加载生成模块并检查 fail-closed 边界 | WASM 复用 typed core 语义；支持项实际执行，未支持项拒绝产物而非返回占位值 |
+
+这组证据也明确了“不共同支持”的处理方式：JS FFI 不要求 native/WASM 模拟宿主对象，WASM 尚未覆盖的语法也
+不要求表层退化。backend 只实现已声明能力，差异在 capability boundary 或稳定 unsupported diagnostic 中显式出现。
 
 ## 8. Agent 语义协议
 

--- a/editing-history/202609130551-layered-semantics-acceptance.md
+++ b/editing-history/202609130551-layered-semantics-acceptance.md
@@ -1,0 +1,22 @@
+# 收口分层语义 RFC
+
+时间：2026-09-13 05:51 +0800
+
+## 背景
+
+#997 已经产出分层语义 RFC，并被 `AGENTS.md`、类型指南、Agent 文档以及后续 source fix/WASM 工作引用，
+但 RFC 仍标记为 Draft，验收要求中的代表性语义例子也没有逐项连接到仓库内的可执行证据。
+
+## 调整
+
+- 将 RFC 状态更新为 Accepted。
+- 增加普通 typed value、开放集合与 `Option<Dynamic>`、macro、JS FFI、WASM typed 子集的证据矩阵。
+- 区分 Calcit definition 所表达的语义契约与脚本承担的 backend/ABI 验证职责。
+- 明确 backend 不共同支持的能力通过 capability boundary 或稳定 unsupported diagnostic 表达，不靠表层语义退化补齐。
+
+## 验证
+
+- 文档检查通过 65 个文件、331 个代码块。
+- core definition tests 通过 257 项，并启用 `--require-match`。
+- native 主测试与生成 JS 后的 Node.js 主测试通过。
+- WASM definition tests 通过 3 项，生成模块的 Node.js 实际执行与 fail-closed 检查通过。


### PR DESCRIPTION
## 中文

### 变更

- 将分层语义 RFC 从 Draft 更新为 Accepted。
- 补充普通 typed value、开放集合与 `Option<Dynamic>`、macro、JS FFI、WASM typed 子集的可执行证据矩阵。
- 明确 Calcit definition 承担表层语义契约，脚本只负责 backend 选择、产物执行、ABI 与零测试防护。
- 记录 backend 不共同支持能力时的 capability boundary 与 fail-closed 规则。

### 验证

- 文档检查：65 files / 331 blocks 全部通过。
- core definition tests：257 passed，启用 `--require-match`。
- native 主测试通过。
- 生成 JS 后的 Node.js 主测试通过。
- WASM：3 个 `:wasm` definition tests 通过，生成模块实际执行与 fail-closed 检查通过。

Closes #997

## English

### Changes

- Promote the layered-semantics RFC from Draft to Accepted.
- Add an executable evidence matrix for ordinary typed values, open collections with `Option<Dynamic>`, macros, JS FFI, and the currently supported typed WASM subset.
- Keep surface semantics in Calcit definitions while scripts only select backends, execute artifacts, verify ABI boundaries, and prevent zero-test false positives.
- Record capability boundaries and fail-closed behavior for capabilities that are not shared by every backend.

### Validation

- Documentation checks: all 65 files and 331 blocks passed.
- Core definition tests: 257 passed with `--require-match`.
- Native main suite passed.
- Generated JavaScript main suite passed under Node.js.
- WASM: 3 tagged definition tests passed; generated-module execution and fail-closed checks passed.

Closes #997