### PR TITLE
feat(fix): 自动迁移 tag-match / migrate tag-match automatically

### DIFF
--- a/docs/CalcitAgent.md
+++ b/docs/CalcitAgent.md
@@ -213,6 +213,8 @@ JSON 中 definition 和 match 都带 `source`、`origin`，并用 `node_kind: le
 `defn`/`fn`/`let` body 本身可以顺序包含多个表达式，返回类型来自最后一项；不要为了类型推断再包一层 `do`。
 只有 `if` 分支、调用参数、binding value 等单表达式位置需要用 `do` 把多个步骤组成一个表达式。清理由
 `calcit fix --rule redundant-do-v1` 完成，不要手工批量改缩进；它会跳过 `defmacro` 与 quote/quasiquote，并用 staged preprocess 验证 splice 后的 scope。
+旧代码中的 `tag-match` 使用 `calcit fix --rule tag-match-to-match-v1` 迁移；只有名称解析确定指向 core deprecated macro
+的 source call 才会改为原生 `match`，本地 shadow、quoted data 和不明确的 macro origin 会保持不变。
 
 同一个 Snapshot 的写命令必须串行执行，包括 `config`、`edit`、`tree` 和 cursor mutation；两个进程同时读取再保存会发生最后写入覆盖。需要并行时使用独立 Snapshot/worktree，需要同一文件内的原子多步修改时使用 transaction 和 `--expect-revision`。
 

--- a/docs/run/fix.md
+++ b/docs/run/fix.md
@@ -39,6 +39,10 @@ calcit calcit.cirru fix --ns app.main --def render! --format json
 - `redundant-do-v1` 整理 `defn`、`fn`、`let` 及嵌套 `do` 的 variadic body。父结构本来就按顺序执行多项、
   并以最后一项作为返回值时，这条规则会把直接子节点的单层 `do` splice 到父 body。`if` 分支、调用参数、binding value
   以及 `defmacro`、`quote`/`quasiquote` 数据不在自动修改范围内；macro 是否把多项 body 打包成一个表达式需要保留显式语义。
+- `tag-match-to-match-v1` 复用 `analyze deprecated` 的名称解析，只改写确定指向 `calcit.core/tag-match` 的
+  source call head，分支 AST 与求值顺序保持不变。本地参数或 `let` 绑定的同名调用、其他 namespace 的同名定义、
+  `quote`/`quasiquote` 数据和无法唯一回到 source 的 macro expansion 不产生 replacement。该规则让原生 `match`
+  保留 enum 分支结构，供穷尽性、payload arity、类型推断与 backend 优化继续使用。
 
 JSON stdout 是一个完整 value，包含 `schema_version`、`command`、Snapshot `revision`、filters、validation、suggestions、diagnostics
 和 `next`。每条 suggestion 携带 Snapshot `source_file`、stable rule ID、diagnostic code、表层 definition/path、subtree fingerprint、

--- a/editing-history/202609130748-tag-match-fix.md
+++ b/editing-history/202609130748-tag-match-fix.md
@@ -1,0 +1,39 @@
+# 增加 `tag-match` 确定性迁移
+
+时间：2026-09-13 07:48 +0800
+
+## 背景
+
+`calcit.core/tag-match` 已废弃，但旧项目仍需要在不直接编辑 Snapshot 文本的前提下迁移到原生 `match`。
+两者共享分支 AST；自动迁移只应修改经过名称解析确认的调用 head，并对本地遮蔽与引用数据保持关闭。
+
+## 调整
+
+- 为 `calcit fix` 增加稳定规则 `tag-match-to-match-v1`，复用 deprecated API 目标解析以及现有 revision、fingerprint、预处理和原子事务协议。
+- 只生成 `tag-match` 到 `match` 的叶子替换；限定运行时表达式，跳过参数、binding pattern、quote/quasiquote 与本地遮蔽。
+- JSON suggestion 保留 deprecated diagnostic、source path、resolved origin、引用后的 original/replacement，并提示 apply 后运行 Calcit 测试与生成 JS。
+- 在 Snapshot `:tests` 中覆盖两个 enum 分支、payload binding、quoted data 与本地 shadow；Rust 集成测试仅负责 CLI transaction、幂等与进程边界，不把 `cargo test` 绑定到尚未安装的 JavaScript runtime。
+- 更新中文 Agent 与命令文档，并把结构化 suggestion 纳入 Agent interface 回归。
+
+## 生态验证
+
+在维护中的 `calcit-lang/recollect` 副本中，仅用 `calcit tree` 把已有 `probe-tag-match` 临时改回旧语法，再完成：
+
+1. `query def`；
+2. `fix` preview；
+3. 带 revision 的 apply；
+4. 19 个 `:unit` Calcit tests；
+5. test entry 的 JavaScript 生成与 Node 执行；
+6. 重复 preview，确认 suggestions 为空。
+
+原项目与副本 Snapshot 均未进行直接文本编辑。
+
+## 验证
+
+- `cargo test --test fix_cli`
+- `cargo test source_guards_reject_parameters_quoted_data_and_lexical_shadows`
+- `yarn check-agent-interface`
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --all-targets`
+- `yarn check-all`

