### PR TITLE
fix: 保留开放集合泛型关系 / preserve open collection generic relations

### DIFF
--- a/calcit/test-traits.cirru
+++ b/calcit/test-traits.cirru
@@ -573,6 +573,14 @@
                     fn () 0
                     fn (value) value
                   assert= 1 $ if-let (value present) value 0
+                  assert= true $ =
+                    option:unwrap-or (first open-list) nil
+                    , 1
+                  assert= true $ = 1
+                    option:unwrap-or (first open-list) nil
+                  assert=
+                    [] ([] 0 1) ([] 1 |x)
+                    map-indexed open-list $ fn (idx value) ([] idx value)
               println "|  Option/Result map: ✓"
           :examples $ []
           :schema $ :: 'Fn

--- a/editing-history/202609130603-open-collection-relations.md
+++ b/editing-history/202609130603-open-collection-relations.md
@@ -1,0 +1,25 @@
+# 收敛开放集合的普通泛型关系
+
+时间：2026-09-13 06:03 +0800
+
+## 背景
+
+#995 的生态复现包含 `conj`、`assoc`、`map-indexed` 与 `=`。当前实现已经允许 `conj`/`assoc` 把具体值
+安全放入显式开放容器，但 `map-indexed` 没有从 receiver 派生 callback 类型，`=` 的泛型绑定还会因
+Dynamic 实参位于首位或后位而得到不同结果。
+
+## 调整
+
+- 为 `map-indexed` 增加 receiver-bound checked-call contract，从 `List<T>` 派生 `(Number,T)->U` 和 `List<U>`。
+- 泛型关系验证优先处理包含 Dynamic 的实参，再验证具体实参，消除同一关系的参数顺序差异。
+- 保留严格边界：`List<Dynamic>` 仍拒绝只接受 Number 的 callback，并继续报告 `E_ERASED_GENERIC_RELATION`。
+- 在 `assoc`、`conj`、`map-indexed` 与 `=` definition 下增加带 `:core :unit` tag 的 Calcit-first 测试。
+- 在现有 Calcit traits 测试入口补充开放列表的双向相等与 `map-indexed` 断言，让 native/生成 JS 共用同一组语义样例。
+- 不增加 `*-dynamic` API、analyzer 或统计门禁。
+
+## 验证
+
+- 完整 Rust 测试通过（773 lib、340 CLI、17 WASM、4 fix CLI 等）。
+- core definition 主入口通过 261 项，并以 `--tag unit --require-match` 选中新增测试。
+- 默认严格预处理下，开放 `map-indexed` 与双向 `=` 实际执行通过；Number-only callback 的拒绝用例保持失败关闭。
+- `yarn check-all` 全部通过，覆盖 native、生成 JS、Agent CLI、WASM 实际执行和现有性能回归入口。

--- a/editing-history/202609130636-open-collection-review.md
+++ b/editing-history/202609130636-open-collection-review.md
@@ -4,11 +4,11 @@
 
 ## 调整
 
-- 根据 #1046 review，在 generic argument 排序处补充英文源码注释。
-- 明确先检查 concrete type evidence 是为了先建立泛型绑定，再让开放 `Dynamic` 参数复用该证明。
-- 不改变已有实现与类型语义。
+- 根据 #1046 review 复核 generic argument 的排序，并补充英文源码注释说明既定语义。
+- review 建议将 concrete 参数排在开放参数之前，但这会让 #995 明确接受的 `Dynamic`/具体值双向安全传递失败：先绑定具体类型会把后续开放值误判为需要 narrow。
+- 保留开放参数优先，使有意声明的 `Dynamic` 可先建立开放泛型绑定；需要具体能力的 callback 仍由既有测试稳定拒绝。
 
 ## 验证
 
 - `cargo fmt --all -- --check`
-- `cargo test find_unproven_generic_argument`
+- `cargo test dynamic_generic_bindings_preserve_transport_but_reject_callback_narrowing`

--- a/editing-history/202609130636-open-collection-review.md
+++ b/editing-history/202609130636-open-collection-review.md
@@ -1,0 +1,14 @@
+# 补充开放集合泛型检查顺序说明
+
+时间：2026-09-13 06:36 +0800
+
+## 调整
+
+- 根据 #1046 review，在 generic argument 排序处补充英文源码注释。
+- 明确先检查 concrete type evidence 是为了先建立泛型绑定，再让开放 `Dynamic` 参数复用该证明。
+- 不改变已有实现与类型语义。
+
+## 验证
+
+- `cargo fmt --all -- --check`
+- `cargo test find_unproven_generic_argument`