--- a/editing-history/202609130800-fix-operation-order.md
+++ b/editing-history/202609130800-fix-operation-order.md
@@ -1,0 +1,15 @@
+# 修正 fix 默认规则的操作顺序
+
+## 背景
+
+CodeRabbit 指出，默认运行多条 `calcit fix` 规则时，如果先展开冗余 `do`，后续位于其内部的 `tag-match` 叶子替换会继续使用旧路径，导致 staged transaction 失败。
+
+## 调整
+
+- 默认规划先生成叶子替换，再生成会改变树坐标的结构 splice。
+- 通过 Calcit CLI 在现有 `tag-match-case` fixture 中加入冗余 `do`，让同一定义同时命中两条规则。
+- 增加 CLI transaction 边界测试，覆盖默认 preview、两条操作的执行顺序、Calcit `:tests` 语义验证以及重复执行的幂等性。
+
+## 测试分层
+
+业务语义继续由 fixture 内定义在 `:tests` 的 Calcit 测试验证；Rust 测试只覆盖进程调用、Snapshot 原子迁移与操作路径稳定性这一 CLI 边界。

--- a/scripts/check-agent-interface.mjs
+++ b/scripts/check-agent-interface.mjs
@@ -404,6 +404,41 @@ const scenarios = [
     },
   },
   {
+    name: "resolved deprecated macro fix preview",
+    args: [
+      "tests/fixtures/fix-command.cirru",
+      "fix",
+      "--ns",
+      "fix-command.main",
+      "--def",
+      "tag-match-case",
+      "--rule",
+      "tag-match-to-match-v1",
+      "--format",
+      "json",
+    ],
+    check(result) {
+      const suggestion = result.data?.suggestions?.[0];
+      if (
+        result.schema_version !== 1 ||
+        result.command !== "fix" ||
+        result.data.changed !== true ||
+        suggestion?.rule_id !== "tag-match-to-match-v1" ||
+        suggestion?.diagnostic_code !== "W_DEPRECATED_API"
+      ) {
+        throw new Error("tag-match fix preview lost its deterministic compiler evidence");
+      }
+      if (
+        suggestion.origin_chain?.[0]?.target !== "calcit.core/tag-match" ||
+        suggestion.original?.value !== "tag-match" ||
+        suggestion.replacement?.value !== "match" ||
+        suggestion.applicability !== "machine-applicable"
+      ) {
+        throw new Error("tag-match fix preview lost resolved origin or quoted AST replacement");
+      }
+    },
+  },
+  {
     name: "machine value schema",
     args: [
       "calcit/test.cirru",

--- a/src/bin/cli_handlers/fix.rs
+++ b/src/bin/cli_handlers/fix.rs
@@ -110,9 +110,6 @@ pub(crate) fn handle_fix_command(
   if options.rule.as_deref().is_none_or(|rule| rule == REMOVED_DATA_API_RULE) {
     suggestions.extend(plan_removed_data_api_fixes(options, &source_snapshot, snapshot_file, &warnings)?);
   }
-  if options.rule.as_deref().is_none_or(|rule| rule == REDUNDANT_DO_RULE) {
-    suggestions.extend(plan_redundant_do_fixes(&source_snapshot, snapshot_file, &selected_definitions)?);
-  }
   if options.rule.as_deref().is_none_or(|rule| rule == TAG_MATCH_RULE) {
     suggestions.extend(plan_tag_match_fixes(
       options,
@@ -121,6 +118,9 @@ pub(crate) fn handle_fix_command(
       snapshot_file,
       &selected_definitions,
     )?);
+  }
+  if options.rule.as_deref().is_none_or(|rule| rule == REDUNDANT_DO_RULE) {
+    suggestions.extend(plan_redundant_do_fixes(&source_snapshot, snapshot_file, &selected_definitions)?);
   }
   let operations = suggestions.iter().flat_map(suggestion_operations).collect::<Vec<_>>();
 

--- a/src/bin/cli_handlers/fix.rs
+++ b/src/bin/cli_handlers/fix.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use calcit::calcit::LocatedWarning;
 use calcit::call_stack::CallStackList;
-use calcit::cli_args::FixCommand;
+use calcit::cli_args::{DeprecatedCommand, FixCommand};
 use calcit::runner;
 use calcit::snapshot::Snapshot;
 use cirru_parser::Cirru;
@@ -16,11 +16,14 @@ use serde_json::Value;
 
 use super::common::{cirru_to_json_value, format_path};
 use super::edit::{load_snapshot, navigate_to_path, run_staged_fix_transaction, snapshot_content_revision};
+use crate::deprecated_api;
 
 const REMOVED_DATA_API_RULE: &str = "removed-data-api-v1";
 const REMOVED_DATA_API_DIAGNOSTIC: &str = "W_REMOVED_DATA_API";
 const REDUNDANT_DO_RULE: &str = "redundant-do-v1";
 const REDUNDANT_DO_DIAGNOSTIC: &str = "FIX_REDUNDANT_DO";
+const TAG_MATCH_RULE: &str = "tag-match-to-match-v1";
+const TAG_MATCH_DIAGNOSTIC: &str = "W_DEPRECATED_API";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum FixOperation {
@@ -109,6 +112,15 @@ pub(crate) fn handle_fix_command(
   }
   if options.rule.as_deref().is_none_or(|rule| rule == REDUNDANT_DO_RULE) {
     suggestions.extend(plan_redundant_do_fixes(&source_snapshot, snapshot_file, &selected_definitions)?);
+  }
+  if options.rule.as_deref().is_none_or(|rule| rule == TAG_MATCH_RULE) {
+    suggestions.extend(plan_tag_match_fixes(
+      options,
+      compiled_snapshot,
+      &source_snapshot,
+      snapshot_file,
+      &selected_definitions,
+    )?);
   }
   let operations = suggestions.iter().flat_map(suggestion_operations).collect::<Vec<_>>();
 
@@ -206,10 +218,10 @@ fn validate_options(options: &FixCommand) -> Result<(), String> {
     return Err("`calcit fix --def` requires an exact `--ns` scope.".to_owned());
   }
   if let Some(rule) = options.rule.as_deref()
-    && !matches!(rule, REMOVED_DATA_API_RULE | REDUNDANT_DO_RULE)
+    && !matches!(rule, REMOVED_DATA_API_RULE | REDUNDANT_DO_RULE | TAG_MATCH_RULE)
   {
     return Err(format!(
-      "Unknown fix rule `{rule}`. Available rules: `{REMOVED_DATA_API_RULE}`, `{REDUNDANT_DO_RULE}`."
+      "Unknown fix rule `{rule}`. Available rules: `{REMOVED_DATA_API_RULE}`, `{REDUNDANT_DO_RULE}`, `{TAG_MATCH_RULE}`."
     ));
   }
   Ok(())
@@ -372,6 +384,209 @@ fn plan_redundant_do_fixes(
     }
   }
   Ok(suggestions)
+}
+
+/// Rewrite source call heads proven to resolve to the deprecated core `tag-match` macro.
+fn plan_tag_match_fixes(
+  options: &FixCommand,
+  compiled_snapshot: &Snapshot,
+  source_snapshot: &Snapshot,
+  snapshot_file: &str,
+  selected_definitions: &[(String, String)],
+) -> Result<Vec<FixSuggestion>, String> {
+  let deprecated_options = DeprecatedCommand {
+    ns: options.ns.clone(),
+    ns_prefix: None,
+    format: "json".to_owned(),
+    deps: false,
+    summary_only: false,
+  };
+  let selected = selected_definitions.iter().cloned().collect::<HashSet<_>>();
+  let rows = deprecated_api::collect_deprecated_api_rows(&deprecated_options, compiled_snapshot)?;
+  let mut suggestions = BTreeMap::new();
+
+  for row in rows {
+    if !selected.contains(&(row.namespace.clone(), row.definition.clone())) {
+      continue;
+    }
+    let Some(entry) = source_snapshot
+      .files
+      .get(&row.namespace)
+      .and_then(|file| file.defs.get(&row.definition))
+    else {
+      continue;
+    };
+    for usage in row.uses {
+      if usage.target_namespace != calcit::calcit::CORE_NS || usage.target_name != "tag-match" {
+        continue;
+      }
+      let Some(call_path) = parse_code_path(&usage.path) else {
+        continue;
+      };
+      if !source_path_is_runtime_expression(&entry.code, &call_path) {
+        continue;
+      }
+      let Ok(Cirru::List(call)) = navigate_to_path(&entry.code, &call_path) else {
+        continue;
+      };
+      if call.len() < 3 {
+        continue;
+      }
+      let Some(Cirru::Leaf(original)) = call.first() else {
+        continue;
+      };
+      if source_call_is_lexically_shadowed(&entry.code, &call_path, original.as_ref()) {
+        continue;
+      }
+      let mut target_path = call_path;
+      target_path.push(0);
+      let original_leaf = original.to_string();
+      let original_node = Cirru::leaf(original_leaf.as_str());
+      let replacement_node = Cirru::leaf("match");
+      let suggestion = FixSuggestion {
+        rule_id: TAG_MATCH_RULE,
+        diagnostic_code: TAG_MATCH_DIAGNOSTIC,
+        semantic_layer: "surface",
+        source_file: snapshot_file.to_owned(),
+        definition: format!("{}/{}", row.namespace, row.definition),
+        path: format!("code{}", format_path(&target_path)),
+        fingerprint: node_fingerprint(&original_node),
+        origin_chain: vec![serde_json::json!({
+          "kind": "resolved-definition",
+          "target": "calcit.core/tag-match",
+        })],
+        original: quoted_json(&original_node),
+        replacement: Some(quoted_json(&replacement_node)),
+        applicability: "machine-applicable",
+        message: "Replace the call resolved to deprecated `calcit.core/tag-match` with native `match`; the branch AST and evaluation order are unchanged. Run affected Calcit tests and a generated-JS build after applying."
+          .to_owned(),
+        target_path: target_path.clone(),
+        operation: Some(FixOperation::ReplaceLeaf {
+          original: original_leaf,
+          replacement: "match".to_owned(),
+        }),
+      };
+      insert_fix_suggestion(
+        &mut suggestions,
+        (row.namespace.clone(), row.definition.clone(), target_path),
+        suggestion,
+      )?;
+    }
+  }
+
+  Ok(suggestions.into_values().collect())
+}
+
+/// Parse the stable `code@0.1` path emitted by deprecated API analysis.
+fn parse_code_path(path: &str) -> Option<Vec<usize>> {
+  if path == "code" {
+    return Some(vec![]);
+  }
+  path
+    .strip_prefix("code@")?
+    .split('.')
+    .map(|segment| segment.parse::<usize>().ok())
+    .collect()
+}
+
+/// Keep fixes out of parameter patterns and quoted syntax while allowing evaluated binding values.
+fn source_path_is_runtime_expression(root: &Cirru, path: &[usize]) -> bool {
+  let mut node = root;
+  for (depth, child_index) in path.iter().copied().enumerate() {
+    let Cirru::List(items) = node else {
+      return false;
+    };
+    let head = items.first().and_then(|item| match item {
+      Cirru::Leaf(value) => Some(value.as_ref()),
+      Cirru::List(_) => None,
+    });
+    match head {
+      Some("quote" | "quasiquote") if child_index >= 1 => return false,
+      Some("defn" | "defmacro") if child_index <= 2 => return false,
+      Some("fn") if child_index <= 1 => return false,
+      Some("let" | "loop") if child_index == 1 => {
+        let remaining = &path[depth + 1..];
+        if remaining.len() < 2 || remaining[1] == 0 {
+          return false;
+        }
+      }
+      Some("&let") if child_index == 1 => {
+        let remaining = &path[depth + 1..];
+        if remaining.first() != Some(&1) {
+          return false;
+        }
+      }
+      _ => {}
+    }
+    let Some(child) = items.get(child_index) else {
+      return false;
+    };
+    node = child;
+  }
+  true
+}
+
+/// Reject analyzer hits whose unqualified source head is bound by an enclosing lexical form.
+fn source_call_is_lexically_shadowed(root: &Cirru, call_path: &[usize], symbol: &str) -> bool {
+  if symbol.contains('/') {
+    return false;
+  }
+  let mut node = root;
+  for (depth, child_index) in call_path.iter().copied().enumerate() {
+    let Cirru::List(items) = node else {
+      return false;
+    };
+    let remaining = &call_path[depth + 1..];
+    if lexical_form_binds(items, child_index, remaining, symbol) {
+      return true;
+    }
+    let Some(child) = items.get(child_index) else {
+      return false;
+    };
+    node = child;
+  }
+  false
+}
+
+fn lexical_form_binds(items: &[Cirru], child_index: usize, remaining: &[usize], symbol: &str) -> bool {
+  let Some(Cirru::Leaf(head)) = items.first() else {
+    return false;
+  };
+  match head.as_ref() {
+    "defn" | "defmacro" if child_index >= 3 => items.get(2).is_some_and(|params| pattern_binds(params, symbol)),
+    "fn" if child_index >= 2 => items.get(1).is_some_and(|params| pattern_binds(params, symbol)),
+    "let" | "loop" => {
+      let Some(Cirru::List(bindings)) = items.get(1) else {
+        return false;
+      };
+      if child_index >= 2 {
+        return bindings.iter().any(|binding| binding_name_matches(binding, symbol));
+      }
+      if child_index != 1 || remaining.len() < 2 || remaining[1] == 0 {
+        return false;
+      }
+      bindings
+        .iter()
+        .take(remaining[0])
+        .any(|binding| binding_name_matches(binding, symbol))
+    }
+    "&let" if child_index >= 2 => items.get(1).is_some_and(|binding| binding_name_matches(binding, symbol)),
+    _ => false,
+  }
+}
+
+fn binding_name_matches(binding: &Cirru, symbol: &str) -> bool {
+  let Cirru::List(pair) = binding else {
+    return false;
+  };
+  pair.first().is_some_and(|pattern| pattern_binds(pattern, symbol))
+}
+
+fn pattern_binds(pattern: &Cirru, symbol: &str) -> bool {
+  match pattern {
+    Cirru::Leaf(value) => value.as_ref() == symbol,
+    Cirru::List(items) => items.iter().any(|item| pattern_binds(item, symbol)),
+  }
 }
 
 /// Collect source paths in evaluation order while treating quoted trees as data.
@@ -579,7 +794,7 @@ fn print_human_report(report: &FixReport<'_>) {
 mod tests {
   use super::{
     FixOperation, FixSuggestion, collect_redundant_do_paths, insert_fix_suggestion, migration_for_source_leaf, resolve_fix_target,
-    suggestion_operations,
+    source_call_is_lexically_shadowed, source_path_is_runtime_expression, suggestion_operations,
   };
   use cirru_parser::Cirru;
   use serde_json::Value;
@@ -610,6 +825,46 @@ mod tests {
     let code = Cirru::List(vec![leaf("do"), Cirru::List(vec![leaf("tuple-enum"), leaf("value")])]);
     assert_eq!(resolve_fix_target(&code, &[1]), Some((vec![1, 0], "tuple-enum".to_owned())));
     assert_eq!(resolve_fix_target(&code, &[1, 0]), Some((vec![1, 0], "tuple-enum".to_owned())));
+  }
+
+  #[test]
+  fn source_guards_reject_parameters_quoted_data_and_lexical_shadows() {
+    let parameter_shadow = Cirru::List(vec![
+      leaf("defn"),
+      leaf("demo"),
+      Cirru::List(vec![leaf("tag-match"), leaf("value")]),
+      Cirru::List(vec![leaf("tag-match"), leaf("value"), leaf("branch")]),
+    ]);
+    assert!(!source_path_is_runtime_expression(&parameter_shadow, &[2]));
+    assert!(source_path_is_runtime_expression(&parameter_shadow, &[3]));
+    assert!(source_call_is_lexically_shadowed(&parameter_shadow, &[3], "tag-match"));
+
+    let quoted = Cirru::List(vec![
+      leaf("defn"),
+      leaf("demo"),
+      Cirru::List(vec![]),
+      Cirru::List(vec![
+        leaf("quote"),
+        Cirru::List(vec![leaf("tag-match"), leaf("value"), leaf("branch")]),
+      ]),
+    ]);
+    assert!(!source_path_is_runtime_expression(&quoted, &[3, 1]));
+
+    let let_shadow = Cirru::List(vec![
+      leaf("let"),
+      Cirru::List(vec![Cirru::List(vec![leaf("tag-match"), leaf("callback")])]),
+      Cirru::List(vec![leaf("tag-match"), leaf("value"), leaf("branch")]),
+    ]);
+    assert!(source_call_is_lexically_shadowed(&let_shadow, &[2], "tag-match"));
+
+    let internal_let_shadow = Cirru::List(vec![
+      leaf("&let"),
+      Cirru::List(vec![leaf("tag-match"), leaf("callback")]),
+      Cirru::List(vec![leaf("tag-match"), leaf("value"), leaf("branch")]),
+    ]);
+    assert!(!source_path_is_runtime_expression(&internal_let_shadow, &[1, 0]));
+    assert!(source_path_is_runtime_expression(&internal_let_shadow, &[1, 1]));
+    assert!(source_call_is_lexically_shadowed(&internal_let_shadow, &[2], "tag-match"));
   }
 
   #[test]

--- a/tests/fix_cli.rs
+++ b/tests/fix_cli.rs
@@ -218,3 +218,143 @@ fn staged_fix_rejects_a_new_compiler_warning_without_writing() {
   assert!(String::from_utf8_lossy(&preview.stderr).contains("W_FN_RETURN_TYPE_MISMATCH"));
   assert_eq!(fs::read(&snapshot).expect("rejected fixture should read"), before);
 }
+
+#[test]
+fn tag_match_fix_uses_resolved_source_origin_and_preserves_semantics() {
+  let directory = TestDirectory::create();
+  let snapshot = directory.path().join("calcit.cirru");
+  fs::copy("tests/fixtures/fix-command.cirru", &snapshot).expect("fixture should copy");
+  let original = fs::read(&snapshot).expect("fixture should read");
+
+  let before = run_calcit(
+    &snapshot,
+    &["test", "fix-command.main/tag-match-case", "--summary-only", "--require-match"],
+  );
+  assert!(before.status.success(), "stderr:\n{}", String::from_utf8_lossy(&before.stderr));
+  let quoted_before = run_calcit(
+    &snapshot,
+    &["test", "fix-command.main/tag-match-quoted", "--summary-only", "--require-match"],
+  );
+  assert!(
+    quoted_before.status.success(),
+    "stderr:\n{}",
+    String::from_utf8_lossy(&quoted_before.stderr)
+  );
+  let shadow_tests = run_calcit(&snapshot, &["query", "tests", "fix-command.main/tag-match-shadowed"]);
+  assert!(
+    shadow_tests.status.success(),
+    "stderr:\n{}",
+    String::from_utf8_lossy(&shadow_tests.stderr)
+  );
+  assert!(String::from_utf8_lossy(&shadow_tests.stdout).contains("keeps-local-shadow"));
+  let preview = run_fix(
+    &snapshot,
+    &[
+      "--ns",
+      "fix-command.main",
+      "--def",
+      "tag-match-case",
+      "--rule",
+      "tag-match-to-match-v1",
+      "--format",
+      "json",
+    ],
+  );
+  assert!(preview.status.success(), "stderr:\n{}", String::from_utf8_lossy(&preview.stderr));
+  let preview_json = parse_stdout(&preview);
+  let suggestion = &preview_json["data"]["suggestions"][0];
+  assert_eq!(suggestion["rule_id"], "tag-match-to-match-v1");
+  assert_eq!(suggestion["diagnostic_code"], "W_DEPRECATED_API");
+  assert_eq!(suggestion["origin_chain"][0]["target"], "calcit.core/tag-match");
+  assert_eq!(suggestion["original"]["value"], "tag-match");
+  assert_eq!(suggestion["replacement"]["value"], "match");
+  assert!(
+    suggestion["message"]
+      .as_str()
+      .is_some_and(|message| message.contains("Calcit tests"))
+  );
+  assert_eq!(preview_json["data"]["validation"]["checked_operations"], 1);
+  assert_eq!(fs::read(&snapshot).expect("preview fixture should read"), original);
+
+  for definition in ["tag-match-shadowed", "tag-match-quoted"] {
+    let negative = run_fix(
+      &snapshot,
+      &[
+        "--ns",
+        "fix-command.main",
+        "--def",
+        definition,
+        "--rule",
+        "tag-match-to-match-v1",
+        "--format",
+        "json",
+      ],
+    );
+    assert!(
+      negative.status.success(),
+      "{definition} stderr:\n{}",
+      String::from_utf8_lossy(&negative.stderr)
+    );
+    let report = parse_stdout(&negative);
+    assert_eq!(report["data"]["changed"], false, "definition: {definition}");
+    assert_eq!(report["data"]["suggestions"].as_array().map(Vec::len), Some(0));
+  }
+
+  let revision = preview_json["revision"].as_str().expect("preview revision should be a string");
+  let applied = run_fix(
+    &snapshot,
+    &[
+      "--ns",
+      "fix-command.main",
+      "--def",
+      "tag-match-case",
+      "--rule",
+      "tag-match-to-match-v1",
+      "--apply",
+      "--allow-no-vcs",
+      "--expect-revision",
+      revision,
+      "--format",
+      "json",
+    ],
+  );
+  assert!(applied.status.success(), "stderr:\n{}", String::from_utf8_lossy(&applied.stderr));
+  let applied_json = parse_stdout(&applied);
+  assert_eq!(applied_json["data"]["changed"], true);
+  let updated = fs::read_to_string(&snapshot).expect("updated fixture should read");
+  assert!(updated.contains("match value"));
+  assert!(updated.contains("defn tag-match-shadowed (tag-match value) (tag-match value)"));
+  assert!(updated.contains("quote $ tag-match (%some 1)"));
+
+  let after = run_calcit(
+    &snapshot,
+    &["test", "fix-command.main/tag-match-case", "--summary-only", "--require-match"],
+  );
+  assert!(after.status.success(), "stderr:\n{}", String::from_utf8_lossy(&after.stderr));
+  let quoted_after = run_calcit(
+    &snapshot,
+    &["test", "fix-command.main/tag-match-quoted", "--summary-only", "--require-match"],
+  );
+  assert!(
+    quoted_after.status.success(),
+    "stderr:\n{}",
+    String::from_utf8_lossy(&quoted_after.stderr)
+  );
+  let repeated = run_fix(
+    &snapshot,
+    &[
+      "--ns",
+      "fix-command.main",
+      "--def",
+      "tag-match-case",
+      "--rule",
+      "tag-match-to-match-v1",
+      "--format",
+      "json",
+    ],
+  );
+  assert!(repeated.status.success(), "stderr:\n{}", String::from_utf8_lossy(&repeated.stderr));
+  let repeated_json = parse_stdout(&repeated);
+  assert_eq!(repeated_json["data"]["changed"], false);
+  assert_eq!(repeated_json["data"]["suggestions"].as_array().map(Vec::len), Some(0));
+}

--- a/tests/fix_cli.rs
+++ b/tests/fix_cli.rs
@@ -358,3 +358,62 @@ fn tag_match_fix_uses_resolved_source_origin_and_preserves_semantics() {
   assert_eq!(repeated_json["data"]["changed"], false);
   assert_eq!(repeated_json["data"]["suggestions"].as_array().map(Vec::len), Some(0));
 }
+
+#[test]
+fn default_fix_applies_leaf_replacements_before_structural_splices() {
+  let directory = TestDirectory::create();
+  let snapshot = directory.path().join("calcit.cirru");
+  fs::copy("tests/fixtures/fix-command.cirru", &snapshot).expect("fixture should copy");
+
+  let preview = run_fix(
+    &snapshot,
+    &["--ns", "fix-command.main", "--def", "tag-match-case", "--format", "json"],
+  );
+  assert!(preview.status.success(), "stderr:\n{}", String::from_utf8_lossy(&preview.stderr));
+  let preview_json = parse_stdout(&preview);
+  let rule_ids = preview_json["data"]["suggestions"]
+    .as_array()
+    .expect("suggestions should be an array")
+    .iter()
+    .map(|suggestion| suggestion["rule_id"].as_str().expect("rule id should be a string"))
+    .collect::<Vec<_>>();
+  assert_eq!(rule_ids, vec!["tag-match-to-match-v1", "redundant-do-v1"]);
+  assert_eq!(preview_json["data"]["validation"]["checked_operations"], 3);
+
+  let revision = preview_json["revision"].as_str().expect("preview revision should be a string");
+  let applied = run_fix(
+    &snapshot,
+    &[
+      "--ns",
+      "fix-command.main",
+      "--def",
+      "tag-match-case",
+      "--apply",
+      "--allow-no-vcs",
+      "--expect-revision",
+      revision,
+      "--format",
+      "json",
+    ],
+  );
+  assert!(applied.status.success(), "stderr:\n{}", String::from_utf8_lossy(&applied.stderr));
+  let applied_json = parse_stdout(&applied);
+  assert_eq!(applied_json["data"]["changed"], true);
+  let updated = fs::read_to_string(&snapshot).expect("updated fixture should read");
+  assert!(updated.contains("match value"));
+  assert!(!updated.contains("do $ match value"));
+
+  let after = run_calcit(
+    &snapshot,
+    &["test", "fix-command.main/tag-match-case", "--summary-only", "--require-match"],
+  );
+  assert!(after.status.success(), "stderr:\n{}", String::from_utf8_lossy(&after.stderr));
+  let repeated = run_fix(
+    &snapshot,
+    &["--ns", "fix-command.main", "--def", "tag-match-case", "--format", "json"],
+  );
+  assert!(repeated.status.success(), "stderr:\n{}", String::from_utf8_lossy(&repeated.stderr));
+  let repeated_json = parse_stdout(&repeated);
+  assert_eq!(repeated_json["data"]["changed"], false);
+  assert_eq!(repeated_json["data"]["suggestions"].as_array().map(Vec::len), Some(0));
+}

--- a/tests/fixtures/fix-command.cirru
+++ b/tests/fixtures/fix-command.cirru
@@ -1,4 +1,5 @@
-{} (:about "|Fix command integration fixture.") (:package |fix-command)
+
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --contract` before mutations; use `--full` for first orientation or changed contract digest. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |fix-command)
   :entries $ {}
     :default $ {} (:description "|Compiler-guided source fix fixture.") (:init-fn 'fix-command.main/main!) (:mode :native) (:reload-fn 'fix-command.main/reload!)
       :feature-policy $ {}
@@ -7,19 +8,6 @@
   :files $ {}
     'fix-command.main $ %{} 'FileEntry
       :defs $ {}
-        'fixable $ %{} 'CodeEntry (:doc "|Exact removed API call.")
-          :code $ quote
-            defn fixable (value) (tuple-enum value)
-          :examples $ []
-          :schema $ :: 'Fn
-            {} (:return $ :: 'Option 'EnumDef)
-              :args $ [] 'Dynamic
-          :tests $ []
-            %{} 'TestEntry (:name |returns-enum-definition)
-              :code $ quote
-                assert= (%some Option)
-                  fixable $ %some 1
-              :tags $ #{} :migration
         'ambiguous $ %{} 'CodeEntry (:doc "|Removed predicate needs a semantic choice.")
           :code $ quote
             defn ambiguous (value) (tuple? value)
@@ -27,9 +15,30 @@
           :schema $ :: 'Fn
             {} (:return 'Bool)
               :args $ [] 'Dynamic
-        'main! $ %{} 'CodeEntry (:doc "|Entry.")
+        'fixable $ %{} 'CodeEntry (:doc "|Exact removed API call.")
+          :code $ quote
+            defn fixable (value) (tuple-enum value)
+          :examples $ []
+          :schema $ :: 'Fn
+            {}
+              :args $ [] 'Dynamic
+              :return $ :: 'Option 'EnumDef
+          :tests $ []
+            %{} 'TestEntry (:name |returns-enum-definition)
+              :code $ quote
+                assert= (%some Option)
+                  fixable $ %some 1
+              :tags $ #{} :migration
+        'main! $ %{} 'CodeEntry (:doc |Entry.)
           :code $ quote
             defn main! () &unit
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
+        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+          :code $ quote
+            defn reload! () &unit
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Unit)
@@ -40,13 +49,66 @@
           :examples $ []
           :schema $ :: 'Fn
             {} (:return 'Dynamic)
-              :args $ [] (:: 'Fn $ {} (:args $ [] 'Dynamic) (:return 'Dynamic)) 'Dynamic
-        'reload! $ %{} 'CodeEntry (:doc "|Reload handler.")
+              :args $ []
+                :: 'Fn $ {} (:return 'Dynamic)
+                  :args $ [] 'Dynamic
+                , 'Dynamic
+        'tag-match-case $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            defn reload! () &unit
+            defn tag-match-case (is-some?)
+              let
+                  value $ if is-some? (:: :some 1) (:: :none)
+                tag-match value
+                  (:some x) (+ x 1)
+                  (:none) 0
           :examples $ []
           :schema $ :: 'Fn
-            {} (:return 'Unit)
+            {} (:return 'Number)
+              :args $ [] 'Bool
+          :tests $ []
+            %{} 'TestEntry (:name |preserves-some-payload)
+              :code $ quote
+                assert= 2 $ tag-match-case true
+              :tags $ #{} :migration
+            %{} 'TestEntry (:name |preserves-none-branch)
+              :code $ quote
+                assert= 0 $ tag-match-case false
+              :tags $ #{} :migration
+        'tag-match-quoted $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn tag-match-quoted () $ quote
+              tag-match (%some 1)
+                (:some x) x
+                (:none) 0
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'CirruQuote)
               :args $ []
+          :tests $ []
+            %{} 'TestEntry (:name |keeps-quoted-data)
+              :code $ quote
+                assert=
+                  quote $ tag-match (%some 1)
+                    (:some x) x
+                    (:none) 0
+                  tag-match-quoted
+              :tags $ #{} :migration
+        'tag-match-shadowed $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defn tag-match-shadowed (tag-match value) (tag-match value)
+          :examples $ []
+          :schema $ :: 'Fn
+            {} (:return 'Number)
+              :args $ []
+                :: 'Fn $ {} (:return 'Number)
+                  :args $ [] 'Number
+                , 'Number
+          :tests $ []
+            %{} 'TestEntry (:name |keeps-local-shadow)
+              :code $ quote
+                assert= 11 $ tag-match-shadowed
+                  fn (value) (+ value 10)
+                  , 1
+              :tags $ #{} :migration
       :ns $ %{} 'NsEntry (:doc "|Fix command fixture.")
         :code $ quote (ns fix-command.main)

--- a/tests/fixtures/fix-command.cirru
+++ b/tests/fixtures/fix-command.cirru
@@ -58,7 +58,7 @@
             defn tag-match-case (is-some?)
               let
                   value $ if is-some? (:: :some 1) (:: :none)
-                tag-match value
+                do $ tag-match value
                   (:some x) (+ x 1)
                   (:none) 0
           :examples $ []


### PR DESCRIPTION
## 中文

### 改动

- 为 `calcit fix` 增加稳定规则 `tag-match-to-match-v1`。
- 只改写名称解析确定指向 `calcit.core/tag-match` 的 source call head，保留分支 AST、求值顺序、revision、fingerprint、staged preprocess 与原子事务协议。
- 对参数/binding pattern、本地 shadow、`quote`/`quasiquote` 数据和非唯一 source origin 保持 fail closed。
- suggestion 提供 deprecated diagnostic、definition/path、resolved origin、引用后的 original/replacement，以及 apply 后的 Calcit/JS 验证提示。
- 新增 Calcit `:tests` 覆盖正常分支、payload、quoted data 与本地 shadow；Rust 仅覆盖 CLI transaction 和 source guard 边界。
- 更新中文 Agent/fix 文档与结构化 Agent interface 回归。

### 验证

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `yarn check-agent-interface`（33/33）
- `yarn check-all`
- `bash scripts/check-docs-md.sh`（65 files / 331 blocks）
- 在 `calcit-lang/recollect` 副本用 Calcit CLI 完成 query → preview → apply → 19 个 `:unit` tests → JS 生成与 Node 执行 → 幂等 preview；未直接文本编辑 Snapshot。

## English

### Changes

- Add the stable `tag-match-to-match-v1` rule to `calcit fix`.
- Rewrite only source call heads proven to resolve to `calcit.core/tag-match`, preserving branch AST, evaluation order, revision, fingerprints, staged preprocessing, and atomic transactions.
- Fail closed for parameter/binding patterns, lexical shadows, quoted/quasiquoted data, and non-unique source origins.
- Include the deprecated diagnostic, definition/path, resolved origin, quoted original/replacement, and post-apply Calcit/JS validation guidance in each suggestion.
- Add Calcit `:tests` for normal branches, payloads, quoted data, and lexical shadows; keep Rust coverage at the CLI transaction and source-guard boundary.
- Update the Chinese Agent/fix documentation and the structured Agent-interface regression.

### Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `yarn check-agent-interface` (33/33)
- `yarn check-all`
- `bash scripts/check-docs-md.sh` (65 files / 331 blocks)
- On a copy of `calcit-lang/recollect`, used only Calcit CLI mutations for query → preview → apply → 19 `:unit` tests → JS generation and Node execution → idempotent preview; no Snapshot was edited as text.

Closes #1049