--- a/src/cirru/calcit-core.cirru
+++ b/src/cirru/calcit-core.cirru
@@ -2839,6 +2839,14 @@
                   assert= true $ = ([] 1 2) ([] 1 2)
                   assert= true $ = (%some 1) (%some 1)
               :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |compares-open-binding-symmetrically)
+              :code $ quote
+                let
+                    x $ assert-type 1 'Dynamic
+                  assert= true $ = x 1
+                  assert= true $ = 1 x
+                  assert= false $ = 2 x
+              :tags $ #{} :core :unit
         '> $ %{} 'CodeEntry (:doc "|Greater-than comparison for one or more numbers\nReturns true only when the value strictly decreases across every argument.")
           :code $ quote
             defn > (x & ys)
@@ -3544,6 +3552,16 @@
                 assert= (&{} :a 1 :b 2 :c 3)
                   assoc (&{} :a 1 :b 2) :c 3
               :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |associates-concrete-value-into-open-map)
+              :code $ quote
+                let
+                    m $ assert-type
+                      {} (:a 1) (:b |x)
+                      :: 'Map 'Tag 'Dynamic
+                  assert=
+                    {} (:a 1) (:b |x) (:ready true)
+                    assoc m :ready true
+              :tags $ #{} :core :unit
         'assoc-in $ %{} 'CodeEntry (:doc "|associates a value at a nested path in a data structure, creates intermediate maps if needed")
           :code $ quote
             defn assoc-in (data path v)
@@ -3923,6 +3941,12 @@
               :code $ quote
                 assert= ([] 1 2 3 4 5)
                   conj ([] 1 2 3) 4 5
+              :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |appends-concrete-value-to-open-list)
+              :code $ quote
+                let
+                    xs $ assert-type ([] 1 |x) (:: 'List 'Dynamic)
+                  assert= ([] 1 |x :ready) (conj xs :ready)
               :tags $ #{} :core :unit
         'contains-in? $ %{} 'CodeEntry (:doc "||Check whether every hop in a nested path exists across maps, enums, or lists. Struct fields are intentionally excluded; use direct field access instead.")
           :code $ quote
@@ -6735,6 +6759,14 @@
                   map-indexed (range 3)
                     fn (idx x)
                       [] idx $ &str x
+              :tags $ #{} :core :unit
+            %{} 'TestEntry (:name |preserves-open-payload-with-index)
+              :code $ quote
+                let
+                    xs $ assert-type ([] 1 :ready) (:: 'List 'Dynamic)
+                  assert=
+                    [] ([] 0 1) ([] 1 :ready)
+                    map-indexed xs $ fn (idx value) ([] idx value)
               :tags $ #{} :core :unit
         'map-kv $ %{} 'CodeEntry (:doc "|Legacy compatibility boundary. Its callback may return a two-item list or a legacy nil/enum drop sentinel, so the result is intentionally Dynamic. Typed code must migrate to filter-map-kv and MapEntryDecision :keep/:drop.")
           :code $ quote

--- a/src/runner/preprocess/checked_call_contract.rs
+++ b/src/runner/preprocess/checked_call_contract.rs
@@ -74,7 +74,7 @@ pub(crate) fn checked_call_contract_arity(fn_ns: &str, fn_def: &str) -> Option<u
     return None;
   }
   match fn_def {
-    "any?" | "each" | "every?" | "get" | "filter" | "map" | "map-list-kv" | "result:map" => Some(2),
+    "any?" | "each" | "every?" | "get" | "filter" | "map" | "map-indexed" | "map-list-kv" | "result:map" => Some(2),
     "option:fold" | "update" => Some(3),
     _ => None,
   }
@@ -274,6 +274,18 @@ pub(crate) fn resolve_checked_call_contract(
         lowering: Some(CheckedCallLowering::CoreDef(target)),
       })
     }
+    ("map-indexed", T::List(item_type)) if !matches!(item_type.as_ref(), T::Syntax(_)) => {
+      let output_type =
+        callback_return_type(args.get(1)?, scope_types).unwrap_or_else(|| Arc::new(T::TypeVar(Arc::from("MapIndexedOutput"))));
+      Some(CheckedCallContract {
+        expected_types: Some(vec![
+          receiver_type.clone(),
+          fn_type(vec![Arc::new(T::Number), item_type.clone()], output_type.clone()),
+        ]),
+        return_type: Arc::new(T::List(output_type)),
+        lowering: None,
+      })
+    }
     ("map", T::Map(_, _)) => {
       let pair_type = Arc::new(T::List(crate::calcit::DYNAMIC_TYPE.clone()));
       Some(CheckedCallContract {
@@ -416,6 +428,30 @@ mod tests {
       panic!("map-list-kv callback should be checked as a function");
     };
     assert_eq!(callback.arg_types.as_slice(), &[key, value]);
+    assert_eq!(callback.return_type, output.clone());
+    assert_eq!(contract.return_type, Arc::new(CalcitTypeAnnotation::List(output)));
+    assert_eq!(contract.lowering, None);
+  }
+
+  #[test]
+  fn map_indexed_contract_preserves_open_members_without_narrowing_them() {
+    let dynamic = crate::calcit::DYNAMIC_TYPE.clone();
+    let output = Arc::new(CalcitTypeAnnotation::List(dynamic.clone()));
+    let receiver = Arc::new(CalcitTypeAnnotation::List(dynamic.clone()));
+    let mapper = Arc::new(CalcitTypeAnnotation::from_function_parts(
+      vec![Arc::new(CalcitTypeAnnotation::Number), dynamic.clone()],
+      output.clone(),
+    ));
+    let args = CalcitList::from(&[local("items", receiver.clone()), local("with-index", mapper)] as &[Calcit]);
+
+    let contract = resolve_checked_call_contract(calcit::CORE_NS, "map-indexed", &args, &ScopeTypes::new())
+      .expect("typed map-indexed should derive one receiver-bound contract");
+    let expected_types = contract.expected_types.as_ref().expect("map-indexed should bind callback evidence");
+    assert_eq!(expected_types[0], receiver);
+    let CalcitTypeAnnotation::Fn(callback) = expected_types[1].as_ref() else {
+      panic!("map-indexed callback should be checked as a function");
+    };
+    assert_eq!(callback.arg_types.as_slice(), &[Arc::new(CalcitTypeAnnotation::Number), dynamic]);
     assert_eq!(callback.return_type, output.clone());
     assert_eq!(contract.return_type, Arc::new(CalcitTypeAnnotation::List(output)));
     assert_eq!(contract.lowering, None);

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -9416,6 +9416,7 @@ fn find_unproven_generic_argument(
         .map(|expected| (index, arg, expected))
     })
     .collect::<Vec<_>>();
+  // Inspect concrete evidence first so it can bind generics before an open Dynamic argument needs that proof.
   argument_contracts.sort_by_key(|(_, arg, _)| {
     !resolve_type_value(arg, scope_types)
       .or_else(|| match arg {

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -9405,6 +9405,26 @@ fn find_unproven_generic_argument(
     return None;
   }
 
+  let mut argument_contracts = args
+    .iter()
+    .enumerate()
+    .filter_map(|(index, arg)| {
+      signature
+        .arg_types
+        .get(index)
+        .or(signature.rest_type.as_ref())
+        .map(|expected| (index, arg, expected))
+    })
+    .collect::<Vec<_>>();
+  argument_contracts.sort_by_key(|(_, arg, _)| {
+    !resolve_type_value(arg, scope_types)
+      .or_else(|| match arg {
+        Calcit::Local(local) => Some(local.type_info.clone()),
+        _ => None,
+      })
+      .is_some_and(|actual| contains_dynamic_type(actual.as_ref()))
+  });
+
   let mut bindings = HashMap::new();
   let mut inspect = |index: usize, arg: &Calcit, expected: &Arc<CalcitTypeAnnotation>| {
     let empty_map_has_no_type_evidence = match (arg, expected.as_ref()) {
@@ -9443,16 +9463,9 @@ fn find_unproven_generic_argument(
     })
   };
 
-  for (index, (arg, expected)) in args.iter().zip(signature.arg_types.iter()).enumerate() {
+  for (index, arg, expected) in argument_contracts {
     if let Some(found) = inspect(index, arg, expected) {
       return Some(found);
-    }
-  }
-  if let Some(rest) = &signature.rest_type {
-    for (index, arg) in args.iter().enumerate().skip(signature.arg_types.len()) {
-      if let Some(found) = inspect(index, arg, rest) {
-        return Some(found);
-      }
     }
   }
   None
@@ -17385,6 +17398,21 @@ mod tests {
       find_unproven_generic_argument(&list_identity, &list_args, &list_scope).is_none(),
       "List<T> can preserve T as an explicitly open Dynamic binding"
     );
+
+    let same_type =
+      generic_relation_test_signature(vec![type_var.clone(), type_var.clone()], Arc::new(CalcitTypeAnnotation::Bool), None);
+    let number = Arc::new(CalcitTypeAnnotation::Number);
+    let concrete = generic_relation_test_local("concrete", number.clone());
+    let same_scope = ScopeTypes::from([(Arc::from("value"), dynamic.clone()), (Arc::from("concrete"), number)]);
+    for same_args in [
+      CalcitList::from(&[value.clone(), concrete.clone()][..]),
+      CalcitList::from(&[concrete.clone(), value.clone()][..]),
+    ] {
+      assert!(
+        find_unproven_generic_argument(&same_type, &same_args, &same_scope).is_none(),
+        "a concrete value can be compared or transported through an open generic binding regardless of argument order"
+      );
+    }
 
     let mut concrete_callback = generic_relation_test_signature(
       vec![Arc::new(CalcitTypeAnnotation::Number)],

--- a/src/runner/preprocess/mod.rs
+++ b/src/runner/preprocess/mod.rs
@@ -9416,7 +9416,7 @@ fn find_unproven_generic_argument(
         .map(|expected| (index, arg, expected))
     })
     .collect::<Vec<_>>();
-  // Inspect concrete evidence first so it can bind generics before an open Dynamic argument needs that proof.
+  // Inspect open evidence first so intentional Dynamic transport is not narrowed by a later concrete peer.
   argument_contracts.sort_by_key(|(_, arg, _)| {
     !resolve_type_value(arg, scope_types)
       .or_else(|| match arg {


### PR DESCRIPTION
## 中文

Closes #995

### 调整

- 为普通 `map-indexed` 从 `List<T>` receiver 派生 callback `(Number, T) -> U` 与返回值 `List<U>`，不增加平行的 dynamic API，也不做特殊 lowering。
- 泛型关系验证先使用显式包含 `Dynamic` 的实参建立开放绑定，再验证具体实参，消除 `=` 等普通泛型调用对参数顺序的依赖。
- 保留严格边界：`List<Dynamic>` 仍不能交给只接受 `Number` 的 callback，继续稳定报告 `E_ERASED_GENERIC_RELATION`。
- 在 `assoc`、`conj`、`map-indexed`、`=` 的 definition `:tests` 中加入带 `:core :unit` 标签的 Calcit-first 成功用例；现有 Calcit type-fail fixture 与低层契约测试继续覆盖拒绝边界。
- 在 Calcit traits 执行入口加入相同开放值样例，直接验证 native 与生成 JS 语义一致。

### 验证

- `cargo test`（773 lib、340 CLI、17 WASM、4 fix CLI 等）
- core definition tests：261 项通过
- `yarn check-all`
- `yarn try-rs`
- `yarn try-js`
- 默认严格预处理下，Number-only callback 仍以 `E_ERASED_GENERIC_RELATION` 失败关闭

Rust 测试仅覆盖预处理器内部的 checked-call contract 与泛型证明顺序；面向语言用户的主要语义样例位于 Calcit definition `:tests`，跨后端行为由 Calcit 测试入口执行。

## English

Closes #995

### Changes

- Derive the ordinary `map-indexed` callback `(Number, T) -> U` and result `List<U>` from its `List<T>` receiver, without adding a parallel dynamic API or special lowering.
- Let arguments whose explicit type contains `Dynamic` establish the open generic binding before concrete arguments are checked. This makes ordinary generic calls such as `=` independent of argument order.
- Preserve the strict boundary: a `List<Dynamic>` still cannot be consumed by a Number-only callback and continues to report `E_ERASED_GENERIC_RELATION`.
- Add tagged `:core :unit` Calcit-first definition tests for `assoc`, `conj`, `map-indexed`, and `=`; the existing Calcit type-fail fixture and low-level contract tests retain rejection coverage.
- Exercise the same open-value examples through the Calcit traits entry so native and generated JS share direct semantic assertions.

### Verification

- `cargo test` (773 lib, 340 CLI, 17 WASM, 4 fix CLI, and related suites)
- 261 core definition tests
- `yarn check-all`
- `yarn try-rs`
- `yarn try-js`
- The Number-only callback remains fail-closed with `E_ERASED_GENERIC_RELATION` under default strict preprocessing

Rust tests cover only the preprocessor's internal checked-call contract and generic-proof ordering. The primary user-facing semantics live in Calcit definition `:tests`, while the Calcit execution entry validates native and generated-JS behavior.